### PR TITLE
[Radio] Allow contributors to mark correct choice as 'none of the above'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,8 +97,6 @@ Each widget consists of the following parts:
    renderer's props
  * An options `hidden` flag, which, if `true`, will prevent the widget from being
    available in the widget menu
- * An options `shorcut`, which is a unique string that can be used to quickly add the widget in the editor
-   * *Note: If not provided the widget will get automatically assigned a shortcut, extracted from `name`*
 
 These are exported in an object at the bottom of every widget file:
 

--- a/src/editor.jsx
+++ b/src/editor.jsx
@@ -236,6 +236,7 @@ var Editor = React.createClass({
             placeholder: "",
             widgets: {},
             images: {},
+            disabled: false,
             widgetEnabled: true,
             immutableWidgets: false,
             apiOptions: ApiOptions.defaults,
@@ -410,6 +411,7 @@ var Editor = React.createClass({
                           onChange={this.handleChange}
                           onKeyDown={this._handleKeyDown}
                           placeholder={this.props.placeholder}
+                          disabled={this.props.disabled}
                           value={this.props.content} />
             ];
         var textareaWrapper;

--- a/src/widgets/radio.jsx
+++ b/src/widgets/radio.jsx
@@ -122,7 +122,8 @@ var ChoiceEditor = React.createClass({
 
         if (this.props.choice.isNoneOfTheAbove) {
             placeholder = this.props.choice.correct ?
-            "Type the answer to reveal to the user..." : "None of the above";
+                "Type the answer to reveal to the user..." :
+                "None of the above";
         }
 
         var editor = <Editor
@@ -201,7 +202,7 @@ var BaseRadio = React.createClass({
                 var showClue = choice.checked &&
                     (exerciseClues || reviewModeClues);
 
-                var element = Choice;
+                var Element = Choice;
                 var elementProps = {
                     ref: `radio${i}`,
                     checked: choice.checked,
@@ -214,10 +215,10 @@ var BaseRadio = React.createClass({
                     onChecked: (checked) => {
                         this.checkOption(i, checked);
                     }
-                }
+                };
 
                 if (choice.isNoneOfTheAbove) {
-                    element = ChoiceNoneAbove;
+                    Element = ChoiceNoneAbove;
                     _.extend(elementProps, { showContent: choice.correct });
                 }
 
@@ -248,7 +249,7 @@ var BaseRadio = React.createClass({
                             }
                     }}>
 
-                    {React.createElement(element, elementProps)}
+                    <Element {...elementProps} />
                 </li>;
             }, this)}
         </ul>;
@@ -538,7 +539,6 @@ var RadioEditor = React.createClass({
                                   multipleSelect={this.props.multipleSelect}
                                   onChange={this.onMultipleSelectChange} />
                 </div>
-
                 <div className="perseus-widget-left-col">
                     <PropCheckBox label="Randomize order"
                                   labelAlignment="right"
@@ -673,15 +673,15 @@ var RadioEditor = React.createClass({
 
         var choices = this.props.choices.slice();
         var newChoice = { isNoneOfTheAbove: noneOfTheAbove };
-        var insertIndex = choices.length - ( this.props.hasNoneOfTheAbove || 0 );
+        var addIndex = choices.length - (this.props.hasNoneOfTheAbove ? 1 : 0);
 
-        choices.splice(insertIndex, 0, newChoice);
+        choices.splice(addIndex, 0, newChoice);
 
         this.props.onChange({
             choices: choices,
             hasNoneOfTheAbove: noneOfTheAbove || this.props.hasNoneOfTheAbove
         }, () => {
-            this.refs[`choice-editor${insertIndex}`].refs['content-editor'].focus();
+            this.refs[`choice-editor${addIndex}`].refs['content-editor'].focus();
         });
     },
 
@@ -690,7 +690,7 @@ var RadioEditor = React.createClass({
     },
 
     focus: function() {
-        this.refs.editor0.refs['content-editor'].focus();
+        this.refs['choice-editor0'].refs['content-editor'].focus()
         return true;
     },
 

--- a/src/widgets/radio.jsx
+++ b/src/widgets/radio.jsx
@@ -671,7 +671,7 @@ var RadioEditor = React.createClass({
     addChoice: function(noneOfTheAbove, e) {
         e.preventDefault();
 
-        var choices = this.props.choices;
+        var choices = this.props.choices.slice();
         var newChoice = { isNoneOfTheAbove: noneOfTheAbove };
         var insertIndex = choices.length - ( this.props.hasNoneOfTheAbove || 0 );
 

--- a/src/widgets/radio.jsx
+++ b/src/widgets/radio.jsx
@@ -481,7 +481,7 @@ var RadioEditor = React.createClass({
         })),
         displayCount: React.PropTypes.number,
         randomize: React.PropTypes.bool,
-        noneOfAbove: React.PropTypes.bool,
+        hasNoneOfTheAbove: React.PropTypes.bool,
         multipleSelect: React.PropTypes.bool,
         onePerLine: React.PropTypes.bool,
         deselectEnabled: React.PropTypes.bool,
@@ -492,7 +492,7 @@ var RadioEditor = React.createClass({
             choices: [{}, {}],
             displayCount: null,
             randomize: false,
-            noneOfAbove: false,
+            hasNoneOfTheAbove: false,
             multipleSelect: false,
             onePerLine: true,
             deselectEnabled: false,
@@ -576,7 +576,7 @@ var RadioEditor = React.createClass({
                     {' '}Add a choice{' '}
                 </a>
 
-                {!this.props.noneOfAbove && <a href="#" className="simple-button"
+                {!this.props.hasNoneOfTheAbove && <a href="#" className="simple-button"
                         onClick={this.addChoice.bind(this, true)}>
                     <span className="icon-plus" />
                     {' '}None of the above{' '}
@@ -651,22 +651,22 @@ var RadioEditor = React.createClass({
 
         this.props.onChange({
             choices: choices,
-            noneOfAbove: !( deleted.isNoneOfTheAbove || !this.props.noneOfAbove )
+            hasNoneOfTheAbove: !( deleted.isNoneOfTheAbove || !this.props.hasNoneOfTheAbove )
         });
     },
 
-    addChoice: function(noneOfAbove, e) {
+    addChoice: function(noneOfTheAbove, e) {
         e.preventDefault();
 
         var choices = this.props.choices;
-        var newChoice = { isNoneOfTheAbove: !!noneOfAbove }
-        var insertIndex = choices.length - ( this.props.noneOfAbove | 0 );
+        var newChoice = { isNoneOfTheAbove: !!noneOfTheAbove }
+        var insertIndex = choices.length - ( this.props.hasNoneOfTheAbove | 0 );
 
         choices.splice(insertIndex, 0, newChoice);
 
         this.props.onChange({
             choices: choices,
-            noneOfAbove: !!noneOfAbove || this.props.noneOfAbove
+            hasNoneOfTheAbove: !!noneOfTheAbove || this.props.hasNoneOfTheAbove
         }, () => {
             this.refs[`choice-editor${insertIndex}`].refs['content-editor'].focus();
         });
@@ -690,7 +690,7 @@ var RadioEditor = React.createClass({
 
     serialize: function() {
         return _.pick(this.props, "choices", "randomize",
-            "multipleSelect", "displayCount", "noneOfAbove", "onePerLine",
+            "multipleSelect", "displayCount", "hasNoneOfTheAbove", "onePerLine",
             "deselectEnabled");
     }
 });
@@ -737,7 +737,7 @@ var choiceTransform = (editorProps, problemNum) => {
     choices = addNoneOfAbove(randomize(choices));
 
     editorProps = _.extend({}, editorProps, { choices: choices });
-    return _.pick(editorProps, "choices", "noneOfAbove", "onePerLine",
+    return _.pick(editorProps, "choices", "hasNoneOfTheAbove", "onePerLine",
         "multipleSelect", "correctAnswer", "deselectEnabled");
 };
 

--- a/src/widgets/radio.jsx
+++ b/src/widgets/radio.jsx
@@ -504,7 +504,7 @@ var RadioEditor = React.createClass({
                                 </div>
                             }
                             {this.props.choices.length >= 2 && deleteLink}
-                            {choice.correct && asNoneOfTheAbove}
+                            {asNoneOfTheAbove}
                         </div>,
                         checked: choice.correct
                     };
@@ -524,7 +524,12 @@ var RadioEditor = React.createClass({
 
     setNoneOfTheAbove: function(choiceIndex, checked) {
         var choices = _.map(this.props.choices, function(choice, i) {
-            return _.extend({}, choice, { isNoneOfTheAbove: choiceIndex === i && checked });
+            isNoneOfTheAbove = choiceIndex === i && checked;
+
+            return _.extend({}, choice, {
+                isNoneOfTheAbove: isNoneOfTheAbove,
+                content: isNoneOfTheAbove && !choice.correct ? '' : choice.content
+            });
         });
 
         this.props.onChange({ choices: choices });
@@ -560,7 +565,7 @@ var RadioEditor = React.createClass({
         var choices = _.map(this.props.choices, (choice, i) => {
             return _.extend({}, choice, {
                 correct: checked[i],
-                isNoneOfTheAbove: false
+                content: choice.isNoneOfTheAbove && !checked[i] ? '' : choice.content
             });
         });
         this.props.onChange({choices: choices});

--- a/src/widgets/radio.jsx
+++ b/src/widgets/radio.jsx
@@ -34,7 +34,6 @@ var BaseRadio = React.createClass({
     getDefaultProps: function() {
         return {
             onePerLine: true,
-            extraItem: null
         };
     },
 
@@ -129,9 +128,6 @@ var BaseRadio = React.createClass({
                 </li>;
 
             }, this)}
-            {this.props.extraItem && <li>
-                {this.props.extraItem}
-            </li>}
         </ul>;
     },
 
@@ -413,7 +409,12 @@ var RadioEditor = React.createClass({
     },
 
     render: function() {
-        return <div>
+        var classSet = {
+            'perseus-widget-editor-content-wrapper': true,
+            'has-none-of-above': this.props.noneOfAbove
+        }
+
+        return <div className={cx(classSet)}>
             <div className="perseus-widget-row">
 
                 <div className="perseus-widget-left-col">
@@ -515,20 +516,22 @@ var RadioEditor = React.createClass({
                         checked: choice.correct
                     };
                 }, this)}
-                onCheckedChange={this.onCheckedChange}
-                extraItem={<div className="add-choice-container">
-                    <a href="#" className="simple-button orange"
-                            onClick={this.addChoice.bind(this, false)}>
-                        <span className="icon-plus" />
-                        {' '}Add a choice{' '}
-                    </a>
+                onCheckedChange={this.onCheckedChange} />
 
-                    {!this.props.noneOfAbove && <a href="#" className="simple-button"
-                            onClick={this.addChoice.bind(this, true)}>
-                        <span className="icon-plus" />
-                        {' '}None of the above{' '}
-                    </a>}
-                </div>} />
+            <div className="add-choice-container">
+                <a href="#" className="simple-button orange"
+                        onClick={this.addChoice.bind(this, false)}>
+                    <span className="icon-plus" />
+                    {' '}Add a choice{' '}
+                </a>
+
+                {!this.props.noneOfAbove && <a href="#" className="simple-button"
+                        onClick={this.addChoice.bind(this, true)}>
+                    <span className="icon-plus" />
+                    {' '}None of the above{' '}
+                </a>}
+            </div>
+
         </div>;
     },
 

--- a/src/widgets/radio.jsx
+++ b/src/widgets/radio.jsx
@@ -34,6 +34,7 @@ var BaseRadio = React.createClass({
     getDefaultProps: function() {
         return {
             onePerLine: true,
+            extraItem: null
         };
     },
 
@@ -86,6 +87,10 @@ var BaseRadio = React.createClass({
                                         shouldToggle ? !choice.checked : true);
                                 }
                             }}>
+                    {choice.isNoneOfTheAbove &&
+                        <div className="instructions">
+                            <$_>None of the above</$_>
+                        </div>}
                     <div>
                         <span className="checkbox">
                             <input
@@ -124,6 +129,9 @@ var BaseRadio = React.createClass({
                 </li>;
 
             }, this)}
+            {this.props.extraItem && <li>
+                {this.props.extraItem}
+            </li>}
         </ul>;
     },
 
@@ -507,22 +515,20 @@ var RadioEditor = React.createClass({
                         checked: choice.correct
                     };
                 }, this)}
-                onCheckedChange={this.onCheckedChange} />
+                onCheckedChange={this.onCheckedChange}
+                extraItem={<div className="add-choice-container">
+                    <a href="#" className="simple-button orange"
+                            onClick={this.addChoice.bind(this, false)}>
+                        <span className="icon-plus" />
+                        {' '}Add a choice{' '}
+                    </a>
 
-            <div className="add-choice-container">
-                <a href="#" className="simple-button orange"
-                        onClick={this.addChoice.bind(this, false)}>
-                    <span className="icon-plus" />
-                    {' '}Add a choice{' '}
-                </a>
-
-                {!this.props.noneOfAbove && <a href="#" className="simple-button"
-                        onClick={this.addChoice.bind(this, true)}>
-                    <span className="icon-plus" />
-                    {' '}None of the above{' '}
-                </a>}
-            </div>
-
+                    {!this.props.noneOfAbove && <a href="#" className="simple-button"
+                            onClick={this.addChoice.bind(this, true)}>
+                        <span className="icon-plus" />
+                        {' '}None of the above{' '}
+                    </a>}
+                </div>} />
         </div>;
     },
 

--- a/src/widgets/radio.jsx
+++ b/src/widgets/radio.jsx
@@ -22,9 +22,9 @@ var cx = React.addons.classSet;
 var Choice = React.createClass({
     propTypes: {
         checked: React.PropTypes.bool,
-        classSet: React.PropTypes.shape,
-        clue: React.PropTypes.shape,
-        content: React.PropTypes.shape,
+        classSet: React.PropTypes.object,
+        clue: React.PropTypes.object,
+        content: React.PropTypes.node,
         disabled: React.PropTypes.bool,
         groupName: React.PropTypes.string,
         showClue: React.PropTypes.bool,
@@ -109,7 +109,7 @@ var ChoiceNoneAbove = React.createClass({
 
 var ChoiceEditor = React.createClass({
     propTypes: {
-        choice: React.PropTypes.shape,
+        choice: React.PropTypes.object,
         showDelete: React.PropTypes.bool,
         onClueChange: React.PropTypes.func,
         onContentChange: React.PropTypes.func,

--- a/src/widgets/radio.jsx
+++ b/src/widgets/radio.jsx
@@ -385,7 +385,6 @@ var RadioEditor = React.createClass({
         })),
         displayCount: React.PropTypes.number,
         randomize: React.PropTypes.bool,
-        noneOfTheAbove: React.PropTypes.bool,
         multipleSelect: React.PropTypes.bool,
         onePerLine: React.PropTypes.bool,
         deselectEnabled: React.PropTypes.bool,
@@ -396,7 +395,6 @@ var RadioEditor = React.createClass({
             choices: [{}, {}],
             displayCount: null,
             randomize: false,
-            noneOfTheAbove: false,
             multipleSelect: false,
             onePerLine: true,
             deselectEnabled: false,
@@ -407,45 +405,34 @@ var RadioEditor = React.createClass({
         return <div>
             <div className="perseus-widget-row">
 
-                <div>
-                    <div className="perseus-widget-left-col">
+                <div className="perseus-widget-left-col">
+                    <div>
                         <PropCheckBox label="One answer per line"
                                       labelAlignment="right"
                                       onePerLine={this.props.onePerLine}
                                       onChange={this.props.onChange} />
+                        <InfoTip>
+                            <p>
+                                Use one answer per line unless your question has
+                                images that might cause the answers to go off the
+                                page.
+                            </p>
+                        </InfoTip>
                     </div>
-                    <InfoTip>
-                        <p>
-                            Use one answer per line unless your question has
-                            images that might cause the answers to go off the
-                            page.
-                        </p>
-                    </InfoTip>
                 </div>
 
-                <div className="perseus-widget-left-col">
+                <div className="perseus-widget-right-col">
                     <PropCheckBox label="Multiple selections"
                                   labelAlignment="right"
                                   multipleSelect={this.props.multipleSelect}
                                   onChange={this.onMultipleSelectChange} />
                 </div>
 
-                <div className="perseus-widget-right-col">
+                <div className="perseus-widget-left-col">
                     <PropCheckBox label="Randomize order"
                                   labelAlignment="right"
                                   randomize={this.props.randomize}
                                   onChange={this.props.onChange} />
-                </div>
-                <div className="perseus-widget-left-col">
-                    <PropCheckBox label="Auto-none of the above"
-                                  labelAlignment="right"
-                                  noneOfTheAbove={this.props.noneOfTheAbove}
-                                  onChange={(e) => {
-                                    var rand = seededRNG(this.props.problemNum)();
-                                    var index = Math.floor(rand * this.props.choices.length);
-
-                                    this.setNoneOfTheAbove(index, e.noneOfTheAbove, true);
-                                  }} />
                 </div>
                 <div className="perseus-widget-right-col">
                     <PropCheckBox label="Radio deselect enabled"
@@ -498,7 +485,6 @@ var RadioEditor = React.createClass({
                         <input
                             type="checkbox"
                             checked={choice.isNoneOfTheAbove}
-                            disabled={this.props.noneOfTheAbove}
                             onChange={(e) => {
                                 this.setNoneOfTheAbove(i, e.target.checked);
                             }} />
@@ -536,15 +522,12 @@ var RadioEditor = React.createClass({
         </div>;
     },
 
-    setNoneOfTheAbove: function(choiceIndex, checked, auto) {
+    setNoneOfTheAbove: function(choiceIndex, checked) {
         var choices = _.map(this.props.choices, function(choice, i) {
             return _.extend({}, choice, { isNoneOfTheAbove: choiceIndex === i && checked });
         });
 
-        this.props.onChange({
-            noneOfTheAbove: auto && checked,
-            choices: choices
-        });
+        this.props.onChange({ choices: choices });
     },
 
     onMultipleSelectChange: function(allowMultiple) {
@@ -577,7 +560,7 @@ var RadioEditor = React.createClass({
         var choices = _.map(this.props.choices, (choice, i) => {
             return _.extend({}, choice, {
                 correct: checked[i],
-                isNoneOfTheAbove: this.props.noneOfTheAbove && choice.isNoneOfTheAbove
+                isNoneOfTheAbove: false
             });
         });
         this.props.onChange({choices: choices});
@@ -636,8 +619,7 @@ var RadioEditor = React.createClass({
 
     serialize: function() {
         return _.pick(this.props, "choices", "randomize",
-            "multipleSelect", "displayCount", "noneOfTheAbove", "onePerLine",
-            "deselectEnabled");
+            "multipleSelect", "displayCount", "onePerLine", "deselectEnabled");
     }
 });
 
@@ -683,7 +665,7 @@ var choiceTransform = (editorProps, problemNum) => {
     choices = addNoneOfAbove(randomize(choices));
 
     editorProps = _.extend({}, editorProps, { choices: choices });
-    return _.pick(editorProps, "choices", "noneOfTheAbove", "onePerLine",
+    return _.pick(editorProps, "choices", "onePerLine",
         "multipleSelect", "correctAnswer", "deselectEnabled");
 };
 

--- a/src/widgets/radio.jsx
+++ b/src/widgets/radio.jsx
@@ -706,21 +706,15 @@ var choiceTransform = (editorProps, problemNum) => {
     };
 
     var addNoneOfAbove = function(array) {
-        var noneIndex = null;
+        var noneOfTheAbove = null;
 
-        _.find(array, function(choice, index) {
-            if (choice.isNoneOfTheAbove) {
-                noneIndex = index;
-                return true;
-            }
+        array = _.reject(array, function(choice, index) {
+            return choice.isNoneOfTheAbove && ( noneOfTheAbove = choice);
         });
 
-        if (noneIndex !== null) {
-            var itemToBeReplaced = array[noneIndex];
-
-            // Shift array left so that 'None of the above' is last
-            array.splice(noneIndex, 1);
-            array.push(itemToBeReplaced);
+        // Place the "None of the above" options last
+        if( noneOfTheAbove ) {
+            array.push(noneOfTheAbove)
         }
 
         return array;

--- a/src/widgets/radio.jsx
+++ b/src/widgets/radio.jsx
@@ -452,17 +452,21 @@ var RadioEditor = React.createClass({
                     var checkedClass = choice.correct ?
                         "correct" :
                         "incorrect";
+                    var placeholder = choice.isNoneOfTheAbove && !choice.correct ?
+                        "None of the above" :
+                        "Type a choice here...";
+
                     var editor = <Editor
                         ref={"editor" + i}
                         content={choice.content || ""}
                         widgetEnabled={false}
-                        placeholder={"Type a choice here..."}
+                        placeholder={placeholder}
+                        disabled={choice.isNoneOfTheAbove && !choice.correct}
                         onChange={newProps => {
                             if ("content" in newProps) {
                                 this.onContentChange(i, newProps.content);
                             }
-                        }}
-                    />;
+                        }} />;
                     var clueEditor = <Editor
                         ref={"clue-editor-" + i}
                         content={choice.clue || ""}
@@ -473,22 +477,31 @@ var RadioEditor = React.createClass({
                             if ("content" in newProps) {
                                 this.onClueChange(i, newProps.content);
                             }
-                        }}
-                    />;
+                        }} />;
                     var deleteLink = <a href="#"
                             className="simple-button orange delete-choice"
                             title="Remove this choice"
                             onClick={this.onDelete.bind(this, i)}>
                         <span className="icon-trash" />
                     </a>;
-                    var asNoneOfTheAbove = <label>
+                    var asNoneOfTheAbove = <label className="none-above-label">
                         <input
                             type="checkbox"
                             checked={choice.isNoneOfTheAbove}
                             onChange={(e) => {
                                 this.setNoneOfTheAbove(i, e.target.checked);
                             }} />
-                        {' '}As none of the above{' '}
+                        None of the above
+                        { choice.correct && <div className="info-tip">
+                            <InfoTip>
+                                <p>
+                                    Use it to mask the correct answer as <em>None 
+                                    of the above</em> and have it revealed only after the
+                                    user has answered correctly.
+                                </p>
+                            </InfoTip>
+                        </div>
+                        }
                     </label>;
 
                     return {

--- a/stylesheets/perseus-admin-package/editor.less
+++ b/stylesheets/perseus-admin-package/editor.less
@@ -822,20 +822,9 @@
     }
 
     .perseus-radio-option.none-of-above {
-        bottom: 0;
-        position: absolute;
-
         .choice-editor.incorrect {
             opacity: 0.5;
         }
-    }
-}
-
-.perseus-widget-editor-content-wrapper {
-    position: relative;
-
-    &.has-none-of-above {
-        padding-bottom: 130px;
     }
 }
 

--- a/stylesheets/perseus-admin-package/editor.less
+++ b/stylesheets/perseus-admin-package/editor.less
@@ -807,12 +807,17 @@
 
 .perseus-widget-editor-content {
     .add-choice-container {
+        order: 0;
+
         .simple-button {
             margin-right: 10px;
         }
     }
 
     .perseus-widget-radio {
+        display: flex;
+        flex-direction: column;
+
         .checkbox, .delete-choice {
             position: relative;
             top: -10px;
@@ -820,7 +825,8 @@
     }
 
     .perseus-radio-option.none-of-above {
-        margin-top: 20px;
+        order: 1;
+        margin-top: 5px;
 
         .choice-editor.incorrect {
             opacity: 0.5;

--- a/stylesheets/perseus-admin-package/editor.less
+++ b/stylesheets/perseus-admin-package/editor.less
@@ -812,10 +812,12 @@
             top: -10px;
         }
 
-        .perseus-radio-selected {
-            .checkbox {
-                top: -57px;
-            }
+        .checkbox {
+            top: -57px;
+        }
+
+        .delete-choice {
+            top: -10px;
         }
     }
 }

--- a/stylesheets/perseus-admin-package/editor.less
+++ b/stylesheets/perseus-admin-package/editor.less
@@ -739,6 +739,7 @@
 //
 
 .perseus-widget-radio {
+    margin-bottom: 10px;
 
     .choice-editor {
         .perseus-single-editor {
@@ -809,6 +810,12 @@
         .checkbox, .delete-choice {
             position: relative;
             top: -10px;
+        }
+
+        .perseus-radio-selected {
+            .checkbox {
+                top: -57px;
+            }
         }
     }
 }

--- a/stylesheets/perseus-admin-package/editor.less
+++ b/stylesheets/perseus-admin-package/editor.less
@@ -833,6 +833,14 @@
     }
 
     .perseus-radio-option.none-of-above {
+
+        &:before {
+            content: 'None of the above';
+            display: block;
+            font-style: italic;
+            font-weight: bold;
+        }
+
         .choice-editor.incorrect {
             opacity: 0.5;
         }

--- a/stylesheets/perseus-admin-package/editor.less
+++ b/stylesheets/perseus-admin-package/editor.less
@@ -784,9 +784,8 @@
     }
 
     .delete-choice {
-        float: right;
-        margin-right: 5px;
-        padding: 0 5px;
+        margin-left: 5px;
+        padding: 5px;
     }
 
     .perseus-single-editor {
@@ -807,18 +806,24 @@
 }
 
 .perseus-widget-editor-content {
+    .add-choice-container {
+        .simple-button {
+            margin-right: 10px;
+        }
+    }
+
     .perseus-widget-radio {
         .checkbox, .delete-choice {
             position: relative;
             top: -10px;
         }
+    }
 
-        .none-above-label {
-            float: left;
-        }
+    .perseus-radio-option.none-of-above {
+        margin-top: 20px;
 
-        .perseus-interactive {
-            position: static;
+        .choice-editor.incorrect {
+            opacity: 0.5;
         }
     }
 }
@@ -997,10 +1002,6 @@
 // Info-tip lives in react-components but these styles are perseus-specific.
 .info-tip {
     display: inline-block;
-
-    div {
-        display: inline-block;
-    }
 }
 
 .info-tip-content-container p {

--- a/stylesheets/perseus-admin-package/editor.less
+++ b/stylesheets/perseus-admin-package/editor.less
@@ -784,8 +784,9 @@
     }
 
     .delete-choice {
-        margin-left: 5px;
-        padding: 5px;
+        float: right;
+        margin-right: 5px;
+        padding: 0 5px;
     }
 
     .perseus-single-editor {
@@ -812,12 +813,12 @@
             top: -10px;
         }
 
-        .checkbox {
-            top: -57px;
+        .none-above-label {
+            float: left;
         }
 
-        .delete-choice {
-            top: -10px;
+        .perseus-interactive {
+            position: static;
         }
     }
 }
@@ -996,6 +997,10 @@
 // Info-tip lives in react-components but these styles are perseus-specific.
 .info-tip {
     display: inline-block;
+
+    div {
+        display: inline-block;
+    }
 }
 
 .info-tip-content-container p {

--- a/stylesheets/perseus-admin-package/editor.less
+++ b/stylesheets/perseus-admin-package/editor.less
@@ -807,16 +807,13 @@
 
 .perseus-widget-editor-content {
     .add-choice-container {
-        order: 0;
-
         .simple-button {
             margin-right: 10px;
         }
     }
 
     .perseus-widget-radio {
-        display: flex;
-        flex-direction: column;
+        position: static;
 
         .checkbox, .delete-choice {
             position: relative;
@@ -825,12 +822,20 @@
     }
 
     .perseus-radio-option.none-of-above {
-        order: 1;
-        margin-top: 5px;
+        bottom: 0;
+        position: absolute;
 
         .choice-editor.incorrect {
             opacity: 0.5;
         }
+    }
+}
+
+.perseus-widget-editor-content-wrapper {
+    position: relative;
+
+    &.has-none-of-above {
+        padding-bottom: 130px;
     }
 }
 


### PR DESCRIPTION
While playing a bit with the radio widget, I realized that there was no way to mask the correct choice as 'none of the above' manually, as this is something that could happen only via the *Auto-none of the above* feature (or least I couldn't find how to do it!).

So I thought of adding under the correct choice a checkbox input that lets the contributor decide if he wants to hide it, only to reveal it when the user chooses correctly. There can be only one 'none of the above' choice at any given time, and if the user decides to use the "auto" feature, then that takes precedence over the manual choice.

![demo](https://cloud.githubusercontent.com/assets/6400898/5863445/ee40b3a2-a279-11e4-9831-9e06280fb8aa.gif)

The idea would be to give contributors more control over how the question is structured, I hope it's something that can be useful to you

@ariabuckles This PR contains a little amendment to the CONTRIBUTING.MD file, as there was an obsolete line related to how the widgets shortcuts were supposed to work before your changes to the feature (they're way better and simpler to use now, nice!)

Thanks,
Alessandro

