### PR TITLE
Rename variable from static

### DIFF
--- a/src/widgets.js
+++ b/src/widgets.js
@@ -165,10 +165,10 @@ var Widgets = {
             alignment = Widgets.getSupportedAlignments(type)[0];
         }
 
-        var static = oldWidgetInfo.static;
+        var widgetStatic = oldWidgetInfo.static;
 
-        if (static == null) {
-            static = DEFAULT_STATIC;
+        if (widgetStatic == null) {
+            widgetStatic = DEFAULT_STATIC;
         }
 
         return _.extend({}, oldWidgetInfo, {  // maintain other info, like type
@@ -179,7 +179,7 @@ var Widgets = {
                 (oldWidgetInfo.graded != null) ? oldWidgetInfo.graded : true
             ),
             alignment: alignment,
-            static: static,
+            static: widgetStatic,
             options: newEditorProps,
         });
     },


### PR DESCRIPTION
This branch simply renames the variable "static" so that it does not conflict with the JavaScript keyword. This allows minification with the google closure compiler.