### PR TITLE
Change jsx to js for react components

### DIFF
--- a/src/answer-area-editor.jsx
+++ b/src/answer-area-editor.jsx
@@ -3,7 +3,7 @@ var _ = require("underscore");
 var ApiOptions = require("./perseus-api.jsx").Options;
 var classNames = require("classnames");
 var Editor = require("./editor.jsx");
-var InfoTip = require("react-components/info-tip.jsx");
+var InfoTip = require("react-components/info-tip.js");
 var React = require('react');
 var Widgets = require("./widgets.js");
 

--- a/src/answer-area-editor.jsx
+++ b/src/answer-area-editor.jsx
@@ -3,7 +3,7 @@ var _ = require("underscore");
 var ApiOptions = require("./perseus-api.jsx").Options;
 var classNames = require("classnames");
 var Editor = require("./editor.jsx");
-var InfoTip = require("react-components/info-tip.js");
+var InfoTip = require("react-components/info-tip");
 var React = require('react');
 var Widgets = require("./widgets.js");
 

--- a/src/components/graph-settings.jsx
+++ b/src/components/graph-settings.jsx
@@ -4,12 +4,12 @@ var _ = require("underscore");
 
 var Changeable  = require("../mixins/changeable.jsx");
 
-var ButtonGroup = require("react-components/button-group.jsx");
-var InfoTip = require("react-components/info-tip.jsx");
+var ButtonGroup = require("react-components/button-group.js");
+var InfoTip = require("react-components/info-tip.js");
 var NumberInput = require("../components/number-input.jsx");
 var PropCheckBox = require("../components/prop-check-box.jsx");
 var RangeInput = require("../components/range-input.jsx");
-var TeX = require("react-components/tex.jsx");
+var TeX = require("react-components/tex.js");
 var Util = require("../util.js");
 
 var defaultBoxSize = 340;

--- a/src/components/graph-settings.jsx
+++ b/src/components/graph-settings.jsx
@@ -4,12 +4,12 @@ var _ = require("underscore");
 
 var Changeable  = require("../mixins/changeable.jsx");
 
-var ButtonGroup = require("react-components/button-group.js");
-var InfoTip = require("react-components/info-tip.js");
+var ButtonGroup = require("react-components/button-group");
+var InfoTip = require("react-components/info-tip");
 var NumberInput = require("../components/number-input.jsx");
 var PropCheckBox = require("../components/prop-check-box.jsx");
 var RangeInput = require("../components/range-input.jsx");
-var TeX = require("react-components/tex.js");
+var TeX = require("react-components/tex");
 var Util = require("../util.js");
 
 var defaultBoxSize = 340;

--- a/src/components/input-with-examples.jsx
+++ b/src/components/input-with-examples.jsx
@@ -1,5 +1,5 @@
 var React = require('react');
-var Tooltip = require("react-components/tooltip.jsx");
+var Tooltip = require("react-components/tooltip.js");
 var _ = require("underscore");
 
 var ApiClassNames = require("../perseus-api.jsx").ClassNames;

--- a/src/components/input-with-examples.jsx
+++ b/src/components/input-with-examples.jsx
@@ -1,5 +1,5 @@
 var React = require('react');
-var Tooltip = require("react-components/tooltip.js");
+var Tooltip = require("react-components/tooltip");
 var _ = require("underscore");
 
 var ApiClassNames = require("../perseus-api.jsx").ClassNames;

--- a/src/components/math-output.jsx
+++ b/src/components/math-output.jsx
@@ -1,8 +1,8 @@
 var React         = require("react");
 var ReactDOM = require("react-dom");
-var TeX           = require("react-components/tex.jsx");
+var TeX           = require("react-components/tex.js");
 var ApiClassNames = require("../perseus-api.jsx").ClassNames;
-var Tooltip       = require("react-components/tooltip.jsx");
+var Tooltip       = require("react-components/tooltip.js");
 var ModifyTex     = require("../tex-wrangler.js").modifyTex;
 
 var MathOutput = React.createClass({

--- a/src/components/math-output.jsx
+++ b/src/components/math-output.jsx
@@ -1,8 +1,8 @@
 var React         = require("react");
 var ReactDOM = require("react-dom");
-var TeX           = require("react-components/tex.js");
+var TeX           = require("react-components/tex");
 var ApiClassNames = require("../perseus-api.jsx").ClassNames;
-var Tooltip       = require("react-components/tooltip.js");
+var Tooltip       = require("react-components/tooltip");
 var ModifyTex     = require("../tex-wrangler.js").modifyTex;
 
 var MathOutput = React.createClass({

--- a/src/components/tex-buttons.jsx
+++ b/src/components/tex-buttons.jsx
@@ -1,7 +1,7 @@
 var React     = require("react");
 var _ = require("underscore");
 
-var TeX       = require("react-components/tex.jsx");
+var TeX       = require("react-components/tex.js");
 
 var prettyBig = { fontSize: "150%" };
 var slightlyBig = { fontSize: "120%" };

--- a/src/components/tex-buttons.jsx
+++ b/src/components/tex-buttons.jsx
@@ -1,7 +1,7 @@
 var React     = require("react");
 var _ = require("underscore");
 
-var TeX       = require("react-components/tex.js");
+var TeX       = require("react-components/tex");
 
 var prettyBig = { fontSize: "150%" };
 var slightlyBig = { fontSize: "120%" };

--- a/src/components/viewport-resizer.jsx
+++ b/src/components/viewport-resizer.jsx
@@ -5,7 +5,7 @@
 
 var React = require("react");
 
-var ButtonGroup = require("react-components/button-group.jsx");
+var ButtonGroup = require("react-components/button-group");
 
 // These values for screen sizes come from dominant screen sizes by device type
 // according to screensiz.es and our own Google Analytics reporting (Nov 2015).

--- a/src/editor.jsx
+++ b/src/editor.jsx
@@ -7,7 +7,7 @@ var $ = require('jquery');
 var _ = require("underscore");
 
 var ApiOptions = require("./perseus-api.jsx").Options;
-var DragTarget = require("react-components/drag-target.jsx");
+var DragTarget = require("react-components/drag-target.js");
 var EnabledFeatures = require("./enabled-features.jsx");
 var PerseusMarkdown = require("./perseus-markdown.jsx");
 var PropCheckBox = require("./components/prop-check-box.jsx");

--- a/src/editor.jsx
+++ b/src/editor.jsx
@@ -7,7 +7,7 @@ var $ = require('jquery');
 var _ = require("underscore");
 
 var ApiOptions = require("./perseus-api.jsx").Options;
-var DragTarget = require("react-components/drag-target.js");
+var DragTarget = require("react-components/drag-target");
 var EnabledFeatures = require("./enabled-features.jsx");
 var PerseusMarkdown = require("./perseus-markdown.jsx");
 var PropCheckBox = require("./components/prop-check-box.jsx");

--- a/src/hint-editor.jsx
+++ b/src/hint-editor.jsx
@@ -7,7 +7,7 @@ var _ = require("underscore");
 
 var Editor = require("./editor.jsx");
 var HintRenderer = require("./hint-renderer.jsx");
-var InfoTip = require("react-components/info-tip.jsx");
+var InfoTip = require("react-components/info-tip.js");
 
 /* Renders a hint editor box
  *

--- a/src/hint-editor.jsx
+++ b/src/hint-editor.jsx
@@ -7,7 +7,7 @@ var _ = require("underscore");
 
 var Editor = require("./editor.jsx");
 var HintRenderer = require("./hint-renderer.jsx");
-var InfoTip = require("react-components/info-tip.js");
+var InfoTip = require("react-components/info-tip");
 
 /* Renders a hint editor box
  *

--- a/src/perseus-markdown.jsx
+++ b/src/perseus-markdown.jsx
@@ -1,7 +1,7 @@
 var _ = require("underscore");
 
 var SimpleMarkdown = require("simple-markdown");
-var TeX = require("react-components/tex.jsx");
+var TeX = require("react-components/tex.js");
 var Util = require("./util.js");
 
 /**

--- a/src/perseus-markdown.jsx
+++ b/src/perseus-markdown.jsx
@@ -1,7 +1,7 @@
 var _ = require("underscore");
 
 var SimpleMarkdown = require("simple-markdown");
-var TeX = require("react-components/tex.js");
+var TeX = require("react-components/tex");
 var Util = require("./util.js");
 
 /**

--- a/src/renderer.jsx
+++ b/src/renderer.jsx
@@ -10,7 +10,7 @@ var JiptParagraphs = require("./jipt-paragraphs.jsx");
 var PerseusMarkdown = require("./perseus-markdown.jsx");
 var QuestionParagraph = require("./question-paragraph.jsx");
 var SvgImage = require("./components/svg-image.jsx");
-var TeX = require("react-components/tex.jsx");
+var TeX = require("react-components/tex.js");
 var WidgetContainer = require("./widget-container.jsx");
 var Widgets = require("./widgets.js");
 

--- a/src/renderer.jsx
+++ b/src/renderer.jsx
@@ -10,7 +10,7 @@ var JiptParagraphs = require("./jipt-paragraphs.jsx");
 var PerseusMarkdown = require("./perseus-markdown.jsx");
 var QuestionParagraph = require("./question-paragraph.jsx");
 var SvgImage = require("./components/svg-image.jsx");
-var TeX = require("react-components/tex.js");
+var TeX = require("react-components/tex");
 var WidgetContainer = require("./widget-container.jsx");
 var Widgets = require("./widgets.js");
 

--- a/src/widgets/cs-program.jsx
+++ b/src/widgets/cs-program.jsx
@@ -5,10 +5,10 @@
 var React = require("react");
 var _ = require("underscore");
 
-var BlurInput = require("react-components/blur-input.jsx");
+var BlurInput = require("react-components/blur-input.js");
 var Changeable = require("../mixins/changeable.jsx");
 var EditorJsonify = require("../mixins/editor-jsonify.jsx");
-var InfoTip = require("react-components/info-tip.jsx");
+var InfoTip = require("react-components/info-tip.js");
 var PropCheckBox  = require("../components/prop-check-box.jsx");
 var updateQueryString = require("../util.js").updateQueryString;
 

--- a/src/widgets/cs-program.jsx
+++ b/src/widgets/cs-program.jsx
@@ -5,10 +5,10 @@
 var React = require("react");
 var _ = require("underscore");
 
-var BlurInput = require("react-components/blur-input.js");
+var BlurInput = require("react-components/blur-input");
 var Changeable = require("../mixins/changeable.jsx");
 var EditorJsonify = require("../mixins/editor-jsonify.jsx");
-var InfoTip = require("react-components/info-tip.js");
+var InfoTip = require("react-components/info-tip");
 var PropCheckBox  = require("../components/prop-check-box.jsx");
 var updateQueryString = require("../util.js").updateQueryString;
 

--- a/src/widgets/dropdown.jsx
+++ b/src/widgets/dropdown.jsx
@@ -1,6 +1,6 @@
 var classNames = require("classnames");
 var FancySelect = require("../components/fancy-select.jsx");
-var InfoTip = require("react-components/info-tip.jsx");
+var InfoTip = require("react-components/info-tip.js");
 var React = require('react');
 var ReactDOM = require("react-dom");
 var _ = require("underscore");

--- a/src/widgets/dropdown.jsx
+++ b/src/widgets/dropdown.jsx
@@ -1,6 +1,6 @@
 var classNames = require("classnames");
 var FancySelect = require("../components/fancy-select.jsx");
-var InfoTip = require("react-components/info-tip.js");
+var InfoTip = require("react-components/info-tip");
 var React = require('react');
 var ReactDOM = require("react-dom");
 var _ = require("underscore");

--- a/src/widgets/expression.jsx
+++ b/src/widgets/expression.jsx
@@ -1,9 +1,9 @@
 var classNames = require("classnames");
-var InfoTip = require("react-components/info-tip.jsx");
+var InfoTip = require("react-components/info-tip.js");
 var React = require("react");
 var ReactDOM = require("react-dom");
-var SortableArea     = require("react-components/sortable.jsx");
-var Tooltip = require("react-components/tooltip.jsx");
+var SortableArea     = require("react-components/sortable.js");
+var Tooltip = require("react-components/tooltip.js");
 var _ = require("underscore");
 
 var ApiOptions = require("../perseus-api.jsx").Options;
@@ -18,7 +18,7 @@ var PropCheckBox = require("../components/prop-check-box.jsx");
 
 var InputWithExamples = require("../components/input-with-examples.jsx");
 var MathInput = require("../components/math-input.jsx");
-var TeX = require("react-components/tex.jsx");// OldExpression only
+var TeX = require("react-components/tex.js");// OldExpression only
 var TexButtons = require("../components/tex-buttons.jsx");
 
 var EnabledFeatures = require("../enabled-features.jsx");

--- a/src/widgets/expression.jsx
+++ b/src/widgets/expression.jsx
@@ -1,9 +1,9 @@
 var classNames = require("classnames");
-var InfoTip = require("react-components/info-tip.js");
+var InfoTip = require("react-components/info-tip");
 var React = require("react");
 var ReactDOM = require("react-dom");
-var SortableArea     = require("react-components/sortable.js");
-var Tooltip = require("react-components/tooltip.js");
+var SortableArea     = require("react-components/sortable");
+var Tooltip = require("react-components/tooltip");
 var _ = require("underscore");
 
 var ApiOptions = require("../perseus-api.jsx").Options;
@@ -18,12 +18,12 @@ var PropCheckBox = require("../components/prop-check-box.jsx");
 
 var InputWithExamples = require("../components/input-with-examples.jsx");
 var MathInput = require("../components/math-input.jsx");
-var TeX = require("react-components/tex.js");// OldExpression only
+var TeX = require("react-components/tex");// OldExpression only
 var TexButtons = require("../components/tex-buttons.jsx");
 
 var EnabledFeatures = require("../enabled-features.jsx");
 
-var lens = require("../../hubble/index.js");
+var lens = require("../../assets/hubble/index.js");
 
 var ERROR_MESSAGE = i18n._("Sorry, I don't understand that!");
 

--- a/src/widgets/expression.jsx
+++ b/src/widgets/expression.jsx
@@ -23,7 +23,7 @@ var TexButtons = require("../components/tex-buttons.jsx");
 
 var EnabledFeatures = require("../enabled-features.jsx");
 
-var lens = require("../../assets/hubble/index.js");
+var lens = require("../../hubble/index.js");
 
 var ERROR_MESSAGE = i18n._("Sorry, I don't understand that!");
 

--- a/src/widgets/grapher.jsx
+++ b/src/widgets/grapher.jsx
@@ -1,11 +1,11 @@
 var React = require("react");
 var _ = require("underscore");
 
-var ButtonGroup      = require("react-components/button-group.jsx");
+var ButtonGroup      = require("react-components/button-group.js");
 var GraphSettings    = require("../components/graph-settings.jsx");
-var InfoTip          = require("react-components/info-tip.jsx");
+var InfoTip          = require("react-components/info-tip.js");
 var Interactive2     = require("../interactive2.js");
-var MultiButtonGroup = require("react-components/multi-button-group.jsx");
+var MultiButtonGroup = require("react-components/multi-button-group.js");
 var SvgImage         = require("../components/svg-image.jsx");
 var Util             = require("../util.js");
 

--- a/src/widgets/grapher.jsx
+++ b/src/widgets/grapher.jsx
@@ -1,11 +1,11 @@
 var React = require("react");
 var _ = require("underscore");
 
-var ButtonGroup      = require("react-components/button-group.js");
+var ButtonGroup      = require("react-components/button-group");
 var GraphSettings    = require("../components/graph-settings.jsx");
-var InfoTip          = require("react-components/info-tip.js");
+var InfoTip          = require("react-components/info-tip");
 var Interactive2     = require("../interactive2.js");
-var MultiButtonGroup = require("react-components/multi-button-group.js");
+var MultiButtonGroup = require("react-components/multi-button-group");
 var SvgImage         = require("../components/svg-image.jsx");
 var Util             = require("../util.js");
 

--- a/src/widgets/iframe.jsx
+++ b/src/widgets/iframe.jsx
@@ -10,7 +10,7 @@
 var React = require("react");
 var _ = require("underscore");
 
-var BlurInput    = require("react-components/blur-input.jsx");
+var BlurInput    = require("react-components/blur-input.js");
 var Changeable = require("../mixins/changeable.jsx");
 var EditorJsonify = require("../mixins/editor-jsonify.jsx");
 var PropCheckBox  = require("../components/prop-check-box.jsx");

--- a/src/widgets/iframe.jsx
+++ b/src/widgets/iframe.jsx
@@ -10,7 +10,7 @@
 var React = require("react");
 var _ = require("underscore");
 
-var BlurInput    = require("react-components/blur-input.js");
+var BlurInput    = require("react-components/blur-input");
 var Changeable = require("../mixins/changeable.jsx");
 var EditorJsonify = require("../mixins/editor-jsonify.jsx");
 var PropCheckBox  = require("../components/prop-check-box.jsx");

--- a/src/widgets/image.jsx
+++ b/src/widgets/image.jsx
@@ -3,9 +3,9 @@ var _ = require("underscore");
 
 var Util = require("../util.js");
 
-var BlurInput    = require("react-components/blur-input.jsx");
+var BlurInput    = require("react-components/blur-input.js");
 var Editor       = require("../editor.jsx");
-var InfoTip      = require("react-components/info-tip.jsx");
+var InfoTip      = require("react-components/info-tip.js");
 var Renderer     = require("../renderer.jsx");
 
 var Changeable    = require("../mixins/changeable.jsx");

--- a/src/widgets/image.jsx
+++ b/src/widgets/image.jsx
@@ -3,9 +3,9 @@ var _ = require("underscore");
 
 var Util = require("../util.js");
 
-var BlurInput    = require("react-components/blur-input.js");
+var BlurInput    = require("react-components/blur-input");
 var Editor       = require("../editor.jsx");
-var InfoTip      = require("react-components/info-tip.js");
+var InfoTip      = require("react-components/info-tip");
 var Renderer     = require("../renderer.jsx");
 
 var Changeable    = require("../mixins/changeable.jsx");

--- a/src/widgets/input-number.jsx
+++ b/src/widgets/input-number.jsx
@@ -3,8 +3,8 @@ var React = require('react');
 var ReactDOM = require("react-dom");
 var _ = require("underscore");
 
-var BlurInput         = require("react-components/blur-input.jsx");
-var InfoTip           = require("react-components/info-tip.jsx");
+var BlurInput         = require("react-components/blur-input.js");
+var InfoTip           = require("react-components/info-tip.js");
 var InputWithExamples = require("../components/input-with-examples.jsx");
 var ParseTex          = require("../tex-wrangler.js").parseTex;
 var PossibleAnswers = require("../components/possible-answers.jsx");

--- a/src/widgets/input-number.jsx
+++ b/src/widgets/input-number.jsx
@@ -3,8 +3,8 @@ var React = require('react');
 var ReactDOM = require("react-dom");
 var _ = require("underscore");
 
-var BlurInput         = require("react-components/blur-input.js");
-var InfoTip           = require("react-components/info-tip.js");
+var BlurInput         = require("react-components/blur-input");
+var InfoTip           = require("react-components/info-tip");
 var InputWithExamples = require("../components/input-with-examples.jsx");
 var ParseTex          = require("../tex-wrangler.js").parseTex;
 var PossibleAnswers = require("../components/possible-answers.jsx");

--- a/src/widgets/interaction.jsx
+++ b/src/widgets/interaction.jsx
@@ -13,7 +13,7 @@ var Graphie = require("../components/graphie.jsx");
 var GraphSettings = require("../components/graph-settings.jsx");
 var MathInput = require("../components/math-input.jsx");
 var NumberInput = require("../components/number-input.jsx");
-var TeX = require("react-components/tex.jsx");
+var TeX = require("react-components/tex.js");
 var TextInput = require("../components/text-input.jsx");
 
 var Label = Graphie.Label;

--- a/src/widgets/interaction.jsx
+++ b/src/widgets/interaction.jsx
@@ -13,7 +13,7 @@ var Graphie = require("../components/graphie.jsx");
 var GraphSettings = require("../components/graph-settings.jsx");
 var MathInput = require("../components/math-input.jsx");
 var NumberInput = require("../components/number-input.jsx");
-var TeX = require("react-components/tex.js");
+var TeX = require("react-components/tex");
 var TextInput = require("../components/text-input.jsx");
 
 var Label = Graphie.Label;

--- a/src/widgets/interaction/arrow-picker.jsx
+++ b/src/widgets/interaction/arrow-picker.jsx
@@ -1,4 +1,4 @@
-var ButtonGroup = require("react-components/button-group.jsx");
+var ButtonGroup = require("react-components/button-group.js");
 var React = require("react");
 
 var ArrowPicker = React.createClass({

--- a/src/widgets/interaction/arrow-picker.jsx
+++ b/src/widgets/interaction/arrow-picker.jsx
@@ -1,4 +1,4 @@
-var ButtonGroup = require("react-components/button-group.js");
+var ButtonGroup = require("react-components/button-group");
 var React = require("react");
 
 var ArrowPicker = React.createClass({

--- a/src/widgets/interaction/color-picker.jsx
+++ b/src/widgets/interaction/color-picker.jsx
@@ -1,4 +1,4 @@
-var ButtonGroup = require("react-components/button-group.jsx");
+var ButtonGroup = require("react-components/button-group.js");
 var React = require("react");
 
 var ColorPicker = React.createClass({

--- a/src/widgets/interaction/color-picker.jsx
+++ b/src/widgets/interaction/color-picker.jsx
@@ -1,4 +1,4 @@
-var ButtonGroup = require("react-components/button-group.js");
+var ButtonGroup = require("react-components/button-group");
 var React = require("react");
 
 var ColorPicker = React.createClass({

--- a/src/widgets/interaction/constraint-editor.jsx
+++ b/src/widgets/interaction/constraint-editor.jsx
@@ -1,7 +1,7 @@
 var React = require("react");
-var TeX = require("react-components/tex.jsx");
+var TeX = require("react-components/tex.js");
 
-var ButtonGroup = require("react-components/button-group.jsx");
+var ButtonGroup = require("react-components/button-group.js");
 var Changeable = require("../../mixins/changeable.jsx");
 var MathInput = require("../../components/math-input.jsx");
 var NumberInput = require("../../components/number-input.jsx");

--- a/src/widgets/interaction/constraint-editor.jsx
+++ b/src/widgets/interaction/constraint-editor.jsx
@@ -1,7 +1,7 @@
 var React = require("react");
-var TeX = require("react-components/tex.js");
+var TeX = require("react-components/tex");
 
-var ButtonGroup = require("react-components/button-group.js");
+var ButtonGroup = require("react-components/button-group");
 var Changeable = require("../../mixins/changeable.jsx");
 var MathInput = require("../../components/math-input.jsx");
 var NumberInput = require("../../components/number-input.jsx");

--- a/src/widgets/interaction/dash-picker.jsx
+++ b/src/widgets/interaction/dash-picker.jsx
@@ -1,4 +1,4 @@
-var ButtonGroup = require("react-components/button-group.jsx");
+var ButtonGroup = require("react-components/button-group.js");
 var React = require("react");
 
 var DashPicker = React.createClass({

--- a/src/widgets/interaction/dash-picker.jsx
+++ b/src/widgets/interaction/dash-picker.jsx
@@ -1,4 +1,4 @@
-var ButtonGroup = require("react-components/button-group.js");
+var ButtonGroup = require("react-components/button-group");
 var React = require("react");
 
 var DashPicker = React.createClass({

--- a/src/widgets/interactive-graph.jsx
+++ b/src/widgets/interactive-graph.jsx
@@ -3,7 +3,7 @@ var _ = require("underscore");
 
 var Graph         = require("../components/graph.jsx");
 var GraphSettings = require("../components/graph-settings.jsx");
-var InfoTip       = require("react-components/info-tip.jsx");
+var InfoTip       = require("react-components/info-tip.js");
 var Interactive2  = require("../interactive2.js");
 var NumberInput   = require("../components/number-input.jsx");
 var Util          = require("../util.js");

--- a/src/widgets/interactive-graph.jsx
+++ b/src/widgets/interactive-graph.jsx
@@ -3,7 +3,7 @@ var _ = require("underscore");
 
 var Graph         = require("../components/graph.jsx");
 var GraphSettings = require("../components/graph-settings.jsx");
-var InfoTip       = require("react-components/info-tip.js");
+var InfoTip       = require("react-components/info-tip");
 var Interactive2  = require("../interactive2.js");
 var NumberInput   = require("../components/number-input.jsx");
 var Util          = require("../util.js");

--- a/src/widgets/lights-puzzle.jsx
+++ b/src/widgets/lights-puzzle.jsx
@@ -5,7 +5,7 @@ var WidgetJsonifyDeprecated = require("../mixins/widget-jsonify-deprecated.jsx")
 
 var NumberInput = require("../components/number-input.jsx");
 var PropCheckBox = require("../components/prop-check-box.jsx");
-var InfoTip = require("react-components/info-tip.jsx");
+var InfoTip = require("react-components/info-tip.js");
 
 var MAX_SIZE = 8;
 

--- a/src/widgets/lights-puzzle.jsx
+++ b/src/widgets/lights-puzzle.jsx
@@ -5,7 +5,7 @@ var WidgetJsonifyDeprecated = require("../mixins/widget-jsonify-deprecated.jsx")
 
 var NumberInput = require("../components/number-input.jsx");
 var PropCheckBox = require("../components/prop-check-box.jsx");
-var InfoTip = require("react-components/info-tip.js");
+var InfoTip = require("react-components/info-tip");
 
 var MAX_SIZE = 8;
 

--- a/src/widgets/matcher.jsx
+++ b/src/widgets/matcher.jsx
@@ -1,7 +1,7 @@
 var React = require('react');
 var _ = require("underscore");
 
-var InfoTip        = require("react-components/info-tip.jsx");
+var InfoTip        = require("react-components/info-tip.js");
 var PropCheckBox   = require("../components/prop-check-box.jsx");
 var Renderer       = require("../renderer.jsx");
 var Sortable       = require("../components/sortable.jsx");

--- a/src/widgets/matcher.jsx
+++ b/src/widgets/matcher.jsx
@@ -1,7 +1,7 @@
 var React = require('react');
 var _ = require("underscore");
 
-var InfoTip        = require("react-components/info-tip.js");
+var InfoTip        = require("react-components/info-tip");
 var PropCheckBox   = require("../components/prop-check-box.jsx");
 var Renderer       = require("../renderer.jsx");
 var Sortable       = require("../components/sortable.jsx");

--- a/src/widgets/measurer.jsx
+++ b/src/widgets/measurer.jsx
@@ -5,7 +5,7 @@ var _ = require("underscore");
 var Changeable   = require("../mixins/changeable.jsx");
 var EditorJsonify = require("../mixins/editor-jsonify.jsx");
 
-var InfoTip       = require("react-components/info-tip.jsx");
+var InfoTip       = require("react-components/info-tip.js");
 var NumberInput   = require("../components/number-input.jsx");
 var PropCheckBox  = require("../components/prop-check-box.jsx");
 var RangeInput    = require("../components/range-input.jsx");

--- a/src/widgets/measurer.jsx
+++ b/src/widgets/measurer.jsx
@@ -5,7 +5,7 @@ var _ = require("underscore");
 var Changeable   = require("../mixins/changeable.jsx");
 var EditorJsonify = require("../mixins/editor-jsonify.jsx");
 
-var InfoTip       = require("react-components/info-tip.js");
+var InfoTip       = require("react-components/info-tip");
 var NumberInput   = require("../components/number-input.jsx");
 var PropCheckBox  = require("../components/prop-check-box.jsx");
 var RangeInput    = require("../components/range-input.jsx");

--- a/src/widgets/number-line.jsx
+++ b/src/widgets/number-line.jsx
@@ -5,8 +5,8 @@ var _ = require("underscore");
 var Changeable   = require("../mixins/changeable.jsx");
 var EditorJsonify = require("../mixins/editor-jsonify.jsx");
 
-var ButtonGroup  = require("react-components/button-group.jsx");
-var InfoTip      = require("react-components/info-tip.jsx");
+var ButtonGroup  = require("react-components/button-group.js");
+var InfoTip      = require("react-components/info-tip.js");
 var NumberInput  = require("../components/number-input.jsx");
 var PropCheckBox = require("../components/prop-check-box.jsx");
 var RangeInput   = require("../components/range-input.jsx");

--- a/src/widgets/number-line.jsx
+++ b/src/widgets/number-line.jsx
@@ -5,8 +5,8 @@ var _ = require("underscore");
 var Changeable   = require("../mixins/changeable.jsx");
 var EditorJsonify = require("../mixins/editor-jsonify.jsx");
 
-var ButtonGroup  = require("react-components/button-group.js");
-var InfoTip      = require("react-components/info-tip.js");
+var ButtonGroup  = require("react-components/button-group");
+var InfoTip      = require("react-components/info-tip");
 var NumberInput  = require("../components/number-input.jsx");
 var PropCheckBox = require("../components/prop-check-box.jsx");
 var RangeInput   = require("../components/range-input.jsx");

--- a/src/widgets/numeric-input.jsx
+++ b/src/widgets/numeric-input.jsx
@@ -5,10 +5,10 @@ var _ = require("underscore");
 var Changeable    = require("../mixins/changeable.jsx");
 var EditorJsonify = require("../mixins/editor-jsonify.jsx");
 
-var ButtonGroup = require("react-components/button-group.jsx");
-var InfoTip = require("react-components/info-tip.jsx");
+var ButtonGroup = require("react-components/button-group.js");
+var InfoTip = require("react-components/info-tip.js");
 var InputWithExamples = require("../components/input-with-examples.jsx");
-var MultiButtonGroup = require("react-components/multi-button-group.jsx");
+var MultiButtonGroup = require("react-components/multi-button-group.js");
 var NumberInput = require("../components/number-input.jsx");
 var ParseTex = require("../tex-wrangler.js").parseTex;
 var PossibleAnswers = require("../components/possible-answers.jsx");

--- a/src/widgets/numeric-input.jsx
+++ b/src/widgets/numeric-input.jsx
@@ -5,10 +5,10 @@ var _ = require("underscore");
 var Changeable    = require("../mixins/changeable.jsx");
 var EditorJsonify = require("../mixins/editor-jsonify.jsx");
 
-var ButtonGroup = require("react-components/button-group.js");
-var InfoTip = require("react-components/info-tip.js");
+var ButtonGroup = require("react-components/button-group");
+var InfoTip = require("react-components/info-tip");
 var InputWithExamples = require("../components/input-with-examples.jsx");
-var MultiButtonGroup = require("react-components/multi-button-group.js");
+var MultiButtonGroup = require("react-components/multi-button-group");
 var NumberInput = require("../components/number-input.jsx");
 var ParseTex = require("../tex-wrangler.js").parseTex;
 var PossibleAnswers = require("../components/possible-answers.jsx");

--- a/src/widgets/orderer.jsx
+++ b/src/widgets/orderer.jsx
@@ -1,4 +1,4 @@
-var InfoTip = require("react-components/info-tip.jsx");
+var InfoTip = require("react-components/info-tip.js");
 var React = require('react');
 var ReactDOM = require("react-dom");
 var _ = require("underscore");

--- a/src/widgets/orderer.jsx
+++ b/src/widgets/orderer.jsx
@@ -1,4 +1,4 @@
-var InfoTip = require("react-components/info-tip.js");
+var InfoTip = require("react-components/info-tip");
 var React = require('react');
 var ReactDOM = require("react-dom");
 var _ = require("underscore");

--- a/src/widgets/passage-ref.jsx
+++ b/src/widgets/passage-ref.jsx
@@ -3,7 +3,7 @@ var _ = require("underscore");
 
 var Changeable   = require("../mixins/changeable.jsx");
 var EditorJsonify = require("../mixins/editor-jsonify.jsx");
-var InfoTip = require("react-components/info-tip.jsx");
+var InfoTip = require("react-components/info-tip.js");
 var NumberInput = require("../components/number-input.jsx");
 var PerseusMarkdown = require("../perseus-markdown.jsx");
 var TextInput = require("../components/text-input.jsx");

--- a/src/widgets/passage-ref.jsx
+++ b/src/widgets/passage-ref.jsx
@@ -3,7 +3,7 @@ var _ = require("underscore");
 
 var Changeable   = require("../mixins/changeable.jsx");
 var EditorJsonify = require("../mixins/editor-jsonify.jsx");
-var InfoTip = require("react-components/info-tip.js");
+var InfoTip = require("react-components/info-tip");
 var NumberInput = require("../components/number-input.jsx");
 var PerseusMarkdown = require("../perseus-markdown.jsx");
 var TextInput = require("../components/text-input.jsx");

--- a/src/widgets/passage.jsx
+++ b/src/widgets/passage.jsx
@@ -7,7 +7,7 @@ var EditorJsonify = require("../mixins/editor-jsonify.jsx");
 
 var Editor = require("../editor.jsx");
 var Renderer = require("../renderer.jsx");
-var InfoTip = require("react-components/info-tip.jsx");
+var InfoTip = require("react-components/info-tip.js");
 var PropCheckBox  = require("../components/prop-check-box.jsx");
 var PassageMarkdown = require("./passage/passage-markdown.jsx");
 

--- a/src/widgets/passage.jsx
+++ b/src/widgets/passage.jsx
@@ -7,7 +7,7 @@ var EditorJsonify = require("../mixins/editor-jsonify.jsx");
 
 var Editor = require("../editor.jsx");
 var Renderer = require("../renderer.jsx");
-var InfoTip = require("react-components/info-tip.js");
+var InfoTip = require("react-components/info-tip");
 var PropCheckBox  = require("../components/prop-check-box.jsx");
 var PassageMarkdown = require("./passage/passage-markdown.jsx");
 

--- a/src/widgets/plotter.jsx
+++ b/src/widgets/plotter.jsx
@@ -1,7 +1,7 @@
 var React = require("react");
 var ReactDOM = require("react-dom");
-var InfoTip = require("react-components/info-tip.jsx");
-var BlurInput = require("react-components/blur-input.jsx");
+var InfoTip = require("react-components/info-tip.js");
+var BlurInput = require("react-components/blur-input.js");
 var _ = require("underscore");
 
 var NumberInput = require("../components/number-input.jsx");

--- a/src/widgets/plotter.jsx
+++ b/src/widgets/plotter.jsx
@@ -1,7 +1,7 @@
 var React = require("react");
 var ReactDOM = require("react-dom");
-var InfoTip = require("react-components/info-tip.js");
-var BlurInput = require("react-components/blur-input.js");
+var InfoTip = require("react-components/info-tip");
+var BlurInput = require("react-components/blur-input");
 var _ = require("underscore");
 
 var NumberInput = require("../components/number-input.jsx");

--- a/src/widgets/radio.jsx
+++ b/src/widgets/radio.jsx
@@ -11,7 +11,7 @@ var Renderer = require("../renderer.jsx");
 var PassageRef = require("./passage-ref.jsx");
 var Util = require("../util.js");
 
-var InfoTip = require("react-components/info-tip.jsx");
+var InfoTip = require("react-components/info-tip.js");
 
 var shuffle = require("../util.js").shuffle;
 var captureScratchpadTouchStart =

--- a/src/widgets/radio.jsx
+++ b/src/widgets/radio.jsx
@@ -11,7 +11,7 @@ var Renderer = require("../renderer.jsx");
 var PassageRef = require("./passage-ref.jsx");
 var Util = require("../util.js");
 
-var InfoTip = require("react-components/info-tip.js");
+var InfoTip = require("react-components/info-tip");
 
 var shuffle = require("../util.js").shuffle;
 var captureScratchpadTouchStart =

--- a/src/widgets/simulator.jsx
+++ b/src/widgets/simulator.jsx
@@ -1,4 +1,4 @@
-var InfoTip = require("react-components/info-tip.jsx");
+var InfoTip = require("react-components/info-tip.js");
 var React = require("react");
 var ReactDOM = require("react-dom");
 var _ = require("underscore");

--- a/src/widgets/simulator.jsx
+++ b/src/widgets/simulator.jsx
@@ -1,4 +1,4 @@
-var InfoTip = require("react-components/info-tip.js");
+var InfoTip = require("react-components/info-tip");
 var React = require("react");
 var ReactDOM = require("react-dom");
 var _ = require("underscore");

--- a/src/widgets/sorter.jsx
+++ b/src/widgets/sorter.jsx
@@ -1,5 +1,5 @@
 var React          = require('react');
-var InfoTip        = require("react-components/info-tip.jsx");
+var InfoTip        = require("react-components/info-tip.js");
 var _ = require("underscore");
 
 var PropCheckBox   = require("../components/prop-check-box.jsx");

--- a/src/widgets/sorter.jsx
+++ b/src/widgets/sorter.jsx
@@ -1,5 +1,5 @@
 var React          = require('react');
-var InfoTip        = require("react-components/info-tip.js");
+var InfoTip        = require("react-components/info-tip");
 var _ = require("underscore");
 
 var PropCheckBox   = require("../components/prop-check-box.jsx");

--- a/src/widgets/table.jsx
+++ b/src/widgets/table.jsx
@@ -3,7 +3,7 @@ var ReactDOM = require("react-dom");
 var _ = require("underscore");
 
 var Editor = require("../editor.jsx");
-var InfoTip = require("react-components/info-tip.jsx");
+var InfoTip = require("react-components/info-tip.js");
 var MathOutput = require("../components/math-output.jsx");
 var NumberInput  = require("../components/number-input.jsx");
 var Renderer = require("../renderer.jsx");

--- a/src/widgets/table.jsx
+++ b/src/widgets/table.jsx
@@ -3,7 +3,7 @@ var ReactDOM = require("react-dom");
 var _ = require("underscore");
 
 var Editor = require("../editor.jsx");
-var InfoTip = require("react-components/info-tip.js");
+var InfoTip = require("react-components/info-tip");
 var MathOutput = require("../components/math-output.jsx");
 var NumberInput  = require("../components/number-input.jsx");
 var Renderer = require("../renderer.jsx");

--- a/src/widgets/transformer.jsx
+++ b/src/widgets/transformer.jsx
@@ -4,11 +4,11 @@ var _ = require("underscore");
 
 var Graph         = require("../components/graph.jsx");
 var GraphSettings = require("../components/graph-settings.jsx");
-var InfoTip       = require("react-components/info-tip.jsx");
+var InfoTip       = require("react-components/info-tip.js");
 var NumberInput   = require("../components/number-input.jsx");
 var MathOutput    = require("../components/math-output.jsx");
 var PropCheckBox  = require("../components/prop-check-box.jsx");
-var TeX           = require("react-components/tex.jsx");
+var TeX           = require("react-components/tex.js");
 
 var ApiOptions = require("../perseus-api.jsx").Options;
 

--- a/src/widgets/transformer.jsx
+++ b/src/widgets/transformer.jsx
@@ -4,11 +4,11 @@ var _ = require("underscore");
 
 var Graph         = require("../components/graph.jsx");
 var GraphSettings = require("../components/graph-settings.jsx");
-var InfoTip       = require("react-components/info-tip.js");
+var InfoTip       = require("react-components/info-tip");
 var NumberInput   = require("../components/number-input.jsx");
 var MathOutput    = require("../components/math-output.jsx");
 var PropCheckBox  = require("../components/prop-check-box.jsx");
-var TeX           = require("react-components/tex.js");
+var TeX           = require("react-components/tex");
 
 var ApiOptions = require("../perseus-api.jsx").Options;
 

--- a/src/widgets/video.jsx
+++ b/src/widgets/video.jsx
@@ -5,11 +5,11 @@
 var React = require("react");
 var _ = require("underscore");
 
-var BlurInput = require("react-components/blur-input.jsx");
+var BlurInput = require("react-components/blur-input.js");
 var Changeable = require("../mixins/changeable.jsx");
 var EditorJsonify = require("../mixins/editor-jsonify.jsx");
 var FixedToResponsive = require("../components/fixed-to-responsive.jsx");
-var InfoTip = require("react-components/info-tip.jsx");
+var InfoTip = require("react-components/info-tip.js");
 
 // Current default is 720p, based on the typical videos we upload currently
 var DEFAULT_WIDTH = 1280;

--- a/src/widgets/video.jsx
+++ b/src/widgets/video.jsx
@@ -5,11 +5,11 @@
 var React = require("react");
 var _ = require("underscore");
 
-var BlurInput = require("react-components/blur-input.js");
+var BlurInput = require("react-components/blur-input");
 var Changeable = require("../mixins/changeable.jsx");
 var EditorJsonify = require("../mixins/editor-jsonify.jsx");
 var FixedToResponsive = require("../components/fixed-to-responsive.jsx");
-var InfoTip = require("react-components/info-tip.js");
+var InfoTip = require("react-components/info-tip");
 
 // Current default is 720p, based on the typical videos we upload currently
 var DEFAULT_WIDTH = 1280;


### PR DESCRIPTION
This is a request that is a bit "up for review". I.e. I'm not sure if this is the right approach. What I want is for Perseus to use NPM as it's source for `react-components`.

Is this solvable by not adding an extension? I.e. `require('react-component/tex')`?

I'm asking a bit because I think that requires some webpack.config.js tuning.
T
