### PR TITLE
Expression-based labels

### DIFF
--- a/src/widgets/interaction/constraint-label.jsx
+++ b/src/widgets/interaction/constraint-label.jsx
@@ -1,0 +1,95 @@
+/**
+ * Constraints and settings for the Interaction widget label element.
+ *
+ * Called from the label editor in interaction.jsx.
+ * Setting for label to be either regular text or evaluated as an expression.
+ * Setting for number of digits to the right of the decimal point for label expressions.
+ * Limits label position to be within X and Y min/max values.
+
+ */
+
+var React = require("react");
+var TeX = require("react-components/tex.jsx");
+
+var ButtonGroup = require("react-components/button-group.jsx");
+var Changeable = require("../../mixins/changeable.jsx");
+var MathInput = require("../../components/math-input.jsx");
+var NumberInput = require("../../components/number-input.jsx");
+
+var ConstraintLabel = React.createClass({
+    mixins: [Changeable],
+
+    propTypes: {
+        constraint: React.PropTypes.string,
+        digits: React.PropTypes.number,
+        onChange: React.PropTypes.func.isRequired,
+        constraintXMin: React.PropTypes.string,
+        constraintXMax: React.PropTypes.string,
+        constraintYMin: React.PropTypes.string,
+        constraintYMax: React.PropTypes.string
+    },
+
+    getDefaultProps: function() {
+        return {
+            kind: "text",
+            digits: 2,
+            constraintXMin: "-10",
+            constraintXMax: "10",
+            constraintYMin: "-10",
+            constraintYMax: "10"
+        };
+    },
+
+    render: function() {
+        return <div>
+            <div className="perseus-widget-row">
+                Kind: <ButtonGroup value={this.props.kind}
+                    allowEmpty={false}
+                    buttons={[
+                        {value: "text", content: "Text"},
+                        {value: "expression", content: "Expression"}]}
+                    onChange={this.change("kind")} />
+            </div>
+            {this.props.kind === "expression" &&
+                <div className="perseus-widget-row">
+                    Digits: <NumberInput
+                        value={this.props.digits}
+                        placeholder={2}
+                        onChange={this.change("digits")} />
+            </div>}
+            Set these so label cannot move off the canvas:
+            <div className="perseus-widget-row">
+                <div className="perseus-widget-row">
+                    <TeX>x \in \Large[</TeX> <MathInput
+                        buttonSets={[]}
+                        buttonsVisible={"never"}
+                        value={this.props.constraintXMin}
+                        onChange={this.change("constraintXMin")} />
+                    <TeX>, </TeX> <MathInput
+                        buttonSets={[]}
+                        buttonsVisible={"never"}
+                        value={this.props.constraintXMax}
+                        onChange={this.change("constraintXMax")}
+                    /> <TeX>\Large]</TeX>
+                </div>
+            </div>
+            <div className="perseus-widget-row">
+                <div className="perseus-widget-row">
+                    <TeX>y \in \Large[</TeX> <MathInput
+                        buttonSets={[]}
+                        buttonsVisible={"never"}
+                        value={this.props.constraintYMin}
+                        onChange={this.change("constraintYMin")} />
+                    <TeX>, </TeX> <MathInput
+                        buttonSets={[]}
+                        buttonsVisible={"never"}
+                        value={this.props.constraintYMax}
+                        onChange={this.change("constraintYMax")}
+                    /> <TeX>\Large]</TeX>
+                </div>
+            </div>
+        </div>;
+    }
+});
+
+module.exports = ConstraintLabel;


### PR DESCRIPTION
Summary:
New features:
- Labels can be regular text (default) or mathematical expressions. Digits (to the right of the decimal point) is settable. Label position can be constrained to X/Y min/max to keep them on the graph.
- New routine constraint-label.jsx is derived from constraint-editor.jsx.
- Bug fixes to allow elements to be deleted (four places).
- Side effects: Opening an existing interaction widget causes existing labels to reset. (This happened when I pasted existing JSON of an interaction widget into my test Perseus.)

Test Plan:
Add widget: Interaction
Add element: moveable point
Add element: label
Enter label text: x_0
Enter label coordinates: x_0 and (y_0)+1 - to make label location follow the moveable point.
Enter x range: -8 +8, enter y range: -9 +9 - to limit location.
Drag orange ball around screen. Label should follow (within allowed range) and display x-coordinate.
Try other expressions in the label text involving y_0.
Try fixed label location. Value still updates.
Click on 'text' button, label should revert to unchanging text.

JSON test:
Find an article with existing interaction widget, copy JSON to clipboard.
Here's one (in staging): https://www.khanacademy.org/prometheus/wmc-electrical-engineering-staging/wmc-circuit-design/a/wmc-voltage-divider/edit
and another (published)
https://www.khanacademy.org/science/electrical-engineering/ee-circuit-analysis/a/ee-capacitor-equation-in-action
And you can get more from Cam.
Go to test version of Perseus, paste JSON. What happens to the existing labels?

Reviewers: alex, kevinb
