### PR TITLE
Use Babel on .js files as well as .jsx

### DIFF
--- a/node/environment.js
+++ b/node/environment.js
@@ -1,7 +1,7 @@
 require("../lib/babel-polyfills.min.js");
 var _ = require("../lib/underscore.js");
 var options = require("./babel-options.js");
-options = _.extend({}, options, { extensions: [".jsx"] });
+options = _.extend({}, options, { extensions: [".js", ".jsx"] });
 require("babel-core/register")(options);
 
 var jsdom = require("jsdom");

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,10 +10,22 @@ module.exports = {
     },
     module: {
         loaders: [
-        { test: /\.json$/, loader: "json-loader" },
-        // https://github.com/webpack/webpack/issues/119
-        { test: /\.jsx$/, loader: path.join(__dirname, "node/jsx-loader.js") },
-        { test: /\.jison$/, loader: "jison-loader" },
+            {
+                test: /\.json$/,
+                loader: "json-loader"
+            },
+            {
+                test: /\.jsx$/,
+                include: [
+                    path.join(__dirname, "src/"),
+                    path.join(__dirname, "node_modules/react-components/"),
+                ],
+                // https://github.com/webpack/webpack/issues/119
+                loader: path.join(__dirname, "node/jsx-loader.js")
+            },
+            {
+                test: /\.jison$/, loader: "jison-loader"
+            },
         ],
     },
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = {
                 loader: "json-loader"
             },
             {
-                test: /\.jsx$/,
+                test: /\.jsx?$/,
                 include: [
                     path.join(__dirname, "src/"),
                     path.join(__dirname, "node_modules/react-components/"),

--- a/webpack.config.node-perseus.js
+++ b/webpack.config.node-perseus.js
@@ -9,17 +9,5 @@ module.exports = {
         libraryTarget: "commonjs2",
     },
     target: "node",
-    module: {
-        loaders: [
-            {
-                test: /\.json$/,
-                loader: "json-loader",
-            },
-            // https://github.com/webpack/webpack/issues/119
-            {
-                test: /\.jsx$/,
-                loader: path.join(__dirname, "node/jsx-loader.js"),
-            },
-        ],
-    },
+    module: require('./webpack.config.js').module,
 };


### PR DESCRIPTION
Hello! I'm working through the lint updating that I mentioned (issue #65) and I ran into a problem when updating things to ES2015 syntax. The .js files aren't currently being run through Babel in the build system so Webpack is rejecting ES2015 code in them.

The attached commit is a quick fix to just treat .js files the same as .jsx files, which keeps things nice and simple. Would that be appropriate? The only problem I can think of with that approach is that it runs the .js files through the React compiler too, so it would allow React code to be (accidentally) added to the .js files without being caught by the build system.

Another thing probably worth mentioning is that this causes the .js dependencies in lib/ to get run through Babel/React too, which makes the build a little slower and causes some new build output:
> [BABEL] Note: The code generator has deoptimised the styling of "unknown" as it exceeds the max of "100KB".
> [BABEL] Note: The code generator has deoptimised the styling of "unknown" as it exceeds the max of "100KB".
> [BABEL] Note: The code generator has deoptimised the styling of "unknown" as it exceeds the max of "100KB".
> [BABEL] Note: The code generator has deoptimised the styling of "unknown" as it exceeds the max of "100KB".
> [BABEL] Note: The code generator has deoptimised the styling of "unknown" as it exceeds the max of "100KB".

I'm open to doing a slightly more elaborate fix which skips the libs and just runs the other .js files through Babel and not React if that would be preferable?