### PR TITLE
[Orderer Widget] correct/incorrect coloring and padding for card bank

### DIFF
--- a/src/components/text-list-editor.jsx
+++ b/src/components/text-list-editor.jsx
@@ -51,6 +51,13 @@ var TextListEditor = React.createClass({
             "layout-" + this.props.layout
         ].join(" ");
 
+        var orderedInputClass;
+        if (this.props.ordered === "ordered") {
+            orderedInputClass = "ordered";
+        } else if (this.props.ordered === "other") {
+            orderedInputClass = "unordered";
+        }
+        // 
         var inputs = _.map(this.state.items, function(item, i) {
             return <li key={i}>
                 <input
@@ -59,7 +66,9 @@ var TextListEditor = React.createClass({
                     value={item}
                     onChange={this.onChange.bind(this, i)}
                     onKeyDown={this.onKeyDown.bind(this, i)}
-                    style={{width: getTextWidth(item)}} />
+                    style={{width: getTextWidth(item)}}
+
+                    className={orderedInputClass} />
             </li>;
         }, this);
 

--- a/src/widgets/orderer-editor.jsx
+++ b/src/widgets/orderer-editor.jsx
@@ -48,7 +48,9 @@ const OrdererEditor = React.createClass({
                <TextListEditor
                    options={_.pluck(this.props.correctOptions, "content")}
                    onChange={this.onOptionsChange.bind(this, "correctOptions")}
-                   layout={this.props.layout} />
+                   layout={this.props.layout}
+
+                   ordered="ordered" />
 
                <div>
                    {' '}Other cards:{' '}
@@ -59,7 +61,9 @@ const OrdererEditor = React.createClass({
                <TextListEditor
                    options={_.pluck(this.props.otherOptions, "content")}
                    onChange={this.onOptionsChange.bind(this, "otherOptions")}
-                   layout={this.props.layout} />
+                   layout={this.props.layout}
+                   
+                   ordered="other" />
 
                <div>
                    <label>

--- a/stylesheets/exercise-content-package/widgets/orderer.less
+++ b/stylesheets/exercise-content-package/widgets/orderer.less
@@ -9,7 +9,7 @@
     .draggable-box {
         padding: 13px;
         min-height: 69px;
-        margin-top: 30px;
+        margin-top: 20px;
     }
 
     .card {
@@ -26,7 +26,13 @@
 
     &.height-normal.layout-horizontal .card {
         line-height: 65px;
-        height: 65px;
+        max-height: 65px;
+        /*height: 65px;*/
+        padding: 20px 8px;
+    }
+
+    &.height-normal.layout-horizontal .card.placeholder {
+        max-height: 65px;
     }
 
     &.height-normal.layout-vertical .card {
@@ -56,7 +62,7 @@
     }
 
     .bank {
-        margin: 0px 13px;
+        margin: 20px 13px;
 
         .card-wrap {
             margin-right: 10px;

--- a/stylesheets/exercise-content-package/widgets/orderer.less
+++ b/stylesheets/exercise-content-package/widgets/orderer.less
@@ -26,8 +26,7 @@
 
     &.height-normal.layout-horizontal .card {
         line-height: 65px;
-        max-height: 65px;
-        padding: 20px 8px;
+        height: 65px;
     }
 
     &.height-normal.layout-vertical .card {

--- a/stylesheets/exercise-content-package/widgets/orderer.less
+++ b/stylesheets/exercise-content-package/widgets/orderer.less
@@ -27,12 +27,7 @@
     &.height-normal.layout-horizontal .card {
         line-height: 65px;
         max-height: 65px;
-        /*height: 65px;*/
         padding: 20px 8px;
-    }
-
-    &.height-normal.layout-horizontal .card.placeholder {
-        max-height: 65px;
     }
 
     &.height-normal.layout-vertical .card {

--- a/stylesheets/perseus-admin-package/editor.less
+++ b/stylesheets/perseus-admin-package/editor.less
@@ -1106,7 +1106,16 @@
     &.layout-horizontal input[type=text] {
         float: left;
     }
+    
+    .ordered {
+        background: @correctGreen;
+    }
+
+    .unordered {
+        background: @wrongRed;
+    }
 }
+
 
 .perseus-matcher-editor {
     .perseus-text-list-editor {


### PR DESCRIPTION
#26

Hi Khan team,

I was inspired by @AkA84 adding the coloring for dropdowns, and I thought this feature might be useful for the orderer widget editor as well. I also added some padding to the card bank.

It's a little less succinct than the dropdown coloring because the inputs are actually TextListEditor components. So now they're passing an extra prop to determine correct/not.

This was fun to do! I'm happy to refactor and will continue to look for places to contribute to Perseus and Khan 😄 
