### PR TITLE
Raphael: Fix error in strict mode

### DIFF
--- a/lib/raphael.js
+++ b/lib/raphael.js
@@ -3746,7 +3746,7 @@
         return token || E;
     };
     R.ninja = function () {
-        oldRaphael.was ? (win.Raphael = oldRaphael.is) : delete Raphael;
+        oldRaphael.was ? (win.Raphael = oldRaphael.is) : delete win.Raphael;
         return R;
     };
     R.el = elproto;


### PR DESCRIPTION
`delete Raphael` will error in strict mode because deleting
variables is unsupported. I believe this should be
`delete window.Raphael`, which I have changed it to, but
it also should be irrelevant because no one actually calls
Raphael.ninja in perseus.