### PR TITLE
README: Add a link to perseus-configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Also, the following global variables are used, if present:
 
 (See `src/perseus-env.js` and `src/demo-perseus.js`)
 
+For an example of supplying these dependencies, or to get an npm package
+of perseus with these dependencies built-in, see
+[perseus-configured](https://github.com/ariabuckles/perseus-configured)
+
 ## Versioning
 
 Perseus uses two types of version numbers: the version of the itemData/content


### PR DESCRIPTION
I made a repo to include all of perseus' global dependencies, and demo
how to require that. This seems to be a lot of the questions we get in
issues, so maybe linking to this in the readme can help people there.

This commit adds a link to https://github.com/ariabuckles/perseus-configured
in the README so that people can more easily find all the globals necessary to
use this, and so that we can maybe link it in issue answers.