### PR TITLE
Simplify rollup.config.js

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -73,17 +73,17 @@ jobs:
     # Make sure our packages aren't growing unexpectedly
     # This must come last as it builds the old code last and so leaves the
     # wrong code in place for the next job.
-    # - name: Check Builds
-    #   uses: preactjs/compressed-size-action@v2
-    #   with:
-    #     # We only care about the browser ES module size, really:
-    #     pattern: "**/dist/es/index.browser.js"
-    #     # Always ignore SourceMaps and node_modules:
-    #     exclude: "{**/*.map,**/node_modules/**}"
-    #     # Clean up before a build
-    #     clean-script: "clean"
-    #     # Build production
-    #     build-script: "build:prodsizecheck"
+    - name: Check Builds
+      uses: preactjs/compressed-size-action@v2
+      with:
+        # We only care about the browser ES module size, really:
+        pattern: "**/dist/es/index.browser.js"
+        # Always ignore SourceMaps and node_modules:
+        exclude: "{**/*.map,**/node_modules/**}"
+        # Clean up before a build
+        clean-script: "clean"
+        # Build production
+        build-script: "build:prodsizecheck"
 
   test:
     name: Test

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -73,17 +73,17 @@ jobs:
     # Make sure our packages aren't growing unexpectedly
     # This must come last as it builds the old code last and so leaves the
     # wrong code in place for the next job.
-    - name: Check Builds
-      uses: preactjs/compressed-size-action@v2
-      with:
-        # We only care about the browser ES module size, really:
-        pattern: "**/dist/es/index.browser.js"
-        # Always ignore SourceMaps and node_modules:
-        exclude: "{**/*.map,**/node_modules/**}"
-        # Clean up before a build
-        clean-script: "clean"
-        # Build production
-        build-script: "build:prodsizecheck"
+    # - name: Check Builds
+    #   uses: preactjs/compressed-size-action@v2
+    #   with:
+    #     # We only care about the browser ES module size, really:
+    #     pattern: "**/dist/es/index.browser.js"
+    #     # Always ignore SourceMaps and node_modules:
+    #     exclude: "{**/*.map,**/node_modules/**}"
+    #     # Clean up before a build
+    #     clean-script: "clean"
+    #     # Build production
+    #     build-script: "build:prodsizecheck"
 
   test:
     name: Test

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "scripts": {
     "build": "rollup -c config/build/rollup.config.js",
-    "build:prodsizecheck": "rollup -c config/build/rollup.config.js --configPlatforms='browser' --configFormats='esm' --configEnvironment='production'",
+    "build:prodsizecheck": "rollup -c config/build/rollup.config.js --configFormats='esm' --configEnvironment='production'",
     "watch": "rollup -c config/build/rollup.config.js --watch",
     "clean": "rm -rf packages/perseus*/dist && rm -rf packages/perseus*/node_modules",
     "coverage": "yarn run jest --coverage",

--- a/packages/perseus-editor/package.json
+++ b/packages/perseus-editor/package.json
@@ -17,10 +17,6 @@
     "devDependencies": {
         "perseus-build-settings": "^0.0.1"
     },
-    "browser": {
-        "dist/es/index.js": "./dist/es/index.browser.js",
-        "dist/index.js": "./dist/index.browser.js"
-    },
     "author": "",
     "license": "MIT"
 }

--- a/packages/perseus/package.json
+++ b/packages/perseus/package.json
@@ -14,10 +14,6 @@
     "devDependencies": {
         "perseus-build-settings": "^0.0.1"
     },
-    "browser": {
-        "dist/es/index.js": "./dist/es/index.browser.js",
-        "dist/index.js": "./dist/index.browser.js"
-    },
     "author": "",
     "license": "MIT"
 }


### PR DESCRIPTION
This also simplifies rollup.config.js.  We now assume that we're always building the browser.  I've also update the package.json files for each of the packages we're building to only set `main` and `module`.  This should avoid any issues that might have arose when consuming the module from the fact that there were essentially two different builds for the same package.

Issue: None

## Test plan:
- yarn build:prodsizecheck
- push to GitHub, see that the "checks" pass