### PR TITLE
[🔥AUDIT🔥] give 'extract_strings' job a unique name

### DIFF
--- a/packages/perseus/src/index.js
+++ b/packages/perseus/src/index.js
@@ -1,4 +1,4 @@
 // @flow
 import * as i18n from "@khanacademy/wonder-blocks-i18n";
 
-export const foo = (): string => i18n._("foobar");
+export const foo = (): string => i18n._("foo");


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
I forgot to give the new job a different name.  This audit fixes that.  The reason why this wasn't picked up when I added this step, is that I didn't make any changes to the source code to check that this step was working.  The workflow doesn't run if there are no changes to the code.

Issue: None

## Test plan:
- [x] make a change to the code and then revert it to see that workflow is working correctly

See https://github.com/Khan/perseus/runs/6158924638?check_suite_focus=true.