### PR TITLE
Add eslint plugin to resolve package aliases

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,16 @@
 /* eslint-disable import/no-commonjs */
+const path = require("path");
+const fs = require("fs");
+
+const aliasMap = fs
+    .readdirSync(path.join(__dirname, "packages"))
+    .map((pkgName) => {
+        return [
+            `@khanacademy/${pkgName}`,
+            `./packages/${pkgName}/src/index.js`,
+        ];
+    });
+
 module.exports = {
     extends: ["@khanacademy"],
     parser: "@babel/eslint-parser",
@@ -8,6 +20,14 @@ module.exports = {
         },
     },
     plugins: ["@babel", "import", "jest", "promise", "monorepo", "disable"],
+    settings: {
+        "import/resolver": {
+            alias: {
+                map: aliasMap,
+                extensions: [".ts", ".js", ".jsx", ".json"],
+            },
+        },
+    },
     overrides: [
         {
             files: ["**/__tests__/*.test.js"],
@@ -54,6 +74,7 @@ module.exports = {
         "import/newline-after-import": "error",
         "import/no-unassigned-import": "error",
         "import/no-named-default": "error",
+        "import/no-relative-packages": "error",
         "import/extensions": [
             "error",
             "always",
@@ -69,7 +90,6 @@ module.exports = {
         "promise/no-new-statics": "error",
         "promise/no-return-in-finally": "error",
         "monorepo/no-internal-import": "error",
-        "monorepo/no-relative-import": "error",
         "import/no-restricted-paths": [
             "error",
             {

--- a/packages/perseus/package.json
+++ b/packages/perseus/package.json
@@ -16,6 +16,8 @@
     },
     "devDependencies": {
         "@khanacademy/wonder-blocks-i18n": "^1.2.3",
+        "eslint-import-resolver-alias": "^1.1.2",
+        "eslint-plugin-import": "^2.26.0",
         "perseus-build-settings": "^0.0.1",
         "react": "16.14.0",
         "react-dom": "16.14.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2965,6 +2965,11 @@ eslint-config-prettier@^8.3.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
   integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
 
+eslint-import-resolver-alias@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-alias/-/eslint-import-resolver-alias-1.1.2.tgz#297062890e31e4d6651eb5eba9534e1f6e68fc97"
+  integrity sha512-WdviM1Eu834zsfjHtcGHtGfcu+F30Od3V7I9Fi57uhBEwPkjDcii7/yW8jAT+gOhn4P/vOxxNAXbFAKsrrc15w==
+
 eslint-import-resolver-node@^0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz#4048b958395da89668252001dbd9eca6b83bacbd"


### PR DESCRIPTION
## Summary:
This makes it so we don't have to rebuild every time we make a change to an export just to make eslint happy.

Issue: none

## Test plan:
- rename 'foo' to 'foobar' and update all imporst
- yarn lint, see that there are no errors