### PR TITLE
[🔥AUDIT🔥] Use the shared-node-cache action to set up node

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,14 +29,16 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [16.x]
     steps:
-      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }} & Install & cache node_modules
+        uses: ./.github/actions/shared-node-cache
         with:
-          fetch-depth: 0
-      - uses: ./.github/actions/setup
-        with:
-          node-version: 12.x
+          node-version: ${{ matrix.node-version }}
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
In #125 I copy/pasta'd the release workflow from khan/graphql-flow and failed to notice that one of the actions was pointing to a path that doesn't exist.  This audit updates the release workflow to use the same shared-node-cache action that we use in the other workflows in this repo.

Issue: None

## Test plan:
- create a PR with a changeset after this lands
- land that PR
- see that the release workflow runs correctly to create a "Versions" PR