### PR TITLE
Tweak package.json files so that pre-publish check succeeds

### DIFF
--- a/packages/perseus-editor/package.json
+++ b/packages/perseus-editor/package.json
@@ -5,8 +5,8 @@
     "name": "@khanacademy/perseus-editor",
     "version": "0.0.1",
     "description": "Perseus editors",
-    "module": "dist/es/index.browser.js",
-    "main": "dist/index.browser.js",
+    "module": "dist/es/index.js",
+    "main": "dist/index.js",
     "source": "src/index.js",
     "scripts": {
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"

--- a/packages/perseus/package.json
+++ b/packages/perseus/package.json
@@ -5,8 +5,8 @@
     "name": "@khanacademy/perseus",
     "version": "0.0.1",
     "description": "Core Perseus API (includes renderers and widgets)",
-    "module": "dist/es/index.browser.js",
-    "main": "dist/index.browser.js",
+    "module": "dist/es/index.js",
+    "main": "dist/index.js",
     "source": "src/index.js",
     "scripts": {
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"


### PR DESCRIPTION
## Summary:
pre-publish checks for index.js in the dist folders.  Since we're only build the "browser" variant, we may as well have the files called index.js.

Issue: None

## Test plan:
- yarn build
- node utils/pre-publish-check-ci.js