### PR TITLE
Make Flow types much better

### DIFF
--- a/.changeset/green-bags-study.md
+++ b/.changeset/green-bags-study.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/kmath": patch
+---
+
+Enhance Flow types for kmath's vector and point

--- a/packages/kmath/src/line.js
+++ b/packages/kmath/src/line.js
@@ -15,10 +15,7 @@ export function distanceToPoint(line: Line, point: Point): number {
     return kpoint.distanceToLine(point, line);
 }
 
-export function reflectPoint(
-    line: Line,
-    point: Point,
-): $ReadOnlyArray<number> /* TODO: convert to Point */ {
+export function reflectPoint(line: Line, point: Point): Point {
     return kpoint.reflectOverLine(point, line);
 }
 

--- a/packages/kmath/src/point.js
+++ b/packages/kmath/src/point.js
@@ -50,10 +50,7 @@ export function distanceToLine(point: Point, line: [Point, Point]): number {
 }
 
 // Reflect point over line
-export function reflectOverLine(
-    point: Point,
-    line: [Point, Point],
-): $ReadOnlyArray<number> /* TODO: convert to Point */ {
+export function reflectOverLine(point: Point, line: [Point, Point]): Point {
     const lv = kvector.subtract(line[1], line[0]);
     const pv = kvector.subtract(point, line[0]);
     const projectedPv = kvector.projection(pv, lv);

--- a/packages/kmath/src/vector.js
+++ b/packages/kmath/src/vector.js
@@ -17,6 +17,14 @@ function arrayProduct(array: $ReadOnlyArray<number>): number {
     return array.reduce((memo, arg) => memo * arg, 1);
 }
 
+/**
+ * Checks if the given vector contains only numbers and, optionally, is of the
+ * right dimension (length).
+ *
+ * is([1, 2, 3]) -> true
+ * is([1, "Hello", 3]) -> false
+ * is([1, 2, 3], 1) -> false
+ */
 export function is<T>(vec: $ReadOnlyArray<T>, dimension?: number): boolean {
     if (!_.isArray(vec)) {
         return false;

--- a/packages/kmath/src/vector.js
+++ b/packages/kmath/src/vector.js
@@ -7,6 +7,8 @@
 import _ from "underscore";
 import * as knumber from "./number.js";
 
+type Vec = $ReadOnlyArray<number>;
+
 function arraySum(array: $ReadOnlyArray<number>): number {
     return array.reduce((memo, arg) => memo + arg, 0);
 }
@@ -15,7 +17,7 @@ function arrayProduct(array: $ReadOnlyArray<number>): number {
     return array.reduce((memo, arg) => memo * arg, 1);
 }
 
-export function is<T>(vec: $ReadOnlyArray<T>, dimension: number): boolean {
+export function is<T>(vec: $ReadOnlyArray<T>, dimension?: number): boolean {
     if (!_.isArray(vec)) {
         return false;
     }
@@ -26,19 +28,16 @@ export function is<T>(vec: $ReadOnlyArray<T>, dimension: number): boolean {
 }
 
 // Normalize to a unit vector
-export function normalize(v: $ReadOnlyArray<number>): $ReadOnlyArray<number> {
+export function normalize<V: Vec>(v: V): V {
     return scale(v, 1 / length(v));
 }
 
 // Length/magnitude of a vector
-export function length(v: $ReadOnlyArray<number>): number {
+export function length(v: Vec): number {
     return Math.sqrt(dot(v, v));
 }
 // Dot product of two vectors
-export function dot(
-    a: $ReadOnlyArray<number>,
-    b: $ReadOnlyArray<number>,
-): number {
+export function dot(a: Vec, b: Vec): number {
     // $FlowFixMe[incompatible-call] underscore doesn't like $ReadOnlyArray
     const zipped = _.zip(a, b);
     const multiplied = zipped.map(arrayProduct);
@@ -49,43 +48,33 @@ export function dot(
  *
  * add([1, 2], [3, 4]) -> [4, 6]
  */
-export function add(
-    ...vecs: $ReadOnlyArray<$ReadOnlyArray<number>>
-): $ReadOnlyArray<number> {
+export function add<V: Vec>(...vecs: $ReadOnlyArray<V>): V {
     // $FlowFixMe[incompatible-call] underscore doesn't like $ReadOnlyArray
     const zipped = _.zip(...vecs);
     return zipped.map(arraySum);
 }
 
-export function subtract(
-    v1: $ReadOnlyArray<number>,
-    v2: $ReadOnlyArray<number>,
-): $ReadOnlyArray<number> {
+export function subtract<V: Vec>(v1: V, v2: V): V {
     // $FlowFixMe[incompatible-call] underscore doesn't like $ReadOnlyArray
     return _.zip(v1, v2).map((dim) => dim[0] - dim[1]);
 }
 
-export function negate(v: $ReadOnlyArray<number>): $ReadOnlyArray<number> {
+export function negate<V: Vec>(v: V): V {
+    // $FlowFixMe[incompatible-return] Flow's `.map()` libdef is lacking
     return v.map((x) => {
         return -x;
     });
 }
 
 // Scale a vector
-export function scale(
-    v1: $ReadOnlyArray<number>,
-    scalar: number,
-): $ReadOnlyArray<number> {
+export function scale<V: Vec>(v1: V, scalar: number): V {
+    // $FlowFixMe[incompatible-return] Flow's `.map()` libdef is lacking
     return v1.map((x) => {
         return x * scalar;
     });
 }
 
-export function equal(
-    v1: $ReadOnlyArray<number>,
-    v2: $ReadOnlyArray<number>,
-    tolerance?: number,
-): boolean {
+export function equal(v1: Vec, v2: Vec, tolerance?: number): boolean {
     // _.zip will nicely deal with the lengths, going through
     // the length of the longest vector. knumber.equal then
     // returns false for any number compared to the undefined
@@ -96,11 +85,7 @@ export function equal(
     );
 }
 
-export function codirectional(
-    v1: $ReadOnlyArray<number>,
-    v2: $ReadOnlyArray<number>,
-    tolerance?: number,
-): boolean {
+export function codirectional(v1: Vec, v2: Vec, tolerance?: number): boolean {
     // The origin is trivially codirectional with all other vectors.
     // This gives nice semantics for codirectionality between points when
     // comparing their difference vectors.
@@ -117,11 +102,7 @@ export function codirectional(
     return equal(v1, v2, tolerance);
 }
 
-export function collinear(
-    v1: $ReadOnlyArray<number>,
-    v2: $ReadOnlyArray<number>,
-    tolerance?: number,
-): boolean {
+export function collinear(v1: Vec, v2: Vec, tolerance?: number): boolean {
     return (
         codirectional(v1, v2, tolerance) ||
         codirectional(v1, negate(v2), tolerance)
@@ -221,10 +202,8 @@ export function projection(
 }
 
 // Round each number to a certain number of decimal places
-export function round(
-    vec: $ReadOnlyArray<number>,
-    precision: $ReadOnlyArray<number> | number,
-): $ReadOnlyArray<number> {
+export function round<V: Vec>(vec: V, precision: V | number): V {
+    // $FlowFixMe[incompatible-return] Flow's `.map()` libdef is lacking
     return vec.map((elem, i) =>
         // $FlowFixMe[prop-missing]
         // $FlowFixMe[incompatible-call]
@@ -233,10 +212,8 @@ export function round(
 }
 
 // Round each number to the nearest increment
-export function roundTo(
-    vec: $ReadOnlyArray<number>,
-    increment: $ReadOnlyArray<number> | number,
-): $ReadOnlyArray<number> {
+export function roundTo<V: Vec>(vec: V, increment: V | number): V {
+    // $FlowFixMe[incompatible-return] Flow's `.map()` libdef is lacking
     return vec.map((elem, i) =>
         // $FlowFixMe[prop-missing]
         // $FlowFixMe[incompatible-call]
@@ -244,10 +221,8 @@ export function roundTo(
     );
 }
 
-export function floorTo(
-    vec: $ReadOnlyArray<number>,
-    increment: $ReadOnlyArray<number> | number,
-): $ReadOnlyArray<number> {
+export function floorTo<V: Vec>(vec: V, increment: V | number): V {
+    // $FlowFixMe[incompatible-return] Flow's `.map()` libdef is lacking
     return vec.map((elem, i) =>
         // $FlowFixMe[prop-missing]
         // $FlowFixMe[incompatible-call]
@@ -255,10 +230,8 @@ export function floorTo(
     );
 }
 
-export function ceilTo(
-    vec: $ReadOnlyArray<number>,
-    increment: $ReadOnlyArray<number> | number,
-): $ReadOnlyArray<number> {
+export function ceilTo<V: Vec>(vec: V, increment: V | number): V {
+    // $FlowFixMe[incompatible-return] Flow's `.map()` libdef is lacking
     return vec.map((elem, i) =>
         // $FlowFixMe[prop-missing]
         // $FlowFixMe[incompatible-call]

--- a/packages/kmath/src/vector.js
+++ b/packages/kmath/src/vector.js
@@ -7,7 +7,7 @@
 import _ from "underscore";
 import * as knumber from "./number.js";
 
-type Vec = $ReadOnlyArray<number>;
+type Vector = $ReadOnlyArray<number>;
 
 function arraySum(array: $ReadOnlyArray<number>): number {
     return array.reduce((memo, arg) => memo + arg, 0);
@@ -36,16 +36,16 @@ export function is<T>(vec: $ReadOnlyArray<T>, dimension?: number): boolean {
 }
 
 // Normalize to a unit vector
-export function normalize<V: Vec>(v: V): V {
+export function normalize<V: Vector>(v: V): V {
     return scale(v, 1 / length(v));
 }
 
 // Length/magnitude of a vector
-export function length(v: Vec): number {
+export function length(v: Vector): number {
     return Math.sqrt(dot(v, v));
 }
 // Dot product of two vectors
-export function dot(a: Vec, b: Vec): number {
+export function dot(a: Vector, b: Vector): number {
     // $FlowFixMe[incompatible-call] underscore doesn't like $ReadOnlyArray
     const zipped = _.zip(a, b);
     const multiplied = zipped.map(arrayProduct);
@@ -56,18 +56,18 @@ export function dot(a: Vec, b: Vec): number {
  *
  * add([1, 2], [3, 4]) -> [4, 6]
  */
-export function add<V: Vec>(...vecs: $ReadOnlyArray<V>): V {
+export function add<V: Vector>(...vecs: $ReadOnlyArray<V>): V {
     // $FlowFixMe[incompatible-call] underscore doesn't like $ReadOnlyArray
     const zipped = _.zip(...vecs);
     return zipped.map(arraySum);
 }
 
-export function subtract<V: Vec>(v1: V, v2: V): V {
+export function subtract<V: Vector>(v1: V, v2: V): V {
     // $FlowFixMe[incompatible-call] underscore doesn't like $ReadOnlyArray
     return _.zip(v1, v2).map((dim) => dim[0] - dim[1]);
 }
 
-export function negate<V: Vec>(v: V): V {
+export function negate<V: Vector>(v: V): V {
     // $FlowFixMe[incompatible-return] Flow's `.map()` libdef is lacking
     return v.map((x) => {
         return -x;
@@ -75,14 +75,14 @@ export function negate<V: Vec>(v: V): V {
 }
 
 // Scale a vector
-export function scale<V: Vec>(v1: V, scalar: number): V {
+export function scale<V: Vector>(v1: V, scalar: number): V {
     // $FlowFixMe[incompatible-return] Flow's `.map()` libdef is lacking
     return v1.map((x) => {
         return x * scalar;
     });
 }
 
-export function equal(v1: Vec, v2: Vec, tolerance?: number): boolean {
+export function equal(v1: Vector, v2: Vector, tolerance?: number): boolean {
     // _.zip will nicely deal with the lengths, going through
     // the length of the longest vector. knumber.equal then
     // returns false for any number compared to the undefined
@@ -93,7 +93,11 @@ export function equal(v1: Vec, v2: Vec, tolerance?: number): boolean {
     );
 }
 
-export function codirectional(v1: Vec, v2: Vec, tolerance?: number): boolean {
+export function codirectional(
+    v1: Vector,
+    v2: Vector,
+    tolerance?: number,
+): boolean {
     // The origin is trivially codirectional with all other vectors.
     // This gives nice semantics for codirectionality between points when
     // comparing their difference vectors.
@@ -110,7 +114,7 @@ export function codirectional(v1: Vec, v2: Vec, tolerance?: number): boolean {
     return equal(v1, v2, tolerance);
 }
 
-export function collinear(v1: Vec, v2: Vec, tolerance?: number): boolean {
+export function collinear(v1: Vector, v2: Vector, tolerance?: number): boolean {
     return (
         codirectional(v1, v2, tolerance) ||
         codirectional(v1, negate(v2), tolerance)
@@ -210,7 +214,7 @@ export function projection(
 }
 
 // Round each number to a certain number of decimal places
-export function round<V: Vec>(vec: V, precision: V | number): V {
+export function round<V: Vector>(vec: V, precision: V | number): V {
     // $FlowFixMe[incompatible-return] Flow's `.map()` libdef is lacking
     return vec.map((elem, i) =>
         // $FlowFixMe[prop-missing]
@@ -220,7 +224,7 @@ export function round<V: Vec>(vec: V, precision: V | number): V {
 }
 
 // Round each number to the nearest increment
-export function roundTo<V: Vec>(vec: V, increment: V | number): V {
+export function roundTo<V: Vector>(vec: V, increment: V | number): V {
     // $FlowFixMe[incompatible-return] Flow's `.map()` libdef is lacking
     return vec.map((elem, i) =>
         // $FlowFixMe[prop-missing]
@@ -229,7 +233,7 @@ export function roundTo<V: Vec>(vec: V, increment: V | number): V {
     );
 }
 
-export function floorTo<V: Vec>(vec: V, increment: V | number): V {
+export function floorTo<V: Vector>(vec: V, increment: V | number): V {
     // $FlowFixMe[incompatible-return] Flow's `.map()` libdef is lacking
     return vec.map((elem, i) =>
         // $FlowFixMe[prop-missing]
@@ -238,7 +242,7 @@ export function floorTo<V: Vec>(vec: V, increment: V | number): V {
     );
 }
 
-export function ceilTo<V: Vec>(vec: V, increment: V | number): V {
+export function ceilTo<V: Vector>(vec: V, increment: V | number): V {
     // $FlowFixMe[incompatible-return] Flow's `.map()` libdef is lacking
     return vec.map((elem, i) =>
         // $FlowFixMe[prop-missing]


### PR DESCRIPTION
## Summary:

`kmath` sometimes interchanges the idea of `$ReadOnlyArray<number>` with `[number, number]` (specifically a 2D array). This causes problems with clients that know they're passing in a tuple of two numbers but receive a `$ReadOnlyArray<number>` out.

This PR changes many of the functions (especially in vector.js) to use a generic type so that the returned vector's arrity matches the input argument(s).

Issue: LP-11430

## Test plan:

`yarn flow` is good
`yarn test` is also good