### PR TITLE
Migrate Perseus Fixtures to Storybooks (round 8)

### DIFF
--- a/packages/perseus/src/widgets/__stories__/unit.stories.jsx
+++ b/packages/perseus/src/widgets/__stories__/unit.stories.jsx
@@ -1,0 +1,45 @@
+// @flow
+import * as React from "react";
+
+import {ApiOptions} from "../../perseus-api.jsx";
+import {OldUnitInput} from "../unit.jsx";
+
+type StoryArgs = {||};
+
+type Story = {|
+    title: string,
+|};
+
+export default ({
+    title: "Perseus/Widgets/Unit",
+}: Story);
+
+export const StaticRender = (args: StoryArgs): React.Node => {
+    return (
+        <OldUnitInput
+            apiOptions={{
+                ...ApiOptions.defaults,
+                staticRender: true,
+            }}
+            value="2 tbsp"
+            onFocus={() => {}}
+            onBlur={() => {}}
+            onChange={({value}) => {}}
+        />
+    );
+};
+
+export const NonStaticRender = (args: StoryArgs): React.Node => {
+    return (
+        <OldUnitInput
+            apiOptions={{
+                ...ApiOptions.defaults,
+                staticRender: false,
+            }}
+            value="2 tbsp"
+            onFocus={() => {}}
+            onBlur={() => {}}
+            onChange={({value}) => {}}
+        />
+    );
+};

--- a/packages/perseus/src/widgets/__stories__/video-transcript-link.stories.jsx
+++ b/packages/perseus/src/widgets/__stories__/video-transcript-link.stories.jsx
@@ -1,0 +1,24 @@
+// @flow
+import * as React from "react";
+
+import VideoTranscriptLink from "../video-transcript-link.jsx";
+
+type StoryArgs = {||};
+
+type Story = {|
+    title: string,
+|};
+
+export default ({
+    title: "Perseus/Components/Video Transcript Link",
+}: Story);
+
+export const YoutubeVideoLink = (args: StoryArgs): React.Node => {
+    return (
+        <VideoTranscriptLink location="https://www.youtube.com/watch?v=YoutubeId" />
+    );
+};
+
+export const SlugVideoLink = (args: StoryArgs): React.Node => {
+    return <VideoTranscriptLink location="slug-video-id" />;
+};

--- a/packages/perseus/src/widgets/unit.jsx
+++ b/packages/perseus/src/widgets/unit.jsx
@@ -81,7 +81,7 @@ type DefaultProps = {|
  * shows and hides an error buddy. The error message is only shown after a
  * rolling two second delay, but hidden immediately on further typing.
  */
-class OldUnitInput extends React.Component<Props> {
+export class OldUnitInput extends React.Component<Props> {
     _errorTimeout: ?TimeoutID;
 
     static defaultProps: DefaultProps = {


### PR DESCRIPTION
## Summary:
Migrates a bunch of fixtures to storybooks for perseus.

Issue: https://khanacademy.atlassian.net/browse/LP-11480

## Test plan:
- Load storybook
- **You should see stories for things that were previously fixtures**