### PR TITLE
Set up React 16 Enzyme adapter for tests

### DIFF
--- a/config/test/test-setup.js
+++ b/config/test/test-setup.js
@@ -4,7 +4,7 @@
  * but before any tests have run.
  */
 import MutationObserver from "@sheerun/mutationobserver-shim";
-import {configure} from "@testing-library/react";
+import {configure} from "@testing-library/dom"; // eslint-disable-line testing-library/no-dom-import, prettier/prettier
 import Enzyme from "enzyme"; // eslint-disable-line no-restricted-imports
 import React16EnzymeAdapter from "enzyme-adapter-react-16"; // eslint-disable-line no-restricted-imports
 import jestSerializerHtml from "jest-serializer-html";

--- a/config/test/test-setup.js
+++ b/config/test/test-setup.js
@@ -6,7 +6,7 @@
 import MutationObserver from "@sheerun/mutationobserver-shim";
 import {configure} from "@testing-library/react";
 import Enzyme from "enzyme"; // eslint-disable-line no-restricted-imports
-import React16EnzymeAdapter from "enzyme-adapter-react-16";
+import React16EnzymeAdapter from "enzyme-adapter-react-16"; // eslint-disable-line no-restricted-imports
 import jestSerializerHtml from "jest-serializer-html";
 import {addSerializer} from "jest-specific-snapshot";
 

--- a/config/test/test-setup.js
+++ b/config/test/test-setup.js
@@ -3,6 +3,8 @@
  * This file is loaded after the jest test framework has be initialized
  * but before any tests have run.
  */
+import React16EnzymeAdapter from "enzyme-adapter-react-16";
+import Enzyme from "enzyme"; // eslint-disable-line no-restricted-imports
 import MutationObserver from "@sheerun/mutationobserver-shim";
 import {configure} from "@testing-library/dom";
 import jestSerializerHtml from "jest-serializer-html";
@@ -11,6 +13,9 @@ import {addSerializer} from "jest-specific-snapshot";
 // Hook in the Jest HTML Serializer to our custom snapshot matcher.
 // See https://www.npmjs.com/package/jest-specific-snapshot#with-custom-serializer
 addSerializer(jestSerializerHtml);
+
+// Enzyme requires an adapater for each version of React.
+Enzyme.configure({adapter: new React16EnzymeAdapter()});
 
 // @testing-library uses "data-testId" by default but wonder-blocks uses "data-test-id"
 configure({

--- a/config/test/test-setup.js
+++ b/config/test/test-setup.js
@@ -3,10 +3,10 @@
  * This file is loaded after the jest test framework has be initialized
  * but before any tests have run.
  */
-import React16EnzymeAdapter from "enzyme-adapter-react-16";
-import Enzyme from "enzyme"; // eslint-disable-line no-restricted-imports
 import MutationObserver from "@sheerun/mutationobserver-shim";
-import {configure} from "@testing-library/dom";
+import {configure} from "@testing-library/react";
+import Enzyme from "enzyme"; // eslint-disable-line no-restricted-imports
+import React16EnzymeAdapter from "enzyme-adapter-react-16";
 import jestSerializerHtml from "jest-serializer-html";
 import {addSerializer} from "jest-specific-snapshot";
 


### PR DESCRIPTION
## Summary:

We still have a few enzyme tests in our codebase. In the near future we'll migrate them (LP-11633), but for now it's relatively easy to get them passing.

Issue: "none"

## Test plan:

`yarn test renderer-api_test matcher_test`