### PR TITLE
Fix path in `packages/perseus/.babelrc.js`

### DIFF
--- a/config/test/test-setup.js
+++ b/config/test/test-setup.js
@@ -3,6 +3,8 @@
  * This file is loaded after the jest test framework has be initialized
  * but before any tests have run.
  */
+import React16EnzymeAdapter from "enzyme-adapter-react-16";
+import Enzyme from "enzyme"; // eslint-disable-line no-restricted-imports
 import MutationObserver from "@sheerun/mutationobserver-shim";
 import {configure} from "@testing-library/dom";
 import jestSerializerHtml from "jest-serializer-html";
@@ -11,6 +13,9 @@ import {addSerializer} from "jest-specific-snapshot";
 // Hook in the Jest HTML Serializer to our custom snapshot matcher.
 // See https://www.npmjs.com/package/jest-specific-snapshot#with-custom-serializer
 addSerializer(jestSerializerHtml);
+
+// Enzyme requires an adapater for each version of React.
+Enzyme.configure({adapter: new React16EnzymeAdapter()});
 
 // @testing-library uses "data-testId" by default but wonder-blocks uses "data-test-id"
 configure({

--- a/packages/kmath/.babelrc.js
+++ b/packages/kmath/.babelrc.js
@@ -5,4 +5,4 @@
  *
  * We should remove this when jest is fixed.
  */
-module.exports = require("../../config/build/babel.config");
+module.exports = require("../../config/build/babel.config.js");

--- a/packages/perseus-editor/.babelrc.js
+++ b/packages/perseus-editor/.babelrc.js
@@ -5,4 +5,4 @@
  *
  * We should remove this when jest is fixed.
  */
-module.exports = require("../../build-settings/babel.config.js");
+module.exports = require("../../config/build/babel.config.js");

--- a/packages/perseus/.babelrc.js
+++ b/packages/perseus/.babelrc.js
@@ -5,4 +5,4 @@
  *
  * We should remove this when jest is fixed.
  */
-module.exports = require("../../build-settings/babel.config.js");
+module.exports = require("../../config/build/babel.config.js");


### PR DESCRIPTION
## Summary:

I attempted to update a snapshot by running something like `yarn test -u zoomable_test.jsx` and I got a babel error. Turns out the `.babelrc.js` in the perseus package dir was pointing at an non-existant file. 

Issue: "none"

## Test plan:

`yarn test -u zoomable_test.jsx` doesn't fail