### PR TITLE
Move widgets have editors to perseus-editor package

### DIFF
--- a/packages/perseus-editor/src/util/register-all-widgets-and-editors-for-testing_test.js
+++ b/packages/perseus-editor/src/util/register-all-widgets-and-editors-for-testing_test.js
@@ -1,17 +1,18 @@
 // @flow
-import * as Widgets from "../widgets.js";
+import {Widgets} from "@khanacademy/perseus";
 
-import {registerAllWidgetsForTesting} from "./register-all-widgets-for-testing.js";
+import {registerAllWidgetsAndEditorsForTesting} from "./register-all-widgets-and-editors-for-testing.js";
 
 describe("Registering all widgets and editors", () => {
     it("should have an editor for every widget", () => {
-        registerAllWidgetsForTesting();
+        registerAllWidgetsAndEditorsForTesting();
 
         const allWidgetsTypes = Widgets.getAllWidgetTypes();
 
         expect(allWidgetsTypes).not.toContain("undefined");
 
         for (const widgetType of allWidgetsTypes) {
+            console.log(widgetType);
             expect(Widgets.getEditor(widgetType)).toBeTruthy();
         }
     });


### PR DESCRIPTION
## Summary:

This test ensures that there is an editor for each widget. Editors are now in a different package so this test makes sense to live in the `perseus-editor` package.

Issue: "none"

## Test plan:

`yarn test register-all-widgets-and-editors-for-testing_test.js`