### PR TITLE
Ensure we collect coverage from jsx files too

### DIFF
--- a/config/test/test.config.js
+++ b/config/test/test.config.js
@@ -44,6 +44,7 @@ module.exports = {
     },
     collectCoverageFrom: [
         "packages/**/*.js",
+        "packages/**/*.jsx",
         "!packages/**/types.js",
         "!packages/**/src/**/index.js",
         "!packages/**/dist/**/*.js",


### PR DESCRIPTION
## Summary:

Without this, Wallaby doesn't let you step into JSX files. There is possibly a bit more work to get Wallaby fully working, but this lets us at least step into JSX files while we get work at getting all tests passing again.

Issue: "none"

## Test plan:

Start Wallaby and step through a test that involves a JSX file