### PR TITLE
Rendering test fixes

### DIFF
--- a/packages/perseus/src/__tests__/renderer_test.jsx
+++ b/packages/perseus/src/__tests__/renderer_test.jsx
@@ -40,12 +40,12 @@ const mockApplyLintErrors = jest.fn();
 jest.mock("../not-gorgon.js", () => {
     // We mock the NotGorgon constructor here setting things up so we can
     // spy/verify calls to instances of NotGorgon
-    return jest.fn().mockImplementation(() => {
+    return function () {
         return {
             runLinter: mockRunLinter,
             applyLintErrors: mockApplyLintErrors,
         };
-    });
+    };
 });
 
 describe("renderer", () => {

--- a/packages/perseus/src/__tests__/renderer_test.jsx
+++ b/packages/perseus/src/__tests__/renderer_test.jsx
@@ -294,23 +294,21 @@ describe("renderer", () => {
         const images = [];
         let originalImage;
 
-        beforeAll(() => {
+        beforeEach(() => {
             // Mock HTML Image so we can trigger onLoad callbacks and see full
-            // image rendering.
+            // image rendering. See also `markImagesAsLoaded`
             originalImage = window.Image;
             window.Image = jest.fn(() => {
                 const img = {};
                 images.push(img);
                 return img;
             });
-        });
 
-        beforeEach(() => {
             // Reset "known" images
             images.splice(0, images.length);
         });
 
-        afterAll(() => {
+        afterEach(() => {
             window.Image = originalImage;
         });
 


### PR DESCRIPTION
## Summary:

After moving to a new repo and upgrading to Jest 28, there were several `Renderer` tests failing. It boiled down to two things:
  * we weren't mocking the `not-gorgon.jsx` module factory correctly (can't use arrow (and apparently jest.fn()) as noted [here](https://jestjs.io/docs/es6-class-mocks#manual-mock-that-is-another-es6-class#mock-using-module-factory-parameter)
  * `window.Image` seems to be reset after every test, so I moved the mocking of it from `beforeAll()` to `beforeEach()`. 

Issue: "none"

## Test plan:

`yarn test renderer_test.jsx` ✅