### PR TITLE
Fix failing tests for dropdown and definition widgets

### DIFF
--- a/config/test/test-setup.js
+++ b/config/test/test-setup.js
@@ -5,10 +5,14 @@
  */
 import MutationObserver from "@sheerun/mutationobserver-shim";
 import {configure} from "@testing-library/dom"; // eslint-disable-line testing-library/no-dom-import, prettier/prettier
+import {StyleSheetTestUtils} from "aphrodite";
 import Enzyme from "enzyme"; // eslint-disable-line no-restricted-imports
 import React16EnzymeAdapter from "enzyme-adapter-react-16"; // eslint-disable-line no-restricted-imports
 import jestSerializerHtml from "jest-serializer-html";
 import {addSerializer} from "jest-specific-snapshot";
+
+// Prevent aphrodite from trying to inject styles into the CSSOM
+StyleSheetTestUtils.suppressStyleInjection();
 
 // Hook in the Jest HTML Serializer to our custom snapshot matcher.
 // See https://www.npmjs.com/package/jest-specific-snapshot#with-custom-serializer

--- a/packages/perseus/src/widgets/__tests__/definition_test.js
+++ b/packages/perseus/src/widgets/__tests__/definition_test.js
@@ -1,5 +1,5 @@
 // @flow
-import {screen} from "@testing-library/react";
+import {screen, waitForElementToBeRemoved} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import "@testing-library/jest-dom"; // Imports custom matchers
@@ -34,6 +34,8 @@ const question = {
 
 describe("Definition widget", () => {
     beforeEach(() => {
+        jest.useRealTimers();
+
         jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
             testDependencies,
         );
@@ -54,70 +56,67 @@ describe("Definition widget", () => {
         // Act
         const definitionAnchor = screen.getByText("the Pequots");
         userEvent.hover(definitionAnchor);
-        jest.advanceTimersByTime(250);
 
         // Assert
         expect(container).toMatchSnapshot("open state");
     });
 
-    it("should display the definition on hover", () => {
+    it("should display the definition on hover", async () => {
         // Arrange
         renderQuestion(question);
 
         // Act
         const definitionAnchor = screen.getByText("the Pequots");
         userEvent.hover(definitionAnchor);
-        jest.advanceTimersByTime(250);
 
         // Assert
-        const tooltip = screen.getByRole("tooltip");
+        const tooltip = await screen.findByRole("tooltip");
         expect(tooltip).toBeVisible();
         expect(tooltip).toHaveTextContent("Definition text");
     });
 
-    it("should display the definition on click", () => {
+    it("should display the definition on click", async () => {
         // Arrange
         renderQuestion(question);
 
         // Act
         const definitionAnchor = screen.getByText("the Pequots");
         userEvent.click(definitionAnchor);
-        const tooltip = screen.getByRole("tooltip");
+        const tooltip = await screen.findByRole("tooltip");
 
         // Assert
         expect(tooltip).toBeVisible();
         expect(tooltip).toHaveTextContent("Definition text");
     });
 
-    it("should show via focus by the tab key", () => {
+    it("should show via focus by the tab key", async () => {
         // Arrange
         renderQuestion(question);
 
         // Act - Tab in to set focus
         userEvent.tab();
-        jest.advanceTimersByTime(250);
 
         // Assert
-        const tooltip = screen.getByRole("tooltip");
+        const tooltip = await screen.findByRole("tooltip");
         expect(tooltip).toBeVisible();
         expect(tooltip).toHaveTextContent("Definition text");
     });
 
-    it("should hide and blur by the tab key", () => {
+    it("should hide and blur by the tab key", async () => {
         // Arrange
         renderQuestion(question);
 
         // Act - Tab in to set focus, tab out to blur
         userEvent.tab();
-        jest.advanceTimersByTime(250);
+        await screen.findByRole("tooltip");
         userEvent.tab();
-        jest.advanceTimersByTime(250);
+        await waitForElementToBeRemoved(() => screen.queryByRole("tooltip"));
 
         // Assert
         expect(screen.queryByRole("tooltip")).toBeNull();
     });
 
-    it("should dimiss by a click when showing", () => {
+    it("should dimiss by a click when showing", async () => {
         renderQuestion(question);
 
         // Act
@@ -127,11 +126,11 @@ describe("Definition widget", () => {
 
         // Move the mouse away and make sure text is still visible
         userEvent.unhover(definitionAnchor);
-        jest.advanceTimersByTime(250);
+        await screen.findByRole("tooltip");
 
         // Click to elsewhere, tooltip is hidden
         userEvent.click((document.body: any));
-        jest.advanceTimersByTime(250);
+        await waitForElementToBeRemoved(() => screen.queryByRole("tooltip"));
 
         // Assert
         expect(screen.queryByRole("tooltip")).toBeNull();

--- a/packages/perseus/src/widgets/__tests__/dropdown_test.jsx
+++ b/packages/perseus/src/widgets/__tests__/dropdown_test.jsx
@@ -6,7 +6,6 @@ import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/extend-expect";
 
 import {testDependencies} from "../../../../../testing/test-dependencies.js";
-import {waitForAnimationFrame} from "../../../../../testing/wait.js";
 import * as Dependencies from "../../dependencies.js";
 import {question1} from "../__testdata__/dropdown_testdata.js";
 
@@ -36,7 +35,7 @@ describe("Dropdown widget", () => {
         // Act
         const dropdown = screen.getByRole("button");
         userEvent.click(dropdown);
-        await waitForAnimationFrame();
+        await screen.findByText("less than or equal to");
 
         // Assert
         expect(container).toMatchSnapshot("dropdown open");
@@ -54,14 +53,13 @@ describe("Dropdown widget", () => {
         expect(dropdown).toHaveTextContent("greater/less than or equal to");
     });
 
-    it("should be answerable correctly", async () => {
+    it("should be answerable correctly", () => {
         // Arrange
         const {renderer} = renderQuestion(question1);
 
         // Act
         const dropdown = screen.getByRole("button");
         userEvent.click(dropdown);
-        await waitForAnimationFrame();
         userEvent.click(screen.getByText("less than or equal to"));
 
         // Assert
@@ -69,15 +67,13 @@ describe("Dropdown widget", () => {
         expect(renderer).toHaveBeenAnsweredCorrectly();
     });
 
-    it("should be answerable incorrectly", async () => {
+    it("should be answerable incorrectly", () => {
         // Arrange
         const {renderer} = renderQuestion(question1);
 
         // Act
         const dropdown = screen.getByRole("button");
         userEvent.click(dropdown);
-        // SingleSelect waits a frame to do some measurement before opening
-        await waitForAnimationFrame();
         userEvent.click(screen.getByText("greater than or equal to"));
 
         // Assert


### PR DESCRIPTION
## Summary:
I ended up having to revert to using real timers to make the tests pass.  It's possible this could be fixed with multiple calls to jest.runOnlyPendingTimers().  This is something we could explore in the future to avoid real timers.

Issue: None

## Test plan:
- yarn test