### PR TITLE
Movable-Point: Re-enable test, it passes, yay

### DIFF
--- a/packages/perseus/src/interactive2/__tests__/movable-point_test.js
+++ b/packages/perseus/src/interactive2/__tests__/movable-point_test.js
@@ -100,9 +100,7 @@ describe("MovablePoint", function () {
     });
 
     describe("onMove", function () {
-        // TODO(emily): [PERSEUS_MERGE] This test crashes phantomjs for me,
-        // make this not crash.
-        it.skip("should be called when movable is moved", function () {
+        it("should be called when movable is moved", function () {
             let movedToCoord;
             const handle = createPoint({
                 coord: [1, 2],


### PR DESCRIPTION
## Summary:

This is an old test, but I was looking at skipped tests. Uncommented it, and it passes. Let's use it!

Issue: "none"

## Test plan:

`yarn test movable-point_test.js` ✅