### PR TITLE
Bring over local actions from graphql-flow to clean up our linting/testing/type checking steps

### DIFF
--- a/.github/actions/filter-files/action.yml
+++ b/.github/actions/filter-files/action.yml
@@ -1,0 +1,37 @@
+name: 'Filter files'
+description: 'Filter the list of changed files'
+inputs:
+  changed-files:
+    description: 'jsonified list of changed files from setup'
+    required: true
+  files:
+    description: 'comma-separated list of files to check for'
+    required: false
+  extensions:
+    description: 'comma-separated list of extensions to check for'
+    required: false
+outputs:
+  filtered:
+    description: 'The jsonified list of files that match'
+    value: ${{ steps.result.outputs.result }}
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/github-script@v6
+      id: result
+      with:
+        script: |
+          const extensionsRaw = "${{ inputs.extensions }}";
+          const exactFilesRaw = "${{ inputs.files }}";
+          const inputFiles = JSON.parse(`${{ inputs.changed-files }}`);
+          const extensions = extensionsRaw.trim() ? extensionsRaw.split(',') : [];
+          const exactFiles = exactFilesRaw.trim() ? exactFilesRaw.split(',') : [];
+
+          const result = inputFiles.filter(name => {
+            return extensions.some(ext => name.endsWith(ext)) || (
+              exactFiles.includes(name)
+            )
+          })
+          console.log(`Filtered Files: ${JSON.stringify(result)}`)
+          return result;
+        result-encoding: json

--- a/.github/actions/full-or-limited/action.yml
+++ b/.github/actions/full-or-limited/action.yml
@@ -1,0 +1,27 @@
+name: Full or Limited
+description:  Do a full run if certain files have changed, or a limited run of some others have changed
+inputs:
+  full-trigger:
+    description: A jsonified Array of string files that would trigger a full run
+    required: true
+  limited-trigger:
+    description: A jsonified Array of string files that should be passed to a limited run
+    required: true
+  full:
+    description: The command to run if a full run is triggered
+  limited:
+    description: The command to run, with {} replaced with the list of files to run on.
+runs:
+  using: "composite"
+  steps:
+    - name: Full run
+      if: inputs.full-trigger != '[]'
+      run: ${{ inputs.full }}
+      shell: bash
+
+    - name: Limited run
+      if: inputs.full-trigger == '[]' && inputs.limited-trigger != '[]'
+      uses: ./.github/actions/json-args
+      with:
+        list: ${{ inputs.limited-trigger }}
+        run: ${{ inputs.limited }}

--- a/.github/actions/json-args/action.yml
+++ b/.github/actions/json-args/action.yml
@@ -1,0 +1,32 @@
+name: 'Pass a jsonified-list of files as shell arguments'
+description: 'Because file names with spaces are the worst'
+inputs:
+  list:
+    description: A jsonified Array of string file names
+    required: true
+  run:
+    description: "a command to run, where the literal '{}' will be replaced with the files as individual arguments. If no '{}' is provided, the files will be appended."
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/github-script@v6
+      with:
+        script: |
+          const listRaw = `${{ inputs.list }}`;
+          const files = JSON.parse(listRaw);
+          const {execSync} = require('child_process');
+          if (files.some(name => name.match(/['"]/))) {
+            throw new Error(`Not going to mess with file names that have quotes in them.`)
+          }
+          const filesList = files.map(name => `"${name}"`).join(' ')
+          let cmd = `${{ inputs.run }}`;
+          if (cmd.includes('{}')) {
+            cmd = cmd.replace('{}', filesList)
+          } else {
+            cmd += ' ' + filesList;
+          }
+          console.log(`Running: ${cmd}`);
+          execSync(cmd, {
+            stdio: 'inherit',
+          })

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -28,40 +28,50 @@ jobs:
       uses: jaredly/get-changed-files@v1.0.1
       id: changed
       with:
-        format: space-delimited
-        absolute: true
+        format: json
+
+    - id: js-files
+      name: Find .js changed files
+      uses: ./.github/actions/filter-files
+      with:
+        changed-files: ${{ steps.changed.outputs.added_modified }}
+        extensions: '.js'
+
+    - id: eslint-reset
+      uses: ./.github/actions/filter-files
+      name: Files that would trigger a full eslint run
+      with:
+        changed-files: ${{ steps.setup.outputs.changed_files }}
+        files: '.eslintrc.js,yarn.lock,.eslintignore'
 
     # Linting / type checking
-    - name: Run ESLint (all files)
-      if: contains(steps.changed.outputs.added_modified, '.eslintrc.js') || contains(steps.changed.outputs.added_modified, 'yarn.lock')
-      run: |
-        yarn lint:ci packages
-    - name: Run ESLint (added/changed files)
-      if: contains(steps.changed.outputs.added_modified, '.eslintrc.js') == false && contains(steps.changed.outputs.added_modified, 'yarn.lock') == false
-      run: |
-        yarn lint:ci ${{ steps.changed.outputs.added_modified }}
-    - name: Run Flow
-      uses: Khan/flow-action@v1.1.3
+    - name: Eslint
+      uses: ./.github/actions/full-or-limited
       with:
-        flow-bin: ./node_modules/.bin/flow
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        full-trigger: ${{ steps.eslint-reset.outputs.filtered }}
+        full: yarn lint:ci packages
+        limited-trigger: ${{ steps.js-files.outputs.filtered }}
+        limited: yarn lint:ci {}
+
+    - name: Run Flow
+      if: steps.js-files.outputs.filtered != '[]'
+      run: yarn flow
 
     # Run tests for our target matrix
-    - name: Run Jest (all files)
-      if: |
-        contains(steps.changed.outputs.added_modified, 'jest.config.js') ||
-        contains(steps.changed.outputs.added_modified, 'yarn.lock') ||
-        contains(steps.changed.outputs.added_modified, 'test.config.js') ||
-        contains(steps.changed.outputs.added_modified, 'test.transform.js')
-      run: yarn test
-    - name: Run Jest (added/changed files)
-      if: |
-        (contains(steps.changed.outputs.added_modified, 'jest.config.js') ||
-         contains(steps.changed.outputs.added_modified, 'yarn.lock') ||
-         contains(steps.changed.outputs.added_modified, 'test.config.js') ||
-         contains(steps.changed.outputs.added_modified, 'test.transform.js')) == false
-      run: yarn test --passWithNoTests ${{ steps.changed.outputs.added_modified }}
+    - id: jest-reset
+      uses: ./.github/actions/filter-files
+      name: Files that would trigger a full jest run
+      with:
+        changed-files: ${{ steps.setup.outputs.changed_files }}
+        files: 'jest.config.js,yarn.lock,test.config.js,test.transform.js'
+
+    - name: Jest
+      uses: ./.github/actions/full-or-limited
+      with:
+        full-trigger: ${{ steps.jest-reset.outputs.filtered }}
+        full: yarn jest
+        limited-trigger: ${{ steps.js-files.outputs.filtered }}
+        limited: yarn jest --passWithNoTests --findRelatedTests {}
 
   check_builds:
     name: Check builds for changes in size

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -35,7 +35,7 @@ jobs:
       uses: ./.github/actions/filter-files
       with:
         changed-files: ${{ steps.changed.outputs.added_modified }}
-        extensions: '.js'
+        extensions: '.js,.jsx'
 
     - id: eslint-reset
       uses: ./.github/actions/filter-files

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -41,7 +41,7 @@ jobs:
       uses: ./.github/actions/filter-files
       name: Files that would trigger a full eslint run
       with:
-        changed-files: ${{ steps.setup.outputs.changed_files }}
+        changed-files: ${{ steps.changed.outputs.added_modified }}
         files: '.eslintrc.js,yarn.lock,.eslintignore'
 
     # Linting / type checking
@@ -62,7 +62,7 @@ jobs:
       uses: ./.github/actions/filter-files
       name: Files that would trigger a full jest run
       with:
-        changed-files: ${{ steps.setup.outputs.changed_files }}
+        changed-files: ${{ steps.changed.outputs.added_modified }}
         files: 'jest.config.js,yarn.lock,test.config.js,test.transform.js'
 
     - name: Jest


### PR DESCRIPTION
## Summary:
Currently, eslint is giving warnings because we're passing it changed files that aren't .js files.
I'm bringing over the composite actions from the graphql-flow repo to fix this. I'm planning on extracting them out into a separate github actions monorepo soon, so this duplication is temporary.

Issue: https://khanacademy.atlassian.net/browse/FEI-4498

## Test plan:
🤞