### PR TITLE
Change imports for simple markdown

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -11,7 +11,7 @@ module.file_ext=.less
 # stub out less imports.
 module.name_mapper.extension='less' -> 'empty/object'
 module.name_mapper='@khanacademy/\(perseus[^/]*\)' -> '<PROJECT_ROOT>/packages/\1/src/index.js'
-module.name_mapper='@khanacademy/simple-markdown)' -> '<PROJECT_ROOT>/packages/simple-markdown/src/index.js'
+module.name_mapper='@khanacademy/simple-markdown' -> '<PROJECT_ROOT>/packages/simple-markdown/src/index.js'
 module.name_mapper='hubble' -> '<PROJECT_ROOT>/vendor/hubble/hubble.js'
 module.name_mapper='jsdiff' -> '<PROJECT_ROOT>/vendor/jsdiff/jsdiff.js'
 module.name_mapper='raphael' -> '<PROJECT_ROOT>/vendor/raphael/raphael.js'

--- a/.flowconfig
+++ b/.flowconfig
@@ -11,6 +11,7 @@ module.file_ext=.less
 # stub out less imports.
 module.name_mapper.extension='less' -> 'empty/object'
 module.name_mapper='@khanacademy/\(perseus[^/]*\)' -> '<PROJECT_ROOT>/packages/\1/src/index.js'
+module.name_mapper='@khanacademy/simple-markdown)' -> '<PROJECT_ROOT>/packages/simple-markdown/src/index.js'
 module.name_mapper='hubble' -> '<PROJECT_ROOT>/vendor/hubble/hubble.js'
 module.name_mapper='jsdiff' -> '<PROJECT_ROOT>/vendor/jsdiff/jsdiff.js'
 module.name_mapper='raphael' -> '<PROJECT_ROOT>/vendor/raphael/raphael.js'

--- a/config/test/test.config.js
+++ b/config/test/test.config.js
@@ -38,6 +38,8 @@ module.exports = {
     moduleNameMapper: {
         "^@khanacademy/perseus(.*)$":
             "<rootDir>/packages/perseus$1/src/index.js",
+        "^@khanacademy/simple-markdown":
+            "<rootDir>/packages/simple-markdown/src/index.js",
         // Load a .js file with no exports whenever a .css or .less file is requested.
         "\\.(css|less)$": "<rootDir>/config/test/style-mock.js",
         ...vendorMap,

--- a/config/test/test.config.js
+++ b/config/test/test.config.js
@@ -38,7 +38,7 @@ module.exports = {
     moduleNameMapper: {
         "^@khanacademy/perseus(.*)$":
             "<rootDir>/packages/perseus$1/src/index.js",
-        "^@khanacademy/simple-markdown":
+        "^@khanacademy/simple-markdown$":
             "<rootDir>/packages/simple-markdown/src/index.js",
         // Load a .js file with no exports whenever a .css or .less file is requested.
         "\\.(css|less)$": "<rootDir>/config/test/style-mock.js",

--- a/packages/perseus/src/jipt-paragraphs.js
+++ b/packages/perseus/src/jipt-paragraphs.js
@@ -3,7 +3,7 @@
  * Paragraph parsing/splitting for article jipt i18n
  */
 
-import SimpleMarkdown from "simple-markdown";
+import SimpleMarkdown from "@khanacademy/simple-markdown";
 
 const arrayRules = {
     fence: {

--- a/packages/perseus/src/perseus-markdown.jsx
+++ b/packages/perseus/src/perseus-markdown.jsx
@@ -3,7 +3,7 @@
 // TODO(FEI-4465): move this into it's own package called perseus-markdown
 import * as i18n from "@khanacademy/wonder-blocks-i18n";
 import * as React from "react";
-import SimpleMarkdown from "simple-markdown";
+import SimpleMarkdown from "@khanacademy/simple-markdown";
 import _ from "underscore";
 
 import Lint from "./components/lint.jsx";

--- a/packages/perseus/src/perseus-markdown.jsx
+++ b/packages/perseus/src/perseus-markdown.jsx
@@ -1,9 +1,9 @@
-/* eslint-disable no-useless-escape */
+/* eslint-disable no-useless-escape, no-prototype-builtins */
 // @flow
 // TODO(FEI-4465): move this into it's own package called perseus-markdown
+import SimpleMarkdown from "@khanacademy/simple-markdown";
 import * as i18n from "@khanacademy/wonder-blocks-i18n";
 import * as React from "react";
-import SimpleMarkdown from "@khanacademy/simple-markdown";
 import _ from "underscore";
 
 import Lint from "./components/lint.jsx";

--- a/packages/perseus/src/pure-markdown.js
+++ b/packages/perseus/src/pure-markdown.js
@@ -3,7 +3,7 @@
  * Contains markdown related functions in pure javascript,
  * extracted from perseus-markdown.jsx
  */
-import SimpleMarkdown from "simple-markdown";
+import SimpleMarkdown from "@khanacademy/simple-markdown";
 
 import Util from "./util.js";
 

--- a/packages/perseus/src/widgets/passage/passage-markdown.jsx
+++ b/packages/perseus/src/widgets/passage/passage-markdown.jsx
@@ -3,7 +3,7 @@
 import * as i18n from "@khanacademy/wonder-blocks-i18n";
 import PropTypes from "prop-types";
 import * as React from "react";
-import SimpleMarkdown from "simple-markdown";
+import SimpleMarkdown from "@khanacademy/simple-markdown";
 import _ from "underscore";
 
 const START_REF_PREFIX = "start-ref-";

--- a/packages/simple-markdown/src/index.js
+++ b/packages/simple-markdown/src/index.js
@@ -1778,10 +1778,7 @@ var defaultRules /* : DefaultRules */ = {
  * @param {any} property
  * @returns {any}
  */
-var ruleOutput = function (
-    /* :: <Rule : Object> */ rules /* : OutputRules<Rule> */,
-    property /* : $Keys<Rule> */,
-) {
+var ruleOutput = function (rules, property) {
     if (!property && typeof console !== "undefined") {
         console.warn(
             "simple-markdown ruleOutput should take 'react' or " +


### PR DESCRIPTION
## Summary:
Lands after moving simple-markdown into the mono-repo.

Changes the imports to use the new @khanacademy prefix for the package.

Issue: https://khanacademy.atlassian.net/browse/LP-11429

## Test plan:
- Build the repo
- **All should be well**