### PR TITLE
Add lint:timing and unify our lint command(s)

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -49,9 +49,9 @@ jobs:
       uses: ./.github/actions/full-or-limited
       with:
         full-trigger: ${{ steps.eslint-reset.outputs.filtered }}
-        full: yarn lint:ci packages
+        full: yarn lint packages
         limited-trigger: ${{ steps.js-files.outputs.filtered }}
-        limited: yarn lint:ci {}
+        limited: yarn lint {}
 
     - name: Run Flow
       if: steps.js-files.outputs.filtered != '[]'

--- a/package.json
+++ b/package.json
@@ -98,8 +98,8 @@
     "coverage": "yarn run jest --coverage",
     "extract-strings": "./utils/extract-strings.js",
     "flow:ci": "flow check --max-workers 0",
-    "lint": "eslint --config .eslintrc.js packages --ext .js --ext .jsx",
-    "lint:ci": "eslint --config .eslintrc.js",
+    "lint": "eslint --config .eslintrc.js --ext .js --ext .jsx",
+    "lint:timing": "TIMING=1 yarn lint",
     "publish:ci": "node utils/pre-publish-check-ci.js && git diff --stat --exit-code HEAD && yarn build && yarn extract-strings && changeset publish",
     "test": "yarn jest"
   }


### PR DESCRIPTION
## Summary:

Adds a npm script to show ESLint timings by rule. Also, removes the `lint:ci` script as it was essentially a duplicate of the `lint` script. We now just use `yarn lint` in CI also.

Issue: "none"

## Test plan:

`yarn lint`