### PR TITLE
Always build everything for size check (otherwise we have missing assets in dist/)

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   "scripts": {
     "gen:parsers": "yarn --cwd packages/kas gen:parsers",
     "build": "yarn gen:parsers && rollup -c config/build/rollup.config.js",
-    "build:prodsizecheck": "yarn gen:parsers && rollup -c config/build/rollup.config.js --configFormats='esm' --configEnvironment='production'",
+    "build:prodsizecheck": "yarn gen:parsers && rollup -c config/build/rollup.config.js --configEnvironment='production'",
     "watch": "rollup -c config/build/rollup.config.js --watch",
     "clean": "rm -rf packages/perseus*/dist && rm -rf packages/perseus*/node_modules",
     "coverage": "yarn run jest --coverage",


### PR DESCRIPTION
## Summary:

I encountered a PR [check that failed](https://github.com/Khan/perseus/runs/6279901778?check_suite_focus=true) when we did the bundle size check (`perseus-renderer.less` imports `math-input`'s generated CSS from `dist/index.css`, but that file isn't generated during the size check... read on). The bundle size check only generates the ESM bundles. This complicates asset generation because Rollup places generates assets in the dir as the output file. 

So currently we end up with duplicated assets in `dist/` and `dist/es`. 

For now I've changed the bundle size check to generate all formats.

Issue: LP-11432

## Test plan:

`yarn build:prodsizecheck` can run to completion