### PR TITLE
[🔥AUDIT🔥] Add @khanacademy prefix to kas package name

### DIFF
--- a/.changeset/yellow-turkeys-call.md
+++ b/.changeset/yellow-turkeys-call.md
@@ -1,5 +1,5 @@
 ---
-"kas": patch
+"@khanacademy/kas": patch
 ---
 
 Move KAS into khan/perseus repo


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
I noticed the issue when I saw that the "Version Packages" PR was going to publish "kas" without the prefix.

## Test plan:
- n/a