### PR TITLE
Ensure that have a module mapper entries for all packages in our jest config

### DIFF
--- a/config/test/test.config.js
+++ b/config/test/test.config.js
@@ -21,6 +21,20 @@ const vendorMap = fs
         };
     }, {});
 
+const pkgMap = fs
+    .readdirSync(path.join(root, "packages"))
+    .reduce((map, name) => {
+        const pkgJson = JSON.parse(
+            fs.readFileSync(path.join(root, "packages", name, "package.json")),
+        );
+        return {
+            ...map,
+            // NOTE(kevinb): we the 'source' field here so that we can run our
+            // tests without having to compile all of the packages first.
+            [`^@khanacademy/${name}$`]: `<rootDir>/packages/${name}/${pkgJson.source}`,
+        };
+    }, {});
+
 module.exports = {
     rootDir: path.join(__dirname, "../../"),
     transform: {
@@ -40,13 +54,10 @@ module.exports = {
         "<rootDir>/node_modules/jest-enzyme/lib/index.js",
     ],
     moduleNameMapper: {
-        "^@khanacademy/perseus(.*)$":
-            "<rootDir>/packages/perseus$1/src/index.js",
-        "^@khanacademy/kas$": "<rootDir>/packages/kas/src/index.js",
-        "^@khanacademy/kmath$": "<rootDir>/packages/kmath/src/index.js",
+        ...pkgMap,
+        ...vendorMap,
         // Load a .js file with no exports whenever a .css or .less file is requested.
         "\\.(css|less)$": "<rootDir>/config/test/style-mock.js",
-        ...vendorMap,
     },
     collectCoverageFrom: [
         "packages/*/src/**/*.js",

--- a/config/test/test.config.js
+++ b/config/test/test.config.js
@@ -29,7 +29,7 @@ const pkgMap = fs
         );
         return {
             ...map,
-            // NOTE(kevinb): we the 'source' field here so that we can run our
+            // NOTE(kevinb): we use the 'source' field here so that we can run our
             // tests without having to compile all of the packages first.
             [`^@khanacademy/${name}$`]: `<rootDir>/packages/${name}/${pkgJson.source}`,
         };

--- a/packages/math-input/src/store/index.js
+++ b/packages/math-input/src/store/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import Redux from "redux";
+import * as Redux from "redux";
 
 import {tabletCutoffPx} from "../components/common-style.js";
 import {computeLayoutParameters} from "../components/compute-layout-parameters.js";


### PR DESCRIPTION
## Summary:
I noticed that some of our tests were failing if we hadn't already built the files.  We should be running tests from source only so that we don't have to rebuild every time we want to run the tests.  I've updated the jest config to read the .source field from the package.json in each of the packages so we shouldn't have to make any changes to this when we add new packages.

This also uncovered an issue with a redux import in one file.

## Test plan:
- yarn clean
- yarn test