### PR TITLE
[🔥AUDIT🔥] Make 'kas' package public

### DIFF
--- a/packages/kas/package.json
+++ b/packages/kas/package.json
@@ -1,4 +1,7 @@
 {
+  "publishConfig": {
+    "access": "public"
+  },
   "name": "@khanacademy/kas",
   "version": "0.2.2",
   "description": "A lightweight JavaScript CAS for comparing expressions and equations.",

--- a/utils/pre-publish-check-ci.js
+++ b/utils/pre-publish-check-ci.js
@@ -13,7 +13,7 @@ const {
 } = require("./internal/pre-publish-utils.js");
 
 // eslint-disable-next-line promise/catch-or-return
-fg(path.join(__dirname, "..", "packages", "**", "package.json")).then(
+fg(path.join(__dirname, "..", "packages", "*", "package.json")).then(
     (pkgPaths) => {
         // eslint-disable-next-line promise/always-return
         for (const pkgPath of pkgPaths) {


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
The pre-publish CI check that we run caught this.  When I ran this check locally, I discovered it was also trying to publish 'underscore' because fast-glob found it (and other packages) in packages/kmath/node_modules.  I tightened up the path to only consider package.json files in immediate subdirs of packages/.  This fixed the 'underscore' issue and the check passes locally now.

Issue: None

## Test plan:
- node utils/pre-publish-check-ci.js