### PR TITLE
Fix failing simple-markdown tests

### DIFF
--- a/packages/simple-markdown/src/__tests__/simple-markdown_test.js
+++ b/packages/simple-markdown/src/__tests__/simple-markdown_test.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-var, no-unused-vars, no-console, import/no-commonjs, no-redeclare, no-useless-escape */
 // @flow
 /* @ts-check */
+import {render} from "@testing-library/react";
 
 // As of 2019-11-03, flow doesn't have definitions for assert.strict:
 // https://github.com/facebook/flow/pull/7660

--- a/packages/simple-markdown/src/index.js
+++ b/packages/simple-markdown/src/index.js
@@ -1789,7 +1789,7 @@ var htmlFor = function (outputFunc: HtmlNodeOutput): HtmlOutput {
 var outputFor = function (
     rules: OutputRules<Rule>,
     property: $Keys<Rule>,
-    defaultState: ?State,
+    defaultState: ?State = {},
 ) {
     if (!property) {
         throw new Error(
@@ -1826,7 +1826,7 @@ var outputFor = function (
     };
 
     var outerOutput: Output<any> = function (ast, state) {
-        latestState = populateInitialState(state, defaultState ?? {});
+        latestState = populateInitialState(state, defaultState);
         return nestedOutput(ast, latestState);
     };
     return outerOutput;

--- a/packages/simple-markdown/src/index.js
+++ b/packages/simple-markdown/src/index.js
@@ -1789,7 +1789,7 @@ var htmlFor = function (outputFunc: HtmlNodeOutput): HtmlOutput {
 var outputFor = function (
     rules: OutputRules<Rule>,
     property: $Keys<Rule>,
-    defaultStat: ?State,
+    defaultState: ?State,
 ) {
     if (!property) {
         throw new Error(
@@ -1825,10 +1825,8 @@ var outputFor = function (
         }
     };
 
-    var defaultState = defaultState || {};
-
     var outerOutput: Output<any> = function (ast, state) {
-        latestState = populateInitialState(state, defaultState);
+        latestState = populateInitialState(state, defaultState ?? {});
         return nestedOutput(ast, latestState);
     };
     return outerOutput;


### PR DESCRIPTION
## Summary:
There was a minor typo which resulted in rules not have access to state in certain situations.

Issue: None

## Test plan:
- yarn test simple-markdown