### PR TITLE
Fix Flow types in math-input

### DIFF
--- a/.changeset/friendly-zoos-smile.md
+++ b/.changeset/friendly-zoos-smile.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/math-input": patch
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Add @flow comment to math-input's index.js and missing props to ProvidedKeypad

--- a/packages/math-input/src/components/provided-keypad.js
+++ b/packages/math-input/src/components/provided-keypad.js
@@ -15,8 +15,12 @@ import {createStore} from "../store/index.js";
 
 import KeypadContainer from "./keypad-container.js";
 
+import type {CSSProperties} from "aphrodite";
+
 type Props = {|
     onElementMounted?: ($FlowFixMe) => void,
+    onDismiss?: () => mixed,
+    style?: CSSProperties,
 |};
 
 class ProvidedKeypad extends React.Component<Props> {

--- a/packages/math-input/src/index.js
+++ b/packages/math-input/src/index.js
@@ -1,3 +1,4 @@
+// @flow
 /**
  * A single entry-point for all of the external-facing functionality.
  */

--- a/packages/perseus-editor/src/components/link.jsx
+++ b/packages/perseus-editor/src/components/link.jsx
@@ -8,12 +8,12 @@
 import {StyleSheet, css} from "aphrodite";
 import * as React from "react";
 
+import type {CSSProperties} from "aphrodite";
+
 // TODO(diedra): This is terrible! If we don't have a href for a link, it should
 // be a button instead. We just need to make sure we override the default browser
 // button styling (backgroundColor, border, and padding).
 const DEFAULT_HREF = "javascript:void(0)";
-
-type AphroditeStyle = any;
 
 type DefaultProps = {|
     element: string | React.AbstractComponent<any>,
@@ -22,7 +22,7 @@ type DefaultProps = {|
     highlighted: boolean,
     href: string,
     // Pass through styles but also add our own to normalize
-    style: AphroditeStyle | Array<AphroditeStyle>,
+    style: CSSProperties | Array<CSSProperties>,
 |};
 
 type LinkProps = {|
@@ -70,7 +70,7 @@ class Link extends React.Component<LinkProps> {
     static defaultProps: DefaultProps = {
         highlighted: false,
         href: DEFAULT_HREF,
-        style: ([]: Array<AphroditeStyle>),
+        style: ([]: Array<CSSProperties>),
         element: "a",
     };
 

--- a/packages/perseus/src/mixins/provide-keypad.jsx
+++ b/packages/perseus/src/mixins/provide-keypad.jsx
@@ -16,12 +16,14 @@ import PropTypes from "prop-types";
 import * as React from "react";
 import ReactDOM from "react-dom";
 
+import type {CSSProperties} from "aphrodite";
+
 export type KeypadProps = {|
     // An Aphrodite style object, to be applied to the keypad container.
     // Note that, given our awkward structure of injecting the keypad, this
     // style won't be applied or updated dynamically. Rather, it will only
     // be applied in `componentDidMount`.
-    keypadStyle?: any,
+    keypadStyle?: CSSProperties,
 |};
 
 export type KeypadApiOptions = {|


### PR DESCRIPTION
## Summary:
After updating webapp to use the new packages, Flow is complaining about @khanacademy/math-input not exporting 'Keypad' even though it is.  Adding a '// @flow' comment to math-input's index.js fixes the issue.  I also noticed that there were some missing props on ProvidedKeypad so I added them.  Since this component spreads its props into one of its child components there's likely more props that could be added.  I only added the ones that people seemed to be using.

Issue: None

## Test plan:
- yarn flow