### PR TITLE
Export VideoData (used by PerseusDependencies)

### DIFF
--- a/.changeset/gorgeous-clouds-grin.md
+++ b/.changeset/gorgeous-clouds-grin.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Add `VideoData` to set of exported Perseus types.

--- a/packages/perseus/src/index.js
+++ b/packages/perseus/src/index.js
@@ -114,6 +114,7 @@ export type {
     PerseusScore,
     RendererInterface,
     Version,
+    VideoData,
     WidgetDict,
     WidgetExports,
     WidgetInfo,

--- a/packages/perseus/src/types.js
+++ b/packages/perseus/src/types.js
@@ -333,7 +333,7 @@ export type JiptTranslationComponents = {|
     removeComponentAtIndex: (index: number) => void,
 |};
 
-type VideoData = {|
+export type VideoData = {|
     __typename: "Video",
     id: string,
     title: ?string,


### PR DESCRIPTION
## Summary:

The `useVideo` hook that is required in PerseusDependencies accepts a parameter type `VideoData`, but we don't export that. So this PR just fixes that. 

Issue: "none"

## Test plan: