### PR TITLE
Don't re-export Perseus from @khanacademy/perseus-editor

### DIFF
--- a/.changeset/five-wasps-raise.md
+++ b/.changeset/five-wasps-raise.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+Don't re-export Perseus from @khanacademy/perseus-editor

--- a/packages/perseus-editor/src/index.js
+++ b/packages/perseus-editor/src/index.js
@@ -1,6 +1,4 @@
 // @flow
-export * as Perseus from "@khanacademy/perseus";
-
 export {default as ArticleEditor} from "./article-editor.jsx";
 export {default as DeviceFramer} from "./components/device-framer.jsx";
 export {default as ViewportResizer} from "./components/viewport-resizer.jsx";


### PR DESCRIPTION
## Summary:
This one re-export was causing issues for webpack in webapp.

Issue: None

## Test plan:
- yarn build
- copy files from packages/perseus-editor/dist into services/static/node_modules/@khanacademy/perseus-editor/dist (in webapp)
- see that the exercise editor loads without errors