### PR TITLE
Trim down InitialRequestUrl to only required fields

### DIFF
--- a/.changeset/heavy-starfishes-check.md
+++ b/.changeset/heavy-starfishes-check.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Remove all unused fields from `Dependencies.InitialRequestUrl`

--- a/packages/perseus/src/types.js
+++ b/packages/perseus/src/types.js
@@ -354,9 +354,9 @@ interface StaticUrlFn {
 
 // A dependency for getting URLs
 type InitialRequestUrlInterface = {|
-    origin: string, // used
-    host: string, // used
-    protocol: string, // used
+    origin: string,
+    host: string,
+    protocol: string,
 |};
 
 // An object for dependency injection, to allow different clients

--- a/packages/perseus/src/types.js
+++ b/packages/perseus/src/types.js
@@ -354,21 +354,9 @@ interface StaticUrlFn {
 
 // A dependency for getting URLs
 type InitialRequestUrlInterface = {|
-    origin: string,
-    host: string,
-    hostname: string,
-    protocol: string,
-    port: string,
-    configParams: {|
-        curriculum: string,
-        country: string,
-        embedded: string,
-        lang: string,
-        preview: string,
-        publish_commit: string,
-        region: string,
-        schemaMode: ?any,
-    |},
+    origin: string, // used
+    host: string, // used
+    protocol: string, // used
 |};
 
 // An object for dependency injection, to allow different clients

--- a/testing/test-dependencies.js
+++ b/testing/test-dependencies.js
@@ -106,19 +106,7 @@ export const testDependencies: PerseusDependencies = {
     InitialRequestUrl: {
         origin: "origin-test-interface",
         host: "host-test-interface",
-        hostname: "hostname-test-interface",
         protocol: "protocol-test-interface",
-        port: "port-test-interface",
-        configParams: {
-            curriculum: "curriculum-test-interface",
-            country: "country-test-interface",
-            embedded: "embedded-test-interface",
-            lang: "lang-test-interface",
-            preview: "preview-test-interface",
-            publish_commit: "publish_commit-test-interface",
-            region: "region-test-interface",
-            schemaMode: {},
-        },
     },
 
     isDevServer: false,


### PR DESCRIPTION
## Summary:

The `InitialRequestUrl` key in PerseusDependencies is quite big and much of it goes unused in Perseus. Trimming it down to teh absolute minimum we need so that we sidestep needing to pass in all these pieces of (unused) data (especially in non-webapp usages).

Issue: "none"

## Test plan:

`yarn flow`
`yarn test`