### PR TITLE
Disable terser rollup plugin

### DIFF
--- a/.changeset/stale-goats-joke.md
+++ b/.changeset/stale-goats-joke.md
@@ -1,0 +1,5 @@
+---
+"perseus-build-settings": patch
+---
+
+Disable terser plugin

--- a/config/build/rollup.config.js
+++ b/config/build/rollup.config.js
@@ -210,7 +210,11 @@ const createConfig = (
             autoExternal({
                 packagePath: makePackageBasedPath(name, "./package.json"),
             }),
-            terser(),
+            // TODO(FEI-4557): Figure out how to make this plugin work so that
+            // @khanacademy/perseus-editor works in webapp.  If we enable this
+            // plugin right now, the content editor pages in webapp will fail
+            // with the following error: `TypeError: Object(...) is not a function`
+            // terser(),
             ...plugins,
         ],
     };

--- a/config/build/rollup.config.js
+++ b/config/build/rollup.config.js
@@ -14,7 +14,6 @@ import autoExternal from "rollup-plugin-auto-external";
 import copy from "rollup-plugin-copy";
 import filesize from "rollup-plugin-filesize";
 import styles from "rollup-plugin-styles";
-import {terser} from "rollup-plugin-terser";
 
 const createBabelPlugins = require("./create-babel-plugins.js");
 const createBabelPresets = require("./create-babel-presets.js");

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "rollup-plugin-filesize": "^9.1.1",
     "rollup-plugin-preserve-shebangs": "^0.2.0",
     "rollup-plugin-styles": "^4.0.0",
-    "rollup-plugin-terser": "^7.0.2",
     "sloc": "^0.2.1",
     "winston": "^3.7.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10903,7 +10903,7 @@ jest-worker@^24.9.0:
     merge-stream "^2.0.0"
     supports-color "^6.1.0"
 
-jest-worker@^26.2.1, jest-worker@^26.5.0, jest-worker@^26.6.2:
+jest-worker@^26.5.0, jest-worker@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.6.2.tgz#7f72cbc4d643c365e27b9fd775f9d0eaa9c7a8ed"
   integrity sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==
@@ -15006,16 +15006,6 @@ rollup-plugin-styles@^4.0.0:
     source-map-js "^1.0.1"
     tslib "^2.3.1"
 
-rollup-plugin-terser@^7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz#e8fbba4869981b2dc35ae7e8a502d5c6c04d324d"
-  integrity sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    jest-worker "^26.2.1"
-    serialize-javascript "^4.0.0"
-    terser "^5.0.0"
-
 rollup@^2.70.2:
   version "2.70.2"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.70.2.tgz#808d206a8851628a065097b7ba2053bd83ba0c0d"
@@ -16129,16 +16119,6 @@ terser@^4.1.2, terser@^4.6.3:
     source-map "~0.6.1"
     source-map-support "~0.5.12"
 
-terser@^5.0.0, terser@^5.6.0:
-  version "5.12.1"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.12.1.tgz#4cf2ebed1f5bceef5c83b9f60104ac4a78b49e9c"
-  integrity sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==
-  dependencies:
-    acorn "^8.5.0"
-    commander "^2.20.0"
-    source-map "~0.7.2"
-    source-map-support "~0.5.20"
-
 terser@^5.3.4:
   version "5.13.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.13.0.tgz#d43fd71861df1b4df743980caa257c6fa03acc44"
@@ -16147,6 +16127,16 @@ terser@^5.3.4:
     acorn "^8.5.0"
     commander "^2.20.0"
     source-map "~0.8.0-beta.0"
+    source-map-support "~0.5.20"
+
+terser@^5.6.0:
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.12.1.tgz#4cf2ebed1f5bceef5c83b9f60104ac4a78b49e9c"
+  integrity sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==
+  dependencies:
+    acorn "^8.5.0"
+    commander "^2.20.0"
+    source-map "~0.7.2"
     source-map-support "~0.5.20"
 
 test-exclude@^5.2.3:


### PR DESCRIPTION
## Summary:
The terser() plugin produces a bundle for @khanacademy/perseus-editor that webapp's webpack has trouble loading correctly.  While the build completes, when a page is loaded the imports this package, it failes with: 'TypeError: Object(...) is not a function'.

Disabling terser() fixes the issue.  I've created FEI-4557 to attempt to fix this in the future, possibly by upgrading to webpack 5 or tweaking the terser() config.

NOTE: The other packages that we publish do not appear to be affected by this issue.

Issue: None

## Test plan:
- yarn build
- copy dist/ folder for perseus-editor over to webapp's static service
- in webapp delete genwebpack/.cache-loader
- restart the dev server
- load http://localhost:8088/devadmin/content/exercises/evaluating_expressions_1/47765362/xf536eb63390a6371, see that it loads without issue