### PR TITLE
[🔥AUDIT🔥] Add perseus-build-settings as a dev dep to packages that were misisng it

### DIFF
--- a/.changeset/wild-shoes-juggle.md
+++ b/.changeset/wild-shoes-juggle.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/kas": patch
+"@khanacademy/math-input": patch
+"@khanacademy/simple-markdown": patch
+---
+
+Add 'perseus-build-settings' as a dev dep to packages that were missing it

--- a/packages/kas/package.json
+++ b/packages/kas/package.json
@@ -24,6 +24,7 @@
     "dependencies": {},
     "devDependencies": {
         "jison": "0.4.15",
+        "perseus-build-settings": "^0.0.1",
         "underscore": "1.4.4"
     },
     "peerDependencies": {

--- a/packages/math-input/package.json
+++ b/packages/math-input/package.json
@@ -30,6 +30,7 @@
         "jquery": "^2.1.1",
         "katex": "^0.11.1",
         "mathquill": "git+https://git@github.com/Khan/mathquill.git#a9ae54e057c5c1acc8244a5627acbff29901d992",
+        "perseus-build-settings": "^0.0.1",
         "prop-types": "15.6.1",
         "react": "^16.8.0",
         "react-dom": "^16.8.0",

--- a/packages/simple-markdown/package.json
+++ b/packages/simple-markdown/package.json
@@ -25,6 +25,7 @@
     },
     "devDependencies": {
         "@types/react-dom": ">=16.0.0",
+        "perseus-build-settings": "^0.0.1",
         "size-limit": "^0.21.1",
         "typescript": "^3.6.4",
         "uglify-js": "^3.6.7"


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
This should hopefully result in more packages being bumped.  In theory all packages should get bumped whenever there's a change to perseus-build-settings.

Issue: None

## Test plan:
- land this audit and check to see what packages were auto-bumped in the "Version Packages" PR