### PR TITLE
[🔥AUDIT🔥] Fix release workflow by building packages before building storybook

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Build packages
+        # This is necessary for the storybook build to succeed because perseus-renderer.less
+        # includes the following line:
+        # @import (inline) "../../../math-input/dist/index.css";
+        run: yarn build
+
       - name: Build Storybook
         # Generate a static version of storybook inside "storybook-static/"
         run: yarn build-storybook


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
There was an issue with storybook not being able to find a .css import from node_modules/math/index.css.  THis PR should fix that.

Issue: None

## Test plan:
- yarn clean
- yarn build
- yarn build-storybook
- wait for release workflow to run