### PR TITLE
Use eslint-plugin-ft-flow plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -112,8 +112,11 @@ module.exports = {
         /**
          * flowtype
          */
-        "flowtype/no-types-missing-file-annotation": "error",
+        "ft-flow/no-types-missing-file-annotation": "error",
         // "flowtype/no-existential-type": "error",
+        // These conflict with Prettier, so just disable them.
+        "ft-flow/generic-spacing": "off",
+        "ft-flow/space-after-type-colon": "off",
 
         /**
          * jest

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
         "plugin:storybook/recommended",
         // This config includes rules from @testing-library/jest-dom as well
         "plugin:testing-library/react",
+        "plugin:ft-flow/recommended",
     ],
     parser: "@babel/eslint-parser",
     parserOptions: {
@@ -46,6 +47,7 @@ module.exports = {
         "monorepo",
         "promise",
         "react-native",
+        "ft-flow",
     ],
     settings: {
         "import/resolver": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "eslint-plugin-disable": "^2.0.3",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-flowtype": "^8.0.3",
+    "eslint-plugin-ft-flow": "^2.0.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jest": "^26.1.4",
     "eslint-plugin-jsx-a11y": "^6.5.1",

--- a/packages/math-input/src/components/input/cursor-contexts.js
+++ b/packages/math-input/src/components/input/cursor-contexts.js
@@ -1,3 +1,5 @@
+// @flow
+
 /**
  * Constants that define the various contexts in which a cursor can exist. The
  * active context is determined first by looking at the cursor's siblings (e.g.,

--- a/packages/math-input/src/index.js
+++ b/packages/math-input/src/index.js
@@ -12,3 +12,8 @@ export {
 } from "./components/prop-types.js";
 export {default as Keypad} from "./components/provided-keypad.js";
 export {KeypadTypes} from "./consts.js";
+export {default as KeyConfigs} from "./data/key-configs.js";
+
+import * as CursorContexts from "./components/input/cursor-contexts.js";
+
+export {CursorContexts};

--- a/yarn.lock
+++ b/yarn.lock
@@ -8631,6 +8631,14 @@ eslint-plugin-flowtype@^8.0.3:
     lodash "^4.17.21"
     string-natural-compare "^3.0.1"
 
+eslint-plugin-ft-flow@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ft-flow/-/eslint-plugin-ft-flow-2.0.1.tgz#57d9a12ef02b7af8f9bd6ccd6bd8fa4034809716"
+  integrity sha512-dGBnCo+ok6H9p6Vw2oPFEM4vA9IEclRXQQAA/Zws51/L5zr3FDl9FxQiWGfaw0WaTIX5biiAxp/q1W5bGXjlVA==
+  dependencies:
+    lodash "^4.17.21"
+    string-natural-compare "^3.0.1"
+
 eslint-plugin-import@^2.26.0:
   version "2.26.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz#f812dc47be4f2b72b478a021605a59fc6fe8b88b"


### PR DESCRIPTION
## Summary:

This PR adopts the `ft-flow` ESLint plugin. One big advantage of this plugin over the original flow-type ESLint plugin is that it fully supports Flow enums. 

Issue: "none"

## Test plan:

`yarn lint` finishes with no errors or warnings (don't forget to `yarn install` first)