### PR TITLE
Export CursorContext

### DIFF
--- a/.changeset/happy-windows-repair.md
+++ b/.changeset/happy-windows-repair.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Export CursorContexts

--- a/packages/math-input/src/index.js
+++ b/packages/math-input/src/index.js
@@ -12,3 +12,7 @@ export {
 } from "./components/prop-types.js";
 export {default as Keypad} from "./components/provided-keypad.js";
 export {KeypadTypes} from "./consts.js";
+
+import * as CursorContexts from "./components/input/cursor-contexts.js";
+
+export {CursorContexts};


### PR DESCRIPTION
## Summary:

@khanacademy/math-input clients sometimes use the CursorContext as part of using the math-input project. Instead of re-defining the values in the object, this PR adds it as an export from the main module.

Issue: MOB-4525

## Test plan: