### PR TITLE
Export KeyConfigs and flow-type CursorContexts

### DIFF
--- a/.changeset/rare-snails-prove.md
+++ b/.changeset/rare-snails-prove.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Export the KeyConfigs type

--- a/packages/math-input/src/components/input/cursor-contexts.js
+++ b/packages/math-input/src/components/input/cursor-contexts.js
@@ -1,3 +1,4 @@
+// @flow
 /**
  * Constants that define the various contexts in which a cursor can exist. The
  * active context is determined first by looking at the cursor's siblings (e.g.,

--- a/packages/math-input/src/index.js
+++ b/packages/math-input/src/index.js
@@ -12,6 +12,7 @@ export {
 } from "./components/prop-types.js";
 export {default as Keypad} from "./components/provided-keypad.js";
 export {KeypadTypes} from "./consts.js";
+export {default as KeyConfigs} from "./data/key-configs.js";
 
 import * as CursorContexts from "./components/input/cursor-contexts.js";
 


### PR DESCRIPTION
## Summary:

As it says on the title, just exporting more types needed by clients.

Issue: "none"

## Test plan: