### PR TITLE
Remove old margin from definition body (Popover manages that now)

### DIFF
--- a/.changeset/thick-lizards-care.md
+++ b/.changeset/thick-lizards-care.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix: remove gap between popover and popover anchor in definition widget

--- a/packages/perseus/src/widgets/definition.jsx
+++ b/packages/perseus/src/widgets/definition.jsx
@@ -88,11 +88,9 @@ class Definition extends React.Component<DefinitionProps> {
 const styles = {
     tooltipBody: {
         color: Color.offBlack,
-        display: "block",
         fontSize: 20,
         fontWeight: 500,
         lineHeight: "30px",
-        margin: Spacing.xSmall_8,
     },
 };
 

--- a/packages/perseus/src/widgets/definition.jsx
+++ b/packages/perseus/src/widgets/definition.jsx
@@ -3,7 +3,6 @@
 import Button from "@khanacademy/wonder-blocks-button";
 import Color from "@khanacademy/wonder-blocks-color";
 import {Popover, PopoverContentCore} from "@khanacademy/wonder-blocks-popover";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
 import * as React from "react";
 
 import Renderer from "../renderer.jsx";
@@ -91,7 +90,6 @@ const styles = {
         fontSize: 20,
         fontWeight: 500,
         lineHeight: "30px",
-        margin: Spacing.xSmall_8,
     },
 };
 

--- a/packages/perseus/src/widgets/definition.jsx
+++ b/packages/perseus/src/widgets/definition.jsx
@@ -91,6 +91,7 @@ const styles = {
         fontSize: 20,
         fontWeight: 500,
         lineHeight: "30px",
+        margin: Spacing.xSmall_8,
     },
 };
 


### PR DESCRIPTION
## Summary:

Now that we're using the WonderBlocks Popover widget, we don't need to manually add `margin` to the body. Leaving it in causes the popover anchor arrow to have a gap between it and the actual popopver. (see screenshots)

| Before | After |
|---|---|
| <img width="300" alt="image" src="https://user-images.githubusercontent.com/77138/172737080-e15a867f-a98d-4d51-892c-6c15def4f2a0.png">|<img width="300" alt="image" src="https://user-images.githubusercontent.com/77138/172737047-f9e7f899-98cf-47fb-a6fe-8a55cf7fe98b.png">| 


Issue: MOB-4532

## Test plan:

Run storybook: `yarn storybook`
Navigate: **Perseus** >> **Widgets** >> **Definition** >> **Question 1**
Tap on one of the definitions. 
Note that the anchor is attached to the popover (no gap)