### PR TITLE
Remove isPhone and isTablet keys in dependencies.

### DIFF
--- a/.changeset/nine-elephants-call.md
+++ b/.changeset/nine-elephants-call.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Remove `isPhone` and `isTablet` from `PerseusDependencies`

--- a/packages/perseus/src/types.js
+++ b/packages/perseus/src/types.js
@@ -404,9 +404,7 @@ export type PerseusDependencies = {|
     // RequestInfo
     isDevServer: boolean,
     kaLocale: string,
-    isPhone: boolean,
     isMobile: boolean,
-    isTablet: boolean,
 |};
 
 export type APIOptionsWithDefaults = $ReadOnly<{|

--- a/testing/test-dependencies.js
+++ b/testing/test-dependencies.js
@@ -113,9 +113,7 @@ export const testDependencies: PerseusDependencies = {
 
     isDevServer: false,
     kaLocale: "en",
-    isPhone: false,
     isMobile: false,
-    isTablet: false,
 
     Log: LogForTesting,
 };


### PR DESCRIPTION
## Summary:

It turns out that we don't ever use these in Perseus, so I'm removing them.

Issue: "none"

## Test plan:

✅ `yarn flow`
✅ `yarn test`
✅ `yarn build`