### PR TITLE
Only show 1 definition at a time

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -11,17 +11,7 @@ Dependencies.setDependencies(storybookTestDependencies);
 
 // These decorators apply to all stories, both inside and outside the fixture
 // framework.
-export const decorators = [
-    // We need to wrap each story to ensure that things look like AppShell and
-    // have the basics such as a router and GraphQL mocking.
-    // This also ensures that page display changes and route changes
-    // get logged instead of actually doing work.
-    (Story, context) => (
-        <RenderStateRoot>
-            <Story />
-        </RenderStateRoot>
-    ),
-];
+export const decorators = [];
 
 // These parameters apply to all stories, both inside and outside the fixture
 // framework.

--- a/packages/perseus/src/widgets/__stories__/definition.stories.jsx
+++ b/packages/perseus/src/widgets/__stories__/definition.stories.jsx
@@ -31,8 +31,52 @@ const question1 = {
     },
 };
 
+const question2 = {
+    content:
+        "Read the excerpt and answer the question below. \n\nThe [[\u2603 definition 2]] and Council of the Massachusetts had much conference many days; and at last . . . . concluded a peace and friendship with [[\u2603 definition 1]], upon these conditions.",
+    images: {},
+    widgets: {
+        "definition 1": {
+            graded: true,
+            version: {
+                major: 0,
+                minor: 0,
+            },
+            static: false,
+            type: "definition",
+            options: {
+                definition:
+                    "A Native American people in Connecticut; white settlers in New England, the Pequots, and their respective allies were at war from 1636-1638.",
+                togglePrompt: "the Pequots",
+                static: false,
+            },
+            alignment: "default",
+        },
+        "definition 2": {
+            graded: true,
+            version: {
+                major: 0,
+                minor: 0,
+            },
+            static: false,
+            type: "definition",
+            options: {
+                definition:
+                    "A governor is an administrative leader and head of a polity or political region, ranking under the head of state and in some cases, such as governors-general, as the head of state's official representative.",
+                togglePrompt: "Governor",
+                static: false,
+            },
+            alignment: "default",
+        },
+    },
+};
+
 type StoryArgs = {||};
 
 export const Question1 = (args: StoryArgs): React.Node => {
     return <RendererWithDebugUI question={question1} />;
+};
+
+export const MultipleDefintions = (args: StoryArgs): React.Node => {
+    return <RendererWithDebugUI question={question2} />;
 };

--- a/packages/perseus/src/widgets/definition.jsx
+++ b/packages/perseus/src/widgets/definition.jsx
@@ -24,11 +24,9 @@ type DefinitionProps = {|
     widgets: PerseusRenderer["widgets"],
 |};
 
-type DefintionState = {|
-    popoverOpen: boolean,
-|};
+var activeDefinitionPopover: string | null = null;
 
-class Definition extends React.Component<DefinitionProps, DefintionState> {
+class Definition extends React.Component<DefinitionProps> {
     static defaultProps: $FlowFixMe = {
         togglePrompt: "define me",
         definition: "definition goes here",
@@ -43,11 +41,6 @@ class Definition extends React.Component<DefinitionProps, DefintionState> {
         };
     }
 
-    constructor(props: DefinitionProps) {
-        super(props);
-        this.state = {popoverOpen: false};
-    }
-
     getUserInput: () => UserInput = () => {
         return {};
     };
@@ -59,9 +52,10 @@ class Definition extends React.Component<DefinitionProps, DefintionState> {
     render(): React.Node {
         return (
             <Popover
-                opened={this.state.popoverOpen}
+                opened={activeDefinitionPopover == this.props.widgetId}
                 onClose={() => {
-                    this.setState({popoverOpen: false});
+                    activeDefinitionPopover = null;
+                    this.forceUpdate();
                 }}
                 content={
                     <PopoverContentCore
@@ -85,7 +79,8 @@ class Definition extends React.Component<DefinitionProps, DefintionState> {
                             kind="tertiary"
                             onClick={() => {
                                 this.props.trackInteraction();
-                                this.setState({popoverOpen: true});
+                                activeDefinitionPopover = this.props.widgetId;
+                                this.forceUpdate();
                             }}
                         >
                             {this.props.togglePrompt}

--- a/packages/perseus/src/widgets/definition.jsx
+++ b/packages/perseus/src/widgets/definition.jsx
@@ -24,7 +24,11 @@ type DefinitionProps = {|
     widgets: PerseusRenderer["widgets"],
 |};
 
-class Definition extends React.Component<DefinitionProps> {
+type DefintionState = {|
+    popoverOpen: boolean,
+|};
+
+class Definition extends React.Component<DefinitionProps, DefintionState> {
     static defaultProps: $FlowFixMe = {
         togglePrompt: "define me",
         definition: "definition goes here",
@@ -39,6 +43,11 @@ class Definition extends React.Component<DefinitionProps> {
         };
     }
 
+    constructor(props: DefinitionProps) {
+        super(props);
+        this.state = {popoverOpen: false};
+    }
+
     getUserInput: () => UserInput = () => {
         return {};
     };
@@ -50,6 +59,10 @@ class Definition extends React.Component<DefinitionProps> {
     render(): React.Node {
         return (
             <Popover
+                opened={this.state.popoverOpen}
+                onClose={() => {
+                    this.setState({popoverOpen: false});
+                }}
                 content={
                     <PopoverContentCore
                         color="white"
@@ -72,7 +85,7 @@ class Definition extends React.Component<DefinitionProps> {
                             kind="tertiary"
                             onClick={() => {
                                 this.props.trackInteraction();
-                                open();
+                                this.setState({popoverOpen: true});
                             }}
                         >
                             {this.props.togglePrompt}


### PR DESCRIPTION
## Summary:
Fixes up defintion widget by only showing 1 widget at a time.

Issue: https://khanacademy.atlassian.net/browse/MOB-4547

## Test plan:
- Go to the storybook page with multiple defintions
- Open one
- Open the other
- **The first one should close when the second one opens**