### PR TITLE
Remove unused JIPT.domInsertChecks

### DIFF
--- a/.changeset/pink-houses-build.md
+++ b/.changeset/pink-houses-build.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Remove JIPT.domInsertChecks from `PerseusDependencies` as its no longer used/needed by Perseus

--- a/packages/perseus/src/types.js
+++ b/packages/perseus/src/types.js
@@ -319,8 +319,6 @@ export type DomInsertCheckFn = (
 
 export type JIPT = {|
     useJIPT: boolean,
-    // eslint-disable-next-line ft-flow/no-mutable-array
-    domInsertChecks: Array<DomInsertCheckFn>,
 |};
 
 export type JiptLabelStore = {|

--- a/packages/perseus/src/widgets/__tests__/graded-group-set-jipt_test.jsx
+++ b/packages/perseus/src/widgets/__tests__/graded-group-set-jipt_test.jsx
@@ -18,7 +18,6 @@ describe("graded-group-set", () => {
             ...testDependencies,
             JIPT: {
                 useJIPT: true,
-                domInsertChecks: [],
             },
         });
     });

--- a/testing/test-dependencies.js
+++ b/testing/test-dependencies.js
@@ -24,7 +24,6 @@ const LogForTesting: ILogger = {
 export const testDependencies: PerseusDependencies = {
     // JIPT
     JIPT: {
-        domInsertChecks: [],
         useJIPT: false,
     },
     graphieMovablesJiptLabels: {


### PR DESCRIPTION
## Summary:

I noticed that the `domInsertChecks` are not used at all in our Perseus code today, except for setting dummy values for tests. Removing it to trim down our Perseus dependencies where we can. 

Issue: "none"

## Test plan:

`yarn test`
`yarn flow`