### PR TITLE
Fix: Numbers display doubled on BT keyboard

### DIFF
--- a/packages/math-input/src/__stories__/main.stories.jsx
+++ b/packages/math-input/src/__stories__/main.stories.jsx
@@ -1,0 +1,15 @@
+// @flow
+import * as React from "react";
+import App from "../components/app.js";
+
+import "../../less/main.less";
+
+export default {
+    title: "Math Input/test",
+};
+
+type StoryArgs = {||};
+
+export const SampleApp = (args: StoryArgs): React.Node => {
+    return <App />;
+};

--- a/packages/math-input/src/__stories__/main.stories.jsx
+++ b/packages/math-input/src/__stories__/main.stories.jsx
@@ -5,7 +5,7 @@ import App from "../components/app.js";
 import "../../less/main.less";
 
 export default {
-    title: "Math Input/test",
+    title: "Math Input/integration test",
 };
 
 type StoryArgs = {||};

--- a/packages/math-input/src/components/input/__stories__/math-input.stories.jsx
+++ b/packages/math-input/src/components/input/__stories__/math-input.stories.jsx
@@ -13,6 +13,7 @@ export const Test = (args: StoryArgs): React.Node => {
     return (
         <MathInput
             onFocus={action("focused")}
+            onFocus={action("blurred")}
             onChange={action("changed")}
             keypadElement={{
                 activate: () => {},

--- a/packages/math-input/src/components/input/__stories__/math-input.stories.jsx
+++ b/packages/math-input/src/components/input/__stories__/math-input.stories.jsx
@@ -1,0 +1,29 @@
+// @flow
+import * as React from "react";
+import {action} from "@storybook/addon-actions";
+import MathInput from "../math-input";
+
+export default {
+    title: "Math Input/Components/Math-Input",
+};
+
+type StoryArgs = {||};
+
+export const Test = (args: StoryArgs): React.Node => {
+    return (
+        <MathInput
+            onFocus={action("focused")}
+            onChange={action("changed")}
+            keypadElement={{
+                activate: () => {},
+                dismiss: () => {},
+                // eslint-disable-next-line no-console
+                configure: (config) => console.log("configure:", config),
+                // eslint-disable-next-line no-console
+                setCursor: (cursor) => console.log("Cursor:", cursor),
+                setKeyHandler: (handler) => {},
+                getDOMNode: () => null,
+            }}
+        />
+    );
+};

--- a/packages/math-input/src/components/input/math-input.js
+++ b/packages/math-input/src/components/input/math-input.js
@@ -1,3 +1,5 @@
+// TODO: Is this file even used????
+
 import Color from "@khanacademy/wonder-blocks-color";
 import * as i18n from "@khanacademy/wonder-blocks-i18n";
 import {StyleSheet} from "aphrodite";
@@ -316,6 +318,7 @@ class MathInput extends React.Component {
         // Pass this component's handleKey method to the keypad so it can call
         // it whenever it needs to trigger a keypress action.
         this.props.keypadElement.setKeyHandler((key) => {
+            // TODO: I think the problem is here
             const cursor = this.mathField.pressKey(key);
 
             // Trigger an `onChange` if the value in the input changed, and hide
@@ -753,6 +756,9 @@ class MathInput extends React.Component {
     };
 
     handleKeyUp = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+
         const mathQuillKey = this.domKeyToMathQuillKey(event.key);
 
         if (mathQuillKey) {
@@ -768,6 +774,8 @@ class MathInput extends React.Component {
                 this._hideCursorHandle();
             }
         }
+
+        return false;
     };
 
     getBorderWidthPx = () => {
@@ -847,6 +855,12 @@ class MathInput extends React.Component {
                     tabIndex={"0"}
                     ref={(node) => {
                         this.inputRef = node;
+                    }}
+                    onKeyDown={(event) => {
+                        // TODO(Nicole): WHY IS THIS NECESSARY???????????
+                        event.stopPropagation();
+                        event.preventDefault();
+                        return false;
                     }}
                     onKeyUp={this.handleKeyUp}
                 >

--- a/packages/math-input/src/components/input/math-input.js
+++ b/packages/math-input/src/components/input/math-input.js
@@ -1,5 +1,3 @@
-// TODO: Is this file even used????
-
 import Color from "@khanacademy/wonder-blocks-color";
 import * as i18n from "@khanacademy/wonder-blocks-i18n";
 import {StyleSheet} from "aphrodite";
@@ -318,7 +316,6 @@ class MathInput extends React.Component {
         // Pass this component's handleKey method to the keypad so it can call
         // it whenever it needs to trigger a keypress action.
         this.props.keypadElement.setKeyHandler((key) => {
-            // TODO: I think the problem is here
             const cursor = this.mathField.pressKey(key);
 
             // Trigger an `onChange` if the value in the input changed, and hide
@@ -763,19 +760,19 @@ class MathInput extends React.Component {
 
         if (mathQuillKey) {
             this.mathField.pressKey(mathQuillKey);
+            this.props.onChange(value, false);
 
-            // TODO(diedra): If the new value being added is off-screen to the right
-            // due to the max-width of the text box, scroll the box to show the newest
-            // value
-            const value = this.mathField.getContent();
-            if (this.props.value !== value) {
-                this.mathField.setContent(this.props.value);
-                this.props.onChange(value, false);
-                this._hideCursorHandle();
-            }
+            // TODO(Nicole): Commenting this out "fixes" thigns
+            // // TODO(diedra): If the new value being added is off-screen to the right
+            // // due to the max-width of the text box, scroll the box to show the newest
+            // // value
+            // const value = this.mathField.getContent();
+            // if (this.props.value !== value) {
+            //     this.mathField.setContent(this.props.value);
+            //     this.props.onChange(value, false);
+            //     this._hideCursorHandle();
+            // }
         }
-
-        return false;
     };
 
     getBorderWidthPx = () => {

--- a/packages/math-input/src/components/input/math-wrapper.js
+++ b/packages/math-input/src/components/input/math-wrapper.js
@@ -4,6 +4,8 @@
  * from MathQuill changes.
  */
 
+// TODO ACTUALLY THE PROBLEM IS HERE MAYBE? 2
+
 import $ from "jquery";
 import MathQuill from "mathquill";
 

--- a/packages/math-input/src/demo.js
+++ b/packages/math-input/src/demo.js
@@ -1,8 +1,0 @@
-import * as React from "react";
-import ReactDOM from "react-dom";
-
-import App from "./components/app.js";
-
-import "../less/main.less";
-
-ReactDOM.render(<App />, document.getElementById("root"));


### PR DESCRIPTION
## Summary:

Fixes Numbers display doubled when entered using a bluetooth keyboard in All Numeric Input Fields on touch devices.

Issue: https://khanacademy.atlassian.net/browse/MOB-4592

## Test plan:
- Open an exercise on a touch device
- Enter number 123
- **You should see 123 and not 112233**