### PR TITLE
Only show 1 definition at a time

### DIFF
--- a/.changeset/bright-mayflies-remain.md
+++ b/.changeset/bright-mayflies-remain.md
@@ -1,13 +1,5 @@
 ---
-"perseus-build-settings": patch
-"@khanacademy/kas": patch
-"@khanacademy/kmath": patch
-"@khanacademy/math-input": patch
-"@khanacademy/perseus-editor": patch
-"@khanacademy/perseus-error": patch
-"@khanacademy/perseus-linter": patch
-"@khanacademy/pure-markdown": patch
-"@khanacademy/simple-markdown": patch
+"@khanacademy/perseus": minor
 ---
 
 Fix bug: 2 definitions displayed at once

--- a/.changeset/bright-mayflies-remain.md
+++ b/.changeset/bright-mayflies-remain.md
@@ -1,0 +1,13 @@
+---
+"perseus-build-settings": patch
+"@khanacademy/kas": patch
+"@khanacademy/kmath": patch
+"@khanacademy/math-input": patch
+"@khanacademy/perseus-editor": patch
+"@khanacademy/perseus-error": patch
+"@khanacademy/perseus-linter": patch
+"@khanacademy/pure-markdown": patch
+"@khanacademy/simple-markdown": patch
+---
+
+Fix bug: 2 definitions displayed at once

--- a/packages/perseus/src/definition-context.js
+++ b/packages/perseus/src/definition-context.js
@@ -4,17 +4,56 @@
  */
 
 import * as React from "react";
+import type {Context} from "react";
 
-type Context = {
+type DefintionContext = {
     activeDefinitionId: ?string,
     setActiveDefinitionId: (string) => void,
 };
 
-const defaultContext: Context = {
+const defaultContext: DefintionContext = {
     activeDefinitionId: null,
     setActiveDefinitionId: () => {},
 };
 
-const context: React.Context<Context> = React.createContext(defaultContext);
+const DefinitionContext: React.Context<DefintionContext> =
+    React.createContext(defaultContext);
 
-export default context;
+type ProviderState = {
+    activeDefinitionId: ?string,
+};
+
+export type ProviderProps = {|children: any|};
+export class DefinitionProvider extends React.Component<
+    ProviderProps,
+    ProviderState,
+> {
+    // Context state
+    state: ProviderState = {
+        activeDefinitionId: null,
+    };
+
+    // Method to update state
+    setActiveDefinitionId = (activeDefinitionId: ?string) => {
+        this.setState((prevState: ProviderState) => ({activeDefinitionId}));
+    };
+
+    render(): React.Node {
+        const {children} = this.props;
+        const {activeDefinitionId} = this.state;
+        const {setActiveDefinitionId} = this;
+
+        return (
+            <DefinitionContext.Provider
+                value={{
+                    activeDefinitionId,
+                    setActiveDefinitionId,
+                }}
+            >
+                {children}
+            </DefinitionContext.Provider>
+        );
+    }
+}
+
+export const DefinitionConsumer = DefinitionContext.Consumer;

--- a/packages/perseus/src/definition-context.js
+++ b/packages/perseus/src/definition-context.js
@@ -4,7 +4,6 @@
  */
 
 import * as React from "react";
-import type {Context} from "react";
 
 type DefintionContext = {
     activeDefinitionId: ?string,

--- a/packages/perseus/src/definition-context.js
+++ b/packages/perseus/src/definition-context.js
@@ -1,0 +1,20 @@
+// @flow
+/**
+ * A React context for ensuring there is one and only one definition showing at a time
+ */
+
+import * as React from "react";
+
+type Context = {
+    activeDefinitionId: ?string,
+    setActiveDefinitionId: (string) => void,
+};
+
+const defaultContext: Context = {
+    activeDefinitionId: null,
+    setActiveDefinitionId: () => {},
+};
+
+const context: React.Context<Context> = React.createContext(defaultContext);
+
+export default context;

--- a/packages/perseus/src/definition-context.js
+++ b/packages/perseus/src/definition-context.js
@@ -8,7 +8,7 @@ import type {Context} from "react";
 
 type DefintionContext = {
     activeDefinitionId: ?string,
-    setActiveDefinitionId: (string) => void,
+    setActiveDefinitionId: (?string) => void,
 };
 
 const defaultContext: DefintionContext = {
@@ -34,7 +34,7 @@ export class DefinitionProvider extends React.Component<
     };
 
     // Method to update state
-    setActiveDefinitionId = (activeDefinitionId: ?string) => {
+    setActiveDefinitionId = (activeDefinitionId: ?string): void => {
         this.setState((prevState: ProviderState) => ({activeDefinitionId}));
     };
 

--- a/packages/perseus/src/definition-context.js
+++ b/packages/perseus/src/definition-context.js
@@ -5,10 +5,10 @@
 
 import * as React from "react";
 
-type DefintionContext = {
+type DefintionContext = {|
     activeDefinitionId: ?string,
     setActiveDefinitionId: (?string) => void,
-};
+|};
 
 const defaultContext: DefintionContext = {
     activeDefinitionId: null,

--- a/packages/perseus/src/definition-context.js
+++ b/packages/perseus/src/definition-context.js
@@ -33,6 +33,7 @@ export class DefinitionProvider extends React.Component<
     };
 
     // Method to update state
+    // $FlowFixMe[signature-verification-failure]
     setActiveDefinitionId = (activeDefinitionId: ?string): void => {
         this.setState((prevState: ProviderState) => ({activeDefinitionId}));
     };

--- a/packages/perseus/src/renderer.jsx
+++ b/packages/perseus/src/renderer.jsx
@@ -12,6 +12,7 @@ import SvgImage from "./components/svg-image.jsx";
 import TeX from "./components/tex.jsx";
 import ZoomableTeX from "./components/zoomable-tex.jsx";
 import Zoomable from "./components/zoomable.jsx";
+import {DefinitionProvider} from "./definition-context.js";
 import {getDependencies} from "./dependencies.js";
 import ErrorBoundary from "./error-boundary.jsx";
 import InteractionTracker from "./interaction-tracker.js";
@@ -27,7 +28,6 @@ import Util from "./util.js";
 import preprocessTex from "./util/katex-preprocess.js";
 import WidgetContainer from "./widget-container.jsx";
 import * as Widgets from "./widgets.js";
-import {DefinitionProvider} from "./definition-context.js";
 
 import type {PerseusRenderer, PerseusWidgetOptions} from "./perseus-types.js";
 import type {

--- a/packages/perseus/src/renderer.jsx
+++ b/packages/perseus/src/renderer.jsx
@@ -27,6 +27,7 @@ import Util from "./util.js";
 import preprocessTex from "./util/katex-preprocess.js";
 import WidgetContainer from "./widget-container.jsx";
 import * as Widgets from "./widgets.js";
+import DefinitionContext from "./definition-context.js";
 
 import type {PerseusRenderer, PerseusWidgetOptions} from "./perseus-types.js";
 import type {
@@ -175,6 +176,7 @@ type State = {|
     widgetProps: $ReadOnly<{|[id: string]: ?$FlowFixMe|}>,
     jiptContent: any,
     lastUsedWidgetId: ?string,
+    definitionPopoverId: ?string,
 |};
 
 type Context = {
@@ -252,6 +254,8 @@ class Renderer extends React.Component<Props, State> {
             // use this to set the `isLastUsedWidget` flag on the
             // corresponding widget.
             lastUsedWidgetId: null,
+
+            definitionPopoverId: null,
 
             ...this._getInitialWidgetState(props),
         };
@@ -1792,6 +1796,13 @@ class Renderer extends React.Component<Props, State> {
             });
         };
 
+    setActiveDefinitionId: (definitionPopoverId: string) => void = (
+        definitionPopoverId,
+    ) => {
+        this.setState({definitionPopoverId: definitionPopoverId});
+        console.log(this.state.definitionPopoverId);
+    };
+
     render(): React.Node {
         const apiOptions = this.getApiOptions();
         const {KatexProvider} = getDependencies();
@@ -1843,11 +1854,22 @@ class Renderer extends React.Component<Props, State> {
                 // this attribute and render the text with markdown.
                 return (
                     <KatexProvider>
-                        <div
-                            data-perseus-component-index={this.translationIndex}
+                        <DefinitionContext.Provider
+                            value={{
+                                activeDefinitionId:
+                                    this.state.definitionPopoverId,
+                                setActiveDefinitionId:
+                                    this.setActiveDefinitionId,
+                            }}
                         >
-                            {content}
-                        </div>
+                            <div
+                                data-perseus-component-index={
+                                    this.translationIndex
+                                }
+                            >
+                                {content}
+                            </div>
+                        </DefinitionContext.Provider>
                     </KatexProvider>
                 );
             }
@@ -1907,7 +1929,14 @@ class Renderer extends React.Component<Props, State> {
 
         this.lastRenderedMarkdown = (
             <KatexProvider>
-                <div className={className}>{markdownContents}</div>
+                <DefinitionContext.Provider
+                    value={{
+                        activeDefinitionId: this.state.definitionPopoverId,
+                        setActiveDefinitionId: this.setActiveDefinitionId,
+                    }}
+                >
+                    <div className={className}>{markdownContents}</div>
+                </DefinitionContext.Provider>
             </KatexProvider>
         );
         return this.lastRenderedMarkdown;

--- a/packages/perseus/src/renderer.jsx
+++ b/packages/perseus/src/renderer.jsx
@@ -27,7 +27,7 @@ import Util from "./util.js";
 import preprocessTex from "./util/katex-preprocess.js";
 import WidgetContainer from "./widget-container.jsx";
 import * as Widgets from "./widgets.js";
-import DefinitionContext from "./definition-context.js";
+import {DefinitionProvider} from "./definition-context.js";
 
 import type {PerseusRenderer, PerseusWidgetOptions} from "./perseus-types.js";
 import type {
@@ -176,7 +176,6 @@ type State = {|
     widgetProps: $ReadOnly<{|[id: string]: ?$FlowFixMe|}>,
     jiptContent: any,
     lastUsedWidgetId: ?string,
-    definitionPopoverId: ?string,
 |};
 
 type Context = {
@@ -254,8 +253,6 @@ class Renderer extends React.Component<Props, State> {
             // use this to set the `isLastUsedWidget` flag on the
             // corresponding widget.
             lastUsedWidgetId: null,
-
-            definitionPopoverId: null,
 
             ...this._getInitialWidgetState(props),
         };
@@ -1796,13 +1793,6 @@ class Renderer extends React.Component<Props, State> {
             });
         };
 
-    setActiveDefinitionId: (definitionPopoverId: string) => void = (
-        definitionPopoverId,
-    ) => {
-        this.setState({definitionPopoverId: definitionPopoverId});
-        console.log(this.state.definitionPopoverId);
-    };
-
     render(): React.Node {
         const apiOptions = this.getApiOptions();
         const {KatexProvider} = getDependencies();
@@ -1854,14 +1844,7 @@ class Renderer extends React.Component<Props, State> {
                 // this attribute and render the text with markdown.
                 return (
                     <KatexProvider>
-                        <DefinitionContext.Provider
-                            value={{
-                                activeDefinitionId:
-                                    this.state.definitionPopoverId,
-                                setActiveDefinitionId:
-                                    this.setActiveDefinitionId,
-                            }}
-                        >
+                        <DefinitionProvider>
                             <div
                                 data-perseus-component-index={
                                     this.translationIndex
@@ -1869,7 +1852,7 @@ class Renderer extends React.Component<Props, State> {
                             >
                                 {content}
                             </div>
-                        </DefinitionContext.Provider>
+                        </DefinitionProvider>
                     </KatexProvider>
                 );
             }
@@ -1929,14 +1912,9 @@ class Renderer extends React.Component<Props, State> {
 
         this.lastRenderedMarkdown = (
             <KatexProvider>
-                <DefinitionContext.Provider
-                    value={{
-                        activeDefinitionId: this.state.definitionPopoverId,
-                        setActiveDefinitionId: this.setActiveDefinitionId,
-                    }}
-                >
+                <DefinitionProvider>
                     <div className={className}>{markdownContents}</div>
-                </DefinitionContext.Provider>
+                </DefinitionProvider>
             </KatexProvider>
         );
         return this.lastRenderedMarkdown;

--- a/packages/perseus/src/widgets/definition.jsx
+++ b/packages/perseus/src/widgets/definition.jsx
@@ -6,6 +6,7 @@ import {Popover, PopoverContentCore} from "@khanacademy/wonder-blocks-popover";
 import * as React from "react";
 
 import Renderer from "../renderer.jsx";
+import DefinitionContext from "../definition-context.js";
 
 import type {
     PerseusRenderer,
@@ -49,37 +50,45 @@ class Definition extends React.Component<DefinitionProps> {
 
     render(): React.Node {
         return (
-            <Popover
-                content={
-                    <PopoverContentCore
-                        color="white"
-                        style={styles.tooltipBody}
-                        closeButtonVisible={true}
+            <DefinitionContext.Consumer>
+                {({activeDefinitionId, setActiveDefinitionId}) => (
+                    <Popover
+                        content={
+                            <PopoverContentCore
+                                color="white"
+                                style={styles.tooltipBody}
+                                closeButtonVisible={true}
+                            >
+                                <Renderer
+                                    apiOptions={this.props.apiOptions}
+                                    content={this.props.definition}
+                                    widgets={this.props.widgets}
+                                />
+                            </PopoverContentCore>
+                        }
+                        opened={activeDefinitionId == this.props.widgetId}
+                        placement="top"
                     >
-                        <Renderer
-                            apiOptions={this.props.apiOptions}
-                            content={this.props.definition}
-                            widgets={this.props.widgets}
-                        />
-                    </PopoverContentCore>
-                }
-                placement="top"
-            >
-                {({open}) => (
-                    <span className="perseus-widget-definition">
-                        <Button
-                            size="small"
-                            kind="tertiary"
-                            onClick={() => {
-                                this.props.trackInteraction();
-                                open();
-                            }}
-                        >
-                            {this.props.togglePrompt}
-                        </Button>
-                    </span>
+                        {({open}) => (
+                            <span className="perseus-widget-definition">
+                                <Button
+                                    size="small"
+                                    kind="tertiary"
+                                    onClick={() => {
+                                        this.props.trackInteraction();
+                                        setActiveDefinitionId(
+                                            this.props.widgetId,
+                                        );
+                                        console.log(activeDefinitionId);
+                                    }}
+                                >
+                                    {this.props.togglePrompt}
+                                </Button>
+                            </span>
+                        )}
+                    </Popover>
                 )}
-            </Popover>
+            </DefinitionContext.Consumer>
         );
     }
 }

--- a/packages/perseus/src/widgets/definition.jsx
+++ b/packages/perseus/src/widgets/definition.jsx
@@ -6,7 +6,7 @@ import {Popover, PopoverContentCore} from "@khanacademy/wonder-blocks-popover";
 import * as React from "react";
 
 import Renderer from "../renderer.jsx";
-import DefinitionContext from "../definition-context.js";
+import {DefinitionConsumer} from "../definition-context.js";
 
 import type {
     PerseusRenderer,
@@ -50,7 +50,7 @@ class Definition extends React.Component<DefinitionProps> {
 
     render(): React.Node {
         return (
-            <DefinitionContext.Consumer>
+            <DefinitionConsumer>
                 {({activeDefinitionId, setActiveDefinitionId}) => (
                     <Popover
                         content={
@@ -67,28 +67,24 @@ class Definition extends React.Component<DefinitionProps> {
                             </PopoverContentCore>
                         }
                         opened={activeDefinitionId == this.props.widgetId}
+                        onClose={() => setActiveDefinitionId(null)}
                         placement="top"
                     >
-                        {({open}) => (
-                            <span className="perseus-widget-definition">
-                                <Button
-                                    size="small"
-                                    kind="tertiary"
-                                    onClick={() => {
-                                        this.props.trackInteraction();
-                                        setActiveDefinitionId(
-                                            this.props.widgetId,
-                                        );
-                                        console.log(activeDefinitionId);
-                                    }}
-                                >
-                                    {this.props.togglePrompt}
-                                </Button>
-                            </span>
-                        )}
+                        <span className="perseus-widget-definition">
+                            <Button
+                                size="small"
+                                kind="tertiary"
+                                onClick={() => {
+                                    this.props.trackInteraction();
+                                    setActiveDefinitionId(this.props.widgetId);
+                                }}
+                            >
+                                {this.props.togglePrompt}
+                            </Button>
+                        </span>
                     </Popover>
                 )}
-            </DefinitionContext.Consumer>
+            </DefinitionConsumer>
         );
     }
 }

--- a/packages/perseus/src/widgets/definition.jsx
+++ b/packages/perseus/src/widgets/definition.jsx
@@ -5,8 +5,8 @@ import Color from "@khanacademy/wonder-blocks-color";
 import {Popover, PopoverContentCore} from "@khanacademy/wonder-blocks-popover";
 import * as React from "react";
 
-import Renderer from "../renderer.jsx";
 import {DefinitionConsumer} from "../definition-context.js";
+import Renderer from "../renderer.jsx";
 
 import type {
     PerseusRenderer,
@@ -66,7 +66,7 @@ class Definition extends React.Component<DefinitionProps> {
                                 />
                             </PopoverContentCore>
                         }
-                        opened={activeDefinitionId == this.props.widgetId}
+                        opened={activeDefinitionId === this.props.widgetId}
                         onClose={() => setActiveDefinitionId(null)}
                         placement="top"
                     >


### PR DESCRIPTION
## Summary:
Use React contexts to only show 1 definition at a time.

Issue: https://khanacademy.atlassian.net/browse/MOB-4547

## Test plan:
- Open the storybook page with multiple definitions
- Open 1 definition
- Click the second definition
- **The first definition should automatically close**