### PR TITLE
removes unused function from numeric-input.jsx named getClasses

### DIFF
--- a/.changeset/moody-mirrors-clean.md
+++ b/.changeset/moody-mirrors-clean.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+removes unused function from numeric-input.jsx named getClasses

--- a/packages/perseus/src/widgets/numeric-input.jsx
+++ b/packages/perseus/src/widgets/numeric-input.jsx
@@ -10,7 +10,7 @@ import _ from "underscore";
 import InputWithExamples from "../components/input-with-examples.jsx";
 import PossibleAnswers from "../components/possible-answers.jsx";
 import SimpleKeypadInput from "../components/simple-keypad-input.jsx";
-import {ApiOptions, ClassNames as ApiClassNames} from "../perseus-api.jsx";
+import {ApiOptions} from "../perseus-api.jsx";
 import TexWrangler from "../tex-wrangler.js";
 import KhanAnswerTypes from "../util/answer-types.js";
 import KhanMath from "../util/math.js";
@@ -290,18 +290,6 @@ export class NumericInput extends React.Component<Props, State> {
             }
         }
         return [answerBlurb, !!correct];
-    };
-
-    getClasses: (boolean, $FlowFixMe) => $FlowFixMe = (correct, rubric) => {
-        const classes = {};
-        classes["perseus-input-size-" + this.props.size] = true;
-        classes["perseus-input-right-align"] = this.props.rightAlign;
-        classes[ApiClassNames.CORRECT] =
-            rubric && correct && this.props.currentValue;
-        classes[ApiClassNames.INCORRECT] =
-            rubric && !correct && this.props.currentValue;
-        classes[ApiClassNames.UNANSWERED] = rubric && !this.props.currentValue;
-        return classes;
     };
 
     // TODO(Nicole, Jeremy): This is maybe never used and should be removed


### PR DESCRIPTION
## Summary:
Found an unused function in numeric-input.jsx called getClasses. This specific function was not used in Perseus or webapp. Removed it to practice doing a PR.

Issue: none

## Test plan:
Load the numeric input. Verify it looks correct. 