### PR TITLE
Inline mathquill.css in math-input's main.less

### DIFF
--- a/.changeset/yellow-cherries-pay.md
+++ b/.changeset/yellow-cherries-pay.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": minor
+---
+
+Inline the import of mathquill.css in math-input's main.less

--- a/packages/math-input/less/main.less
+++ b/packages/math-input/less/main.less
@@ -1,5 +1,5 @@
 @import "./echo.less";
 @import "./overrides.less";
 @import "./popover.less";
-@import "../../../node_modules/mathquill/build/mathquill.css";
+@import (inline) "../../../node_modules/mathquill/build/mathquill.css";
 @import "./tabbar.less";


### PR DESCRIPTION
## Summary:
We were seeing '@import' statements in built .css files which was causing some of the tooling in webapp to break since imports aren't a thing in CSS.  This PR fixes the issue by inlining MathQuill CSS in main.less.

Issue: None

## Test plan:
- yarn build
- verify that dist/index.css for math-input and perseus packages no longer contains '@import'