### PR TITLE
radio widget fix where multi-select options cannot be deselected 

### DIFF
--- a/.changeset/tough-kids-itch.md
+++ b/.changeset/tough-kids-itch.md
@@ -2,4 +2,4 @@
 "@khanacademy/perseus": patch
 ---
 
-The Clickable component in choice.jsx now toggles the checked prop on click to allow deselecting choices; also adds unit test for this and for single select widgets.
+fixes a bug in the multiselect radio widget to allow selected choices to be unselected

--- a/.changeset/tough-kids-itch.md
+++ b/.changeset/tough-kids-itch.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+The Clickable component in choice.jsx now toggles the checked prop on click to allow deselecting choices; also adds unit test for this and for single select widgets.

--- a/packages/perseus/src/widgets/__tests__/radio/base-radio_test.jsx
+++ b/packages/perseus/src/widgets/__tests__/radio/base-radio_test.jsx
@@ -71,7 +71,9 @@ describe("base-radio", () => {
             );
 
             // Act
-            userEvent.click(screen.getByText("(Choice C)", {selector: "div"}));
+            userEvent.click(
+                screen.getByRole("checkbox", {name: "Select Choice C"}),
+            );
 
             // Assert
             expect(updatedValues).toMatchObject({
@@ -114,9 +116,10 @@ describe("base-radio", () => {
             );
 
             // Act
-            userEvent.click(
-                screen.getByText("(Choice C, Checked)", {selector: "div"}),
-            );
+            const radioButton = screen.getByRole("checkbox", {
+                name: "Select Choice C",
+            });
+            userEvent.click(radioButton);
 
             // Assert
             expect(updatedValues).toMatchObject({
@@ -154,7 +157,9 @@ describe("base-radio", () => {
             );
 
             // Act
-            userEvent.click(screen.getByText("(Choice C)", {selector: "div"}));
+            userEvent.click(
+                screen.getByRole("checkbox", {name: "Select Choice C"}),
+            );
 
             // Assert
             expect(updatedValues).toMatchObject({

--- a/packages/perseus/src/widgets/__tests__/radio/base-radio_test.jsx
+++ b/packages/perseus/src/widgets/__tests__/radio/base-radio_test.jsx
@@ -79,4 +79,87 @@ describe("base-radio", () => {
             });
         });
     });
+
+    describe("selecting and deselecting options", () => {
+        it("deselects multi-select choices", () => {
+            // Arrange
+            const apiOptions: APIOptions = {
+                styling: {radioStyleVersion: "final"},
+            };
+            let updatedValues = null;
+            const onChangeHandler = (newValues) => {
+                updatedValues = newValues;
+            };
+
+            render(
+                <BaseRadio
+                    multipleSelect={true}
+                    countChoices={false}
+                    numCorrect={1}
+                    editMode={false}
+                    labelWrap={false}
+                    apiOptions={apiOptions}
+                    choices={[
+                        {content: "Option 1", correct: false, checked: false},
+                        {content: "Option B", correct: false, checked: false},
+                        {content: "Option Gamma", correct: true, checked: true},
+                        {
+                            content: "Option Delta",
+                            correct: false,
+                            checked: false,
+                        },
+                    ]}
+                    onChange={onChangeHandler}
+                />,
+            );
+
+            // Act
+            userEvent.click(
+                screen.getByText("(Choice C, Checked)", {selector: "div"}),
+            );
+
+            // Assert
+            expect(updatedValues).toMatchObject({
+                checked: [false, false, false, false],
+            });
+        });
+
+        //Equivalent to "should toggle choice when inner element clicked" but with editMode set to false
+        it("select single select choices", () => {
+            // Arrange
+            const apiOptions: APIOptions = {
+                styling: {radioStyleVersion: "final"},
+            };
+            let updatedValues = null;
+            const onChangeHandler = (newValues) => {
+                updatedValues = newValues;
+            };
+
+            render(
+                <BaseRadio
+                    multipleSelect={false}
+                    countChoices={false}
+                    numCorrect={1}
+                    editMode={false}
+                    labelWrap={false}
+                    apiOptions={apiOptions}
+                    choices={[
+                        {content: "Option 1", correct: false},
+                        {content: "Option B", correct: false},
+                        {content: "Option Gamma", correct: true},
+                        {content: "Option Delta", correct: false},
+                    ]}
+                    onChange={onChangeHandler}
+                />,
+            );
+
+            // Act
+            userEvent.click(screen.getByText("(Choice C)", {selector: "div"}));
+
+            // Assert
+            expect(updatedValues).toMatchObject({
+                checked: [false, false, true, false],
+            });
+        });
+    });
 });

--- a/packages/perseus/src/widgets/__tests__/radio/base-radio_test.jsx
+++ b/packages/perseus/src/widgets/__tests__/radio/base-radio_test.jsx
@@ -124,7 +124,7 @@ describe("base-radio", () => {
             });
         });
 
-        //Equivalent to "should toggle choice when inner element clicked" but with editMode set to false
+        // Equivalent to "should toggle choice when inner element clicked" but with editMode set to false
         it("select single select choices", () => {
             // Arrange
             const apiOptions: APIOptions = {

--- a/packages/perseus/src/widgets/radio/choice.jsx
+++ b/packages/perseus/src/widgets/radio/choice.jsx
@@ -275,7 +275,7 @@ class Choice extends React.Component<$FlowFixMe, State> {
                             // If we're checking a crossed-out option, let's
                             // also uncross it.
                             this._sendChange({
-                                checked: true,
+                                checked: !this.props.checked,
                                 crossedOut: false,
                             });
                         }}


### PR DESCRIPTION
## Summary:
The problem being solved is that previously the multi-select radio widget would not deselect selected items. As a result, once all options were checked, it was not possible to deselect any. We found where the checked prop was being set and changed it to be a toggle based on the previous value of checked. We also set up a test for that functionality and created a copy of an older test to run outside of edit mode that tests selecting choices in single-select radio widgets.

Issue: LP-12636

## Test plan:
Check functionality works as it should with checked options un-checking using Storybook
-Go to the multi-select section under the Radio widget
-Scroll down to multi-select within the docs tab (not the canvas)
-Try selecting and deselecting options to confirm they can be deselected
-Scroll up and confirm the single select widget works as expected with only one choice being selected at any time

Confirm jest tests pass
-Run the jest tests in base-radio_test.jsx where the new tests were added
-confirm all tests pass 