### PR TITLE
Fix import/no-extraneous-deps config

### DIFF
--- a/.changeset/popular-paws-relate.md
+++ b/.changeset/popular-paws-relate.md
@@ -1,0 +1,14 @@
+---
+"perseus-build-settings": patch
+"@khanacademy/kas": patch
+"@khanacademy/kmath": patch
+"@khanacademy/math-input": patch
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+"@khanacademy/perseus-error": patch
+"@khanacademy/perseus-linter": patch
+"@khanacademy/pure-markdown": patch
+"@khanacademy/simple-markdown": patch
+---
+
+Fix our use of import/no-extraneous-dependencies

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,10 +10,6 @@ const pkgAliases = pkgNames.map((pkgName) => {
     return [`@khanacademy/${pkgName}`, `./packages/${pkgName}/src/index.js`];
 });
 
-const pkgDirs = pkgNames.map((pkgName) => {
-    return `./packages/${pkgName}`;
-});
-
 const vendorAliases = fs
     .readdirSync(path.join(__dirname, "vendor"))
     .map((name) => {
@@ -35,7 +31,7 @@ module.exports = {
     parser: "@babel/eslint-parser",
     parserOptions: {
         babelOptions: {
-            configFile: "./config/build/babel.config.js",
+            configFile: path.join(__dirname, "./config/build/babel.config.js"),
         },
     },
     plugins: [
@@ -178,12 +174,6 @@ module.exports = {
             "always",
             {
                 ignorePackages: true,
-            },
-        ],
-        "import/no-extraneous-dependencies": [
-            "error",
-            {
-                packageDir: pkgDirs,
             },
         ],
         "import/no-restricted-paths": [

--- a/packages/kas/.eslintrc.js
+++ b/packages/kas/.eslintrc.js
@@ -1,0 +1,6 @@
+/* eslint-disable import/no-commonjs */
+module.exports = {
+    rules: {
+        "import/no-extraneous-dependencies": "error",
+    },
+};

--- a/packages/kmath/.eslintrc.js
+++ b/packages/kmath/.eslintrc.js
@@ -1,0 +1,6 @@
+/* eslint-disable import/no-commonjs */
+module.exports = {
+    rules: {
+        "import/no-extraneous-dependencies": "error",
+    },
+};

--- a/packages/math-input/.eslintrc.js
+++ b/packages/math-input/.eslintrc.js
@@ -1,0 +1,6 @@
+/* eslint-disable import/no-commonjs */
+module.exports = {
+    rules: {
+        "import/no-extraneous-dependencies": "error",
+    },
+};

--- a/packages/perseus-editor/.eslintrc.js
+++ b/packages/perseus-editor/.eslintrc.js
@@ -1,0 +1,6 @@
+/* eslint-disable import/no-commonjs */
+module.exports = {
+    rules: {
+        "import/no-extraneous-dependencies": "error",
+    },
+};

--- a/packages/perseus-editor/package.json
+++ b/packages/perseus-editor/package.json
@@ -21,6 +21,7 @@
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
     },
     "dependencies": {
+        "@khanacademy/kas": "^0.2.5",
         "@khanacademy/kmath": "^0.0.6",
         "@khanacademy/perseus": "^0.4.1"
     },

--- a/packages/perseus-error/.eslintrc.js
+++ b/packages/perseus-error/.eslintrc.js
@@ -1,0 +1,6 @@
+/* eslint-disable import/no-commonjs */
+module.exports = {
+    rules: {
+        "import/no-extraneous-dependencies": "error",
+    },
+};

--- a/packages/perseus-linter/.eslintrc.js
+++ b/packages/perseus-linter/.eslintrc.js
@@ -1,0 +1,6 @@
+/* eslint-disable import/no-commonjs */
+module.exports = {
+    rules: {
+        "import/no-extraneous-dependencies": "error",
+    },
+};

--- a/packages/perseus-linter/package.json
+++ b/packages/perseus-linter/package.json
@@ -24,8 +24,11 @@
         "@khanacademy/perseus-error": "^0.1.1"
     },
     "devDependencies": {
-        "@khanacademy/pure-markdown": "^0.1.1"
+        "@khanacademy/pure-markdown": "^0.1.1",
+        "prop-types": "^15.6.1"
     },
-    "peerDependencies": {},
+    "peerDependencies": {
+        "prop-types": "^15.6.1"
+    },
     "keywords": []
 }

--- a/packages/perseus/.eslintrc.js
+++ b/packages/perseus/.eslintrc.js
@@ -1,0 +1,6 @@
+/* eslint-disable import/no-commonjs */
+module.exports = {
+    rules: {
+        "import/no-extraneous-dependencies": "error",
+    },
+};

--- a/packages/pure-markdown/.eslintrc.js
+++ b/packages/pure-markdown/.eslintrc.js
@@ -1,0 +1,6 @@
+/* eslint-disable import/no-commonjs */
+module.exports = {
+    rules: {
+        "import/no-extraneous-dependencies": "error",
+    },
+};

--- a/packages/simple-markdown/.eslintrc.js
+++ b/packages/simple-markdown/.eslintrc.js
@@ -1,0 +1,6 @@
+/* eslint-disable import/no-commonjs */
+module.exports = {
+    rules: {
+        "import/no-extraneous-dependencies": "error",
+    },
+};


### PR DESCRIPTION
## Summary:
It turns out that setting the "packageDir" option on this rule to be an array of all of the packages ends up checking the package.json in each of those directories when checking **any** file in the whole project.

What we want is to only consult the package.json that lives in packages/perseus/ when linting the files in that subdirectory.  Thankfully, eslint supports cascading config files.  This means we can add an .eslintrc.js in each of our packages' directories with only the 'import/no-extraneous-deps' rule.  Eslint will combine that with the .eslintrc.js at the root when linting files in each package directory.

Issue: None

## Test plan:
- remove '@khanacademy/wonder-blocks-clickable' from packages/perseus/package.json
- see that widges/radio/choice.jsx now has a lint error for that import