### PR TITLE
Don't collect coverage on tests or stories

### DIFF
--- a/.changeset/thick-cats-do.md
+++ b/.changeset/thick-cats-do.md
@@ -1,0 +1,5 @@
+---
+"perseus-build-settings": patch
+---
+
+Update jest config to exclude stories and test files from collecting coverage

--- a/config/test/test.config.js
+++ b/config/test/test.config.js
@@ -64,6 +64,8 @@ module.exports = {
         "packages/*/src/**/*.js",
         "packages/*/src/**/*.jsx",
         "!packages/*/node_modules/",
+        "!**/__tests__/**",
+        "!**/__stories__/**",
     ],
     // Only output log messages on test failure. From:
     // https://github.com/facebook/jest/issues/4156#issuecomment-490764080


### PR DESCRIPTION
## Summary:
I was pairing with @handeyeco this morning and we noticed that test and stories files were showing up in the coverage reports generated by Wallaby.  We don't want them be included in the coverage report since they don't contain code that we're actually shipping.

Issue: None

## Test plan:
- start wallaby
- wait for it generate a coverage report
- see that .stories.jsx and _test.js(x) files don't appear in the "files" tab