### PR TITLE
Upgrade codecov action to v3

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -106,7 +106,7 @@ jobs:
     - name: Upload Coverage
       # We don't bother collecting a record of coverage for dependabot changes
       if: ${{ github.actor != 'dependabot[bot]' }}
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         files: ./coverage/coverage-final.json
         fail_ci_if_error: true


### PR DESCRIPTION
## Summary:
We're noticing that Codecov uploads are failing from time to time.  This is especially painful in the Perseus repo where we upload both jest and cypress coverage reports which are merged.  If both aren't uploaded it looks like we lost a bunch of coverage.  I'm not particularly hopeful that v3 will fix the issue since looking at the source code for the action doesn't reveal any retry logic.  We can try adding our own try logic to the action in the future, but I thought I'd give upgrading a try just in case it helps.

Issue: None

## Test plan:
- watch CI and see what happens