### PR TITLE
Add lint rules from React hooks

### DIFF
--- a/.changeset/clean-sheep-add.md
+++ b/.changeset/clean-sheep-add.md
@@ -1,0 +1,5 @@
+---
+"perseus-build-settings": patch
+---
+
+Added eslint rules for react hooks

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,6 +42,8 @@ module.exports = {
         "jest",
         "monorepo",
         "promise",
+        "react",
+        "react-hooks",
         "react-native",
         "ft-flow",
     ],
@@ -220,6 +222,12 @@ module.exports = {
                 ],
             },
         ],
+
+        /**
+         * react-hooks
+         */
+        "react-hooks/rules-of-hooks": "error",
+        "react-hooks/exhaustive-deps": "error",
 
         /**
          * react-native

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-react": "^7.29.4",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-native": "^3.10.0",
     "eslint-plugin-storybook": "^0.5.7",
     "eslint-plugin-testing-library": "^5.0.0",

--- a/testing/test-tex.jsx
+++ b/testing/test-tex.jsx
@@ -40,6 +40,9 @@ export const TestTeX = (props: Props): React.Node => {
         if (onRender) {
             onRender();
         }
+        // NOTE(kevinb): We intentionally leave the deps list empty here
+        // since we want this code to only run once on mount.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -8882,6 +8882,11 @@ eslint-plugin-promise@^6.0.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-6.0.0.tgz#017652c07c9816413a41e11c30adc42c3d55ff18"
   integrity sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==
 
+eslint-plugin-react-hooks@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
+  integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
+
 eslint-plugin-react-native-globals@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-native-globals/-/eslint-plugin-react-native-globals-0.1.2.tgz#ee1348bc2ceb912303ce6bdbd22e2f045ea86ea2"


### PR DESCRIPTION
## Summary:
Now that hooks are starting to get more use in Perseus, we should adopt the same lint rules that webapp is using for hooks.  This PR enables the following rules:
- react-hooks/rules-of-hooks: complains if hooks are used conditionally
- react-hooks/exhaustive-deps: complains if any deps are missing from useEffect's deps list.

It's okay to disable the 'exhaustive-deps' check, but it should be accompanied by a comment about why the rule is being disabled.

Issue: None

## Test plan:
- yarn lint