### PR TITLE
Proposal for tweaks to radio widget flow types

### DIFF
--- a/packages/perseus/src/perseus-types.js
+++ b/packages/perseus/src/perseus-types.js
@@ -968,10 +968,6 @@ export type PerseusRadioChoice = {|
     // deprecated
     // NOTE: perseus_data.go says this is required even though it isn't necessary.
     widgets?: {|[string]: PerseusWidget|},
-    // Indicates the original index
-    originalIndex?: number,
-    // Indicates whether the option has been crossed out or not
-    crossedOut?: boolean,
 |};
 // sync-end:perseus-data-format-radio-choice
 

--- a/packages/perseus/src/types.js
+++ b/packages/perseus/src/types.js
@@ -9,7 +9,7 @@ import * as React from "react";
 import type {SerializedHighlightSet} from "./components/highlighting/types.js";
 import type {ILogger} from "./logging/log.js";
 import type {Item} from "./multi-items/item-types.js";
-import type {PerseusWidget} from "./perseus-types.js";
+import type {PerseusWidget, PerseusRadioChoice} from "./perseus-types.js";
 import type {SizeClass} from "./util/sizing-utils.js";
 import type {Result} from "@khanacademy/wonder-blocks-data";
 
@@ -83,6 +83,12 @@ export type ChoiceState = {|
     correctnessShown: boolean,
     previouslyAnswered: boolean,
     readOnly: boolean,
+|};
+
+export type RadioChoiceWithMetadata = {|
+    ...PerseusRadioChoice,
+    originalIndex: number,
+    correct: boolean,
 |};
 
 export type ChangeHandler = (

--- a/packages/perseus/src/widgets/radio.jsx
+++ b/packages/perseus/src/widgets/radio.jsx
@@ -6,11 +6,8 @@ import Util from "../util.js";
 
 import Radio from "./radio/widget.jsx";
 
-import type {
-    PerseusRadioWidgetOptions,
-    PerseusRadioChoice,
-} from "../perseus-types.js";
-import type {WidgetExports} from "../types.js";
+import type {PerseusRadioWidgetOptions} from "../perseus-types.js";
+import type {WidgetExports, RadioChoiceWithMetadata} from "../types.js";
 import type {RenderProps} from "./radio/widget.jsx";
 
 const {shuffle, random} = Util;
@@ -43,15 +40,16 @@ const _choiceTransform = (
     };
 
     const _addNoneOfAbove = function (
-        choices: $ReadOnlyArray<PerseusRadioChoice>,
-    ): $ReadOnlyArray<PerseusRadioChoice> {
+        choices: $ReadOnlyArray<RadioChoiceWithMetadata>,
+    ) {
         let noneOfTheAbove = null;
 
-        const newChoices = _.reject(choices, function (choice, index) {
+        const newChoices = choices.filter((choice, index) => {
             if (choice.isNoneOfTheAbove) {
                 noneOfTheAbove = choice;
-                return true;
+                return false;
             }
+            return true;
         });
 
         // Place the "None of the above" options last
@@ -63,8 +61,8 @@ const _choiceTransform = (
     };
 
     const enforceOrdering = (
-        choices: $ReadOnlyArray<PerseusRadioChoice>,
-    ): $ReadOnlyArray<PerseusRadioChoice> => {
+        choices: $ReadOnlyArray<RadioChoiceWithMetadata>,
+    ) => {
         const content = choices.map((c) => c.content);
         if (ReversedChoices.some((reversed) => _.isEqual(content, reversed))) {
             return [choices[1], choices[0]];
@@ -73,13 +71,14 @@ const _choiceTransform = (
     };
 
     // Add meta-information to choices
-    let choices = widgetOptions.choices.slice();
-    choices = _.map(choices, (choice, i) => {
-        return _.extend({}, choice, {
-            originalIndex: i,
-            correct: Boolean(choice.correct),
+    const choices: $ReadOnlyArray<RadioChoiceWithMetadata> =
+        widgetOptions.choices.map((choice, i): RadioChoiceWithMetadata => {
+            return {
+                ...choice,
+                originalIndex: i,
+                correct: Boolean(choice.correct),
+            };
         });
-    });
 
     // Apply all the transforms. Note that the order we call these is
     // important!

--- a/packages/perseus/src/widgets/radio/widget.jsx
+++ b/packages/perseus/src/widgets/radio/widget.jsx
@@ -456,17 +456,15 @@ class Radio extends React.Component<Props> {
             const numCorrect = props.numCorrect;
 
             for (let i = 0; i < choicesSelected.length; i++) {
-                if (props.choices[i].originalIndex != null) {
-                    const index = props.choices[i].originalIndex;
+                const index = props.choices[i].originalIndex;
 
-                    choicesSelected[index] = choiceStates[i].selected;
+                choicesSelected[index] = choiceStates[i].selected;
 
-                    if (props.choices[i].isNoneOfTheAbove) {
-                        noneOfTheAboveIndex = index;
+                if (props.choices[i].isNoneOfTheAbove) {
+                    noneOfTheAboveIndex = index;
 
-                        if (choicesSelected[i]) {
-                            noneOfTheAboveSelected = true;
-                        }
+                    if (choicesSelected[i]) {
+                        noneOfTheAboveSelected = true;
                     }
                 }
             }


### PR DESCRIPTION
## Summary:
This PR introduces a 'RadioChoiceWithMetadata' type to model the shape of props.choices in radio/widget.jsx without having to modify PerseusRadioChoice in perseus-types.js.

This PR is only for illustration purposes and shouldn't be merged.

Issue: None

## Test plan:
- yarn flow