### PR TITLE
Stabilization: Add Flow types to passage and passage-markdown

### DIFF
--- a/.changeset/mighty-doors-explode.md
+++ b/.changeset/mighty-doors-explode.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/simple-markdown": patch
+---
+
+Add more Flow typing to passage and passage-markdown widgets

--- a/packages/perseus/src/widgets/passage.jsx
+++ b/packages/perseus/src/widgets/passage.jsx
@@ -38,18 +38,19 @@ class LineHeightMeasurer extends React.Component<{...}> {
     }
 
     forceMeasureLineHeight() {
-        const $body = $(this.body);
-        const $end = $(this.end);
+        if (this.body && this.end) {
+            // Add some text which magically fills an entire line.
+            this.body.textContent = " \u0080";
 
-        // Add some text which magically fills an entire line.
-        $body.text(" \u0080");
+            // Now, the line height is the difference between the top of the
+            // second line and the top of the first line.
+            this._cachedLineHeight = getLineHeightForNode(this.body, this.end);
+        }
 
-        // Now, the line height is the difference between the top of the
-        // second line and the top of the first line.
-        this._cachedLineHeight = getLineHeightForNode($body, $end);
-
-        // Clear out the first line so it doesn't overlap the passage.
-        $body.text("");
+        if (this.body) {
+            // Clear out the first line so it doesn't overlap the passage.
+            this.body.textContent = "";
+        }
     }
 
     render(): React.Node {

--- a/packages/perseus/src/widgets/passage.jsx
+++ b/packages/perseus/src/widgets/passage.jsx
@@ -246,16 +246,15 @@ class Passage extends React.Component<PassageProps, PassageState> {
 
     _getInitialLineNumber(): number {
         let isPassageBeforeThisPassage = true;
-        const passagesBeforeUs: $ReadOnlyArray<Passage> =
-            this.props.findWidgets((id, widgetInfo) => {
-                if (widgetInfo.type !== "passage") {
-                    return false;
-                }
-                if (id === this.props.widgetId) {
-                    isPassageBeforeThisPassage = false;
-                }
-                return isPassageBeforeThisPassage;
-            });
+        const passagesBeforeUs = this.props.findWidgets((id, widgetInfo) => {
+            if (widgetInfo.type !== "passage") {
+                return false;
+            }
+            if (id === this.props.widgetId) {
+                isPassageBeforeThisPassage = false;
+            }
+            return isPassageBeforeThisPassage;
+        });
 
         return passagesBeforeUs
             .map((passageWidget) => {

--- a/packages/perseus/src/widgets/passage.jsx
+++ b/packages/perseus/src/widgets/passage.jsx
@@ -286,6 +286,11 @@ class Passage extends React.Component<PassageProps, PassageState> {
      * These are functions to support the passage refs inter-widgets feature
      * where other widgets can fetch the line numbers of a reference inside of
      * a passage.
+     *
+     * todo(matthewc): The refs are created by PassageMarkdown's refStart and refEnd,
+     * somehow bubbling up to Passage's `this.refs`. This runs against
+     * current best practices for refs by using string refs, but also
+     * by breaking our expectation of explicit data flow.
      */
 
     _getStartRefLineNumber(referenceNumber: number): ?number {

--- a/packages/perseus/src/widgets/passage.jsx
+++ b/packages/perseus/src/widgets/passage.jsx
@@ -45,19 +45,22 @@ class LineHeightMeasurer extends React.Component<{...}> {
     }
 
     forceMeasureLineHeight() {
-        if (this.body && this.end) {
-            // Add some text which magically fills an entire line.
-            this.body.textContent = " \u0080";
+        const body = this.body;
+        const end = this.end;
 
-            // Now, the line height is the difference between the top of the
-            // second line and the top of the first line.
-            this._cachedLineHeight = getLineHeightForNode(this.body, this.end);
+        if (!body || !end) {
+            return;
         }
 
-        if (this.body) {
-            // Clear out the first line so it doesn't overlap the passage.
-            this.body.textContent = "";
-        }
+        // Add some text which magically fills an entire line.
+        body.textContent = " \u0080";
+
+        // Now, the line height is the difference between the top of the
+        // second line and the top of the first line.
+        this._cachedLineHeight = getLineHeightForNode(body, end);
+
+        // Clear out the first line so it doesn't overlap the passage.
+        body.textContent = "";
     }
 
     render(): React.Node {
@@ -509,7 +512,7 @@ class Passage extends React.Component<PassageProps, PassageState> {
             });
         }
 
-        const parseState: ParseState = {};
+        const parseState: ParseState = PassageMarkdown.getInitialParseState();
 
         // Replace the vertical double quote characters quoting text with
         // an unicode left and right double quote characters. This would

--- a/packages/perseus/src/widgets/passage.jsx
+++ b/packages/perseus/src/widgets/passage.jsx
@@ -329,8 +329,8 @@ class Passage extends React.Component<PassageProps, PassageState> {
             // use the ref itself.
             $refText = $ref;
         }
-        const height = $refText.height();
-        const vPos = $refText.offset().top;
+        const height: number = $refText.height();
+        const vPos: number = $refText.offset().top;
 
         let line = this._convertPosToLineNumber(vPos + height);
         if (height === 0) {
@@ -347,8 +347,8 @@ class Passage extends React.Component<PassageProps, PassageState> {
     }
 
     _convertPosToLineNumber(absoluteVPos: number): number {
-        const $content = $(ReactDOM.findDOMNode(this._contentRef));
-        const relativeVPos = absoluteVPos - $content.offset().top;
+        const content = ReactDOM.findDOMNode(this._contentRef);
+        const relativeVPos = absoluteVPos - $(content).offset().top;
         const lineHeight = this._getLineHeight();
 
         const line = Math.round(relativeVPos / lineHeight);
@@ -489,7 +489,7 @@ class Passage extends React.Component<PassageProps, PassageState> {
     }
 
     render(): React.Element<"div"> {
-        let lineNumbers;
+        let lineNumbers: $ReadOnlyArray<React.Node>;
         const nLines = this.state.nLines;
         if (this.props.showLineNumbers && nLines) {
             // lineN is the line number in the current passage

--- a/packages/perseus/src/widgets/passage.jsx
+++ b/packages/perseus/src/widgets/passage.jsx
@@ -24,6 +24,8 @@ import type {
     WidgetInfo,
     WidgetProps,
 } from "../types";
+import type {ParseState} from "./passage/passage-markdown.jsx";
+import type {SingleASTNode} from "@khanacademy/simple-markdown";
 
 // A fake paragraph to measure the line height of the passage. In CSS we always
 // set the line height to 22 pixels, but when using the browser zoom feature,
@@ -117,13 +119,6 @@ type PassageState = {|
     startLineNumbersAfter: number,
     stylesAreApplied: boolean,
 |};
-
-// State kept track of by the PassageMarkdown parser.
-type PassageParseState = {
-    firstQuestionRef: ?any,
-    firstSentenceRef: ?any,
-    ...
-};
 
 // Information about a passage reference, used in inter-widgets.
 type Reference = {
@@ -415,7 +410,7 @@ class Passage extends React.Component<PassageProps, PassageState> {
      * Functions to render the passage widget.
      */
 
-    _renderInstructions(parseState: PassageParseState): React.Element<any> {
+    _renderInstructions(parseState: ParseState): React.Element<any> {
         const firstQuestionNumber = parseState.firstQuestionRef;
         const firstSentenceRef = parseState.firstSentenceRef;
 
@@ -455,7 +450,7 @@ class Passage extends React.Component<PassageProps, PassageState> {
         return JIPT.useJIPT && this.props.passageText.indexOf("crwdns") !== -1;
     }
 
-    _renderContent(parsed: $ReadOnlyArray<any>): React.Element<any> {
+    _renderContent(parsed: Array<SingleASTNode>): React.Element<any> {
         // Wait until Aphrodite styles are applied before enabling highlights,
         // so that we measure the correct positions.
         const enabled = this.state.stylesAreApplied;
@@ -487,7 +482,7 @@ class Passage extends React.Component<PassageProps, PassageState> {
         return !isEmpty;
     }
 
-    _renderFootnotes(): React.Element<any> {
+    _renderFootnotes(): React.Node {
         const rawContent = this.props.footnotes;
         const parsed = PassageMarkdown.parse(rawContent);
         return PassageMarkdown.output(parsed);
@@ -515,10 +510,7 @@ class Passage extends React.Component<PassageProps, PassageState> {
             });
         }
 
-        const parseState: PassageParseState = {
-            firstSentenceRef: null,
-            firstQuestionRef: null,
-        };
+        const parseState: ParseState = {};
 
         // Replace the vertical double quote characters quoting text with
         // an unicode left and right double quote characters. This would
@@ -529,7 +521,7 @@ class Passage extends React.Component<PassageProps, PassageState> {
             re,
             "\u201c$2\u201d",
         );
-        const parsedContent: $ReadOnlyArray<*> = PassageMarkdown.parse(
+        const parsedContent = PassageMarkdown.parse(
             doubleQuoteParsedContent,
             parseState,
         );

--- a/packages/perseus/src/widgets/passage/__tests__/passage-markdown_test.jsx
+++ b/packages/perseus/src/widgets/passage/__tests__/passage-markdown_test.jsx
@@ -7,7 +7,6 @@ import _ from "underscore";
 import PassageMarkdown from "../passage-markdown.jsx";
 
 const parse = PassageMarkdown.parse;
-const rules = PassageMarkdown._rulesForTesting;
 
 const validateParse = (parsed, expected) => {
     if (!_.isEqual(parsed, expected)) {
@@ -349,14 +348,6 @@ describe.skip("passage markdown", () => {
                     ],
                 },
             ]);
-        });
-    });
-
-    describe("orders", () => {
-        it("should always be numbers", () => {
-            _.each(rules, (rule) => {
-                expect(typeof rule.order === "number").toBeTruthy();
-            });
         });
     });
 

--- a/packages/perseus/src/widgets/passage/get-line-height-for-node.js
+++ b/packages/perseus/src/widgets/passage/get-line-height-for-node.js
@@ -1,10 +1,9 @@
 // @flow
-
-type JQueryCollection = $FlowFixMe;
+import $ from "jquery";
 
 export const getLineHeightForNode = (
-    $line1: JQueryCollection,
-    $line2: JQueryCollection,
+    line1: HTMLDivElement,
+    line2: HTMLDivElement,
 ): number => {
-    return $line2.offset().top - $line1.offset().top;
+    return $(line2).offset().top - $(line1).offset().top;
 };

--- a/packages/perseus/src/widgets/passage/passage-markdown.jsx
+++ b/packages/perseus/src/widgets/passage/passage-markdown.jsx
@@ -75,17 +75,10 @@ class RefEnd extends React.Component<{}> {
 
 const rules = {
     newline: SimpleMarkdown.defaultRules.newline,
-    // $FlowFixMe[prop-missing]
-    // $FlowFixMe[incompatible-use]
     paragraph: SimpleMarkdown.defaultRules.paragraph,
-    // $FlowFixMe[prop-missing]
-    // $FlowFixMe[incompatible-use]
     escape: SimpleMarkdown.defaultRules.escape,
     passageFootnote: {
-        // $FlowFixMe[prop-missing]
-        // $FlowFixMe[incompatible-use]
         order: SimpleMarkdown.defaultRules.escape.order + 0.1,
-        // $FlowFixMe[prop-missing]
         match: SimpleMarkdown.inlineRegex(/^\^/),
         parse: (
             capture: Capture,
@@ -117,8 +110,6 @@ const rules = {
         },
     },
     refStart: {
-        // $FlowFixMe[prop-missing]
-        // $FlowFixMe[incompatible-use]
         order: SimpleMarkdown.defaultRules.escape.order + 0.2,
         match: function (source) {
             const capture = /^\{\{/.exec(source);
@@ -217,10 +208,7 @@ const rules = {
         },
     },
     refEnd: {
-        // $FlowFixMe[prop-missing]
-        // $FlowFixMe[incompatible-use]
         order: SimpleMarkdown.defaultRules.escape.order + 0.3,
-        // $FlowFixMe[prop-missing]
         match: SimpleMarkdown.inlineRegex(/^\}\}/),
         parse: (capture, parse, state: ParseState): RefEndNode => {
             if (!state.useRefs) {
@@ -252,10 +240,7 @@ const rules = {
         },
     },
     squareLabel: {
-        // $FlowFixMe[prop-missing]
-        // $FlowFixMe[incompatible-use]
         order: SimpleMarkdown.defaultRules.escape.order + 0.4,
-        // $FlowFixMe[prop-missing]
         match: SimpleMarkdown.inlineRegex(/^\[\[(\w+)\]\]( *)/),
         parse: (capture, parse, state: ParseState): LabelNode => {
             if (!state.firstQuestionRef) {
@@ -286,10 +271,7 @@ const rules = {
         },
     },
     circleLabel: {
-        // $FlowFixMe[prop-missing]
-        // $FlowFixMe[incompatible-use]
         order: SimpleMarkdown.defaultRules.escape.order + 0.5,
-        // $FlowFixMe[prop-missing]
         match: SimpleMarkdown.inlineRegex(/^\(\((\w+)\)\)( *)/),
         parse: (capture, parse, state: ParseState): LabelNode => {
             return {
@@ -317,10 +299,7 @@ const rules = {
         },
     },
     squareBracketRef: {
-        // $FlowFixMe[prop-missing]
-        // $FlowFixMe[incompatible-use]
         order: SimpleMarkdown.defaultRules.escape.order + 0.6,
-        // $FlowFixMe[prop-missing]
         match: SimpleMarkdown.inlineRegex(/^\[(\d+)\]( *)/),
         parse: (capture, parse, state: ParseState): LabelNode => {
             if (!state.firstSentenceRef) {
@@ -348,10 +327,7 @@ const rules = {
         },
     },
     highlight: {
-        // $FlowFixMe[prop-missing]
-        // $FlowFixMe[incompatible-use]
         order: SimpleMarkdown.defaultRules.escape.order + 0.7,
-        // $FlowFixMe[prop-missing]
         match: SimpleMarkdown.inlineRegex(
             /^{highlighting.start}(.+?){highlighting.end}/,
         ),
@@ -369,10 +345,7 @@ const rules = {
         },
     },
     reviewHighlight: {
-        // $FlowFixMe[prop-missing]
-        // $FlowFixMe[incompatible-use]
         order: SimpleMarkdown.defaultRules.escape.order + 0.7,
-        // $FlowFixMe[prop-missing]
         match: SimpleMarkdown.inlineRegex(
             /^{review-highlighting.start}(.+?){review-highlighting.end}/,
         ),
@@ -389,21 +362,11 @@ const rules = {
             ];
         },
     },
-    // $FlowFixMe[prop-missing]
-    // $FlowFixMe[incompatible-use]
     strong: SimpleMarkdown.defaultRules.strong,
-    // $FlowFixMe[prop-missing]
-    // $FlowFixMe[incompatible-use]
     u: SimpleMarkdown.defaultRules.u,
-    // $FlowFixMe[prop-missing]
-    // $FlowFixMe[incompatible-use]
     em: SimpleMarkdown.defaultRules.em,
-    // $FlowFixMe[prop-missing]
-    // $FlowFixMe[incompatible-use]
     del: SimpleMarkdown.defaultRules.del,
     text: {
-        // $FlowFixMe[prop-missing]
-        // $FlowFixMe[incompatible-use]
         ...SimpleMarkdown.defaultRules.text,
         react(node, output, state) {
             return <span key={state.key}>{node.content}</span>;
@@ -468,5 +431,4 @@ export default {
     START_REF_PREFIX,
     END_REF_PREFIX,
     INITIAL_PARSE_STATE,
-    _rulesForTesting: (rules: $FlowFixMe),
 };

--- a/packages/perseus/src/widgets/passage/passage-markdown.jsx
+++ b/packages/perseus/src/widgets/passage/passage-markdown.jsx
@@ -23,6 +23,8 @@ export type ParseState = {|
     lastFootnote: {id: number, text: string},
 |};
 
+type OutputFun = $FlowFixMe;
+
 type FootnoteType = {|
     id: number,
     text: string,
@@ -109,7 +111,7 @@ const rules = {
             state.lastFootnote = footnote;
             return footnote;
         },
-        react: (node: FootnoteType, output, state) => {
+        react: (node: FootnoteType, output: OutputFun, state: ParseState) => {
             return <sup key={state.key}>{node.text}</sup>;
         },
     },
@@ -154,7 +156,11 @@ const rules = {
             }
             return null;
         },
-        parse: (capture, parse, state: ParseState): RefStartNode => {
+        parse: (
+            capture: Capture,
+            parse: Parser,
+            state: ParseState,
+        ): RefStartNode => {
             if (!state.useRefs) {
                 return {
                     ref: null,
@@ -186,7 +192,7 @@ const rules = {
                 refContent: refContent,
             };
         },
-        react: (node: RefStartNode, output) => {
+        react: (node: RefStartNode, output: OutputFun, state: ParseState) => {
             const ref = node.ref;
             if (ref == null) {
                 return null;
@@ -211,7 +217,11 @@ const rules = {
     refEnd: {
         order: SimpleMarkdown.defaultRules.escape.order + 0.3,
         match: SimpleMarkdown.inlineRegex(/^\}\}/),
-        parse: (capture, parse, state: ParseState): RefEndNode => {
+        parse: (
+            capture: Capture,
+            parse: Parser,
+            state: ParseState,
+        ): RefEndNode => {
             if (!state.useRefs) {
                 return {
                     ref: null,
@@ -223,7 +233,7 @@ const rules = {
                 ref: ref,
             };
         },
-        react: (node: RefEndNode) => {
+        react: (node: RefEndNode, output: OutputFun, state: ParseState) => {
             if (node.ref != null) {
                 // note(matthewc) the refs created here become the refs
                 // pulled from `this.refs` in passage.jsx
@@ -243,7 +253,11 @@ const rules = {
     squareLabel: {
         order: SimpleMarkdown.defaultRules.escape.order + 0.4,
         match: SimpleMarkdown.inlineRegex(/^\[\[(\w+)\]\]( *)/),
-        parse: (capture, parse, state: ParseState): LabelNode => {
+        parse: (
+            capture: Capture,
+            parse: Parser,
+            state: ParseState,
+        ): LabelNode => {
             if (!state.firstQuestionRef) {
                 state.firstQuestionRef = capture[1];
             }
@@ -252,7 +266,7 @@ const rules = {
                 space: capture[2].length > 0,
             };
         },
-        react: (node: LabelNode) => {
+        react: (node: LabelNode, output: OutputFun, state: ParseState) => {
             return [
                 <span
                     key="visual-square"
@@ -274,13 +288,21 @@ const rules = {
     circleLabel: {
         order: SimpleMarkdown.defaultRules.escape.order + 0.5,
         match: SimpleMarkdown.inlineRegex(/^\(\((\w+)\)\)( *)/),
-        parse: (capture, parse, state: ParseState): LabelNode => {
+        parse: (
+            capture: Capture,
+            parse: Parser,
+            state: ParseState,
+        ): LabelNode => {
             return {
                 content: capture[1],
                 space: capture[2].length > 0,
             };
         },
-        react: (node: LabelNode): React.Node => {
+        react: (
+            node: LabelNode,
+            output: OutputFun,
+            state: ParseState,
+        ): React.Node => {
             return [
                 <span
                     key="visual-circle"
@@ -302,7 +324,11 @@ const rules = {
     squareBracketRef: {
         order: SimpleMarkdown.defaultRules.escape.order + 0.6,
         match: SimpleMarkdown.inlineRegex(/^\[(\d+)\]( *)/),
-        parse: (capture, parse, state: ParseState): LabelNode => {
+        parse: (
+            capture: Capture,
+            parse: Parser,
+            state: ParseState,
+        ): LabelNode => {
             if (!state.firstSentenceRef) {
                 state.firstSentenceRef = capture[1];
             }
@@ -311,7 +337,7 @@ const rules = {
                 space: capture[2].length > 0,
             };
         },
-        react: (node: LabelNode) => {
+        react: (node: LabelNode, output: OutputFun, state: ParseState) => {
             return [
                 <span
                     key="visual-brackets"
@@ -332,12 +358,16 @@ const rules = {
         match: SimpleMarkdown.inlineRegex(
             /^{highlighting.start}(.+?){highlighting.end}/,
         ),
-        parse: (capture, parse, state: ParseState): HighlightNode => {
+        parse: (
+            capture: Capture,
+            parse: Parser,
+            state: ParseState,
+        ): HighlightNode => {
             return {
                 content: capture[1],
             };
         },
-        react: (node: HighlightNode) => {
+        react: (node: HighlightNode, output: OutputFun, state: ParseState) => {
             return [
                 <span key={0} className="perseus-highlight">
                     {node.content}
@@ -350,12 +380,16 @@ const rules = {
         match: SimpleMarkdown.inlineRegex(
             /^{review-highlighting.start}(.+?){review-highlighting.end}/,
         ),
-        parse: (capture, parse, state: ParseState): HighlightNode => {
+        parse: (
+            capture: Capture,
+            parse: Parser,
+            state: ParseState,
+        ): HighlightNode => {
             return {
                 content: capture[1],
             };
         },
-        react: (node: HighlightNode) => {
+        react: (node: HighlightNode, output: OutputFun, state: ParseState) => {
             return [
                 <span key={0} className="perseus-review-highlight">
                     {node.content}

--- a/packages/perseus/src/widgets/passage/passage-markdown.jsx
+++ b/packages/perseus/src/widgets/passage/passage-markdown.jsx
@@ -1,10 +1,434 @@
 /* eslint-disable react/sort-comp */
 // @flow
+
 import SimpleMarkdown from "@khanacademy/simple-markdown";
 import * as i18n from "@khanacademy/wonder-blocks-i18n";
-import PropTypes from "prop-types";
 import * as React from "react";
 import _ from "underscore";
+
+import type {Capture, Parser} from "@khanacademy/simple-markdown";
+
+type ParseState = {
+    currentRef: number[],
+    useRefs: boolean,
+    lastRef: number,
+    firstSentenceRef?: string,
+    firstQuestionRef?: string,
+    lastFootnote: {id: number, text: string},
+};
+
+type FootnoteType = {
+    id: number,
+    text: string,
+};
+
+type RefStartNode = {
+    ref: ?number,
+    refContent: React.Node,
+};
+
+type RefEndNode = {
+    ref: ?number,
+};
+
+type LabelNode = {
+    content: string,
+    space: boolean,
+};
+
+type HighlightNode = {
+    content: string,
+};
+
+type RefStartProps = {
+    refContent: React.Node,
+};
+
+const INITIAL_PARSE_STATE: ParseState = {
+    currentRef: [],
+    useRefs: true,
+    lastRef: 0,
+    lastFootnote: {id: 0, text: ""},
+};
+
+class RefStart extends React.Component<RefStartProps> {
+    render(): React.Node {
+        return <span style={REF_STYLE}>{i18n.doNotTranslate("_")}</span>;
+    }
+
+    getRefContent = () => {
+        return this.props.refContent;
+    };
+}
+
+class RefEnd extends React.Component<{}> {
+    render(): React.Node {
+        return <span style={REF_STYLE}>{i18n.doNotTranslate("_")}</span>;
+    }
+}
+
+const rules: $FlowFixMe = {
+    // $FlowFixMe[prop-missing]
+    // $FlowFixMe[incompatible-use]
+    newline: SimpleMarkdown.defaultRules.newline,
+    // $FlowFixMe[prop-missing]
+    // $FlowFixMe[incompatible-use]
+    paragraph: SimpleMarkdown.defaultRules.paragraph,
+    // $FlowFixMe[prop-missing]
+    // $FlowFixMe[incompatible-use]
+    escape: SimpleMarkdown.defaultRules.escape,
+    passageFootnote: {
+        // $FlowFixMe[prop-missing]
+        // $FlowFixMe[incompatible-use]
+        order: SimpleMarkdown.defaultRules.escape.order + 0.1,
+        // $FlowFixMe[prop-missing]
+        match: SimpleMarkdown.inlineRegex(/^\^/),
+        parse: (
+            capture: Capture,
+            parse: Parser,
+            state: ParseState,
+        ): FootnoteType => {
+            // if no footnotes have been seen, we're id 1. otherwise,
+            // we're the next subsequent id
+            const id = state.lastFootnote.id + 1;
+            const footnote = {
+                id: id,
+                // our text is what to output. if there is only one footnote,
+                // it's a *; otherwise it's a superscript number
+                text: id === 1 ? "*" : "" + id,
+            };
+
+            // If the previous footnote was a *, we need to adjust it to be
+            // a number, since now we know there is more than one footnote
+            if (state.lastFootnote.text === "*") {
+                state.lastFootnote.text = "" + state.lastFootnote.id;
+            }
+
+            // and update our last footnote, + return.
+            state.lastFootnote = footnote;
+            return footnote;
+        },
+        react: (node: FootnoteType, output, state) => {
+            return <sup key={state.key}>{node.text}</sup>;
+        },
+    },
+    refStart: {
+        // $FlowFixMe[prop-missing]
+        // $FlowFixMe[incompatible-use]
+        order: SimpleMarkdown.defaultRules.escape.order + 0.2,
+        match: function (source: string, state) {
+            const capture = /^\{\{/.exec(source);
+            if (capture) {
+                // We need to do extra processing here to capture the
+                // full text of the reference, which we include so that
+                // we can use that information as a screenreader
+                let closeIndex = 2; // start looking after the opening "{{"
+                let refNestingLevel = 0;
+
+                // Find the closing "}}" for our opening "{{"
+                while (closeIndex < source.length) {
+                    const token = source.slice(closeIndex, closeIndex + 2);
+                    if (token === "{{") {
+                        refNestingLevel++;
+                        // increment an extra character so we get the
+                        // full 2-char token
+                        closeIndex++;
+                    } else if (token === "}}") {
+                        if (refNestingLevel > 0) {
+                            refNestingLevel--;
+                            // increment an extra character so we get the
+                            // full 2-char token
+                            closeIndex++;
+                        } else {
+                            break;
+                        }
+                    }
+                    closeIndex++;
+                }
+
+                const refText = source.slice(2, closeIndex);
+
+                // A "magic" capture that matches the opening {{
+                // but captures the full ref text internally :D
+                return [capture[0], refText];
+            }
+            return null;
+        },
+        parse: (
+            capture: Capture,
+            parse: Parser,
+            state: ParseState,
+        ): RefStartNode => {
+            if (!state.useRefs) {
+                return {
+                    ref: null,
+                    refContent: null,
+                };
+            }
+
+            const ref = state.lastRef + 1;
+            state.lastRef = ref;
+            state.currentRef.push(ref);
+
+            const refContent = parse(
+                // Curly quotes
+                "(\u201C" + capture[1] + "\u201D)\n\n",
+                _.defaults(
+                    {
+                        // We don't want to parse refs while looking through
+                        // this refs contents. We definitely don't want
+                        // to make those refs into react refs on the
+                        // passage, for instance!
+                        useRefs: false,
+                    },
+                    INITIAL_PARSE_STATE,
+                ),
+            );
+
+            return {
+                ref: ref,
+                refContent: refContent,
+            };
+        },
+        react: (node: RefStartNode, output, state) => {
+            if (node.ref == null) {
+                return null;
+            }
+
+            // We don't pass state here because this is parsed
+            // and output out-of-band. We don't want to affect
+            // our state by the double-output here :).
+            const refContent = output(node.refContent, {});
+
+            if (node.ref == null) {
+                return null;
+            }
+
+            return (
+                <RefStart
+                    ref={START_REF_PREFIX + node.ref}
+                    key={START_REF_PREFIX + node.ref}
+                    refContent={refContent}
+                />
+            );
+        },
+    },
+    refEnd: {
+        // $FlowFixMe[prop-missing]
+        // $FlowFixMe[incompatible-use]
+        order: SimpleMarkdown.defaultRules.escape.order + 0.3,
+        // $FlowFixMe[prop-missing]
+        match: SimpleMarkdown.inlineRegex(/^\}\}/),
+        parse: (
+            capture: Capture,
+            parse: Parser,
+            state: ParseState,
+        ): RefEndNode => {
+            if (!state.useRefs) {
+                return {
+                    ref: null,
+                };
+            }
+
+            const ref = state.currentRef.pop() || null;
+            return {
+                ref: ref,
+            };
+        },
+        react: (node: RefEndNode, output, state) => {
+            if (node.ref != null) {
+                return (
+                    <RefEnd
+                        ref={END_REF_PREFIX + node.ref}
+                        key={END_REF_PREFIX + node.ref}
+                    />
+                );
+            }
+            // if we didn't have a matching start reference, or
+            // we aren't parsing refs for this pass (we do this
+            // inside of refContent), don't output a ref
+            return null;
+        },
+    },
+    squareLabel: {
+        // $FlowFixMe[prop-missing]
+        // $FlowFixMe[incompatible-use]
+        order: SimpleMarkdown.defaultRules.escape.order + 0.4,
+        // $FlowFixMe[prop-missing]
+        match: SimpleMarkdown.inlineRegex(/^\[\[(\w+)\]\]( *)/),
+        parse: (
+            capture: Capture,
+            parse: Parser,
+            state: ParseState,
+        ): LabelNode => {
+            if (!state.firstQuestionRef) {
+                state.firstQuestionRef = capture[1];
+            }
+            return {
+                content: capture[1],
+                space: capture[2].length > 0,
+            };
+        },
+        react: (node: LabelNode, output, state) => {
+            return [
+                <span
+                    key="visual-square"
+                    className="perseus-passage-square-label"
+                    style={LABEL_OUTER_STYLE}
+                    aria-hidden="true"
+                >
+                    <span style={SQUARE_LABEL_STYLE}>{node.content}</span>
+                </span>,
+                <span key="alt-text" className="perseus-sr-only">
+                    {i18n.$_("[Marker for question %(number)s]", {
+                        number: node.content,
+                    })}
+                </span>,
+                node.space ? "\u00A0" : null,
+            ];
+        },
+    },
+    circleLabel: {
+        // $FlowFixMe[prop-missing]
+        // $FlowFixMe[incompatible-use]
+        order: SimpleMarkdown.defaultRules.escape.order + 0.5,
+        // $FlowFixMe[prop-missing]
+        match: SimpleMarkdown.inlineRegex(/^\(\((\w+)\)\)( *)/),
+        parse: (
+            capture: Capture,
+            parse: Parser,
+            state: ParseState,
+        ): LabelNode => {
+            return {
+                content: capture[1],
+                space: capture[2].length > 0,
+            };
+        },
+        react: (node: LabelNode, output, state) => {
+            return [
+                <span
+                    key="visual-circle"
+                    className="perseus-passage-circle-label"
+                    style={LABEL_OUTER_STYLE}
+                    aria-hidden={true}
+                >
+                    <span style={CIRCLE_LABEL_STYLE}>{node.content}</span>
+                </span>,
+                <span key="alt-text" className="perseus-sr-only">
+                    {i18n.$_("[Circle marker %(number)s]", {
+                        number: node.content,
+                    })}
+                </span>,
+                node.space ? "\u00A0" : null,
+            ];
+        },
+    },
+    squareBracketRef: {
+        // $FlowFixMe[prop-missing]
+        // $FlowFixMe[incompatible-use]
+        order: SimpleMarkdown.defaultRules.escape.order + 0.6,
+        // $FlowFixMe[prop-missing]
+        match: SimpleMarkdown.inlineRegex(/^\[(\d+)\]( *)/),
+        parse: (
+            capture: Capture,
+            parse: Parser,
+            state: ParseState,
+        ): LabelNode => {
+            if (!state.firstSentenceRef) {
+                state.firstSentenceRef = capture[1];
+            }
+            return {
+                content: capture[1],
+                space: capture[2].length > 0,
+            };
+        },
+        react: (node: LabelNode, output, state) => {
+            return [
+                <span
+                    key="visual-brackets"
+                    className="perseus-passage-bracket-label"
+                    aria-hidden="true"
+                >
+                    [{node.content}]
+                </span>,
+                <span key="alt-text" className="perseus-sr-only">
+                    {i18n.$_("[Sentence %(number)s]", {number: node.content})}
+                </span>,
+                node.space ? "\u00A0" : null,
+            ];
+        },
+    },
+    highlight: {
+        // $FlowFixMe[prop-missing]
+        // $FlowFixMe[incompatible-use]
+        order: SimpleMarkdown.defaultRules.escape.order + 0.7,
+        // $FlowFixMe[prop-missing]
+        match: SimpleMarkdown.inlineRegex(
+            /^{highlighting.start}(.+?){highlighting.end}/,
+        ),
+        parse: (
+            capture: Capture,
+            parse: Parser,
+            state: ParseState,
+        ): HighlightNode => {
+            return {
+                content: capture[1],
+            };
+        },
+        react: (node: HighlightNode, output, state) => {
+            return [
+                <span key={0} className="perseus-highlight">
+                    {node.content}
+                </span>,
+            ];
+        },
+    },
+    reviewHighlight: {
+        // $FlowFixMe[prop-missing]
+        // $FlowFixMe[incompatible-use]
+        order: SimpleMarkdown.defaultRules.escape.order + 0.7,
+        // $FlowFixMe[prop-missing]
+        match: SimpleMarkdown.inlineRegex(
+            /^{review-highlighting.start}(.+?){review-highlighting.end}/,
+        ),
+        parse: (
+            capture: Capture,
+            parse: Parser,
+            state: ParseState,
+        ): HighlightNode => {
+            return {
+                content: capture[1],
+            };
+        },
+        react: (node: HighlightNode, output, state) => {
+            return [
+                <span key={0} className="perseus-review-highlight">
+                    {node.content}
+                </span>,
+            ];
+        },
+    },
+    // $FlowFixMe[prop-missing]
+    // $FlowFixMe[incompatible-use]
+    strong: SimpleMarkdown.defaultRules.strong,
+    // $FlowFixMe[prop-missing]
+    // $FlowFixMe[incompatible-use]
+    u: SimpleMarkdown.defaultRules.u,
+    // $FlowFixMe[prop-missing]
+    // $FlowFixMe[incompatible-use]
+    em: SimpleMarkdown.defaultRules.em,
+    // $FlowFixMe[prop-missing]
+    // $FlowFixMe[incompatible-use]
+    del: SimpleMarkdown.defaultRules.del,
+    text: {
+        // $FlowFixMe[prop-missing]
+        // $FlowFixMe[incompatible-use]
+        ...SimpleMarkdown.defaultRules.text,
+        react(node, output, state) {
+            return <span key={state.key}>{node.content}</span>;
+        },
+    },
+};
 
 const START_REF_PREFIX = "start-ref-";
 const END_REF_PREFIX = "end-ref-";
@@ -43,358 +467,6 @@ const CIRCLE_LABEL_STYLE = {
     textAlign: "center",
 };
 
-class RefStart extends React.Component<$FlowFixMe> {
-    static propTypes = {
-        refContent: PropTypes.node.isRequired,
-    };
-
-    render(): React.Node {
-        return <span style={REF_STYLE}>{i18n.doNotTranslate("_")}</span>;
-    }
-
-    getRefContent = () => {
-        return this.props.refContent;
-    };
-}
-
-class RefEnd extends React.Component<$FlowFixMe> {
-    render(): React.Node {
-        return <span style={REF_STYLE}>{i18n.doNotTranslate("_")}</span>;
-    }
-}
-
-const rules: $FlowFixMe = {
-    // $FlowFixMe[prop-missing]
-    // $FlowFixMe[incompatible-use]
-    newline: SimpleMarkdown.defaultRules.newline,
-    // $FlowFixMe[prop-missing]
-    // $FlowFixMe[incompatible-use]
-    paragraph: SimpleMarkdown.defaultRules.paragraph,
-    // $FlowFixMe[prop-missing]
-    // $FlowFixMe[incompatible-use]
-    escape: SimpleMarkdown.defaultRules.escape,
-    passageFootnote: {
-        // $FlowFixMe[prop-missing]
-        // $FlowFixMe[incompatible-use]
-        order: SimpleMarkdown.defaultRules.escape.order + 0.1,
-        // $FlowFixMe[prop-missing]
-        match: SimpleMarkdown.inlineRegex(/^\^/),
-        parse: (capture, parse, state) => {
-            // if no footnotes have been seen, we're id 1. otherwise,
-            // we're the next subsequent id
-            const id = state.lastFootnote.id + 1;
-            const footnote = {
-                id: id,
-                // our text is what to output. if there is only one footnote,
-                // it's a *; otherwise it's a superscript number
-                text: id === 1 ? "*" : "" + id,
-            };
-
-            // If the previous footnote was a *, we need to adjust it to be
-            // a number, since now we know there is more than one footnote
-            if (state.lastFootnote.text === "*") {
-                state.lastFootnote.text = "" + state.lastFootnote.id;
-            }
-
-            // and update our last footnote, + return.
-            state.lastFootnote = footnote;
-            return footnote;
-        },
-        react: (node, output, state) => {
-            return <sup key={state.key}>{node.text}</sup>;
-        },
-    },
-    refStart: {
-        // $FlowFixMe[prop-missing]
-        // $FlowFixMe[incompatible-use]
-        order: SimpleMarkdown.defaultRules.escape.order + 0.2,
-        match: function (source, state) {
-            const capture = /^\{\{/.exec(source);
-            if (capture) {
-                // We need to do extra processing here to capture the
-                // full text of the reference, which we include so that
-                // we can use that information as a screenreader
-                let closeIndex = 2; // start looking after the opening "{{"
-                let refNestingLevel = 0;
-
-                // Find the closing "}}" for our opening "{{"
-                while (closeIndex < source.length) {
-                    const token = source.slice(closeIndex, closeIndex + 2);
-                    if (token === "{{") {
-                        refNestingLevel++;
-                        // increment an extra character so we get the
-                        // full 2-char token
-                        closeIndex++;
-                    } else if (token === "}}") {
-                        if (refNestingLevel > 0) {
-                            refNestingLevel--;
-                            // increment an extra character so we get the
-                            // full 2-char token
-                            closeIndex++;
-                        } else {
-                            break;
-                        }
-                    }
-                    closeIndex++;
-                }
-
-                const refText = source.slice(2, closeIndex);
-
-                // A "magic" capture that matches the opening {{
-                // but captures the full ref text internally :D
-                return [capture[0], refText];
-            }
-            return null;
-        },
-        parse: (capture, parse, state) => {
-            if (!state.useRefs) {
-                return {
-                    ref: null,
-                    refContent: null,
-                };
-            }
-
-            const ref = state.lastRef + 1;
-            state.lastRef = ref;
-            state.currentRef.push(ref);
-
-            const refContent = parse(
-                // Curly quotes
-                "(\u201C" + capture[1] + "\u201D)\n\n",
-                _.defaults(
-                    {
-                        // We don't want to parse refs while looking through
-                        // this refs contents. We definitely don't want
-                        // to make those refs into react refs on the
-                        // passage, for instance!
-                        useRefs: false,
-                    },
-                    INITIAL_PARSE_STATE,
-                ),
-            );
-
-            return {
-                ref: ref,
-                refContent: refContent,
-            };
-        },
-        react: (node, output, state) => {
-            if (node.ref == null) {
-                return null;
-            }
-
-            // We don't pass state here because this is parsed
-            // and output out-of-band. We don't want to affect
-            // our state by the double-output here :).
-            const refContent = output(node.refContent, {});
-            return (
-                <RefStart
-                    ref={START_REF_PREFIX + node.ref}
-                    key={START_REF_PREFIX + node.ref}
-                    refContent={refContent}
-                />
-            );
-        },
-    },
-    refEnd: {
-        // $FlowFixMe[prop-missing]
-        // $FlowFixMe[incompatible-use]
-        order: SimpleMarkdown.defaultRules.escape.order + 0.3,
-        // $FlowFixMe[prop-missing]
-        match: SimpleMarkdown.inlineRegex(/^\}\}/),
-        parse: (capture, parse, state) => {
-            if (!state.useRefs) {
-                return {
-                    ref: null,
-                };
-            }
-
-            const ref = state.currentRef.pop() || null;
-            return {
-                ref: ref,
-            };
-        },
-        react: (node, output, state) => {
-            if (node.ref != null) {
-                return (
-                    <RefEnd
-                        ref={END_REF_PREFIX + node.ref}
-                        key={END_REF_PREFIX + node.ref}
-                    />
-                );
-            }
-            // if we didn't have a matching start reference, or
-            // we aren't parsing refs for this pass (we do this
-            // inside of refContent), don't output a ref
-            return null;
-        },
-    },
-    squareLabel: {
-        // $FlowFixMe[prop-missing]
-        // $FlowFixMe[incompatible-use]
-        order: SimpleMarkdown.defaultRules.escape.order + 0.4,
-        // $FlowFixMe[prop-missing]
-        match: SimpleMarkdown.inlineRegex(/^\[\[(\w+)\]\]( *)/),
-        parse: (capture, parse, state) => {
-            if (!state.firstQuestionRef) {
-                state.firstQuestionRef = capture[1];
-            }
-            return {
-                content: capture[1],
-                space: capture[2].length > 0,
-            };
-        },
-        react: (node, output, state) => {
-            return [
-                <span
-                    key="visual-square"
-                    className="perseus-passage-square-label"
-                    style={LABEL_OUTER_STYLE}
-                    aria-hidden="true"
-                >
-                    <span style={SQUARE_LABEL_STYLE}>{node.content}</span>
-                </span>,
-                <span key="alt-text" className="perseus-sr-only">
-                    {i18n.$_("[Marker for question %(number)s]", {
-                        number: node.content,
-                    })}
-                </span>,
-                node.space ? "\u00A0" : null,
-            ];
-        },
-    },
-    circleLabel: {
-        // $FlowFixMe[prop-missing]
-        // $FlowFixMe[incompatible-use]
-        order: SimpleMarkdown.defaultRules.escape.order + 0.5,
-        // $FlowFixMe[prop-missing]
-        match: SimpleMarkdown.inlineRegex(/^\(\((\w+)\)\)( *)/),
-        parse: (capture, parse, state) => {
-            return {
-                content: capture[1],
-                space: capture[2].length > 0,
-            };
-        },
-        react: (node, output, state) => {
-            return [
-                <span
-                    key="visual-circle"
-                    className="perseus-passage-circle-label"
-                    style={LABEL_OUTER_STYLE}
-                    aria-hidden={true}
-                >
-                    <span style={CIRCLE_LABEL_STYLE}>{node.content}</span>
-                </span>,
-                <span key="alt-text" className="perseus-sr-only">
-                    {i18n.$_("[Circle marker %(number)s]", {
-                        number: node.content,
-                    })}
-                </span>,
-                node.space ? "\u00A0" : null,
-            ];
-        },
-    },
-    squareBracketRef: {
-        // $FlowFixMe[prop-missing]
-        // $FlowFixMe[incompatible-use]
-        order: SimpleMarkdown.defaultRules.escape.order + 0.6,
-        // $FlowFixMe[prop-missing]
-        match: SimpleMarkdown.inlineRegex(/^\[(\d+)\]( *)/),
-        parse: (capture, parse, state) => {
-            if (!state.firstSentenceRef) {
-                state.firstSentenceRef = capture[1];
-            }
-            return {
-                content: capture[1],
-                space: capture[2].length > 0,
-            };
-        },
-        react: (node, output, state) => {
-            return [
-                <span
-                    key="visual-brackets"
-                    className="perseus-passage-bracket-label"
-                    aria-hidden="true"
-                >
-                    [{node.content}]
-                </span>,
-                <span key="alt-text" className="perseus-sr-only">
-                    {i18n.$_("[Sentence %(number)s]", {number: node.content})}
-                </span>,
-                node.space ? "\u00A0" : null,
-            ];
-        },
-    },
-    highlight: {
-        // $FlowFixMe[prop-missing]
-        // $FlowFixMe[incompatible-use]
-        order: SimpleMarkdown.defaultRules.escape.order + 0.7,
-        // $FlowFixMe[prop-missing]
-        match: SimpleMarkdown.inlineRegex(
-            /^{highlighting.start}(.+?){highlighting.end}/,
-        ),
-        parse: (capture, parse, state) => {
-            return {
-                content: capture[1],
-            };
-        },
-        react: (node, output, state) => {
-            return [
-                <span key={0} className="perseus-highlight">
-                    {node.content}
-                </span>,
-            ];
-        },
-    },
-    reviewHighlight: {
-        // $FlowFixMe[prop-missing]
-        // $FlowFixMe[incompatible-use]
-        order: SimpleMarkdown.defaultRules.escape.order + 0.7,
-        // $FlowFixMe[prop-missing]
-        match: SimpleMarkdown.inlineRegex(
-            /^{review-highlighting.start}(.+?){review-highlighting.end}/,
-        ),
-        parse: (capture, parse, state) => {
-            return {
-                content: capture[1],
-            };
-        },
-        react: (node, output, state) => {
-            return [
-                <span key={0} className="perseus-review-highlight">
-                    {node.content}
-                </span>,
-            ];
-        },
-    },
-    // $FlowFixMe[prop-missing]
-    // $FlowFixMe[incompatible-use]
-    strong: SimpleMarkdown.defaultRules.strong,
-    // $FlowFixMe[prop-missing]
-    // $FlowFixMe[incompatible-use]
-    u: SimpleMarkdown.defaultRules.u,
-    // $FlowFixMe[prop-missing]
-    // $FlowFixMe[incompatible-use]
-    em: SimpleMarkdown.defaultRules.em,
-    // $FlowFixMe[prop-missing]
-    // $FlowFixMe[incompatible-use]
-    del: SimpleMarkdown.defaultRules.del,
-    text: {
-        // $FlowFixMe[prop-missing]
-        // $FlowFixMe[incompatible-use]
-        ...SimpleMarkdown.defaultRules.text,
-        react(node, output, state) {
-            return <span key={state.key}>{node.content}</span>;
-        },
-    },
-};
-
-const INITIAL_PARSE_STATE = {
-    currentRef: [],
-    useRefs: true,
-    lastRef: 0,
-    lastFootnote: {id: 0, text: ""},
-};
 // $FlowFixMe[prop-missing]
 const builtParser = SimpleMarkdown.parserFor(rules);
 const parse: (string, $FlowFixMe) => $FlowFixMe = (source, state) => {

--- a/packages/perseus/src/widgets/passage/passage-markdown.jsx
+++ b/packages/perseus/src/widgets/passage/passage-markdown.jsx
@@ -56,7 +56,7 @@ class RefStart extends React.Component<RefStartProps> {
         return <span style={REF_STYLE}>{i18n.doNotTranslate("_")}</span>;
     }
 
-    getRefContent = () => {
+    getRefContent: () => React.Node = () => {
         return this.props.refContent;
     };
 }
@@ -116,7 +116,7 @@ const rules: $FlowFixMe = {
         // $FlowFixMe[prop-missing]
         // $FlowFixMe[incompatible-use]
         order: SimpleMarkdown.defaultRules.escape.order + 0.2,
-        match: function (source: string, state) {
+        match: function (source: string) {
             const capture = /^\{\{/.exec(source);
             if (capture) {
                 // We need to do extra processing here to capture the
@@ -190,7 +190,7 @@ const rules: $FlowFixMe = {
                 refContent: refContent,
             };
         },
-        react: (node: RefStartNode, output, state) => {
+        react: function (node: RefStartNode, output) {
             if (node.ref == null) {
                 return null;
             }
@@ -204,6 +204,8 @@ const rules: $FlowFixMe = {
                 return null;
             }
 
+            // note(matthewc) the refs created here become the refs
+            // pulled from `this.refs` in passage.jsx
             return (
                 <RefStart
                     ref={START_REF_PREFIX + node.ref}
@@ -235,8 +237,10 @@ const rules: $FlowFixMe = {
                 ref: ref,
             };
         },
-        react: (node: RefEndNode, output, state) => {
+        react: function (node: RefEndNode) {
             if (node.ref != null) {
+                // note(matthewc) the refs created here become the refs
+                // pulled from `this.refs` in passage.jsx
                 return (
                     <RefEnd
                         ref={END_REF_PREFIX + node.ref}
@@ -269,7 +273,7 @@ const rules: $FlowFixMe = {
                 space: capture[2].length > 0,
             };
         },
-        react: (node: LabelNode, output, state) => {
+        react: (node: LabelNode) => {
             return [
                 <span
                     key="visual-square"
@@ -304,7 +308,7 @@ const rules: $FlowFixMe = {
                 space: capture[2].length > 0,
             };
         },
-        react: (node: LabelNode, output, state) => {
+        react: (node: LabelNode): React.Node => {
             return [
                 <span
                     key="visual-circle"
@@ -342,7 +346,7 @@ const rules: $FlowFixMe = {
                 space: capture[2].length > 0,
             };
         },
-        react: (node: LabelNode, output, state) => {
+        react: (node: LabelNode) => {
             return [
                 <span
                     key="visual-brackets"
@@ -375,7 +379,7 @@ const rules: $FlowFixMe = {
                 content: capture[1],
             };
         },
-        react: (node: HighlightNode, output, state) => {
+        react: (node: HighlightNode) => {
             return [
                 <span key={0} className="perseus-highlight">
                     {node.content}
@@ -400,7 +404,7 @@ const rules: $FlowFixMe = {
                 content: capture[1],
             };
         },
-        react: (node: HighlightNode, output, state) => {
+        react: (node: HighlightNode) => {
             return [
                 <span key={0} className="perseus-review-highlight">
                     {node.content}
@@ -467,7 +471,6 @@ const CIRCLE_LABEL_STYLE = {
     textAlign: "center",
 };
 
-// $FlowFixMe[prop-missing]
 const builtParser = SimpleMarkdown.parserFor(rules);
 const parse: (string, $FlowFixMe) => $FlowFixMe = (source, state) => {
     state = state || {};
@@ -477,12 +480,10 @@ const parse: (string, $FlowFixMe) => $FlowFixMe = (source, state) => {
 
 export default {
     parse: parse,
-    // $FlowFixMe[prop-missing]
     output: (SimpleMarkdown.reactFor(
-        // $FlowFixMe[prop-missing]
         SimpleMarkdown.ruleOutput(rules, "react"),
     ): $FlowFixMe),
-    START_REF_PREFIX: START_REF_PREFIX,
-    END_REF_PREFIX: END_REF_PREFIX,
+    START_REF_PREFIX,
+    END_REF_PREFIX,
     _rulesForTesting: rules,
 };

--- a/packages/simple-markdown/src/index.js
+++ b/packages/simple-markdown/src/index.js
@@ -1994,6 +1994,7 @@ export type {
     Rules,
     ReactRules,
     HtmlRules,
+    SingleASTNode,
 };
 
 // $FlowFixMe


### PR DESCRIPTION
## Summary:
This work kind of spiraled out, so I thought I would stop here and try to land some of this. It's not a perfect win, but it's an improvement:
- `passage`: 76% to 85% (uncovered bits are mostly jQuery and Underscore)
- `passage-markdown`: 62% to 96%

### Context

Passage is kind of an extension of SimpleMarkdown that allows for adding special MD features like references (to a part of the passage, not a React ref) and footnotes. PassageMarkdown is the set of custom rules that extends SimpleMarkdown which is then used by Passage to render the content. Since Passage and PassageMarkdown are so tightly bound together, it was difficult to work on one without working on the other.

Passage relies a lot of JQuery and Underscore; I wanted to remove them, but I kept breaking tests. Might make another pass in a future PR.

Part of issue: LP-12822

## Test plan:
Nothing should change, it should just be better typed