### PR TITLE
Update perseus fonts to match wonderblocks

### DIFF
--- a/.changeset/brave-birds-fail.md
+++ b/.changeset/brave-birds-fail.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Update CSS to match wonderblocks, round I

--- a/packages/perseus/src/styles/perseus-renderer.less
+++ b/packages/perseus/src/styles/perseus-renderer.less
@@ -107,7 +107,7 @@
     }
 
     div.paragraph {
-        font-family: '"Noto Serif", serif';
+        font-family: "Noto Serif", serif;
         font-weight: 400;
         font-size: 18px;
         line-height: 22px;

--- a/packages/perseus/src/styles/perseus-renderer.less
+++ b/packages/perseus/src/styles/perseus-renderer.less
@@ -107,7 +107,10 @@
     }
 
     div.paragraph {
-        .legacy-typography;
+        font-family: '"Noto Serif", serif';
+        font-weight: 400;
+        font-size: 18px;
+        line-height: 22px;
         margin: 22px 0px;
     }
 
@@ -131,8 +134,11 @@
 
     div.instructions {
         display: block;
+        font-family: "Noto Serif", serif;
+        font-weight: 800;
+        font-size: 18px;
+        line-height: 22px;
         font-style: italic;
-        font-weight: bold;
     }
 
     .perseus-renderer > .paragraph > ul:not(.perseus-widget-radio),

--- a/packages/perseus/src/styles/widgets/passage.less
+++ b/packages/perseus/src/styles/widgets/passage.less
@@ -38,15 +38,19 @@
         line-height: @line-height - 2;
     }
     .passage-title div.paragraph {
-        font-size: @font-size;
+        font-family: "Noto Serif", serif;
         font-weight: 700;
+        font-size: 20px;
+        line-height: 22px;
+
         margin: 0 0 10px;
     }
     .passage-text div.paragraph {
-        font-size: @font-size;
-        line-height: @line-height;
-        margin: 0;
-        text-indent: 20px;
+        font-family: "Noto Serif", serif;
+        font-weight: 400;
+        font-size: 20px;
+        line-height: 24px;
+
         span {
             text-indent: 0;
         }

--- a/packages/perseus/src/widgets/definition.jsx
+++ b/packages/perseus/src/widgets/definition.jsx
@@ -72,7 +72,7 @@ class Definition extends React.Component<DefinitionProps> {
                     >
                         <span className="perseus-widget-definition">
                             <Button
-                                size="small"
+                                size="medium"
                                 kind="tertiary"
                                 onClick={() => {
                                     this.props.trackInteraction();


### PR DESCRIPTION
## Summary:
Updates perseus body font and passage font to match wonderblocks.

<img width="1256" alt="Screen Shot 2022-11-16 at 12 46 15 PM" src="https://user-images.githubusercontent.com/18454/202281744-b7274b44-ff8b-4980-975e-cc91db789209.png">

Issue: https://khanacademy.atlassian.net/browse/LP-12340

## Test plan:
- Open storybooks
- Make sure everything is still readable