### PR TITLE
Highlight tooltip storybook

### DIFF
--- a/packages/perseus/src/components/__stories__/highlight-tooltip.stories.jsx
+++ b/packages/perseus/src/components/__stories__/highlight-tooltip.stories.jsx
@@ -1,0 +1,12 @@
+// @flow
+
+import * as React from "react";
+
+import * as IconPaths from "../../icon-paths.js";
+import IconComponent from "../icon.jsx";
+
+export default {
+    title: "Perseus/Components/Highlight Toolip",
+};
+
+export const Main = (args: any): React.Node => <p>Hello</p>;

--- a/packages/perseus/src/components/__stories__/highlight-tooltip.stories.jsx
+++ b/packages/perseus/src/components/__stories__/highlight-tooltip.stories.jsx
@@ -1,6 +1,7 @@
 // @flow
 
 import * as React from "react";
+import {action} from "@storybook/addon-actions";
 
 import HighlightTooltip from "../highlighting/ui/highlight-tooltip";
 
@@ -12,9 +13,9 @@ export const Main = (args: any): React.Node => (
     // $FlowIgnore[prop-missing]
     <HighlightTooltip
         label="Highlight"
-        onClick={() => {
-            console.log("ok");
-        }}
+        onClick={action("clicked")}
+        onMouseEnter={action("onMouseEnter")}
+        onMouseLeave={action("onMouseLeave")}
         __testFocusRest={{
             top: 400,
             left: 200,

--- a/packages/perseus/src/components/__stories__/highlight-tooltip.stories.jsx
+++ b/packages/perseus/src/components/__stories__/highlight-tooltip.stories.jsx
@@ -2,11 +2,23 @@
 
 import * as React from "react";
 
-import * as IconPaths from "../../icon-paths.js";
-import IconComponent from "../icon.jsx";
+import HighlightTooltip from "../highlighting/ui/highlight-tooltip";
 
 export default {
     title: "Perseus/Components/Highlight Toolip",
 };
 
-export const Main = (args: any): React.Node => <p>Hello</p>;
+export const Main = (args: any): React.Node => (
+    // $FlowIgnore[prop-missing]
+    <HighlightTooltip
+        label="Highlight"
+        onClick={() => {
+            console.log("ok");
+        }}
+        __testFocusRest={{
+            top: 400,
+            left: 200,
+            height: 80,
+        }}
+    />
+);

--- a/packages/perseus/src/components/highlighting/ui/highlight-tooltip.jsx
+++ b/packages/perseus/src/components/highlighting/ui/highlight-tooltip.jsx
@@ -30,6 +30,15 @@ type HighlightTooltipProps = {|
     onMouseEnter?: () => mixed,
     onMouseLeave?: () => mixed,
 
+    // This is only to be used by tests and exists because
+    // tests don't seem to play nicely with building a highlight
+    // range in `_getFocusRect`
+    __testFocusRest?: {
+        top: number,
+        left: number,
+        height: number,
+    },
+
     focusNode: Node,
     focusOffset: number,
     offsetParent: Element,
@@ -89,7 +98,7 @@ class HighlightTooltip extends React.PureComponent<HighlightTooltipProps> {
     }
 
     render(): null | React.Node {
-        const focusRect = this._getFocusRect();
+        const focusRect = this.props.__testFocusRest || this._getFocusRect();
         if (!focusRect) {
             return null;
         }


### PR DESCRIPTION
## Summary:
Adds a storybook page for `HighlightTooltip` which is used in passage and closes out my work on the new tooltip project.

Note: I added a test-only prop. I normally don't love doing this but in this case I just couldn't get the storybook to do measuring correctly. Even in the passage storybook page the tooltip is broken:


https://user-images.githubusercontent.com/18454/203143240-c2d69aa5-613d-4d2e-9755-4fa5befb279f.mov

I don't want to sink a ton of time into making this perfect- we just need a storybook page to demo the component and this does that.

Here's a demo of it working:

<img width="877" alt="Screen Shot 2022-11-21 at 11 30 24 AM" src="https://user-images.githubusercontent.com/18454/203143019-0022e311-8505-45d8-9fff-5fd4cd2a814e.png">

Issue: https://khanacademy.atlassian.net/browse/LP-12585

## Test plan:
- Open the storybook page
- **You should see a demo for highlight tooltip**