### PR TITLE
Numeric-Input stabilization (Flow)

### DIFF
--- a/.changeset/angry-cameras-share.md
+++ b/.changeset/angry-cameras-share.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+add shared types to perseus-types

--- a/.changeset/angry-cameras-share.md
+++ b/.changeset/angry-cameras-share.md
@@ -2,4 +2,4 @@
 "@khanacademy/perseus": patch
 ---
 
-add shared types to perseus-types
+add shared PerseusNumericInputAnswerForm and MathFormat types to perseus-types

--- a/packages/perseus/src/components/number-input.jsx
+++ b/packages/perseus/src/components/number-input.jsx
@@ -11,7 +11,7 @@ import _ from "underscore";
 import Util from "../util.js";
 import KhanMath from "../util/math.js";
 
-import type {Format} from "../util/math.js";
+import type {MathFormat} from "../perseus-types";
 
 const {firstNumericalParse, captureScratchpadTouchStart} = Util;
 const toNumericString = KhanMath.toNumericString;
@@ -242,7 +242,7 @@ class NumberInput extends React.Component<$FlowFixMe, $FlowFixMe> {
         }
     };
 
-    _setValue: (number, Format) => void = (val, format) => {
+    _setValue: (number, MathFormat) => void = (val, format) => {
         // eslint-disable-next-line react/no-string-refs
         $(ReactDOM.findDOMNode(this.refs.input)).val(
             toNumericString(val, format),

--- a/packages/perseus/src/components/simple-keypad-input.jsx
+++ b/packages/perseus/src/components/simple-keypad-input.jsx
@@ -14,42 +14,35 @@ import {
     KeypadTypes,
     keypadElementPropType,
 } from "@khanacademy/math-input";
-import createReactClass from "create-react-class";
 import PropTypes from "prop-types";
 import * as React from "react";
 
-const SimpleKeypadInput: any = createReactClass({
-    displayName: "SimpleKeypadInput",
-
-    propTypes: {
-        keypadElement: keypadElementPropType,
-        onFocus: PropTypes.func,
-        value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    },
-
-    componentDidMount: function () {
+export default class SimpleKeypadInput extends React.Component<$FlowFixMe> {
+    componentDidMount() {
         // TODO(scottgrant): This is a hack to remove the deprecated call to
         // this.isMounted() but is still considered an anti-pattern.
         this._isMounted = true;
-    },
+    }
 
-    componentWillUnmount: function () {
+    componentWillUnmount() {
         this._isMounted = false;
-    },
+    }
+
+    _isMounted: boolean = false;
 
     focus() {
         // $FlowFixMe[object-this-reference]
         this.refs.input.focus(); // eslint-disable-line react/no-string-refs
-    },
+    }
 
     blur() {
         // $FlowFixMe[object-this-reference]
         this.refs.input.blur(); // eslint-disable-line react/no-string-refs
-    },
+    }
 
-    getValue: function () {
+    getValue(): string | number {
         return this.props.value;
-    },
+    }
 
     render(): React.Node {
         // $FlowFixMe[object-this-reference]
@@ -85,7 +78,11 @@ const SimpleKeypadInput: any = createReactClass({
                 {...rest}
             />
         );
-    },
-});
+    }
+}
 
-export default SimpleKeypadInput;
+SimpleKeypadInput.propTypes = {
+    keypadElement: keypadElementPropType,
+    onFocus: PropTypes.func,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};

--- a/packages/perseus/src/index.js
+++ b/packages/perseus/src/index.js
@@ -121,11 +121,11 @@ export type {
     WidgetInfo,
 } from "./types.js";
 export type {
+    MathFormat,
     InputNumberWidget,
     PerseusRadioWidgetOptions,
     PerseusRenderer,
 } from "./perseus-types.js";
-export type {Format} from "./util/math.js";
 export type {Coord} from "./interactive2/types.js";
 export type {MarkerType} from "./widgets/label-image/types.js";
 

--- a/packages/perseus/src/perseus-types.js
+++ b/packages/perseus/src/perseus-types.js
@@ -1404,7 +1404,7 @@ export type PerseusInputNumberWidgetOptions = {|
     rightAlign?: boolean,
     simplify: "required" | "optional" | "enforced",
     size: "normal" | "small",
-    value: string | number | boolean,
+    value: string | number,
     customKeypad?: boolean,
 |};
 

--- a/packages/perseus/src/perseus-types.js
+++ b/packages/perseus/src/perseus-types.js
@@ -706,9 +706,18 @@ export type PerseusMeasurerWidgetOptions = {|
     static: boolean,
 |};
 
+export type MathFormat =
+    | "integer"
+    | "mixed"
+    | "improper"
+    | "proper"
+    | "decimal"
+    | "percent"
+    | "pi";
+
 export type PerseusNumericInputAnswerForm = {|
     simplify: ?("required" | "correct" | "enforced"),
-    name: "integer" | "decimal" | "proper" | "improper" | "mixed" | "pi",
+    name: MathFormat,
 |};
 
 export type PerseusNumericInputWidgetOptions = {|
@@ -733,15 +742,6 @@ export type PerseusNumericInputWidgetOptions = {|
     // see TODO in numeric-input
     answerForms?: $ReadOnlyArray<PerseusNumericInputAnswerForm>,
 |};
-
-export type MathFormat =
-    | "integer"
-    | "mixed"
-    | "improper"
-    | "proper"
-    | "decimal"
-    | "percent"
-    | "pi";
 
 export type PerseusNumericInputAnswer = {|
     // Translatable Display; A description for why this answer is correct, wrong, or ungraded

--- a/packages/perseus/src/perseus-types.js
+++ b/packages/perseus/src/perseus-types.js
@@ -716,7 +716,7 @@ export type MathFormat =
     | "pi";
 
 export type PerseusNumericInputAnswerForm = {|
-    simplify: ?("required" | "correct" | "enforced"),
+    simplify: ?("required" | "correct" | "enforced" | "optional"),
     name: MathFormat,
 |};
 

--- a/packages/perseus/src/perseus-types.js
+++ b/packages/perseus/src/perseus-types.js
@@ -706,6 +706,11 @@ export type PerseusMeasurerWidgetOptions = {|
     static: boolean,
 |};
 
+export type PerseusNumericInputAnswerForm = {|
+    simplify: ?("required" | "correct" | "enforced"),
+    name: "integer" | "decimal" | "proper" | "improper" | "mixed" | "pi",
+|};
+
 export type PerseusNumericInputWidgetOptions = {|
     // A list of all the possible correct and incorrect answers
     answers: $ReadOnlyArray<PerseusNumericInputAnswer>,
@@ -726,22 +731,28 @@ export type PerseusNumericInputWidgetOptions = {|
 
     // Used by examples, maybe not used and should be removed in the future
     // see TODO in numeric-input
-    answerForms?: $ReadOnlyArray<{|
-        simplify: ?("required" | "correct" | "enforced"),
-        name: "integer" | "decimal" | "proper" | "improper" | "mixed" | "pi",
-    |}>,
+    answerForms?: $ReadOnlyArray<PerseusNumericInputAnswerForm>,
 |};
+
+export type MathFormat =
+    | "integer"
+    | "mixed"
+    | "improper"
+    | "proper"
+    | "decimal"
+    | "percent"
+    | "pi";
 
 export type PerseusNumericInputAnswer = {|
     // Translatable Display; A description for why this answer is correct, wrong, or ungraded
     message: string,
     // The expected answer
-    value: ?number,
+    value: number,
     // Whether this answer is "correct", "wrong", or "ungraded"
     status: string,
     // The forms available for this answer.  Options: "integer, ""decimal", "proper", "improper", "mixed", or "pi"
     // NOTE: perseus_data.go says this is required even though it isn't necessary.
-    answerForms?: $ReadOnlyArray<string>,
+    answerForms?: $ReadOnlyArray<MathFormat>,
     // Whether the answerForms should be strictly matched
     strict: boolean,
     // A range of error +/- the value

--- a/packages/perseus/src/util/answer-types.js
+++ b/packages/perseus/src/util/answer-types.js
@@ -106,7 +106,7 @@ export const errors = {
  *
  */
 
-const KhanAnswerTypes: $FlowFixMe = {
+const KhanAnswerTypes = {
     /*
      * predicate answer type
      *
@@ -653,8 +653,7 @@ const KhanAnswerTypes: $FlowFixMe = {
             correctAnswer: string,
             options: $FlowFixMe,
         ): Predicate {
-            // TODO(alpert): Don't think this $.trim is necessary
-            const correctFloat = parseFloat($.trim(correctAnswer));
+            const correctFloat = parseFloat(correctAnswer);
 
             return [
                 function (guess, maxError) {

--- a/packages/perseus/src/util/math.js
+++ b/packages/perseus/src/util/math.js
@@ -4,14 +4,7 @@ import {number as knumber} from "@khanacademy/kmath";
 import $ from "jquery";
 import _ from "underscore";
 
-export type Format =
-    | "integer"
-    | "mixed"
-    | "improper"
-    | "proper"
-    | "decimal"
-    | "percent"
-    | "pi";
+import type {MathFormat} from "../perseus-types";
 
 const KhanMath = {
     // Simplify formulas before display
@@ -213,7 +206,7 @@ const KhanMath = {
     // Returns the format (string) of a given numeric string
     // Note: purposively more inclusive than answer-types' predicate.forms
     // That is, it is not necessarily true that interpreted input are numeric
-    getNumericFormat: function (text: string): ?Format {
+    getNumericFormat: function (text: string): ?MathFormat {
         text = $.trim(text);
         text = text.replace(/\u2212/, "-").replace(/([+-])\s+/g, "$1");
         if (text.match(/^[+-]?\d+$/)) {
@@ -238,7 +231,7 @@ const KhanMath = {
     },
 
     // Returns a string of the number in a specified format
-    toNumericString: function (number: number, format?: Format): string {
+    toNumericString: function (number: number, format?: MathFormat): string {
         if (number == null) {
             return "";
         }

--- a/packages/perseus/src/widgets/__tests__/numeric-input_test.jsx
+++ b/packages/perseus/src/widgets/__tests__/numeric-input_test.jsx
@@ -529,14 +529,18 @@ describe("unionAnswerForms utility function", () => {
     it("removes duplicates", () => {
         // arrange
         const forms = [
-            {
-                status: "correct",
-                value: 1,
-            },
-            {
-                status: "correct",
-                value: 1,
-            },
+            [
+                {
+                    simplify: "required",
+                    name: "integer",
+                },
+            ],
+            [
+                {
+                    simplify: "required",
+                    name: "integer",
+                },
+            ],
         ];
 
         // act

--- a/packages/perseus/src/widgets/input-number.jsx
+++ b/packages/perseus/src/widgets/input-number.jsx
@@ -332,8 +332,13 @@ class InputNumber extends React.Component<Props> {
         if (rubric.answerType == null) {
             rubric.answerType = "number";
         }
+
+        // note(matthewc): this will get immediately parsed again by
+        // `KhanAnswerTypes.number.convertToPredicate`, but a string is
+        // expected here
+        const stringValue = `${rubric.value}`;
         const val = KhanAnswerTypes.number.createValidatorFunctional(
-            rubric.value,
+            stringValue,
             {
                 simplify: rubric.simplify,
                 inexact: rubric.inexact || undefined,

--- a/packages/perseus/src/widgets/numeric-input.jsx
+++ b/packages/perseus/src/widgets/numeric-input.jsx
@@ -16,10 +16,16 @@ import KhanAnswerTypes from "../util/answer-types.js";
 import KhanMath from "../util/math.js";
 
 import type {
+    MathFormat,
     PerseusNumericInputWidgetOptions,
     PerseusNumericInputAnswer,
-} from "../perseus-types.js";
+} from "../perseus-types";
 import type {PerseusScore, WidgetExports, WidgetProps} from "../types.js";
+
+type GenericAnswerForm = {|
+    simplify: ?string,
+    name: string,
+|};
 
 const ParseTex = TexWrangler.parseTex;
 
@@ -36,7 +42,7 @@ const answerFormButtons = [
     {title: "Numbers with \u03C0", value: "pi", content: "\u03C0"},
 ];
 
-const formExamples = {
+const formExamples: {[string]: (GenericAnswerForm) => string} = {
     integer: () => i18n._("an integer, like $6$"),
     proper: (form) =>
         form.simplify === "optional"
@@ -261,14 +267,13 @@ export class NumericInput extends React.Component<Props, State> {
             correct = score.type === "points" && score.earned === score.total;
 
             if (!correct) {
-                const correctAnswers = _.filter(
-                    rubric.answers,
+                const correctAnswers = rubric.answers.filter(
                     (answer) => answer.status === "correct",
                 );
-                const answerStrings = _.map(correctAnswers, (answer) => {
+                const answerStrings = correctAnswers.map((answer) => {
                     // Figure out how this answer is supposed to be
                     // displayed
-                    let format = "decimal";
+                    let format: MathFormat = "decimal";
                     if (answer.answerForms && answer.answerForms[0]) {
                         // NOTE(johnsullivan): This isn't exactly ideal, but
                         // it does behave well for all the currently known
@@ -300,7 +305,7 @@ export class NumericInput extends React.Component<Props, State> {
         const forms =
             this.props.answerForms?.length !== 0
                 ? this.props.answerForms
-                : _.map(_.keys(formExamples), (name) => {
+                : Object.keys(formExamples).map((name) => {
                       return {
                           name: name,
                           simplify: "required",

--- a/packages/perseus/src/widgets/numeric-input.jsx
+++ b/packages/perseus/src/widgets/numeric-input.jsx
@@ -554,10 +554,10 @@ type RenderProps = {|
 // can accept several input forms with or without "%", the decision
 // to parse based on the presence of "%" in the input, is so that we
 // don't accidently scale the user typed value before grading, CP-930.
-export const maybeParsePercentInput: (
-    string | number,
-    boolean,
-) => string | number = (inputValue, normalizedAnswerExpected) => {
+export function maybeParsePercentInput(
+    inputValue: string | number,
+    normalizedAnswerExpected: boolean,
+): string | number {
     // If the input value is not a string ending with "%", then there's
     // nothing more to do. The value will be graded as inputted by user.
     if (!(typeof inputValue === "string" && inputValue.endsWith("%"))) {
@@ -582,7 +582,7 @@ export const maybeParsePercentInput: (
 
     // Otherwise, we return input valuåe (number) stripped of the "%".
     return value;
-};
+}
 
 const propsTransform = function (
     widgetOptions: PerseusNumericInputWidgetOptions,

--- a/packages/perseus/src/widgets/numeric-input.jsx
+++ b/packages/perseus/src/widgets/numeric-input.jsx
@@ -95,6 +95,8 @@ type State = {|
 |};
 
 export class NumericInput extends React.Component<Props, State> {
+    inputRef: ?(SimpleKeypadInput | InputWithExamples);
+
     static defaultProps: DefaultProps = {
         currentValue: "",
         size: "normal",
@@ -332,20 +334,16 @@ export class NumericInput extends React.Component<Props, State> {
     };
 
     focus: () => boolean = () => {
-        // eslint-disable-next-line react/no-string-refs
-        this.refs.input.focus();
+        this.inputRef?.focus();
         return true;
     };
 
-    focusInputPath: ($FlowFixMe) => void = (inputPath) => {
-        /* istanbul ignore next */
-        // eslint-disable-next-line react/no-string-refs
-        this.refs.input.focus();
+    focusInputPath: () => void = () => {
+        this.inputRef?.focus();
     };
 
-    blurInputPath: ($FlowFixMe) => void = (inputPath) => {
-        // eslint-disable-next-line react/no-string-refs
-        this.refs.input.blur();
+    blurInputPath: () => void = () => {
+        this.inputRef?.blur();
     };
 
     getInputPaths: () => $ReadOnlyArray<$ReadOnlyArray<string>> = () => {
@@ -429,8 +427,7 @@ export class NumericInput extends React.Component<Props, State> {
             // TODO(charlie): Support "Review Mode".
             return maybeRightAlignKeypadInput(
                 <SimpleKeypadInput
-                    // eslint-disable-next-line react/no-string-refs
-                    ref="input"
+                    ref={(ref) => (this.inputRef = ref)}
                     value={this.props.currentValue}
                     keypadElement={this.props.keypadElement}
                     onChange={this.handleChange}
@@ -442,8 +439,7 @@ export class NumericInput extends React.Component<Props, State> {
 
         const input = (
             <InputWithExamples
-                // eslint-disable-next-line react/no-string-refs
-                ref="input"
+                ref={(ref) => (this.inputRef = ref)}
                 value={this.props.currentValue}
                 onChange={this.handleChange}
                 className={classNames(classes)}
@@ -547,10 +543,10 @@ type RenderProps = {|
 // can accept several input forms with or without "%", the decision
 // to parse based on the presence of "%" in the input, is so that we
 // don't accidently scale the user typed value before grading, CP-930.
-export const maybeParsePercentInput: ($FlowFixMe, $FlowFixMe) => $FlowFixMe = (
-    inputValue,
-    normalizedAnswerExpected,
-) => {
+export const maybeParsePercentInput: (
+    string | number,
+    boolean,
+) => $FlowFixMe = (inputValue, normalizedAnswerExpected) => {
     // If the input value is not a string ending with "%", then there's
     // nothing more to do. The value will be graded as inputted by user.
     if (!(typeof inputValue === "string" && inputValue.endsWith("%"))) {


### PR DESCRIPTION
## Summary:
- Brought flow types from ~60% to ~90%
  - Created a shared `MathFormat` type
  - Created a shared `PerseusNumericInputAnswerForm` type
- Converted `SimpleKeypadInput` from `createReactClass` to a class component since Numeric-Input was using it
- Tried to switch Underscore to Native JS as much as I could figure out
- Refactored string ref into a callback ref

Issue: LP-13032

## Test plan:
Everything should work the same, but be typed better