### PR TITLE
Tiny fix that communicates the "current" state to screen readers.

### DIFF
--- a/.changeset/tidy-gifts-fly.md
+++ b/.changeset/tidy-gifts-fly.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Small fix to communicate the "current" state of graded-group-sets to screen readers.

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group-set_test.jsx.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group-set_test.jsx.snap
@@ -51,7 +51,7 @@ exports[`graded group widget should snapshot 1`] = `
                     <span
                       class="srOnly_19bpjuy"
                     >
-                      current
+                      Current
                     </span>
                   </div>
                   <div

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group-set_test.jsx.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group-set_test.jsx.snap
@@ -47,7 +47,13 @@ exports[`graded group widget should snapshot 1`] = `
                     aria-label="Skip to Problem 1a"
                     class="indicator_1ezvcme-o_O-selectedIndicator_1v68a6x"
                     role="button"
-                  />
+                  >
+                    <span
+                      class="srOnly_19bpjuy"
+                    >
+                      current
+                    </span>
+                  </div>
                   <div
                     aria-label="Skip to Problem 1b"
                     class="indicator_1ezvcme"

--- a/packages/perseus/src/widgets/graded-group-set.jsx
+++ b/packages/perseus/src/widgets/graded-group-set.jsx
@@ -54,7 +54,9 @@ class Indicators extends React.Component<IndicatorsProps> {
                     onClick={() => this.props.onChangeCurrentGroup(i)}
                 >
                     {i === this.props.currentGroup && (
-                        <span className={css(a11y.srOnly)}>current</span>
+                        <span className={css(a11y.srOnly)}>
+                            {i18n._("Current")}
+                        </span>
                     )}
                 </div>,
             );

--- a/packages/perseus/src/widgets/graded-group-set.jsx
+++ b/packages/perseus/src/widgets/graded-group-set.jsx
@@ -14,6 +14,7 @@ import {
     phoneMargin,
     negativePhoneMargin,
 } from "../styles/constants.js";
+import a11y from "../util/a11y.js";
 
 import GradedGroupWidget from "./graded-group.jsx";
 
@@ -51,7 +52,11 @@ class Indicators extends React.Component<IndicatorsProps> {
                             styles.selectedIndicator,
                     )}
                     onClick={() => this.props.onChangeCurrentGroup(i)}
-                />,
+                >
+                    {i === this.props.currentGroup && (
+                        <span className={css(a11y.srOnly)}>current</span>
+                    )}
+                </div>,
             );
         }
         return <div className={css(styles.indicatorContainer)}>{items}</div>;


### PR DESCRIPTION
## Summary:
This PR adds a tiny span tag that indicates which graded group is "current" to screen readers. It makes use of the a11y style for "srOnly". This was done as part of the work identified by the Level Access Accessibility Audit. 

Issue: LP-13084

## Test plan:
- Existing tests 
- Manual testing