### PR TITLE
Ensure that there is sufficient contrast between the graded-group title and the background.

### DIFF
--- a/.changeset/olive-pillows-invent.md
+++ b/.changeset/olive-pillows-invent.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Another microfix that updates a title to use the next darker level of gray so that it can pass our a11y requirements.

--- a/.changeset/olive-pillows-invent.md
+++ b/.changeset/olive-pillows-invent.md
@@ -2,4 +2,4 @@
 "@khanacademy/perseus": patch
 ---
 
-Another microfix that updates a title to use the next darker level of gray so that it can pass our a11y requirements.
+Update graded-group widget title to use a darker gray to meet a11y requirements

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group-set-jipt_test.jsx.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group-set-jipt_test.jsx.snap
@@ -33,7 +33,7 @@ exports[`graded-group-set should render all graded groups 1`] = `
                 class="perseus-graded-group"
               >
                 <div
-                  class="title_14cfb9x"
+                  class="title_1lagzkb"
                 >
                   Problem 1a
                 </div>
@@ -270,7 +270,7 @@ exports[`graded-group-set should render all graded groups 1`] = `
                 class="perseus-graded-group"
               >
                 <div
-                  class="title_14cfb9x"
+                  class="title_1lagzkb"
                 >
                   Problem 1b
                 </div>
@@ -507,7 +507,7 @@ exports[`graded-group-set should render all graded groups 1`] = `
                 class="perseus-graded-group"
               >
                 <div
-                  class="title_14cfb9x"
+                  class="title_1lagzkb"
                 >
                   Problem 1c
                 </div>

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group-set-jipt_test.jsx.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group-set-jipt_test.jsx.snap
@@ -33,7 +33,7 @@ exports[`graded-group-set should render all graded groups 1`] = `
                 class="perseus-graded-group"
               >
                 <div
-                  class="title_6pk9ag"
+                  class="title_14cfb9x"
                 >
                   Problem 1a
                 </div>
@@ -270,7 +270,7 @@ exports[`graded-group-set should render all graded groups 1`] = `
                 class="perseus-graded-group"
               >
                 <div
-                  class="title_6pk9ag"
+                  class="title_14cfb9x"
                 >
                   Problem 1b
                 </div>
@@ -507,7 +507,7 @@ exports[`graded-group-set should render all graded groups 1`] = `
                 class="perseus-graded-group"
               >
                 <div
-                  class="title_6pk9ag"
+                  class="title_14cfb9x"
                 >
                   Problem 1c
                 </div>

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group_test.jsx.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group_test.jsx.snap
@@ -36,7 +36,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
               class="perseus-graded-group"
             >
               <div
-                class="title_6pk9ag"
+                class="title_14cfb9x"
               >
                 Metabolic strategies of bacteria
               </div>
@@ -525,7 +525,7 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
               class="gradedGroup_14sgdtb perseus-graded-group"
             >
               <div
-                class="title_6pk9ag"
+                class="title_14cfb9x"
               >
                 Metabolic strategies of bacteria
               </div>

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group_test.jsx.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group_test.jsx.snap
@@ -36,7 +36,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
               class="perseus-graded-group"
             >
               <div
-                class="title_14cfb9x"
+                class="title_1lagzkb"
               >
                 Metabolic strategies of bacteria
               </div>
@@ -525,7 +525,7 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
               class="gradedGroup_14sgdtb perseus-graded-group"
             >
               <div
-                class="title_14cfb9x"
+                class="title_1lagzkb"
               >
                 Metabolic strategies of bacteria
               </div>

--- a/packages/perseus/src/widgets/graded-group.jsx
+++ b/packages/perseus/src/widgets/graded-group.jsx
@@ -13,6 +13,7 @@ import * as Changeable from "../mixins/changeable.jsx";
 import {ApiOptions} from "../perseus-api.jsx";
 import Renderer from "../renderer.jsx";
 import {
+    gray68,
     gray76,
     phoneMargin,
     negativePhoneMargin,
@@ -433,7 +434,7 @@ const styles = StyleSheet.create({
 
     title: {
         fontSize: 12,
-        color: gray76,
+        color: gray68,
         textTransform: "uppercase",
         marginBottom: 11,
         letterSpacing: 0.8,


### PR DESCRIPTION
## Summary:
Another microfix that updates the graded-group title to use the next darker level of gray so that it can pass our a11y requirements. This was done as part of the tasks that were generated out of the Level Access Accessibility Audit. 

![Screen Shot 2022-12-14 at 1 00 49 PM](https://user-images.githubusercontent.com/12463099/207713033-85548e45-bf75-4f34-aa56-19bf94b07df6.png)

Issue: LP-13083

## Test plan:
make tesc