### PR TITLE
wip: fixup crossout

### DIFF
--- a/packages/perseus/src/widgets/radio/choice-icon/cross-out-line.jsx
+++ b/packages/perseus/src/widgets/radio/choice-icon/cross-out-line.jsx
@@ -47,8 +47,8 @@ const styles = StyleSheet.create({
     crossOutLine: {
         // Center the icon within the container.
         position: "absolute",
-        top: `calc(50% - ${CROSS_OUT_LINE_SIZE / 2}px)`,
-        left: `calc(50% - ${CROSS_OUT_LINE_SIZE / 2}px)`,
+        top: `0px`,
+        left: `0px`,
     },
 });
 


### PR DESCRIPTION
## Summary:
Fixes alignment of crosscut line when a radio choice has multiple lines.

Issue: https://khanacademy.atlassian.net/browse/LP-13046

Before:

<img width="1185" alt="Screen Shot 2022-12-14 at 10 38 01 AM" src="https://user-images.githubusercontent.com/18454/207668774-9f6ad73a-59f5-4872-8d1e-206c950a090d.png">

After:

<img width="337" alt="Screen Shot 2022-12-14 at 10 41 43 AM" src="https://user-images.githubusercontent.com/18454/207668807-cfedfcd7-3968-4031-9e60-614081d973e7.png">


## Test plan:
- Open the storybook to the radio widget
- Turn on SAT Styling and crosscut
- Resize the screen until the radio option takes up multiple lines
- **The crossout line should line up with the radio button**