### PR TITLE
SPIKE: Use DOM events to pass data between keypad and input field

### DIFF
--- a/packages/math-input/src/components/__stories__/app.stories.jsx
+++ b/packages/math-input/src/components/__stories__/app.stories.jsx
@@ -1,0 +1,16 @@
+// @flow
+import * as React from "react";
+
+import App from "../app.js";
+
+import "../../../less/main.less";
+
+export default {
+    title: "math-input/components/App",
+};
+
+type StoryArgs = {||};
+
+export const Demo = (args: StoryArgs): React.Node => {
+    return <App />;
+};

--- a/packages/math-input/src/components/gesture-manager.js
+++ b/packages/math-input/src/components/gesture-manager.js
@@ -140,6 +140,8 @@ class GestureManager {
                 swipeEnabled,
             );
         }
+
+        evt.preventDefault();
     }
 
     /**
@@ -161,6 +163,8 @@ class GestureManager {
                 x,
             );
         }
+
+        evt.preventDefault();
     }
 
     /**
@@ -179,6 +183,8 @@ class GestureManager {
                 evt.changedTouches[i].identifier,
             );
         }
+
+        evt.preventDefault();
     }
 
     /**

--- a/packages/math-input/src/components/input/math-input.js
+++ b/packages/math-input/src/components/input/math-input.js
@@ -315,29 +315,29 @@ class MathInput extends React.Component {
     focus = () => {
         // Pass this component's handleKey method to the keypad so it can call
         // it whenever it needs to trigger a keypress action.
-        this.props.keypadElement.setKeyHandler((key) => {
-            const cursor = this.mathField.pressKey(key);
+        // this.props.keypadElement.setKeyHandler((key) => {
+        //     const cursor = this.mathField.pressKey(key);
 
-            // Trigger an `onChange` if the value in the input changed, and hide
-            // the cursor handle whenever the user types a key. If the value
-            // changed as a result of a keypress, we need to be careful not to
-            // call `setState` until after `onChange` has resolved.
-            const hideCursor = () => {
-                this.setState({
-                    handle: {
-                        visible: false,
-                    },
-                });
-            };
-            const value = this.mathField.getContent();
-            if (this.props.value !== value) {
-                this.props.onChange(value, hideCursor);
-            } else {
-                hideCursor();
-            }
+        //     // Trigger an `onChange` if the value in the input changed, and hide
+        //     // the cursor handle whenever the user types a key. If the value
+        //     // changed as a result of a keypress, we need to be careful not to
+        //     // call `setState` until after `onChange` has resolved.
+        //     const hideCursor = () => {
+        //         this.setState({
+        //             handle: {
+        //                 visible: false,
+        //             },
+        //         });
+        //     };
+        //     const value = this.mathField.getContent();
+        //     if (this.props.value !== value) {
+        //         this.props.onChange(value, hideCursor);
+        //     } else {
+        //         hideCursor();
+        //     }
 
-            return cursor;
-        });
+        //     return cursor;
+        // });
 
         this.mathField.focus();
         this.props.onFocus && this.props.onFocus();
@@ -848,7 +848,15 @@ class MathInput extends React.Component {
                     ref={(node) => {
                         this.inputRef = node;
                     }}
-                    onKeyUp={this.handleKeyUp}
+                    onKeyUp={(e) => {
+                        const cursor = this.mathField.pressKey(e.key);
+
+                        // TODO: only dispatch this weheen the cursor context changes
+                        const event = new CustomEvent("cursor_context", {
+                            detail: {cursor},
+                        });
+                        document.body.dispatchEvent(event);
+                    }}
                 >
                     {/* NOTE(charlie): This element must be styled with inline
                     styles rather than with Aphrodite classes, as MathQuill

--- a/packages/math-input/src/components/provided-keypad.js
+++ b/packages/math-input/src/components/provided-keypad.js
@@ -29,6 +29,16 @@ class ProvidedKeypad extends React.Component<Props> {
 
     UNSAFE_componentWillMount() {
         this.store = createStore();
+
+        if (document.body) {
+            // $FlowIgnore[incompatible-call]: Flow doesn't like this custom event
+            document.body.addEventListener(
+                "cursor_context",
+                (e: CustomEvent) => {
+                    this.store.dispatch(setCursor(e.detail.cursor));
+                },
+            );
+        }
     }
 
     componentDidMount() {


### PR DESCRIPTION
## Summary:
This is an experimental PR and is not intended to be landed.

Using DOM events to communicate between keypad and input field will make using these components much easier because we won't have to:
- render them as a descendent of a common redux Provider
- know about the redux Provider at all b/c it could be contained with the keypad component itself (most of the state management has to do with the keypad)
- set the keyHandler, keypadElement, etc. which makes for an awkward setup in webapp

Issue: None

## Test plan:
- yarn storybook
- open http://localhost:6006/iframe.html?id=math-input-components-app--demo&args=&viewMode=story in Chrome with mobile emulation enabled
- click in the input field, see the keypad appear
- type some stuff on the keypad, see it appear in the field
- enter a fraction, see the dismiss keypad turn into a special icon, click it, see that the cursor moves from the numerator into the denominator and change again

https://user-images.githubusercontent.com/1044413/208494129-5f478b51-a4a9-4084-8b17-415baf05246f.mov


