### PR TITLE
Update fonts from Noto -> Lato

### DIFF
--- a/.changeset/smart-ants-relate.md
+++ b/.changeset/smart-ants-relate.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Update body fonts

--- a/packages/perseus/src/styles/perseus-renderer.less
+++ b/packages/perseus/src/styles/perseus-renderer.less
@@ -107,7 +107,7 @@
     }
 
     div.paragraph {
-        font-family: "Noto Serif", serif;
+        font-family: "Lato", sans-serif;
         font-weight: 400;
         font-size: 18px;
         line-height: 22px;


### PR DESCRIPTION
## Summary:
Updates fonts so that they match the rest of Khan Academy.

<img width="1195" alt="Screen Shot 2023-01-05 at 10 56 20 AM" src="https://user-images.githubusercontent.com/18454/210848091-05e8cfb7-5cad-4d88-9d60-6fe888d814d6.png">

Issue: https://khanacademy.atlassian.net/browse/LP-13214

## Test plan:
- Load an exercise within the context of webapp
- **The paragraph font should use Lato**

[LP-13214]: https://khanacademy.atlassian.net/browse/LP-13214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ