### PR TITLE
Remove gradient background on math

### DIFF
--- a/.changeset/green-guests-build.md
+++ b/.changeset/green-guests-build.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+CSS fix to remove gradient background on math

--- a/packages/perseus/src/styles/articles.less
+++ b/packages/perseus/src/styles/articles.less
@@ -178,8 +178,6 @@
         position: relative;
 
         &:before {
-            background: linear-gradient(to right,
-                rgba(255,255,255,0) 0%, rgba(255,255,255,1) 100%);
             bottom: 0;
             content: "";
             position: absolute;


### PR DESCRIPTION
## Summary:
There was a gradient background on some math that looked strange. It was probably part of a past design but doesn't fit with our current aesthetic needs.

### Before:
<img width="414" alt="Screen Shot 2023-01-04 at 11 27 59 AM" src="https://user-images.githubusercontent.com/18454/210624375-01dc1663-1003-4bf7-baba-5bcf1974cafa.png">

### After:
<img width="382" alt="Screen Shot 2023-01-04 at 11 27 52 AM" src="https://user-images.githubusercontent.com/18454/210624397-185a50a2-c051-4938-b965-e3dd274b2e69.png">


Issue: https://khanacademy.atlassian.net/browse/LP-13105

## Test plan:
- After these changes are deployed, load /internal-courses/test-everything/test-everything-1/categorizer/a/categorizer-article?modal=1
- **You shouldn't see a weird backgroud on the math**

[LP-13105]: https://khanacademy.atlassian.net/browse/LP-13105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ