### PR TITLE
Make yarn start boot storybook

### DIFF
--- a/.changeset/heavy-fireants-whisper.md
+++ b/.changeset/heavy-fireants-whisper.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Update package.json with yarn start command

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "test": "yarn jest",
     "test:no-console-mock": "cross-env GLOBAL_CONSOLE_MOCK=false yarn jest",
     "storybook": "start-storybook -p 6006",
+    "start": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "cypress": "cypress open-ct",
     "cypress:ci": "cross-env BABEL_COVERAGE=1 cypress run-ct --env CYPRESS_COVERAGE=1"


### PR DESCRIPTION
## Summary:
It's a rough edge for me that yarn start doesn't do the "main" thing in this project.

This PR fixes that by making it boot up storybook.

## Test plan:
- run `yarn start`
- **You should see storybook startup**