### PR TITLE
Fix Passage refs refer to the wrong line

### DIFF
--- a/.changeset/young-worms-explode.md
+++ b/.changeset/young-worms-explode.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Update gutter line numbers in passage

--- a/packages/perseus/src/styles/widgets/passage.less
+++ b/packages/perseus/src/styles/widgets/passage.less
@@ -6,7 +6,7 @@
     //     typography, abandon this LESS entirely, and refactor to use the
     //     BodySerif component instead. (TP-3112)
     @font-size: 16px;
-    @line-height: 20px;
+    @line-height: 24px;
 
     .perseus-widget-passage {
         line-height: @line-height;


### PR DESCRIPTION
## Summary:
Fixes passage refs not refering to the right line.

Issue: https://khanacademy.atlassian.net/browse/LP-13254

## Test plan:
- Load a passage
- **The gutter lines should line up with the right line**