### PR TITLE
Fix passage text by making it exactly like it was before

### DIFF
--- a/.changeset/tender-planets-approve.md
+++ b/.changeset/tender-planets-approve.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Fix passage fonts because content depends on it being an exact size

--- a/packages/perseus/src/styles/widgets/passage.less
+++ b/packages/perseus/src/styles/widgets/passage.less
@@ -6,7 +6,7 @@
     //     typography, abandon this LESS entirely, and refactor to use the
     //     BodySerif component instead. (TP-3112)
     @font-size: 16px;
-    @line-height: 24px;
+    @line-height: 16px;
 
     .perseus-widget-passage {
         line-height: @line-height;
@@ -49,7 +49,7 @@
         font-family: Lato, "Noto Sans", Helvetica, Corbel, sans-serif, Helvetica, Corbel, sans-serif;
         font-weight: 400;
         font-size: 14px;
-        line-height: @line-height;
+        line-height: 16px;
         text-indent: 20px;
 
         span {

--- a/packages/perseus/src/styles/widgets/passage.less
+++ b/packages/perseus/src/styles/widgets/passage.less
@@ -46,10 +46,10 @@
         margin: 0 0 10px;
     }
     .passage-text div.paragraph {
-        font-family: "Noto Serif", serif;
+        font-family: Lato, "Noto Sans", Helvetica, Corbel, sans-serif, Helvetica, Corbel, sans-serif;
         font-weight: 400;
-        font-size: 20px;
-        line-height: 24px;
+        font-size: 14px;
+        line-height: @line-height;
         text-indent: 20px;
 
         span {


### PR DESCRIPTION
## Summary:
This fixes passage line numbers not lining up by using the exact same style we did before (screenshot is prod's computed style)

Because passage depends on exact styling we can't update it to wonderblocks without updating all of our content. That's a no-go so let's keep it as-is.

Working prod style:

<img width="846" alt="image" src="https://user-images.githubusercontent.com/18454/211404416-41687270-58b8-45ef-9af9-0f85d71f208c.png">

<img width="998" alt="image" src="https://user-images.githubusercontent.com/18454/211405448-040554db-e672-4239-be61-903f3f8da918.png">

Issue: https://khanacademy.atlassian.net/browse/LP-13254

## Test plan:

This depends on the exact container we use in prod so it's not testable in a storybook.
- Deploy a ZND
- Load `/internal-courses/test-everything/test-everything-2-without-mastery/te-passage-ref/e/passage-ref`
- **Check that line numbers in the answer section line up with actual passage text**