### PR TITLE
Indicators are now in explicit list markup and operable by keyboard

### DIFF
--- a/.changeset/mighty-apples-add.md
+++ b/.changeset/mighty-apples-add.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Indicators on exercises are now accessible via the keyboard! Additionally, they use explicit list markup! 🟢⚪⚪

--- a/packages/perseus/src/styles/perseus-renderer.less
+++ b/packages/perseus/src/styles/perseus-renderer.less
@@ -149,9 +149,6 @@
     .paragraph ul:not(.perseus-widget-radio) {
         .legacy-typography;
         padding-left: 35px;
-    }
-
-    .paragraph ul:not(.perseus-widget-radio) li {
         list-style-type: disc;
     }
 

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group-set-jipt_test.jsx.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group-set-jipt_test.jsx.snap
@@ -260,7 +260,7 @@ exports[`graded-group-set should render all graded groups 1`] = `
                   </span>
                 </button>
                 <button
-                  class="showHintLink_112g8fo"
+                  class="showHintLink_oak3yy"
                   tabindex="0"
                 >
                   Explain
@@ -497,7 +497,7 @@ exports[`graded-group-set should render all graded groups 1`] = `
                   </span>
                 </button>
                 <button
-                  class="showHintLink_112g8fo"
+                  class="showHintLink_oak3yy"
                   tabindex="0"
                 >
                   Explain
@@ -734,7 +734,7 @@ exports[`graded-group-set should render all graded groups 1`] = `
                   </span>
                 </button>
                 <button
-                  class="showHintLink_112g8fo"
+                  class="showHintLink_oak3yy"
                   tabindex="0"
                 >
                   Explain

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group-set_test.jsx.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group-set_test.jsx.snap
@@ -40,31 +40,34 @@ exports[`graded group widget should snapshot 1`] = `
                 <div
                   class="spacer_bc4egv"
                 />
-                <div
-                  class="indicatorContainer_cjo0m2"
+                <ul
+                  class="indicatorContainer_13i3db2"
                 >
-                  <div
+                  <li
                     aria-label="Skip to Problem 1a"
                     class="indicator_1ezvcme-o_O-selectedIndicator_1v68a6x"
                     role="button"
+                    tabindex="0"
                   >
                     <span
                       class="srOnly_19bpjuy"
                     >
                       Current
                     </span>
-                  </div>
-                  <div
+                  </li>
+                  <li
                     aria-label="Skip to Problem 1b"
                     class="indicator_1ezvcme"
                     role="button"
+                    tabindex="0"
                   />
-                  <div
+                  <li
                     aria-label="Skip to Problem 1c"
                     class="indicator_1ezvcme"
                     role="button"
+                    tabindex="0"
                   />
-                </div>
+                </ul>
               </div>
               <div
                 class="perseus-graded-group"

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group-set_test.jsx.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group-set_test.jsx.snap
@@ -41,7 +41,7 @@ exports[`graded group widget should snapshot 1`] = `
                   class="spacer_bc4egv"
                 />
                 <ul
-                  class="indicatorContainer_13i3db2"
+                  class="indicatorContainer_rjg7c2"
                 >
                   <li
                     aria-label="Skip to Problem 1a"

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group-set_test.jsx.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group-set_test.jsx.snap
@@ -33,7 +33,7 @@ exports[`graded group widget should snapshot 1`] = `
                 class="top_cjo0m2"
               >
                 <div
-                  class="title_6pk9ag"
+                  class="title_vo78fw"
                 >
                   Problem 1a
                 </div>
@@ -45,7 +45,7 @@ exports[`graded group widget should snapshot 1`] = `
                 >
                   <li
                     aria-label="Skip to Problem 1a"
-                    class="indicator_1ezvcme-o_O-selectedIndicator_1v68a6x"
+                    class="indicator_qk5jgn-o_O-selectedIndicator_14jsc6v"
                     role="button"
                     tabindex="0"
                   >
@@ -57,13 +57,13 @@ exports[`graded group widget should snapshot 1`] = `
                   </li>
                   <li
                     aria-label="Skip to Problem 1b"
-                    class="indicator_1ezvcme"
+                    class="indicator_qk5jgn"
                     role="button"
                     tabindex="0"
                   />
                   <li
                     aria-label="Skip to Problem 1c"
-                    class="indicator_1ezvcme"
+                    class="indicator_qk5jgn"
                     role="button"
                     tabindex="0"
                   />
@@ -295,7 +295,7 @@ exports[`graded group widget should snapshot 1`] = `
                   </span>
                 </button>
                 <button
-                  class="showHintLink_112g8fo"
+                  class="showHintLink_oak3yy"
                   tabindex="0"
                 >
                   Explain

--- a/packages/perseus/src/widgets/__tests__/graded-group-set_test.jsx
+++ b/packages/perseus/src/widgets/__tests__/graded-group-set_test.jsx
@@ -139,10 +139,14 @@ describe("graded group widget", () => {
             // Act
             userEvent.tab(); // 1a
             userEvent.tab(); // 1b
+            userEvent.keyboard(" ");
+
+            // Assert
+            expect(screen.getByText("Problem 1b")).toBeVisible();
+
             userEvent.tab(); // 1c
             userEvent.keyboard("[Enter]");
 
-            // Assert
             expect(screen.getByText("Problem 1c")).toBeVisible();
         });
     });

--- a/packages/perseus/src/widgets/__tests__/graded-group-set_test.jsx
+++ b/packages/perseus/src/widgets/__tests__/graded-group-set_test.jsx
@@ -118,17 +118,33 @@ describe("graded group widget", () => {
         ).not.toBeInTheDocument();
     });
 
-    it("should be able to jump to an arbitrary question using Indicators", () => {
-        // Arrange
-        renderQuestion(article1);
+    describe("should be able to jump to an arbitrary question using Indicators", () => {
+        it("by click", () => {
+            // Arrange
+            renderQuestion(article1);
 
-        // Act
-        userEvent.click(
-            screen.getByRole("button", {name: "Skip to Problem 1c"}),
-        );
+            // Act
+            userEvent.click(
+                screen.getByRole("button", {name: "Skip to Problem 1c"}),
+            );
 
-        // Assert
-        expect(screen.getByText("Problem 1c")).toBeVisible();
+            // Assert
+            expect(screen.getByText("Problem 1c")).toBeVisible();
+        });
+
+        it("by key", () => {
+            // Arrange
+            renderQuestion(article1);
+
+            // Act
+            userEvent.tab(); // 1a
+            userEvent.tab(); // 1b
+            userEvent.tab(); // 1c
+            userEvent.keyboard("[Enter]");
+
+            // Assert
+            expect(screen.getByText("Problem 1c")).toBeVisible();
+        });
     });
 
     it("should return input paths", () => {

--- a/packages/perseus/src/widgets/graded-group-set.jsx
+++ b/packages/perseus/src/widgets/graded-group-set.jsx
@@ -33,9 +33,13 @@ type IndicatorsProps = {|
     onChangeCurrentGroup: (groupNumber: number) => void,
 |};
 
-// TODO(jeremy): This indicator panel is not accessible for keyboard
-// navigation. Add in keyboard handling and tab indexes to make accessible.
 class Indicators extends React.Component<IndicatorsProps> {
+    handleKeyDown = (e: SyntheticKeyboardEvent<>, i: number) => {
+        if (e.key === "Enter") {
+            this.props.onChangeCurrentGroup(i);
+        }
+    };
+
     render(): React.Node {
         return (
             <ul className={css(styles.indicatorContainer)}>
@@ -53,6 +57,7 @@ class Indicators extends React.Component<IndicatorsProps> {
                         )}
                         tabIndex={0}
                         onClick={() => this.props.onChangeCurrentGroup(i)}
+                        onKeyDown={(e) => this.handleKeyDown(e, i)}
                     >
                         {i === this.props.currentGroup && (
                             <span className={css(a11y.srOnly)}>

--- a/packages/perseus/src/widgets/graded-group-set.jsx
+++ b/packages/perseus/src/widgets/graded-group-set.jsx
@@ -37,31 +37,32 @@ type IndicatorsProps = {|
 // navigation. Add in keyboard handling and tab indexes to make accessible.
 class Indicators extends React.Component<IndicatorsProps> {
     render(): React.Node {
-        const items = [];
-        for (let i = 0; i < this.props.numGroups; i++) {
-            items.push(
-                <div
-                    role="button"
-                    aria-label={i18n._("Skip to %(title)s", {
-                        title: this.props.groupTitles[i],
-                    })}
-                    key={i}
-                    className={css(
-                        styles.indicator,
-                        i === this.props.currentGroup &&
-                            styles.selectedIndicator,
-                    )}
-                    onClick={() => this.props.onChangeCurrentGroup(i)}
-                >
-                    {i === this.props.currentGroup && (
-                        <span className={css(a11y.srOnly)}>
-                            {i18n._("Current")}
-                        </span>
-                    )}
-                </div>,
-            );
-        }
-        return <div className={css(styles.indicatorContainer)}>{items}</div>;
+        return (
+            <ul className={css(styles.indicatorContainer)}>
+                {this.props.groupTitles.map((title, i) => (
+                    <li
+                        role="button"
+                        aria-label={i18n._("Skip to %(title)s", {
+                            title: this.props.groupTitles[i],
+                        })}
+                        key={i}
+                        className={css(
+                            styles.indicator,
+                            i === this.props.currentGroup &&
+                                styles.selectedIndicator,
+                        )}
+                        tabIndex={0}
+                        onClick={() => this.props.onChangeCurrentGroup(i)}
+                    >
+                        {i === this.props.currentGroup && (
+                            <span className={css(a11y.srOnly)}>
+                                {i18n._("Current")}
+                            </span>
+                        )}
+                    </li>
+                ))}
+            </ul>
+        );
     }
 }
 
@@ -262,6 +263,8 @@ const styles = StyleSheet.create({
     indicatorContainer: {
         display: "flex",
         flexDirection: "row",
+        listStyle: "none",
+        margin: "inherit",
     },
 
     indicator: {

--- a/packages/perseus/src/widgets/graded-group-set.jsx
+++ b/packages/perseus/src/widgets/graded-group-set.jsx
@@ -28,7 +28,7 @@ const GradedGroup = GradedGroupWidget.widget;
 
 type IndicatorsProps = {|
     currentGroup: number,
-    groupTitles: $ReadOnlyArray<string>,
+    gradedGroups: $ReadOnlyArray<PerseusGradedGroupWidgetOptions>,
     onChangeCurrentGroup: (groupNumber: number) => void,
 |};
 
@@ -42,7 +42,7 @@ class Indicators extends React.Component<IndicatorsProps> {
     render(): React.Node {
         return (
             <ul className={css(styles.indicatorContainer)}>
-                {this.props.groupTitles.map((title, i) => (
+                {this.props.gradedGroups.map(({title}, i) => (
                     <li
                         role="button"
                         aria-label={i18n._("Skip to %(title)s", {
@@ -195,9 +195,7 @@ class GradedGroupSet extends React.Component<Props, State> {
                     <div className={css(styles.spacer)} />
                     <Indicators
                         currentGroup={this.state.currentGroup}
-                        groupTitles={this.props.gradedGroups.map(
-                            (g) => g.title,
-                        )}
+                        gradedGroups={this.props.gradedGroups}
                         onChangeCurrentGroup={(currentGroup) =>
                             this.setState({currentGroup})
                         }

--- a/packages/perseus/src/widgets/graded-group-set.jsx
+++ b/packages/perseus/src/widgets/graded-group-set.jsx
@@ -1,5 +1,6 @@
 // @flow
 import {linterContextDefault} from "@khanacademy/perseus-linter";
+import Color from "@khanacademy/wonder-blocks-color";
 import * as i18n from "@khanacademy/wonder-blocks-i18n";
 import {StyleSheet, css} from "aphrodite";
 import * as React from "react";
@@ -7,10 +8,8 @@ import * as React from "react";
 import {getDependencies} from "../dependencies.js";
 import * as Changeable from "../mixins/changeable.jsx";
 import {
-    grayLight,
     gray76,
     tableBackgroundAccent,
-    kaGreen,
     phoneMargin,
     negativePhoneMargin,
 } from "../styles/constants.js";
@@ -255,7 +254,7 @@ const styles = StyleSheet.create({
 
     title: {
         fontSize: 12,
-        color: gray76,
+        color: Color.offBlack64,
         textTransform: "uppercase",
         marginBottom: 11,
         letterSpacing: 0.8,
@@ -271,14 +270,15 @@ const styles = StyleSheet.create({
     indicator: {
         width: 10,
         height: 10,
-        borderRadius: 5,
-        backgroundColor: grayLight,
+        borderRadius: "100%",
+        border: "3px solid",
+        borderColor: Color.blue,
         marginLeft: 5,
         cursor: "pointer",
     },
 
     selectedIndicator: {
-        backgroundColor: kaGreen,
+        backgroundColor: Color.blue,
     },
 
     container: {

--- a/packages/perseus/src/widgets/graded-group-set.jsx
+++ b/packages/perseus/src/widgets/graded-group-set.jsx
@@ -28,14 +28,13 @@ const GradedGroup = GradedGroupWidget.widget;
 
 type IndicatorsProps = {|
     currentGroup: number,
-    numGroups: number,
     groupTitles: $ReadOnlyArray<string>,
     onChangeCurrentGroup: (groupNumber: number) => void,
 |};
 
 class Indicators extends React.Component<IndicatorsProps> {
     handleKeyDown = (e: SyntheticKeyboardEvent<>, i: number) => {
-        if (e.key === "Enter") {
+        if (e.key === "Enter" || e.key === " ") {
             this.props.onChangeCurrentGroup(i);
         }
     };
@@ -47,9 +46,9 @@ class Indicators extends React.Component<IndicatorsProps> {
                     <li
                         role="button"
                         aria-label={i18n._("Skip to %(title)s", {
-                            title: this.props.groupTitles[i],
+                            title,
                         })}
-                        key={i}
+                        key={title}
                         className={css(
                             styles.indicator,
                             i === this.props.currentGroup &&
@@ -195,7 +194,6 @@ class GradedGroupSet extends React.Component<Props, State> {
                     </div>
                     <div className={css(styles.spacer)} />
                     <Indicators
-                        numGroups={numGroups}
                         currentGroup={this.state.currentGroup}
                         groupTitles={this.props.gradedGroups.map(
                             (g) => g.title,
@@ -269,7 +267,7 @@ const styles = StyleSheet.create({
         display: "flex",
         flexDirection: "row",
         listStyle: "none",
-        margin: "inherit",
+        margin: "unset",
     },
 
     indicator: {

--- a/packages/perseus/src/widgets/graded-group.jsx
+++ b/packages/perseus/src/widgets/graded-group.jsx
@@ -1,6 +1,7 @@
 // @flow
 import {linterContextDefault} from "@khanacademy/perseus-linter";
 import Button from "@khanacademy/wonder-blocks-button";
+import Color from "@khanacademy/wonder-blocks-color";
 import * as i18n from "@khanacademy/wonder-blocks-i18n";
 import {StyleSheet, css} from "aphrodite";
 import classNames from "classnames";
@@ -18,7 +19,6 @@ import {
     phoneMargin,
     negativePhoneMargin,
     tableBackgroundAccent,
-    kaGreen,
 } from "../styles/constants.js";
 import a11y from "../util/a11y.js";
 
@@ -413,7 +413,7 @@ const styles = StyleSheet.create({
         padding: 0,
         border: "none",
         marginTop: 20,
-        color: kaGreen,
+        color: Color.blue,
         cursor: "pointer",
         display: "block",
         clear: "both",
@@ -422,7 +422,7 @@ const styles = StyleSheet.create({
     explanationTitle: {
         backgroundColor: "unset",
         marginTop: 20,
-        color: kaGreen,
+        color: Color.blue,
         marginBottom: 10,
         cursor: "pointer",
         fontSize: 14,


### PR DESCRIPTION
## Summary:
Indicators ⚪⚪🟢⚪⚪⚪⚪ are now in explicit list markup and operable by keyboard.
- `<div>` replaced by `<ul>` and `<li>`
- `tabindex` has been added for keyboard navigation
- keyDown event handler has been added to navigate to problem on enter key

Also added some bonus a11y style changes per design request: https://khanacademy.slack.com/archives/C01AZ9H8TTQ/p1674230818950029

Issue: LP-13089
Issue: LP-13091

## Test plan:
Added RTL tests to confirm keyboard navigation works as expected. Tested manually in Storybook as well.