### PR TITLE
Export/create types used by the mobile app

### DIFF
--- a/.changeset/kind-ducks-sing.md
+++ b/.changeset/kind-ducks-sing.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Exports new types to support custom keypads: `CursorContext`, `KeypadType`, `KeyType`, and `Key`

--- a/packages/math-input/src/components/input/cursor-contexts.js
+++ b/packages/math-input/src/components/input/cursor-contexts.js
@@ -11,6 +11,27 @@
  * the radical.
  */
 
+export type CursorContext =
+    // The cursor is not in any of the other viable contexts.
+    | "NONE"
+    // The cursor is within a set of parentheses.
+    | "IN_PARENS"
+    // The cursor is within a superscript (e.g., an exponent).
+    | "IN_SUPER_SCRIPT"
+    // The cursor is within a subscript (e.g., the base of a custom logarithm).
+    | "IN_SUB_SCRIPT"
+    // The cursor is in the numerator of a fraction.
+    | "IN_NUMERATOR"
+    // The cursor is in the denominator of a fraction.
+    | "IN_DENOMINATOR"
+    // The cursor is sitting before a fraction; that is, the cursor is within
+    // what looks to be a mixed number preceding a fraction. This will only be
+    // the case when the only math between the cursor and the fraction to its
+    // write is non-leaf math (numbers and variables).
+    | "BEFORE_FRACTION";
+
+// TODO: Get rid of these constants in favour of CursorContext type.
+
 // The cursor is not in any of the other viable contexts.
 export const NONE = "NONE";
 // The cursor is within a set of parentheses.

--- a/packages/math-input/src/consts.js
+++ b/packages/math-input/src/consts.js
@@ -6,7 +6,7 @@
 export type KeypadType = "FRACTION" | "EXPRESSION";
 
 // TODO: Retire this in favour of KeypadType (above)
-export const KeypadTypes: {[key: KeypadType]: KeypadType} = {
+export const KeypadTypes = {
     FRACTION: "FRACTION",
     EXPRESSION: "EXPRESSION",
 };

--- a/packages/math-input/src/consts.js
+++ b/packages/math-input/src/consts.js
@@ -3,10 +3,32 @@
  * Constants that are shared between multiple files.
  */
 
-export const KeypadTypes = {
+export type KeypadType = "FRACTION" | "EXPRESSION";
+
+// TODO: Retire this in favour of KeypadType (above)
+export const KeypadTypes: {[key: KeypadType]: KeypadType} = {
     FRACTION: "FRACTION",
     EXPRESSION: "EXPRESSION",
 };
+
+export type KeyType =
+    | "EMPTY"
+    // For numerals, variables, and any other characters that themselves
+    // compose 'values'.
+    | "VALUE"
+    // For buttons that insert or adjust math in an input.
+    | "OPERATOR"
+    // For buttons that move the cursor in an input (including via
+    // deletion).
+    | "INPUT_NAVIGATION"
+    // For buttons that modify the broader keypad state (e.g., by changing
+    // the visible pane).
+    | "KEYPAD_NAVIGATION"
+    // For buttons that house multiple buttons and have no action
+    // themselves.
+    | "MANY"
+    // For the echo animation that appears on press.
+    | "ECHO";
 
 export const KeyTypes = {
     EMPTY: "EMPTY",

--- a/packages/math-input/src/data/key-configs.js
+++ b/packages/math-input/src/data/key-configs.js
@@ -14,6 +14,7 @@ export type KeyConfig = {
     type: string,
     ariaLabel: string,
 };
+
 const KeyConfigs: Object = {
     // Basic math keys.
     [Keys.PLUS]: {

--- a/packages/math-input/src/data/keys.js
+++ b/packages/math-input/src/data/keys.js
@@ -4,6 +4,64 @@
  * alphanumeric characters.
  */
 
+export type Key =
+    | "PLUS"
+    | "MINUS"
+    | "NEGATIVE"
+    | "TIMES"
+    | "DIVIDE"
+    | "DECIMAL"
+    | "PERIOD"
+    | "PERCENT"
+    | "CDOT"
+    | "EQUAL"
+    | "NEQ"
+    | "GT"
+    | "LT"
+    | "GEQ"
+    | "LEQ"
+    | "FRAC_INCLUSIVE" // mobile native only
+    | "FRAC_EXCLUSIVE" // mobile native only
+    | "FRAC"
+    | "EXP"
+    | "EXP_2"
+    | "EXP_3"
+    | "SQRT"
+    | "CUBE_ROOT"
+    | "RADICAL"
+    | "LEFT_PAREN"
+    | "RIGHT_PAREN"
+    | "LN"
+    | "LOG"
+    | "LOG_N"
+    | "SIN"
+    | "COS"
+    | "TAN"
+
+    // TODO(charlie): Add in additional Greek letters.
+    | "PI"
+    | "THETA"
+    | "UP"
+    | "RIGHT"
+    | "DOWN"
+    | "LEFT"
+    | "BACKSPACE"
+    | "DISMISS"
+    | "JUMP_OUT_PARENTHESES"
+    | "JUMP_OUT_EXPONENT"
+    | "JUMP_OUT_BASE"
+    | "JUMP_INTO_NUMERATOR"
+    | "JUMP_OUT_NUMERATOR"
+    | "JUMP_OUT_DENOMINATOR"
+    | "NOOP"
+
+    // Multi-functional keys.
+    | "FRAC_MULTI" // mobile native only
+
+    // A custom key that captures an arbitrary number of symbols but has no
+    // 'default' symbol or action.
+    | "MANY";
+
 // TODO(charlie): There's duplication between this file and key-configs.js.
 // We should clean it up by removing this file and requiring clients to use the
 // `id` field on the key configurations.

--- a/packages/math-input/src/index.js
+++ b/packages/math-input/src/index.js
@@ -17,3 +17,7 @@ export {default as KeyConfigs} from "./data/key-configs.js";
 import * as CursorContexts from "./components/input/cursor-contexts.js";
 
 export {CursorContexts};
+
+export type {KeypadType, KeyType} from "./consts.js";
+export type {Key} from "./data/keys.js";
+export type {CursorContext} from "./components/input/cursor-contexts.js";

--- a/packages/perseus/src/index.js
+++ b/packages/perseus/src/index.js
@@ -103,6 +103,7 @@ export type {
     DeviceType,
     DomInsertCheckFn,
     EditorMode,
+    FocusPath,
     Hint,
     ImageDict,
     ImageUploader,


### PR DESCRIPTION
## Summary:

The mobile app implements a custom keypad (using the `customKeypad` and `nativeKeypadProxy` API options. Some of the types used by these behaviours are not currently exported by `@khanacademy/math-input` and are duplicated in the mobile app right now. 

This PR introduces new types for this (previously we only have constants). Longer term we should migrate the `@khanacademy/math-input` codebase to use these types and deprecate the "config objecs" they replace.

Issue: "none"

## Test plan:

Review the changes. No tests added as only types are new.