### PR TITLE
Remove line that throws Cypress test step when codecov upload fails

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -135,7 +135,6 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         files: ./coverage/coverage-final.json
-        fail_ci_if_error: true
 
   check_builds:
     name: Check builds for changes in size


### PR DESCRIPTION
## Summary:
This line defaults to false in the action. Setting it to true causes false negatives in the Cypress test step when the codecov upload fails.
This forced test step failure can cause true failures to be overlooked.

Issue: N/A

## Test plan:
Unfortunately, GitHub actions can only be tested in the repo itself. Since this is returning the codecov action to its default behavior, this shouldn't CAUSE any issues, but it will not surface issues in uploading test data. On the other hand, it will prevent false negatives in the Cypress test step.