### PR TITLE
Fix KaTeX rendering in Storybook

### DIFF
--- a/.changeset/tall-points-check.md
+++ b/.changeset/tall-points-check.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/math-input": patch
+"@khanacademy/perseus": patch
+---
+
+Wrap all ReactDOM.render() calls in `<RenderStateRoot>` to ensure it propagates properly

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -189,6 +189,14 @@ module.exports = {
                 ],
             },
         ],
+        "no-restricted-syntax": [
+            "error",
+            {
+                selector:
+                    "MemberExpression[property.name='render'][object.name='ReactDOM']",
+                message: "DEPRECATED: Use a React Portal instead.",
+            },
+        ],
 
         /**
          * monorepo

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,7 +4,18 @@ const path = require("path");
 const fs = require("fs");
 
 module.exports = {
-    stories: ["../packages/**/*.@(stories|fixturestories).@(js|jsx|ts|tsx)"],
+    stories: [
+        // NOTE(jeremy): This glob is extremely finicky! I would have written
+        // this as a negated match to exclude node_modules, but I was never
+        // able to get it to work. For example, the following regex included
+        // stories from wonder-blocks packages in node_modules.
+        //     "../packages!(/node_modules)/**/*@(.stories|.fixturestories).@(js|jsx|ts|tsx|mdx)",
+        // So, instead of fighting it, I changed this glob to restrict stories
+        // to be ones in any of our local packages 'src' dirs. This effectively
+        // eliminates stories showing up inside node_modules within any package
+        // dir.
+        "../packages/*/src/**/*@(.stories|.fixturestories).@(js|jsx)",
+    ],
     addons: [
         "@storybook/addon-links",
         "@storybook/addon-essentials",

--- a/packages/math-input/src/demo.js
+++ b/packages/math-input/src/demo.js
@@ -5,4 +5,5 @@ import App from "./components/app.js";
 
 import "../less/main.less";
 
+// eslint-disable-next-line no-restricted-syntax
 ReactDOM.render(<App />, document.getElementById("root"));

--- a/packages/math-input/src/native-app.js
+++ b/packages/math-input/src/native-app.js
@@ -81,4 +81,5 @@ class App extends React.Component {
     }
 }
 
+// eslint-disable-next-line no-restricted-syntax
 ReactDOM.render(<App />, document.getElementById("root"));

--- a/packages/perseus/src/components/__stories__/tex.stories.jsx
+++ b/packages/perseus/src/components/__stories__/tex.stories.jsx
@@ -3,7 +3,9 @@ import * as React from "react";
 
 import TeX from "../tex.jsx";
 
-type StoryArgs = {||};
+type StoryArgs = {|
+    equation: string,
+|};
 
 type Story = {|
     title: string,
@@ -11,8 +13,11 @@ type Story = {|
 
 export default ({
     title: "Perseus/Components/Tex",
+    args: {
+        equation: "f(x) = x + 1",
+    },
 }: Story);
 
 export const BasicOperation = (args: StoryArgs): React.Node => {
-    return <TeX setAssetStatus={() => {}} children="f(x) = x + 1" />;
+    return <TeX setAssetStatus={() => {}} children={args.equation} />;
 };

--- a/packages/perseus/src/components/__stories__/tex.stories.jsx
+++ b/packages/perseus/src/components/__stories__/tex.stories.jsx
@@ -9,6 +9,7 @@ type StoryArgs = {|
 
 type Story = {|
     title: string,
+    args: StoryArgs,
 |};
 
 export default ({

--- a/packages/perseus/src/interactive2/movable-point.jsx
+++ b/packages/perseus/src/interactive2/movable-point.jsx
@@ -52,12 +52,12 @@
  */
 import {point as kpoint, vector as kvector} from "@khanacademy/kmath";
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import _ from "underscore";
 
 import InlineIcon from "../components/inline-icon.jsx";
 import {iconTrash} from "../icon-paths.js";
 import KhanColors from "../util/colors.js";
+import reactRender from "../util/react-render.js";
 import Tex from "../util/tex.js";
 
 import InteractiveUtil from "./interactive-util.js";
@@ -275,9 +275,7 @@ _.extend(MovablePoint.prototype, {
 
         const showTrashTooltip = () => {
             this._showTooltip((container) => {
-                // TODO(LP-11406): Replace with React Portal
-                // eslint-disable-next-line no-restricted-syntax
-                ReactDOM.render(
+                reactRender(
                     <span style={{fontSize: "2em"}}>
                         <InlineIcon
                             {...iconTrash}

--- a/packages/perseus/src/item-renderer.jsx
+++ b/packages/perseus/src/item-renderer.jsx
@@ -13,6 +13,7 @@ import ProvideKeypad from "./mixins/provide-keypad.jsx";
 import {ApiOptions} from "./perseus-api.jsx";
 import Renderer from "./renderer.jsx";
 import Util from "./util.js";
+import reactRender from "./util/react-render.js";
 
 import type {KeypadProps} from "./mixins/provide-keypad.jsx";
 import type {PerseusItem} from "./perseus-types.js";
@@ -178,83 +179,56 @@ class ItemRenderer extends React.Component<Props, State> {
         // that have completely different places in the DOM, we have to do this
         // strangeness instead of relying on React's normal render() method.
         // TODO(alpert): Figure out how to clean this up somehow
-        // TODO(LP-11406): Replace with React Portal
-        // eslint-disable-next-line no-restricted-syntax
-        ReactDOM.render(
-            /**
-             * `RenderStateRoot` is responsible for tracking whether it's
-             * the initial render or subsequent renders.  It's used by
-             * `useUniqueId` and will be used by `UniqueIDProvider` and
-             * `WithSSRPlaceholder` in the future.  We're placing it as
-             * high up in the render tree as possible to ensure that any
-             * components using that hook or those components will function
-             * correctly.
-             */
-            <RenderStateRoot throwIfNested={false}>
-                {/* metadata (from item.question, aka PerseusRenderer)  */}
-                {/* replace (also item.question, aka PerseusRenderer)  */}
-                {/* savedState (I _think_ this is serializedState on Renderer)  */}
-                {/* $FlowFixMe[prop-missing] metadata, replace, savedState (see above) */}
-                <Renderer
-                    ref={(node) => {
-                        if (!node) {
-                            return;
-                        }
-                        this.questionRenderer = node;
+        reactRender(
+            // metadata (from item.question, aka PerseusRenderer)
+            // replace (also item.question, aka PerseusRenderer)
+            // savedState (I _think_ this is serializedState on Renderer)
+            // $FlowFixMe[prop-missing] metadata, replace, savedState (see above)
+            <Renderer
+                ref={(node) => {
+                    if (!node) {
+                        return;
+                    }
+                    this.questionRenderer = node;
 
-                        // NOTE(jeremy): Why don't we just pass this into the
-                        // renderer as a prop?
-                        const {answerableCallback} = apiOptions;
-                        if (answerableCallback) {
-                            const isAnswerable =
-                                this.questionRenderer.emptyWidgets().length ===
-                                0;
-                            answerableCallback(isAnswerable);
-                        }
-                    }}
-                    keypadElement={this.keypadElement()}
-                    problemNum={this.props.problemNum}
-                    onInteractWithWidget={this.handleInteractWithWidget}
-                    highlightedWidgets={this.state.questionHighlightedWidgets}
-                    apiOptions={apiOptions}
-                    questionCompleted={this.state.questionCompleted}
-                    reviewMode={this.props.reviewMode}
-                    savedState={this.props.savedState}
-                    linterContext={PerseusLinter.pushContextStack(
-                        this.props.linterContext,
-                        "question",
-                    )}
-                    {...this.props.item.question}
-                    legacyPerseusLint={this.props.legacyPerseusLint}
-                />
-            </RenderStateRoot>,
+                    // NOTE(jeremy): Why don't we just pass this into the
+                    // renderer as a prop?
+                    const {answerableCallback} = apiOptions;
+                    if (answerableCallback) {
+                        const isAnswerable =
+                            this.questionRenderer.emptyWidgets().length === 0;
+                        answerableCallback(isAnswerable);
+                    }
+                }}
+                keypadElement={this.keypadElement()}
+                problemNum={this.props.problemNum}
+                onInteractWithWidget={this.handleInteractWithWidget}
+                highlightedWidgets={this.state.questionHighlightedWidgets}
+                apiOptions={apiOptions}
+                questionCompleted={this.state.questionCompleted}
+                reviewMode={this.props.reviewMode}
+                savedState={this.props.savedState}
+                linterContext={PerseusLinter.pushContextStack(
+                    this.props.linterContext,
+                    "question",
+                )}
+                {...this.props.item.question}
+                legacyPerseusLint={this.props.legacyPerseusLint}
+            />,
             workArea,
         );
 
-        // TODO(LP-11406): Replace with React Portal
-        // eslint-disable-next-line no-restricted-syntax
-        ReactDOM.render(
-            /**
-             * `RenderStateRoot` is responsible for tracking whether it's
-             * the initial render or subsequent renders.  It's used by
-             * `useUniqueId` and will be used by `UniqueIDProvider` and
-             * `WithSSRPlaceholder` in the future.  We're placing it as
-             * high up in the render tree as possible to ensure that any
-             * components using that hook or those components will function
-             * correctly.
-             */
-            <RenderStateRoot throwIfNested={false}>
-                <HintsRenderer
-                    ref={(node) => (this.hintsRenderer = node)}
-                    hints={this.props.item.hints}
-                    hintsVisible={this.state.hintsVisible}
-                    apiOptions={apiOptions}
-                    linterContext={PerseusLinter.pushContextStack(
-                        this.props.linterContext,
-                        "hints",
-                    )}
-                />
-            </RenderStateRoot>,
+        reactRender(
+            <HintsRenderer
+                ref={(node) => (this.hintsRenderer = node)}
+                hints={this.props.item.hints}
+                hintsVisible={this.state.hintsVisible}
+                apiOptions={apiOptions}
+                linterContext={PerseusLinter.pushContextStack(
+                    this.props.linterContext,
+                    "hints",
+                )}
+            />,
             hintsArea,
         );
 

--- a/packages/perseus/src/item-renderer.jsx
+++ b/packages/perseus/src/item-renderer.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/no-unsafe */
 // @flow
 import * as PerseusLinter from "@khanacademy/perseus-linter";
+import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 import $ from "jquery";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
@@ -180,57 +181,80 @@ class ItemRenderer extends React.Component<Props, State> {
         // TODO(LP-11406): Replace with React Portal
         // eslint-disable-next-line no-restricted-syntax
         ReactDOM.render(
-            // metadata (from item.question, aka PerseusRenderer)
-            // replace (also item.question, aka PerseusRenderer)
-            // savedState (I _think_ this is serializedState on Renderer)
-            // $FlowFixMe[prop-missing] metadata, replace, savedState (see above)
-            <Renderer
-                ref={(node) => {
-                    if (!node) {
-                        return;
-                    }
-                    this.questionRenderer = node;
+            /**
+             * `RenderStateRoot` is responsible for tracking whether it's
+             * the initial render or subsequent renders.  It's used by
+             * `useUniqueId` and will be used by `UniqueIDProvider` and
+             * `WithSSRPlaceholder` in the future.  We're placing it as
+             * high up in the render tree as possible to ensure that any
+             * components using that hook or those components will function
+             * correctly.
+             */
+            <RenderStateRoot throwIfNested={false}>
+                {/* metadata (from item.question, aka PerseusRenderer)  */}
+                {/* replace (also item.question, aka PerseusRenderer)  */}
+                {/* savedState (I _think_ this is serializedState on Renderer)  */}
+                {/* $FlowFixMe[prop-missing] metadata, replace, savedState (see above) */}
+                <Renderer
+                    ref={(node) => {
+                        if (!node) {
+                            return;
+                        }
+                        this.questionRenderer = node;
 
-                    // NOTE(jeremy): Why don't we just pass this into the
-                    // renderer as a prop?
-                    const {answerableCallback} = apiOptions;
-                    if (answerableCallback) {
-                        const isAnswerable =
-                            this.questionRenderer.emptyWidgets().length === 0;
-                        answerableCallback(isAnswerable);
-                    }
-                }}
-                keypadElement={this.keypadElement()}
-                problemNum={this.props.problemNum}
-                onInteractWithWidget={this.handleInteractWithWidget}
-                highlightedWidgets={this.state.questionHighlightedWidgets}
-                apiOptions={apiOptions}
-                questionCompleted={this.state.questionCompleted}
-                reviewMode={this.props.reviewMode}
-                savedState={this.props.savedState}
-                linterContext={PerseusLinter.pushContextStack(
-                    this.props.linterContext,
-                    "question",
-                )}
-                {...this.props.item.question}
-                legacyPerseusLint={this.props.legacyPerseusLint}
-            />,
+                        // NOTE(jeremy): Why don't we just pass this into the
+                        // renderer as a prop?
+                        const {answerableCallback} = apiOptions;
+                        if (answerableCallback) {
+                            const isAnswerable =
+                                this.questionRenderer.emptyWidgets().length ===
+                                0;
+                            answerableCallback(isAnswerable);
+                        }
+                    }}
+                    keypadElement={this.keypadElement()}
+                    problemNum={this.props.problemNum}
+                    onInteractWithWidget={this.handleInteractWithWidget}
+                    highlightedWidgets={this.state.questionHighlightedWidgets}
+                    apiOptions={apiOptions}
+                    questionCompleted={this.state.questionCompleted}
+                    reviewMode={this.props.reviewMode}
+                    savedState={this.props.savedState}
+                    linterContext={PerseusLinter.pushContextStack(
+                        this.props.linterContext,
+                        "question",
+                    )}
+                    {...this.props.item.question}
+                    legacyPerseusLint={this.props.legacyPerseusLint}
+                />
+            </RenderStateRoot>,
             workArea,
         );
 
         // TODO(LP-11406): Replace with React Portal
         // eslint-disable-next-line no-restricted-syntax
         ReactDOM.render(
-            <HintsRenderer
-                ref={(node) => (this.hintsRenderer = node)}
-                hints={this.props.item.hints}
-                hintsVisible={this.state.hintsVisible}
-                apiOptions={apiOptions}
-                linterContext={PerseusLinter.pushContextStack(
-                    this.props.linterContext,
-                    "hints",
-                )}
-            />,
+            /**
+             * `RenderStateRoot` is responsible for tracking whether it's
+             * the initial render or subsequent renders.  It's used by
+             * `useUniqueId` and will be used by `UniqueIDProvider` and
+             * `WithSSRPlaceholder` in the future.  We're placing it as
+             * high up in the render tree as possible to ensure that any
+             * components using that hook or those components will function
+             * correctly.
+             */
+            <RenderStateRoot throwIfNested={false}>
+                <HintsRenderer
+                    ref={(node) => (this.hintsRenderer = node)}
+                    hints={this.props.item.hints}
+                    hintsVisible={this.state.hintsVisible}
+                    apiOptions={apiOptions}
+                    linterContext={PerseusLinter.pushContextStack(
+                        this.props.linterContext,
+                        "hints",
+                    )}
+                />
+            </RenderStateRoot>,
             hintsArea,
         );
 

--- a/packages/perseus/src/item-renderer.jsx
+++ b/packages/perseus/src/item-renderer.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/no-unsafe */
 // @flow
 import * as PerseusLinter from "@khanacademy/perseus-linter";
-import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 import $ from "jquery";
 import * as React from "react";
 import * as ReactDOM from "react-dom";

--- a/packages/perseus/src/mixins/provide-keypad.jsx
+++ b/packages/perseus/src/mixins/provide-keypad.jsx
@@ -16,6 +16,8 @@ import PropTypes from "prop-types";
 import * as React from "react";
 import ReactDOM from "react-dom";
 
+import reactRender from "../util/react-render.js";
+
 import type {CSSProperties} from "aphrodite";
 
 export type KeypadProps = {|
@@ -83,9 +85,7 @@ const ProvideKeypad = {
             _this._keypadContainer = document.createElement("div");
             document.body?.appendChild(_this._keypadContainer);
 
-            // TODO(LP-11406): Replace with React Portal
-            // eslint-disable-next-line no-restricted-syntax
-            ReactDOM.render(
+            reactRender(
                 <Keypad
                     onElementMounted={(element) => {
                         // NOTE(kevinb): The reason why this setState works is

--- a/packages/perseus/src/util/react-render.js
+++ b/packages/perseus/src/util/react-render.js
@@ -1,0 +1,27 @@
+// @flow
+import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
+import * as React from "react";
+import ReactDOM from "react-dom";
+
+export default function render<ElementType: React$ElementType>(
+    element: React.Node,
+    container: HTMLElement,
+    callback?: () => void,
+): React$ElementRef<ElementType> {
+    // TODO(LP-11406): Replace this, or callers, with React Portal
+    // eslint-disable-next-line no-restricted-syntax
+    return ReactDOM.render(
+        /**
+         * `RenderStateRoot` is responsible for tracking whether it's
+         * the initial render or subsequent renders.  It's used by
+         * `useUniqueId` and will be used by `UniqueIDProvider` and
+         * `WithSSRPlaceholder` in the future.  We're placing it as
+         * high up in the render tree as possible to ensure that any
+         * components using that hook or those components will function
+         * correctly.
+         */
+        <RenderStateRoot throwIfNested={false}>{element}</RenderStateRoot>,
+        container,
+        callback,
+    );
+}

--- a/testing/item-renderer-with-debug-ui.jsx
+++ b/testing/item-renderer-with-debug-ui.jsx
@@ -5,11 +5,10 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import * as React from "react";
 
-import {Dependencies, ItemRenderer} from "../packages/perseus/src/index.js";
+import {ItemRenderer} from "../packages/perseus/src/index.js";
 
 import KEScoreUI from "./ke-score-ui.js";
 import SideBySide from "./side-by-side.jsx";
-import {testDependencies} from "./test-dependencies.js";
 
 import type {PerseusItem} from "../packages/perseus/src/perseus-types.js";
 import type {APIOptions, KEScore} from "../packages/perseus/src/types.js";
@@ -25,8 +24,6 @@ export const ItemRendererWithDebugUI = ({
 }: Props): React.Node => {
     const ref = React.useRef<?ItemRenderer>(null);
     const [state, setState] = React.useState<?KEScore>(null);
-
-    Dependencies.setDependencies(testDependencies);
 
     return (
         <SideBySide

--- a/testing/multi-item-renderer-with-debug-ui.jsx
+++ b/testing/multi-item-renderer-with-debug-ui.jsx
@@ -4,12 +4,11 @@ import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import * as React from "react";
 
-import {Dependencies, MultiItems} from "../packages/perseus/src/index.js";
+import {MultiItems} from "../packages/perseus/src/index.js";
 import {simpleQuestionShape} from "../packages/perseus/src/multi-items/__testdata__/multi-renderer_testdata.js";
 
 import KEScoreUI from "./ke-score-ui.js";
 import SideBySide from "./side-by-side.jsx";
-import {testDependencies} from "./test-dependencies.js";
 
 import type {Item as MultiItem} from "../packages/perseus/src/multi-items/item-types.js";
 import type {APIOptions, KEScore} from "../packages/perseus/src/types.js";
@@ -35,8 +34,6 @@ export const MultiItemRendererWithDebugUI = ({
 }: Props): React.Node => {
     const ref = React.useRef<?MultiItems.MultiRenderer>(null);
     const [state, setState] = React.useState<?KEScore>(null);
-
-    Dependencies.setDependencies(testDependencies);
 
     return (
         <SideBySide


### PR DESCRIPTION
## Summary:

@zhiyi-zhang-duke [had a question](https://khanacademy.slack.com/archives/C01AZ9H8TTQ/p1674661600228329) of how to test KaTeX markup in Perseus content. I pointed him to our handy Storybook stories for our renderers.... and then we noticed that no KaTeX was actually rendered.

It turns out there are two, inter-related issues:
1. Our storybook configuration was picking up storybook files found in dependant npm packages (specifically the wonder-blocks packages)
2. We were configuring the helper renderers that we use in Storybook with test dependencies that mock out the `<KatexProvider>` which caused us to render the KaTeX markup literally instead of actually processing it with `katex`.

<img width="300" alt="image" src="https://user-images.githubusercontent.com/77138/214680208-0dcceadb-4944-4cff-abd2-01a294e2209a.png">

Issue: "none"

## Test plan:

`yarn storybook` >> Perseus >> Components >> Tex >> Basic Operation
You should see a rendered equation (inspect it using the browser dev tools and make sure it is inside a `<span class="katex-html">`.

`yarn cypress:ci` >> all cypress tests should still pass
`yarn test` >> all tests should still pass