### PR TITLE
Radio editor bugfix: selection/deletion propagation issues

### DIFF
--- a/.changeset/shiny-squids-sip.md
+++ b/.changeset/shiny-squids-sip.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+bugfix for Radio editor selection and deletion

--- a/packages/perseus-editor/src/editor.jsx
+++ b/packages/perseus-editor/src/editor.jsx
@@ -696,6 +696,7 @@ class Editor extends React.Component<EditorProps, EditorState> {
     _handleKeyDown: (e: SyntheticKeyboardEvent<HTMLTextAreaElement>) => void = (
         e: SyntheticKeyboardEvent<HTMLTextAreaElement>,
     ) => {
+        e.stopPropagation();
         // Tab-completion of widgets. For example, to insert an image:
         // type `[[im`, then tab.
         if (e.key === "Tab") {

--- a/packages/perseus-editor/src/widgets/radio/editor.jsx
+++ b/packages/perseus-editor/src/widgets/radio/editor.jsx
@@ -326,8 +326,6 @@ class RadioEditor extends React.Component<$FlowFixMe> {
     };
 
     onDelete: (number) => void = (choiceIndex) => {
-        console.log("delete", choiceIndex);
-
         const choices = this.props.choices.slice();
         const deleted = choices[choiceIndex];
 

--- a/packages/perseus-editor/src/widgets/radio/editor.jsx
+++ b/packages/perseus-editor/src/widgets/radio/editor.jsx
@@ -75,7 +75,11 @@ class ChoiceEditor extends React.Component<$FlowFixMe> {
             <a
                 className="simple-button orange delete-choice"
                 href="#"
-                onClick={this.props.onDelete}
+                onClick={(e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    this.props.onDelete();
+                }}
                 title="Remove this choice"
             >
                 <InlineIcon {...iconTrash} />
@@ -185,7 +189,7 @@ class RadioEditor extends React.Component<$FlowFixMe> {
                     editMode={true}
                     labelWrap={false}
                     apiOptions={this.props.apiOptions}
-                    choices={this.props.choices.map(function (choice, i) {
+                    choices={this.props.choices.map((choice, i) => {
                         return {
                             content: (
                                 <ChoiceEditor
@@ -208,8 +212,7 @@ class RadioEditor extends React.Component<$FlowFixMe> {
                                             );
                                         }
                                     }}
-                                    // eslint-disable-next-line react/jsx-no-bind
-                                    onDelete={this.onDelete.bind(this, i)}
+                                    onDelete={() => this.onDelete(i)}
                                     showDelete={this.props.choices.length >= 2}
                                 />
                             ),
@@ -322,8 +325,8 @@ class RadioEditor extends React.Component<$FlowFixMe> {
         this.props.onChange({choices: choices});
     };
 
-    onDelete: (number, $FlowFixMe) => void = (choiceIndex, e) => {
-        e.preventDefault();
+    onDelete: (number) => void = (choiceIndex) => {
+        console.log("delete", choiceIndex);
 
         const choices = this.props.choices.slice();
         const deleted = choices[choiceIndex];

--- a/packages/perseus/src/widgets/__tests__/radio/base-radio_test.jsx
+++ b/packages/perseus/src/widgets/__tests__/radio/base-radio_test.jsx
@@ -132,7 +132,7 @@ describe("base-radio", () => {
             expect(screen.getAllByRole("listitem")).toHaveLength(4);
         });
 
-        it("should toggle choice when inner element clicked", () => {
+        it("should not toggle choice when inner element clicked", () => {
             // Arrange
             let updatedValues = null;
             const onChangeHandler = (newValues) => {
@@ -154,6 +154,31 @@ describe("base-radio", () => {
             userEvent.click(
                 screen.getByRole("radio", {name: "(Choice C) Option Gamma"}),
             );
+
+            // Assert
+            expect(updatedValues).toBeNull();
+        });
+
+        it("should toggle choice when data-is-radio-icon clicked", () => {
+            // Arrange
+            let updatedValues = null;
+            const onChangeHandler = (newValues) => {
+                updatedValues = newValues;
+            };
+
+            renderBaseRadio({
+                editMode: true,
+                choices: [
+                    generateChoice({content: "Option 1", correct: false}),
+                    generateChoice({content: "Option B", correct: false}),
+                    generateChoice({content: "Option Gamma", correct: true}),
+                    generateChoice({content: "Option Delta", correct: false}),
+                ],
+                onChange: onChangeHandler,
+            });
+
+            // Act
+            userEvent.click(screen.getAllByTestId("is-radio-icon")[2]);
 
             // Assert
             expect(updatedValues).toMatchObject({

--- a/packages/perseus/src/widgets/__tests__/radio/base-radio_test.jsx
+++ b/packages/perseus/src/widgets/__tests__/radio/base-radio_test.jsx
@@ -159,7 +159,7 @@ describe("base-radio", () => {
             expect(updatedValues).toBeNull();
         });
 
-        it("should toggle choice when data-is-radio-icon clicked", () => {
+        it("should toggle choice when choice icon clicked", () => {
             // Arrange
             let updatedValues = null;
             const onChangeHandler = (newValues) => {
@@ -178,7 +178,9 @@ describe("base-radio", () => {
             });
 
             // Act
-            userEvent.click(screen.getAllByTestId("is-radio-icon")[2]);
+            userEvent.click(
+                screen.getAllByTestId("choice-icon__library-choice-icon")[2],
+            );
 
             // Assert
             expect(updatedValues).toMatchObject({

--- a/packages/perseus/src/widgets/radio/base-radio.jsx
+++ b/packages/perseus/src/widgets/radio/base-radio.jsx
@@ -278,7 +278,9 @@ function BaseRadio(props: Props): React.Node {
                         pos: i,
                         onChange: (newValues) => {
                             // editMode selection is handled in clickHandler
-                            if (editMode) return;
+                            if (editMode) {
+                                return;
+                            }
 
                             updateChoice(i, newValues);
                         },

--- a/packages/perseus/src/widgets/radio/base-radio.jsx
+++ b/packages/perseus/src/widgets/radio/base-radio.jsx
@@ -256,7 +256,7 @@ function BaseRadio(props: Props): React.Node {
                 </div>
             )}
             <ul className={className} style={{listStyle: "none"}}>
-                {choices.map(function (choice, i) {
+                {choices.map((choice, i) => {
                     let Element = Choice;
                     const ref = React.createRef();
                     choiceRefs.current[i] = ref;
@@ -277,6 +277,9 @@ function BaseRadio(props: Props): React.Node {
                             (reviewMode || choice.showRationale),
                         pos: i,
                         onChange: (newValues) => {
+                            // editMode selection is handled in clickHandler
+                            if (editMode) return;
+
                             updateChoice(i, newValues);
                         },
                         ref,
@@ -379,7 +382,7 @@ function BaseRadio(props: Props): React.Node {
                                 // radio icon, then we want to trigger the
                                 // check by flipping the choice of the icon.
                                 if (elem.getAttribute("data-is-radio-icon")) {
-                                    this.updateChoice(i, {
+                                    updateChoice(i, {
                                         checked: !choice.checked,
                                         crossedOut: choice.crossedOut,
                                     });
@@ -408,7 +411,7 @@ function BaseRadio(props: Props): React.Node {
                             <Element {...elementProps} />
                         </li>
                     );
-                }, this)}
+                })}
             </ul>
         </fieldset>
     );

--- a/packages/perseus/src/widgets/radio/choice-icon/library-choice-icon.jsx
+++ b/packages/perseus/src/widgets/radio/choice-icon/library-choice-icon.jsx
@@ -152,7 +152,6 @@ function LibraryChoiceIcon(props: LibraryChoiceIconProps): React.Node {
                     // used in BaseRadio editMode to check
                     // if we actually clicked on the radio icon
                     data-is-radio-icon={true}
-                    data-test-id="is-radio-icon"
                 >
                     <div className={css(styles.innerWrapper)}>
                         <ChoiceInner

--- a/packages/perseus/src/widgets/radio/choice-icon/library-choice-icon.jsx
+++ b/packages/perseus/src/widgets/radio/choice-icon/library-choice-icon.jsx
@@ -149,9 +149,10 @@ function LibraryChoiceIcon(props: LibraryChoiceIconProps): React.Node {
                             (checked || previouslyAnswered) &&
                             styles.circleIncorrectAnswered,
                     )}
-                    // used in BaseRadio to check if we actually clicked on the
-                    // radio icon
+                    // used in BaseRadio editMode to check
+                    // if we actually clicked on the radio icon
                     data-is-radio-icon={true}
+                    data-test-id="is-radio-icon"
                 >
                     <div className={css(styles.innerWrapper)}>
                         <ChoiceInner


### PR DESCRIPTION
## Summary:

Basically what seemed to be happening was that onClick handlers were propagating upwards.

Also when I migrated BaseRadio from a class to a functional component I left a `this.` and for some reason none of our safeguards caught that.

Issue: LC-505

## Test plan:
- Go to the content editor and make sure you can select items, update text without selecting items, and delete items