### PR TITLE
LC-520: Fix input-number to handle rightAlign and width options

### DIFF
--- a/.changeset/warm-rice-yawn.md
+++ b/.changeset/warm-rice-yawn.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Fix input-number widget to obey rightAlign and size options again

--- a/packages/perseus-editor/src/widgets/input-number-editor.jsx
+++ b/packages/perseus-editor/src/widgets/input-number-editor.jsx
@@ -1,12 +1,13 @@
 /* eslint-disable react/sort-comp */
 // @flow
-import {components, Util} from "@khanacademy/perseus";
-import PropTypes from "prop-types";
+import {components, Util, InputNumber} from "@khanacademy/perseus";
 import * as React from "react";
 import ReactDOM from "react-dom";
 import _ from "underscore";
 
 import BlurInput from "../components/blur-input.jsx";
+
+import type {ParsedValue} from "@khanacademy/perseus";
 
 const {InfoTip} = components;
 
@@ -45,22 +46,44 @@ const answerTypes = {
     },
 };
 
-type Props = $FlowFixMe;
+type Props = {|
+    value: number,
+    simplify: React.ElementConfig<typeof InputNumber.widget>["simplify"],
+    size: React.ElementConfig<typeof InputNumber.widget>["size"],
+    inexact: React.ElementConfig<
+        typeof InputNumber.widget,
+    >["reviewModeRubric"]["inexact"],
+    maxError: React.ElementConfig<
+        typeof InputNumber.widget,
+    >["reviewModeRubric"]["maxError"],
+    answerType: React.ElementConfig<typeof InputNumber.widget>["answerType"],
+    rightAlign: React.ElementConfig<typeof InputNumber.widget>["rightAlign"],
+
+    onChange: ({|
+        value?: ParsedValue | 0,
+        simplify?: Props["simplify"],
+        size?: Props["size"],
+        inexact?: Props["inexact"],
+        maxError?: Props["maxError"],
+        answerType?: Props["answerType"],
+        rightAlign?: Props["rightAlign"],
+    |}) => void,
+|};
+
+type DefaultProps = {|
+    value: Props["value"],
+    simplify: Props["simplify"],
+    size: Props["size"],
+    inexact: Props["inexact"],
+    maxError: Props["maxError"],
+    answerType: Props["answerType"],
+    rightAlign: Props["rightAlign"],
+|};
 
 class InputNumberEditor extends React.Component<Props> {
-    static propTypes = {
-        value: PropTypes.number,
-        simplify: PropTypes.oneOf(["required", "optional", "enforced"]),
-        size: PropTypes.oneOf(["normal", "small"]),
-        inexact: PropTypes.bool,
-        maxError: PropTypes.number,
-        answerType: PropTypes.string,
-        rightAlign: PropTypes.bool,
-    };
-
     static widgetName: "input-number" = "input-number";
 
-    static defaultProps: Props = {
+    static defaultProps: DefaultProps = {
         value: 0,
         simplify: "required",
         size: "normal",
@@ -245,25 +268,22 @@ class InputNumberEditor extends React.Component<Props> {
     };
 
     serialize: () => {|
-        value: $FlowFixMe,
-        simplify: $FlowFixMe,
-        size: $FlowFixMe,
-        inexact: $FlowFixMe,
-        maxError: $FlowFixMe,
-        answerType: $FlowFixMe,
-        rightAlign: $FlowFixMe,
-    |} = () => {
-        return _.pick(
-            this.props,
-            "value",
-            "simplify",
-            "size",
-            "inexact",
-            "maxError",
-            "answerType",
-            "rightAlign",
-        );
-    };
+        value: Props["value"],
+        simplify: Props["simplify"],
+        size: Props["size"],
+        inexact: Props["inexact"],
+        maxError: Props["maxError"],
+        answerType: Props["answerType"],
+        rightAlign: Props["rightAlign"],
+    |} = () => ({
+        value: this.props.value,
+        simplify: this.props.simplify,
+        size: this.props.size,
+        inexact: this.props.inexact,
+        maxError: this.props.maxError,
+        answerType: this.props.answerType,
+        rightAlign: this.props.rightAlign,
+    });
 }
 
 export default InputNumberEditor;

--- a/packages/perseus/src/components/input-with-examples.jsx
+++ b/packages/perseus/src/components/input-with-examples.jsx
@@ -14,6 +14,7 @@ import TextInput from "./text-input.jsx";
 import Tooltip from "./tooltip.jsx";
 
 import type {LinterContextProps} from "../types.js";
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 const {captureScratchpadTouchStart} = Util;
 const MATH = "math";
@@ -34,7 +35,7 @@ type Props = {|
     onFocus: () => void,
     onBlur: () => void,
     disabled: boolean,
-    style?: $FlowFixMe,
+    style?: StyleType,
     id: string,
     linterContext: LinterContextProps,
 |};
@@ -154,6 +155,7 @@ class InputWithExamples extends React.Component<Props, State> {
                 return TextInput;
 
             default:
+                (this.props.type: empty);
                 return null;
         }
     };

--- a/packages/perseus/src/index.js
+++ b/packages/perseus/src/index.js
@@ -121,6 +121,7 @@ export type {
     WidgetExports,
     WidgetInfo,
 } from "./types.js";
+export type {ParsedValue} from "./util.js";
 export type {
     MathFormat,
     InputNumberWidget,

--- a/packages/perseus/src/perseus-types.js
+++ b/packages/perseus/src/perseus-types.js
@@ -1404,12 +1404,13 @@ export type PerseusVideoWidgetOptions = {|
 export type PerseusInputNumberWidgetOptions = {|
     answerType?:
         | "number"
-        | "percent"
+        | "decimal"
         | "integer"
-        | "improper"
         | "rational"
-        | "pi"
-        | "decimal",
+        | "improper"
+        | "mixed"
+        | "percent"
+        | "pi",
     inexact?: boolean,
     maxError?: number | string,
     rightAlign?: boolean,

--- a/packages/perseus/src/util.js
+++ b/packages/perseus/src/util.js
@@ -20,7 +20,7 @@ type WordAndPosition = {|
 
 type RNG = () => number;
 
-type ParsedValue = {|
+export type ParsedValue = {|
     value: number,
     exact: boolean,
 |};

--- a/packages/perseus/src/widgets/__stories__/input-number.stories.jsx
+++ b/packages/perseus/src/widgets/__stories__/input-number.stories.jsx
@@ -72,7 +72,13 @@ const updateWidgetOptions = (
     return {
         ...question,
         widgets: {
-            [widgetId]: {...widget, options},
+            [widgetId]: {
+                ...widget,
+                options: {
+                    ...widget.options,
+                    ...options,
+                },
+            },
         },
     };
 };
@@ -94,3 +100,17 @@ export const Percent = (args: InputNumberOptions): React.Node => {
     return <RendererWithDebugUI question={question} />;
 };
 Percent.args = question3.widgets["input-number 1"].options;
+
+export const RationalWithSatStyling = (
+    args: InputNumberOptions,
+): React.Node => {
+    const question = updateWidgetOptions(question1, "input-number 1", args);
+    return (
+        <RendererWithDebugUI
+            question={question}
+            apiOptions={{satStyling: true}}
+            reviewMode={true}
+        />
+    );
+};
+Rational.args = question1.widgets["input-number 1"].options;

--- a/packages/perseus/src/widgets/__stories__/input-number.stories.jsx
+++ b/packages/perseus/src/widgets/__stories__/input-number.stories.jsx
@@ -54,6 +54,9 @@ export default {
         size: {
             control: {type: "select", options: ["normal", "small"]},
         },
+        rightAlign: {
+            control: {type: "boolean"},
+        },
     },
 };
 

--- a/packages/perseus/src/widgets/__stories__/input-number.stories.jsx
+++ b/packages/perseus/src/widgets/__stories__/input-number.stories.jsx
@@ -31,7 +31,10 @@ export default {
             control: {type: "number"},
         },
         simplify: {
-            control: {type: "select", options: ["optional", "required"]},
+            control: {
+                type: "select",
+                options: ["required", "optional", "enforced"],
+            },
         },
         answerType: {
             control: {
@@ -49,7 +52,7 @@ export default {
             },
         },
         size: {
-            control: {type: "select", options: ["normal", "large"]},
+            control: {type: "select", options: ["normal", "small"]},
         },
     },
 };

--- a/packages/perseus/src/widgets/input-number.jsx
+++ b/packages/perseus/src/widgets/input-number.jsx
@@ -3,14 +3,23 @@
 // @flow
 import {linterContextDefault} from "@khanacademy/perseus-linter";
 import * as i18n from "@khanacademy/wonder-blocks-i18n";
-import classNames from "classnames";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {StyleSheet} from "aphrodite";
 import * as React from "react";
 import _ from "underscore";
 
 import InputWithExamples from "../components/input-with-examples.jsx";
 import PossibleAnswers from "../components/possible-answers.jsx";
 import SimpleKeypadInput from "../components/simple-keypad-input.jsx";
-import {ClassNames as ApiClassNames, ApiOptions} from "../perseus-api.jsx";
+import {ApiOptions} from "../perseus-api.jsx";
+import {
+    satCorrectBackgroundColor,
+    satCorrectBorderColor,
+    satCorrectColor,
+    satIncorrectBackgroundColor,
+    satIncorrectBorderColor,
+    satIncorrectColor,
+} from "../styles/constants.js";
 import TexWrangler from "../tex-wrangler.js";
 import KhanAnswerTypes from "../util/answer-types.js";
 
@@ -187,14 +196,26 @@ class InputNumber extends React.Component<Props> {
             }
         }
 
-        const classes = {};
-        classes["perseus-input-size-" + this.props.size] = true;
-        classes["perseus-input-right-align"] = this.props.rightAlign;
-        classes[ApiClassNames.CORRECT] =
-            rubric && correct && this.props.currentValue;
-        classes[ApiClassNames.INCORRECT] =
-            rubric && !correct && this.props.currentValue;
-        classes[ApiClassNames.UNANSWERED] = rubric && !this.props.currentValue;
+        // Note: This is _very_ similar to what `numeric-input.jsx` does. If
+        // you modify this, double-check if you also need to modify that
+        // component.
+        const inputStyles = [
+            styles.default,
+            this.props.size === "small" ? styles.small : null,
+            this.props.rightAlign ? styles.rightAlign : styles.leftAlign,
+        ];
+        // Correct
+        if (rubric && correct && this.props.currentValue) {
+            inputStyles.push(styles.answerStateCorrect);
+        }
+        // Incorrect
+        if (rubric && !correct && this.props.currentValue) {
+            inputStyles.push(styles.answerStateIncorrect);
+        }
+        // Unanswered
+        if (rubric && !this.props.currentValue) {
+            inputStyles.push(styles.answerStateUnanswered);
+        }
 
         const input = (
             <InputWithExamples
@@ -202,7 +223,7 @@ class InputNumber extends React.Component<Props> {
                 ref="input"
                 value={this.props.currentValue}
                 onChange={this.handleChange}
-                className={classNames(classes)}
+                style={inputStyles}
                 type={this._getInputType()}
                 examples={this.examples()}
                 shouldShowExamples={this.shouldShowExamples()}
@@ -392,6 +413,39 @@ class InputNumber extends React.Component<Props> {
         return answerString;
     }
 }
+
+const styles = StyleSheet.create({
+    default: {
+        width: 80,
+        height: "auto",
+    },
+    small: {
+        width: 40,
+    },
+    leftAlign: {
+        paddingLeft: Spacing.xxxSmall_4,
+        paddingRight: 0,
+    },
+    rightAlign: {
+        textAlign: "right",
+        paddingLeft: 0,
+        paddingRight: Spacing.xxxSmall_4,
+    },
+    answerStateCorrect: {
+        color: satCorrectColor,
+        backgroundColor: satCorrectBackgroundColor,
+        border: `solid 1px ${satCorrectBorderColor}`,
+    },
+    answerStateIncorrect: {
+        color: satIncorrectColor,
+        backgroundColor: satIncorrectBackgroundColor,
+        border: `solid 1px ${satIncorrectBorderColor}`,
+    },
+    answerStateUnanswered: {
+        backgroundColor: "#eee",
+        border: "solid 1px #999",
+    },
+});
 
 const propTransform = (
     widgetOptions: PerseusInputNumberWidgetOptions,

--- a/packages/perseus/src/widgets/numeric-input.jsx
+++ b/packages/perseus/src/widgets/numeric-input.jsx
@@ -448,6 +448,9 @@ export class NumericInput extends React.Component<Props, State> {
             );
         }
 
+        // Note: This is _very_ similar to what `input-number.jsx` does. If
+        // you modify this, double-check if you also need to modify that
+        // component.
         const styles = StyleSheet.create({
             input: {
                 textAlign: this.props.rightAlign ? "right" : "left",


### PR DESCRIPTION
## Summary:

This fix is very closely related to #330 (which fixed the same issue for `numeric-input`). `input-number` has similar ancestry as `numeric-input` but is less-used today and so we didn't notice that we caused the same regression. 

This PR makes a few changes:
  1. It switches from using class names found in `perseus-renderer.less` to using Aphrodite styles
  2. It fixes the Storybook story for `input-number` so that the controls actually work
  3. It adds Flow typing (leave the campground better than you found it 🏕️)
  4. Adds a missing `answerType` value (we derived these from data so we likely don't have any data that uses the 'mixed' answer type, but the `input-number` widgets supports it so I've added it in). 
  5. Fixed some inconsistencies with the options that the Storybook controls present compared to what the `input-number` widget actually supports!

Whew. Sorry, this is a large-ish PR. Maybe I should break this up!

Issue: LC-520

## Test plan:

TBD