### PR TITLE
LC-520: Make correctness checks explicit comparisons to true/false

### DIFF
--- a/.changeset/mean-llamas-hammer.md
+++ b/.changeset/mean-llamas-hammer.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fixes styling of input-number when answer is incorrect in review mode

--- a/packages/perseus/src/widgets/input-number.jsx
+++ b/packages/perseus/src/widgets/input-number.jsx
@@ -205,11 +205,11 @@ class InputNumber extends React.Component<Props> {
             this.props.rightAlign ? styles.rightAlign : styles.leftAlign,
         ];
         // Correct
-        if (rubric && correct && this.props.currentValue) {
+        if (rubric && correct === true && this.props.currentValue) {
             inputStyles.push(styles.answerStateCorrect);
         }
         // Incorrect
-        if (rubric && !correct && this.props.currentValue) {
+        if (rubric && correct === false && this.props.currentValue) {
             inputStyles.push(styles.answerStateIncorrect);
         }
         // Unanswered


### PR DESCRIPTION
## Summary:

This PR fixes a very long-standing bug in the `input-number` where we use the bang operator (`!`) to check if a value is true or false, but in doing so equate `null` to false becuase it's "falsey".

Ref: https://github.com/Khan/perseus/blob/old-master/src/widgets/input-number.jsx#L137..L161

That block of code seems to have been equating `null` to incorrect (which happens when `satStyling` is `false` always). I think the fix I've got is as minimal as I can make it and corrects the situation. 

Issue: LC-520

## Test plan:

I imported these changes into local webapp (using the `services/static/tools/dev_update_perseus.sh` script) and then checked the following exercise: https://khanacademy.dev/math/algebra/x2f8bb11595b61c86:functions/x2f8bb11595b61c86:inputs-and-outputs-of-a-function/e/functions_matching_inputs_outputs

When answering correctly, the input is disabled and styled with a light-grey background.
<img width="221" alt="image" src="https://user-images.githubusercontent.com/77138/220782439-5cc247d4-7d46-4041-9e7c-896bc9e80d26.png">

When answered incorrectly, the input is simply left enabled and no style changes.