### PR TITLE
[Remove SAT] Remove satStyling from hint-renderer

### DIFF
--- a/.changeset/tricky-dolphins-film.md
+++ b/.changeset/tricky-dolphins-film.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": major
+---
+
+Remove `satStyling` from `APIOptions`

--- a/packages/perseus/src/__stories__/hints-renderer.stories.jsx
+++ b/packages/perseus/src/__stories__/hints-renderer.stories.jsx
@@ -1,7 +1,7 @@
 // @flow
 
-import React from "react";
 import {View} from "@khanacademy/wonder-blocks-core";
+import React from "react";
 
 import HintsRenderer from "../hints-renderer.jsx";
 

--- a/packages/perseus/src/__stories__/hints-renderer.stories.jsx
+++ b/packages/perseus/src/__stories__/hints-renderer.stories.jsx
@@ -1,6 +1,7 @@
 // @flow
 
 import React from "react";
+import {View} from "@khanacademy/wonder-blocks-core";
 
 import HintsRenderer from "../hints-renderer.jsx";
 
@@ -48,5 +49,12 @@ export default ({
 }: Story);
 
 export const Interactive = (args: StoryArgs): $FlowFixMe => {
-    return <HintsRenderer {...args} />;
+    return (
+        // Sorry for the hacks! The HintRenderer uses absolute positioning
+        // for the "1 / 3" label that is rendered left of the hint. So we shift
+        // everything over so we can see it.
+        <View style={{left: 80}}>
+            <HintsRenderer {...args} />
+        </View>
+    );
 };

--- a/packages/perseus/src/hint-renderer.jsx
+++ b/packages/perseus/src/hint-renderer.jsx
@@ -93,20 +93,17 @@ class HintRenderer extends React.Component<Props> {
                         {i18n._("Hint #%(pos)s", {pos: pos + 1})}
                     </span>
                 )}
-                {!apiOptions.isMobile &&
-                    !apiOptions.satStyling &&
-                    totalHints &&
-                    pos != null && (
-                        <span
-                            className="perseus-hint-label"
-                            style={{
-                                display: "block",
-                                color: apiOptions.hintProgressColor,
-                            }}
-                        >
-                            {`${pos + 1} / ${totalHints}`}
-                        </span>
-                    )}
+                {!apiOptions.isMobile && totalHints && pos != null && (
+                    <span
+                        className="perseus-hint-label"
+                        style={{
+                            display: "block",
+                            color: apiOptions.hintProgressColor,
+                        }}
+                    >
+                        {`${pos + 1} / ${totalHints}`}
+                    </span>
+                )}
                 <Renderer
                     // eslint-disable-next-line react/no-string-refs
                     ref="renderer"

--- a/packages/perseus/src/hint-renderer.jsx
+++ b/packages/perseus/src/hint-renderer.jsx
@@ -93,7 +93,7 @@ class HintRenderer extends React.Component<Props> {
                         {i18n._("Hint #%(pos)s", {pos: pos + 1})}
                     </span>
                 )}
-                {!apiOptions.isMobile && totalHints && pos != null && (
+                {!apiOptions.isMobile && totalHints != null && pos != null && (
                     <span
                         className="perseus-hint-label"
                         style={{


### PR DESCRIPTION
## Summary:

This PR opens a series of PRs to remove custom code to support SAT from Perseus. 

This one removes `satStyling` support from the Hint Renderer. It was pretty minimal but just removes an `satStyling` check which suppresses the `X / Y hints` label in SAT.

I've also tweaked the HintsRenderer story so that we can see the `x / y` hints label (which was previously hidden under the storybook navigation panel.

<img width="300" alt="image" src="https://user-images.githubusercontent.com/77138/223242580-cba37910-38b8-4b49-8ac9-277fe51873a1.png">


Issue: LC-588

## Test plan:

`yarn test`
`yarn flow`