### PR TITLE
Attempt to make codecov action less flakey by specifying an upload token

### DIFF
--- a/.github/workflows/node-ci-main.yml
+++ b/.github/workflows/node-ci-main.yml
@@ -53,5 +53,6 @@ jobs:
     - name: Upload Coverage
       uses: codecov/codecov-action@v3
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage/coverage-final.json
         fail_ci_if_error: true


### PR DESCRIPTION
## Summary:
The codecov action is currently quite flakey.  Sometimes when it fails, it leaves the following error message:

as an error running the uploader: Error uploading to https://codecov.io: Error: There was an error fetching the storage URL during POST: 404 - {'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}

This PR implemented to suggested resolution by specifying an upload token.  I've already added the token as a repository secret.

Issue: None

## Test plan:
- run the workflow multiple times to see if it's less flaky now