### PR TITLE
Update TS to v5 and update @babel/preset-env to match other repos more closely

### DIFF
--- a/.changeset/old-scissors-rush.md
+++ b/.changeset/old-scissors-rush.md
@@ -1,0 +1,6 @@
+---
+"perseus-build-settings": patch
+"@khanacademy/perseus": patch
+---
+
+Update TS to 5.0 and @babel/preset-env settings to match other repos

--- a/config/build/create-babel-plugins.js
+++ b/config/build/create-babel-plugins.js
@@ -4,5 +4,15 @@ module.exports = function createBabelPlugins({platform, format, coverage}) {
     if (coverage) {
         plugins.push("istanbul");
     }
+    if (platform === "browser" && format === "esm") {
+        plugins.push([
+            "@babel/plugin-transform-runtime",
+            {
+                corejs: false,
+                helpers: true,
+                regenerator: false,
+            },
+        ]);
+    }
     return plugins;
 };

--- a/config/build/create-babel-presets.js
+++ b/config/build/create-babel-presets.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-commonjs */
 module.exports = function createBabelPresets({platform, format}) {
     const targets = {};
+    const options = {targets};
 
     if (platform === "node") {
         targets.node = true;
@@ -15,16 +16,14 @@ module.exports = function createBabelPresets({platform, format}) {
 
         case "esm":
             targets.esmodules = true;
+            options.bugfixes = true;
+            options.loose = true;
             break;
     }
+
     return [
         "@babel/preset-typescript",
-        [
-            "@babel/preset-env",
-            {
-                targets,
-            },
-        ],
+        ["@babel/preset-env", options],
         "@babel/preset-react",
     ];
 };

--- a/config/build/rollup.config.js
+++ b/config/build/rollup.config.js
@@ -205,7 +205,10 @@ const createConfig = (
                 url: false,
             }),
             babel({
-                babelHelpers: "bundled",
+                babelHelpers:
+                    platform === "browser" && format === "esm"
+                        ? "runtime"
+                        : "bundled",
                 presets: createBabelPresets({platform, format}),
                 plugins: createBabelPlugins({platform, format}),
                 exclude: "node_modules/**",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@babel/eslint-parser": "^7.16.5",
     "@babel/eslint-plugin": "^7.17.7",
     "@babel/node": "^7.16.8",
+    "@babel/plugin-transform-runtime": "^7.21.0",
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-flow": "^7.16.7",
     "@babel/preset-react": "^7.16.0",
@@ -115,7 +116,7 @@
     "rollup-plugin-preserve-shebangs": "^0.2.0",
     "rollup-plugin-styles": "^4.0.0",
     "sloc": "^0.2.1",
-    "typescript": "4.9.5",
+    "typescript": "5.0.2",
     "webpack-dev-server": "^4.9.0",
     "winston": "^3.7.2"
   },

--- a/packages/perseus/src/util/interactive.ts
+++ b/packages/perseus/src/util/interactive.ts
@@ -2591,7 +2591,7 @@ _.extend(GraphUtils.Graphie.prototype, {
         // and maximum angle values bounding a circle sector, and
         // the third column refers to the cursor name that will be
         // applied if the mouse position falls inside the given sector.
-        const cursorAxes = [
+        const cursorAxes: Array<[number, number, string]> = [
             [Math.PI * -1.0, Math.PI * -0.875, "ew-resize"],
             [Math.PI * -0.875, Math.PI * -0.625, "nesw-resize"],
             [Math.PI * -0.625, Math.PI * -0.375, "ns-resize"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -286,6 +286,18 @@
     resolve "^1.14.2"
     semver "^6.1.2"
 
+"@babel/helper-define-polyfill-provider@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.3.tgz#8612e55be5d51f0cd1f36b4a5a83924e89884b7a"
+  integrity sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==
+  dependencies:
+    "@babel/helper-compilation-targets" "^7.17.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
+    debug "^4.1.1"
+    lodash.debounce "^4.0.8"
+    resolve "^1.14.2"
+    semver "^6.1.2"
+
 "@babel/helper-environment-visitor@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz#ff484094a839bde9d89cd63cba017d7aae80ecd7"
@@ -1223,6 +1235,18 @@
   integrity sha512-KQzzDnZ9hWQBjwi5lpY5v9shmm6IVG0U9pB18zvMu2i4H90xpT4gmqwPYsn8rObiadYe2M0gmgsiOIF5A/2rtg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
+
+"@babel/plugin-transform-runtime@^7.21.0":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.21.0.tgz#2a884f29556d0a68cd3d152dcc9e6c71dfb6eee8"
+  integrity sha512-ReY6pxwSzEU0b3r2/T/VhqMKg/AkceBT19X0UptA3/tYi5Pe2eXgEUH+NNMC5nok6c6XQz5tyVTUpuezRfSMSg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.18.6"
+    "@babel/helper-plugin-utils" "^7.20.2"
+    babel-plugin-polyfill-corejs2 "^0.3.3"
+    babel-plugin-polyfill-corejs3 "^0.6.0"
+    babel-plugin-polyfill-regenerator "^0.4.1"
+    semver "^6.3.0"
 
 "@babel/plugin-transform-shorthand-properties@^7.12.1", "@babel/plugin-transform-shorthand-properties@^7.16.7":
   version "7.16.7"
@@ -6108,6 +6132,15 @@ babel-plugin-polyfill-corejs2@^0.3.0:
     "@babel/helper-define-polyfill-provider" "^0.3.1"
     semver "^6.1.1"
 
+babel-plugin-polyfill-corejs2@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz#5d1bd3836d0a19e1b84bbf2d9640ccb6f951c122"
+  integrity sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==
+  dependencies:
+    "@babel/compat-data" "^7.17.7"
+    "@babel/helper-define-polyfill-provider" "^0.3.3"
+    semver "^6.1.1"
+
 babel-plugin-polyfill-corejs3@^0.1.0:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.1.7.tgz#80449d9d6f2274912e05d9e182b54816904befd0"
@@ -6124,12 +6157,27 @@ babel-plugin-polyfill-corejs3@^0.5.0:
     "@babel/helper-define-polyfill-provider" "^0.3.1"
     core-js-compat "^3.21.0"
 
+babel-plugin-polyfill-corejs3@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.6.0.tgz#56ad88237137eade485a71b52f72dbed57c6230a"
+  integrity sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==
+  dependencies:
+    "@babel/helper-define-polyfill-provider" "^0.3.3"
+    core-js-compat "^3.25.1"
+
 babel-plugin-polyfill-regenerator@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.1.tgz#2c0678ea47c75c8cc2fbb1852278d8fb68233990"
   integrity sha512-Y2B06tvgHYt1x0yz17jGkGeeMr5FeKUu+ASJ+N6nB5lQ8Dapfg42i0OVrf8PNGJ3zKL4A23snMi1IRwrqqND7A==
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.3.1"
+
+babel-plugin-polyfill-regenerator@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.4.1.tgz#390f91c38d90473592ed43351e801a9d3e0fd747"
+  integrity sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==
+  dependencies:
+    "@babel/helper-define-polyfill-provider" "^0.3.3"
 
 babel-plugin-react-docgen@^4.2.1:
   version "4.2.1"
@@ -6521,7 +6569,7 @@ browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.16.6:
     node-releases "^2.0.3"
     picocolors "^1.0.0"
 
-browserslist@^4.14.5, browserslist@^4.21.3:
+browserslist@^4.14.5, browserslist@^4.21.3, browserslist@^4.21.5:
   version "4.21.5"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.5.tgz#75c5dae60063ee641f977e00edd3cfb2fb7af6a7"
   integrity sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==
@@ -7494,6 +7542,13 @@ core-js-compat@^3.20.2, core-js-compat@^3.21.0:
   dependencies:
     browserslist "^4.20.2"
     semver "7.0.0"
+
+core-js-compat@^3.25.1:
+  version "3.29.1"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.29.1.tgz#15c0fb812ea27c973c18d425099afa50b934b41b"
+  integrity sha512-QmchCua884D8wWskMX8tW5ydINzd8oSJVx38lx/pVkFGqztxt73GYre3pm/hyYq8bPf+MW5In4I/uRShFDsbrA==
+  dependencies:
+    browserslist "^4.21.5"
 
 core-js-compat@^3.8.1:
   version "3.22.2"
@@ -18878,10 +18933,10 @@ typescript-compiler@^1.4.1-2:
   resolved "https://registry.yarnpkg.com/typescript-compiler/-/typescript-compiler-1.4.1-2.tgz#ba4f7db22d91534a1929d90009dce161eb72fd3f"
   integrity sha512-EMopKmoAEJqA4XXRFGOb7eSBhmQMbBahW6P1Koayeatp0b4AW2q/bBqYWkpG7QVQc9HGQUiS4trx2ZHcnAaZUg==
 
-typescript@4.9.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"
+  integrity sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==
 
 typescript@^3.6.4:
   version "3.9.10"


### PR DESCRIPTION
## Summary:
TS 5.0 (5.0.2) was recently release so we may as well try out the new version and see if we run into any issues.  It did pick up one issue with the types in interactive.ts which was easily correctly.

This PR also updates the settings of @babel/preset-env to match the settings used by wonder-blocks and webapp.  These changes only affect the esm modules that are generated.  I didn't want to mess with the cjs module settings since I think those are specially configured to work with old versions of Android.

Issue: None

## Test plan:
- yarn tsc
- yarn build
- yarn build:types