### PR TITLE
[🔥AUDIT🔥] Bump all packages manually

### DIFF
--- a/.changeset/metal-clouds-film.md
+++ b/.changeset/metal-clouds-film.md
@@ -1,0 +1,14 @@
+---
+"perseus-build-settings": patch
+"@khanacademy/kas": patch
+"@khanacademy/kmath": patch
+"@khanacademy/math-input": patch
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+"@khanacademy/perseus-error": patch
+"@khanacademy/perseus-linter": patch
+"@khanacademy/pure-markdown": patch
+"@khanacademy/simple-markdown": patch
+---
+
+Bump all package versions since the build settings have been updated


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
For some reason bumping "perseus-build-settings"'s version wasn't enough to bump all of the packages automatically that depend on it.  I'm guessing that's b/c it's listed as a dev dependency.

Issue: None

## Test plan:
- n/a