### PR TITLE
Fix simple-markdown's Flow types

### DIFF
--- a/config/build/gen-flow-types.ts
+++ b/config/build/gen-flow-types.ts
@@ -5,7 +5,7 @@ import * as fglob from "fast-glob";
 import {compiler, beautify} from "flowgen";
 
 const rootDir = path.join(__dirname, "..", "..");
-const files = fglob.sync("packages/*/dist/**/*.d.ts", {
+const files = fglob.sync("packages/simple-markdown/dist/**/*.d.ts", {
     cwd: rootDir,
 });
 

--- a/packages/simple-markdown/src/index.ts
+++ b/packages/simple-markdown/src/index.ts
@@ -20,15 +20,9 @@
  */
 import * as React from "react";
 
-// Type Definitions:
+import type {Capture, MatchFunction, State} from "./troublesome-types";
 
-type Capture =
-    | (Array<string> & {
-          index: number;
-      })
-    | (Array<string> & {
-          index?: number;
-      });
+// Type Definitions:
 
 type Attr = string | number | boolean | null | undefined;
 
@@ -43,22 +37,8 @@ type UnTypedASTNode = {
 
 type ASTNode = SingleASTNode | Array<SingleASTNode>;
 
-type State = {
-    key?: string | number | undefined;
-    inline?: boolean | null | undefined;
-    [key: string]: any;
-};
-
 type ReactElement = React.ReactElement<any>;
 type ReactElements = React.ReactNode;
-
-type MatchFunction = {
-    regex?: RegExp;
-} & ((
-    source: string,
-    state: State,
-    prevCapture: string,
-) => Capture | null | undefined);
 
 type Parser = (
     source: string,

--- a/packages/simple-markdown/src/troublesome-types.js.flow
+++ b/packages/simple-markdown/src/troublesome-types.js.flow
@@ -1,0 +1,22 @@
+// @flow
+export type Capture =
+    | (Array<string> & {
+          index: number,
+      })
+    | (Array<string> & {
+          index?: number,
+      });
+
+export type State = {
+    key?: string | number | undefined,
+    inline?: boolean | null | undefined,
+    [key: string]: any,
+};
+
+export type MatchFunction = {
+    regex?: RegExp,
+} & ((
+    source: string,
+    state: State,
+    prevCapture: string,
+) => Capture | null | undefined);

--- a/packages/simple-markdown/src/troublesome-types.ts
+++ b/packages/simple-markdown/src/troublesome-types.ts
@@ -1,0 +1,21 @@
+export type Capture =
+    | (Array<string> & {
+          index: number;
+      })
+    | (Array<string> & {
+          index?: number;
+      });
+
+export type State = {
+    key?: string | number | undefined;
+    inline?: boolean | null | undefined;
+    [key: string]: any;
+};
+
+export type MatchFunction = {
+    regex?: RegExp;
+} & ((
+    source: string,
+    state: State,
+    prevCapture: string,
+) => Capture | null | undefined);


### PR DESCRIPTION
## Summary:
flowgen outputs exact types, but there are a few types in simple-markdown that don't work properly in with this setting.  This PR extracts those types into a separate file and provides an Flow override file to avoid the issue.

Issue: None

## Test plan:
- yarn build:types
- yarn build:flowtypes
- copy generated .js.flow files from simple-markdown/dist into webapp/services/static/node_modules/@khanacademy/simple-markdown/dist
- restart flow in the static service and see that there are no errors