### PR TITLE
Break most of Perseus's dependencies on KaTeX

### DIFF
--- a/packages/perseus-editor/src/__stories__/editor.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/editor.stories.tsx
@@ -1,4 +1,4 @@
-import {ApiOptions, Dependencies} from "@khanacademy/perseus";
+import {ApiOptions} from "@khanacademy/perseus";
 import * as React from "react";
 
 import {question1} from "../__testdata__/input-number.testdata";
@@ -11,7 +11,6 @@ export default {
 
 export const Rational = (): React.ReactElement => {
     registerAllWidgetsAndEditorsForTesting();
-    Dependencies.getDependencies().shouldUseFutureKaTeX(false);
 
     return (
         <Editor

--- a/packages/perseus-editor/src/__tests__/editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/editor.test.tsx
@@ -27,7 +27,6 @@ describe("Editor", () => {
 
         test("clicking on the widget editor should open it", async () => {
             // Arrange
-            testDependencies.shouldUseFutureKaTeX(false);
             render(
                 <Editor
                     apiOptions={ApiOptions.defaults}
@@ -60,7 +59,6 @@ describe("Editor", () => {
         it("should update values", async () => {
             // Arrange
             const changeFn = jest.fn();
-            testDependencies.shouldUseFutureKaTeX(false);
             render(
                 <Editor
                     apiOptions={ApiOptions.defaults}

--- a/packages/perseus-editor/src/article-editor.tsx
+++ b/packages/perseus-editor/src/article-editor.tsx
@@ -9,7 +9,6 @@ import {
     icons,
     ApiOptions,
     Changeable,
-    Dependencies,
     Errors,
     PerseusError,
 } from "@khanacademy/perseus";
@@ -144,8 +143,6 @@ export default class ArticleEditor extends React.Component<
             isArticle: true,
         } as const;
 
-        const {KatexProvider} = Dependencies.getDependencies();
-
         const sections = this._sections();
 
         return (
@@ -212,19 +209,17 @@ export default class ArticleEditor extends React.Component<
                                         />
                                     </div>
                                 </div>
-                                <KatexProvider>
-                                    <Editor
-                                        {...section}
-                                        apiOptions={apiOptions}
-                                        imageUploader={imageUploader}
-                                        onChange={_.partial(
-                                            this._handleEditorChange,
-                                            i,
-                                        )}
-                                        placeholder="Type your section text here..."
-                                        ref={"editor" + i}
-                                    />
-                                </KatexProvider>
+                                <Editor
+                                    {...section}
+                                    apiOptions={apiOptions}
+                                    imageUploader={imageUploader}
+                                    onChange={_.partial(
+                                        this._handleEditorChange,
+                                        i,
+                                    )}
+                                    placeholder="Type your section text here..."
+                                    ref={"editor" + i}
+                                />
                             </div>
 
                             <div className="editor-preview">

--- a/packages/perseus/src/__tests__/__snapshots__/item-renderer.test.tsx.snap
+++ b/packages/perseus/src/__tests__/__snapshots__/item-renderer.test.tsx.snap
@@ -6,191 +6,183 @@ exports[`item renderer should snapshot: initial render 1`] = `
   <div
     id="workarea"
   >
-    <span
-      class="mock-KatexProvider"
+    <div
+      class="perseus-renderer perseus-renderer-responsive"
     >
       <div
-        class="perseus-renderer perseus-renderer-responsive"
+        class="paragraph"
+        data-perseus-paragraph-index="0"
       >
         <div
           class="paragraph"
-          data-perseus-paragraph-index="0"
         >
-          <div
-            class="paragraph"
+          Enter the number 
+          <span
+            style="white-space: nowrap;"
           >
-            Enter the number 
+            <span />
             <span
-              style="white-space: nowrap;"
-            >
-              <span />
-              <span
-                class="mock-TeX"
-              />
-              <span />
-            </span>
-            -42
+              class="mock-TeX"
+            />
+            <span />
+          </span>
+          -42
+          <span
+            style="white-space: nowrap;"
+          >
+            <span />
             <span
-              style="white-space: nowrap;"
-            >
-              <span />
-              <span
-                class="mock-TeX"
-              />
-              <span />
-            </span>
-             in the box: 
-            <div
-              class="perseus-widget-container widget-nohighlight widget-inline-block"
-            >
-              <span>
-                <div>
-                  <input
-                    autocapitalize="off"
-                    autocomplete="off"
-                    autocorrect="off"
-                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-default_1gznapd-o_O-leftAlign_7jg4r4"
-                    id="input-with-examples-aW5wdXQtbnVtYmVyIDE"
-                    type="text"
-                    value=""
-                  />
-                </div>
+              class="mock-TeX"
+            />
+            <span />
+          </span>
+           in the box: 
+          <div
+            class="perseus-widget-container widget-nohighlight widget-inline-block"
+          >
+            <span>
+              <div>
+                <input
+                  autocapitalize="off"
+                  autocomplete="off"
+                  autocorrect="off"
+                  class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-default_1gznapd-o_O-leftAlign_7jg4r4"
+                  id="input-with-examples-aW5wdXQtbnVtYmVyIDE"
+                  type="text"
+                  value=""
+                />
+              </div>
+              <div
+                style="position: relative; height: 0px; display: none;"
+              >
                 <div
-                  style="position: relative; height: 0px; display: none;"
+                  class="tooltipContainer"
+                  style="position: absolute; left: 0px;"
                 >
                   <div
-                    class="tooltipContainer"
-                    style="position: absolute; left: 0px;"
+                    style="display: block; position: relative; visibility: visible; left: 0px; top: -1px; width: 12px; height: 11px; margin-top: -1px; margin-bottom: -2px; z-index: 10;"
                   >
                     <div
-                      style="display: block; position: relative; visibility: visible; left: 0px; top: -1px; width: 12px; height: 11px; margin-top: -1px; margin-bottom: -2px; z-index: 10;"
-                    >
-                      <div
-                        style="display: block; height: 0px; width: 0px; position: absolute; left: 0px; top: -1px; border-right: 12px solid transparent; border-bottom: 12px solid #ccc;"
-                      />
-                      <div
-                        style="display: block; height: 0px; width: 0px; position: absolute; left: 1px; top: 1px; border-right: 10px solid transparent; border-bottom: 10px solid white;"
-                      />
-                    </div>
+                      style="display: block; height: 0px; width: 0px; position: absolute; left: 0px; top: -1px; border-right: 12px solid transparent; border-bottom: 12px solid #ccc;"
+                    />
                     <div
-                      class="perseus-formats-tooltip preview-measure"
-                      style="position: relative; top: 0px; left: 0px; border: 1px solid #ccc; box-shadow: 0 1px 3px #ccc; z-index: 9;"
+                      style="display: block; height: 0px; width: 0px; position: absolute; left: 1px; top: 1px; border-right: 10px solid transparent; border-bottom: 10px solid white;"
+                    />
+                  </div>
+                  <div
+                    class="perseus-formats-tooltip preview-measure"
+                    style="position: relative; top: 0px; left: 0px; border: 1px solid #ccc; box-shadow: 0 1px 3px #ccc; z-index: 9;"
+                  >
+                    <div
+                      id="input-with-examples-aW5wdXQtbnVtYmVyIDE"
                     >
                       <div
-                        id="input-with-examples-aW5wdXQtbnVtYmVyIDE"
+                        class="perseus-renderer perseus-renderer-responsive"
                       >
-                        <span
-                          class="mock-KatexProvider"
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
                         >
-                          <div
-                            class="perseus-renderer perseus-renderer-responsive"
-                          >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <ul>
-                                <li>
-                                  <strong>
-                                    Your answer should be
-                                  </strong>
-                                </li>
-                                <li>
-                                  an integer, like 
-                                  <span
-                                    style="white-space: nowrap;"
-                                  >
-                                    <span />
-                                    <span
-                                      class="mock-TeX"
-                                    >
-                                      6
-                                    </span>
-                                    <span />
-                                  </span>
-                                </li>
-                                <li>
-                                  an 
-                                  <em>
-                                    exact
-                                  </em>
-                                   decimal, like 
-                                  <span
-                                    style="white-space: nowrap;"
-                                  >
-                                    <span />
-                                    <span
-                                      class="mock-TeX"
-                                    >
-                                      0.75
-                                    </span>
-                                    <span />
-                                  </span>
-                                </li>
-                                <li>
-                                  a 
-                                  <em>
-                                    simplified proper
-                                  </em>
-                                   fraction, like 
-                                  <span
-                                    style="white-space: nowrap;"
-                                  >
-                                    <span />
-                                    <span
-                                      class="mock-TeX"
-                                    >
-                                      3/5
-                                    </span>
-                                    <span />
-                                  </span>
-                                </li>
-                                <li>
-                                  a 
-                                  <em>
-                                    simplified improper
-                                  </em>
-                                   fraction, like 
-                                  <span
-                                    style="white-space: nowrap;"
-                                  >
-                                    <span />
-                                    <span
-                                      class="mock-TeX"
-                                    >
-                                      7/4
-                                    </span>
-                                    <span />
-                                  </span>
-                                </li>
-                                <li>
-                                  a mixed number, like 
-                                  <span
-                                    style="white-space: nowrap;"
-                                  >
-                                    <span />
-                                    <span
-                                      class="mock-TeX"
-                                    >
-                                      1\\ 3/4
-                                    </span>
-                                    <span />
-                                  </span>
-                                </li>
-                              </ul>
-                            </div>
-                          </div>
-                        </span>
+                          <ul>
+                            <li>
+                              <strong>
+                                Your answer should be
+                              </strong>
+                            </li>
+                            <li>
+                              an integer, like 
+                              <span
+                                style="white-space: nowrap;"
+                              >
+                                <span />
+                                <span
+                                  class="mock-TeX"
+                                >
+                                  6
+                                </span>
+                                <span />
+                              </span>
+                            </li>
+                            <li>
+                              an 
+                              <em>
+                                exact
+                              </em>
+                               decimal, like 
+                              <span
+                                style="white-space: nowrap;"
+                              >
+                                <span />
+                                <span
+                                  class="mock-TeX"
+                                >
+                                  0.75
+                                </span>
+                                <span />
+                              </span>
+                            </li>
+                            <li>
+                              a 
+                              <em>
+                                simplified proper
+                              </em>
+                               fraction, like 
+                              <span
+                                style="white-space: nowrap;"
+                              >
+                                <span />
+                                <span
+                                  class="mock-TeX"
+                                >
+                                  3/5
+                                </span>
+                                <span />
+                              </span>
+                            </li>
+                            <li>
+                              a 
+                              <em>
+                                simplified improper
+                              </em>
+                               fraction, like 
+                              <span
+                                style="white-space: nowrap;"
+                              >
+                                <span />
+                                <span
+                                  class="mock-TeX"
+                                >
+                                  7/4
+                                </span>
+                                <span />
+                              </span>
+                            </li>
+                            <li>
+                              a mixed number, like 
+                              <span
+                                style="white-space: nowrap;"
+                              >
+                                <span />
+                                <span
+                                  class="mock-TeX"
+                                >
+                                  1\\ 3/4
+                                </span>
+                                <span />
+                              </span>
+                            </li>
+                          </ul>
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </span>
-            </div>
+              </div>
+            </span>
           </div>
         </div>
       </div>
-    </span>
+    </div>
   </div>
   <div
     id="hintsarea"

--- a/packages/perseus/src/__tests__/__snapshots__/renderer.test.tsx.snap
+++ b/packages/perseus/src/__tests__/__snapshots__/renderer.test.tsx.snap
@@ -2,584 +2,548 @@
 
 exports[`renderer rendering should render a table when isMobile: false 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="0"
-      >
-        <table>
-          <thead>
-            <tr>
-              <th
-                scope="col"
-              >
-                Heading 1
-              </th>
-              <th
-                scope="col"
-              >
-                Heading 2
-              </th>
-              <th
-                scope="col"
-              >
-                Heading 3
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>
-                r1c1
-              </td>
-              <td>
-                r1c2
-              </td>
-              <td>
-                r1c3
-              </td>
-            </tr>
-            <tr>
-              <td>
-                r2c1
-              </td>
-              <td>
-                r2c2
-              </td>
-              <td>
-                r2c3
-              </td>
-            </tr>
-            <tr>
-              <td>
-                r3c1
-              </td>
-              <td>
-                r3c2
-              </td>
-              <td>
-                r3c3
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+      <table>
+        <thead>
+          <tr>
+            <th
+              scope="col"
+            >
+              Heading 1
+            </th>
+            <th
+              scope="col"
+            >
+              Heading 2
+            </th>
+            <th
+              scope="col"
+            >
+              Heading 3
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              r1c1
+            </td>
+            <td>
+              r1c2
+            </td>
+            <td>
+              r1c3
+            </td>
+          </tr>
+          <tr>
+            <td>
+              r2c1
+            </td>
+            <td>
+              r2c2
+            </td>
+            <td>
+              r2c3
+            </td>
+          </tr>
+          <tr>
+            <td>
+              r3c1
+            </td>
+            <td>
+              r3c2
+            </td>
+            <td>
+              r3c3
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`renderer rendering should render a table when isMobile: true 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
-        class="paragraph"
-        data-perseus-paragraph-index="0"
+        style="margin-left: -16px; margin-right: -16px;"
       >
         <div
-          style="margin-left: -16px; margin-right: -16px;"
+          style="padding-left: 0px; padding-right: 0px; transform: translate3d(0,0,0); overflow-x: auto;"
         >
-          <div
-            style="padding-left: 0px; padding-right: 0px; transform: translate3d(0,0,0); overflow-x: auto;"
+          <span
+            style="display: block; width: 100%; transform: scale(1, 1)  translate(0, 8px); transform-origin: 0 0; opacity: 0;"
           >
-            <span
-              style="display: block; width: 100%; transform: scale(1, 1)  translate(0, 8px); transform-origin: 0 0; opacity: 0;"
+            <table
+              tabindex="0"
             >
-              <table
-                tabindex="0"
-              >
-                <thead>
-                  <tr>
-                    <th
-                      scope="col"
-                    >
-                      Heading 1
-                    </th>
-                    <th
-                      scope="col"
-                    >
-                      Heading 2
-                    </th>
-                    <th
-                      scope="col"
-                    >
-                      Heading 3
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>
-                      r1c1
-                    </td>
-                    <td>
-                      r1c2
-                    </td>
-                    <td>
-                      r1c3
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      r2c1
-                    </td>
-                    <td>
-                      r2c2
-                    </td>
-                    <td>
-                      r2c3
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      r3c1
-                    </td>
-                    <td>
-                      r3c2
-                    </td>
-                    <td>
-                      r3c3
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </span>
-          </div>
+              <thead>
+                <tr>
+                  <th
+                    scope="col"
+                  >
+                    Heading 1
+                  </th>
+                  <th
+                    scope="col"
+                  >
+                    Heading 2
+                  </th>
+                  <th
+                    scope="col"
+                  >
+                    Heading 3
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    r1c1
+                  </td>
+                  <td>
+                    r1c2
+                  </td>
+                  <td>
+                    r1c3
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    r2c1
+                  </td>
+                  <td>
+                    r2c2
+                  </td>
+                  <td>
+                    r2c3
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    r3c1
+                  </td>
+                  <td>
+                    r3c2
+                  </td>
+                  <td>
+                    r3c3
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </span>
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`renderer rendering should render block math 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          This is some block math
-        </div>
+        This is some block math
       </div>
+    </div>
+    <div
+      class="paragraph perseus-paragraph-centered"
+      data-perseus-paragraph-index="1"
+    >
       <div
-        class="paragraph perseus-paragraph-centered"
-        data-perseus-paragraph-index="1"
+        class="perseus-block-math"
       >
         <div
-          class="perseus-block-math"
+          class="perseus-block-math-inner"
+          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
         >
-          <div
-            class="perseus-block-math-inner"
-            style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+          <span
+            class="mock-TeX"
           >
-            <span
-              class="mock-TeX"
-            >
-              1 + 2
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="2"
-      >
-        <div
-          class="paragraph"
-        >
-          And a footer.
+            1 + 2
+          </span>
         </div>
       </div>
     </div>
-  </span>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
+    >
+      <div
+        class="paragraph"
+      >
+        And a footer.
+      </div>
+    </div>
+  </div>
 </div>
 `;
 
 exports[`renderer rendering should render block math on mobile 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          This is some block math
-        </div>
-      </div>
-      <div
-        class="paragraph perseus-paragraph-centered"
-        data-perseus-paragraph-index="1"
-      >
-        <div
-          class="perseus-block-math"
-          style="margin-left: -16px; margin-right: -16px;"
-        >
-          <div
-            class="perseus-block-math-inner"
-            style="overflow-x: auto; overflow-y: hidden; margin-top: -10px; margin-bottom: -10px; transform: translate3d(0,0,0); padding: 10px 16px 10px 16px;"
-          >
-            <span
-              style="display: block; width: 100%; transform: scale(1, 1)  translate(0, 8px); transform-origin: 0 0; opacity: 0;"
-            >
-              <span
-                class="mock-TeX"
-              >
-                1 + 2
-              </span>
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="2"
-      >
-        <div
-          class="paragraph"
-        >
-          And a footer.
-        </div>
+        This is some block math
       </div>
     </div>
-  </span>
-</div>
-`;
-
-exports[`renderer rendering should render columns 1`] = `
-<div>
-  <span
-    class="mock-KatexProvider"
-  >
     <div
-      class="perseus-renderer perseus-renderer-responsive perseus-renderer-two-columns"
+      class="paragraph perseus-paragraph-centered"
+      data-perseus-paragraph-index="1"
     >
       <div
-        class="paragraph"
-        data-perseus-paragraph-index="0"
+        class="perseus-block-math"
+        style="margin-left: -16px; margin-right: -16px;"
       >
         <div
-          class="perseus-two-columns"
+          class="perseus-block-math-inner"
+          style="overflow-x: auto; overflow-y: hidden; margin-top: -10px; margin-bottom: -10px; transform: translate3d(0,0,0); padding: 10px 16px 10px 16px;"
         >
-          <div
-            class="perseus-column"
-          >
-            <div
-              class="perseus-column-content"
-            >
-              <div
-                class="paragraph"
-              >
-                Stuff in column 1
-              </div>
-            </div>
-          </div>
-          <div
-            class="perseus-column"
-          >
-            <div
-              class="perseus-column-content"
-            >
-              <div
-                class="paragraph"
-              >
-                Stuff in column 2
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </span>
-</div>
-`;
-
-exports[`renderer rendering should render the math 1`] = `
-<div>
-  <span
-    class="mock-KatexProvider"
-  >
-    <div
-      class="perseus-renderer perseus-renderer-responsive"
-    >
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="0"
-      >
-        <div
-          class="paragraph"
-        >
-          This is some inline math: 
           <span
-            style="white-space: nowrap;"
+            style="display: block; width: 100%; transform: scale(1, 1)  translate(0, 8px); transform-origin: 0 0; opacity: 0;"
           >
-            <span />
             <span
               class="mock-TeX"
             >
               1 + 2
             </span>
-            <span />
           </span>
         </div>
       </div>
     </div>
-  </span>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
+    >
+      <div
+        class="paragraph"
+      >
+        And a footer.
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renderer rendering should render columns 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive perseus-renderer-two-columns"
+  >
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="perseus-two-columns"
+      >
+        <div
+          class="perseus-column"
+        >
+          <div
+            class="perseus-column-content"
+          >
+            <div
+              class="paragraph"
+            >
+              Stuff in column 1
+            </div>
+          </div>
+        </div>
+        <div
+          class="perseus-column"
+        >
+          <div
+            class="perseus-column-content"
+          >
+            <div
+              class="paragraph"
+            >
+              Stuff in column 2
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renderer rendering should render the math 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="paragraph"
+      >
+        This is some inline math: 
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            1 + 2
+          </span>
+          <span />
+        </span>
+      </div>
+    </div>
+  </div>
 </div>
 `;
 
 exports[`renderer snapshots correct answer: correct answer 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
+        The total number of boxes the forklift can carry is 
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-inline-block"
         >
-          The total number of boxes the forklift can carry is 
-          <div
-            class="perseus-widget-container widget-nohighlight widget-inline-block"
-          >
-            <div>
-              <div
-                class="default_xu2jcg-o_O-menuWrapper_wvrnr4"
+          <div>
+            <div
+              class="default_xu2jcg-o_O-menuWrapper_wvrnr4"
+            >
+              <span
+                aria-atomic="true"
+                aria-live="polite"
+                aria-relevant="additions text"
+                class="srOnly_19bpjuy"
+                data-test-id="dropdown-live-region"
+              />
+              <button
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                class="button_vr44p2-o_O-shared_u51dsh-o_O-default_kjzwx1-o_O-focus_1qpi544"
+                type="button"
               >
                 <span
-                  aria-atomic="true"
-                  aria-live="polite"
-                  aria-relevant="additions text"
-                  class="srOnly_19bpjuy"
-                  data-test-id="dropdown-live-region"
-                />
-                <button
-                  aria-expanded="false"
-                  aria-haspopup="listbox"
-                  class="button_vr44p2-o_O-shared_u51dsh-o_O-default_kjzwx1-o_O-focus_1qpi544"
-                  type="button"
+                  class="text_f1191h-o_O-LabelMedium_1rew30o-o_O-text_16ujc3c"
                 >
-                  <span
-                    class="text_f1191h-o_O-LabelMedium_1rew30o-o_O-text_16ujc3c"
-                  >
-                    less than or equal to
-                  </span>
-                  <svg
-                    aria-hidden="true"
-                    class="svg_aeiopc-o_O-caret_ntkmq"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    width="16"
-                  >
-                    <path
-                      d="M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z"
-                      fill="rgba(33,36,44,0.64)"
-                    />
-                  </svg>
-                </button>
-              </div>
+                  less than or equal to
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="svg_aeiopc-o_O-caret_ntkmq"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <path
+                    d="M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z"
+                    fill="rgba(33,36,44,0.64)"
+                  />
+                </svg>
+              </button>
             </div>
           </div>
-           
-          <span
-            style="white-space: nowrap;"
-          >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              60
-            </span>
-            <span />
-          </span>
-          .
         </div>
+         
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            60
+          </span>
+          <span />
+        </span>
+        .
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`renderer snapshots incorrect answer: incorrect answer 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
+        The total number of boxes the forklift can carry is 
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-inline-block"
         >
-          The total number of boxes the forklift can carry is 
-          <div
-            class="perseus-widget-container widget-nohighlight widget-inline-block"
-          >
-            <div>
-              <div
-                class="default_xu2jcg-o_O-menuWrapper_wvrnr4"
+          <div>
+            <div
+              class="default_xu2jcg-o_O-menuWrapper_wvrnr4"
+            >
+              <span
+                aria-atomic="true"
+                aria-live="polite"
+                aria-relevant="additions text"
+                class="srOnly_19bpjuy"
+                data-test-id="dropdown-live-region"
+              />
+              <button
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                class="button_vr44p2-o_O-shared_u51dsh-o_O-default_kjzwx1-o_O-focus_1qpi544"
+                type="button"
               >
                 <span
-                  aria-atomic="true"
-                  aria-live="polite"
-                  aria-relevant="additions text"
-                  class="srOnly_19bpjuy"
-                  data-test-id="dropdown-live-region"
-                />
-                <button
-                  aria-expanded="false"
-                  aria-haspopup="listbox"
-                  class="button_vr44p2-o_O-shared_u51dsh-o_O-default_kjzwx1-o_O-focus_1qpi544"
-                  type="button"
+                  class="text_f1191h-o_O-LabelMedium_1rew30o-o_O-text_16ujc3c"
                 >
-                  <span
-                    class="text_f1191h-o_O-LabelMedium_1rew30o-o_O-text_16ujc3c"
-                  >
-                    greater than or equal to
-                  </span>
-                  <svg
-                    aria-hidden="true"
-                    class="svg_aeiopc-o_O-caret_ntkmq"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    width="16"
-                  >
-                    <path
-                      d="M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z"
-                      fill="rgba(33,36,44,0.64)"
-                    />
-                  </svg>
-                </button>
-              </div>
+                  greater than or equal to
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="svg_aeiopc-o_O-caret_ntkmq"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <path
+                    d="M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z"
+                    fill="rgba(33,36,44,0.64)"
+                  />
+                </svg>
+              </button>
             </div>
           </div>
-           
-          <span
-            style="white-space: nowrap;"
-          >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              60
-            </span>
-            <span />
-          </span>
-          .
         </div>
+         
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            60
+          </span>
+          <span />
+        </span>
+        .
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`renderer snapshots initial render: initial render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
+        The total number of boxes the forklift can carry is 
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-inline-block"
         >
-          The total number of boxes the forklift can carry is 
-          <div
-            class="perseus-widget-container widget-nohighlight widget-inline-block"
-          >
-            <div>
-              <div
-                class="default_xu2jcg-o_O-menuWrapper_wvrnr4"
+          <div>
+            <div
+              class="default_xu2jcg-o_O-menuWrapper_wvrnr4"
+            >
+              <span
+                aria-atomic="true"
+                aria-live="polite"
+                aria-relevant="additions text"
+                class="srOnly_19bpjuy"
+                data-test-id="dropdown-live-region"
+              />
+              <button
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                class="button_vr44p2-o_O-shared_u51dsh-o_O-default_kjzwx1"
+                type="button"
               >
                 <span
-                  aria-atomic="true"
-                  aria-live="polite"
-                  aria-relevant="additions text"
-                  class="srOnly_19bpjuy"
-                  data-test-id="dropdown-live-region"
-                />
-                <button
-                  aria-expanded="false"
-                  aria-haspopup="listbox"
-                  class="button_vr44p2-o_O-shared_u51dsh-o_O-default_kjzwx1"
-                  type="button"
+                  class="text_f1191h-o_O-LabelMedium_1rew30o-o_O-text_16ujc3c"
                 >
-                  <span
-                    class="text_f1191h-o_O-LabelMedium_1rew30o-o_O-text_16ujc3c"
-                  >
-                    greater/less than or equal to
-                  </span>
-                  <svg
-                    aria-hidden="true"
-                    class="svg_aeiopc-o_O-caret_ntkmq"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    width="16"
-                  >
-                    <path
-                      d="M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z"
-                      fill="rgba(33,36,44,0.64)"
-                    />
-                  </svg>
-                </button>
-              </div>
+                  greater/less than or equal to
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="svg_aeiopc-o_O-caret_ntkmq"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <path
+                    d="M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z"
+                    fill="rgba(33,36,44,0.64)"
+                  />
+                </svg>
+              </button>
             </div>
           </div>
-           
-          <span
-            style="white-space: nowrap;"
-          >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              60
-            </span>
-            <span />
-          </span>
-          .
         </div>
+         
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            60
+          </span>
+          <span />
+        </span>
+        .
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/__tests__/__snapshots__/server-item-renderer.test.tsx.snap
+++ b/packages/perseus/src/__tests__/__snapshots__/server-item-renderer.test.tsx.snap
@@ -4,191 +4,183 @@ exports[`server item renderer should snapshot: initial render 1`] = `
 <div>
   <div>
     <div>
-      <span
-        class="mock-KatexProvider"
+      <div
+        class="perseus-renderer perseus-renderer-responsive"
       >
         <div
-          class="perseus-renderer perseus-renderer-responsive"
+          class="paragraph"
+          data-perseus-paragraph-index="0"
         >
           <div
             class="paragraph"
-            data-perseus-paragraph-index="0"
           >
-            <div
-              class="paragraph"
+            Enter the number 
+            <span
+              style="white-space: nowrap;"
             >
-              Enter the number 
+              <span />
               <span
-                style="white-space: nowrap;"
-              >
-                <span />
-                <span
-                  class="mock-TeX"
-                />
-                <span />
-              </span>
-              -42
+                class="mock-TeX"
+              />
+              <span />
+            </span>
+            -42
+            <span
+              style="white-space: nowrap;"
+            >
+              <span />
               <span
-                style="white-space: nowrap;"
-              >
-                <span />
-                <span
-                  class="mock-TeX"
-                />
-                <span />
-              </span>
-               in the box: 
-              <div
-                class="perseus-widget-container widget-nohighlight widget-inline-block"
-              >
-                <span>
-                  <div>
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-default_1gznapd-o_O-leftAlign_7jg4r4"
-                      id="input-with-examples-aW5wdXQtbnVtYmVyIDE"
-                      type="text"
-                      value=""
-                    />
-                  </div>
+                class="mock-TeX"
+              />
+              <span />
+            </span>
+             in the box: 
+            <div
+              class="perseus-widget-container widget-nohighlight widget-inline-block"
+            >
+              <span>
+                <div>
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-default_1gznapd-o_O-leftAlign_7jg4r4"
+                    id="input-with-examples-aW5wdXQtbnVtYmVyIDE"
+                    type="text"
+                    value=""
+                  />
+                </div>
+                <div
+                  style="position: relative; height: 0px; display: none;"
+                >
                   <div
-                    style="position: relative; height: 0px; display: none;"
+                    class="tooltipContainer"
+                    style="position: absolute; left: 0px;"
                   >
                     <div
-                      class="tooltipContainer"
-                      style="position: absolute; left: 0px;"
+                      style="display: block; position: relative; visibility: visible; left: 0px; top: -1px; width: 12px; height: 11px; margin-top: -1px; margin-bottom: -2px; z-index: 10;"
                     >
                       <div
-                        style="display: block; position: relative; visibility: visible; left: 0px; top: -1px; width: 12px; height: 11px; margin-top: -1px; margin-bottom: -2px; z-index: 10;"
-                      >
-                        <div
-                          style="display: block; height: 0px; width: 0px; position: absolute; left: 0px; top: -1px; border-right: 12px solid transparent; border-bottom: 12px solid #ccc;"
-                        />
-                        <div
-                          style="display: block; height: 0px; width: 0px; position: absolute; left: 1px; top: 1px; border-right: 10px solid transparent; border-bottom: 10px solid white;"
-                        />
-                      </div>
+                        style="display: block; height: 0px; width: 0px; position: absolute; left: 0px; top: -1px; border-right: 12px solid transparent; border-bottom: 12px solid #ccc;"
+                      />
                       <div
-                        class="perseus-formats-tooltip preview-measure"
-                        style="position: relative; top: 0px; left: 0px; border: 1px solid #ccc; box-shadow: 0 1px 3px #ccc; z-index: 9;"
+                        style="display: block; height: 0px; width: 0px; position: absolute; left: 1px; top: 1px; border-right: 10px solid transparent; border-bottom: 10px solid white;"
+                      />
+                    </div>
+                    <div
+                      class="perseus-formats-tooltip preview-measure"
+                      style="position: relative; top: 0px; left: 0px; border: 1px solid #ccc; box-shadow: 0 1px 3px #ccc; z-index: 9;"
+                    >
+                      <div
+                        id="input-with-examples-aW5wdXQtbnVtYmVyIDE"
                       >
                         <div
-                          id="input-with-examples-aW5wdXQtbnVtYmVyIDE"
+                          class="perseus-renderer perseus-renderer-responsive"
                         >
-                          <span
-                            class="mock-KatexProvider"
+                          <div
+                            class="paragraph"
+                            data-perseus-paragraph-index="0"
                           >
-                            <div
-                              class="perseus-renderer perseus-renderer-responsive"
-                            >
-                              <div
-                                class="paragraph"
-                                data-perseus-paragraph-index="0"
-                              >
-                                <ul>
-                                  <li>
-                                    <strong>
-                                      Your answer should be
-                                    </strong>
-                                  </li>
-                                  <li>
-                                    an integer, like 
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        6
-                                      </span>
-                                      <span />
-                                    </span>
-                                  </li>
-                                  <li>
-                                    an 
-                                    <em>
-                                      exact
-                                    </em>
-                                     decimal, like 
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        0.75
-                                      </span>
-                                      <span />
-                                    </span>
-                                  </li>
-                                  <li>
-                                    a 
-                                    <em>
-                                      simplified proper
-                                    </em>
-                                     fraction, like 
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        3/5
-                                      </span>
-                                      <span />
-                                    </span>
-                                  </li>
-                                  <li>
-                                    a 
-                                    <em>
-                                      simplified improper
-                                    </em>
-                                     fraction, like 
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        7/4
-                                      </span>
-                                      <span />
-                                    </span>
-                                  </li>
-                                  <li>
-                                    a mixed number, like 
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        1\\ 3/4
-                                      </span>
-                                      <span />
-                                    </span>
-                                  </li>
-                                </ul>
-                              </div>
-                            </div>
-                          </span>
+                            <ul>
+                              <li>
+                                <strong>
+                                  Your answer should be
+                                </strong>
+                              </li>
+                              <li>
+                                an integer, like 
+                                <span
+                                  style="white-space: nowrap;"
+                                >
+                                  <span />
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    6
+                                  </span>
+                                  <span />
+                                </span>
+                              </li>
+                              <li>
+                                an 
+                                <em>
+                                  exact
+                                </em>
+                                 decimal, like 
+                                <span
+                                  style="white-space: nowrap;"
+                                >
+                                  <span />
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    0.75
+                                  </span>
+                                  <span />
+                                </span>
+                              </li>
+                              <li>
+                                a 
+                                <em>
+                                  simplified proper
+                                </em>
+                                 fraction, like 
+                                <span
+                                  style="white-space: nowrap;"
+                                >
+                                  <span />
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    3/5
+                                  </span>
+                                  <span />
+                                </span>
+                              </li>
+                              <li>
+                                a 
+                                <em>
+                                  simplified improper
+                                </em>
+                                 fraction, like 
+                                <span
+                                  style="white-space: nowrap;"
+                                >
+                                  <span />
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    7/4
+                                  </span>
+                                  <span />
+                                </span>
+                              </li>
+                              <li>
+                                a mixed number, like 
+                                <span
+                                  style="white-space: nowrap;"
+                                >
+                                  <span />
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    1\\ 3/4
+                                  </span>
+                                  <span />
+                                </span>
+                              </li>
+                            </ul>
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
-                </span>
-              </div>
+                </div>
+              </span>
             </div>
           </div>
         </div>
-      </span>
+      </div>
     </div>
     <div
       class="hintsContainer_1g61p95"
@@ -211,24 +203,20 @@ exports[`server item renderer should snapshot: initial render 1`] = `
           >
             1 / 3
           </span>
-          <span
-            class="mock-KatexProvider"
+          <div
+            class="perseus-renderer perseus-renderer-responsive"
           >
             <div
-              class="perseus-renderer perseus-renderer-responsive"
+              class="paragraph"
+              data-perseus-paragraph-index="0"
             >
               <div
                 class="paragraph"
-                data-perseus-paragraph-index="0"
               >
-                <div
-                  class="paragraph"
-                >
-                  Hint #1
-                </div>
+                Hint #1
               </div>
             </div>
-          </span>
+          </div>
         </div>
         <div
           class="perseus-hint-renderer"
@@ -245,24 +233,20 @@ exports[`server item renderer should snapshot: initial render 1`] = `
           >
             2 / 3
           </span>
-          <span
-            class="mock-KatexProvider"
+          <div
+            class="perseus-renderer perseus-renderer-responsive"
           >
             <div
-              class="perseus-renderer perseus-renderer-responsive"
+              class="paragraph"
+              data-perseus-paragraph-index="0"
             >
               <div
                 class="paragraph"
-                data-perseus-paragraph-index="0"
               >
-                <div
-                  class="paragraph"
-                >
-                  Hint #2
-                </div>
+                Hint #2
               </div>
             </div>
-          </span>
+          </div>
         </div>
         <div
           class="perseus-hint-renderer last-hint last-rendered"
@@ -279,24 +263,20 @@ exports[`server item renderer should snapshot: initial render 1`] = `
           >
             3 / 3
           </span>
-          <span
-            class="mock-KatexProvider"
+          <div
+            class="perseus-renderer perseus-renderer-responsive"
           >
             <div
-              class="perseus-renderer perseus-renderer-responsive"
+              class="paragraph"
+              data-perseus-paragraph-index="0"
             >
               <div
                 class="paragraph"
-                data-perseus-paragraph-index="0"
               >
-                <div
-                  class="paragraph"
-                >
-                  Hint #3
-                </div>
+                Hint #3
               </div>
             </div>
-          </span>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/perseus/src/components/__tests__/__snapshots__/sortable.test.tsx.snap
+++ b/packages/perseus/src/components/__tests__/__snapshots__/sortable.test.tsx.snap
@@ -9,70 +9,58 @@ exports[`Sortable should snapshot: first render 1`] = `
       class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
       style="position: static; margin: 0px 5px 0px 0px;"
     >
-      <span
-        class="mock-KatexProvider"
+      <div
+        class="perseus-renderer perseus-renderer-responsive"
       >
         <div
-          class="perseus-renderer perseus-renderer-responsive"
+          class="paragraph"
+          data-perseus-paragraph-index="0"
         >
           <div
             class="paragraph"
-            data-perseus-paragraph-index="0"
           >
-            <div
-              class="paragraph"
-            >
-              a
-            </div>
+            a
           </div>
         </div>
-      </span>
+      </div>
     </li>
     <li
       class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
       style="position: static; margin: 0px 5px 0px 0px;"
     >
-      <span
-        class="mock-KatexProvider"
+      <div
+        class="perseus-renderer perseus-renderer-responsive"
       >
         <div
-          class="perseus-renderer perseus-renderer-responsive"
+          class="paragraph"
+          data-perseus-paragraph-index="0"
         >
           <div
             class="paragraph"
-            data-perseus-paragraph-index="0"
           >
-            <div
-              class="paragraph"
-            >
-              b
-            </div>
+            b
           </div>
         </div>
-      </span>
+      </div>
     </li>
     <li
       class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
       style="position: static; margin: 0px;"
     >
-      <span
-        class="mock-KatexProvider"
+      <div
+        class="perseus-renderer perseus-renderer-responsive"
       >
         <div
-          class="perseus-renderer perseus-renderer-responsive"
+          class="paragraph"
+          data-perseus-paragraph-index="0"
         >
           <div
             class="paragraph"
-            data-perseus-paragraph-index="0"
           >
-            <div
-              class="paragraph"
-            >
-              c
-            </div>
+            c
           </div>
         </div>
-      </span>
+      </div>
     </li>
   </ul>
 </div>

--- a/packages/perseus/src/components/__tests__/__snapshots__/sorter.test.tsx.snap
+++ b/packages/perseus/src/components/__tests__/__snapshots__/sorter.test.tsx.snap
@@ -2,296 +2,264 @@
 
 exports[`sorter widget should snapshot on mobile: first mobile render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          <strong>
-            Arrange the following measurements in order from smallest to largest.
-          </strong>
-        </div>
+        <strong>
+          Arrange the following measurements in order from smallest to largest.
+        </strong>
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="1"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+            class="perseus-widget-sorter perseus-clearfix"
           >
-            <div
-              class="perseus-widget-sorter perseus-clearfix"
+            <ul
+              class="sortable_13d4756 perseus-sortable"
             >
-              <ul
-                class="sortable_13d4756 perseus-sortable"
+              <li
+                class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
+                style="position: static; margin: 0px 8px 0px 0px;"
               >
-                <li
-                  class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
-                  style="position: static; margin: 0px 8px 0px 0px;"
+                <div
+                  class="perseus-renderer perseus-renderer-responsive"
                 >
-                  <span
-                    class="mock-KatexProvider"
+                  <div
+                    class="paragraph"
+                    data-perseus-paragraph-index="0"
                   >
                     <div
-                      class="perseus-renderer perseus-renderer-responsive"
+                      class="paragraph"
                     >
-                      <div
-                        class="paragraph"
-                        data-perseus-paragraph-index="0"
+                      <span
+                        style="white-space: nowrap;"
                       >
-                        <div
-                          class="paragraph"
+                        <span />
+                        <span
+                          class="tex-mock"
                         >
-                          <span
-                            style="white-space: nowrap;"
-                          >
-                            <span />
-                            <span
-                              class="tex-mock"
-                            >
-                              15
-                            </span>
-                            <span />
-                          </span>
-                           grams
-                        </div>
-                      </div>
+                          15
+                        </span>
+                        <span />
+                      </span>
+                       grams
                     </div>
-                  </span>
-                </li>
-                <li
-                  class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
-                  style="position: static; margin: 0px 8px 0px 0px;"
+                  </div>
+                </div>
+              </li>
+              <li
+                class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
+                style="position: static; margin: 0px 8px 0px 0px;"
+              >
+                <div
+                  class="perseus-renderer perseus-renderer-responsive"
                 >
-                  <span
-                    class="mock-KatexProvider"
+                  <div
+                    class="paragraph"
+                    data-perseus-paragraph-index="0"
                   >
                     <div
-                      class="perseus-renderer perseus-renderer-responsive"
+                      class="paragraph"
                     >
-                      <div
-                        class="paragraph"
-                        data-perseus-paragraph-index="0"
+                      <span
+                        style="white-space: nowrap;"
                       >
-                        <div
-                          class="paragraph"
+                        <span />
+                        <span
+                          class="tex-mock"
                         >
-                          <span
-                            style="white-space: nowrap;"
-                          >
-                            <span />
-                            <span
-                              class="tex-mock"
-                            >
-                              0.005
-                            </span>
-                            <span />
-                          </span>
-                           kilograms
-                        </div>
-                      </div>
+                          0.005
+                        </span>
+                        <span />
+                      </span>
+                       kilograms
                     </div>
-                  </span>
-                </li>
-                <li
-                  class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
-                  style="position: static; margin: 0px;"
+                  </div>
+                </div>
+              </li>
+              <li
+                class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
+                style="position: static; margin: 0px;"
+              >
+                <div
+                  class="perseus-renderer perseus-renderer-responsive"
                 >
-                  <span
-                    class="mock-KatexProvider"
+                  <div
+                    class="paragraph"
+                    data-perseus-paragraph-index="0"
                   >
                     <div
-                      class="perseus-renderer perseus-renderer-responsive"
+                      class="paragraph"
                     >
-                      <div
-                        class="paragraph"
-                        data-perseus-paragraph-index="0"
+                      <span
+                        style="white-space: nowrap;"
                       >
-                        <div
-                          class="paragraph"
+                        <span />
+                        <span
+                          class="tex-mock"
                         >
-                          <span
-                            style="white-space: nowrap;"
-                          >
-                            <span />
-                            <span
-                              class="tex-mock"
-                            >
-                              55
-                            </span>
-                            <span />
-                          </span>
-                           grams
-                        </div>
-                      </div>
+                          55
+                        </span>
+                        <span />
+                      </span>
+                       grams
                     </div>
-                  </span>
-                </li>
-              </ul>
-            </div>
+                  </div>
+                </div>
+              </li>
+            </ul>
           </div>
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`sorter widget should snapshot: first render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          <strong>
-            Arrange the following measurements in order from smallest to largest.
-          </strong>
-        </div>
+        <strong>
+          Arrange the following measurements in order from smallest to largest.
+        </strong>
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="1"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+            class="perseus-widget-sorter perseus-clearfix"
           >
-            <div
-              class="perseus-widget-sorter perseus-clearfix"
+            <ul
+              class="sortable_13d4756 perseus-sortable"
             >
-              <ul
-                class="sortable_13d4756 perseus-sortable"
+              <li
+                class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
+                style="position: static; margin: 0px 5px 0px 0px;"
               >
-                <li
-                  class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
-                  style="position: static; margin: 0px 5px 0px 0px;"
+                <div
+                  class="perseus-renderer perseus-renderer-responsive"
                 >
-                  <span
-                    class="mock-KatexProvider"
+                  <div
+                    class="paragraph"
+                    data-perseus-paragraph-index="0"
                   >
                     <div
-                      class="perseus-renderer perseus-renderer-responsive"
+                      class="paragraph"
                     >
-                      <div
-                        class="paragraph"
-                        data-perseus-paragraph-index="0"
+                      <span
+                        style="white-space: nowrap;"
                       >
-                        <div
-                          class="paragraph"
+                        <span />
+                        <span
+                          class="tex-mock"
                         >
-                          <span
-                            style="white-space: nowrap;"
-                          >
-                            <span />
-                            <span
-                              class="tex-mock"
-                            >
-                              15
-                            </span>
-                            <span />
-                          </span>
-                           grams
-                        </div>
-                      </div>
+                          15
+                        </span>
+                        <span />
+                      </span>
+                       grams
                     </div>
-                  </span>
-                </li>
-                <li
-                  class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
-                  style="position: static; margin: 0px 5px 0px 0px;"
+                  </div>
+                </div>
+              </li>
+              <li
+                class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
+                style="position: static; margin: 0px 5px 0px 0px;"
+              >
+                <div
+                  class="perseus-renderer perseus-renderer-responsive"
                 >
-                  <span
-                    class="mock-KatexProvider"
+                  <div
+                    class="paragraph"
+                    data-perseus-paragraph-index="0"
                   >
                     <div
-                      class="perseus-renderer perseus-renderer-responsive"
+                      class="paragraph"
                     >
-                      <div
-                        class="paragraph"
-                        data-perseus-paragraph-index="0"
+                      <span
+                        style="white-space: nowrap;"
                       >
-                        <div
-                          class="paragraph"
+                        <span />
+                        <span
+                          class="tex-mock"
                         >
-                          <span
-                            style="white-space: nowrap;"
-                          >
-                            <span />
-                            <span
-                              class="tex-mock"
-                            >
-                              0.005
-                            </span>
-                            <span />
-                          </span>
-                           kilograms
-                        </div>
-                      </div>
+                          0.005
+                        </span>
+                        <span />
+                      </span>
+                       kilograms
                     </div>
-                  </span>
-                </li>
-                <li
-                  class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
-                  style="position: static; margin: 0px;"
+                  </div>
+                </div>
+              </li>
+              <li
+                class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
+                style="position: static; margin: 0px;"
+              >
+                <div
+                  class="perseus-renderer perseus-renderer-responsive"
                 >
-                  <span
-                    class="mock-KatexProvider"
+                  <div
+                    class="paragraph"
+                    data-perseus-paragraph-index="0"
                   >
                     <div
-                      class="perseus-renderer perseus-renderer-responsive"
+                      class="paragraph"
                     >
-                      <div
-                        class="paragraph"
-                        data-perseus-paragraph-index="0"
+                      <span
+                        style="white-space: nowrap;"
                       >
-                        <div
-                          class="paragraph"
+                        <span />
+                        <span
+                          class="tex-mock"
                         >
-                          <span
-                            style="white-space: nowrap;"
-                          >
-                            <span />
-                            <span
-                              class="tex-mock"
-                            >
-                              55
-                            </span>
-                            <span />
-                          </span>
-                           grams
-                        </div>
-                      </div>
+                          55
+                        </span>
+                        <span />
+                      </span>
+                       grams
                     </div>
-                  </span>
-                </li>
-              </ul>
-            </div>
+                  </div>
+                </div>
+              </li>
+            </ul>
           </div>
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/components/__tests__/sorter.test.tsx
+++ b/packages/perseus/src/components/__tests__/sorter.test.tsx
@@ -1,4 +1,3 @@
-import getRenderA11yString from "katex/dist/contrib/render-a11y-string";
 import * as React from "react";
 import "@testing-library/jest-dom";
 
@@ -28,8 +27,6 @@ describe("sorter widget", () => {
             TeX: ({children}: {children: React.ReactNode}) => (
                 <span className="tex-mock">{children}</span>
             ),
-            // @ts-expect-error [FEI-5003] - TS2322 - Type 'Promise<any>' is not assignable to type '() => Promise<katexA11y>'.
-            getRenderA11yString: Promise.resolve(getRenderA11yString),
             shouldUseFutureKaTeX: (flag: boolean) => {},
         });
     });

--- a/packages/perseus/src/components/__tests__/sorter.test.tsx
+++ b/packages/perseus/src/components/__tests__/sorter.test.tsx
@@ -27,7 +27,6 @@ describe("sorter widget", () => {
             TeX: ({children}: {children: React.ReactNode}) => (
                 <span className="tex-mock">{children}</span>
             ),
-            shouldUseFutureKaTeX: (flag: boolean) => {},
         });
     });
 

--- a/packages/perseus/src/multi-items/__tests__/__snapshots__/multi-renderer.test.tsx.snap
+++ b/packages/perseus/src/multi-items/__tests__/__snapshots__/multi-renderer.test.tsx.snap
@@ -6,159 +6,236 @@ exports[`multi-item renderer should snapshot: initial render 1`] = `
     <div
       id="blurb"
     >
-      <span
-        class="mock-KatexProvider"
+      <div
+        class="perseus-renderer perseus-renderer-responsive"
       >
         <div
-          class="perseus-renderer perseus-renderer-responsive"
+          class="paragraph perseus-paragraph-centered"
+          data-perseus-paragraph-index="0"
         >
-          <div
-            class="paragraph perseus-paragraph-centered"
-            data-perseus-paragraph-index="0"
-          >
-            
+          
 
-          </div>
         </div>
-      </span>
+      </div>
     </div>
     <div
       id="question"
     >
-      <span
-        class="mock-KatexProvider"
+      <div
+        class="perseus-renderer perseus-renderer-responsive"
       >
         <div
-          class="perseus-renderer perseus-renderer-responsive"
+          class="paragraph"
+          data-perseus-paragraph-index="0"
         >
           <div
             class="paragraph"
-            data-perseus-paragraph-index="0"
           >
-            <div
-              class="paragraph"
+            Triangle 
+            <span
+              style="white-space: nowrap;"
             >
-              Triangle 
+              <span />
               <span
-                style="white-space: nowrap;"
+                class="mock-TeX"
               >
-                <span />
-                <span
-                  class="mock-TeX"
-                >
-                  ABC
-                </span>
-                <span />
+                ABC
               </span>
-               has side lengths of 
+              <span />
+            </span>
+             has side lengths of 
+            <span
+              style="white-space: nowrap;"
+            >
+              <span />
               <span
-                style="white-space: nowrap;"
+                class="mock-TeX"
               >
-                <span />
-                <span
-                  class="mock-TeX"
-                >
-                  12
-                </span>
-                <span />
+                12
               </span>
-              , 
+              <span />
+            </span>
+            , 
+            <span
+              style="white-space: nowrap;"
+            >
+              <span />
               <span
-                style="white-space: nowrap;"
+                class="mock-TeX"
               >
-                <span />
-                <span
-                  class="mock-TeX"
-                >
-                  14
-                </span>
-                <span />
+                14
               </span>
-              , and 
+              <span />
+            </span>
+            , and 
+            <span
+              style="white-space: nowrap;"
+            >
+              <span />
               <span
-                style="white-space: nowrap;"
+                class="mock-TeX"
               >
-                <span />
-                <span
-                  class="mock-TeX"
-                >
-                  20
-                </span>
-                <span />
+                20
               </span>
-              . Which of the following triangles is congruent to triangle 
+              <span />
+            </span>
+            . Which of the following triangles is congruent to triangle 
+            <span
+              style="white-space: nowrap;"
+            >
+              <span />
               <span
-                style="white-space: nowrap;"
+                class="mock-TeX"
               >
-                <span />
-                <span
-                  class="mock-TeX"
-                >
-                  ABC
-                </span>
-                <span />
+                ABC
               </span>
-               ?
-            </div>
+              <span />
+            </span>
+             ?
           </div>
+        </div>
+        <div
+          class="paragraph"
+          data-perseus-paragraph-index="1"
+        >
           <div
             class="paragraph"
-            data-perseus-paragraph-index="1"
           >
             <div
-              class="paragraph"
+              class="perseus-widget-container widget-nohighlight widget-block"
             >
               <div
-                class="perseus-widget-container widget-nohighlight widget-block"
+                class="responsiveContainer_vq37gq"
               >
-                <div
-                  class="responsiveContainer_vq37gq"
+                <fieldset
+                  class="perseus-widget-radio-fieldset responsiveFieldset_c0l5kf"
                 >
-                  <fieldset
-                    class="perseus-widget-radio-fieldset responsiveFieldset_c0l5kf"
+                  <legend
+                    class="perseus-sr-only"
                   >
-                    <legend
-                      class="perseus-sr-only"
+                    Choose 1 answer:
+                  </legend>
+                  <div
+                    aria-hidden="true"
+                    class="instructions instructions_125m8j1"
+                  >
+                    Choose 1 answer:
+                  </div>
+                  <ul
+                    class="perseus-widget-radio perseus-rendered-radio radio_1gyjybc-o_O-responsiveRadioContainer_1ybwre2"
+                    style="list-style: none;"
+                  >
+                    <li
+                      class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                     >
-                      Choose 1 answer:
-                    </legend>
-                    <div
-                      aria-hidden="true"
-                      class="instructions instructions_125m8j1"
-                    >
-                      Choose 1 answer:
-                    </div>
-                    <ul
-                      class="perseus-widget-radio perseus-rendered-radio radio_1gyjybc-o_O-responsiveRadioContainer_1ybwre2"
-                      style="list-style: none;"
-                    >
-                      <li
-                        class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                      <div
+                        class="description description_psmgei"
+                        style="flex-direction: column; color: rgb(33, 36, 44);"
                       >
                         <div
-                          class="description description_psmgei"
-                          style="flex-direction: column; color: rgb(33, 36, 44);"
+                          style="display: flex; flex-direction: row; opacity: 1;"
                         >
                           <div
-                            style="display: flex; flex-direction: row; opacity: 1;"
+                            class="perseus-sr-only"
+                          >
+                            <input
+                              class="perseus-radio-option-content"
+                              id="choice-0"
+                              tabindex="-1"
+                              type="radio"
+                            />
+                            <label
+                              for="choice-0"
+                            >
+                              (Choice A)
+                                 
+                              <div
+                                class="perseus-renderer perseus-renderer-responsive"
+                              >
+                                <div
+                                  class="paragraph"
+                                  data-perseus-paragraph-index="0"
+                                >
+                                  <div
+                                    class="paragraph"
+                                  >
+                                    A triangle with side lengths of 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        3
+                                      </span>
+                                      <span />
+                                    </span>
+                                    , 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        4
+                                      </span>
+                                      <span />
+                                    </span>
+                                    , and 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        5
+                                      </span>
+                                      <span />
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </label>
+                          </div>
+                          <button
+                            aria-disabled="false"
+                            aria-hidden="true"
+                            class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                            type="button"
                           >
                             <div
-                              class="perseus-sr-only"
+                              style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
                             >
-                              <input
-                                class="perseus-radio-option-content"
-                                id="choice-0"
-                                tabindex="-1"
-                                type="radio"
-                              />
-                              <label
-                                for="choice-0"
+                              <div
+                                class="iconWrapper_17y0hv9"
                               >
-                                (Choice A)
-                                   
                                 <span
-                                  class="mock-KatexProvider"
+                                  class="ring_ya75gi"
+                                  data-test-id="focus-ring"
+                                  style="border-color: transparent; border-radius: 50%;"
                                 >
+                                  <div
+                                    class="circle_1tys2th"
+                                    data-is-radio-icon="true"
+                                    data-test-id="choice-icon__library-choice-icon"
+                                    style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                                  >
+                                    <div
+                                      class="innerWrapper_177sg8x"
+                                    >
+                                      A
+                                    </div>
+                                  </div>
+                                </span>
+                              </div>
+                              <span
+                                style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                              >
+                                <div />
+                                <div>
                                   <div
                                     class="perseus-renderer perseus-renderer-responsive"
                                   >
@@ -208,132 +285,124 @@ exports[`multi-item renderer should snapshot: initial render 1`] = `
                                       </div>
                                     </div>
                                   </div>
-                                </span>
-                              </label>
+                                </div>
+                              </span>
                             </div>
-                            <button
-                              aria-disabled="false"
-                              aria-hidden="true"
-                              class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                              type="button"
+                          </button>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                    >
+                      <div
+                        class="description description_psmgei"
+                        style="flex-direction: column; color: rgb(33, 36, 44);"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; opacity: 1;"
+                        >
+                          <div
+                            class="perseus-sr-only"
+                          >
+                            <input
+                              class="perseus-radio-option-content"
+                              id="choice-1"
+                              tabindex="-1"
+                              type="radio"
+                            />
+                            <label
+                              for="choice-1"
                             >
+                              (Choice B)
+                                 
                               <div
-                                style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                                class="perseus-renderer perseus-renderer-responsive"
                               >
                                 <div
-                                  class="iconWrapper_17y0hv9"
+                                  class="paragraph"
+                                  data-perseus-paragraph-index="0"
                                 >
-                                  <span
-                                    class="ring_ya75gi"
-                                    data-test-id="focus-ring"
-                                    style="border-color: transparent; border-radius: 50%;"
+                                  <div
+                                    class="paragraph"
+                                  >
+                                    A triangle with side lengths of 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        6
+                                      </span>
+                                      <span />
+                                    </span>
+                                    , 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        7
+                                      </span>
+                                      <span />
+                                    </span>
+                                    , and 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        10
+                                      </span>
+                                      <span />
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </label>
+                          </div>
+                          <button
+                            aria-disabled="false"
+                            aria-hidden="true"
+                            class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                            type="button"
+                          >
+                            <div
+                              style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                            >
+                              <div
+                                class="iconWrapper_17y0hv9"
+                              >
+                                <span
+                                  class="ring_ya75gi"
+                                  data-test-id="focus-ring"
+                                  style="border-color: transparent; border-radius: 50%;"
+                                >
+                                  <div
+                                    class="circle_1tys2th"
+                                    data-is-radio-icon="true"
+                                    data-test-id="choice-icon__library-choice-icon"
+                                    style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
                                   >
                                     <div
-                                      class="circle_1tys2th"
-                                      data-is-radio-icon="true"
-                                      data-test-id="choice-icon__library-choice-icon"
-                                      style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                                      class="innerWrapper_177sg8x"
                                     >
-                                      <div
-                                        class="innerWrapper_177sg8x"
-                                      >
-                                        A
-                                      </div>
+                                      B
                                     </div>
-                                  </span>
-                                </div>
-                                <span
-                                  style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                                >
-                                  <div />
-                                  <div>
-                                    <span
-                                      class="mock-KatexProvider"
-                                    >
-                                      <div
-                                        class="perseus-renderer perseus-renderer-responsive"
-                                      >
-                                        <div
-                                          class="paragraph"
-                                          data-perseus-paragraph-index="0"
-                                        >
-                                          <div
-                                            class="paragraph"
-                                          >
-                                            A triangle with side lengths of 
-                                            <span
-                                              style="white-space: nowrap;"
-                                            >
-                                              <span />
-                                              <span
-                                                class="mock-TeX"
-                                              >
-                                                3
-                                              </span>
-                                              <span />
-                                            </span>
-                                            , 
-                                            <span
-                                              style="white-space: nowrap;"
-                                            >
-                                              <span />
-                                              <span
-                                                class="mock-TeX"
-                                              >
-                                                4
-                                              </span>
-                                              <span />
-                                            </span>
-                                            , and 
-                                            <span
-                                              style="white-space: nowrap;"
-                                            >
-                                              <span />
-                                              <span
-                                                class="mock-TeX"
-                                              >
-                                                5
-                                              </span>
-                                              <span />
-                                            </span>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </span>
                                   </div>
                                 </span>
                               </div>
-                            </button>
-                          </div>
-                        </div>
-                      </li>
-                      <li
-                        class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                      >
-                        <div
-                          class="description description_psmgei"
-                          style="flex-direction: column; color: rgb(33, 36, 44);"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; opacity: 1;"
-                          >
-                            <div
-                              class="perseus-sr-only"
-                            >
-                              <input
-                                class="perseus-radio-option-content"
-                                id="choice-1"
-                                tabindex="-1"
-                                type="radio"
-                              />
-                              <label
-                                for="choice-1"
+                              <span
+                                style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
                               >
-                                (Choice B)
-                                   
-                                <span
-                                  class="mock-KatexProvider"
-                                >
+                                <div />
+                                <div>
                                   <div
                                     class="perseus-renderer perseus-renderer-responsive"
                                   >
@@ -383,132 +452,124 @@ exports[`multi-item renderer should snapshot: initial render 1`] = `
                                       </div>
                                     </div>
                                   </div>
-                                </span>
-                              </label>
+                                </div>
+                              </span>
                             </div>
-                            <button
-                              aria-disabled="false"
-                              aria-hidden="true"
-                              class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                              type="button"
+                          </button>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                    >
+                      <div
+                        class="description description_psmgei"
+                        style="flex-direction: column; color: rgb(33, 36, 44);"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; opacity: 1;"
+                        >
+                          <div
+                            class="perseus-sr-only"
+                          >
+                            <input
+                              class="perseus-radio-option-content"
+                              id="choice-2"
+                              tabindex="-1"
+                              type="radio"
+                            />
+                            <label
+                              for="choice-2"
                             >
+                              (Choice C)
+                                 
                               <div
-                                style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                                class="perseus-renderer perseus-renderer-responsive"
                               >
                                 <div
-                                  class="iconWrapper_17y0hv9"
+                                  class="paragraph"
+                                  data-perseus-paragraph-index="0"
                                 >
-                                  <span
-                                    class="ring_ya75gi"
-                                    data-test-id="focus-ring"
-                                    style="border-color: transparent; border-radius: 50%;"
+                                  <div
+                                    class="paragraph"
+                                  >
+                                    A triangle with side lengths of 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        10
+                                      </span>
+                                      <span />
+                                    </span>
+                                    , 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        12
+                                      </span>
+                                      <span />
+                                    </span>
+                                    , and 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        18
+                                      </span>
+                                      <span />
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </label>
+                          </div>
+                          <button
+                            aria-disabled="false"
+                            aria-hidden="true"
+                            class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                            type="button"
+                          >
+                            <div
+                              style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                            >
+                              <div
+                                class="iconWrapper_17y0hv9"
+                              >
+                                <span
+                                  class="ring_ya75gi"
+                                  data-test-id="focus-ring"
+                                  style="border-color: transparent; border-radius: 50%;"
+                                >
+                                  <div
+                                    class="circle_1tys2th"
+                                    data-is-radio-icon="true"
+                                    data-test-id="choice-icon__library-choice-icon"
+                                    style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
                                   >
                                     <div
-                                      class="circle_1tys2th"
-                                      data-is-radio-icon="true"
-                                      data-test-id="choice-icon__library-choice-icon"
-                                      style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                                      class="innerWrapper_177sg8x"
                                     >
-                                      <div
-                                        class="innerWrapper_177sg8x"
-                                      >
-                                        B
-                                      </div>
+                                      C
                                     </div>
-                                  </span>
-                                </div>
-                                <span
-                                  style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                                >
-                                  <div />
-                                  <div>
-                                    <span
-                                      class="mock-KatexProvider"
-                                    >
-                                      <div
-                                        class="perseus-renderer perseus-renderer-responsive"
-                                      >
-                                        <div
-                                          class="paragraph"
-                                          data-perseus-paragraph-index="0"
-                                        >
-                                          <div
-                                            class="paragraph"
-                                          >
-                                            A triangle with side lengths of 
-                                            <span
-                                              style="white-space: nowrap;"
-                                            >
-                                              <span />
-                                              <span
-                                                class="mock-TeX"
-                                              >
-                                                6
-                                              </span>
-                                              <span />
-                                            </span>
-                                            , 
-                                            <span
-                                              style="white-space: nowrap;"
-                                            >
-                                              <span />
-                                              <span
-                                                class="mock-TeX"
-                                              >
-                                                7
-                                              </span>
-                                              <span />
-                                            </span>
-                                            , and 
-                                            <span
-                                              style="white-space: nowrap;"
-                                            >
-                                              <span />
-                                              <span
-                                                class="mock-TeX"
-                                              >
-                                                10
-                                              </span>
-                                              <span />
-                                            </span>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </span>
                                   </div>
                                 </span>
                               </div>
-                            </button>
-                          </div>
-                        </div>
-                      </li>
-                      <li
-                        class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                      >
-                        <div
-                          class="description description_psmgei"
-                          style="flex-direction: column; color: rgb(33, 36, 44);"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; opacity: 1;"
-                          >
-                            <div
-                              class="perseus-sr-only"
-                            >
-                              <input
-                                class="perseus-radio-option-content"
-                                id="choice-2"
-                                tabindex="-1"
-                                type="radio"
-                              />
-                              <label
-                                for="choice-2"
+                              <span
+                                style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
                               >
-                                (Choice C)
-                                   
-                                <span
-                                  class="mock-KatexProvider"
-                                >
+                                <div />
+                                <div>
                                   <div
                                     class="perseus-renderer perseus-renderer-responsive"
                                   >
@@ -558,132 +619,124 @@ exports[`multi-item renderer should snapshot: initial render 1`] = `
                                       </div>
                                     </div>
                                   </div>
-                                </span>
-                              </label>
+                                </div>
+                              </span>
                             </div>
-                            <button
-                              aria-disabled="false"
-                              aria-hidden="true"
-                              class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                              type="button"
+                          </button>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                    >
+                      <div
+                        class="description description_psmgei"
+                        style="flex-direction: column; color: rgb(33, 36, 44);"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; opacity: 1;"
+                        >
+                          <div
+                            class="perseus-sr-only"
+                          >
+                            <input
+                              class="perseus-radio-option-content"
+                              id="choice-3"
+                              tabindex="-1"
+                              type="radio"
+                            />
+                            <label
+                              for="choice-3"
                             >
+                              (Choice D)
+                                 
                               <div
-                                style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                                class="perseus-renderer perseus-renderer-responsive"
                               >
                                 <div
-                                  class="iconWrapper_17y0hv9"
+                                  class="paragraph"
+                                  data-perseus-paragraph-index="0"
                                 >
-                                  <span
-                                    class="ring_ya75gi"
-                                    data-test-id="focus-ring"
-                                    style="border-color: transparent; border-radius: 50%;"
+                                  <div
+                                    class="paragraph"
+                                  >
+                                    A triangle with side lengths of 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        12
+                                      </span>
+                                      <span />
+                                    </span>
+                                    , 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        14
+                                      </span>
+                                      <span />
+                                    </span>
+                                    , and 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        20
+                                      </span>
+                                      <span />
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </label>
+                          </div>
+                          <button
+                            aria-disabled="false"
+                            aria-hidden="true"
+                            class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                            type="button"
+                          >
+                            <div
+                              style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                            >
+                              <div
+                                class="iconWrapper_17y0hv9"
+                              >
+                                <span
+                                  class="ring_ya75gi"
+                                  data-test-id="focus-ring"
+                                  style="border-color: transparent; border-radius: 50%;"
+                                >
+                                  <div
+                                    class="circle_1tys2th"
+                                    data-is-radio-icon="true"
+                                    data-test-id="choice-icon__library-choice-icon"
+                                    style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
                                   >
                                     <div
-                                      class="circle_1tys2th"
-                                      data-is-radio-icon="true"
-                                      data-test-id="choice-icon__library-choice-icon"
-                                      style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                                      class="innerWrapper_177sg8x"
                                     >
-                                      <div
-                                        class="innerWrapper_177sg8x"
-                                      >
-                                        C
-                                      </div>
+                                      D
                                     </div>
-                                  </span>
-                                </div>
-                                <span
-                                  style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                                >
-                                  <div />
-                                  <div>
-                                    <span
-                                      class="mock-KatexProvider"
-                                    >
-                                      <div
-                                        class="perseus-renderer perseus-renderer-responsive"
-                                      >
-                                        <div
-                                          class="paragraph"
-                                          data-perseus-paragraph-index="0"
-                                        >
-                                          <div
-                                            class="paragraph"
-                                          >
-                                            A triangle with side lengths of 
-                                            <span
-                                              style="white-space: nowrap;"
-                                            >
-                                              <span />
-                                              <span
-                                                class="mock-TeX"
-                                              >
-                                                10
-                                              </span>
-                                              <span />
-                                            </span>
-                                            , 
-                                            <span
-                                              style="white-space: nowrap;"
-                                            >
-                                              <span />
-                                              <span
-                                                class="mock-TeX"
-                                              >
-                                                12
-                                              </span>
-                                              <span />
-                                            </span>
-                                            , and 
-                                            <span
-                                              style="white-space: nowrap;"
-                                            >
-                                              <span />
-                                              <span
-                                                class="mock-TeX"
-                                              >
-                                                18
-                                              </span>
-                                              <span />
-                                            </span>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </span>
                                   </div>
                                 </span>
                               </div>
-                            </button>
-                          </div>
-                        </div>
-                      </li>
-                      <li
-                        class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                      >
-                        <div
-                          class="description description_psmgei"
-                          style="flex-direction: column; color: rgb(33, 36, 44);"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; opacity: 1;"
-                          >
-                            <div
-                              class="perseus-sr-only"
-                            >
-                              <input
-                                class="perseus-radio-option-content"
-                                id="choice-3"
-                                tabindex="-1"
-                                type="radio"
-                              />
-                              <label
-                                for="choice-3"
+                              <span
+                                style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
                               >
-                                (Choice D)
-                                   
-                                <span
-                                  class="mock-KatexProvider"
-                                >
+                                <div />
+                                <div>
                                   <div
                                     class="perseus-renderer perseus-renderer-responsive"
                                   >
@@ -733,132 +786,124 @@ exports[`multi-item renderer should snapshot: initial render 1`] = `
                                       </div>
                                     </div>
                                   </div>
-                                </span>
-                              </label>
+                                </div>
+                              </span>
                             </div>
-                            <button
-                              aria-disabled="false"
-                              aria-hidden="true"
-                              class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                              type="button"
+                          </button>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                    >
+                      <div
+                        class="description description_psmgei"
+                        style="flex-direction: column; color: rgb(33, 36, 44);"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; opacity: 1;"
+                        >
+                          <div
+                            class="perseus-sr-only"
+                          >
+                            <input
+                              class="perseus-radio-option-content"
+                              id="choice-4"
+                              tabindex="-1"
+                              type="radio"
+                            />
+                            <label
+                              for="choice-4"
                             >
+                              (Choice E)
+                                 
                               <div
-                                style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                                class="perseus-renderer perseus-renderer-responsive"
                               >
                                 <div
-                                  class="iconWrapper_17y0hv9"
+                                  class="paragraph"
+                                  data-perseus-paragraph-index="0"
                                 >
-                                  <span
-                                    class="ring_ya75gi"
-                                    data-test-id="focus-ring"
-                                    style="border-color: transparent; border-radius: 50%;"
+                                  <div
+                                    class="paragraph"
+                                  >
+                                    A triangle with side lengths of 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        24
+                                      </span>
+                                      <span />
+                                    </span>
+                                    , 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        28
+                                      </span>
+                                      <span />
+                                    </span>
+                                    , and 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        40
+                                      </span>
+                                      <span />
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </label>
+                          </div>
+                          <button
+                            aria-disabled="false"
+                            aria-hidden="true"
+                            class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                            type="button"
+                          >
+                            <div
+                              style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                            >
+                              <div
+                                class="iconWrapper_17y0hv9"
+                              >
+                                <span
+                                  class="ring_ya75gi"
+                                  data-test-id="focus-ring"
+                                  style="border-color: transparent; border-radius: 50%;"
+                                >
+                                  <div
+                                    class="circle_1tys2th"
+                                    data-is-radio-icon="true"
+                                    data-test-id="choice-icon__library-choice-icon"
+                                    style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
                                   >
                                     <div
-                                      class="circle_1tys2th"
-                                      data-is-radio-icon="true"
-                                      data-test-id="choice-icon__library-choice-icon"
-                                      style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                                      class="innerWrapper_177sg8x"
                                     >
-                                      <div
-                                        class="innerWrapper_177sg8x"
-                                      >
-                                        D
-                                      </div>
+                                      E
                                     </div>
-                                  </span>
-                                </div>
-                                <span
-                                  style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                                >
-                                  <div />
-                                  <div>
-                                    <span
-                                      class="mock-KatexProvider"
-                                    >
-                                      <div
-                                        class="perseus-renderer perseus-renderer-responsive"
-                                      >
-                                        <div
-                                          class="paragraph"
-                                          data-perseus-paragraph-index="0"
-                                        >
-                                          <div
-                                            class="paragraph"
-                                          >
-                                            A triangle with side lengths of 
-                                            <span
-                                              style="white-space: nowrap;"
-                                            >
-                                              <span />
-                                              <span
-                                                class="mock-TeX"
-                                              >
-                                                12
-                                              </span>
-                                              <span />
-                                            </span>
-                                            , 
-                                            <span
-                                              style="white-space: nowrap;"
-                                            >
-                                              <span />
-                                              <span
-                                                class="mock-TeX"
-                                              >
-                                                14
-                                              </span>
-                                              <span />
-                                            </span>
-                                            , and 
-                                            <span
-                                              style="white-space: nowrap;"
-                                            >
-                                              <span />
-                                              <span
-                                                class="mock-TeX"
-                                              >
-                                                20
-                                              </span>
-                                              <span />
-                                            </span>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </span>
                                   </div>
                                 </span>
                               </div>
-                            </button>
-                          </div>
-                        </div>
-                      </li>
-                      <li
-                        class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                      >
-                        <div
-                          class="description description_psmgei"
-                          style="flex-direction: column; color: rgb(33, 36, 44);"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; opacity: 1;"
-                          >
-                            <div
-                              class="perseus-sr-only"
-                            >
-                              <input
-                                class="perseus-radio-option-content"
-                                id="choice-4"
-                                tabindex="-1"
-                                type="radio"
-                              />
-                              <label
-                                for="choice-4"
+                              <span
+                                style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
                               >
-                                (Choice E)
-                                   
-                                <span
-                                  class="mock-KatexProvider"
-                                >
+                                <div />
+                                <div>
                                   <div
                                     class="perseus-renderer perseus-renderer-responsive"
                                   >
@@ -908,270 +953,173 @@ exports[`multi-item renderer should snapshot: initial render 1`] = `
                                       </div>
                                     </div>
                                   </div>
-                                </span>
-                              </label>
-                            </div>
-                            <button
-                              aria-disabled="false"
-                              aria-hidden="true"
-                              class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                              type="button"
-                            >
-                              <div
-                                style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                              >
-                                <div
-                                  class="iconWrapper_17y0hv9"
-                                >
-                                  <span
-                                    class="ring_ya75gi"
-                                    data-test-id="focus-ring"
-                                    style="border-color: transparent; border-radius: 50%;"
-                                  >
-                                    <div
-                                      class="circle_1tys2th"
-                                      data-is-radio-icon="true"
-                                      data-test-id="choice-icon__library-choice-icon"
-                                      style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                    >
-                                      <div
-                                        class="innerWrapper_177sg8x"
-                                      >
-                                        E
-                                      </div>
-                                    </div>
-                                  </span>
                                 </div>
-                                <span
-                                  style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                                >
-                                  <div />
-                                  <div>
-                                    <span
-                                      class="mock-KatexProvider"
-                                    >
-                                      <div
-                                        class="perseus-renderer perseus-renderer-responsive"
-                                      >
-                                        <div
-                                          class="paragraph"
-                                          data-perseus-paragraph-index="0"
-                                        >
-                                          <div
-                                            class="paragraph"
-                                          >
-                                            A triangle with side lengths of 
-                                            <span
-                                              style="white-space: nowrap;"
-                                            >
-                                              <span />
-                                              <span
-                                                class="mock-TeX"
-                                              >
-                                                24
-                                              </span>
-                                              <span />
-                                            </span>
-                                            , 
-                                            <span
-                                              style="white-space: nowrap;"
-                                            >
-                                              <span />
-                                              <span
-                                                class="mock-TeX"
-                                              >
-                                                28
-                                              </span>
-                                              <span />
-                                            </span>
-                                            , and 
-                                            <span
-                                              style="white-space: nowrap;"
-                                            >
-                                              <span />
-                                              <span
-                                                class="mock-TeX"
-                                              >
-                                                40
-                                              </span>
-                                              <span />
-                                            </span>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </span>
-                                  </div>
-                                </span>
-                              </div>
-                            </button>
-                          </div>
-                        </div>
-                      </li>
-                    </ul>
-                  </fieldset>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="paragraph"
-            data-perseus-paragraph-index="2"
-          >
-            <div
-              class="paragraph"
-            >
-              Enter the number 3 into this field: 
-              <div
-                class="perseus-widget-container widget-nohighlight widget-inline-block"
-              >
-                <span>
-                  <div>
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-default_1gznapd-o_O-leftAlign_7jg4r4"
-                      id="input-with-examples-aW5wdXQtbnVtYmVyIDE"
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                  <div
-                    style="position: relative; height: 0px; display: none;"
-                  >
-                    <div
-                      class="tooltipContainer"
-                      style="position: absolute; left: 0px;"
-                    >
-                      <div
-                        style="display: block; position: relative; visibility: visible; left: 0px; top: -1px; width: 12px; height: 11px; margin-top: -1px; margin-bottom: -2px; z-index: 10;"
-                      >
-                        <div
-                          style="display: block; height: 0px; width: 0px; position: absolute; left: 0px; top: -1px; border-right: 12px solid transparent; border-bottom: 12px solid #ccc;"
-                        />
-                        <div
-                          style="display: block; height: 0px; width: 0px; position: absolute; left: 1px; top: 1px; border-right: 10px solid transparent; border-bottom: 10px solid white;"
-                        />
-                      </div>
-                      <div
-                        class="perseus-formats-tooltip preview-measure"
-                        style="position: relative; top: 0px; left: 0px; border: 1px solid #ccc; box-shadow: 0 1px 3px #ccc; z-index: 9;"
-                      >
-                        <div
-                          id="input-with-examples-aW5wdXQtbnVtYmVyIDE"
-                        >
-                          <span
-                            class="mock-KatexProvider"
-                          >
-                            <div
-                              class="perseus-renderer perseus-renderer-responsive"
-                            >
-                              <div
-                                class="paragraph"
-                                data-perseus-paragraph-index="0"
-                              >
-                                <ul>
-                                  <li>
-                                    <strong>
-                                      Your answer should be
-                                    </strong>
-                                  </li>
-                                  <li>
-                                    an integer, like 
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        6
-                                      </span>
-                                      <span />
-                                    </span>
-                                  </li>
-                                  <li>
-                                    an 
-                                    <em>
-                                      exact
-                                    </em>
-                                     decimal, like 
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        0.75
-                                      </span>
-                                      <span />
-                                    </span>
-                                  </li>
-                                  <li>
-                                    a 
-                                    <em>
-                                      simplified proper
-                                    </em>
-                                     fraction, like 
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        3/5
-                                      </span>
-                                      <span />
-                                    </span>
-                                  </li>
-                                  <li>
-                                    a 
-                                    <em>
-                                      simplified improper
-                                    </em>
-                                     fraction, like 
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        7/4
-                                      </span>
-                                      <span />
-                                    </span>
-                                  </li>
-                                  <li>
-                                    a mixed number, like 
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        1\\ 3/4
-                                      </span>
-                                      <span />
-                                    </span>
-                                  </li>
-                                </ul>
-                              </div>
+                              </span>
                             </div>
-                          </span>
+                          </button>
                         </div>
                       </div>
-                    </div>
-                  </div>
-                </span>
+                    </li>
+                  </ul>
+                </fieldset>
               </div>
             </div>
           </div>
         </div>
-      </span>
+        <div
+          class="paragraph"
+          data-perseus-paragraph-index="2"
+        >
+          <div
+            class="paragraph"
+          >
+            Enter the number 3 into this field: 
+            <div
+              class="perseus-widget-container widget-nohighlight widget-inline-block"
+            >
+              <span>
+                <div>
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-default_1gznapd-o_O-leftAlign_7jg4r4"
+                    id="input-with-examples-aW5wdXQtbnVtYmVyIDE"
+                    type="text"
+                    value=""
+                  />
+                </div>
+                <div
+                  style="position: relative; height: 0px; display: none;"
+                >
+                  <div
+                    class="tooltipContainer"
+                    style="position: absolute; left: 0px;"
+                  >
+                    <div
+                      style="display: block; position: relative; visibility: visible; left: 0px; top: -1px; width: 12px; height: 11px; margin-top: -1px; margin-bottom: -2px; z-index: 10;"
+                    >
+                      <div
+                        style="display: block; height: 0px; width: 0px; position: absolute; left: 0px; top: -1px; border-right: 12px solid transparent; border-bottom: 12px solid #ccc;"
+                      />
+                      <div
+                        style="display: block; height: 0px; width: 0px; position: absolute; left: 1px; top: 1px; border-right: 10px solid transparent; border-bottom: 10px solid white;"
+                      />
+                    </div>
+                    <div
+                      class="perseus-formats-tooltip preview-measure"
+                      style="position: relative; top: 0px; left: 0px; border: 1px solid #ccc; box-shadow: 0 1px 3px #ccc; z-index: 9;"
+                    >
+                      <div
+                        id="input-with-examples-aW5wdXQtbnVtYmVyIDE"
+                      >
+                        <div
+                          class="perseus-renderer perseus-renderer-responsive"
+                        >
+                          <div
+                            class="paragraph"
+                            data-perseus-paragraph-index="0"
+                          >
+                            <ul>
+                              <li>
+                                <strong>
+                                  Your answer should be
+                                </strong>
+                              </li>
+                              <li>
+                                an integer, like 
+                                <span
+                                  style="white-space: nowrap;"
+                                >
+                                  <span />
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    6
+                                  </span>
+                                  <span />
+                                </span>
+                              </li>
+                              <li>
+                                an 
+                                <em>
+                                  exact
+                                </em>
+                                 decimal, like 
+                                <span
+                                  style="white-space: nowrap;"
+                                >
+                                  <span />
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    0.75
+                                  </span>
+                                  <span />
+                                </span>
+                              </li>
+                              <li>
+                                a 
+                                <em>
+                                  simplified proper
+                                </em>
+                                 fraction, like 
+                                <span
+                                  style="white-space: nowrap;"
+                                >
+                                  <span />
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    3/5
+                                  </span>
+                                  <span />
+                                </span>
+                              </li>
+                              <li>
+                                a 
+                                <em>
+                                  simplified improper
+                                </em>
+                                 fraction, like 
+                                <span
+                                  style="white-space: nowrap;"
+                                >
+                                  <span />
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    7/4
+                                  </span>
+                                  <span />
+                                </span>
+                              </li>
+                              <li>
+                                a mixed number, like 
+                                <span
+                                  style="white-space: nowrap;"
+                                >
+                                  <span />
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    1\\ 3/4
+                                  </span>
+                                  <span />
+                                </span>
+                              </li>
+                            </ul>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
     <div
       id="hints"
@@ -1194,24 +1142,20 @@ exports[`multi-item renderer should snapshot: initial render 1`] = `
           >
             1 / 3
           </span>
-          <span
-            class="mock-KatexProvider"
+          <div
+            class="perseus-renderer perseus-renderer-responsive"
           >
             <div
-              class="perseus-renderer perseus-renderer-responsive"
+              class="paragraph"
+              data-perseus-paragraph-index="0"
             >
               <div
                 class="paragraph"
-                data-perseus-paragraph-index="0"
               >
-                <div
-                  class="paragraph"
-                >
-                  If two triangles are congruent, then they have the same side lengths and angle measures.
-                </div>
+                If two triangles are congruent, then they have the same side lengths and angle measures.
               </div>
             </div>
-          </span>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -35,7 +35,6 @@ import type {
     FilterCriterion,
     FocusPath,
     LinterContextProps,
-    PerseusDependencies,
     PerseusScore,
     WidgetInfo,
     WidgetProps,
@@ -223,10 +222,7 @@ class Renderer extends React.Component<Props, State> {
     // The i18n linter.
     _translationLinter: TranslationLinter;
 
-    // @ts-expect-error [FEI-5003] - TS2564 - Property 'lastRenderedMarkdown' has no initializer and is not definitely assigned in the constructor.
-    lastRenderedMarkdown: React.ReactElement<
-        React.ComponentProps<PerseusDependencies["KatexProvider"]>
-    >;
+    lastRenderedMarkdown: React.ReactNode;
     // @ts-expect-error [FEI-5003] - TS2564 - Property 'reuseMarkdown' has no initializer and is not definitely assigned in the constructor.
     reuseMarkdown: boolean;
     // @ts-expect-error [FEI-5003] - TS2564 - Property 'translationIndex' has no initializer and is not definitely assigned in the constructor.
@@ -1848,7 +1844,6 @@ class Renderer extends React.Component<Props, State> {
 
     render(): React.ReactNode {
         const apiOptions = this.getApiOptions();
-        const {KatexProvider} = getDependencies();
 
         if (this.reuseMarkdown) {
             return this.lastRenderedMarkdown;
@@ -1896,17 +1891,13 @@ class Renderer extends React.Component<Props, State> {
                 // calls its before_dom_insert we can lookup this component by
                 // this attribute and render the text with markdown.
                 return (
-                    <KatexProvider>
-                        <DefinitionProvider>
-                            <div
-                                data-perseus-component-index={
-                                    this.translationIndex
-                                }
-                            >
-                                {content}
-                            </div>
-                        </DefinitionProvider>
-                    </KatexProvider>
+                    <DefinitionProvider>
+                        <div
+                            data-perseus-component-index={this.translationIndex}
+                        >
+                            {content}
+                        </div>
+                    </DefinitionProvider>
                 );
             }
         }
@@ -1963,11 +1954,9 @@ class Renderer extends React.Component<Props, State> {
         });
 
         this.lastRenderedMarkdown = (
-            <KatexProvider>
-                <DefinitionProvider>
-                    <div className={className}>{markdownContents}</div>
-                </DefinitionProvider>
-            </KatexProvider>
+            <DefinitionProvider>
+                <div className={className}>{markdownContents}</div>
+            </DefinitionProvider>
         );
         return this.lastRenderedMarkdown;
     }

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -309,7 +309,6 @@ export type PerseusDependencies = {
     rendererTranslationComponents: JiptTranslationComponents;
     // KaTeX related dependencies
     getKaTeX: () => Promise<katex>;
-    loadMathjax: () => Promise<unknown>;
     logKaTeXError: (
         expression: string,
         error: Error,

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -313,9 +313,6 @@ export type PerseusDependencies = {
         expression: string,
         error: Error,
     ) => Promise<Response | null | undefined>;
-    // TODO(kevinb): Update `getKaTeX` to return the version of `katex` that
-    // webapp (or mobile) wants perseus to use.
-    shouldUseFutureKaTeX: (flag: boolean) => void;
     TeX: React.ComponentType<TeXProps>;
     //misc
     staticUrl: StaticUrlFn;

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -1,7 +1,5 @@
 // eslint-disable-next-line import/no-unresolved
 import katex from "katex";
-// eslint-disable-next-line import/no-unresolved
-import katexA11y from "katex/dist/contrib/render-a11y-string";
 import * as React from "react";
 
 import type {SerializedHighlightSet} from "./components/highlighting/types";
@@ -311,7 +309,6 @@ export type PerseusDependencies = {
     rendererTranslationComponents: JiptTranslationComponents;
     // KaTeX related dependencies
     getKaTeX: () => Promise<katex>;
-    getRenderA11yString: () => Promise<katexA11y>;
     loadMathjax: () => Promise<unknown>;
     logKaTeXError: (
         expression: string,

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -314,9 +314,6 @@ export type PerseusDependencies = {
         expression: string,
         error: Error,
     ) => Promise<Response | null | undefined>;
-    KatexProvider: React.ComponentType<{
-        children: React.ReactNode;
-    }>;
     // TODO(kevinb): Update `getKaTeX` to return the version of `katex` that
     // webapp (or mobile) wants perseus to use.
     shouldUseFutureKaTeX: (flag: boolean) => void;

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/categorizer.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/categorizer.test.ts.snap
@@ -2,995 +2,939 @@
 
 exports[`categorizer widget should snapshot on mobile: first mobile render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          <strong>
-            Classify each graph according to the kind of relationship it suggests.
-          </strong>
-        </div>
-      </div>
-      <div
-        class="paragraph perseus-paragraph-centered"
-        data-perseus-paragraph-index="1"
-      >
-        <div
-          class="perseus-block-math"
-          style="margin-left: -16px; margin-right: -16px;"
-        >
-          <div
-            class="perseus-block-math-inner"
-            style="overflow-x: auto; overflow-y: hidden; margin-top: -10px; margin-bottom: -10px; transform: translate3d(0,0,0); padding: 10px 16px 10px 16px;"
-          >
-            <span
-              style="display: block; width: 100%; transform: scale(1, 1)  translate(0, 8px); transform-origin: 0 0; opacity: 0;"
-            >
-              <span
-                class="mock-TeX"
-              >
-                \\qquad\\qquad\\quad\\text{Graph 1}\\qquad\\qquad\\quad\\qquad\\qquad\\quad\\text{Graph 2}
-              </span>
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="2"
-      >
-        <div
-          class="paragraph"
-        >
-          <div
-            class="perseus-widget-container widget-nohighlight widget-block"
-          >
-            <div
-              class="categorizer-container fullBleedContainer_8ybp6"
-            >
-              <table
-                class="categorizer-table mobileTable_1wmcwov"
-              >
-                <thead>
-                  <tr>
-                    <td
-                      class="emptyHeaderCell_1mttrgd"
-                    />
-                    <th
-                      class="header_whrfk4"
-                    >
-                      <span
-                        class="mock-KatexProvider"
-                      >
-                        <div
-                          class="perseus-renderer perseus-renderer-responsive"
-                        >
-                          <div
-                            class="paragraph"
-                            data-perseus-paragraph-index="0"
-                          >
-                            <div
-                              class="paragraph"
-                            >
-                              No relationship
-                            </div>
-                          </div>
-                        </div>
-                      </span>
-                    </th>
-                    <th
-                      class="header_whrfk4"
-                    >
-                      <span
-                        class="mock-KatexProvider"
-                      >
-                        <div
-                          class="perseus-renderer perseus-renderer-responsive"
-                        >
-                          <div
-                            class="paragraph"
-                            data-perseus-paragraph-index="0"
-                          >
-                            <div
-                              class="paragraph"
-                            >
-                              Positive linear relationship
-                            </div>
-                          </div>
-                        </div>
-                      </span>
-                    </th>
-                    <th
-                      class="header_whrfk4"
-                    >
-                      <span
-                        class="mock-KatexProvider"
-                      >
-                        <div
-                          class="perseus-renderer perseus-renderer-responsive"
-                        >
-                          <div
-                            class="paragraph"
-                            data-perseus-paragraph-index="0"
-                          >
-                            <div
-                              class="paragraph"
-                            >
-                              Negative linear relationship
-                            </div>
-                          </div>
-                        </div>
-                      </span>
-                    </th>
-                    <th
-                      class="header_whrfk4"
-                    >
-                      <span
-                        class="mock-KatexProvider"
-                      >
-                        <div
-                          class="perseus-renderer perseus-renderer-responsive"
-                        >
-                          <div
-                            class="paragraph"
-                            data-perseus-paragraph-index="0"
-                          >
-                            <div
-                              class="paragraph"
-                            >
-                              Nonlinear relationship
-                            </div>
-                          </div>
-                        </div>
-                      </span>
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>
-                      <span
-                        class="mock-KatexProvider"
-                      >
-                        <div
-                          class="perseus-renderer perseus-renderer-responsive"
-                        >
-                          <div
-                            class="paragraph"
-                            data-perseus-paragraph-index="0"
-                          >
-                            <div
-                              class="paragraph"
-                            >
-                              Graph 
-                              <span
-                                style="white-space: nowrap;"
-                              >
-                                <span />
-                                <span
-                                  class="mock-TeX"
-                                >
-                                  1
-                                </span>
-                                <span />
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                      </span>
-                    </td>
-                    <td
-                      class="category cell_13aakpm"
-                    >
-                      <div
-                        aria-label="No relationship"
-                        class="perseus-interactive"
-                        role="button"
-                      >
-                        <input
-                          class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
-                          name="perseus_radio_10_0"
-                          type="radio"
-                        />
-                      </div>
-                    </td>
-                    <td
-                      class="category cell_13aakpm"
-                    >
-                      <div
-                        aria-label="Positive linear relationship"
-                        class="perseus-interactive"
-                        role="button"
-                      >
-                        <input
-                          class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
-                          name="perseus_radio_10_0"
-                          type="radio"
-                        />
-                      </div>
-                    </td>
-                    <td
-                      class="category cell_13aakpm"
-                    >
-                      <div
-                        aria-label="Negative linear relationship"
-                        class="perseus-interactive"
-                        role="button"
-                      >
-                        <input
-                          class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
-                          name="perseus_radio_10_0"
-                          type="radio"
-                        />
-                      </div>
-                    </td>
-                    <td
-                      class="category cell_13aakpm"
-                    >
-                      <div
-                        aria-label="Nonlinear relationship"
-                        class="perseus-interactive"
-                        role="button"
-                      >
-                        <input
-                          class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
-                          name="perseus_radio_10_0"
-                          type="radio"
-                        />
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <span
-                        class="mock-KatexProvider"
-                      >
-                        <div
-                          class="perseus-renderer perseus-renderer-responsive"
-                        >
-                          <div
-                            class="paragraph"
-                            data-perseus-paragraph-index="0"
-                          >
-                            <div
-                              class="paragraph"
-                            >
-                              Graph 
-                              <span
-                                style="white-space: nowrap;"
-                              >
-                                <span />
-                                <span
-                                  class="mock-TeX"
-                                >
-                                  2
-                                </span>
-                                <span />
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                      </span>
-                    </td>
-                    <td
-                      class="category cell_13aakpm"
-                    >
-                      <div
-                        aria-label="No relationship"
-                        class="perseus-interactive"
-                        role="button"
-                      >
-                        <input
-                          class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
-                          name="perseus_radio_10_1"
-                          type="radio"
-                        />
-                      </div>
-                    </td>
-                    <td
-                      class="category cell_13aakpm"
-                    >
-                      <div
-                        aria-label="Positive linear relationship"
-                        class="perseus-interactive"
-                        role="button"
-                      >
-                        <input
-                          class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
-                          name="perseus_radio_10_1"
-                          type="radio"
-                        />
-                      </div>
-                    </td>
-                    <td
-                      class="category cell_13aakpm"
-                    >
-                      <div
-                        aria-label="Negative linear relationship"
-                        class="perseus-interactive"
-                        role="button"
-                      >
-                        <input
-                          class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
-                          name="perseus_radio_10_1"
-                          type="radio"
-                        />
-                      </div>
-                    </td>
-                    <td
-                      class="category cell_13aakpm"
-                    >
-                      <div
-                        aria-label="Nonlinear relationship"
-                        class="perseus-interactive"
-                        role="button"
-                      >
-                        <input
-                          class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
-                          name="perseus_radio_10_1"
-                          type="radio"
-                        />
-                      </div>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="3"
-      >
-        <div
-          class="paragraph"
-        >
-          <strong>
-            Graph 1.
-          </strong>
-        </div>
-      </div>
-      <div
-        class="paragraph perseus-paragraph-centered"
-        data-perseus-paragraph-index="4"
-      >
-        <div
-          class="paragraph"
-        >
-          <div
-            class="fixed-to-responsive svg-image"
-            style="max-width: 220px; max-height: 223px;"
-          >
-            <div
-              style="padding-bottom: 101.36%;"
-            />
-            <span
-              style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
-            >
-              <div
-                class="default_xu2jcg-o_O-spinnerContainer_agrn11"
-              >
-                <svg
-                  height="48"
-                  viewBox="0 0 48 48"
-                  width="48"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
-                    d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
-                    fill-rule="nonzero"
-                  />
-                </svg>
-              </div>
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="5"
-      >
-        <div
-          class="paragraph"
-        >
-          <strong>
-            Graph 2.
-          </strong>
-        </div>
-      </div>
-      <div
-        class="paragraph perseus-paragraph-centered"
-        data-perseus-paragraph-index="6"
-      >
-        <div
-          class="paragraph"
-        >
-          <div
-            class="fixed-to-responsive svg-image"
-            style="max-width: 244px; max-height: 223px;"
-          >
-            <div
-              style="padding-bottom: 91.39%;"
-            />
-            <span
-              style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
-            >
-              <div
-                class="default_xu2jcg-o_O-spinnerContainer_agrn11"
-              >
-                <svg
-                  height="48"
-                  viewBox="0 0 48 48"
-                  width="48"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
-                    d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
-                    fill-rule="nonzero"
-                  />
-                </svg>
-              </div>
-            </span>
-          </div>
-            
-        </div>
+        <strong>
+          Classify each graph according to the kind of relationship it suggests.
+        </strong>
       </div>
     </div>
-  </span>
-</div>
-`;
-
-exports[`categorizer widget should snapshot: first render 1`] = `
-<div>
-  <span
-    class="mock-KatexProvider"
-  >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph perseus-paragraph-centered"
+      data-perseus-paragraph-index="1"
     >
       <div
-        class="paragraph"
-        data-perseus-paragraph-index="0"
+        class="perseus-block-math"
+        style="margin-left: -16px; margin-right: -16px;"
       >
         <div
-          class="paragraph"
+          class="perseus-block-math-inner"
+          style="overflow-x: auto; overflow-y: hidden; margin-top: -10px; margin-bottom: -10px; transform: translate3d(0,0,0); padding: 10px 16px 10px 16px;"
         >
-          <strong>
-            Classify each graph according to the kind of relationship it suggests.
-          </strong>
-        </div>
-      </div>
-      <div
-        class="paragraph perseus-paragraph-centered"
-        data-perseus-paragraph-index="1"
-      >
-        <div
-          class="perseus-block-math"
-        >
-          <div
-            class="perseus-block-math-inner"
-            style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+          <span
+            style="display: block; width: 100%; transform: scale(1, 1)  translate(0, 8px); transform-origin: 0 0; opacity: 0;"
           >
             <span
               class="mock-TeX"
             >
               \\qquad\\qquad\\quad\\text{Graph 1}\\qquad\\qquad\\quad\\qquad\\qquad\\quad\\text{Graph 2}
             </span>
-          </div>
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="2"
-      >
-        <div
-          class="paragraph"
-        >
-          <div
-            class="perseus-widget-container widget-nohighlight widget-block"
-          >
-            <div
-              class="categorizer-container "
-            >
-              <table
-                class="categorizer-table mobileTable_1wmcwov"
-              >
-                <thead>
-                  <tr>
-                    <td
-                      class="emptyHeaderCell_1mttrgd"
-                    />
-                    <th
-                      class="header_whrfk4"
-                    >
-                      <span
-                        class="mock-KatexProvider"
-                      >
-                        <div
-                          class="perseus-renderer perseus-renderer-responsive"
-                        >
-                          <div
-                            class="paragraph"
-                            data-perseus-paragraph-index="0"
-                          >
-                            <div
-                              class="paragraph"
-                            >
-                              No relationship
-                            </div>
-                          </div>
-                        </div>
-                      </span>
-                    </th>
-                    <th
-                      class="header_whrfk4"
-                    >
-                      <span
-                        class="mock-KatexProvider"
-                      >
-                        <div
-                          class="perseus-renderer perseus-renderer-responsive"
-                        >
-                          <div
-                            class="paragraph"
-                            data-perseus-paragraph-index="0"
-                          >
-                            <div
-                              class="paragraph"
-                            >
-                              Positive linear relationship
-                            </div>
-                          </div>
-                        </div>
-                      </span>
-                    </th>
-                    <th
-                      class="header_whrfk4"
-                    >
-                      <span
-                        class="mock-KatexProvider"
-                      >
-                        <div
-                          class="perseus-renderer perseus-renderer-responsive"
-                        >
-                          <div
-                            class="paragraph"
-                            data-perseus-paragraph-index="0"
-                          >
-                            <div
-                              class="paragraph"
-                            >
-                              Negative linear relationship
-                            </div>
-                          </div>
-                        </div>
-                      </span>
-                    </th>
-                    <th
-                      class="header_whrfk4"
-                    >
-                      <span
-                        class="mock-KatexProvider"
-                      >
-                        <div
-                          class="perseus-renderer perseus-renderer-responsive"
-                        >
-                          <div
-                            class="paragraph"
-                            data-perseus-paragraph-index="0"
-                          >
-                            <div
-                              class="paragraph"
-                            >
-                              Nonlinear relationship
-                            </div>
-                          </div>
-                        </div>
-                      </span>
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>
-                      <span
-                        class="mock-KatexProvider"
-                      >
-                        <div
-                          class="perseus-renderer perseus-renderer-responsive"
-                        >
-                          <div
-                            class="paragraph"
-                            data-perseus-paragraph-index="0"
-                          >
-                            <div
-                              class="paragraph"
-                            >
-                              Graph 
-                              <span
-                                style="white-space: nowrap;"
-                              >
-                                <span />
-                                <span
-                                  class="mock-TeX"
-                                >
-                                  1
-                                </span>
-                                <span />
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                      </span>
-                    </td>
-                    <td
-                      class="category cell_13aakpm"
-                    >
-                      <div
-                        aria-label="No relationship"
-                        class="perseus-interactive"
-                        role="button"
-                      >
-                        <span
-                          class="radioSpan_1mq3xs9"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: middle;"
-                            viewBox="0 0 100 99.944"
-                            width="1.0005603137757144em"
-                          >
-                            <path
-                              d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </span>
-                      </div>
-                    </td>
-                    <td
-                      class="category cell_13aakpm"
-                    >
-                      <div
-                        aria-label="Positive linear relationship"
-                        class="perseus-interactive"
-                        role="button"
-                      >
-                        <span
-                          class="radioSpan_1mq3xs9"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: middle;"
-                            viewBox="0 0 100 99.944"
-                            width="1.0005603137757144em"
-                          >
-                            <path
-                              d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </span>
-                      </div>
-                    </td>
-                    <td
-                      class="category cell_13aakpm"
-                    >
-                      <div
-                        aria-label="Negative linear relationship"
-                        class="perseus-interactive"
-                        role="button"
-                      >
-                        <span
-                          class="radioSpan_1mq3xs9"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: middle;"
-                            viewBox="0 0 100 99.944"
-                            width="1.0005603137757144em"
-                          >
-                            <path
-                              d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </span>
-                      </div>
-                    </td>
-                    <td
-                      class="category cell_13aakpm"
-                    >
-                      <div
-                        aria-label="Nonlinear relationship"
-                        class="perseus-interactive"
-                        role="button"
-                      >
-                        <span
-                          class="radioSpan_1mq3xs9"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: middle;"
-                            viewBox="0 0 100 99.944"
-                            width="1.0005603137757144em"
-                          >
-                            <path
-                              d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <span
-                        class="mock-KatexProvider"
-                      >
-                        <div
-                          class="perseus-renderer perseus-renderer-responsive"
-                        >
-                          <div
-                            class="paragraph"
-                            data-perseus-paragraph-index="0"
-                          >
-                            <div
-                              class="paragraph"
-                            >
-                              Graph 
-                              <span
-                                style="white-space: nowrap;"
-                              >
-                                <span />
-                                <span
-                                  class="mock-TeX"
-                                >
-                                  2
-                                </span>
-                                <span />
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                      </span>
-                    </td>
-                    <td
-                      class="category cell_13aakpm"
-                    >
-                      <div
-                        aria-label="No relationship"
-                        class="perseus-interactive"
-                        role="button"
-                      >
-                        <span
-                          class="radioSpan_1mq3xs9"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: middle;"
-                            viewBox="0 0 100 99.944"
-                            width="1.0005603137757144em"
-                          >
-                            <path
-                              d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </span>
-                      </div>
-                    </td>
-                    <td
-                      class="category cell_13aakpm"
-                    >
-                      <div
-                        aria-label="Positive linear relationship"
-                        class="perseus-interactive"
-                        role="button"
-                      >
-                        <span
-                          class="radioSpan_1mq3xs9"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: middle;"
-                            viewBox="0 0 100 99.944"
-                            width="1.0005603137757144em"
-                          >
-                            <path
-                              d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </span>
-                      </div>
-                    </td>
-                    <td
-                      class="category cell_13aakpm"
-                    >
-                      <div
-                        aria-label="Negative linear relationship"
-                        class="perseus-interactive"
-                        role="button"
-                      >
-                        <span
-                          class="radioSpan_1mq3xs9"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: middle;"
-                            viewBox="0 0 100 99.944"
-                            width="1.0005603137757144em"
-                          >
-                            <path
-                              d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </span>
-                      </div>
-                    </td>
-                    <td
-                      class="category cell_13aakpm"
-                    >
-                      <div
-                        aria-label="Nonlinear relationship"
-                        class="perseus-interactive"
-                        role="button"
-                      >
-                        <span
-                          class="radioSpan_1mq3xs9"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: middle;"
-                            viewBox="0 0 100 99.944"
-                            width="1.0005603137757144em"
-                          >
-                            <path
-                              d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="3"
-      >
-        <div
-          class="paragraph"
-        >
-          <strong>
-            Graph 1.
-          </strong>
-        </div>
-      </div>
-      <div
-        class="paragraph perseus-paragraph-centered"
-        data-perseus-paragraph-index="4"
-      >
-        <div
-          class="paragraph"
-        >
-          <div
-            class="fixed-to-responsive svg-image"
-            style="max-width: 220px; max-height: 223px;"
-          >
-            <div
-              style="padding-bottom: 101.36%;"
-            />
-            <span
-              style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
-            >
-              <div
-                class="default_xu2jcg-o_O-spinnerContainer_agrn11"
-              >
-                <svg
-                  height="48"
-                  viewBox="0 0 48 48"
-                  width="48"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
-                    d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
-                    fill-rule="nonzero"
-                  />
-                </svg>
-              </div>
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="5"
-      >
-        <div
-          class="paragraph"
-        >
-          <strong>
-            Graph 2.
-          </strong>
-        </div>
-      </div>
-      <div
-        class="paragraph perseus-paragraph-centered"
-        data-perseus-paragraph-index="6"
-      >
-        <div
-          class="paragraph"
-        >
-          <div
-            class="fixed-to-responsive svg-image"
-            style="max-width: 244px; max-height: 223px;"
-          >
-            <div
-              style="padding-bottom: 91.39%;"
-            />
-            <span
-              style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
-            >
-              <div
-                class="default_xu2jcg-o_O-spinnerContainer_agrn11"
-              >
-                <svg
-                  height="48"
-                  viewBox="0 0 48 48"
-                  width="48"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
-                    d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
-                    fill-rule="nonzero"
-                  />
-                </svg>
-              </div>
-            </span>
-          </div>
-            
+          </span>
         </div>
       </div>
     </div>
-  </span>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <div
+            class="categorizer-container fullBleedContainer_8ybp6"
+          >
+            <table
+              class="categorizer-table mobileTable_1wmcwov"
+            >
+              <thead>
+                <tr>
+                  <td
+                    class="emptyHeaderCell_1mttrgd"
+                  />
+                  <th
+                    class="header_whrfk4"
+                  >
+                    <div
+                      class="perseus-renderer perseus-renderer-responsive"
+                    >
+                      <div
+                        class="paragraph"
+                        data-perseus-paragraph-index="0"
+                      >
+                        <div
+                          class="paragraph"
+                        >
+                          No relationship
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="header_whrfk4"
+                  >
+                    <div
+                      class="perseus-renderer perseus-renderer-responsive"
+                    >
+                      <div
+                        class="paragraph"
+                        data-perseus-paragraph-index="0"
+                      >
+                        <div
+                          class="paragraph"
+                        >
+                          Positive linear relationship
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="header_whrfk4"
+                  >
+                    <div
+                      class="perseus-renderer perseus-renderer-responsive"
+                    >
+                      <div
+                        class="paragraph"
+                        data-perseus-paragraph-index="0"
+                      >
+                        <div
+                          class="paragraph"
+                        >
+                          Negative linear relationship
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="header_whrfk4"
+                  >
+                    <div
+                      class="perseus-renderer perseus-renderer-responsive"
+                    >
+                      <div
+                        class="paragraph"
+                        data-perseus-paragraph-index="0"
+                      >
+                        <div
+                          class="paragraph"
+                        >
+                          Nonlinear relationship
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    <div
+                      class="perseus-renderer perseus-renderer-responsive"
+                    >
+                      <div
+                        class="paragraph"
+                        data-perseus-paragraph-index="0"
+                      >
+                        <div
+                          class="paragraph"
+                        >
+                          Graph 
+                          <span
+                            style="white-space: nowrap;"
+                          >
+                            <span />
+                            <span
+                              class="mock-TeX"
+                            >
+                              1
+                            </span>
+                            <span />
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="category cell_13aakpm"
+                  >
+                    <div
+                      aria-label="No relationship"
+                      class="perseus-interactive"
+                      role="button"
+                    >
+                      <input
+                        class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                        name="perseus_radio_10_0"
+                        type="radio"
+                      />
+                    </div>
+                  </td>
+                  <td
+                    class="category cell_13aakpm"
+                  >
+                    <div
+                      aria-label="Positive linear relationship"
+                      class="perseus-interactive"
+                      role="button"
+                    >
+                      <input
+                        class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                        name="perseus_radio_10_0"
+                        type="radio"
+                      />
+                    </div>
+                  </td>
+                  <td
+                    class="category cell_13aakpm"
+                  >
+                    <div
+                      aria-label="Negative linear relationship"
+                      class="perseus-interactive"
+                      role="button"
+                    >
+                      <input
+                        class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                        name="perseus_radio_10_0"
+                        type="radio"
+                      />
+                    </div>
+                  </td>
+                  <td
+                    class="category cell_13aakpm"
+                  >
+                    <div
+                      aria-label="Nonlinear relationship"
+                      class="perseus-interactive"
+                      role="button"
+                    >
+                      <input
+                        class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                        name="perseus_radio_10_0"
+                        type="radio"
+                      />
+                    </div>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <div
+                      class="perseus-renderer perseus-renderer-responsive"
+                    >
+                      <div
+                        class="paragraph"
+                        data-perseus-paragraph-index="0"
+                      >
+                        <div
+                          class="paragraph"
+                        >
+                          Graph 
+                          <span
+                            style="white-space: nowrap;"
+                          >
+                            <span />
+                            <span
+                              class="mock-TeX"
+                            >
+                              2
+                            </span>
+                            <span />
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="category cell_13aakpm"
+                  >
+                    <div
+                      aria-label="No relationship"
+                      class="perseus-interactive"
+                      role="button"
+                    >
+                      <input
+                        class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                        name="perseus_radio_10_1"
+                        type="radio"
+                      />
+                    </div>
+                  </td>
+                  <td
+                    class="category cell_13aakpm"
+                  >
+                    <div
+                      aria-label="Positive linear relationship"
+                      class="perseus-interactive"
+                      role="button"
+                    >
+                      <input
+                        class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                        name="perseus_radio_10_1"
+                        type="radio"
+                      />
+                    </div>
+                  </td>
+                  <td
+                    class="category cell_13aakpm"
+                  >
+                    <div
+                      aria-label="Negative linear relationship"
+                      class="perseus-interactive"
+                      role="button"
+                    >
+                      <input
+                        class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                        name="perseus_radio_10_1"
+                        type="radio"
+                      />
+                    </div>
+                  </td>
+                  <td
+                    class="category cell_13aakpm"
+                  >
+                    <div
+                      aria-label="Nonlinear relationship"
+                      class="perseus-interactive"
+                      role="button"
+                    >
+                      <input
+                        class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                        name="perseus_radio_10_1"
+                        type="radio"
+                      />
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="3"
+    >
+      <div
+        class="paragraph"
+      >
+        <strong>
+          Graph 1.
+        </strong>
+      </div>
+    </div>
+    <div
+      class="paragraph perseus-paragraph-centered"
+      data-perseus-paragraph-index="4"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="fixed-to-responsive svg-image"
+          style="max-width: 220px; max-height: 223px;"
+        >
+          <div
+            style="padding-bottom: 101.36%;"
+          />
+          <span
+            style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
+          >
+            <div
+              class="default_xu2jcg-o_O-spinnerContainer_agrn11"
+            >
+              <svg
+                height="48"
+                viewBox="0 0 48 48"
+                width="48"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
+                  d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
+                  fill-rule="nonzero"
+                />
+              </svg>
+            </div>
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="5"
+    >
+      <div
+        class="paragraph"
+      >
+        <strong>
+          Graph 2.
+        </strong>
+      </div>
+    </div>
+    <div
+      class="paragraph perseus-paragraph-centered"
+      data-perseus-paragraph-index="6"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="fixed-to-responsive svg-image"
+          style="max-width: 244px; max-height: 223px;"
+        >
+          <div
+            style="padding-bottom: 91.39%;"
+          />
+          <span
+            style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
+          >
+            <div
+              class="default_xu2jcg-o_O-spinnerContainer_agrn11"
+            >
+              <svg
+                height="48"
+                viewBox="0 0 48 48"
+                width="48"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
+                  d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
+                  fill-rule="nonzero"
+                />
+              </svg>
+            </div>
+          </span>
+        </div>
+          
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`categorizer widget should snapshot: first render 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="paragraph"
+      >
+        <strong>
+          Classify each graph according to the kind of relationship it suggests.
+        </strong>
+      </div>
+    </div>
+    <div
+      class="paragraph perseus-paragraph-centered"
+      data-perseus-paragraph-index="1"
+    >
+      <div
+        class="perseus-block-math"
+      >
+        <div
+          class="perseus-block-math-inner"
+          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+        >
+          <span
+            class="mock-TeX"
+          >
+            \\qquad\\qquad\\quad\\text{Graph 1}\\qquad\\qquad\\quad\\qquad\\qquad\\quad\\text{Graph 2}
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <div
+            class="categorizer-container "
+          >
+            <table
+              class="categorizer-table mobileTable_1wmcwov"
+            >
+              <thead>
+                <tr>
+                  <td
+                    class="emptyHeaderCell_1mttrgd"
+                  />
+                  <th
+                    class="header_whrfk4"
+                  >
+                    <div
+                      class="perseus-renderer perseus-renderer-responsive"
+                    >
+                      <div
+                        class="paragraph"
+                        data-perseus-paragraph-index="0"
+                      >
+                        <div
+                          class="paragraph"
+                        >
+                          No relationship
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="header_whrfk4"
+                  >
+                    <div
+                      class="perseus-renderer perseus-renderer-responsive"
+                    >
+                      <div
+                        class="paragraph"
+                        data-perseus-paragraph-index="0"
+                      >
+                        <div
+                          class="paragraph"
+                        >
+                          Positive linear relationship
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="header_whrfk4"
+                  >
+                    <div
+                      class="perseus-renderer perseus-renderer-responsive"
+                    >
+                      <div
+                        class="paragraph"
+                        data-perseus-paragraph-index="0"
+                      >
+                        <div
+                          class="paragraph"
+                        >
+                          Negative linear relationship
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="header_whrfk4"
+                  >
+                    <div
+                      class="perseus-renderer perseus-renderer-responsive"
+                    >
+                      <div
+                        class="paragraph"
+                        data-perseus-paragraph-index="0"
+                      >
+                        <div
+                          class="paragraph"
+                        >
+                          Nonlinear relationship
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    <div
+                      class="perseus-renderer perseus-renderer-responsive"
+                    >
+                      <div
+                        class="paragraph"
+                        data-perseus-paragraph-index="0"
+                      >
+                        <div
+                          class="paragraph"
+                        >
+                          Graph 
+                          <span
+                            style="white-space: nowrap;"
+                          >
+                            <span />
+                            <span
+                              class="mock-TeX"
+                            >
+                              1
+                            </span>
+                            <span />
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="category cell_13aakpm"
+                  >
+                    <div
+                      aria-label="No relationship"
+                      class="perseus-interactive"
+                      role="button"
+                    >
+                      <span
+                        class="radioSpan_1mq3xs9"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: middle;"
+                          viewBox="0 0 100 99.944"
+                          width="1.0005603137757144em"
+                        >
+                          <path
+                            d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="category cell_13aakpm"
+                  >
+                    <div
+                      aria-label="Positive linear relationship"
+                      class="perseus-interactive"
+                      role="button"
+                    >
+                      <span
+                        class="radioSpan_1mq3xs9"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: middle;"
+                          viewBox="0 0 100 99.944"
+                          width="1.0005603137757144em"
+                        >
+                          <path
+                            d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="category cell_13aakpm"
+                  >
+                    <div
+                      aria-label="Negative linear relationship"
+                      class="perseus-interactive"
+                      role="button"
+                    >
+                      <span
+                        class="radioSpan_1mq3xs9"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: middle;"
+                          viewBox="0 0 100 99.944"
+                          width="1.0005603137757144em"
+                        >
+                          <path
+                            d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="category cell_13aakpm"
+                  >
+                    <div
+                      aria-label="Nonlinear relationship"
+                      class="perseus-interactive"
+                      role="button"
+                    >
+                      <span
+                        class="radioSpan_1mq3xs9"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: middle;"
+                          viewBox="0 0 100 99.944"
+                          width="1.0005603137757144em"
+                        >
+                          <path
+                            d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <div
+                      class="perseus-renderer perseus-renderer-responsive"
+                    >
+                      <div
+                        class="paragraph"
+                        data-perseus-paragraph-index="0"
+                      >
+                        <div
+                          class="paragraph"
+                        >
+                          Graph 
+                          <span
+                            style="white-space: nowrap;"
+                          >
+                            <span />
+                            <span
+                              class="mock-TeX"
+                            >
+                              2
+                            </span>
+                            <span />
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="category cell_13aakpm"
+                  >
+                    <div
+                      aria-label="No relationship"
+                      class="perseus-interactive"
+                      role="button"
+                    >
+                      <span
+                        class="radioSpan_1mq3xs9"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: middle;"
+                          viewBox="0 0 100 99.944"
+                          width="1.0005603137757144em"
+                        >
+                          <path
+                            d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="category cell_13aakpm"
+                  >
+                    <div
+                      aria-label="Positive linear relationship"
+                      class="perseus-interactive"
+                      role="button"
+                    >
+                      <span
+                        class="radioSpan_1mq3xs9"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: middle;"
+                          viewBox="0 0 100 99.944"
+                          width="1.0005603137757144em"
+                        >
+                          <path
+                            d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="category cell_13aakpm"
+                  >
+                    <div
+                      aria-label="Negative linear relationship"
+                      class="perseus-interactive"
+                      role="button"
+                    >
+                      <span
+                        class="radioSpan_1mq3xs9"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: middle;"
+                          viewBox="0 0 100 99.944"
+                          width="1.0005603137757144em"
+                        >
+                          <path
+                            d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="category cell_13aakpm"
+                  >
+                    <div
+                      aria-label="Nonlinear relationship"
+                      class="perseus-interactive"
+                      role="button"
+                    >
+                      <span
+                        class="radioSpan_1mq3xs9"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: middle;"
+                          viewBox="0 0 100 99.944"
+                          width="1.0005603137757144em"
+                        >
+                          <path
+                            d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="3"
+    >
+      <div
+        class="paragraph"
+      >
+        <strong>
+          Graph 1.
+        </strong>
+      </div>
+    </div>
+    <div
+      class="paragraph perseus-paragraph-centered"
+      data-perseus-paragraph-index="4"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="fixed-to-responsive svg-image"
+          style="max-width: 220px; max-height: 223px;"
+        >
+          <div
+            style="padding-bottom: 101.36%;"
+          />
+          <span
+            style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
+          >
+            <div
+              class="default_xu2jcg-o_O-spinnerContainer_agrn11"
+            >
+              <svg
+                height="48"
+                viewBox="0 0 48 48"
+                width="48"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
+                  d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
+                  fill-rule="nonzero"
+                />
+              </svg>
+            </div>
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="5"
+    >
+      <div
+        class="paragraph"
+      >
+        <strong>
+          Graph 2.
+        </strong>
+      </div>
+    </div>
+    <div
+      class="paragraph perseus-paragraph-centered"
+      data-perseus-paragraph-index="6"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="fixed-to-responsive svg-image"
+          style="max-width: 244px; max-height: 223px;"
+        >
+          <div
+            style="padding-bottom: 91.39%;"
+          />
+          <span
+            style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
+          >
+            <div
+              class="default_xu2jcg-o_O-spinnerContainer_agrn11"
+            >
+              <svg
+                height="48"
+                viewBox="0 0 48 48"
+                width="48"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
+                  d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
+                  fill-rule="nonzero"
+                />
+              </svg>
+            </div>
+          </span>
+        </div>
+          
+      </div>
+    </div>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/cs-program.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/cs-program.test.ts.snap
@@ -2,74 +2,66 @@
 
 exports[`cs-program widget should snapshot on mobile: first mobile render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+            class="widthOverride_1vdzrqd-o_O-container_1v2yujs"
           >
-            <div
-              class="widthOverride_1vdzrqd-o_O-container_1v2yujs"
-            >
-              <iframe
-                allowfullscreen=""
-                class="perseus-scratchpad"
-                sandbox="allow-popups allow-same-origin allow-scripts allow-top-navigation"
-                src="http://localhost:8081/computer-programming/program/6293105639817216/embedded?embed=yes&author=no&editor=no&width=688&buttons=no&settings=%7B%7D"
-                style="height: 540px; width: 100%;"
-              />
-            </div>
+            <iframe
+              allowfullscreen=""
+              class="perseus-scratchpad"
+              sandbox="allow-popups allow-same-origin allow-scripts allow-top-navigation"
+              src="http://localhost:8081/computer-programming/program/6293105639817216/embedded?embed=yes&author=no&editor=no&width=688&buttons=no&settings=%7B%7D"
+              style="height: 540px; width: 100%;"
+            />
           </div>
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`cs-program widget should snapshot: first render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+            class="widthOverride_1vdzrqd-o_O-container_1v2yujs"
           >
-            <div
-              class="widthOverride_1vdzrqd-o_O-container_1v2yujs"
-            >
-              <iframe
-                allowfullscreen=""
-                class="perseus-scratchpad"
-                sandbox="allow-popups allow-same-origin allow-scripts allow-top-navigation"
-                src="http://localhost:8081/computer-programming/program/6293105639817216/embedded?embed=yes&author=no&editor=no&width=688&buttons=no&settings=%7B%7D"
-                style="height: 540px; width: 100%;"
-              />
-            </div>
+            <iframe
+              allowfullscreen=""
+              class="perseus-scratchpad"
+              sandbox="allow-popups allow-same-origin allow-scripts allow-top-navigation"
+              src="http://localhost:8081/computer-programming/program/6293105639817216/embedded?embed=yes&author=no&editor=no&width=688&buttons=no&settings=%7B%7D"
+              style="height: 540px; width: 100%;"
+            />
           </div>
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/definition.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/definition.test.ts.snap
@@ -2,104 +2,96 @@
 
 exports[`Definition widget should have a default snapshot: first render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          Read the excerpt and answer the question below. 
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="1"
-      >
-        <div
-          class="paragraph"
-        >
-          The Governor and Council of the Massachusetts had much conference many days; and at last . . . . concluded a peace and friendship with 
-          <div
-            class="perseus-widget-container widget-nohighlight perseus-widget__definition widget-inline"
-          >
-            <button
-              aria-controls="uid-popover-0-wb-id"
-              aria-disabled="false"
-              aria-expanded="false"
-              class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4"
-              id="uid-popover-0-wb-id-anchor"
-              type="button"
-            >
-              <span
-                style="color: rgb(24, 101, 242);"
-              >
-                the Pequots
-              </span>
-            </button>
-          </div>
-          , upon these conditions.
-        </div>
+        Read the excerpt and answer the question below. 
       </div>
     </div>
-  </span>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
+      <div
+        class="paragraph"
+      >
+        The Governor and Council of the Massachusetts had much conference many days; and at last . . . . concluded a peace and friendship with 
+        <div
+          class="perseus-widget-container widget-nohighlight perseus-widget__definition widget-inline"
+        >
+          <button
+            aria-controls="uid-popover-0-wb-id"
+            aria-disabled="false"
+            aria-expanded="false"
+            class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4"
+            id="uid-popover-0-wb-id-anchor"
+            type="button"
+          >
+            <span
+              style="color: rgb(24, 101, 242);"
+            >
+              the Pequots
+            </span>
+          </button>
+        </div>
+        , upon these conditions.
+      </div>
+    </div>
+  </div>
 </div>
 `;
 
 exports[`Definition widget should have an open state snapshot: open state 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          Read the excerpt and answer the question below. 
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="1"
-      >
-        <div
-          class="paragraph"
-        >
-          The Governor and Council of the Massachusetts had much conference many days; and at last . . . . concluded a peace and friendship with 
-          <div
-            class="perseus-widget-container widget-nohighlight perseus-widget__definition widget-inline"
-          >
-            <button
-              aria-controls="uid-popover-1-wb-id"
-              aria-disabled="false"
-              aria-expanded="true"
-              class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4"
-              id="uid-popover-1-wb-id-anchor"
-              type="button"
-            >
-              <span
-                style="color: rgb(24, 101, 242); border-bottom: 2px solid #1865f2;"
-              >
-                the Pequots
-              </span>
-            </button>
-          </div>
-          , upon these conditions.
-        </div>
+        Read the excerpt and answer the question below. 
       </div>
     </div>
-  </span>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
+      <div
+        class="paragraph"
+      >
+        The Governor and Council of the Massachusetts had much conference many days; and at last . . . . concluded a peace and friendship with 
+        <div
+          class="perseus-widget-container widget-nohighlight perseus-widget__definition widget-inline"
+        >
+          <button
+            aria-controls="uid-popover-1-wb-id"
+            aria-disabled="false"
+            aria-expanded="true"
+            class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4"
+            id="uid-popover-1-wb-id-anchor"
+            type="button"
+          >
+            <span
+              style="color: rgb(24, 101, 242); border-bottom: 2px solid #1865f2;"
+            >
+              the Pequots
+            </span>
+          </button>
+        </div>
+        , upon these conditions.
+      </div>
+    </div>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/dropdown.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/dropdown.test.ts.snap
@@ -2,156 +2,148 @@
 
 exports[`Dropdown widget should snapshot when opened: dropdown open 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
+        The total number of boxes the forklift can carry is 
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-inline-block"
         >
-          The total number of boxes the forklift can carry is 
-          <div
-            class="perseus-widget-container widget-nohighlight widget-inline-block"
-          >
-            <div>
-              <div
-                class="default_xu2jcg-o_O-menuWrapper_wvrnr4"
+          <div>
+            <div
+              class="default_xu2jcg-o_O-menuWrapper_wvrnr4"
+            >
+              <span
+                aria-atomic="true"
+                aria-live="polite"
+                aria-relevant="additions text"
+                class="srOnly_19bpjuy"
+                data-test-id="dropdown-live-region"
+              >
+                3 items
+              </span>
+              <button
+                aria-expanded="true"
+                aria-haspopup="listbox"
+                class="button_vr44p2-o_O-shared_u51dsh-o_O-default_kjzwx1-o_O-focus_1qpi544"
+                type="button"
               >
                 <span
-                  aria-atomic="true"
-                  aria-live="polite"
-                  aria-relevant="additions text"
-                  class="srOnly_19bpjuy"
-                  data-test-id="dropdown-live-region"
+                  class="text_f1191h-o_O-LabelMedium_1rew30o-o_O-text_16ujc3c"
                 >
-                  3 items
+                  greater/less than or equal to
                 </span>
-                <button
-                  aria-expanded="true"
-                  aria-haspopup="listbox"
-                  class="button_vr44p2-o_O-shared_u51dsh-o_O-default_kjzwx1-o_O-focus_1qpi544"
-                  type="button"
+                <svg
+                  aria-hidden="true"
+                  class="svg_aeiopc-o_O-caret_ntkmq"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
                 >
-                  <span
-                    class="text_f1191h-o_O-LabelMedium_1rew30o-o_O-text_16ujc3c"
-                  >
-                    greater/less than or equal to
-                  </span>
-                  <svg
-                    aria-hidden="true"
-                    class="svg_aeiopc-o_O-caret_ntkmq"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    width="16"
-                  >
-                    <path
-                      d="M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z"
-                      fill="rgba(33,36,44,0.64)"
-                    />
-                  </svg>
-                </button>
-              </div>
+                  <path
+                    d="M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z"
+                    fill="rgba(33,36,44,0.64)"
+                  />
+                </svg>
+              </button>
             </div>
           </div>
-           
-          <span
-            style="white-space: nowrap;"
-          >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              60
-            </span>
-            <span />
-          </span>
-          .
         </div>
+         
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            60
+          </span>
+          <span />
+        </span>
+        .
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`Dropdown widget should snapshot: initial render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
+        The total number of boxes the forklift can carry is 
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-inline-block"
         >
-          The total number of boxes the forklift can carry is 
-          <div
-            class="perseus-widget-container widget-nohighlight widget-inline-block"
-          >
-            <div>
-              <div
-                class="default_xu2jcg-o_O-menuWrapper_wvrnr4"
+          <div>
+            <div
+              class="default_xu2jcg-o_O-menuWrapper_wvrnr4"
+            >
+              <span
+                aria-atomic="true"
+                aria-live="polite"
+                aria-relevant="additions text"
+                class="srOnly_19bpjuy"
+                data-test-id="dropdown-live-region"
+              />
+              <button
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                class="button_vr44p2-o_O-shared_u51dsh-o_O-default_kjzwx1"
+                type="button"
               >
                 <span
-                  aria-atomic="true"
-                  aria-live="polite"
-                  aria-relevant="additions text"
-                  class="srOnly_19bpjuy"
-                  data-test-id="dropdown-live-region"
-                />
-                <button
-                  aria-expanded="false"
-                  aria-haspopup="listbox"
-                  class="button_vr44p2-o_O-shared_u51dsh-o_O-default_kjzwx1"
-                  type="button"
+                  class="text_f1191h-o_O-LabelMedium_1rew30o-o_O-text_16ujc3c"
                 >
-                  <span
-                    class="text_f1191h-o_O-LabelMedium_1rew30o-o_O-text_16ujc3c"
-                  >
-                    greater/less than or equal to
-                  </span>
-                  <svg
-                    aria-hidden="true"
-                    class="svg_aeiopc-o_O-caret_ntkmq"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    width="16"
-                  >
-                    <path
-                      d="M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z"
-                      fill="rgba(33,36,44,0.64)"
-                    />
-                  </svg>
-                </button>
-              </div>
+                  greater/less than or equal to
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="svg_aeiopc-o_O-caret_ntkmq"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <path
+                    d="M8 8.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 8.586z"
+                    fill="rgba(33,36,44,0.64)"
+                  />
+                </svg>
+              </button>
             </div>
           </div>
-           
-          <span
-            style="white-space: nowrap;"
-          >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              60
-            </span>
-            <span />
-          </span>
-          .
         </div>
+         
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            60
+          </span>
+          <span />
+        </span>
+        .
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/explanation.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/explanation.test.ts.snap
@@ -2,472 +2,424 @@
 
 exports[`Explanation should snapshot for article when expanded: expanded 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          Here's the explanation
+        Here's the explanation
 
+        <div
+          class="perseus-widget-container widget-nohighlight widget-inline"
+        >
           <div
-            class="perseus-widget-container widget-nohighlight widget-inline"
+            class="container_167wsvl"
           >
             <div
-              class="container_167wsvl"
+              class="linkContainer_36rlri-o_O-articleLink_17wlykh"
+            >
+              <a
+                aria-expanded="true"
+                class="explanationLink_7n4oib"
+                href="javascript:void(0)"
+                role="button"
+              >
+                [Hide explanation!]
+              </a>
+            </div>
+            <div
+              class="content_z5b02x-o_O-contentExpanded_1c06cap"
             >
               <div
-                class="linkContainer_36rlri-o_O-articleLink_17wlykh"
+                class="perseus-renderer perseus-renderer-responsive"
               >
-                <a
-                  aria-expanded="true"
-                  class="explanationLink_7n4oib"
-                  href="javascript:void(0)"
-                  role="button"
-                >
-                  [Hide explanation!]
-                </a>
-              </div>
-              <div
-                class="content_z5b02x-o_O-contentExpanded_1c06cap"
-              >
-                <span
-                  class="mock-KatexProvider"
+                <div
+                  class="paragraph"
+                  data-perseus-paragraph-index="0"
                 >
                   <div
-                    class="perseus-renderer perseus-renderer-responsive"
+                    class="paragraph"
                   >
-                    <div
-                      class="paragraph"
-                      data-perseus-paragraph-index="0"
-                    >
-                      <div
-                        class="paragraph"
-                      >
-                        This is an explanation
-                      </div>
-                    </div>
+                    This is an explanation
                   </div>
-                </span>
+                </div>
               </div>
             </div>
           </div>
-          
-Did you get that?
         </div>
+        
+Did you get that?
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`Explanation should snapshot for article+mobile when expanded: expanded 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          Here's the explanation
+        Here's the explanation
 
+        <div
+          class="perseus-widget-container widget-nohighlight widget-inline"
+        >
           <div
-            class="perseus-widget-container widget-nohighlight widget-inline"
+            class="container_167wsvl"
           >
             <div
-              class="container_167wsvl"
+              class="linkContainer_36rlri"
+            >
+              <a
+                aria-expanded="true"
+                class="mobileExplanationLink_his27d"
+                href="javascript:void(0)"
+                role="button"
+              >
+                Hide explanation!
+              </a>
+              <svg
+                class="disclosureArrow_12nx0hv"
+              >
+                <polygon
+                  points="0,14 30,14 15,0"
+                  style="fill: #F0F1F2;"
+                />
+              </svg>
+            </div>
+            <div
+              class="content_z5b02x-o_O-contentMobile_1wvx5oh-o_O-contentExpandedMobile_knze7z"
             >
               <div
-                class="linkContainer_36rlri"
+                class="perseus-renderer perseus-renderer-responsive"
               >
-                <a
-                  aria-expanded="true"
-                  class="mobileExplanationLink_his27d"
-                  href="javascript:void(0)"
-                  role="button"
-                >
-                  Hide explanation!
-                </a>
-                <svg
-                  class="disclosureArrow_12nx0hv"
-                >
-                  <polygon
-                    points="0,14 30,14 15,0"
-                    style="fill: #F0F1F2;"
-                  />
-                </svg>
-              </div>
-              <div
-                class="content_z5b02x-o_O-contentMobile_1wvx5oh-o_O-contentExpandedMobile_knze7z"
-              >
-                <span
-                  class="mock-KatexProvider"
+                <div
+                  class="paragraph"
+                  data-perseus-paragraph-index="0"
                 >
                   <div
-                    class="perseus-renderer perseus-renderer-responsive"
+                    class="paragraph"
                   >
-                    <div
-                      class="paragraph"
-                      data-perseus-paragraph-index="0"
-                    >
-                      <div
-                        class="paragraph"
-                      >
-                        This is an explanation
-                      </div>
-                    </div>
+                    This is an explanation
                   </div>
-                </span>
+                </div>
               </div>
             </div>
           </div>
-          
-Did you get that?
         </div>
+        
+Did you get that?
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`Explanation should snapshot for article+mobile: initial render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          Here's the explanation
+        Here's the explanation
 
+        <div
+          class="perseus-widget-container widget-nohighlight widget-inline"
+        >
           <div
-            class="perseus-widget-container widget-nohighlight widget-inline"
+            class="container_167wsvl"
           >
             <div
-              class="container_167wsvl"
+              class="linkContainer_36rlri"
             >
-              <div
-                class="linkContainer_36rlri"
+              <a
+                aria-expanded="false"
+                class="mobileExplanationLink_his27d"
+                href="javascript:void(0)"
+                role="button"
               >
-                <a
-                  aria-expanded="false"
-                  class="mobileExplanationLink_his27d"
-                  href="javascript:void(0)"
-                  role="button"
-                >
-                  Explanation
-                </a>
-              </div>
+                Explanation
+              </a>
             </div>
           </div>
-          
-Did you get that?
         </div>
+        
+Did you get that?
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`Explanation should snapshot for article: initial render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          Here's the explanation
+        Here's the explanation
 
+        <div
+          class="perseus-widget-container widget-nohighlight widget-inline"
+        >
           <div
-            class="perseus-widget-container widget-nohighlight widget-inline"
+            class="container_167wsvl"
           >
             <div
-              class="container_167wsvl"
+              class="linkContainer_36rlri-o_O-articleLink_17wlykh"
             >
-              <div
-                class="linkContainer_36rlri-o_O-articleLink_17wlykh"
+              <a
+                aria-expanded="false"
+                class="explanationLink_7n4oib"
+                href="javascript:void(0)"
+                role="button"
               >
-                <a
-                  aria-expanded="false"
-                  class="explanationLink_7n4oib"
-                  href="javascript:void(0)"
-                  role="button"
-                >
-                  [Explanation]
-                </a>
-              </div>
+                [Explanation]
+              </a>
             </div>
           </div>
-          
-Did you get that?
         </div>
+        
+Did you get that?
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`Explanation should snapshot for mobile when expanded: expanded 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          Here's the explanation
+        Here's the explanation
 
+        <div
+          class="perseus-widget-container widget-nohighlight widget-inline"
+        >
           <div
-            class="perseus-widget-container widget-nohighlight widget-inline"
+            class="container_167wsvl"
           >
             <div
-              class="container_167wsvl"
+              class="linkContainer_36rlri"
+            >
+              <a
+                aria-expanded="true"
+                class="mobileExplanationLink_his27d"
+                href="javascript:void(0)"
+                role="button"
+              >
+                Hide explanation!
+              </a>
+              <svg
+                class="disclosureArrow_12nx0hv"
+              >
+                <polygon
+                  points="0,14 30,14 15,0"
+                  style="fill: #F0F1F2;"
+                />
+              </svg>
+            </div>
+            <div
+              class="content_z5b02x-o_O-contentMobile_1wvx5oh-o_O-contentExpandedMobile_knze7z"
             >
               <div
-                class="linkContainer_36rlri"
+                class="perseus-renderer perseus-renderer-responsive"
               >
-                <a
-                  aria-expanded="true"
-                  class="mobileExplanationLink_his27d"
-                  href="javascript:void(0)"
-                  role="button"
-                >
-                  Hide explanation!
-                </a>
-                <svg
-                  class="disclosureArrow_12nx0hv"
-                >
-                  <polygon
-                    points="0,14 30,14 15,0"
-                    style="fill: #F0F1F2;"
-                  />
-                </svg>
-              </div>
-              <div
-                class="content_z5b02x-o_O-contentMobile_1wvx5oh-o_O-contentExpandedMobile_knze7z"
-              >
-                <span
-                  class="mock-KatexProvider"
+                <div
+                  class="paragraph"
+                  data-perseus-paragraph-index="0"
                 >
                   <div
-                    class="perseus-renderer perseus-renderer-responsive"
+                    class="paragraph"
                   >
-                    <div
-                      class="paragraph"
-                      data-perseus-paragraph-index="0"
-                    >
-                      <div
-                        class="paragraph"
-                      >
-                        This is an explanation
-                      </div>
-                    </div>
+                    This is an explanation
                   </div>
-                </span>
+                </div>
               </div>
             </div>
           </div>
-          
-Did you get that?
         </div>
+        
+Did you get that?
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`Explanation should snapshot for mobile: initial render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          Here's the explanation
+        Here's the explanation
 
+        <div
+          class="perseus-widget-container widget-nohighlight widget-inline"
+        >
           <div
-            class="perseus-widget-container widget-nohighlight widget-inline"
+            class="container_167wsvl"
           >
             <div
-              class="container_167wsvl"
+              class="linkContainer_36rlri"
             >
-              <div
-                class="linkContainer_36rlri"
+              <a
+                aria-expanded="false"
+                class="mobileExplanationLink_his27d"
+                href="javascript:void(0)"
+                role="button"
               >
-                <a
-                  aria-expanded="false"
-                  class="mobileExplanationLink_his27d"
-                  href="javascript:void(0)"
-                  role="button"
-                >
-                  Explanation
-                </a>
-              </div>
+                Explanation
+              </a>
             </div>
           </div>
-          
-Did you get that?
         </div>
+        
+Did you get that?
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`Explanation should snapshot when expanded: expanded 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          Here's the explanation
+        Here's the explanation
 
+        <div
+          class="perseus-widget-container widget-nohighlight widget-inline"
+        >
           <div
-            class="perseus-widget-container widget-nohighlight widget-inline"
+            class="container_167wsvl"
           >
             <div
-              class="container_167wsvl"
+              class="linkContainer_36rlri-o_O-exerciseLink_574wt1"
+            >
+              <a
+                aria-expanded="true"
+                class="explanationLink_7n4oib"
+                href="javascript:void(0)"
+                role="button"
+              >
+                [Hide explanation!]
+              </a>
+            </div>
+            <div
+              class="content_z5b02x-o_O-contentExpanded_1c06cap"
             >
               <div
-                class="linkContainer_36rlri-o_O-exerciseLink_574wt1"
+                class="perseus-renderer perseus-renderer-responsive"
               >
-                <a
-                  aria-expanded="true"
-                  class="explanationLink_7n4oib"
-                  href="javascript:void(0)"
-                  role="button"
-                >
-                  [Hide explanation!]
-                </a>
-              </div>
-              <div
-                class="content_z5b02x-o_O-contentExpanded_1c06cap"
-              >
-                <span
-                  class="mock-KatexProvider"
+                <div
+                  class="paragraph"
+                  data-perseus-paragraph-index="0"
                 >
                   <div
-                    class="perseus-renderer perseus-renderer-responsive"
+                    class="paragraph"
                   >
-                    <div
-                      class="paragraph"
-                      data-perseus-paragraph-index="0"
-                    >
-                      <div
-                        class="paragraph"
-                      >
-                        This is an explanation
-                      </div>
-                    </div>
+                    This is an explanation
                   </div>
-                </span>
+                </div>
               </div>
             </div>
           </div>
-          
-Did you get that?
         </div>
+        
+Did you get that?
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`Explanation should snapshot: initial render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          Here's the explanation
+        Here's the explanation
 
+        <div
+          class="perseus-widget-container widget-nohighlight widget-inline"
+        >
           <div
-            class="perseus-widget-container widget-nohighlight widget-inline"
+            class="container_167wsvl"
           >
             <div
-              class="container_167wsvl"
+              class="linkContainer_36rlri-o_O-exerciseLink_574wt1"
             >
-              <div
-                class="linkContainer_36rlri-o_O-exerciseLink_574wt1"
+              <a
+                aria-expanded="false"
+                class="explanationLink_7n4oib"
+                href="javascript:void(0)"
+                role="button"
               >
-                <a
-                  aria-expanded="false"
-                  class="explanationLink_7n4oib"
-                  href="javascript:void(0)"
-                  role="button"
-                >
-                  [Explanation]
-                </a>
-              </div>
+                [Explanation]
+              </a>
             </div>
           </div>
-          
-Did you get that?
         </div>
+        
+Did you get that?
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group-set-jipt.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group-set-jipt.test.ts.snap
@@ -2,756 +2,728 @@
 
 exports[`graded-group-set should render all graded groups 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
+    >
+      <h1>
+        Section 1: Adding tenths less than one
+      </h1>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
-      >
-        <h1>
-          Section 1: Adding tenths less than one
-        </h1>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="1"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+            class="container_14sgdtb"
           >
             <div
-              class="container_14sgdtb"
+              class="perseus-graded-group"
             >
               <div
-                class="perseus-graded-group"
+                class="title_1lagzkb"
               >
-                <div
-                  class="title_1lagzkb"
-                >
-                  Problem 1a
-                </div>
-                <span
-                  class="mock-KatexProvider"
-                >
-                  <div
-                    class="perseus-renderer perseus-renderer-responsive"
-                  >
-                    <div
-                      class="paragraph"
-                      data-perseus-paragraph-index="0"
-                    >
-                      <div
-                        class="paragraph"
-                      >
-                        <span
-                          style="white-space: nowrap;"
-                        >
-                          <span />
-                          <span
-                            class="mock-TeX"
-                          >
-                            0.5 + 0.4 =
-                          </span>
-                          <span />
-                        </span>
-                           
-                        <div
-                          class="perseus-widget-container widget-nohighlight widget-inline-block"
-                        >
-                          <div>
-                            <span>
-                              <div>
-                                <input
-                                  aria-label="Your answer:"
-                                  autocapitalize="off"
-                                  autocomplete="off"
-                                  autocorrect="off"
-                                  class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_19vw1dn"
-                                  id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
-                                  type="text"
-                                  value=""
-                                />
-                              </div>
-                              <div
-                                style="position: relative; height: 0px; display: none;"
-                              >
-                                <div
-                                  class="tooltipContainer"
-                                  style="position: absolute; left: 0px;"
-                                >
-                                  <div
-                                    style="display: block; position: relative; visibility: visible; left: 0px; top: -1px; width: 12px; height: 11px; margin-top: -1px; margin-bottom: -2px; z-index: 10;"
-                                  >
-                                    <div
-                                      style="display: block; height: 0px; width: 0px; position: absolute; left: 0px; top: -1px; border-right: 12px solid transparent; border-bottom: 12px solid #ccc;"
-                                    />
-                                    <div
-                                      style="display: block; height: 0px; width: 0px; position: absolute; left: 1px; top: 1px; border-right: 10px solid transparent; border-bottom: 10px solid white;"
-                                    />
-                                  </div>
-                                  <div
-                                    class="perseus-formats-tooltip preview-measure"
-                                    style="position: relative; top: 0px; left: 0px; border: 1px solid #ccc; box-shadow: 0 1px 3px #ccc; z-index: 9;"
-                                  >
-                                    <div
-                                      id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
-                                    >
-                                      <span
-                                        class="mock-KatexProvider"
-                                      >
-                                        <div
-                                          class="perseus-renderer perseus-renderer-responsive"
-                                        >
-                                          <div
-                                            class="paragraph"
-                                            data-perseus-paragraph-index="0"
-                                          >
-                                            <ul>
-                                              <li>
-                                                <strong>
-                                                  Your answer should be
-                                                </strong>
-                                              </li>
-                                              <li>
-                                                an integer, like 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    6
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                              </li>
-                                              <li>
-                                                a 
-                                                <em>
-                                                  simplified proper
-                                                </em>
-                                                 fraction, like 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    3/5
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                              </li>
-                                              <li>
-                                                a 
-                                                <em>
-                                                  simplified improper
-                                                </em>
-                                                 fraction, like 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    7/4
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                              </li>
-                                              <li>
-                                                a mixed number, like 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    1\\ 3/4
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                              </li>
-                                              <li>
-                                                an 
-                                                <em>
-                                                  exact
-                                                </em>
-                                                 decimal, like 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    0.75
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                              </li>
-                                              <li>
-                                                a multiple of pi, like 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    12\\ \\text{pi}
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                                 or 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    2/3\\ \\text{pi}
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                              </li>
-                                            </ul>
-                                          </div>
-                                        </div>
-                                      </span>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </span>
-                <p
-                  aria-live="polite"
-                  role="status"
-                />
-                <button
-                  aria-disabled="false"
-                  class="button_vr44p2-o_O-shared_lwskrm-o_O-default_1w5v67"
-                  role="button"
-                  type="button"
-                >
-                  <span
-                    class="text_f1191h-o_O-LabelLarge_5s82ln-o_O-text_m8a8ki"
-                  >
-                    Check
-                  </span>
-                </button>
-                <button
-                  class="showHintLink_oak3yy"
-                  tabindex="0"
-                >
-                  Explain
-                </button>
+                Problem 1a
               </div>
               <div
-                class="perseus-graded-group"
+                class="perseus-renderer perseus-renderer-responsive"
               >
                 <div
-                  class="title_1lagzkb"
-                >
-                  Problem 1b
-                </div>
-                <span
-                  class="mock-KatexProvider"
+                  class="paragraph"
+                  data-perseus-paragraph-index="0"
                 >
                   <div
-                    class="perseus-renderer perseus-renderer-responsive"
+                    class="paragraph"
                   >
-                    <div
-                      class="paragraph"
-                      data-perseus-paragraph-index="0"
+                    <span
+                      style="white-space: nowrap;"
                     >
-                      <div
-                        class="paragraph"
+                      <span />
+                      <span
+                        class="mock-TeX"
                       >
-                        <span
-                          style="white-space: nowrap;"
-                        >
-                          <span />
-                          <span
-                            class="mock-TeX"
-                          >
-                            0.6 + 0.4 =
-                          </span>
-                          <span />
-                        </span>
-                           
-                        <div
-                          class="perseus-widget-container widget-nohighlight widget-inline-block"
-                        >
+                        0.5 + 0.4 =
+                      </span>
+                      <span />
+                    </span>
+                       
+                    <div
+                      class="perseus-widget-container widget-nohighlight widget-inline-block"
+                    >
+                      <div>
+                        <span>
                           <div>
-                            <span>
-                              <div>
-                                <input
-                                  aria-label="Your answer:"
-                                  autocapitalize="off"
-                                  autocomplete="off"
-                                  autocorrect="off"
-                                  class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_19vw1dn"
-                                  id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
-                                  type="text"
-                                  value=""
+                            <input
+                              aria-label="Your answer:"
+                              autocapitalize="off"
+                              autocomplete="off"
+                              autocorrect="off"
+                              class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_19vw1dn"
+                              id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                              type="text"
+                              value=""
+                            />
+                          </div>
+                          <div
+                            style="position: relative; height: 0px; display: none;"
+                          >
+                            <div
+                              class="tooltipContainer"
+                              style="position: absolute; left: 0px;"
+                            >
+                              <div
+                                style="display: block; position: relative; visibility: visible; left: 0px; top: -1px; width: 12px; height: 11px; margin-top: -1px; margin-bottom: -2px; z-index: 10;"
+                              >
+                                <div
+                                  style="display: block; height: 0px; width: 0px; position: absolute; left: 0px; top: -1px; border-right: 12px solid transparent; border-bottom: 12px solid #ccc;"
+                                />
+                                <div
+                                  style="display: block; height: 0px; width: 0px; position: absolute; left: 1px; top: 1px; border-right: 10px solid transparent; border-bottom: 10px solid white;"
                                 />
                               </div>
                               <div
-                                style="position: relative; height: 0px; display: none;"
+                                class="perseus-formats-tooltip preview-measure"
+                                style="position: relative; top: 0px; left: 0px; border: 1px solid #ccc; box-shadow: 0 1px 3px #ccc; z-index: 9;"
                               >
                                 <div
-                                  class="tooltipContainer"
-                                  style="position: absolute; left: 0px;"
+                                  id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
                                 >
                                   <div
-                                    style="display: block; position: relative; visibility: visible; left: 0px; top: -1px; width: 12px; height: 11px; margin-top: -1px; margin-bottom: -2px; z-index: 10;"
+                                    class="perseus-renderer perseus-renderer-responsive"
                                   >
                                     <div
-                                      style="display: block; height: 0px; width: 0px; position: absolute; left: 0px; top: -1px; border-right: 12px solid transparent; border-bottom: 12px solid #ccc;"
-                                    />
-                                    <div
-                                      style="display: block; height: 0px; width: 0px; position: absolute; left: 1px; top: 1px; border-right: 10px solid transparent; border-bottom: 10px solid white;"
-                                    />
-                                  </div>
-                                  <div
-                                    class="perseus-formats-tooltip preview-measure"
-                                    style="position: relative; top: 0px; left: 0px; border: 1px solid #ccc; box-shadow: 0 1px 3px #ccc; z-index: 9;"
-                                  >
-                                    <div
-                                      id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                                      class="paragraph"
+                                      data-perseus-paragraph-index="0"
                                     >
-                                      <span
-                                        class="mock-KatexProvider"
-                                      >
-                                        <div
-                                          class="perseus-renderer perseus-renderer-responsive"
-                                        >
-                                          <div
-                                            class="paragraph"
-                                            data-perseus-paragraph-index="0"
+                                      <ul>
+                                        <li>
+                                          <strong>
+                                            Your answer should be
+                                          </strong>
+                                        </li>
+                                        <li>
+                                          an integer, like 
+                                          <span
+                                            style="white-space: nowrap;"
                                           >
-                                            <ul>
-                                              <li>
-                                                <strong>
-                                                  Your answer should be
-                                                </strong>
-                                              </li>
-                                              <li>
-                                                an integer, like 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    6
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                              </li>
-                                              <li>
-                                                a 
-                                                <em>
-                                                  simplified proper
-                                                </em>
-                                                 fraction, like 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    3/5
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                              </li>
-                                              <li>
-                                                a 
-                                                <em>
-                                                  simplified improper
-                                                </em>
-                                                 fraction, like 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    7/4
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                              </li>
-                                              <li>
-                                                a mixed number, like 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    1\\ 3/4
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                              </li>
-                                              <li>
-                                                an 
-                                                <em>
-                                                  exact
-                                                </em>
-                                                 decimal, like 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    0.75
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                              </li>
-                                              <li>
-                                                a multiple of pi, like 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    12\\ \\text{pi}
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                                 or 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    2/3\\ \\text{pi}
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                              </li>
-                                            </ul>
-                                          </div>
-                                        </div>
-                                      </span>
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              6
+                                            </span>
+                                            <span />
+                                          </span>
+                                        </li>
+                                        <li>
+                                          a 
+                                          <em>
+                                            simplified proper
+                                          </em>
+                                           fraction, like 
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              3/5
+                                            </span>
+                                            <span />
+                                          </span>
+                                        </li>
+                                        <li>
+                                          a 
+                                          <em>
+                                            simplified improper
+                                          </em>
+                                           fraction, like 
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              7/4
+                                            </span>
+                                            <span />
+                                          </span>
+                                        </li>
+                                        <li>
+                                          a mixed number, like 
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              1\\ 3/4
+                                            </span>
+                                            <span />
+                                          </span>
+                                        </li>
+                                        <li>
+                                          an 
+                                          <em>
+                                            exact
+                                          </em>
+                                           decimal, like 
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              0.75
+                                            </span>
+                                            <span />
+                                          </span>
+                                        </li>
+                                        <li>
+                                          a multiple of pi, like 
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              12\\ \\text{pi}
+                                            </span>
+                                            <span />
+                                          </span>
+                                           or 
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              2/3\\ \\text{pi}
+                                            </span>
+                                            <span />
+                                          </span>
+                                        </li>
+                                      </ul>
                                     </div>
                                   </div>
                                 </div>
                               </div>
-                            </span>
+                            </div>
                           </div>
-                        </div>
+                        </span>
                       </div>
                     </div>
                   </div>
+                </div>
+              </div>
+              <p
+                aria-live="polite"
+                role="status"
+              />
+              <button
+                aria-disabled="false"
+                class="button_vr44p2-o_O-shared_lwskrm-o_O-default_1w5v67"
+                role="button"
+                type="button"
+              >
+                <span
+                  class="text_f1191h-o_O-LabelLarge_5s82ln-o_O-text_m8a8ki"
+                >
+                  Check
                 </span>
-                <p
-                  aria-live="polite"
-                  role="status"
-                />
-                <button
-                  aria-disabled="false"
-                  class="button_vr44p2-o_O-shared_lwskrm-o_O-default_1w5v67"
-                  role="button"
-                  type="button"
-                >
-                  <span
-                    class="text_f1191h-o_O-LabelLarge_5s82ln-o_O-text_m8a8ki"
-                  >
-                    Check
-                  </span>
-                </button>
-                <button
-                  class="showHintLink_oak3yy"
-                  tabindex="0"
-                >
-                  Explain
-                </button>
+              </button>
+              <button
+                class="showHintLink_oak3yy"
+                tabindex="0"
+              >
+                Explain
+              </button>
+            </div>
+            <div
+              class="perseus-graded-group"
+            >
+              <div
+                class="title_1lagzkb"
+              >
+                Problem 1b
               </div>
               <div
-                class="perseus-graded-group"
+                class="perseus-renderer perseus-renderer-responsive"
               >
                 <div
-                  class="title_1lagzkb"
-                >
-                  Problem 1c
-                </div>
-                <span
-                  class="mock-KatexProvider"
+                  class="paragraph"
+                  data-perseus-paragraph-index="0"
                 >
                   <div
-                    class="perseus-renderer perseus-renderer-responsive"
+                    class="paragraph"
                   >
-                    <div
-                      class="paragraph"
-                      data-perseus-paragraph-index="0"
+                    <span
+                      style="white-space: nowrap;"
                     >
-                      <div
-                        class="paragraph"
+                      <span />
+                      <span
+                        class="mock-TeX"
                       >
-                        <span
-                          style="white-space: nowrap;"
-                        >
-                          <span />
-                          <span
-                            class="mock-TeX"
-                          >
-                            0.8 + 0.4 =
-                          </span>
-                          <span />
-                        </span>
-                           
-                        <div
-                          class="perseus-widget-container widget-nohighlight widget-inline-block"
-                        >
+                        0.6 + 0.4 =
+                      </span>
+                      <span />
+                    </span>
+                       
+                    <div
+                      class="perseus-widget-container widget-nohighlight widget-inline-block"
+                    >
+                      <div>
+                        <span>
                           <div>
-                            <span>
-                              <div>
-                                <input
-                                  aria-label="Your answer:"
-                                  autocapitalize="off"
-                                  autocomplete="off"
-                                  autocorrect="off"
-                                  class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_19vw1dn"
-                                  id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
-                                  type="text"
-                                  value=""
+                            <input
+                              aria-label="Your answer:"
+                              autocapitalize="off"
+                              autocomplete="off"
+                              autocorrect="off"
+                              class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_19vw1dn"
+                              id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                              type="text"
+                              value=""
+                            />
+                          </div>
+                          <div
+                            style="position: relative; height: 0px; display: none;"
+                          >
+                            <div
+                              class="tooltipContainer"
+                              style="position: absolute; left: 0px;"
+                            >
+                              <div
+                                style="display: block; position: relative; visibility: visible; left: 0px; top: -1px; width: 12px; height: 11px; margin-top: -1px; margin-bottom: -2px; z-index: 10;"
+                              >
+                                <div
+                                  style="display: block; height: 0px; width: 0px; position: absolute; left: 0px; top: -1px; border-right: 12px solid transparent; border-bottom: 12px solid #ccc;"
+                                />
+                                <div
+                                  style="display: block; height: 0px; width: 0px; position: absolute; left: 1px; top: 1px; border-right: 10px solid transparent; border-bottom: 10px solid white;"
                                 />
                               </div>
                               <div
-                                style="position: relative; height: 0px; display: none;"
+                                class="perseus-formats-tooltip preview-measure"
+                                style="position: relative; top: 0px; left: 0px; border: 1px solid #ccc; box-shadow: 0 1px 3px #ccc; z-index: 9;"
                               >
                                 <div
-                                  class="tooltipContainer"
-                                  style="position: absolute; left: 0px;"
+                                  id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
                                 >
                                   <div
-                                    style="display: block; position: relative; visibility: visible; left: 0px; top: -1px; width: 12px; height: 11px; margin-top: -1px; margin-bottom: -2px; z-index: 10;"
+                                    class="perseus-renderer perseus-renderer-responsive"
                                   >
                                     <div
-                                      style="display: block; height: 0px; width: 0px; position: absolute; left: 0px; top: -1px; border-right: 12px solid transparent; border-bottom: 12px solid #ccc;"
-                                    />
-                                    <div
-                                      style="display: block; height: 0px; width: 0px; position: absolute; left: 1px; top: 1px; border-right: 10px solid transparent; border-bottom: 10px solid white;"
-                                    />
-                                  </div>
-                                  <div
-                                    class="perseus-formats-tooltip preview-measure"
-                                    style="position: relative; top: 0px; left: 0px; border: 1px solid #ccc; box-shadow: 0 1px 3px #ccc; z-index: 9;"
-                                  >
-                                    <div
-                                      id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                                      class="paragraph"
+                                      data-perseus-paragraph-index="0"
                                     >
-                                      <span
-                                        class="mock-KatexProvider"
-                                      >
-                                        <div
-                                          class="perseus-renderer perseus-renderer-responsive"
-                                        >
-                                          <div
-                                            class="paragraph"
-                                            data-perseus-paragraph-index="0"
+                                      <ul>
+                                        <li>
+                                          <strong>
+                                            Your answer should be
+                                          </strong>
+                                        </li>
+                                        <li>
+                                          an integer, like 
+                                          <span
+                                            style="white-space: nowrap;"
                                           >
-                                            <ul>
-                                              <li>
-                                                <strong>
-                                                  Your answer should be
-                                                </strong>
-                                              </li>
-                                              <li>
-                                                an integer, like 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    6
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                              </li>
-                                              <li>
-                                                a 
-                                                <em>
-                                                  simplified proper
-                                                </em>
-                                                 fraction, like 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    3/5
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                              </li>
-                                              <li>
-                                                a 
-                                                <em>
-                                                  simplified improper
-                                                </em>
-                                                 fraction, like 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    7/4
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                              </li>
-                                              <li>
-                                                a mixed number, like 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    1\\ 3/4
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                              </li>
-                                              <li>
-                                                an 
-                                                <em>
-                                                  exact
-                                                </em>
-                                                 decimal, like 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    0.75
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                              </li>
-                                              <li>
-                                                a multiple of pi, like 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    12\\ \\text{pi}
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                                 or 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    2/3\\ \\text{pi}
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                              </li>
-                                            </ul>
-                                          </div>
-                                        </div>
-                                      </span>
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              6
+                                            </span>
+                                            <span />
+                                          </span>
+                                        </li>
+                                        <li>
+                                          a 
+                                          <em>
+                                            simplified proper
+                                          </em>
+                                           fraction, like 
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              3/5
+                                            </span>
+                                            <span />
+                                          </span>
+                                        </li>
+                                        <li>
+                                          a 
+                                          <em>
+                                            simplified improper
+                                          </em>
+                                           fraction, like 
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              7/4
+                                            </span>
+                                            <span />
+                                          </span>
+                                        </li>
+                                        <li>
+                                          a mixed number, like 
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              1\\ 3/4
+                                            </span>
+                                            <span />
+                                          </span>
+                                        </li>
+                                        <li>
+                                          an 
+                                          <em>
+                                            exact
+                                          </em>
+                                           decimal, like 
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              0.75
+                                            </span>
+                                            <span />
+                                          </span>
+                                        </li>
+                                        <li>
+                                          a multiple of pi, like 
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              12\\ \\text{pi}
+                                            </span>
+                                            <span />
+                                          </span>
+                                           or 
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              2/3\\ \\text{pi}
+                                            </span>
+                                            <span />
+                                          </span>
+                                        </li>
+                                      </ul>
                                     </div>
                                   </div>
                                 </div>
                               </div>
-                            </span>
+                            </div>
                           </div>
-                        </div>
+                        </span>
                       </div>
                     </div>
                   </div>
-                </span>
-                <p
-                  aria-live="polite"
-                  role="status"
-                />
-                <button
-                  aria-disabled="false"
-                  class="button_vr44p2-o_O-shared_lwskrm-o_O-default_1w5v67"
-                  role="button"
-                  type="button"
-                >
-                  <span
-                    class="text_f1191h-o_O-LabelLarge_5s82ln-o_O-text_m8a8ki"
-                  >
-                    Check
-                  </span>
-                </button>
-                <button
-                  class="showHintLink_oak3yy"
-                  tabindex="0"
-                >
-                  Explain
-                </button>
+                </div>
               </div>
+              <p
+                aria-live="polite"
+                role="status"
+              />
+              <button
+                aria-disabled="false"
+                class="button_vr44p2-o_O-shared_lwskrm-o_O-default_1w5v67"
+                role="button"
+                type="button"
+              >
+                <span
+                  class="text_f1191h-o_O-LabelLarge_5s82ln-o_O-text_m8a8ki"
+                >
+                  Check
+                </span>
+              </button>
+              <button
+                class="showHintLink_oak3yy"
+                tabindex="0"
+              >
+                Explain
+              </button>
+            </div>
+            <div
+              class="perseus-graded-group"
+            >
+              <div
+                class="title_1lagzkb"
+              >
+                Problem 1c
+              </div>
+              <div
+                class="perseus-renderer perseus-renderer-responsive"
+              >
+                <div
+                  class="paragraph"
+                  data-perseus-paragraph-index="0"
+                >
+                  <div
+                    class="paragraph"
+                  >
+                    <span
+                      style="white-space: nowrap;"
+                    >
+                      <span />
+                      <span
+                        class="mock-TeX"
+                      >
+                        0.8 + 0.4 =
+                      </span>
+                      <span />
+                    </span>
+                       
+                    <div
+                      class="perseus-widget-container widget-nohighlight widget-inline-block"
+                    >
+                      <div>
+                        <span>
+                          <div>
+                            <input
+                              aria-label="Your answer:"
+                              autocapitalize="off"
+                              autocomplete="off"
+                              autocorrect="off"
+                              class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_19vw1dn"
+                              id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                              type="text"
+                              value=""
+                            />
+                          </div>
+                          <div
+                            style="position: relative; height: 0px; display: none;"
+                          >
+                            <div
+                              class="tooltipContainer"
+                              style="position: absolute; left: 0px;"
+                            >
+                              <div
+                                style="display: block; position: relative; visibility: visible; left: 0px; top: -1px; width: 12px; height: 11px; margin-top: -1px; margin-bottom: -2px; z-index: 10;"
+                              >
+                                <div
+                                  style="display: block; height: 0px; width: 0px; position: absolute; left: 0px; top: -1px; border-right: 12px solid transparent; border-bottom: 12px solid #ccc;"
+                                />
+                                <div
+                                  style="display: block; height: 0px; width: 0px; position: absolute; left: 1px; top: 1px; border-right: 10px solid transparent; border-bottom: 10px solid white;"
+                                />
+                              </div>
+                              <div
+                                class="perseus-formats-tooltip preview-measure"
+                                style="position: relative; top: 0px; left: 0px; border: 1px solid #ccc; box-shadow: 0 1px 3px #ccc; z-index: 9;"
+                              >
+                                <div
+                                  id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                                >
+                                  <div
+                                    class="perseus-renderer perseus-renderer-responsive"
+                                  >
+                                    <div
+                                      class="paragraph"
+                                      data-perseus-paragraph-index="0"
+                                    >
+                                      <ul>
+                                        <li>
+                                          <strong>
+                                            Your answer should be
+                                          </strong>
+                                        </li>
+                                        <li>
+                                          an integer, like 
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              6
+                                            </span>
+                                            <span />
+                                          </span>
+                                        </li>
+                                        <li>
+                                          a 
+                                          <em>
+                                            simplified proper
+                                          </em>
+                                           fraction, like 
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              3/5
+                                            </span>
+                                            <span />
+                                          </span>
+                                        </li>
+                                        <li>
+                                          a 
+                                          <em>
+                                            simplified improper
+                                          </em>
+                                           fraction, like 
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              7/4
+                                            </span>
+                                            <span />
+                                          </span>
+                                        </li>
+                                        <li>
+                                          a mixed number, like 
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              1\\ 3/4
+                                            </span>
+                                            <span />
+                                          </span>
+                                        </li>
+                                        <li>
+                                          an 
+                                          <em>
+                                            exact
+                                          </em>
+                                           decimal, like 
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              0.75
+                                            </span>
+                                            <span />
+                                          </span>
+                                        </li>
+                                        <li>
+                                          a multiple of pi, like 
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              12\\ \\text{pi}
+                                            </span>
+                                            <span />
+                                          </span>
+                                           or 
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              2/3\\ \\text{pi}
+                                            </span>
+                                            <span />
+                                          </span>
+                                        </li>
+                                      </ul>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <p
+                aria-live="polite"
+                role="status"
+              />
+              <button
+                aria-disabled="false"
+                class="button_vr44p2-o_O-shared_lwskrm-o_O-default_1w5v67"
+                role="button"
+                type="button"
+              >
+                <span
+                  class="text_f1191h-o_O-LabelLarge_5s82ln-o_O-text_m8a8ki"
+                >
+                  Check
+                </span>
+              </button>
+              <button
+                class="showHintLink_oak3yy"
+                tabindex="0"
+              >
+                Explain
+              </button>
             </div>
           </div>
         </div>
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="2"
       >
-        <div
-          class="paragraph"
-        >
-          Beautiful, let's move on to problems with whole numbers and tenths.
-        </div>
+        Beautiful, let's move on to problems with whole numbers and tenths.
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group-set.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group-set.test.ts.snap
@@ -2,319 +2,307 @@
 
 exports[`graded group widget should snapshot 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
+    >
+      <h1>
+        Section 1: Adding tenths less than one
+      </h1>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
-      >
-        <h1>
-          Section 1: Adding tenths less than one
-        </h1>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="1"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+            class="container_14sgdtb"
           >
             <div
-              class="container_14sgdtb"
+              class="top_cjo0m2"
             >
               <div
-                class="top_cjo0m2"
+                class="title_vo78fw"
               >
-                <div
-                  class="title_vo78fw"
-                >
-                  Problem 1a
-                </div>
-                <div
-                  class="spacer_bc4egv"
-                />
-                <ul
-                  class="indicatorContainer_rjg7c2"
-                >
-                  <li
-                    aria-label="Skip to Problem 1a"
-                    class="indicator_qk5jgn-o_O-selectedIndicator_14jsc6v"
-                    role="button"
-                    tabindex="0"
-                  >
-                    <span
-                      class="srOnly_19bpjuy"
-                    >
-                      Current
-                    </span>
-                  </li>
-                  <li
-                    aria-label="Skip to Problem 1b"
-                    class="indicator_qk5jgn"
-                    role="button"
-                    tabindex="0"
-                  />
-                  <li
-                    aria-label="Skip to Problem 1c"
-                    class="indicator_qk5jgn"
-                    role="button"
-                    tabindex="0"
-                  />
-                </ul>
+                Problem 1a
               </div>
               <div
-                class="perseus-graded-group"
+                class="spacer_bc4egv"
+              />
+              <ul
+                class="indicatorContainer_rjg7c2"
               >
-                <span
-                  class="mock-KatexProvider"
+                <li
+                  aria-label="Skip to Problem 1a"
+                  class="indicator_qk5jgn-o_O-selectedIndicator_14jsc6v"
+                  role="button"
+                  tabindex="0"
+                >
+                  <span
+                    class="srOnly_19bpjuy"
+                  >
+                    Current
+                  </span>
+                </li>
+                <li
+                  aria-label="Skip to Problem 1b"
+                  class="indicator_qk5jgn"
+                  role="button"
+                  tabindex="0"
+                />
+                <li
+                  aria-label="Skip to Problem 1c"
+                  class="indicator_qk5jgn"
+                  role="button"
+                  tabindex="0"
+                />
+              </ul>
+            </div>
+            <div
+              class="perseus-graded-group"
+            >
+              <div
+                class="perseus-renderer perseus-renderer-responsive"
+              >
+                <div
+                  class="paragraph"
+                  data-perseus-paragraph-index="0"
                 >
                   <div
-                    class="perseus-renderer perseus-renderer-responsive"
+                    class="paragraph"
                   >
-                    <div
-                      class="paragraph"
-                      data-perseus-paragraph-index="0"
+                    <span
+                      style="white-space: nowrap;"
                     >
-                      <div
-                        class="paragraph"
+                      <span />
+                      <span
+                        class="mock-TeX"
                       >
-                        <span
-                          style="white-space: nowrap;"
-                        >
-                          <span />
-                          <span
-                            class="mock-TeX"
-                          >
-                            0.5 + 0.4 =
-                          </span>
-                          <span />
-                        </span>
-                           
-                        <div
-                          class="perseus-widget-container widget-nohighlight widget-inline-block"
-                        >
+                        0.5 + 0.4 =
+                      </span>
+                      <span />
+                    </span>
+                       
+                    <div
+                      class="perseus-widget-container widget-nohighlight widget-inline-block"
+                    >
+                      <div>
+                        <span>
                           <div>
-                            <span>
-                              <div>
-                                <input
-                                  aria-label="Your answer:"
-                                  autocapitalize="off"
-                                  autocomplete="off"
-                                  autocorrect="off"
-                                  class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_19vw1dn"
-                                  id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
-                                  type="text"
-                                  value=""
+                            <input
+                              aria-label="Your answer:"
+                              autocapitalize="off"
+                              autocomplete="off"
+                              autocorrect="off"
+                              class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_19vw1dn"
+                              id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                              type="text"
+                              value=""
+                            />
+                          </div>
+                          <div
+                            style="position: relative; height: 0px; display: none;"
+                          >
+                            <div
+                              class="tooltipContainer"
+                              style="position: absolute; left: 0px;"
+                            >
+                              <div
+                                style="display: block; position: relative; visibility: visible; left: 0px; top: -1px; width: 12px; height: 11px; margin-top: -1px; margin-bottom: -2px; z-index: 10;"
+                              >
+                                <div
+                                  style="display: block; height: 0px; width: 0px; position: absolute; left: 0px; top: -1px; border-right: 12px solid transparent; border-bottom: 12px solid #ccc;"
+                                />
+                                <div
+                                  style="display: block; height: 0px; width: 0px; position: absolute; left: 1px; top: 1px; border-right: 10px solid transparent; border-bottom: 10px solid white;"
                                 />
                               </div>
                               <div
-                                style="position: relative; height: 0px; display: none;"
+                                class="perseus-formats-tooltip preview-measure"
+                                style="position: relative; top: 0px; left: 0px; border: 1px solid #ccc; box-shadow: 0 1px 3px #ccc; z-index: 9;"
                               >
                                 <div
-                                  class="tooltipContainer"
-                                  style="position: absolute; left: 0px;"
+                                  id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
                                 >
                                   <div
-                                    style="display: block; position: relative; visibility: visible; left: 0px; top: -1px; width: 12px; height: 11px; margin-top: -1px; margin-bottom: -2px; z-index: 10;"
+                                    class="perseus-renderer perseus-renderer-responsive"
                                   >
                                     <div
-                                      style="display: block; height: 0px; width: 0px; position: absolute; left: 0px; top: -1px; border-right: 12px solid transparent; border-bottom: 12px solid #ccc;"
-                                    />
-                                    <div
-                                      style="display: block; height: 0px; width: 0px; position: absolute; left: 1px; top: 1px; border-right: 10px solid transparent; border-bottom: 10px solid white;"
-                                    />
-                                  </div>
-                                  <div
-                                    class="perseus-formats-tooltip preview-measure"
-                                    style="position: relative; top: 0px; left: 0px; border: 1px solid #ccc; box-shadow: 0 1px 3px #ccc; z-index: 9;"
-                                  >
-                                    <div
-                                      id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                                      class="paragraph"
+                                      data-perseus-paragraph-index="0"
                                     >
-                                      <span
-                                        class="mock-KatexProvider"
-                                      >
-                                        <div
-                                          class="perseus-renderer perseus-renderer-responsive"
-                                        >
-                                          <div
-                                            class="paragraph"
-                                            data-perseus-paragraph-index="0"
+                                      <ul>
+                                        <li>
+                                          <strong>
+                                            Your answer should be
+                                          </strong>
+                                        </li>
+                                        <li>
+                                          an integer, like 
+                                          <span
+                                            style="white-space: nowrap;"
                                           >
-                                            <ul>
-                                              <li>
-                                                <strong>
-                                                  Your answer should be
-                                                </strong>
-                                              </li>
-                                              <li>
-                                                an integer, like 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    6
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                              </li>
-                                              <li>
-                                                a 
-                                                <em>
-                                                  simplified proper
-                                                </em>
-                                                 fraction, like 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    3/5
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                              </li>
-                                              <li>
-                                                a 
-                                                <em>
-                                                  simplified improper
-                                                </em>
-                                                 fraction, like 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    7/4
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                              </li>
-                                              <li>
-                                                a mixed number, like 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    1\\ 3/4
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                              </li>
-                                              <li>
-                                                an 
-                                                <em>
-                                                  exact
-                                                </em>
-                                                 decimal, like 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    0.75
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                              </li>
-                                              <li>
-                                                a multiple of pi, like 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    12\\ \\text{pi}
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                                 or 
-                                                <span
-                                                  style="white-space: nowrap;"
-                                                >
-                                                  <span />
-                                                  <span
-                                                    class="mock-TeX"
-                                                  >
-                                                    2/3\\ \\text{pi}
-                                                  </span>
-                                                  <span />
-                                                </span>
-                                              </li>
-                                            </ul>
-                                          </div>
-                                        </div>
-                                      </span>
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              6
+                                            </span>
+                                            <span />
+                                          </span>
+                                        </li>
+                                        <li>
+                                          a 
+                                          <em>
+                                            simplified proper
+                                          </em>
+                                           fraction, like 
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              3/5
+                                            </span>
+                                            <span />
+                                          </span>
+                                        </li>
+                                        <li>
+                                          a 
+                                          <em>
+                                            simplified improper
+                                          </em>
+                                           fraction, like 
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              7/4
+                                            </span>
+                                            <span />
+                                          </span>
+                                        </li>
+                                        <li>
+                                          a mixed number, like 
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              1\\ 3/4
+                                            </span>
+                                            <span />
+                                          </span>
+                                        </li>
+                                        <li>
+                                          an 
+                                          <em>
+                                            exact
+                                          </em>
+                                           decimal, like 
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              0.75
+                                            </span>
+                                            <span />
+                                          </span>
+                                        </li>
+                                        <li>
+                                          a multiple of pi, like 
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              12\\ \\text{pi}
+                                            </span>
+                                            <span />
+                                          </span>
+                                           or 
+                                          <span
+                                            style="white-space: nowrap;"
+                                          >
+                                            <span />
+                                            <span
+                                              class="mock-TeX"
+                                            >
+                                              2/3\\ \\text{pi}
+                                            </span>
+                                            <span />
+                                          </span>
+                                        </li>
+                                      </ul>
                                     </div>
                                   </div>
                                 </div>
                               </div>
-                            </span>
+                            </div>
                           </div>
-                        </div>
+                        </span>
                       </div>
                     </div>
                   </div>
-                </span>
-                <p
-                  aria-live="polite"
-                  role="status"
-                />
-                <button
-                  aria-disabled="false"
-                  class="button_vr44p2-o_O-shared_lwskrm-o_O-default_1w5v67"
-                  role="button"
-                  type="button"
-                >
-                  <span
-                    class="text_f1191h-o_O-LabelLarge_5s82ln-o_O-text_m8a8ki"
-                  >
-                    Check
-                  </span>
-                </button>
-                <button
-                  class="showHintLink_oak3yy"
-                  tabindex="0"
-                >
-                  Explain
-                </button>
+                </div>
               </div>
+              <p
+                aria-live="polite"
+                role="status"
+              />
+              <button
+                aria-disabled="false"
+                class="button_vr44p2-o_O-shared_lwskrm-o_O-default_1w5v67"
+                role="button"
+                type="button"
+              >
+                <span
+                  class="text_f1191h-o_O-LabelLarge_5s82ln-o_O-text_m8a8ki"
+                >
+                  Check
+                </span>
+              </button>
+              <button
+                class="showHintLink_oak3yy"
+                tabindex="0"
+              >
+                Explain
+              </button>
             </div>
           </div>
         </div>
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="2"
       >
-        <div
-          class="paragraph"
-        >
-          Beautiful, let's move on to problems with whole numbers and tenths.
-        </div>
+        Beautiful, let's move on to problems with whole numbers and tenths.
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group.test.ts.snap
@@ -2,864 +2,800 @@
 
 exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph perseus-paragraph-centered"
+      data-perseus-paragraph-index="0"
+    >
+      <hr />
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
+      <h2>
+        Check your understanding!
+      </h2>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
     >
       <div
-        class="paragraph perseus-paragraph-centered"
-        data-perseus-paragraph-index="0"
-      >
-        <hr />
-      </div>
-      <div
         class="paragraph"
-        data-perseus-paragraph-index="1"
-      >
-        <h2>
-          Check your understanding!
-        </h2>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="2"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+            class="perseus-graded-group"
           >
             <div
-              class="perseus-graded-group"
+              class="title_1lagzkb"
+            >
+              Metabolic strategies of bacteria
+            </div>
+            <div
+              class="perseus-renderer perseus-renderer-responsive"
             >
               <div
-                class="title_1lagzkb"
+                class="paragraph"
+                data-perseus-paragraph-index="0"
               >
-                Metabolic strategies of bacteria
-              </div>
-              <span
-                class="mock-KatexProvider"
-              >
-                <div
-                  class="perseus-renderer perseus-renderer-responsive"
+                <ol
+                  start="1"
                 >
-                  <div
-                    class="paragraph"
-                    data-perseus-paragraph-index="0"
-                  >
-                    <ol
-                      start="1"
+                  <li>
+                    <div
+                      class="paragraph"
                     >
-                      <li>
+                      <strong>
+                        Which of the following statements about metabolic strategies of bacteria are true?
+                      </strong>
+                    </div>
+                    <div
+                      class="paragraph"
+                    >
+                      <div
+                        class="perseus-widget-container widget-nohighlight widget-block"
+                      >
                         <div
-                          class="paragraph"
+                          class="categorizer-container "
                         >
-                          <strong>
-                            Which of the following statements about metabolic strategies of bacteria are true?
-                          </strong>
-                        </div>
-                        <div
-                          class="paragraph"
-                        >
-                          <div
-                            class="perseus-widget-container widget-nohighlight widget-block"
+                          <table
+                            class="categorizer-table mobileTable_1wmcwov"
                           >
-                            <div
-                              class="categorizer-container "
-                            >
-                              <table
-                                class="categorizer-table mobileTable_1wmcwov"
-                              >
-                                <thead>
-                                  <tr>
-                                    <td
-                                      class="emptyHeaderCell_1mttrgd"
-                                    />
-                                    <th
-                                      class="header_whrfk4"
-                                    >
-                                      <span
-                                        class="mock-KatexProvider"
-                                      >
-                                        <div
-                                          class="perseus-renderer perseus-renderer-responsive"
-                                        >
-                                          <div
-                                            class="paragraph"
-                                            data-perseus-paragraph-index="0"
-                                          >
-                                            <div
-                                              class="paragraph"
-                                            >
-                                              True
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </span>
-                                    </th>
-                                    <th
-                                      class="header_whrfk4"
-                                    >
-                                      <span
-                                        class="mock-KatexProvider"
-                                      >
-                                        <div
-                                          class="perseus-renderer perseus-renderer-responsive"
-                                        >
-                                          <div
-                                            class="paragraph"
-                                            data-perseus-paragraph-index="0"
-                                          >
-                                            <div
-                                              class="paragraph"
-                                            >
-                                              False
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </span>
-                                    </th>
-                                  </tr>
-                                </thead>
-                                <tbody>
-                                  <tr>
-                                    <td>
-                                      <span
-                                        class="mock-KatexProvider"
-                                      >
-                                        <div
-                                          class="perseus-renderer perseus-renderer-responsive"
-                                        >
-                                          <div
-                                            class="paragraph"
-                                            data-perseus-paragraph-index="0"
-                                          >
-                                            <div
-                                              class="paragraph"
-                                            >
-                                               Some bacteria conduct photosynthesis and produce oxygen, much like plants.
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </span>
-                                    </td>
-                                    <td
-                                      class="category cell_13aakpm"
-                                    >
-                                      <div
-                                        aria-label="True"
-                                        class="perseus-interactive"
-                                        role="button"
-                                      >
-                                        <span
-                                          class="radioSpan_1mq3xs9"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            height="1em"
-                                            role="img"
-                                            style="vertical-align: middle;"
-                                            viewBox="0 0 100 99.944"
-                                            width="1.0005603137757144em"
-                                          >
-                                            <path
-                                              d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
-                                              fill="currentColor"
-                                            />
-                                          </svg>
-                                        </span>
-                                      </div>
-                                    </td>
-                                    <td
-                                      class="category cell_13aakpm"
-                                    >
-                                      <div
-                                        aria-label="False"
-                                        class="perseus-interactive"
-                                        role="button"
-                                      >
-                                        <span
-                                          class="radioSpan_1mq3xs9"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            height="1em"
-                                            role="img"
-                                            style="vertical-align: middle;"
-                                            viewBox="0 0 100 99.944"
-                                            width="1.0005603137757144em"
-                                          >
-                                            <path
-                                              d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
-                                              fill="currentColor"
-                                            />
-                                          </svg>
-                                        </span>
-                                      </div>
-                                    </td>
-                                  </tr>
-                                  <tr>
-                                    <td>
-                                      <span
-                                        class="mock-KatexProvider"
-                                      >
-                                        <div
-                                          class="perseus-renderer perseus-renderer-responsive"
-                                        >
-                                          <div
-                                            class="paragraph"
-                                            data-perseus-paragraph-index="0"
-                                          >
-                                            <div
-                                              class="paragraph"
-                                            >
-                                              Bacteria are always autotrophic but they may get energy from either light or chemical sources.
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </span>
-                                    </td>
-                                    <td
-                                      class="category cell_13aakpm"
-                                    >
-                                      <div
-                                        aria-label="True"
-                                        class="perseus-interactive"
-                                        role="button"
-                                      >
-                                        <span
-                                          class="radioSpan_1mq3xs9"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            height="1em"
-                                            role="img"
-                                            style="vertical-align: middle;"
-                                            viewBox="0 0 100 99.944"
-                                            width="1.0005603137757144em"
-                                          >
-                                            <path
-                                              d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
-                                              fill="currentColor"
-                                            />
-                                          </svg>
-                                        </span>
-                                      </div>
-                                    </td>
-                                    <td
-                                      class="category cell_13aakpm"
-                                    >
-                                      <div
-                                        aria-label="False"
-                                        class="perseus-interactive"
-                                        role="button"
-                                      >
-                                        <span
-                                          class="radioSpan_1mq3xs9"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            height="1em"
-                                            role="img"
-                                            style="vertical-align: middle;"
-                                            viewBox="0 0 100 99.944"
-                                            width="1.0005603137757144em"
-                                          >
-                                            <path
-                                              d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
-                                              fill="currentColor"
-                                            />
-                                          </svg>
-                                        </span>
-                                      </div>
-                                    </td>
-                                  </tr>
-                                  <tr>
-                                    <td>
-                                      <span
-                                        class="mock-KatexProvider"
-                                      >
-                                        <div
-                                          class="perseus-renderer perseus-renderer-responsive"
-                                        >
-                                          <div
-                                            class="paragraph"
-                                            data-perseus-paragraph-index="0"
-                                          >
-                                            <div
-                                              class="paragraph"
-                                            >
-                                              Some chemosynthetic bacteria introduce energy and fixed carbon into communities where photosynthesis is not possible (e.g., deep-sea vents).
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </span>
-                                    </td>
-                                    <td
-                                      class="category cell_13aakpm"
-                                    >
-                                      <div
-                                        aria-label="True"
-                                        class="perseus-interactive"
-                                        role="button"
-                                      >
-                                        <span
-                                          class="radioSpan_1mq3xs9"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            height="1em"
-                                            role="img"
-                                            style="vertical-align: middle;"
-                                            viewBox="0 0 100 99.944"
-                                            width="1.0005603137757144em"
-                                          >
-                                            <path
-                                              d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
-                                              fill="currentColor"
-                                            />
-                                          </svg>
-                                        </span>
-                                      </div>
-                                    </td>
-                                    <td
-                                      class="category cell_13aakpm"
-                                    >
-                                      <div
-                                        aria-label="False"
-                                        class="perseus-interactive"
-                                        role="button"
-                                      >
-                                        <span
-                                          class="radioSpan_1mq3xs9"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            height="1em"
-                                            role="img"
-                                            style="vertical-align: middle;"
-                                            viewBox="0 0 100 99.944"
-                                            width="1.0005603137757144em"
-                                          >
-                                            <path
-                                              d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
-                                              fill="currentColor"
-                                            />
-                                          </svg>
-                                        </span>
-                                      </div>
-                                    </td>
-                                  </tr>
-                                  <tr>
-                                    <td>
-                                      <span
-                                        class="mock-KatexProvider"
-                                      >
-                                        <div
-                                          class="perseus-renderer perseus-renderer-responsive"
-                                        >
-                                          <div
-                                            class="paragraph"
-                                            data-perseus-paragraph-index="0"
-                                          >
-                                            <div
-                                              class="paragraph"
-                                            >
-                                              Some bacteria live symbiotically inside of host organisms and provide the host with nutrients.
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </span>
-                                    </td>
-                                    <td
-                                      class="category cell_13aakpm"
-                                    >
-                                      <div
-                                        aria-label="True"
-                                        class="perseus-interactive"
-                                        role="button"
-                                      >
-                                        <span
-                                          class="radioSpan_1mq3xs9"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            height="1em"
-                                            role="img"
-                                            style="vertical-align: middle;"
-                                            viewBox="0 0 100 99.944"
-                                            width="1.0005603137757144em"
-                                          >
-                                            <path
-                                              d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
-                                              fill="currentColor"
-                                            />
-                                          </svg>
-                                        </span>
-                                      </div>
-                                    </td>
-                                    <td
-                                      class="category cell_13aakpm"
-                                    >
-                                      <div
-                                        aria-label="False"
-                                        class="perseus-interactive"
-                                        role="button"
-                                      >
-                                        <span
-                                          class="radioSpan_1mq3xs9"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            height="1em"
-                                            role="img"
-                                            style="vertical-align: middle;"
-                                            viewBox="0 0 100 99.944"
-                                            width="1.0005603137757144em"
-                                          >
-                                            <path
-                                              d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
-                                              fill="currentColor"
-                                            />
-                                          </svg>
-                                        </span>
-                                      </div>
-                                    </td>
-                                  </tr>
-                                </tbody>
-                              </table>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="paragraph"
-                        >
-                          <div
-                            class="perseus-widget-container widget-nohighlight widget-inline"
-                          >
-                            <div
-                              class="container_167wsvl"
-                            >
-                              <div
-                                class="linkContainer_36rlri-o_O-exerciseLink_574wt1"
-                              >
-                                <a
-                                  aria-expanded="false"
-                                  class="explanationLink_7n4oib"
-                                  href="javascript:void(0)"
-                                  role="button"
+                            <thead>
+                              <tr>
+                                <td
+                                  class="emptyHeaderCell_1mttrgd"
+                                />
+                                <th
+                                  class="header_whrfk4"
                                 >
-                                  [Hint]
-                                </a>
-                              </div>
-                            </div>
+                                  <div
+                                    class="perseus-renderer perseus-renderer-responsive"
+                                  >
+                                    <div
+                                      class="paragraph"
+                                      data-perseus-paragraph-index="0"
+                                    >
+                                      <div
+                                        class="paragraph"
+                                      >
+                                        True
+                                      </div>
+                                    </div>
+                                  </div>
+                                </th>
+                                <th
+                                  class="header_whrfk4"
+                                >
+                                  <div
+                                    class="perseus-renderer perseus-renderer-responsive"
+                                  >
+                                    <div
+                                      class="paragraph"
+                                      data-perseus-paragraph-index="0"
+                                    >
+                                      <div
+                                        class="paragraph"
+                                      >
+                                        False
+                                      </div>
+                                    </div>
+                                  </div>
+                                </th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              <tr>
+                                <td>
+                                  <div
+                                    class="perseus-renderer perseus-renderer-responsive"
+                                  >
+                                    <div
+                                      class="paragraph"
+                                      data-perseus-paragraph-index="0"
+                                    >
+                                      <div
+                                        class="paragraph"
+                                      >
+                                         Some bacteria conduct photosynthesis and produce oxygen, much like plants.
+                                      </div>
+                                    </div>
+                                  </div>
+                                </td>
+                                <td
+                                  class="category cell_13aakpm"
+                                >
+                                  <div
+                                    aria-label="True"
+                                    class="perseus-interactive"
+                                    role="button"
+                                  >
+                                    <span
+                                      class="radioSpan_1mq3xs9"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        height="1em"
+                                        role="img"
+                                        style="vertical-align: middle;"
+                                        viewBox="0 0 100 99.944"
+                                        width="1.0005603137757144em"
+                                      >
+                                        <path
+                                          d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
+                                          fill="currentColor"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </td>
+                                <td
+                                  class="category cell_13aakpm"
+                                >
+                                  <div
+                                    aria-label="False"
+                                    class="perseus-interactive"
+                                    role="button"
+                                  >
+                                    <span
+                                      class="radioSpan_1mq3xs9"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        height="1em"
+                                        role="img"
+                                        style="vertical-align: middle;"
+                                        viewBox="0 0 100 99.944"
+                                        width="1.0005603137757144em"
+                                      >
+                                        <path
+                                          d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
+                                          fill="currentColor"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td>
+                                  <div
+                                    class="perseus-renderer perseus-renderer-responsive"
+                                  >
+                                    <div
+                                      class="paragraph"
+                                      data-perseus-paragraph-index="0"
+                                    >
+                                      <div
+                                        class="paragraph"
+                                      >
+                                        Bacteria are always autotrophic but they may get energy from either light or chemical sources.
+                                      </div>
+                                    </div>
+                                  </div>
+                                </td>
+                                <td
+                                  class="category cell_13aakpm"
+                                >
+                                  <div
+                                    aria-label="True"
+                                    class="perseus-interactive"
+                                    role="button"
+                                  >
+                                    <span
+                                      class="radioSpan_1mq3xs9"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        height="1em"
+                                        role="img"
+                                        style="vertical-align: middle;"
+                                        viewBox="0 0 100 99.944"
+                                        width="1.0005603137757144em"
+                                      >
+                                        <path
+                                          d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
+                                          fill="currentColor"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </td>
+                                <td
+                                  class="category cell_13aakpm"
+                                >
+                                  <div
+                                    aria-label="False"
+                                    class="perseus-interactive"
+                                    role="button"
+                                  >
+                                    <span
+                                      class="radioSpan_1mq3xs9"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        height="1em"
+                                        role="img"
+                                        style="vertical-align: middle;"
+                                        viewBox="0 0 100 99.944"
+                                        width="1.0005603137757144em"
+                                      >
+                                        <path
+                                          d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
+                                          fill="currentColor"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td>
+                                  <div
+                                    class="perseus-renderer perseus-renderer-responsive"
+                                  >
+                                    <div
+                                      class="paragraph"
+                                      data-perseus-paragraph-index="0"
+                                    >
+                                      <div
+                                        class="paragraph"
+                                      >
+                                        Some chemosynthetic bacteria introduce energy and fixed carbon into communities where photosynthesis is not possible (e.g., deep-sea vents).
+                                      </div>
+                                    </div>
+                                  </div>
+                                </td>
+                                <td
+                                  class="category cell_13aakpm"
+                                >
+                                  <div
+                                    aria-label="True"
+                                    class="perseus-interactive"
+                                    role="button"
+                                  >
+                                    <span
+                                      class="radioSpan_1mq3xs9"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        height="1em"
+                                        role="img"
+                                        style="vertical-align: middle;"
+                                        viewBox="0 0 100 99.944"
+                                        width="1.0005603137757144em"
+                                      >
+                                        <path
+                                          d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
+                                          fill="currentColor"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </td>
+                                <td
+                                  class="category cell_13aakpm"
+                                >
+                                  <div
+                                    aria-label="False"
+                                    class="perseus-interactive"
+                                    role="button"
+                                  >
+                                    <span
+                                      class="radioSpan_1mq3xs9"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        height="1em"
+                                        role="img"
+                                        style="vertical-align: middle;"
+                                        viewBox="0 0 100 99.944"
+                                        width="1.0005603137757144em"
+                                      >
+                                        <path
+                                          d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
+                                          fill="currentColor"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td>
+                                  <div
+                                    class="perseus-renderer perseus-renderer-responsive"
+                                  >
+                                    <div
+                                      class="paragraph"
+                                      data-perseus-paragraph-index="0"
+                                    >
+                                      <div
+                                        class="paragraph"
+                                      >
+                                        Some bacteria live symbiotically inside of host organisms and provide the host with nutrients.
+                                      </div>
+                                    </div>
+                                  </div>
+                                </td>
+                                <td
+                                  class="category cell_13aakpm"
+                                >
+                                  <div
+                                    aria-label="True"
+                                    class="perseus-interactive"
+                                    role="button"
+                                  >
+                                    <span
+                                      class="radioSpan_1mq3xs9"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        height="1em"
+                                        role="img"
+                                        style="vertical-align: middle;"
+                                        viewBox="0 0 100 99.944"
+                                        width="1.0005603137757144em"
+                                      >
+                                        <path
+                                          d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
+                                          fill="currentColor"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </td>
+                                <td
+                                  class="category cell_13aakpm"
+                                >
+                                  <div
+                                    aria-label="False"
+                                    class="perseus-interactive"
+                                    role="button"
+                                  >
+                                    <span
+                                      class="radioSpan_1mq3xs9"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        height="1em"
+                                        role="img"
+                                        style="vertical-align: middle;"
+                                        viewBox="0 0 100 99.944"
+                                        width="1.0005603137757144em"
+                                      >
+                                        <path
+                                          d="M50.046 8.322q-8.493 0-16.188 3.306-15.561 6.669-22.173 22.23-3.363 7.695-3.363 16.188t3.306 16.188 8.949 13.281q5.586 5.586 13.281 8.892t16.188 3.306 16.188-3.306 13.281-8.892 8.892-13.281 3.306-16.188-3.306-16.188-8.892-13.281-13.281-8.949q-7.695-3.306-16.188-3.306zm0 91.713q-13.623 0-25.137-6.726t-18.183-18.183q-6.726-11.571-6.726-25.137t6.726-25.08 18.24-18.24 25.08-6.669q13.566 0 25.08 6.726 11.514 6.669 18.24 18.183t6.726 25.137-6.726 25.137-18.24 18.126q-11.514 6.726-25.08 6.726z"
+                                          fill="currentColor"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="paragraph"
+                    >
+                      <div
+                        class="perseus-widget-container widget-nohighlight widget-inline"
+                      >
+                        <div
+                          class="container_167wsvl"
+                        >
+                          <div
+                            class="linkContainer_36rlri-o_O-exerciseLink_574wt1"
+                          >
+                            <a
+                              aria-expanded="false"
+                              class="explanationLink_7n4oib"
+                              href="javascript:void(0)"
+                              role="button"
+                            >
+                              [Hint]
+                            </a>
                           </div>
                         </div>
-                      </li>
-                    </ol>
-                  </div>
-                </div>
-              </span>
-              <p
-                aria-live="polite"
-                role="status"
-              />
-              <button
-                aria-disabled="false"
-                class="button_vr44p2-o_O-shared_lwskrm-o_O-default_1w5v67"
-                role="button"
-                type="button"
-              >
-                <span
-                  class="text_f1191h-o_O-LabelLarge_5s82ln-o_O-text_m8a8ki"
-                >
-                  Check
-                </span>
-              </button>
+                      </div>
+                    </div>
+                  </li>
+                </ol>
+              </div>
             </div>
+            <p
+              aria-live="polite"
+              role="status"
+            />
+            <button
+              aria-disabled="false"
+              class="button_vr44p2-o_O-shared_lwskrm-o_O-default_1w5v67"
+              role="button"
+              type="button"
+            >
+              <span
+                class="text_f1191h-o_O-LabelLarge_5s82ln-o_O-text_m8a8ki"
+              >
+                Check
+              </span>
+            </button>
           </div>
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph perseus-paragraph-centered"
+      data-perseus-paragraph-index="0"
+    >
+      <hr />
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
+      <h2>
+        Check your understanding!
+      </h2>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
     >
       <div
-        class="paragraph perseus-paragraph-centered"
-        data-perseus-paragraph-index="0"
-      >
-        <hr />
-      </div>
-      <div
         class="paragraph"
-        data-perseus-paragraph-index="1"
-      >
-        <h2>
-          Check your understanding!
-        </h2>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="2"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+            class="gradedGroup_14sgdtb perseus-graded-group"
           >
             <div
-              class="gradedGroup_14sgdtb perseus-graded-group"
+              class="title_1lagzkb"
+            >
+              Metabolic strategies of bacteria
+            </div>
+            <div
+              class="perseus-renderer perseus-renderer-responsive"
             >
               <div
-                class="title_1lagzkb"
+                class="paragraph"
+                data-perseus-paragraph-index="0"
               >
-                Metabolic strategies of bacteria
-              </div>
-              <span
-                class="mock-KatexProvider"
-              >
-                <div
-                  class="perseus-renderer perseus-renderer-responsive"
+                <ol
+                  start="1"
                 >
-                  <div
-                    class="paragraph"
-                    data-perseus-paragraph-index="0"
-                  >
-                    <ol
-                      start="1"
+                  <li>
+                    <div
+                      class="paragraph"
                     >
-                      <li>
+                      <strong>
+                        Which of the following statements about metabolic strategies of bacteria are true?
+                      </strong>
+                    </div>
+                    <div
+                      class="paragraph"
+                    >
+                      <div
+                        class="perseus-widget-container widget-nohighlight widget-block"
+                      >
                         <div
-                          class="paragraph"
+                          class="categorizer-container fullBleedContainer_8ybp6"
                         >
-                          <strong>
-                            Which of the following statements about metabolic strategies of bacteria are true?
-                          </strong>
-                        </div>
-                        <div
-                          class="paragraph"
-                        >
-                          <div
-                            class="perseus-widget-container widget-nohighlight widget-block"
+                          <table
+                            class="categorizer-table mobileTable_1wmcwov"
                           >
-                            <div
-                              class="categorizer-container fullBleedContainer_8ybp6"
-                            >
-                              <table
-                                class="categorizer-table mobileTable_1wmcwov"
-                              >
-                                <thead>
-                                  <tr>
-                                    <td
-                                      class="emptyHeaderCell_1mttrgd"
-                                    />
-                                    <th
-                                      class="header_whrfk4"
-                                    >
-                                      <span
-                                        class="mock-KatexProvider"
-                                      >
-                                        <div
-                                          class="perseus-renderer perseus-renderer-responsive"
-                                        >
-                                          <div
-                                            class="paragraph"
-                                            data-perseus-paragraph-index="0"
-                                          >
-                                            <div
-                                              class="paragraph"
-                                            >
-                                              True
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </span>
-                                    </th>
-                                    <th
-                                      class="header_whrfk4"
-                                    >
-                                      <span
-                                        class="mock-KatexProvider"
-                                      >
-                                        <div
-                                          class="perseus-renderer perseus-renderer-responsive"
-                                        >
-                                          <div
-                                            class="paragraph"
-                                            data-perseus-paragraph-index="0"
-                                          >
-                                            <div
-                                              class="paragraph"
-                                            >
-                                              False
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </span>
-                                    </th>
-                                  </tr>
-                                </thead>
-                                <tbody>
-                                  <tr>
-                                    <td>
-                                      <span
-                                        class="mock-KatexProvider"
-                                      >
-                                        <div
-                                          class="perseus-renderer perseus-renderer-responsive"
-                                        >
-                                          <div
-                                            class="paragraph"
-                                            data-perseus-paragraph-index="0"
-                                          >
-                                            <div
-                                              class="paragraph"
-                                            >
-                                               Some bacteria conduct photosynthesis and produce oxygen, much like plants.
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </span>
-                                    </td>
-                                    <td
-                                      class="category cell_13aakpm"
-                                    >
-                                      <div
-                                        aria-label="True"
-                                        class="perseus-interactive"
-                                        role="button"
-                                      >
-                                        <input
-                                          class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
-                                          name="perseus_radio_9_0"
-                                          type="radio"
-                                        />
-                                      </div>
-                                    </td>
-                                    <td
-                                      class="category cell_13aakpm"
-                                    >
-                                      <div
-                                        aria-label="False"
-                                        class="perseus-interactive"
-                                        role="button"
-                                      >
-                                        <input
-                                          class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
-                                          name="perseus_radio_9_0"
-                                          type="radio"
-                                        />
-                                      </div>
-                                    </td>
-                                  </tr>
-                                  <tr>
-                                    <td>
-                                      <span
-                                        class="mock-KatexProvider"
-                                      >
-                                        <div
-                                          class="perseus-renderer perseus-renderer-responsive"
-                                        >
-                                          <div
-                                            class="paragraph"
-                                            data-perseus-paragraph-index="0"
-                                          >
-                                            <div
-                                              class="paragraph"
-                                            >
-                                              Bacteria are always autotrophic but they may get energy from either light or chemical sources.
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </span>
-                                    </td>
-                                    <td
-                                      class="category cell_13aakpm"
-                                    >
-                                      <div
-                                        aria-label="True"
-                                        class="perseus-interactive"
-                                        role="button"
-                                      >
-                                        <input
-                                          class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
-                                          name="perseus_radio_9_1"
-                                          type="radio"
-                                        />
-                                      </div>
-                                    </td>
-                                    <td
-                                      class="category cell_13aakpm"
-                                    >
-                                      <div
-                                        aria-label="False"
-                                        class="perseus-interactive"
-                                        role="button"
-                                      >
-                                        <input
-                                          class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
-                                          name="perseus_radio_9_1"
-                                          type="radio"
-                                        />
-                                      </div>
-                                    </td>
-                                  </tr>
-                                  <tr>
-                                    <td>
-                                      <span
-                                        class="mock-KatexProvider"
-                                      >
-                                        <div
-                                          class="perseus-renderer perseus-renderer-responsive"
-                                        >
-                                          <div
-                                            class="paragraph"
-                                            data-perseus-paragraph-index="0"
-                                          >
-                                            <div
-                                              class="paragraph"
-                                            >
-                                              Some chemosynthetic bacteria introduce energy and fixed carbon into communities where photosynthesis is not possible (e.g., deep-sea vents).
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </span>
-                                    </td>
-                                    <td
-                                      class="category cell_13aakpm"
-                                    >
-                                      <div
-                                        aria-label="True"
-                                        class="perseus-interactive"
-                                        role="button"
-                                      >
-                                        <input
-                                          class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
-                                          name="perseus_radio_9_2"
-                                          type="radio"
-                                        />
-                                      </div>
-                                    </td>
-                                    <td
-                                      class="category cell_13aakpm"
-                                    >
-                                      <div
-                                        aria-label="False"
-                                        class="perseus-interactive"
-                                        role="button"
-                                      >
-                                        <input
-                                          class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
-                                          name="perseus_radio_9_2"
-                                          type="radio"
-                                        />
-                                      </div>
-                                    </td>
-                                  </tr>
-                                  <tr>
-                                    <td>
-                                      <span
-                                        class="mock-KatexProvider"
-                                      >
-                                        <div
-                                          class="perseus-renderer perseus-renderer-responsive"
-                                        >
-                                          <div
-                                            class="paragraph"
-                                            data-perseus-paragraph-index="0"
-                                          >
-                                            <div
-                                              class="paragraph"
-                                            >
-                                              Some bacteria live symbiotically inside of host organisms and provide the host with nutrients.
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </span>
-                                    </td>
-                                    <td
-                                      class="category cell_13aakpm"
-                                    >
-                                      <div
-                                        aria-label="True"
-                                        class="perseus-interactive"
-                                        role="button"
-                                      >
-                                        <input
-                                          class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
-                                          name="perseus_radio_9_3"
-                                          type="radio"
-                                        />
-                                      </div>
-                                    </td>
-                                    <td
-                                      class="category cell_13aakpm"
-                                    >
-                                      <div
-                                        aria-label="False"
-                                        class="perseus-interactive"
-                                        role="button"
-                                      >
-                                        <input
-                                          class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
-                                          name="perseus_radio_9_3"
-                                          type="radio"
-                                        />
-                                      </div>
-                                    </td>
-                                  </tr>
-                                </tbody>
-                              </table>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="paragraph"
-                        >
-                          <div
-                            class="perseus-widget-container widget-nohighlight widget-inline"
-                          >
-                            <div
-                              class="container_167wsvl"
-                            >
-                              <div
-                                class="linkContainer_36rlri"
-                              >
-                                <a
-                                  aria-expanded="false"
-                                  class="mobileExplanationLink_his27d"
-                                  href="javascript:void(0)"
-                                  role="button"
+                            <thead>
+                              <tr>
+                                <td
+                                  class="emptyHeaderCell_1mttrgd"
+                                />
+                                <th
+                                  class="header_whrfk4"
                                 >
-                                  Hint
-                                </a>
-                              </div>
-                            </div>
+                                  <div
+                                    class="perseus-renderer perseus-renderer-responsive"
+                                  >
+                                    <div
+                                      class="paragraph"
+                                      data-perseus-paragraph-index="0"
+                                    >
+                                      <div
+                                        class="paragraph"
+                                      >
+                                        True
+                                      </div>
+                                    </div>
+                                  </div>
+                                </th>
+                                <th
+                                  class="header_whrfk4"
+                                >
+                                  <div
+                                    class="perseus-renderer perseus-renderer-responsive"
+                                  >
+                                    <div
+                                      class="paragraph"
+                                      data-perseus-paragraph-index="0"
+                                    >
+                                      <div
+                                        class="paragraph"
+                                      >
+                                        False
+                                      </div>
+                                    </div>
+                                  </div>
+                                </th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              <tr>
+                                <td>
+                                  <div
+                                    class="perseus-renderer perseus-renderer-responsive"
+                                  >
+                                    <div
+                                      class="paragraph"
+                                      data-perseus-paragraph-index="0"
+                                    >
+                                      <div
+                                        class="paragraph"
+                                      >
+                                         Some bacteria conduct photosynthesis and produce oxygen, much like plants.
+                                      </div>
+                                    </div>
+                                  </div>
+                                </td>
+                                <td
+                                  class="category cell_13aakpm"
+                                >
+                                  <div
+                                    aria-label="True"
+                                    class="perseus-interactive"
+                                    role="button"
+                                  >
+                                    <input
+                                      class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                                      name="perseus_radio_9_0"
+                                      type="radio"
+                                    />
+                                  </div>
+                                </td>
+                                <td
+                                  class="category cell_13aakpm"
+                                >
+                                  <div
+                                    aria-label="False"
+                                    class="perseus-interactive"
+                                    role="button"
+                                  >
+                                    <input
+                                      class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                                      name="perseus_radio_9_0"
+                                      type="radio"
+                                    />
+                                  </div>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td>
+                                  <div
+                                    class="perseus-renderer perseus-renderer-responsive"
+                                  >
+                                    <div
+                                      class="paragraph"
+                                      data-perseus-paragraph-index="0"
+                                    >
+                                      <div
+                                        class="paragraph"
+                                      >
+                                        Bacteria are always autotrophic but they may get energy from either light or chemical sources.
+                                      </div>
+                                    </div>
+                                  </div>
+                                </td>
+                                <td
+                                  class="category cell_13aakpm"
+                                >
+                                  <div
+                                    aria-label="True"
+                                    class="perseus-interactive"
+                                    role="button"
+                                  >
+                                    <input
+                                      class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                                      name="perseus_radio_9_1"
+                                      type="radio"
+                                    />
+                                  </div>
+                                </td>
+                                <td
+                                  class="category cell_13aakpm"
+                                >
+                                  <div
+                                    aria-label="False"
+                                    class="perseus-interactive"
+                                    role="button"
+                                  >
+                                    <input
+                                      class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                                      name="perseus_radio_9_1"
+                                      type="radio"
+                                    />
+                                  </div>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td>
+                                  <div
+                                    class="perseus-renderer perseus-renderer-responsive"
+                                  >
+                                    <div
+                                      class="paragraph"
+                                      data-perseus-paragraph-index="0"
+                                    >
+                                      <div
+                                        class="paragraph"
+                                      >
+                                        Some chemosynthetic bacteria introduce energy and fixed carbon into communities where photosynthesis is not possible (e.g., deep-sea vents).
+                                      </div>
+                                    </div>
+                                  </div>
+                                </td>
+                                <td
+                                  class="category cell_13aakpm"
+                                >
+                                  <div
+                                    aria-label="True"
+                                    class="perseus-interactive"
+                                    role="button"
+                                  >
+                                    <input
+                                      class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                                      name="perseus_radio_9_2"
+                                      type="radio"
+                                    />
+                                  </div>
+                                </td>
+                                <td
+                                  class="category cell_13aakpm"
+                                >
+                                  <div
+                                    aria-label="False"
+                                    class="perseus-interactive"
+                                    role="button"
+                                  >
+                                    <input
+                                      class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                                      name="perseus_radio_9_2"
+                                      type="radio"
+                                    />
+                                  </div>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td>
+                                  <div
+                                    class="perseus-renderer perseus-renderer-responsive"
+                                  >
+                                    <div
+                                      class="paragraph"
+                                      data-perseus-paragraph-index="0"
+                                    >
+                                      <div
+                                        class="paragraph"
+                                      >
+                                        Some bacteria live symbiotically inside of host organisms and provide the host with nutrients.
+                                      </div>
+                                    </div>
+                                  </div>
+                                </td>
+                                <td
+                                  class="category cell_13aakpm"
+                                >
+                                  <div
+                                    aria-label="True"
+                                    class="perseus-interactive"
+                                    role="button"
+                                  >
+                                    <input
+                                      class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                                      name="perseus_radio_9_3"
+                                      type="radio"
+                                    />
+                                  </div>
+                                </td>
+                                <td
+                                  class="category cell_13aakpm"
+                                >
+                                  <div
+                                    aria-label="False"
+                                    class="perseus-interactive"
+                                    role="button"
+                                  >
+                                    <input
+                                      class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                                      name="perseus_radio_9_3"
+                                      type="radio"
+                                    />
+                                  </div>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="paragraph"
+                    >
+                      <div
+                        class="perseus-widget-container widget-nohighlight widget-inline"
+                      >
+                        <div
+                          class="container_167wsvl"
+                        >
+                          <div
+                            class="linkContainer_36rlri"
+                          >
+                            <a
+                              aria-expanded="false"
+                              class="mobileExplanationLink_his27d"
+                              href="javascript:void(0)"
+                              role="button"
+                            >
+                              Hint
+                            </a>
                           </div>
                         </div>
-                      </li>
-                    </ol>
-                  </div>
-                </div>
-              </span>
+                      </div>
+                    </div>
+                  </li>
+                </ol>
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/grapher.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/grapher.test.ts.snap
@@ -2,1366 +2,1362 @@
 
 exports[`grapher widget should snapshot linear graph question: initial render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          <strong>
-            Graph 
+        <strong>
+          Graph 
+          <span
+            style="white-space: nowrap;"
+          >
+            <span />
             <span
-              style="white-space: nowrap;"
+              class="mock-TeX"
             >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                5x+3y=15
-              </span>
-              <span />
+              5x+3y=15
             </span>
-            .
-          </strong>
-        </div>
+            <span />
+          </span>
+          .
+        </strong>
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="1"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
-          <div
-            class="perseus-widget-container widget-nohighlight widget-block"
-          >
-            <div>
+          <div>
+            <div
+              class="perseus-widget perseus-widget-grapher"
+              style="width: 400px; height: 400px; box-sizing: initial;"
+            >
               <div
-                class="perseus-widget perseus-widget-grapher"
-                style="width: 400px; height: 400px; box-sizing: initial;"
+                class="graphie-container above-scratchpad"
+                style="width: 400px; height: 400px;"
               >
                 <div
-                  class="graphie-container above-scratchpad"
-                  style="width: 400px; height: 400px;"
+                  class="graphie-container"
                 >
                   <div
-                    class="graphie-container"
+                    class="graphie"
+                    style="position: relative; width: 400px; height: 400px;"
                   >
-                    <div
-                      class="graphie"
-                      style="position: relative; width: 400px; height: 400px;"
+                    <svg
+                      height="400"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
+                      version="1.1"
+                      width="400"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        height="400"
-                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
-                        version="1.1"
-                        width="400"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                      </svg>
-                      <svg
-                        height="400"
+                      <desc
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="400"
-                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <path
-                          d="M0,400L0,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M20,400L20,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M40,400L40,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M60,400L60,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M80,400L80,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M100,400L100,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M120,400L120,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M140,400L140,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M160,400L160,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M180,400L180,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M200,400L200,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M220,400L220,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M240,400L240,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M260,400L260,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M280,400L280,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M300,400L300,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M320,400L320,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M340,400L340,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M360,400L360,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M380,400L380,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M400,400L400,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,400L400,400"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,380L400,380"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,360L400,360"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,340L400,340"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,320L400,320"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,300L400,300"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,280L400,280"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,260L400,260"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,240L400,240"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,220L400,220"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,200L400,200"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,180L400,180"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,160L400,160"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,140L400,140"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,120L400,120"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,100L400,100"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,80L400,80"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,60L400,60"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,40L400,40"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,20L400,20"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,0L400,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M-3.4499999999999886,205.6C-3.0999999999999885,203.5,0.7500000000000115,200.35,1.8000000000000114,200C0.7500000000000113,199.65,-3.099999999999989,196.5,-3.4499999999999886,194.4"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1; stroke-linejoin: round; stroke-linecap: round;"
-                          transform="rotate(180 1.8000000000000114 200)"
-                        />
-                        <path
-                          d="M200,200C200,200,200,200,1.0500000000000114,200"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
-                        />
-                        <path
-                          d="M394.45,205.6C394.8,203.5,398.65,200.35,399.7,200C398.65,199.65,394.8,196.5,394.45,194.4"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1; stroke-linejoin: round; stroke-linecap: round;"
-                          transform=""
-                        />
-                        <path
-                          d="M200,200C200,200,200,200,398.95,200"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
-                        />
-                        <path
-                          d="M195.5,404.55C195.85,402.45,199.7,399.3,200.75,398.95C199.7,398.59999999999997,195.85,395.45,195.5,393.34999999999997"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1; stroke-linejoin: round; stroke-linecap: round;"
-                          transform="rotate(90 200.75 398.95)"
-                        />
-                        <path
-                          d="M200,200C200,200,200,200,200,398.95"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
-                        />
-                        <path
-                          d="M195.5,6.650000000000011C195.85,4.550000000000011,199.7,1.400000000000011,200.75,1.0500000000000114C199.7,0.7000000000000114,195.85,-2.4499999999999886,195.5,-4.549999999999988"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1; stroke-linejoin: round; stroke-linecap: round;"
-                          transform="rotate(-90 200.75 1.0500000000000114)"
-                        />
-                        <path
-                          d="M200,200C200,200,200,200,200,1.0500000000000114"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
-                        />
-                        <path
-                          d="M220,205L220,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M240,205L240,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M260,205L260,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M280,205L280,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M300,205L300,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M320,205L320,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M340,205L340,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M360,205L360,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M380,205L380,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M180,205L180,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M160,205L160,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M140,205L140,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M120,205L120,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M100,205L100,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M80,205L80,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M60,205L60,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M40,205L40,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M20,205L20,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,180L205,180"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,160L205,160"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,140L205,140"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,120L205,120"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,100L205,100"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,80L205,80"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,60L205,60"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,40L205,40"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,20L205,20"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,220L205,220"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,240L205,240"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,260L205,260"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,280L205,280"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,300L205,300"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,320L205,320"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,340L205,340"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,360L205,360"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,380L205,380"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M0,100L0.5000000000000071,100L1.0000000000000142,100L1.5000000000000213,100L2.0000000000000284,100L2.5000000000000355,100L3.0000000000000426,100L3.5000000000000497,100L4.000000000000057,100L4.500000000000064,100L5.000000000000071,100L5.500000000000078,100L6.000000000000085,100L6.500000000000092,100L7.0000000000000995,100L7.500000000000107,100L8.000000000000114,100L8.50000000000012,100L9.000000000000128,100L9.500000000000135,100L10.000000000000142,100L10.50000000000015,100L11.000000000000156,100L11.500000000000163,100L12.00000000000017,100L12.500000000000178,100L13.000000000000185,100L13.500000000000192,100L14.000000000000199,100L14.500000000000206,100L15.000000000000213,100L15.50000000000022,100L16.000000000000227,100L16.500000000000234,100L17.00000000000024,100L17.50000000000025,100L18.000000000000256,100L18.500000000000263,100L19.00000000000027,100L19.500000000000277,100L20.000000000000284,100L20.50000000000029,100L21.0000000000003,100L21.500000000000306,100L22.000000000000313,100L22.50000000000032,100L23.000000000000327,100L23.500000000000334,100L24.00000000000034,100L24.500000000000348,100L25.000000000000355,100L25.500000000000362,100L26.00000000000037,100L26.500000000000377,100L27.000000000000384,100L27.50000000000039,100L28.000000000000398,100L28.500000000000405,100L29.000000000000412,100L29.50000000000042,100L30.000000000000426,100L30.500000000000433,100L31.00000000000044,100L31.500000000000448,100L32.000000000000455,100L32.50000000000046,100L33.00000000000047,100L33.500000000000476,100L34.00000000000048,100L34.50000000000049,100L35.0000000000005,100L35.500000000000504,100L36.00000000000051,100L36.50000000000052,100L37.000000000000526,100L37.50000000000053,100L38.00000000000054,100L38.50000000000055,100L39.000000000000554,100L39.50000000000056,100L40.00000000000057,100L40.500000000000576,100L41.00000000000058,100L41.50000000000059,100L42.0000000000006,100L42.500000000000604,100L43.00000000000061,100L43.50000000000062,100L44.000000000000625,100L44.50000000000063,100L45.00000000000064,100L45.50000000000065,100L46.000000000000654,100L46.50000000000066,100L47.00000000000067,100L47.500000000000675,100L48.00000000000068,100L48.50000000000069,100L49.000000000000696,100L49.5000000000007,100L50.00000000000071,100L50.50000000000072,100L51.000000000000725,100L51.50000000000073,100L52.00000000000074,100L52.500000000000746,100L53.00000000000075,100L53.50000000000076,100L54.00000000000077,100L54.500000000000774,100L55.00000000000078,100L55.50000000000079,100L56.000000000000796,100L56.5000000000008,100L57.00000000000081,100L57.50000000000082,100L58.000000000000824,100L58.50000000000083,100L59.00000000000084,100L59.500000000000846,100L60.00000000000085,100L60.50000000000086,100L61.00000000000087,100L61.500000000000874,100L62.00000000000088,100L62.50000000000089,100L63.000000000000895,100L63.5000000000009,100L64.00000000000091,100L64.50000000000091,100L65.00000000000092,100L65.50000000000094,100L66.00000000000094,100L66.50000000000094,100L67.00000000000095,100L67.50000000000097,100L68.00000000000097,100L68.50000000000097,100L69.00000000000098,100L69.500000000001,100L70.000000000001,100L70.500000000001,100L71.00000000000101,100L71.50000000000102,100L72.00000000000102,100L72.50000000000102,100L73.00000000000104,100L73.50000000000105,100L74.00000000000105,100L74.50000000000105,100L75.00000000000107,100L75.50000000000108,100L76.00000000000108,100L76.50000000000108,100L77.0000000000011,100L77.50000000000111,100L78.00000000000111,100L78.50000000000111,100L79.00000000000112,100L79.50000000000114,100L80.00000000000114,100L80.50000000000114,100L81.00000000000115,100L81.50000000000117,100L82.00000000000117,100L82.50000000000117,100L83.00000000000118,100L83.5000000000012,100L84.0000000000012,100L84.5000000000012,100L85.00000000000121,100L85.50000000000122,100L86.00000000000122,100L86.50000000000122,100L87.00000000000124,100L87.50000000000125,100L88.00000000000125,100L88.50000000000125,100L89.00000000000126,100L89.50000000000128,100L90.00000000000128,100L90.50000000000128,100L91.0000000000013,100L91.50000000000131,100L92.00000000000131,100L92.50000000000131,100L93.00000000000132,100L93.50000000000134,100L94.00000000000134,100L94.50000000000134,100L95.00000000000135,100L95.50000000000136,100L96.00000000000136,100L96.50000000000136,100L97.00000000000138,100L97.50000000000139,100L98.00000000000139,100L98.50000000000139,100L99.0000000000014,100L99.50000000000142,100L100.00000000000142,100L100.50000000000142,100L101.00000000000144,100L101.50000000000145,100L102.00000000000145,100L102.50000000000145,100L103.00000000000146,100L103.50000000000148,100L104.00000000000148,100L104.50000000000148,100L105.00000000000149,100L105.5000000000015,100L106.0000000000015,100L106.5000000000015,100L107.00000000000152,100L107.50000000000153,100L108.00000000000153,100L108.50000000000153,100L109.00000000000155,100L109.50000000000156,100L110.00000000000156,100L110.50000000000156,100L111.00000000000158,100L111.50000000000159,100L112.00000000000159,100L112.50000000000159,100L113.0000000000016,100L113.50000000000162,100L114.00000000000162,100L114.50000000000162,100L115.00000000000163,100L115.50000000000165,100L116.00000000000165,100L116.50000000000165,100L117.00000000000166,100L117.50000000000168,100L118.00000000000168,100L118.50000000000168,100L119.00000000000169,100L119.5000000000017,100L120.0000000000017,100L120.50000000000169,100L121.00000000000168,100L121.50000000000169,100L122.0000000000017,100L122.50000000000169,100L123.00000000000168,100L123.50000000000168,100L124.00000000000169,100L124.50000000000168,100L125.00000000000168,100L125.50000000000168,100L126.00000000000168,100L126.50000000000168,100L127.00000000000166,100L127.50000000000168,100L128.00000000000168,100L128.50000000000168,100L129.00000000000165,100L129.50000000000165,100L130.00000000000168,100L130.50000000000165,100L131.00000000000165,100L131.50000000000165,100L132.00000000000165,100L132.50000000000165,100L133.00000000000165,100L133.50000000000165,100L134.00000000000165,100L134.50000000000165,100L135.00000000000165,100L135.50000000000165,100L136.00000000000165,100L136.50000000000165,100L137.00000000000162,100L137.50000000000165,100L138.00000000000165,100L138.50000000000162,100L139.00000000000162,100L139.50000000000162,100L140.00000000000165,100L140.50000000000162,100L141.00000000000162,100L141.50000000000162,100L142.00000000000162,100L142.50000000000162,100L143.0000000000016,100L143.50000000000162,100L144.00000000000162,100L144.50000000000162,100L145.0000000000016,100L145.5000000000016,100L146.00000000000162,100L146.5000000000016,100L147.0000000000016,100L147.5000000000016,100L148.0000000000016,100L148.5000000000016,100L149.0000000000016,100L149.5000000000016,100L150.0000000000016,100L150.5000000000016,100L151.0000000000016,100L151.5000000000016,100L152.0000000000016,100L152.5000000000016,100L153.00000000000156,100L153.5000000000016,100L154.0000000000016,100L154.50000000000156,100L155.00000000000156,100L155.50000000000156,100L156.0000000000016,100L156.50000000000156,100L157.00000000000156,100L157.50000000000156,100L158.00000000000156,100L158.50000000000156,100L159.00000000000153,100L159.50000000000156,100L160.00000000000156,100L160.50000000000153,100L161.00000000000153,100L161.50000000000153,100L162.00000000000156,100L162.50000000000156,100L163.00000000000153,100L163.50000000000153,100L164.00000000000153,100L164.50000000000153,100L165.00000000000153,100L165.50000000000153,100L166.00000000000153,100L166.50000000000153,100L167.00000000000153,100L167.50000000000153,100L168.00000000000153,100L168.5000000000015,100L169.0000000000015,100L169.50000000000153,100L170.00000000000153,100L170.50000000000153,100L171.0000000000015,100L171.5000000000015,100L172.00000000000153,100L172.50000000000148,100L173.0000000000015,100L173.5000000000015,100L174.0000000000015,100L174.50000000000153,100L175.00000000000148,100L175.5000000000015,100L176.0000000000015,100L176.50000000000148,100L177.00000000000148,100L177.50000000000148,100L178.0000000000015,100L178.5000000000015,100L179.00000000000148,100L179.50000000000148,100L180.00000000000148,100L180.5000000000015,100L181.00000000000148,100L181.50000000000148,100L182.00000000000148,100L182.50000000000148,100L183.0000000000015,100L183.5000000000015,100L184.00000000000148,100L184.50000000000148,100L185.00000000000148,100L185.5000000000015,100L186.0000000000015,100L186.50000000000148,100L187.00000000000148,100L187.50000000000148,100L188.0000000000015,100L188.5000000000015,100L189.00000000000148,100L189.50000000000148,100L190.00000000000148,100L190.5000000000015,100L191.0000000000015,100L191.50000000000148,100L192.00000000000148,100L192.50000000000148,100L193.0000000000015,100L193.5000000000015,100L194.0000000000015,100L194.50000000000148,100L195.00000000000148,100L195.5000000000015,100L196.0000000000015,100L196.5000000000015,100L197.00000000000148,100L197.50000000000148,100L198.0000000000015,100L198.5000000000015,100L199.0000000000015,100L199.50000000000148,100L200.00000000000148,100L200.5000000000015,100L201.0000000000015,100L201.5000000000015,100L202.00000000000148,100L202.50000000000148,100L203.0000000000015,100L203.5000000000015,100L204.0000000000015,100L204.50000000000148,100L205.00000000000148,100L205.5000000000015,100L206.0000000000015,100L206.5000000000015,100L207.00000000000148,100L207.50000000000148,100L208.0000000000015,100L208.5000000000015,100L209.0000000000015,100L209.50000000000148,100L210.00000000000148,100L210.5000000000015,100L211.0000000000015,100L211.5000000000015,100L212.00000000000153,100L212.50000000000148,100L213.0000000000015,100L213.5000000000015,100L214.0000000000015,100L214.50000000000153,100L215.00000000000148,100L215.5000000000015,100L216.0000000000015,100L216.5000000000015,100L217.00000000000153,100L217.50000000000148,100L218.0000000000015,100L218.5000000000015,100L219.0000000000015,100L219.50000000000153,100L220.00000000000148,100L220.5000000000015,100L221.0000000000015,100L221.5000000000015,100L222.00000000000153,100L222.50000000000148,100L223.0000000000015,100L223.5000000000015,100L224.00000000000148,100L224.50000000000148,100L225.00000000000148,100L225.5000000000015,100L226.0000000000015,100L226.50000000000148,100L227.00000000000148,100L227.50000000000148,100L228.00000000000148,100L228.50000000000148,100L229.00000000000148,100L229.50000000000148,100L230.00000000000148,100L230.50000000000148,100L231.00000000000148,100L231.50000000000148,100L232.00000000000145,100L232.50000000000145,100L233.00000000000148,100L233.50000000000148,100L234.00000000000148,100L234.50000000000145,100L235.00000000000145,100L235.50000000000148,100L236.00000000000142,100L236.50000000000145,100L237.00000000000145,100L237.50000000000145,100L238.00000000000148,100L238.50000000000142,100L239.00000000000145,100L239.50000000000145,100L240.00000000000142,100L240.50000000000142,100L241.00000000000142,100L241.50000000000145,100L242.00000000000145,100L242.50000000000142,100L243.00000000000142,100L243.50000000000142,100L244.00000000000142,100L244.50000000000142,100L245.00000000000142,100L245.50000000000142,100L246.00000000000142,100L246.50000000000142,100L247.00000000000142,100L247.50000000000142,100L248.0000000000014,100L248.5000000000014,100L249.00000000000142,100L249.50000000000142,100L250.00000000000142,100L250.5000000000014,100L251.0000000000014,100L251.50000000000142,100L252.00000000000136,100L252.5000000000014,100L253.0000000000014,100L253.5000000000014,100L254.00000000000142,100L254.50000000000136,100L255.0000000000014,100L255.5000000000014,100L256.00000000000136,100L256.50000000000136,100L257.00000000000136,100L257.50000000000136,100L258.00000000000136,100L258.50000000000136,100L259.00000000000136,100L259.50000000000136,100L260.00000000000136,100L260.50000000000136,100L261.00000000000136,100L261.50000000000136,100L262.00000000000136,100L262.50000000000136,100L263.00000000000136,100L263.50000000000136,100L264.00000000000136,100L264.50000000000136,100L265.00000000000136,100L265.50000000000136,100L266.00000000000136,100L266.50000000000136,100L267.00000000000136,100L267.50000000000136,100L268.0000000000013,100L268.5000000000013,100L269.00000000000136,100L269.50000000000136,100L270.00000000000136,100L270.5000000000013,100L271.0000000000013,100L271.50000000000136,100L272.0000000000013,100L272.5000000000013,100L273.0000000000013,100L273.5000000000013,100L274.00000000000136,100L274.5000000000013,100L275.0000000000013,100L275.5000000000013,100L276.0000000000013,100L276.5000000000013,100L277.0000000000013,100L277.5000000000013,100L278.0000000000013,100L278.5000000000013,100L279.0000000000013,100L279.5000000000013,100L280.00000000000125,100L280.5000000000013,100L281.0000000000013,100L281.50000000000136,100L282.0000000000013,100L282.50000000000136,100L283.0000000000013,100L283.50000000000136,100L284.00000000000136,100L284.50000000000136,100L285.00000000000136,100L285.50000000000136,100L286.00000000000136,100L286.5000000000014,100L287.00000000000136,100L287.5000000000014,100L288.00000000000136,100L288.5000000000014,100L289.0000000000014,100L289.5000000000015,100L290.0000000000014,100L290.5000000000015,100L291.0000000000014,100L291.5000000000015,100L292.0000000000015,100L292.5000000000015,100L293.0000000000015,100L293.5000000000015,100L294.0000000000015,100L294.50000000000153,100L295.0000000000015,100L295.50000000000153,100L296.0000000000015,100L296.50000000000153,100L297.00000000000153,100L297.5000000000016,100L298.00000000000153,100L298.5000000000016,100L299.00000000000153,100L299.5000000000016,100L300.0000000000016,100L300.5000000000016,100L301.0000000000016,100L301.5000000000016,100L302.0000000000016,100L302.50000000000165,100L303.0000000000016,100L303.50000000000165,100L304.0000000000016,100L304.50000000000165,100L305.00000000000165,100L305.5000000000017,100L306.00000000000165,100L306.5000000000017,100L307.00000000000165,100L307.5000000000017,100L308.0000000000017,100L308.5000000000017,100L309.0000000000017,100L309.5000000000017,100L310.0000000000017,100L310.50000000000176,100L311.0000000000017,100L311.50000000000176,100L312.0000000000017,100L312.50000000000176,100L313.00000000000176,100L313.5000000000018,100L314.00000000000176,100L314.5000000000018,100L315.00000000000176,100L315.5000000000018,100L316.0000000000018,100L316.5000000000018,100L317.0000000000018,100L317.5000000000018,100L318.0000000000018,100L318.5000000000019,100L319.0000000000018,100L319.5000000000019,100L320.0000000000018,100L320.5000000000019,100L321.0000000000019,100L321.50000000000193,100L322.0000000000019,100L322.50000000000193,100L323.0000000000019,100L323.50000000000193,100L324.00000000000193,100L324.50000000000193,100L325.00000000000193,100L325.50000000000193,100L326.00000000000193,100L326.500000000002,100L327.00000000000193,100L327.500000000002,100L328.00000000000193,100L328.500000000002,100L329.000000000002,100L329.50000000000205,100L330.000000000002,100L330.50000000000205,100L331.000000000002,100L331.50000000000205,100L332.00000000000205,100L332.50000000000205,100L333.00000000000205,100L333.50000000000205,100L334.00000000000205,100L334.5000000000021,100L335.00000000000205,100L335.5000000000021,100L336.00000000000205,100L336.5000000000021,100L337.0000000000021,100L337.50000000000216,100L338.0000000000021,100L338.50000000000216,100L339.0000000000021,100L339.50000000000216,100L340.00000000000216,100L340.50000000000216,100L341.00000000000216,100L341.50000000000216,100L342.00000000000216,100L342.5000000000022,100L343.00000000000216,100L343.5000000000022,100L344.00000000000216,100L344.5000000000022,100L345.0000000000022,100L345.5000000000023,100L346.0000000000022,100L346.5000000000023,100L347.0000000000022,100L347.5000000000023,100L348.0000000000023,100L348.5000000000023,100L349.0000000000023,100L349.5000000000023,100L350.0000000000023,100L350.50000000000233,100L351.0000000000023,100L351.50000000000233,100L352.0000000000023,100L352.50000000000233,100L353.00000000000233,100L353.5000000000024,100L354.00000000000233,100L354.5000000000024,100L355.00000000000233,100L355.5000000000024,100L356.0000000000024,100L356.5000000000024,100L357.0000000000024,100L357.5000000000024,100L358.0000000000024,100L358.50000000000244,100L359.0000000000024,100L359.50000000000244,100L360.0000000000024,100L360.5000000000024,100L361.00000000000244,100L361.5000000000025,100L362.00000000000244,100L362.5000000000024,100L363.00000000000244,100L363.5000000000025,100L364.0000000000025,100L364.50000000000244,100L365.0000000000025,100L365.5000000000025,100L366.0000000000025,100L366.5000000000025,100L367.0000000000025,100L367.50000000000256,100L368.0000000000025,100L368.5000000000025,100L369.00000000000256,100L369.5000000000026,100L370.00000000000256,100L370.5000000000025,100L371.00000000000256,100L371.5000000000026,100L372.0000000000026,100L372.50000000000256,100L373.0000000000026,100L373.5000000000026,100L374.0000000000026,100L374.5000000000026,100L375.0000000000026,100L375.5000000000027,100L376.0000000000026,100L376.5000000000026,100L377.0000000000027,100L377.50000000000273,100L378.0000000000027,100L378.5000000000026,100L379.0000000000027,100L379.50000000000273,100L380.00000000000273,100L380.5000000000027,100L381.00000000000273,100L381.50000000000273,100L382.00000000000273,100L382.50000000000273,100L383.00000000000273,100L383.5000000000028,100L384.00000000000273,100L384.50000000000273,100L385.0000000000028,100L385.50000000000284,100L386.0000000000028,100L386.50000000000273,100L387.0000000000028,100L387.50000000000284,100L388.00000000000284,100L388.5000000000028,100L389.00000000000284,100L389.50000000000284,100L390.00000000000284,100L390.50000000000284,100L391.00000000000284,100L391.5000000000029,100L392.00000000000284,100L392.50000000000284,100L393.0000000000029,100L393.50000000000296,100L394.0000000000029,100L394.50000000000284,100L395.0000000000029,100L395.50000000000296,100L396.00000000000296,100L396.5000000000029,100L397.00000000000296,100L397.50000000000296,100L398.00000000000296,100L398.50000000000296,100L399.00000000000296,100L399.500000000003,100"
-                          fill="none"
-                          stroke="#6495ed"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
-                        />
-                      </svg>
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                    </svg>
+                    <svg
+                      height="400"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="400"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <path
+                        d="M0,400L0,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M20,400L20,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M40,400L40,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M60,400L60,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M80,400L80,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M100,400L100,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M120,400L120,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M140,400L140,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M160,400L160,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M180,400L180,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M200,400L200,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M220,400L220,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M240,400L240,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M260,400L260,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M280,400L280,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M300,400L300,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M320,400L320,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M340,400L340,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M360,400L360,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M380,400L380,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M400,400L400,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,400L400,400"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,380L400,380"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,360L400,360"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,340L400,340"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,320L400,320"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,300L400,300"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,280L400,280"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,260L400,260"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,240L400,240"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,220L400,220"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,200L400,200"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,180L400,180"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,160L400,160"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,140L400,140"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,120L400,120"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,100L400,100"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,80L400,80"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,60L400,60"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,40L400,40"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,20L400,20"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,0L400,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M-3.4499999999999886,205.6C-3.0999999999999885,203.5,0.7500000000000115,200.35,1.8000000000000114,200C0.7500000000000113,199.65,-3.099999999999989,196.5,-3.4499999999999886,194.4"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1; stroke-linejoin: round; stroke-linecap: round;"
+                        transform="rotate(180 1.8000000000000114 200)"
+                      />
+                      <path
+                        d="M200,200C200,200,200,200,1.0500000000000114,200"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
+                      />
+                      <path
+                        d="M394.45,205.6C394.8,203.5,398.65,200.35,399.7,200C398.65,199.65,394.8,196.5,394.45,194.4"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1; stroke-linejoin: round; stroke-linecap: round;"
+                        transform=""
+                      />
+                      <path
+                        d="M200,200C200,200,200,200,398.95,200"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
+                      />
+                      <path
+                        d="M195.5,404.55C195.85,402.45,199.7,399.3,200.75,398.95C199.7,398.59999999999997,195.85,395.45,195.5,393.34999999999997"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1; stroke-linejoin: round; stroke-linecap: round;"
+                        transform="rotate(90 200.75 398.95)"
+                      />
+                      <path
+                        d="M200,200C200,200,200,200,200,398.95"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
+                      />
+                      <path
+                        d="M195.5,6.650000000000011C195.85,4.550000000000011,199.7,1.400000000000011,200.75,1.0500000000000114C199.7,0.7000000000000114,195.85,-2.4499999999999886,195.5,-4.549999999999988"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1; stroke-linejoin: round; stroke-linecap: round;"
+                        transform="rotate(-90 200.75 1.0500000000000114)"
+                      />
+                      <path
+                        d="M200,200C200,200,200,200,200,1.0500000000000114"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
+                      />
+                      <path
+                        d="M220,205L220,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M240,205L240,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M260,205L260,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M280,205L280,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M300,205L300,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M320,205L320,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M340,205L340,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M360,205L360,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M380,205L380,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M180,205L180,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M160,205L160,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M140,205L140,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M120,205L120,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M100,205L100,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M80,205L80,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M60,205L60,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M40,205L40,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M20,205L20,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,180L205,180"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,160L205,160"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,140L205,140"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,120L205,120"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,100L205,100"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,80L205,80"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,60L205,60"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,40L205,40"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,20L205,20"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,220L205,220"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,240L205,240"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,260L205,260"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,280L205,280"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,300L205,300"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,320L205,320"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,340L205,340"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,360L205,360"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,380L205,380"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M0,100L0.5000000000000071,100L1.0000000000000142,100L1.5000000000000213,100L2.0000000000000284,100L2.5000000000000355,100L3.0000000000000426,100L3.5000000000000497,100L4.000000000000057,100L4.500000000000064,100L5.000000000000071,100L5.500000000000078,100L6.000000000000085,100L6.500000000000092,100L7.0000000000000995,100L7.500000000000107,100L8.000000000000114,100L8.50000000000012,100L9.000000000000128,100L9.500000000000135,100L10.000000000000142,100L10.50000000000015,100L11.000000000000156,100L11.500000000000163,100L12.00000000000017,100L12.500000000000178,100L13.000000000000185,100L13.500000000000192,100L14.000000000000199,100L14.500000000000206,100L15.000000000000213,100L15.50000000000022,100L16.000000000000227,100L16.500000000000234,100L17.00000000000024,100L17.50000000000025,100L18.000000000000256,100L18.500000000000263,100L19.00000000000027,100L19.500000000000277,100L20.000000000000284,100L20.50000000000029,100L21.0000000000003,100L21.500000000000306,100L22.000000000000313,100L22.50000000000032,100L23.000000000000327,100L23.500000000000334,100L24.00000000000034,100L24.500000000000348,100L25.000000000000355,100L25.500000000000362,100L26.00000000000037,100L26.500000000000377,100L27.000000000000384,100L27.50000000000039,100L28.000000000000398,100L28.500000000000405,100L29.000000000000412,100L29.50000000000042,100L30.000000000000426,100L30.500000000000433,100L31.00000000000044,100L31.500000000000448,100L32.000000000000455,100L32.50000000000046,100L33.00000000000047,100L33.500000000000476,100L34.00000000000048,100L34.50000000000049,100L35.0000000000005,100L35.500000000000504,100L36.00000000000051,100L36.50000000000052,100L37.000000000000526,100L37.50000000000053,100L38.00000000000054,100L38.50000000000055,100L39.000000000000554,100L39.50000000000056,100L40.00000000000057,100L40.500000000000576,100L41.00000000000058,100L41.50000000000059,100L42.0000000000006,100L42.500000000000604,100L43.00000000000061,100L43.50000000000062,100L44.000000000000625,100L44.50000000000063,100L45.00000000000064,100L45.50000000000065,100L46.000000000000654,100L46.50000000000066,100L47.00000000000067,100L47.500000000000675,100L48.00000000000068,100L48.50000000000069,100L49.000000000000696,100L49.5000000000007,100L50.00000000000071,100L50.50000000000072,100L51.000000000000725,100L51.50000000000073,100L52.00000000000074,100L52.500000000000746,100L53.00000000000075,100L53.50000000000076,100L54.00000000000077,100L54.500000000000774,100L55.00000000000078,100L55.50000000000079,100L56.000000000000796,100L56.5000000000008,100L57.00000000000081,100L57.50000000000082,100L58.000000000000824,100L58.50000000000083,100L59.00000000000084,100L59.500000000000846,100L60.00000000000085,100L60.50000000000086,100L61.00000000000087,100L61.500000000000874,100L62.00000000000088,100L62.50000000000089,100L63.000000000000895,100L63.5000000000009,100L64.00000000000091,100L64.50000000000091,100L65.00000000000092,100L65.50000000000094,100L66.00000000000094,100L66.50000000000094,100L67.00000000000095,100L67.50000000000097,100L68.00000000000097,100L68.50000000000097,100L69.00000000000098,100L69.500000000001,100L70.000000000001,100L70.500000000001,100L71.00000000000101,100L71.50000000000102,100L72.00000000000102,100L72.50000000000102,100L73.00000000000104,100L73.50000000000105,100L74.00000000000105,100L74.50000000000105,100L75.00000000000107,100L75.50000000000108,100L76.00000000000108,100L76.50000000000108,100L77.0000000000011,100L77.50000000000111,100L78.00000000000111,100L78.50000000000111,100L79.00000000000112,100L79.50000000000114,100L80.00000000000114,100L80.50000000000114,100L81.00000000000115,100L81.50000000000117,100L82.00000000000117,100L82.50000000000117,100L83.00000000000118,100L83.5000000000012,100L84.0000000000012,100L84.5000000000012,100L85.00000000000121,100L85.50000000000122,100L86.00000000000122,100L86.50000000000122,100L87.00000000000124,100L87.50000000000125,100L88.00000000000125,100L88.50000000000125,100L89.00000000000126,100L89.50000000000128,100L90.00000000000128,100L90.50000000000128,100L91.0000000000013,100L91.50000000000131,100L92.00000000000131,100L92.50000000000131,100L93.00000000000132,100L93.50000000000134,100L94.00000000000134,100L94.50000000000134,100L95.00000000000135,100L95.50000000000136,100L96.00000000000136,100L96.50000000000136,100L97.00000000000138,100L97.50000000000139,100L98.00000000000139,100L98.50000000000139,100L99.0000000000014,100L99.50000000000142,100L100.00000000000142,100L100.50000000000142,100L101.00000000000144,100L101.50000000000145,100L102.00000000000145,100L102.50000000000145,100L103.00000000000146,100L103.50000000000148,100L104.00000000000148,100L104.50000000000148,100L105.00000000000149,100L105.5000000000015,100L106.0000000000015,100L106.5000000000015,100L107.00000000000152,100L107.50000000000153,100L108.00000000000153,100L108.50000000000153,100L109.00000000000155,100L109.50000000000156,100L110.00000000000156,100L110.50000000000156,100L111.00000000000158,100L111.50000000000159,100L112.00000000000159,100L112.50000000000159,100L113.0000000000016,100L113.50000000000162,100L114.00000000000162,100L114.50000000000162,100L115.00000000000163,100L115.50000000000165,100L116.00000000000165,100L116.50000000000165,100L117.00000000000166,100L117.50000000000168,100L118.00000000000168,100L118.50000000000168,100L119.00000000000169,100L119.5000000000017,100L120.0000000000017,100L120.50000000000169,100L121.00000000000168,100L121.50000000000169,100L122.0000000000017,100L122.50000000000169,100L123.00000000000168,100L123.50000000000168,100L124.00000000000169,100L124.50000000000168,100L125.00000000000168,100L125.50000000000168,100L126.00000000000168,100L126.50000000000168,100L127.00000000000166,100L127.50000000000168,100L128.00000000000168,100L128.50000000000168,100L129.00000000000165,100L129.50000000000165,100L130.00000000000168,100L130.50000000000165,100L131.00000000000165,100L131.50000000000165,100L132.00000000000165,100L132.50000000000165,100L133.00000000000165,100L133.50000000000165,100L134.00000000000165,100L134.50000000000165,100L135.00000000000165,100L135.50000000000165,100L136.00000000000165,100L136.50000000000165,100L137.00000000000162,100L137.50000000000165,100L138.00000000000165,100L138.50000000000162,100L139.00000000000162,100L139.50000000000162,100L140.00000000000165,100L140.50000000000162,100L141.00000000000162,100L141.50000000000162,100L142.00000000000162,100L142.50000000000162,100L143.0000000000016,100L143.50000000000162,100L144.00000000000162,100L144.50000000000162,100L145.0000000000016,100L145.5000000000016,100L146.00000000000162,100L146.5000000000016,100L147.0000000000016,100L147.5000000000016,100L148.0000000000016,100L148.5000000000016,100L149.0000000000016,100L149.5000000000016,100L150.0000000000016,100L150.5000000000016,100L151.0000000000016,100L151.5000000000016,100L152.0000000000016,100L152.5000000000016,100L153.00000000000156,100L153.5000000000016,100L154.0000000000016,100L154.50000000000156,100L155.00000000000156,100L155.50000000000156,100L156.0000000000016,100L156.50000000000156,100L157.00000000000156,100L157.50000000000156,100L158.00000000000156,100L158.50000000000156,100L159.00000000000153,100L159.50000000000156,100L160.00000000000156,100L160.50000000000153,100L161.00000000000153,100L161.50000000000153,100L162.00000000000156,100L162.50000000000156,100L163.00000000000153,100L163.50000000000153,100L164.00000000000153,100L164.50000000000153,100L165.00000000000153,100L165.50000000000153,100L166.00000000000153,100L166.50000000000153,100L167.00000000000153,100L167.50000000000153,100L168.00000000000153,100L168.5000000000015,100L169.0000000000015,100L169.50000000000153,100L170.00000000000153,100L170.50000000000153,100L171.0000000000015,100L171.5000000000015,100L172.00000000000153,100L172.50000000000148,100L173.0000000000015,100L173.5000000000015,100L174.0000000000015,100L174.50000000000153,100L175.00000000000148,100L175.5000000000015,100L176.0000000000015,100L176.50000000000148,100L177.00000000000148,100L177.50000000000148,100L178.0000000000015,100L178.5000000000015,100L179.00000000000148,100L179.50000000000148,100L180.00000000000148,100L180.5000000000015,100L181.00000000000148,100L181.50000000000148,100L182.00000000000148,100L182.50000000000148,100L183.0000000000015,100L183.5000000000015,100L184.00000000000148,100L184.50000000000148,100L185.00000000000148,100L185.5000000000015,100L186.0000000000015,100L186.50000000000148,100L187.00000000000148,100L187.50000000000148,100L188.0000000000015,100L188.5000000000015,100L189.00000000000148,100L189.50000000000148,100L190.00000000000148,100L190.5000000000015,100L191.0000000000015,100L191.50000000000148,100L192.00000000000148,100L192.50000000000148,100L193.0000000000015,100L193.5000000000015,100L194.0000000000015,100L194.50000000000148,100L195.00000000000148,100L195.5000000000015,100L196.0000000000015,100L196.5000000000015,100L197.00000000000148,100L197.50000000000148,100L198.0000000000015,100L198.5000000000015,100L199.0000000000015,100L199.50000000000148,100L200.00000000000148,100L200.5000000000015,100L201.0000000000015,100L201.5000000000015,100L202.00000000000148,100L202.50000000000148,100L203.0000000000015,100L203.5000000000015,100L204.0000000000015,100L204.50000000000148,100L205.00000000000148,100L205.5000000000015,100L206.0000000000015,100L206.5000000000015,100L207.00000000000148,100L207.50000000000148,100L208.0000000000015,100L208.5000000000015,100L209.0000000000015,100L209.50000000000148,100L210.00000000000148,100L210.5000000000015,100L211.0000000000015,100L211.5000000000015,100L212.00000000000153,100L212.50000000000148,100L213.0000000000015,100L213.5000000000015,100L214.0000000000015,100L214.50000000000153,100L215.00000000000148,100L215.5000000000015,100L216.0000000000015,100L216.5000000000015,100L217.00000000000153,100L217.50000000000148,100L218.0000000000015,100L218.5000000000015,100L219.0000000000015,100L219.50000000000153,100L220.00000000000148,100L220.5000000000015,100L221.0000000000015,100L221.5000000000015,100L222.00000000000153,100L222.50000000000148,100L223.0000000000015,100L223.5000000000015,100L224.00000000000148,100L224.50000000000148,100L225.00000000000148,100L225.5000000000015,100L226.0000000000015,100L226.50000000000148,100L227.00000000000148,100L227.50000000000148,100L228.00000000000148,100L228.50000000000148,100L229.00000000000148,100L229.50000000000148,100L230.00000000000148,100L230.50000000000148,100L231.00000000000148,100L231.50000000000148,100L232.00000000000145,100L232.50000000000145,100L233.00000000000148,100L233.50000000000148,100L234.00000000000148,100L234.50000000000145,100L235.00000000000145,100L235.50000000000148,100L236.00000000000142,100L236.50000000000145,100L237.00000000000145,100L237.50000000000145,100L238.00000000000148,100L238.50000000000142,100L239.00000000000145,100L239.50000000000145,100L240.00000000000142,100L240.50000000000142,100L241.00000000000142,100L241.50000000000145,100L242.00000000000145,100L242.50000000000142,100L243.00000000000142,100L243.50000000000142,100L244.00000000000142,100L244.50000000000142,100L245.00000000000142,100L245.50000000000142,100L246.00000000000142,100L246.50000000000142,100L247.00000000000142,100L247.50000000000142,100L248.0000000000014,100L248.5000000000014,100L249.00000000000142,100L249.50000000000142,100L250.00000000000142,100L250.5000000000014,100L251.0000000000014,100L251.50000000000142,100L252.00000000000136,100L252.5000000000014,100L253.0000000000014,100L253.5000000000014,100L254.00000000000142,100L254.50000000000136,100L255.0000000000014,100L255.5000000000014,100L256.00000000000136,100L256.50000000000136,100L257.00000000000136,100L257.50000000000136,100L258.00000000000136,100L258.50000000000136,100L259.00000000000136,100L259.50000000000136,100L260.00000000000136,100L260.50000000000136,100L261.00000000000136,100L261.50000000000136,100L262.00000000000136,100L262.50000000000136,100L263.00000000000136,100L263.50000000000136,100L264.00000000000136,100L264.50000000000136,100L265.00000000000136,100L265.50000000000136,100L266.00000000000136,100L266.50000000000136,100L267.00000000000136,100L267.50000000000136,100L268.0000000000013,100L268.5000000000013,100L269.00000000000136,100L269.50000000000136,100L270.00000000000136,100L270.5000000000013,100L271.0000000000013,100L271.50000000000136,100L272.0000000000013,100L272.5000000000013,100L273.0000000000013,100L273.5000000000013,100L274.00000000000136,100L274.5000000000013,100L275.0000000000013,100L275.5000000000013,100L276.0000000000013,100L276.5000000000013,100L277.0000000000013,100L277.5000000000013,100L278.0000000000013,100L278.5000000000013,100L279.0000000000013,100L279.5000000000013,100L280.00000000000125,100L280.5000000000013,100L281.0000000000013,100L281.50000000000136,100L282.0000000000013,100L282.50000000000136,100L283.0000000000013,100L283.50000000000136,100L284.00000000000136,100L284.50000000000136,100L285.00000000000136,100L285.50000000000136,100L286.00000000000136,100L286.5000000000014,100L287.00000000000136,100L287.5000000000014,100L288.00000000000136,100L288.5000000000014,100L289.0000000000014,100L289.5000000000015,100L290.0000000000014,100L290.5000000000015,100L291.0000000000014,100L291.5000000000015,100L292.0000000000015,100L292.5000000000015,100L293.0000000000015,100L293.5000000000015,100L294.0000000000015,100L294.50000000000153,100L295.0000000000015,100L295.50000000000153,100L296.0000000000015,100L296.50000000000153,100L297.00000000000153,100L297.5000000000016,100L298.00000000000153,100L298.5000000000016,100L299.00000000000153,100L299.5000000000016,100L300.0000000000016,100L300.5000000000016,100L301.0000000000016,100L301.5000000000016,100L302.0000000000016,100L302.50000000000165,100L303.0000000000016,100L303.50000000000165,100L304.0000000000016,100L304.50000000000165,100L305.00000000000165,100L305.5000000000017,100L306.00000000000165,100L306.5000000000017,100L307.00000000000165,100L307.5000000000017,100L308.0000000000017,100L308.5000000000017,100L309.0000000000017,100L309.5000000000017,100L310.0000000000017,100L310.50000000000176,100L311.0000000000017,100L311.50000000000176,100L312.0000000000017,100L312.50000000000176,100L313.00000000000176,100L313.5000000000018,100L314.00000000000176,100L314.5000000000018,100L315.00000000000176,100L315.5000000000018,100L316.0000000000018,100L316.5000000000018,100L317.0000000000018,100L317.5000000000018,100L318.0000000000018,100L318.5000000000019,100L319.0000000000018,100L319.5000000000019,100L320.0000000000018,100L320.5000000000019,100L321.0000000000019,100L321.50000000000193,100L322.0000000000019,100L322.50000000000193,100L323.0000000000019,100L323.50000000000193,100L324.00000000000193,100L324.50000000000193,100L325.00000000000193,100L325.50000000000193,100L326.00000000000193,100L326.500000000002,100L327.00000000000193,100L327.500000000002,100L328.00000000000193,100L328.500000000002,100L329.000000000002,100L329.50000000000205,100L330.000000000002,100L330.50000000000205,100L331.000000000002,100L331.50000000000205,100L332.00000000000205,100L332.50000000000205,100L333.00000000000205,100L333.50000000000205,100L334.00000000000205,100L334.5000000000021,100L335.00000000000205,100L335.5000000000021,100L336.00000000000205,100L336.5000000000021,100L337.0000000000021,100L337.50000000000216,100L338.0000000000021,100L338.50000000000216,100L339.0000000000021,100L339.50000000000216,100L340.00000000000216,100L340.50000000000216,100L341.00000000000216,100L341.50000000000216,100L342.00000000000216,100L342.5000000000022,100L343.00000000000216,100L343.5000000000022,100L344.00000000000216,100L344.5000000000022,100L345.0000000000022,100L345.5000000000023,100L346.0000000000022,100L346.5000000000023,100L347.0000000000022,100L347.5000000000023,100L348.0000000000023,100L348.5000000000023,100L349.0000000000023,100L349.5000000000023,100L350.0000000000023,100L350.50000000000233,100L351.0000000000023,100L351.50000000000233,100L352.0000000000023,100L352.50000000000233,100L353.00000000000233,100L353.5000000000024,100L354.00000000000233,100L354.5000000000024,100L355.00000000000233,100L355.5000000000024,100L356.0000000000024,100L356.5000000000024,100L357.0000000000024,100L357.5000000000024,100L358.0000000000024,100L358.50000000000244,100L359.0000000000024,100L359.50000000000244,100L360.0000000000024,100L360.5000000000024,100L361.00000000000244,100L361.5000000000025,100L362.00000000000244,100L362.5000000000024,100L363.00000000000244,100L363.5000000000025,100L364.0000000000025,100L364.50000000000244,100L365.0000000000025,100L365.5000000000025,100L366.0000000000025,100L366.5000000000025,100L367.0000000000025,100L367.50000000000256,100L368.0000000000025,100L368.5000000000025,100L369.00000000000256,100L369.5000000000026,100L370.00000000000256,100L370.5000000000025,100L371.00000000000256,100L371.5000000000026,100L372.0000000000026,100L372.50000000000256,100L373.0000000000026,100L373.5000000000026,100L374.0000000000026,100L374.5000000000026,100L375.0000000000026,100L375.5000000000027,100L376.0000000000026,100L376.5000000000026,100L377.0000000000027,100L377.50000000000273,100L378.0000000000027,100L378.5000000000026,100L379.0000000000027,100L379.50000000000273,100L380.00000000000273,100L380.5000000000027,100L381.00000000000273,100L381.50000000000273,100L382.00000000000273,100L382.50000000000273,100L383.00000000000273,100L383.5000000000028,100L384.00000000000273,100L384.50000000000273,100L385.0000000000028,100L385.50000000000284,100L386.0000000000028,100L386.50000000000273,100L387.0000000000028,100L387.50000000000284,100L388.00000000000284,100L388.5000000000028,100L389.00000000000284,100L389.50000000000284,100L390.00000000000284,100L390.50000000000284,100L391.00000000000284,100L391.5000000000029,100L392.00000000000284,100L392.50000000000284,100L393.0000000000029,100L393.50000000000296,100L394.0000000000029,100L394.50000000000284,100L395.0000000000029,100L395.50000000000296,100L396.00000000000296,100L396.5000000000029,100L397.00000000000296,100L397.50000000000296,100L398.00000000000296,100L398.50000000000296,100L399.00000000000296,100L399.500000000003,100"
+                        fill="none"
+                        stroke="#6495ed"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                      />
+                    </svg>
+                    <div
+                      style="position: absolute; left: 0px; top: 0px;"
+                    >
                       <div
-                        style="position: absolute; left: 0px; top: 0px;"
+                        style="position: absolute; width: 26px; height: 26px; left: 87px; top: 87px; transform: translateX(0px) translateY(0px) translateZ(0);"
                       >
-                        <div
-                          style="position: absolute; width: 26px; height: 26px; left: 87px; top: 87px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                        <svg
+                          height="26"
+                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                          version="1.1"
+                          width="26"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <svg
-                            height="26"
+                          <desc
                             style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                            version="1.1"
-                            width="26"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <desc
-                              style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                            >
-                              Created with Raphaël
-                            </desc>
-                            <defs
-                              style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                            />
-                            <ellipse
-                              cx="NaN"
-                              cy="NaN"
-                              fill="#71b307"
-                              r="NaN"
-                              rx="4"
-                              ry="4"
-                              stroke="#71b307"
-                              style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                              transform=""
-                            />
-                          </svg>
-                        </div>
-                        <div
-                          style="position: absolute; width: 26px; height: 26px; left: 287px; top: 87px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                        >
-                          <svg
-                            height="26"
+                            Created with Raphaël
+                          </desc>
+                          <defs
                             style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                            version="1.1"
-                            width="26"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <desc
-                              style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                            >
-                              Created with Raphaël
-                            </desc>
-                            <defs
-                              style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                            />
-                            <ellipse
-                              cx="NaN"
-                              cy="NaN"
-                              fill="#71b307"
-                              r="NaN"
-                              rx="4"
-                              ry="4"
-                              stroke="#71b307"
-                              style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                              transform=""
-                            />
-                          </svg>
-                        </div>
+                          />
+                          <ellipse
+                            cx="NaN"
+                            cy="NaN"
+                            fill="#71b307"
+                            r="NaN"
+                            rx="4"
+                            ry="4"
+                            stroke="#71b307"
+                            style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                            transform=""
+                          />
+                        </svg>
                       </div>
                       <div
-                        style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                        style="position: absolute; width: 26px; height: 26px; left: 287px; top: 87px; transform: translateX(0px) translateY(0px) translateZ(0);"
                       >
-                        <div
-                          data-interactive-kind-for-testing="movable-point"
-                          style="position: absolute; width: 48px; height: 48px; left: 76px; top: 76px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                        <svg
+                          height="26"
+                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                          version="1.1"
+                          width="26"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <svg
-                            height="48"
+                          <desc
                             style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                            version="1.1"
-                            width="48"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <desc
-                              style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                            >
-                              Created with Raphaël
-                            </desc>
-                            <defs
-                              style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                            />
-                            <ellipse
-                              cx="24"
-                              cy="24"
-                              fill="#000000"
-                              opacity="0"
-                              rx="24"
-                              ry="24"
-                              stroke="#000"
-                              style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                            />
-                          </svg>
-                        </div>
-                        <div
-                          data-interactive-kind-for-testing="movable-point"
-                          style="position: absolute; width: 48px; height: 48px; left: 276px; top: 76px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                        >
-                          <svg
-                            height="48"
+                            Created with Raphaël
+                          </desc>
+                          <defs
                             style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                            version="1.1"
-                            width="48"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <desc
-                              style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                            >
-                              Created with Raphaël
-                            </desc>
-                            <defs
-                              style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                            />
-                            <ellipse
-                              cx="24"
-                              cy="24"
-                              fill="#000000"
-                              opacity="0"
-                              rx="24"
-                              ry="24"
-                              stroke="#000"
-                              style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                            />
-                          </svg>
-                        </div>
+                          />
+                          <ellipse
+                            cx="NaN"
+                            cy="NaN"
+                            fill="#71b307"
+                            r="NaN"
+                            rx="4"
+                            ry="4"
+                            stroke="#71b307"
+                            style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                            transform=""
+                          />
+                        </svg>
                       </div>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{1}"
-                        style="position: absolute; padding: 7px; color: black; left: 220px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{2}"
-                        style="position: absolute; padding: 7px; color: black; left: 240px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{3}"
-                        style="position: absolute; padding: 7px; color: black; left: 260px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{4}"
-                        style="position: absolute; padding: 7px; color: black; left: 280px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{5}"
-                        style="position: absolute; padding: 7px; color: black; left: 300px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{6}"
-                        style="position: absolute; padding: 7px; color: black; left: 320px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{7}"
-                        style="position: absolute; padding: 7px; color: black; left: 340px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{8}"
-                        style="position: absolute; padding: 7px; color: black; left: 360px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{9}"
-                        style="position: absolute; padding: 7px; color: black; left: 380px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}2}"
-                        style="position: absolute; padding: 7px; color: black; left: 160px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}3}"
-                        style="position: absolute; padding: 7px; color: black; left: 140px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}4}"
-                        style="position: absolute; padding: 7px; color: black; left: 120px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}5}"
-                        style="position: absolute; padding: 7px; color: black; left: 100px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}6}"
-                        style="position: absolute; padding: 7px; color: black; left: 80px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}7}"
-                        style="position: absolute; padding: 7px; color: black; left: 60px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}8}"
-                        style="position: absolute; padding: 7px; color: black; left: 40px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}9}"
-                        style="position: absolute; padding: 7px; color: black; left: 20px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{1}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 180px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{2}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 160px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{3}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 140px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{4}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 120px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{5}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 100px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{6}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 80px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{7}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 60px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{8}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 40px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{9}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 20px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}2}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 240px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}3}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 260px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}4}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 280px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}5}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 300px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}6}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 320px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}7}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 340px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}8}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 360px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}9}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 380px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="y"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 0px; fill: none;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="x"
-                        style="position: absolute; padding: 7px; color: black; left: 400px; top: 200px; fill: none;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
                     </div>
+                    <div
+                      style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                    >
+                      <div
+                        data-interactive-kind-for-testing="movable-point"
+                        style="position: absolute; width: 48px; height: 48px; left: 76px; top: 76px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                      >
+                        <svg
+                          height="48"
+                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                          version="1.1"
+                          width="48"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <desc
+                            style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                          >
+                            Created with Raphaël
+                          </desc>
+                          <defs
+                            style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                          />
+                          <ellipse
+                            cx="24"
+                            cy="24"
+                            fill="#000000"
+                            opacity="0"
+                            rx="24"
+                            ry="24"
+                            stroke="#000"
+                            style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        data-interactive-kind-for-testing="movable-point"
+                        style="position: absolute; width: 48px; height: 48px; left: 276px; top: 76px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                      >
+                        <svg
+                          height="48"
+                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                          version="1.1"
+                          width="48"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <desc
+                            style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                          >
+                            Created with Raphaël
+                          </desc>
+                          <defs
+                            style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                          />
+                          <ellipse
+                            cx="24"
+                            cy="24"
+                            fill="#000000"
+                            opacity="0"
+                            rx="24"
+                            ry="24"
+                            stroke="#000"
+                            style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{1}"
+                      style="position: absolute; padding: 7px; color: black; left: 220px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{2}"
+                      style="position: absolute; padding: 7px; color: black; left: 240px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{3}"
+                      style="position: absolute; padding: 7px; color: black; left: 260px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{4}"
+                      style="position: absolute; padding: 7px; color: black; left: 280px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{5}"
+                      style="position: absolute; padding: 7px; color: black; left: 300px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{6}"
+                      style="position: absolute; padding: 7px; color: black; left: 320px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{7}"
+                      style="position: absolute; padding: 7px; color: black; left: 340px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{8}"
+                      style="position: absolute; padding: 7px; color: black; left: 360px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{9}"
+                      style="position: absolute; padding: 7px; color: black; left: 380px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}2}"
+                      style="position: absolute; padding: 7px; color: black; left: 160px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}3}"
+                      style="position: absolute; padding: 7px; color: black; left: 140px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}4}"
+                      style="position: absolute; padding: 7px; color: black; left: 120px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}5}"
+                      style="position: absolute; padding: 7px; color: black; left: 100px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}6}"
+                      style="position: absolute; padding: 7px; color: black; left: 80px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}7}"
+                      style="position: absolute; padding: 7px; color: black; left: 60px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}8}"
+                      style="position: absolute; padding: 7px; color: black; left: 40px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}9}"
+                      style="position: absolute; padding: 7px; color: black; left: 20px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{1}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 180px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{2}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 160px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{3}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 140px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{4}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 120px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{5}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 100px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{6}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 80px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{7}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 60px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{8}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 40px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{9}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 20px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}2}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 240px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}3}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 260px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}4}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 280px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}5}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 300px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}6}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 320px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}7}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 340px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}8}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 360px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}9}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 380px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="y"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 0px; fill: none;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="x"
+                      style="position: absolute; padding: 7px; color: black; left: 400px; top: 200px; fill: none;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
                   </div>
                 </div>
               </div>
@@ -1370,26 +1366,80 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`grapher widget should snapshot question with multiple graph types: initial render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
+        Let 
+        <span
+          style="white-space: nowrap;"
         >
-          Let 
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            f(x)=- 2^{-x}-x+5
+          </span>
+          <span />
+        </span>
+         and let 
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            g(x)=3|x-1|-3
+          </span>
+          <span />
+        </span>
+        .  
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
+      <div
+        class="paragraph"
+      >
+        The graph of 
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            y=f(x)
+          </span>
+          <span />
+        </span>
+         is shown below.
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
+    >
+      <div
+        class="paragraph"
+      >
+        <strong>
+          Use the interactive graph to sketch a graph of 
           <span
             style="white-space: nowrap;"
           >
@@ -1397,1501 +1447,1443 @@ exports[`grapher widget should snapshot question with multiple graph types: init
             <span
               class="mock-TeX"
             >
-              f(x)=- 2^{-x}-x+5
+              y=g(x)
             </span>
             <span />
           </span>
-           and let 
-          <span
-            style="white-space: nowrap;"
-          >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              g(x)=3|x-1|-3
-            </span>
-            <span />
-          </span>
-          .  
-        </div>
+          . 
+        </strong>
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="3"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="1"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
-          The graph of 
-          <span
-            style="white-space: nowrap;"
-          >
-            <span />
-            <span
-              class="mock-TeX"
+          <div>
+            <div
+              class="perseus-widget perseus-widget-grapher"
+              style="width: 400px; height: 400px; box-sizing: initial;"
             >
-              y=f(x)
-            </span>
-            <span />
-          </span>
-           is shown below.
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="2"
-      >
-        <div
-          class="paragraph"
-        >
-          <strong>
-            Use the interactive graph to sketch a graph of 
-            <span
-              style="white-space: nowrap;"
-            >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                y=g(x)
-              </span>
-              <span />
-            </span>
-            . 
-          </strong>
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="3"
-      >
-        <div
-          class="paragraph"
-        >
-          <div
-            class="perseus-widget-container widget-nohighlight widget-block"
-          >
-            <div>
               <div
-                class="perseus-widget perseus-widget-grapher"
-                style="width: 400px; height: 400px; box-sizing: initial;"
+                class="graphie-container above-scratchpad"
+                style="width: 400px; height: 400px;"
               >
                 <div
-                  class="graphie-container above-scratchpad"
-                  style="width: 400px; height: 400px;"
+                  class="fixed-to-responsive svg-image"
+                  style="max-width: 400px; max-height: 400px;"
                 >
                   <div
-                    class="fixed-to-responsive svg-image"
-                    style="max-width: 400px; max-height: 400px;"
+                    style="padding-bottom: 100%;"
+                  />
+                  <span
+                    style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
                   >
                     <div
-                      style="padding-bottom: 100%;"
-                    />
-                    <span
-                      style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
+                      class="default_xu2jcg-o_O-spinnerContainer_agrn11"
+                    >
+                      <svg
+                        height="48"
+                        viewBox="0 0 48 48"
+                        width="48"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
+                          d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
+                          fill-rule="nonzero"
+                        />
+                      </svg>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  class="graphie-container"
+                >
+                  <div
+                    class="graphie"
+                    style="position: relative; width: 400px; height: 400px;"
+                  >
+                    <svg
+                      height="400"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
+                      version="1.1"
+                      width="400"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                    </svg>
+                    <svg
+                      height="400"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="400"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <path
+                        d="M0,400L0,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M20,400L20,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M40,400L40,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M60,400L60,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M80,400L80,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M100,400L100,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M120,400L120,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M140,400L140,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M160,400L160,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M180,400L180,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M200,400L200,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M220,400L220,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M240,400L240,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M260,400L260,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M280,400L280,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M300,400L300,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M320,400L320,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M340,400L340,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M360,400L360,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M380,400L380,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M400,400L400,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,400L400,400"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,380L400,380"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,360L400,360"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,340L400,340"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,320L400,320"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,300L400,300"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,280L400,280"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,260L400,260"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,240L400,240"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,220L400,220"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,200L400,200"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,180L400,180"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,160L400,160"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,140L400,140"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,120L400,120"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,100L400,100"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,80L400,80"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,60L400,60"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,40L400,40"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,20L400,20"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M0,0L400,0"
+                        fill="none"
+                        opacity="0.1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                      />
+                      <path
+                        d="M-3.4499999999999886,205.6C-3.0999999999999885,203.5,0.7500000000000115,200.35,1.8000000000000114,200C0.7500000000000113,199.65,-3.099999999999989,196.5,-3.4499999999999886,194.4"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1; stroke-linejoin: round; stroke-linecap: round;"
+                        transform="rotate(180 1.8000000000000114 200)"
+                      />
+                      <path
+                        d="M200,200C200,200,200,200,1.0500000000000114,200"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
+                      />
+                      <path
+                        d="M394.45,205.6C394.8,203.5,398.65,200.35,399.7,200C398.65,199.65,394.8,196.5,394.45,194.4"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1; stroke-linejoin: round; stroke-linecap: round;"
+                        transform=""
+                      />
+                      <path
+                        d="M200,200C200,200,200,200,398.95,200"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
+                      />
+                      <path
+                        d="M195.5,404.55C195.85,402.45,199.7,399.3,200.75,398.95C199.7,398.59999999999997,195.85,395.45,195.5,393.34999999999997"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1; stroke-linejoin: round; stroke-linecap: round;"
+                        transform="rotate(90 200.75 398.95)"
+                      />
+                      <path
+                        d="M200,200C200,200,200,200,200,398.95"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
+                      />
+                      <path
+                        d="M195.5,6.650000000000011C195.85,4.550000000000011,199.7,1.400000000000011,200.75,1.0500000000000114C199.7,0.7000000000000114,195.85,-2.4499999999999886,195.5,-4.549999999999988"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1; stroke-linejoin: round; stroke-linecap: round;"
+                        transform="rotate(-90 200.75 1.0500000000000114)"
+                      />
+                      <path
+                        d="M200,200C200,200,200,200,200,1.0500000000000114"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
+                      />
+                      <path
+                        d="M220,205L220,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M240,205L240,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M260,205L260,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M280,205L280,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M300,205L300,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M320,205L320,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M340,205L340,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M360,205L360,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M380,205L380,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M180,205L180,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M160,205L160,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M140,205L140,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M120,205L120,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M100,205L100,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M80,205L80,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M60,205L60,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M40,205L40,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M20,205L20,195"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,180L205,180"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,160L205,160"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,140L205,140"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,120L205,120"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,100L205,100"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,80L205,80"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,60L205,60"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,40L205,40"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,20L205,20"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,220L205,220"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,240L205,240"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,260L205,260"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,280L205,280"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,300L205,300"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,320L205,320"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,340L205,340"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,360L205,360"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M195,380L205,380"
+                        fill="none"
+                        opacity="1"
+                        stroke="#000000"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                      />
+                      <path
+                        d="M0,100L0.5000000000000071,100L1.0000000000000142,100L1.5000000000000213,100L2.0000000000000284,100L2.5000000000000355,100L3.0000000000000426,100L3.5000000000000497,100L4.000000000000057,100L4.500000000000064,100L5.000000000000071,100L5.500000000000078,100L6.000000000000085,100L6.500000000000092,100L7.0000000000000995,100L7.500000000000107,100L8.000000000000114,100L8.50000000000012,100L9.000000000000128,100L9.500000000000135,100L10.000000000000142,100L10.50000000000015,100L11.000000000000156,100L11.500000000000163,100L12.00000000000017,100L12.500000000000178,100L13.000000000000185,100L13.500000000000192,100L14.000000000000199,100L14.500000000000206,100L15.000000000000213,100L15.50000000000022,100L16.000000000000227,100L16.500000000000234,100L17.00000000000024,100L17.50000000000025,100L18.000000000000256,100L18.500000000000263,100L19.00000000000027,100L19.500000000000277,100L20.000000000000284,100L20.50000000000029,100L21.0000000000003,100L21.500000000000306,100L22.000000000000313,100L22.50000000000032,100L23.000000000000327,100L23.500000000000334,100L24.00000000000034,100L24.500000000000348,100L25.000000000000355,100L25.500000000000362,100L26.00000000000037,100L26.500000000000377,100L27.000000000000384,100L27.50000000000039,100L28.000000000000398,100L28.500000000000405,100L29.000000000000412,100L29.50000000000042,100L30.000000000000426,100L30.500000000000433,100L31.00000000000044,100L31.500000000000448,100L32.000000000000455,100L32.50000000000046,100L33.00000000000047,100L33.500000000000476,100L34.00000000000048,100L34.50000000000049,100L35.0000000000005,100L35.500000000000504,100L36.00000000000051,100L36.50000000000052,100L37.000000000000526,100L37.50000000000053,100L38.00000000000054,100L38.50000000000055,100L39.000000000000554,100L39.50000000000056,100L40.00000000000057,100L40.500000000000576,100L41.00000000000058,100L41.50000000000059,100L42.0000000000006,100L42.500000000000604,100L43.00000000000061,100L43.50000000000062,100L44.000000000000625,100L44.50000000000063,100L45.00000000000064,100L45.50000000000065,100L46.000000000000654,100L46.50000000000066,100L47.00000000000067,100L47.500000000000675,100L48.00000000000068,100L48.50000000000069,100L49.000000000000696,100L49.5000000000007,100L50.00000000000071,100L50.50000000000072,100L51.000000000000725,100L51.50000000000073,100L52.00000000000074,100L52.500000000000746,100L53.00000000000075,100L53.50000000000076,100L54.00000000000077,100L54.500000000000774,100L55.00000000000078,100L55.50000000000079,100L56.000000000000796,100L56.5000000000008,100L57.00000000000081,100L57.50000000000082,100L58.000000000000824,100L58.50000000000083,100L59.00000000000084,100L59.500000000000846,100L60.00000000000085,100L60.50000000000086,100L61.00000000000087,100L61.500000000000874,100L62.00000000000088,100L62.50000000000089,100L63.000000000000895,100L63.5000000000009,100L64.00000000000091,100L64.50000000000091,100L65.00000000000092,100L65.50000000000094,100L66.00000000000094,100L66.50000000000094,100L67.00000000000095,100L67.50000000000097,100L68.00000000000097,100L68.50000000000097,100L69.00000000000098,100L69.500000000001,100L70.000000000001,100L70.500000000001,100L71.00000000000101,100L71.50000000000102,100L72.00000000000102,100L72.50000000000102,100L73.00000000000104,100L73.50000000000105,100L74.00000000000105,100L74.50000000000105,100L75.00000000000107,100L75.50000000000108,100L76.00000000000108,100L76.50000000000108,100L77.0000000000011,100L77.50000000000111,100L78.00000000000111,100L78.50000000000111,100L79.00000000000112,100L79.50000000000114,100L80.00000000000114,100L80.50000000000114,100L81.00000000000115,100L81.50000000000117,100L82.00000000000117,100L82.50000000000117,100L83.00000000000118,100L83.5000000000012,100L84.0000000000012,100L84.5000000000012,100L85.00000000000121,100L85.50000000000122,100L86.00000000000122,100L86.50000000000122,100L87.00000000000124,100L87.50000000000125,100L88.00000000000125,100L88.50000000000125,100L89.00000000000126,100L89.50000000000128,100L90.00000000000128,100L90.50000000000128,100L91.0000000000013,100L91.50000000000131,100L92.00000000000131,100L92.50000000000131,100L93.00000000000132,100L93.50000000000134,100L94.00000000000134,100L94.50000000000134,100L95.00000000000135,100L95.50000000000136,100L96.00000000000136,100L96.50000000000136,100L97.00000000000138,100L97.50000000000139,100L98.00000000000139,100L98.50000000000139,100L99.0000000000014,100L99.50000000000142,100L100.00000000000142,100L100.50000000000142,100L101.00000000000144,100L101.50000000000145,100L102.00000000000145,100L102.50000000000145,100L103.00000000000146,100L103.50000000000148,100L104.00000000000148,100L104.50000000000148,100L105.00000000000149,100L105.5000000000015,100L106.0000000000015,100L106.5000000000015,100L107.00000000000152,100L107.50000000000153,100L108.00000000000153,100L108.50000000000153,100L109.00000000000155,100L109.50000000000156,100L110.00000000000156,100L110.50000000000156,100L111.00000000000158,100L111.50000000000159,100L112.00000000000159,100L112.50000000000159,100L113.0000000000016,100L113.50000000000162,100L114.00000000000162,100L114.50000000000162,100L115.00000000000163,100L115.50000000000165,100L116.00000000000165,100L116.50000000000165,100L117.00000000000166,100L117.50000000000168,100L118.00000000000168,100L118.50000000000168,100L119.00000000000169,100L119.5000000000017,100L120.0000000000017,100L120.50000000000169,100L121.00000000000168,100L121.50000000000169,100L122.0000000000017,100L122.50000000000169,100L123.00000000000168,100L123.50000000000168,100L124.00000000000169,100L124.50000000000168,100L125.00000000000168,100L125.50000000000168,100L126.00000000000168,100L126.50000000000168,100L127.00000000000166,100L127.50000000000168,100L128.00000000000168,100L128.50000000000168,100L129.00000000000165,100L129.50000000000165,100L130.00000000000168,100L130.50000000000165,100L131.00000000000165,100L131.50000000000165,100L132.00000000000165,100L132.50000000000165,100L133.00000000000165,100L133.50000000000165,100L134.00000000000165,100L134.50000000000165,100L135.00000000000165,100L135.50000000000165,100L136.00000000000165,100L136.50000000000165,100L137.00000000000162,100L137.50000000000165,100L138.00000000000165,100L138.50000000000162,100L139.00000000000162,100L139.50000000000162,100L140.00000000000165,100L140.50000000000162,100L141.00000000000162,100L141.50000000000162,100L142.00000000000162,100L142.50000000000162,100L143.0000000000016,100L143.50000000000162,100L144.00000000000162,100L144.50000000000162,100L145.0000000000016,100L145.5000000000016,100L146.00000000000162,100L146.5000000000016,100L147.0000000000016,100L147.5000000000016,100L148.0000000000016,100L148.5000000000016,100L149.0000000000016,100L149.5000000000016,100L150.0000000000016,100L150.5000000000016,100L151.0000000000016,100L151.5000000000016,100L152.0000000000016,100L152.5000000000016,100L153.00000000000156,100L153.5000000000016,100L154.0000000000016,100L154.50000000000156,100L155.00000000000156,100L155.50000000000156,100L156.0000000000016,100L156.50000000000156,100L157.00000000000156,100L157.50000000000156,100L158.00000000000156,100L158.50000000000156,100L159.00000000000153,100L159.50000000000156,100L160.00000000000156,100L160.50000000000153,100L161.00000000000153,100L161.50000000000153,100L162.00000000000156,100L162.50000000000156,100L163.00000000000153,100L163.50000000000153,100L164.00000000000153,100L164.50000000000153,100L165.00000000000153,100L165.50000000000153,100L166.00000000000153,100L166.50000000000153,100L167.00000000000153,100L167.50000000000153,100L168.00000000000153,100L168.5000000000015,100L169.0000000000015,100L169.50000000000153,100L170.00000000000153,100L170.50000000000153,100L171.0000000000015,100L171.5000000000015,100L172.00000000000153,100L172.50000000000148,100L173.0000000000015,100L173.5000000000015,100L174.0000000000015,100L174.50000000000153,100L175.00000000000148,100L175.5000000000015,100L176.0000000000015,100L176.50000000000148,100L177.00000000000148,100L177.50000000000148,100L178.0000000000015,100L178.5000000000015,100L179.00000000000148,100L179.50000000000148,100L180.00000000000148,100L180.5000000000015,100L181.00000000000148,100L181.50000000000148,100L182.00000000000148,100L182.50000000000148,100L183.0000000000015,100L183.5000000000015,100L184.00000000000148,100L184.50000000000148,100L185.00000000000148,100L185.5000000000015,100L186.0000000000015,100L186.50000000000148,100L187.00000000000148,100L187.50000000000148,100L188.0000000000015,100L188.5000000000015,100L189.00000000000148,100L189.50000000000148,100L190.00000000000148,100L190.5000000000015,100L191.0000000000015,100L191.50000000000148,100L192.00000000000148,100L192.50000000000148,100L193.0000000000015,100L193.5000000000015,100L194.0000000000015,100L194.50000000000148,100L195.00000000000148,100L195.5000000000015,100L196.0000000000015,100L196.5000000000015,100L197.00000000000148,100L197.50000000000148,100L198.0000000000015,100L198.5000000000015,100L199.0000000000015,100L199.50000000000148,100L200.00000000000148,100L200.5000000000015,100L201.0000000000015,100L201.5000000000015,100L202.00000000000148,100L202.50000000000148,100L203.0000000000015,100L203.5000000000015,100L204.0000000000015,100L204.50000000000148,100L205.00000000000148,100L205.5000000000015,100L206.0000000000015,100L206.5000000000015,100L207.00000000000148,100L207.50000000000148,100L208.0000000000015,100L208.5000000000015,100L209.0000000000015,100L209.50000000000148,100L210.00000000000148,100L210.5000000000015,100L211.0000000000015,100L211.5000000000015,100L212.00000000000153,100L212.50000000000148,100L213.0000000000015,100L213.5000000000015,100L214.0000000000015,100L214.50000000000153,100L215.00000000000148,100L215.5000000000015,100L216.0000000000015,100L216.5000000000015,100L217.00000000000153,100L217.50000000000148,100L218.0000000000015,100L218.5000000000015,100L219.0000000000015,100L219.50000000000153,100L220.00000000000148,100L220.5000000000015,100L221.0000000000015,100L221.5000000000015,100L222.00000000000153,100L222.50000000000148,100L223.0000000000015,100L223.5000000000015,100L224.00000000000148,100L224.50000000000148,100L225.00000000000148,100L225.5000000000015,100L226.0000000000015,100L226.50000000000148,100L227.00000000000148,100L227.50000000000148,100L228.00000000000148,100L228.50000000000148,100L229.00000000000148,100L229.50000000000148,100L230.00000000000148,100L230.50000000000148,100L231.00000000000148,100L231.50000000000148,100L232.00000000000145,100L232.50000000000145,100L233.00000000000148,100L233.50000000000148,100L234.00000000000148,100L234.50000000000145,100L235.00000000000145,100L235.50000000000148,100L236.00000000000142,100L236.50000000000145,100L237.00000000000145,100L237.50000000000145,100L238.00000000000148,100L238.50000000000142,100L239.00000000000145,100L239.50000000000145,100L240.00000000000142,100L240.50000000000142,100L241.00000000000142,100L241.50000000000145,100L242.00000000000145,100L242.50000000000142,100L243.00000000000142,100L243.50000000000142,100L244.00000000000142,100L244.50000000000142,100L245.00000000000142,100L245.50000000000142,100L246.00000000000142,100L246.50000000000142,100L247.00000000000142,100L247.50000000000142,100L248.0000000000014,100L248.5000000000014,100L249.00000000000142,100L249.50000000000142,100L250.00000000000142,100L250.5000000000014,100L251.0000000000014,100L251.50000000000142,100L252.00000000000136,100L252.5000000000014,100L253.0000000000014,100L253.5000000000014,100L254.00000000000142,100L254.50000000000136,100L255.0000000000014,100L255.5000000000014,100L256.00000000000136,100L256.50000000000136,100L257.00000000000136,100L257.50000000000136,100L258.00000000000136,100L258.50000000000136,100L259.00000000000136,100L259.50000000000136,100L260.00000000000136,100L260.50000000000136,100L261.00000000000136,100L261.50000000000136,100L262.00000000000136,100L262.50000000000136,100L263.00000000000136,100L263.50000000000136,100L264.00000000000136,100L264.50000000000136,100L265.00000000000136,100L265.50000000000136,100L266.00000000000136,100L266.50000000000136,100L267.00000000000136,100L267.50000000000136,100L268.0000000000013,100L268.5000000000013,100L269.00000000000136,100L269.50000000000136,100L270.00000000000136,100L270.5000000000013,100L271.0000000000013,100L271.50000000000136,100L272.0000000000013,100L272.5000000000013,100L273.0000000000013,100L273.5000000000013,100L274.00000000000136,100L274.5000000000013,100L275.0000000000013,100L275.5000000000013,100L276.0000000000013,100L276.5000000000013,100L277.0000000000013,100L277.5000000000013,100L278.0000000000013,100L278.5000000000013,100L279.0000000000013,100L279.5000000000013,100L280.00000000000125,100L280.5000000000013,100L281.0000000000013,100L281.50000000000136,100L282.0000000000013,100L282.50000000000136,100L283.0000000000013,100L283.50000000000136,100L284.00000000000136,100L284.50000000000136,100L285.00000000000136,100L285.50000000000136,100L286.00000000000136,100L286.5000000000014,100L287.00000000000136,100L287.5000000000014,100L288.00000000000136,100L288.5000000000014,100L289.0000000000014,100L289.5000000000015,100L290.0000000000014,100L290.5000000000015,100L291.0000000000014,100L291.5000000000015,100L292.0000000000015,100L292.5000000000015,100L293.0000000000015,100L293.5000000000015,100L294.0000000000015,100L294.50000000000153,100L295.0000000000015,100L295.50000000000153,100L296.0000000000015,100L296.50000000000153,100L297.00000000000153,100L297.5000000000016,100L298.00000000000153,100L298.5000000000016,100L299.00000000000153,100L299.5000000000016,100L300.0000000000016,100L300.5000000000016,100L301.0000000000016,100L301.5000000000016,100L302.0000000000016,100L302.50000000000165,100L303.0000000000016,100L303.50000000000165,100L304.0000000000016,100L304.50000000000165,100L305.00000000000165,100L305.5000000000017,100L306.00000000000165,100L306.5000000000017,100L307.00000000000165,100L307.5000000000017,100L308.0000000000017,100L308.5000000000017,100L309.0000000000017,100L309.5000000000017,100L310.0000000000017,100L310.50000000000176,100L311.0000000000017,100L311.50000000000176,100L312.0000000000017,100L312.50000000000176,100L313.00000000000176,100L313.5000000000018,100L314.00000000000176,100L314.5000000000018,100L315.00000000000176,100L315.5000000000018,100L316.0000000000018,100L316.5000000000018,100L317.0000000000018,100L317.5000000000018,100L318.0000000000018,100L318.5000000000019,100L319.0000000000018,100L319.5000000000019,100L320.0000000000018,100L320.5000000000019,100L321.0000000000019,100L321.50000000000193,100L322.0000000000019,100L322.50000000000193,100L323.0000000000019,100L323.50000000000193,100L324.00000000000193,100L324.50000000000193,100L325.00000000000193,100L325.50000000000193,100L326.00000000000193,100L326.500000000002,100L327.00000000000193,100L327.500000000002,100L328.00000000000193,100L328.500000000002,100L329.000000000002,100L329.50000000000205,100L330.000000000002,100L330.50000000000205,100L331.000000000002,100L331.50000000000205,100L332.00000000000205,100L332.50000000000205,100L333.00000000000205,100L333.50000000000205,100L334.00000000000205,100L334.5000000000021,100L335.00000000000205,100L335.5000000000021,100L336.00000000000205,100L336.5000000000021,100L337.0000000000021,100L337.50000000000216,100L338.0000000000021,100L338.50000000000216,100L339.0000000000021,100L339.50000000000216,100L340.00000000000216,100L340.50000000000216,100L341.00000000000216,100L341.50000000000216,100L342.00000000000216,100L342.5000000000022,100L343.00000000000216,100L343.5000000000022,100L344.00000000000216,100L344.5000000000022,100L345.0000000000022,100L345.5000000000023,100L346.0000000000022,100L346.5000000000023,100L347.0000000000022,100L347.5000000000023,100L348.0000000000023,100L348.5000000000023,100L349.0000000000023,100L349.5000000000023,100L350.0000000000023,100L350.50000000000233,100L351.0000000000023,100L351.50000000000233,100L352.0000000000023,100L352.50000000000233,100L353.00000000000233,100L353.5000000000024,100L354.00000000000233,100L354.5000000000024,100L355.00000000000233,100L355.5000000000024,100L356.0000000000024,100L356.5000000000024,100L357.0000000000024,100L357.5000000000024,100L358.0000000000024,100L358.50000000000244,100L359.0000000000024,100L359.50000000000244,100L360.0000000000024,100L360.5000000000024,100L361.00000000000244,100L361.5000000000025,100L362.00000000000244,100L362.5000000000024,100L363.00000000000244,100L363.5000000000025,100L364.0000000000025,100L364.50000000000244,100L365.0000000000025,100L365.5000000000025,100L366.0000000000025,100L366.5000000000025,100L367.0000000000025,100L367.50000000000256,100L368.0000000000025,100L368.5000000000025,100L369.00000000000256,100L369.5000000000026,100L370.00000000000256,100L370.5000000000025,100L371.00000000000256,100L371.5000000000026,100L372.0000000000026,100L372.50000000000256,100L373.0000000000026,100L373.5000000000026,100L374.0000000000026,100L374.5000000000026,100L375.0000000000026,100L375.5000000000027,100L376.0000000000026,100L376.5000000000026,100L377.0000000000027,100L377.50000000000273,100L378.0000000000027,100L378.5000000000026,100L379.0000000000027,100L379.50000000000273,100L380.00000000000273,100L380.5000000000027,100L381.00000000000273,100L381.50000000000273,100L382.00000000000273,100L382.50000000000273,100L383.00000000000273,100L383.5000000000028,100L384.00000000000273,100L384.50000000000273,100L385.0000000000028,100L385.50000000000284,100L386.0000000000028,100L386.50000000000273,100L387.0000000000028,100L387.50000000000284,100L388.00000000000284,100L388.5000000000028,100L389.00000000000284,100L389.50000000000284,100L390.00000000000284,100L390.50000000000284,100L391.00000000000284,100L391.5000000000029,100L392.00000000000284,100L392.50000000000284,100L393.0000000000029,100L393.50000000000296,100L394.0000000000029,100L394.50000000000284,100L395.0000000000029,100L395.50000000000296,100L396.00000000000296,100L396.5000000000029,100L397.00000000000296,100L397.50000000000296,100L398.00000000000296,100L398.50000000000296,100L399.00000000000296,100L399.500000000003,100"
+                        fill="none"
+                        stroke="#6495ed"
+                        stroke-width="2"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                      />
+                    </svg>
+                    <div
+                      style="position: absolute; left: 0px; top: 0px;"
                     >
                       <div
-                        class="default_xu2jcg-o_O-spinnerContainer_agrn11"
+                        style="position: absolute; width: 26px; height: 26px; left: 87px; top: 87px; transform: translateX(0px) translateY(0px) translateZ(0);"
                       >
                         <svg
-                          height="48"
-                          viewBox="0 0 48 48"
-                          width="48"
+                          height="26"
+                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                          version="1.1"
+                          width="26"
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
-                            d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
-                            fill-rule="nonzero"
+                          <desc
+                            style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                          >
+                            Created with Raphaël
+                          </desc>
+                          <defs
+                            style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                          />
+                          <ellipse
+                            cx="NaN"
+                            cy="NaN"
+                            fill="#71b307"
+                            r="NaN"
+                            rx="4"
+                            ry="4"
+                            stroke="#71b307"
+                            style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                            transform=""
                           />
                         </svg>
                       </div>
-                    </span>
-                  </div>
-                  <div
-                    class="graphie-container"
-                  >
-                    <div
-                      class="graphie"
-                      style="position: relative; width: 400px; height: 400px;"
-                    >
-                      <svg
-                        height="400"
-                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
-                        version="1.1"
-                        width="400"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                      </svg>
-                      <svg
-                        height="400"
-                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="400"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <path
-                          d="M0,400L0,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M20,400L20,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M40,400L40,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M60,400L60,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M80,400L80,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M100,400L100,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M120,400L120,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M140,400L140,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M160,400L160,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M180,400L180,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M200,400L200,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M220,400L220,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M240,400L240,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M260,400L260,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M280,400L280,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M300,400L300,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M320,400L320,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M340,400L340,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M360,400L360,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M380,400L380,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M400,400L400,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,400L400,400"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,380L400,380"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,360L400,360"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,340L400,340"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,320L400,320"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,300L400,300"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,280L400,280"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,260L400,260"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,240L400,240"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,220L400,220"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,200L400,200"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,180L400,180"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,160L400,160"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,140L400,140"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,120L400,120"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,100L400,100"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,80L400,80"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,60L400,60"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,40L400,40"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,20L400,20"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M0,0L400,0"
-                          fill="none"
-                          opacity="0.1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
-                        />
-                        <path
-                          d="M-3.4499999999999886,205.6C-3.0999999999999885,203.5,0.7500000000000115,200.35,1.8000000000000114,200C0.7500000000000113,199.65,-3.099999999999989,196.5,-3.4499999999999886,194.4"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1; stroke-linejoin: round; stroke-linecap: round;"
-                          transform="rotate(180 1.8000000000000114 200)"
-                        />
-                        <path
-                          d="M200,200C200,200,200,200,1.0500000000000114,200"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
-                        />
-                        <path
-                          d="M394.45,205.6C394.8,203.5,398.65,200.35,399.7,200C398.65,199.65,394.8,196.5,394.45,194.4"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1; stroke-linejoin: round; stroke-linecap: round;"
-                          transform=""
-                        />
-                        <path
-                          d="M200,200C200,200,200,200,398.95,200"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
-                        />
-                        <path
-                          d="M195.5,404.55C195.85,402.45,199.7,399.3,200.75,398.95C199.7,398.59999999999997,195.85,395.45,195.5,393.34999999999997"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1; stroke-linejoin: round; stroke-linecap: round;"
-                          transform="rotate(90 200.75 398.95)"
-                        />
-                        <path
-                          d="M200,200C200,200,200,200,200,398.95"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
-                        />
-                        <path
-                          d="M195.5,6.650000000000011C195.85,4.550000000000011,199.7,1.400000000000011,200.75,1.0500000000000114C199.7,0.7000000000000114,195.85,-2.4499999999999886,195.5,-4.549999999999988"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1; stroke-linejoin: round; stroke-linecap: round;"
-                          transform="rotate(-90 200.75 1.0500000000000114)"
-                        />
-                        <path
-                          d="M200,200C200,200,200,200,200,1.0500000000000114"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
-                        />
-                        <path
-                          d="M220,205L220,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M240,205L240,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M260,205L260,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M280,205L280,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M300,205L300,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M320,205L320,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M340,205L340,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M360,205L360,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M380,205L380,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M180,205L180,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M160,205L160,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M140,205L140,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M120,205L120,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M100,205L100,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M80,205L80,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M60,205L60,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M40,205L40,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M20,205L20,195"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,180L205,180"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,160L205,160"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,140L205,140"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,120L205,120"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,100L205,100"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,80L205,80"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,60L205,60"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,40L205,40"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,20L205,20"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,220L205,220"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,240L205,240"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,260L205,260"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,280L205,280"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,300L205,300"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,320L205,320"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,340L205,340"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,360L205,360"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M195,380L205,380"
-                          fill="none"
-                          opacity="1"
-                          stroke="#000000"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
-                        />
-                        <path
-                          d="M0,100L0.5000000000000071,100L1.0000000000000142,100L1.5000000000000213,100L2.0000000000000284,100L2.5000000000000355,100L3.0000000000000426,100L3.5000000000000497,100L4.000000000000057,100L4.500000000000064,100L5.000000000000071,100L5.500000000000078,100L6.000000000000085,100L6.500000000000092,100L7.0000000000000995,100L7.500000000000107,100L8.000000000000114,100L8.50000000000012,100L9.000000000000128,100L9.500000000000135,100L10.000000000000142,100L10.50000000000015,100L11.000000000000156,100L11.500000000000163,100L12.00000000000017,100L12.500000000000178,100L13.000000000000185,100L13.500000000000192,100L14.000000000000199,100L14.500000000000206,100L15.000000000000213,100L15.50000000000022,100L16.000000000000227,100L16.500000000000234,100L17.00000000000024,100L17.50000000000025,100L18.000000000000256,100L18.500000000000263,100L19.00000000000027,100L19.500000000000277,100L20.000000000000284,100L20.50000000000029,100L21.0000000000003,100L21.500000000000306,100L22.000000000000313,100L22.50000000000032,100L23.000000000000327,100L23.500000000000334,100L24.00000000000034,100L24.500000000000348,100L25.000000000000355,100L25.500000000000362,100L26.00000000000037,100L26.500000000000377,100L27.000000000000384,100L27.50000000000039,100L28.000000000000398,100L28.500000000000405,100L29.000000000000412,100L29.50000000000042,100L30.000000000000426,100L30.500000000000433,100L31.00000000000044,100L31.500000000000448,100L32.000000000000455,100L32.50000000000046,100L33.00000000000047,100L33.500000000000476,100L34.00000000000048,100L34.50000000000049,100L35.0000000000005,100L35.500000000000504,100L36.00000000000051,100L36.50000000000052,100L37.000000000000526,100L37.50000000000053,100L38.00000000000054,100L38.50000000000055,100L39.000000000000554,100L39.50000000000056,100L40.00000000000057,100L40.500000000000576,100L41.00000000000058,100L41.50000000000059,100L42.0000000000006,100L42.500000000000604,100L43.00000000000061,100L43.50000000000062,100L44.000000000000625,100L44.50000000000063,100L45.00000000000064,100L45.50000000000065,100L46.000000000000654,100L46.50000000000066,100L47.00000000000067,100L47.500000000000675,100L48.00000000000068,100L48.50000000000069,100L49.000000000000696,100L49.5000000000007,100L50.00000000000071,100L50.50000000000072,100L51.000000000000725,100L51.50000000000073,100L52.00000000000074,100L52.500000000000746,100L53.00000000000075,100L53.50000000000076,100L54.00000000000077,100L54.500000000000774,100L55.00000000000078,100L55.50000000000079,100L56.000000000000796,100L56.5000000000008,100L57.00000000000081,100L57.50000000000082,100L58.000000000000824,100L58.50000000000083,100L59.00000000000084,100L59.500000000000846,100L60.00000000000085,100L60.50000000000086,100L61.00000000000087,100L61.500000000000874,100L62.00000000000088,100L62.50000000000089,100L63.000000000000895,100L63.5000000000009,100L64.00000000000091,100L64.50000000000091,100L65.00000000000092,100L65.50000000000094,100L66.00000000000094,100L66.50000000000094,100L67.00000000000095,100L67.50000000000097,100L68.00000000000097,100L68.50000000000097,100L69.00000000000098,100L69.500000000001,100L70.000000000001,100L70.500000000001,100L71.00000000000101,100L71.50000000000102,100L72.00000000000102,100L72.50000000000102,100L73.00000000000104,100L73.50000000000105,100L74.00000000000105,100L74.50000000000105,100L75.00000000000107,100L75.50000000000108,100L76.00000000000108,100L76.50000000000108,100L77.0000000000011,100L77.50000000000111,100L78.00000000000111,100L78.50000000000111,100L79.00000000000112,100L79.50000000000114,100L80.00000000000114,100L80.50000000000114,100L81.00000000000115,100L81.50000000000117,100L82.00000000000117,100L82.50000000000117,100L83.00000000000118,100L83.5000000000012,100L84.0000000000012,100L84.5000000000012,100L85.00000000000121,100L85.50000000000122,100L86.00000000000122,100L86.50000000000122,100L87.00000000000124,100L87.50000000000125,100L88.00000000000125,100L88.50000000000125,100L89.00000000000126,100L89.50000000000128,100L90.00000000000128,100L90.50000000000128,100L91.0000000000013,100L91.50000000000131,100L92.00000000000131,100L92.50000000000131,100L93.00000000000132,100L93.50000000000134,100L94.00000000000134,100L94.50000000000134,100L95.00000000000135,100L95.50000000000136,100L96.00000000000136,100L96.50000000000136,100L97.00000000000138,100L97.50000000000139,100L98.00000000000139,100L98.50000000000139,100L99.0000000000014,100L99.50000000000142,100L100.00000000000142,100L100.50000000000142,100L101.00000000000144,100L101.50000000000145,100L102.00000000000145,100L102.50000000000145,100L103.00000000000146,100L103.50000000000148,100L104.00000000000148,100L104.50000000000148,100L105.00000000000149,100L105.5000000000015,100L106.0000000000015,100L106.5000000000015,100L107.00000000000152,100L107.50000000000153,100L108.00000000000153,100L108.50000000000153,100L109.00000000000155,100L109.50000000000156,100L110.00000000000156,100L110.50000000000156,100L111.00000000000158,100L111.50000000000159,100L112.00000000000159,100L112.50000000000159,100L113.0000000000016,100L113.50000000000162,100L114.00000000000162,100L114.50000000000162,100L115.00000000000163,100L115.50000000000165,100L116.00000000000165,100L116.50000000000165,100L117.00000000000166,100L117.50000000000168,100L118.00000000000168,100L118.50000000000168,100L119.00000000000169,100L119.5000000000017,100L120.0000000000017,100L120.50000000000169,100L121.00000000000168,100L121.50000000000169,100L122.0000000000017,100L122.50000000000169,100L123.00000000000168,100L123.50000000000168,100L124.00000000000169,100L124.50000000000168,100L125.00000000000168,100L125.50000000000168,100L126.00000000000168,100L126.50000000000168,100L127.00000000000166,100L127.50000000000168,100L128.00000000000168,100L128.50000000000168,100L129.00000000000165,100L129.50000000000165,100L130.00000000000168,100L130.50000000000165,100L131.00000000000165,100L131.50000000000165,100L132.00000000000165,100L132.50000000000165,100L133.00000000000165,100L133.50000000000165,100L134.00000000000165,100L134.50000000000165,100L135.00000000000165,100L135.50000000000165,100L136.00000000000165,100L136.50000000000165,100L137.00000000000162,100L137.50000000000165,100L138.00000000000165,100L138.50000000000162,100L139.00000000000162,100L139.50000000000162,100L140.00000000000165,100L140.50000000000162,100L141.00000000000162,100L141.50000000000162,100L142.00000000000162,100L142.50000000000162,100L143.0000000000016,100L143.50000000000162,100L144.00000000000162,100L144.50000000000162,100L145.0000000000016,100L145.5000000000016,100L146.00000000000162,100L146.5000000000016,100L147.0000000000016,100L147.5000000000016,100L148.0000000000016,100L148.5000000000016,100L149.0000000000016,100L149.5000000000016,100L150.0000000000016,100L150.5000000000016,100L151.0000000000016,100L151.5000000000016,100L152.0000000000016,100L152.5000000000016,100L153.00000000000156,100L153.5000000000016,100L154.0000000000016,100L154.50000000000156,100L155.00000000000156,100L155.50000000000156,100L156.0000000000016,100L156.50000000000156,100L157.00000000000156,100L157.50000000000156,100L158.00000000000156,100L158.50000000000156,100L159.00000000000153,100L159.50000000000156,100L160.00000000000156,100L160.50000000000153,100L161.00000000000153,100L161.50000000000153,100L162.00000000000156,100L162.50000000000156,100L163.00000000000153,100L163.50000000000153,100L164.00000000000153,100L164.50000000000153,100L165.00000000000153,100L165.50000000000153,100L166.00000000000153,100L166.50000000000153,100L167.00000000000153,100L167.50000000000153,100L168.00000000000153,100L168.5000000000015,100L169.0000000000015,100L169.50000000000153,100L170.00000000000153,100L170.50000000000153,100L171.0000000000015,100L171.5000000000015,100L172.00000000000153,100L172.50000000000148,100L173.0000000000015,100L173.5000000000015,100L174.0000000000015,100L174.50000000000153,100L175.00000000000148,100L175.5000000000015,100L176.0000000000015,100L176.50000000000148,100L177.00000000000148,100L177.50000000000148,100L178.0000000000015,100L178.5000000000015,100L179.00000000000148,100L179.50000000000148,100L180.00000000000148,100L180.5000000000015,100L181.00000000000148,100L181.50000000000148,100L182.00000000000148,100L182.50000000000148,100L183.0000000000015,100L183.5000000000015,100L184.00000000000148,100L184.50000000000148,100L185.00000000000148,100L185.5000000000015,100L186.0000000000015,100L186.50000000000148,100L187.00000000000148,100L187.50000000000148,100L188.0000000000015,100L188.5000000000015,100L189.00000000000148,100L189.50000000000148,100L190.00000000000148,100L190.5000000000015,100L191.0000000000015,100L191.50000000000148,100L192.00000000000148,100L192.50000000000148,100L193.0000000000015,100L193.5000000000015,100L194.0000000000015,100L194.50000000000148,100L195.00000000000148,100L195.5000000000015,100L196.0000000000015,100L196.5000000000015,100L197.00000000000148,100L197.50000000000148,100L198.0000000000015,100L198.5000000000015,100L199.0000000000015,100L199.50000000000148,100L200.00000000000148,100L200.5000000000015,100L201.0000000000015,100L201.5000000000015,100L202.00000000000148,100L202.50000000000148,100L203.0000000000015,100L203.5000000000015,100L204.0000000000015,100L204.50000000000148,100L205.00000000000148,100L205.5000000000015,100L206.0000000000015,100L206.5000000000015,100L207.00000000000148,100L207.50000000000148,100L208.0000000000015,100L208.5000000000015,100L209.0000000000015,100L209.50000000000148,100L210.00000000000148,100L210.5000000000015,100L211.0000000000015,100L211.5000000000015,100L212.00000000000153,100L212.50000000000148,100L213.0000000000015,100L213.5000000000015,100L214.0000000000015,100L214.50000000000153,100L215.00000000000148,100L215.5000000000015,100L216.0000000000015,100L216.5000000000015,100L217.00000000000153,100L217.50000000000148,100L218.0000000000015,100L218.5000000000015,100L219.0000000000015,100L219.50000000000153,100L220.00000000000148,100L220.5000000000015,100L221.0000000000015,100L221.5000000000015,100L222.00000000000153,100L222.50000000000148,100L223.0000000000015,100L223.5000000000015,100L224.00000000000148,100L224.50000000000148,100L225.00000000000148,100L225.5000000000015,100L226.0000000000015,100L226.50000000000148,100L227.00000000000148,100L227.50000000000148,100L228.00000000000148,100L228.50000000000148,100L229.00000000000148,100L229.50000000000148,100L230.00000000000148,100L230.50000000000148,100L231.00000000000148,100L231.50000000000148,100L232.00000000000145,100L232.50000000000145,100L233.00000000000148,100L233.50000000000148,100L234.00000000000148,100L234.50000000000145,100L235.00000000000145,100L235.50000000000148,100L236.00000000000142,100L236.50000000000145,100L237.00000000000145,100L237.50000000000145,100L238.00000000000148,100L238.50000000000142,100L239.00000000000145,100L239.50000000000145,100L240.00000000000142,100L240.50000000000142,100L241.00000000000142,100L241.50000000000145,100L242.00000000000145,100L242.50000000000142,100L243.00000000000142,100L243.50000000000142,100L244.00000000000142,100L244.50000000000142,100L245.00000000000142,100L245.50000000000142,100L246.00000000000142,100L246.50000000000142,100L247.00000000000142,100L247.50000000000142,100L248.0000000000014,100L248.5000000000014,100L249.00000000000142,100L249.50000000000142,100L250.00000000000142,100L250.5000000000014,100L251.0000000000014,100L251.50000000000142,100L252.00000000000136,100L252.5000000000014,100L253.0000000000014,100L253.5000000000014,100L254.00000000000142,100L254.50000000000136,100L255.0000000000014,100L255.5000000000014,100L256.00000000000136,100L256.50000000000136,100L257.00000000000136,100L257.50000000000136,100L258.00000000000136,100L258.50000000000136,100L259.00000000000136,100L259.50000000000136,100L260.00000000000136,100L260.50000000000136,100L261.00000000000136,100L261.50000000000136,100L262.00000000000136,100L262.50000000000136,100L263.00000000000136,100L263.50000000000136,100L264.00000000000136,100L264.50000000000136,100L265.00000000000136,100L265.50000000000136,100L266.00000000000136,100L266.50000000000136,100L267.00000000000136,100L267.50000000000136,100L268.0000000000013,100L268.5000000000013,100L269.00000000000136,100L269.50000000000136,100L270.00000000000136,100L270.5000000000013,100L271.0000000000013,100L271.50000000000136,100L272.0000000000013,100L272.5000000000013,100L273.0000000000013,100L273.5000000000013,100L274.00000000000136,100L274.5000000000013,100L275.0000000000013,100L275.5000000000013,100L276.0000000000013,100L276.5000000000013,100L277.0000000000013,100L277.5000000000013,100L278.0000000000013,100L278.5000000000013,100L279.0000000000013,100L279.5000000000013,100L280.00000000000125,100L280.5000000000013,100L281.0000000000013,100L281.50000000000136,100L282.0000000000013,100L282.50000000000136,100L283.0000000000013,100L283.50000000000136,100L284.00000000000136,100L284.50000000000136,100L285.00000000000136,100L285.50000000000136,100L286.00000000000136,100L286.5000000000014,100L287.00000000000136,100L287.5000000000014,100L288.00000000000136,100L288.5000000000014,100L289.0000000000014,100L289.5000000000015,100L290.0000000000014,100L290.5000000000015,100L291.0000000000014,100L291.5000000000015,100L292.0000000000015,100L292.5000000000015,100L293.0000000000015,100L293.5000000000015,100L294.0000000000015,100L294.50000000000153,100L295.0000000000015,100L295.50000000000153,100L296.0000000000015,100L296.50000000000153,100L297.00000000000153,100L297.5000000000016,100L298.00000000000153,100L298.5000000000016,100L299.00000000000153,100L299.5000000000016,100L300.0000000000016,100L300.5000000000016,100L301.0000000000016,100L301.5000000000016,100L302.0000000000016,100L302.50000000000165,100L303.0000000000016,100L303.50000000000165,100L304.0000000000016,100L304.50000000000165,100L305.00000000000165,100L305.5000000000017,100L306.00000000000165,100L306.5000000000017,100L307.00000000000165,100L307.5000000000017,100L308.0000000000017,100L308.5000000000017,100L309.0000000000017,100L309.5000000000017,100L310.0000000000017,100L310.50000000000176,100L311.0000000000017,100L311.50000000000176,100L312.0000000000017,100L312.50000000000176,100L313.00000000000176,100L313.5000000000018,100L314.00000000000176,100L314.5000000000018,100L315.00000000000176,100L315.5000000000018,100L316.0000000000018,100L316.5000000000018,100L317.0000000000018,100L317.5000000000018,100L318.0000000000018,100L318.5000000000019,100L319.0000000000018,100L319.5000000000019,100L320.0000000000018,100L320.5000000000019,100L321.0000000000019,100L321.50000000000193,100L322.0000000000019,100L322.50000000000193,100L323.0000000000019,100L323.50000000000193,100L324.00000000000193,100L324.50000000000193,100L325.00000000000193,100L325.50000000000193,100L326.00000000000193,100L326.500000000002,100L327.00000000000193,100L327.500000000002,100L328.00000000000193,100L328.500000000002,100L329.000000000002,100L329.50000000000205,100L330.000000000002,100L330.50000000000205,100L331.000000000002,100L331.50000000000205,100L332.00000000000205,100L332.50000000000205,100L333.00000000000205,100L333.50000000000205,100L334.00000000000205,100L334.5000000000021,100L335.00000000000205,100L335.5000000000021,100L336.00000000000205,100L336.5000000000021,100L337.0000000000021,100L337.50000000000216,100L338.0000000000021,100L338.50000000000216,100L339.0000000000021,100L339.50000000000216,100L340.00000000000216,100L340.50000000000216,100L341.00000000000216,100L341.50000000000216,100L342.00000000000216,100L342.5000000000022,100L343.00000000000216,100L343.5000000000022,100L344.00000000000216,100L344.5000000000022,100L345.0000000000022,100L345.5000000000023,100L346.0000000000022,100L346.5000000000023,100L347.0000000000022,100L347.5000000000023,100L348.0000000000023,100L348.5000000000023,100L349.0000000000023,100L349.5000000000023,100L350.0000000000023,100L350.50000000000233,100L351.0000000000023,100L351.50000000000233,100L352.0000000000023,100L352.50000000000233,100L353.00000000000233,100L353.5000000000024,100L354.00000000000233,100L354.5000000000024,100L355.00000000000233,100L355.5000000000024,100L356.0000000000024,100L356.5000000000024,100L357.0000000000024,100L357.5000000000024,100L358.0000000000024,100L358.50000000000244,100L359.0000000000024,100L359.50000000000244,100L360.0000000000024,100L360.5000000000024,100L361.00000000000244,100L361.5000000000025,100L362.00000000000244,100L362.5000000000024,100L363.00000000000244,100L363.5000000000025,100L364.0000000000025,100L364.50000000000244,100L365.0000000000025,100L365.5000000000025,100L366.0000000000025,100L366.5000000000025,100L367.0000000000025,100L367.50000000000256,100L368.0000000000025,100L368.5000000000025,100L369.00000000000256,100L369.5000000000026,100L370.00000000000256,100L370.5000000000025,100L371.00000000000256,100L371.5000000000026,100L372.0000000000026,100L372.50000000000256,100L373.0000000000026,100L373.5000000000026,100L374.0000000000026,100L374.5000000000026,100L375.0000000000026,100L375.5000000000027,100L376.0000000000026,100L376.5000000000026,100L377.0000000000027,100L377.50000000000273,100L378.0000000000027,100L378.5000000000026,100L379.0000000000027,100L379.50000000000273,100L380.00000000000273,100L380.5000000000027,100L381.00000000000273,100L381.50000000000273,100L382.00000000000273,100L382.50000000000273,100L383.00000000000273,100L383.5000000000028,100L384.00000000000273,100L384.50000000000273,100L385.0000000000028,100L385.50000000000284,100L386.0000000000028,100L386.50000000000273,100L387.0000000000028,100L387.50000000000284,100L388.00000000000284,100L388.5000000000028,100L389.00000000000284,100L389.50000000000284,100L390.00000000000284,100L390.50000000000284,100L391.00000000000284,100L391.5000000000029,100L392.00000000000284,100L392.50000000000284,100L393.0000000000029,100L393.50000000000296,100L394.0000000000029,100L394.50000000000284,100L395.0000000000029,100L395.50000000000296,100L396.00000000000296,100L396.5000000000029,100L397.00000000000296,100L397.50000000000296,100L398.00000000000296,100L398.50000000000296,100L399.00000000000296,100L399.500000000003,100"
-                          fill="none"
-                          stroke="#6495ed"
-                          stroke-width="2"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
-                        />
-                      </svg>
                       <div
-                        style="position: absolute; left: 0px; top: 0px;"
+                        style="position: absolute; width: 26px; height: 26px; left: 287px; top: 87px; transform: translateX(0px) translateY(0px) translateZ(0);"
                       >
-                        <div
-                          style="position: absolute; width: 26px; height: 26px; left: 87px; top: 87px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                        <svg
+                          height="26"
+                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                          version="1.1"
+                          width="26"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <svg
-                            height="26"
+                          <desc
                             style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                            version="1.1"
-                            width="26"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <desc
-                              style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                            >
-                              Created with Raphaël
-                            </desc>
-                            <defs
-                              style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                            />
-                            <ellipse
-                              cx="NaN"
-                              cy="NaN"
-                              fill="#71b307"
-                              r="NaN"
-                              rx="4"
-                              ry="4"
-                              stroke="#71b307"
-                              style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                              transform=""
-                            />
-                          </svg>
-                        </div>
-                        <div
-                          style="position: absolute; width: 26px; height: 26px; left: 287px; top: 87px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                        >
-                          <svg
-                            height="26"
+                            Created with Raphaël
+                          </desc>
+                          <defs
                             style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                            version="1.1"
-                            width="26"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <desc
-                              style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                            >
-                              Created with Raphaël
-                            </desc>
-                            <defs
-                              style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                            />
-                            <ellipse
-                              cx="NaN"
-                              cy="NaN"
-                              fill="#71b307"
-                              r="NaN"
-                              rx="4"
-                              ry="4"
-                              stroke="#71b307"
-                              style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                              transform=""
-                            />
-                          </svg>
-                        </div>
+                          />
+                          <ellipse
+                            cx="NaN"
+                            cy="NaN"
+                            fill="#71b307"
+                            r="NaN"
+                            rx="4"
+                            ry="4"
+                            stroke="#71b307"
+                            style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                            transform=""
+                          />
+                        </svg>
                       </div>
-                      <div
-                        style="position: absolute; left: 0px; top: 0px; z-index: 2;"
-                      >
-                        <div
-                          data-interactive-kind-for-testing="movable-point"
-                          style="position: absolute; width: 48px; height: 48px; left: 76px; top: 76px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                        >
-                          <svg
-                            height="48"
-                            style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                            version="1.1"
-                            width="48"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <desc
-                              style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                            >
-                              Created with Raphaël
-                            </desc>
-                            <defs
-                              style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                            />
-                            <ellipse
-                              cx="24"
-                              cy="24"
-                              fill="#000000"
-                              opacity="0"
-                              rx="24"
-                              ry="24"
-                              stroke="#000"
-                              style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                            />
-                          </svg>
-                        </div>
-                        <div
-                          data-interactive-kind-for-testing="movable-point"
-                          style="position: absolute; width: 48px; height: 48px; left: 276px; top: 76px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                        >
-                          <svg
-                            height="48"
-                            style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                            version="1.1"
-                            width="48"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <desc
-                              style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                            >
-                              Created with Raphaël
-                            </desc>
-                            <defs
-                              style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                            />
-                            <ellipse
-                              cx="24"
-                              cy="24"
-                              fill="#000000"
-                              opacity="0"
-                              rx="24"
-                              ry="24"
-                              stroke="#000"
-                              style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{1}"
-                        style="position: absolute; padding: 7px; color: black; left: 220px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{2}"
-                        style="position: absolute; padding: 7px; color: black; left: 240px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{3}"
-                        style="position: absolute; padding: 7px; color: black; left: 260px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{4}"
-                        style="position: absolute; padding: 7px; color: black; left: 280px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{5}"
-                        style="position: absolute; padding: 7px; color: black; left: 300px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{6}"
-                        style="position: absolute; padding: 7px; color: black; left: 320px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{7}"
-                        style="position: absolute; padding: 7px; color: black; left: 340px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{8}"
-                        style="position: absolute; padding: 7px; color: black; left: 360px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{9}"
-                        style="position: absolute; padding: 7px; color: black; left: 380px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}2}"
-                        style="position: absolute; padding: 7px; color: black; left: 160px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}3}"
-                        style="position: absolute; padding: 7px; color: black; left: 140px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}4}"
-                        style="position: absolute; padding: 7px; color: black; left: 120px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}5}"
-                        style="position: absolute; padding: 7px; color: black; left: 100px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}6}"
-                        style="position: absolute; padding: 7px; color: black; left: 80px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}7}"
-                        style="position: absolute; padding: 7px; color: black; left: 60px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}8}"
-                        style="position: absolute; padding: 7px; color: black; left: 40px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}9}"
-                        style="position: absolute; padding: 7px; color: black; left: 20px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{1}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 180px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{2}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 160px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{3}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 140px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{4}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 120px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{5}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 100px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{6}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 80px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{7}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 60px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{8}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 40px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{9}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 20px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}2}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 240px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}3}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 260px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}4}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 280px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}5}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 300px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}6}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 320px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}7}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 340px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}8}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 360px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="\\small{\\llap{-}9}"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 380px; fill: none; stroke: #000000; opacity: 1;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="y"
-                        style="position: absolute; padding: 7px; color: black; left: 200px; top: 0px; fill: none;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
-                      <span
-                        class="graphie-label"
-                        data-math-formula="x"
-                        style="position: absolute; padding: 7px; color: black; left: 400px; top: 200px; fill: none;"
-                      >
-                        <span
-                          class="katex-holder"
-                        />
-                        <span
-                          class="mathjax-holder"
-                        />
-                      </span>
                     </div>
+                    <div
+                      style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                    >
+                      <div
+                        data-interactive-kind-for-testing="movable-point"
+                        style="position: absolute; width: 48px; height: 48px; left: 76px; top: 76px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                      >
+                        <svg
+                          height="48"
+                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                          version="1.1"
+                          width="48"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <desc
+                            style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                          >
+                            Created with Raphaël
+                          </desc>
+                          <defs
+                            style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                          />
+                          <ellipse
+                            cx="24"
+                            cy="24"
+                            fill="#000000"
+                            opacity="0"
+                            rx="24"
+                            ry="24"
+                            stroke="#000"
+                            style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        data-interactive-kind-for-testing="movable-point"
+                        style="position: absolute; width: 48px; height: 48px; left: 276px; top: 76px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                      >
+                        <svg
+                          height="48"
+                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                          version="1.1"
+                          width="48"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <desc
+                            style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                          >
+                            Created with Raphaël
+                          </desc>
+                          <defs
+                            style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                          />
+                          <ellipse
+                            cx="24"
+                            cy="24"
+                            fill="#000000"
+                            opacity="0"
+                            rx="24"
+                            ry="24"
+                            stroke="#000"
+                            style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{1}"
+                      style="position: absolute; padding: 7px; color: black; left: 220px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{2}"
+                      style="position: absolute; padding: 7px; color: black; left: 240px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{3}"
+                      style="position: absolute; padding: 7px; color: black; left: 260px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{4}"
+                      style="position: absolute; padding: 7px; color: black; left: 280px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{5}"
+                      style="position: absolute; padding: 7px; color: black; left: 300px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{6}"
+                      style="position: absolute; padding: 7px; color: black; left: 320px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{7}"
+                      style="position: absolute; padding: 7px; color: black; left: 340px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{8}"
+                      style="position: absolute; padding: 7px; color: black; left: 360px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{9}"
+                      style="position: absolute; padding: 7px; color: black; left: 380px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}2}"
+                      style="position: absolute; padding: 7px; color: black; left: 160px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}3}"
+                      style="position: absolute; padding: 7px; color: black; left: 140px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}4}"
+                      style="position: absolute; padding: 7px; color: black; left: 120px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}5}"
+                      style="position: absolute; padding: 7px; color: black; left: 100px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}6}"
+                      style="position: absolute; padding: 7px; color: black; left: 80px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}7}"
+                      style="position: absolute; padding: 7px; color: black; left: 60px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}8}"
+                      style="position: absolute; padding: 7px; color: black; left: 40px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}9}"
+                      style="position: absolute; padding: 7px; color: black; left: 20px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{1}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 180px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{2}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 160px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{3}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 140px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{4}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 120px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{5}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 100px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{6}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 80px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{7}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 60px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{8}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 40px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{9}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 20px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}2}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 240px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}3}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 260px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}4}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 280px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}5}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 300px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}6}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 320px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}7}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 340px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}8}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 360px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="\\small{\\llap{-}9}"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 380px; fill: none; stroke: #000000; opacity: 1;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="y"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 0px; fill: none;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
+                    <span
+                      class="graphie-label"
+                      data-math-formula="x"
+                      style="position: absolute; padding: 7px; color: black; left: 400px; top: 200px; fill: none;"
+                    >
+                      <span
+                        class="katex-holder"
+                      />
+                      <span
+                        class="mathjax-holder"
+                      />
+                    </span>
                   </div>
                 </div>
               </div>
+            </div>
+            <div
+              class="above-scratchpad"
+              style="padding: 5px 5px;"
+            >
               <div
-                class="above-scratchpad"
-                style="padding: 5px 5px;"
+                style="display: inline-block;"
               >
-                <div
-                  style="display: inline-block;"
+                <button
+                  class="buttonStyle_1xlhe29-o_O-selectedStyle_1ewmj59"
+                  id="0"
+                  title="Linear"
+                  type="button"
                 >
-                  <button
-                    class="buttonStyle_1xlhe29-o_O-selectedStyle_1ewmj59"
-                    id="0"
-                    title="Linear"
-                    type="button"
-                  >
-                    <img
-                      alt="Linear"
-                      src="mockStaticUrl(https://ka-perseus-graphie.s3.amazonaws.com/67aaf581e6d9ef9038c10558a1f70ac21c11c9f8.png)"
-                    />
-                  </button>
-                  <button
-                    class="buttonStyle_1xlhe29"
-                    id="1"
-                    title="Absolute_value"
-                    type="button"
-                  >
-                    <img
-                      alt="Absolute_value"
-                      src="mockStaticUrl(https://ka-perseus-graphie.s3.amazonaws.com/8256a630175a0cb1d11de223d6de0266daf98721.png)"
-                    />
-                  </button>
-                  <button
-                    class="buttonStyle_1xlhe29"
-                    id="2"
-                    title="Quadratic"
-                    type="button"
-                  >
-                    <img
-                      alt="Quadratic"
-                      src="mockStaticUrl(https://ka-perseus-graphie.s3.amazonaws.com/e23d36e6fc29ee37174e92c9daba2a66677128ab.png)"
-                    />
-                  </button>
-                  <button
-                    class="buttonStyle_1xlhe29"
-                    id="3"
-                    title="Exponential"
-                    type="button"
-                  >
-                    <img
-                      alt="Exponential"
-                      src="mockStaticUrl(https://ka-perseus-graphie.s3.amazonaws.com/9cbfad55525e3ce755a31a631b074670a5dad611.png)"
-                    />
-                  </button>
-                  <button
-                    class="buttonStyle_1xlhe29"
-                    id="4"
-                    title="Logarithm"
-                    type="button"
-                  >
-                    <img
-                      alt="Logarithm"
-                      src="mockStaticUrl(https://ka-perseus-graphie.s3.amazonaws.com/f6491e99d34af34d924bfe0231728ad912068dc3.png)"
-                    />
-                  </button>
-                </div>
+                  <img
+                    alt="Linear"
+                    src="mockStaticUrl(https://ka-perseus-graphie.s3.amazonaws.com/67aaf581e6d9ef9038c10558a1f70ac21c11c9f8.png)"
+                  />
+                </button>
+                <button
+                  class="buttonStyle_1xlhe29"
+                  id="1"
+                  title="Absolute_value"
+                  type="button"
+                >
+                  <img
+                    alt="Absolute_value"
+                    src="mockStaticUrl(https://ka-perseus-graphie.s3.amazonaws.com/8256a630175a0cb1d11de223d6de0266daf98721.png)"
+                  />
+                </button>
+                <button
+                  class="buttonStyle_1xlhe29"
+                  id="2"
+                  title="Quadratic"
+                  type="button"
+                >
+                  <img
+                    alt="Quadratic"
+                    src="mockStaticUrl(https://ka-perseus-graphie.s3.amazonaws.com/e23d36e6fc29ee37174e92c9daba2a66677128ab.png)"
+                  />
+                </button>
+                <button
+                  class="buttonStyle_1xlhe29"
+                  id="3"
+                  title="Exponential"
+                  type="button"
+                >
+                  <img
+                    alt="Exponential"
+                    src="mockStaticUrl(https://ka-perseus-graphie.s3.amazonaws.com/9cbfad55525e3ce755a31a631b074670a5dad611.png)"
+                  />
+                </button>
+                <button
+                  class="buttonStyle_1xlhe29"
+                  id="4"
+                  title="Logarithm"
+                  type="button"
+                >
+                  <img
+                    alt="Logarithm"
+                    src="mockStaticUrl(https://ka-perseus-graphie.s3.amazonaws.com/f6491e99d34af34d924bfe0231728ad912068dc3.png)"
+                  />
+                </button>
               </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/group.test.tsx.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/group.test.tsx.snap
@@ -2,1265 +2,1201 @@
 
 exports[`group widget should snapshot: initial render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive perseus-renderer-two-columns"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive perseus-renderer-two-columns"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
-        class="paragraph"
-        data-perseus-paragraph-index="0"
+        class="perseus-two-columns"
       >
         <div
-          class="perseus-two-columns"
+          class="perseus-column"
         >
           <div
-            class="perseus-column"
+            class="perseus-column-content"
           >
             <div
-              class="perseus-column-content"
+              class="paragraph"
             >
               <div
-                class="paragraph"
+                class="fixed-to-responsive svg-image"
+                style="max-width: 428px; max-height: 480px;"
               >
                 <div
-                  class="fixed-to-responsive svg-image"
-                  style="max-width: 428px; max-height: 480px;"
+                  style="padding-bottom: 112.14999999999999%;"
+                />
+                <span
+                  style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
                 >
                   <div
-                    style="padding-bottom: 112.14999999999999%;"
-                  />
-                  <span
-                    style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
+                    class="default_xu2jcg-o_O-spinnerContainer_agrn11"
                   >
-                    <div
-                      class="default_xu2jcg-o_O-spinnerContainer_agrn11"
+                    <svg
+                      height="48"
+                      viewBox="0 0 48 48"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        height="48"
-                        viewBox="0 0 48 48"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
-                          d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
-                          fill-rule="nonzero"
-                        />
-                      </svg>
-                    </div>
-                  </span>
-                </div>
+                      <path
+                        class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
+                        d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
+                        fill-rule="nonzero"
+                      />
+                    </svg>
+                  </div>
+                </span>
               </div>
             </div>
           </div>
+        </div>
+        <div
+          class="perseus-column"
+        >
           <div
-            class="perseus-column"
+            class="perseus-column-content"
           >
             <div
-              class="perseus-column-content"
+              class="paragraph"
             >
               <div
-                class="paragraph"
+                class="perseus-widget-container widget-nohighlight widget-block"
               >
                 <div
-                  class="perseus-widget-container widget-nohighlight widget-block"
+                  class="perseus-group perseus-group-invalid-answer"
                 >
                   <div
-                    class="perseus-group perseus-group-invalid-answer"
+                    class="perseus-renderer perseus-renderer-responsive"
                   >
-                    <span
-                      class="mock-KatexProvider"
+                    <div
+                      class="paragraph"
+                      data-perseus-paragraph-index="0"
                     >
                       <div
-                        class="perseus-renderer perseus-renderer-responsive"
+                        class="paragraph"
+                      >
+                        <strong>
+                          In one week, how many more hours are in the periods with a 
+                          <span
+                            style="white-space: nowrap;"
+                          >
+                            <span />
+                            <span
+                              class="mock-TeX"
+                            >
+                              35
+                            </span>
+                            <span />
+                          </span>
+                           percent discount than in the periods with the regular price?
+                        </strong>
+                      </div>
+                    </div>
+                    <div
+                      class="paragraph"
+                      data-perseus-paragraph-index="1"
+                    >
+                      <div
+                        class="paragraph"
                       >
                         <div
-                          class="paragraph"
-                          data-perseus-paragraph-index="0"
+                          class="perseus-widget-container widget-nohighlight widget-block"
                         >
                           <div
-                            class="paragraph"
+                            class="responsiveContainer_vq37gq"
                           >
-                            <strong>
-                              In one week, how many more hours are in the periods with a 
-                              <span
-                                style="white-space: nowrap;"
-                              >
-                                <span />
-                                <span
-                                  class="mock-TeX"
-                                >
-                                  35
-                                </span>
-                                <span />
-                              </span>
-                               percent discount than in the periods with the regular price?
-                            </strong>
-                          </div>
-                        </div>
-                        <div
-                          class="paragraph"
-                          data-perseus-paragraph-index="1"
-                        >
-                          <div
-                            class="paragraph"
-                          >
-                            <div
-                              class="perseus-widget-container widget-nohighlight widget-block"
+                            <fieldset
+                              class="perseus-widget-radio-fieldset responsiveFieldset_c0l5kf"
                             >
-                              <div
-                                class="responsiveContainer_vq37gq"
+                              <legend
+                                class="perseus-sr-only"
                               >
-                                <fieldset
-                                  class="perseus-widget-radio-fieldset responsiveFieldset_c0l5kf"
-                                >
-                                  <legend
-                                    class="perseus-sr-only"
-                                  >
-                                    Choose 1 answer:
-                                  </legend>
-                                  <div
-                                    aria-hidden="true"
-                                    class="instructions instructions_125m8j1"
-                                  >
-                                    Choose 1 answer:
-                                  </div>
-                                  <ul
-                                    class="perseus-widget-radio perseus-rendered-radio radio_1gyjybc-o_O-responsiveRadioContainer_1ybwre2"
-                                    style="list-style: none;"
-                                  >
-                                    <li
-                                      class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                                    >
-                                      <div
-                                        class="description description_psmgei"
-                                        style="flex-direction: column; color: rgb(33, 36, 44);"
-                                      >
-                                        <div
-                                          style="display: flex; flex-direction: row; opacity: 1;"
-                                        >
-                                          <div
-                                            class="perseus-sr-only"
-                                          >
-                                            <input
-                                              class="perseus-radio-option-content"
-                                              id="choice-5"
-                                              tabindex="-1"
-                                              type="radio"
-                                            />
-                                            <label
-                                              for="choice-5"
-                                            >
-                                              (Choice A)
-                                                 
-                                              <span
-                                                class="mock-KatexProvider"
-                                              >
-                                                <div
-                                                  class="perseus-renderer perseus-renderer-responsive"
-                                                >
-                                                  <div
-                                                    class="paragraph perseus-paragraph-centered"
-                                                    data-perseus-paragraph-index="0"
-                                                  >
-                                                    <div
-                                                      class="perseus-block-math"
-                                                    >
-                                                      <div
-                                                        class="perseus-block-math-inner"
-                                                        style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                                      >
-                                                        <span
-                                                          class="mock-TeX"
-                                                        >
-                                                          45
-                                                        </span>
-                                                      </div>
-                                                    </div>
-                                                  </div>
-                                                </div>
-                                              </span>
-                                            </label>
-                                          </div>
-                                          <button
-                                            aria-disabled="false"
-                                            aria-hidden="true"
-                                            class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                                            type="button"
-                                          >
-                                            <div
-                                              style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                                            >
-                                              <div
-                                                class="iconWrapper_17y0hv9"
-                                              >
-                                                <span
-                                                  class="ring_ya75gi"
-                                                  data-test-id="focus-ring"
-                                                  style="border-color: transparent; border-radius: 50%;"
-                                                >
-                                                  <div
-                                                    class="circle_1tys2th"
-                                                    data-is-radio-icon="true"
-                                                    data-test-id="choice-icon__library-choice-icon"
-                                                    style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                                  >
-                                                    <div
-                                                      class="innerWrapper_177sg8x"
-                                                    >
-                                                      A
-                                                    </div>
-                                                  </div>
-                                                </span>
-                                              </div>
-                                              <span
-                                                style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                                              >
-                                                <div />
-                                                <div>
-                                                  <span
-                                                    class="mock-KatexProvider"
-                                                  >
-                                                    <div
-                                                      class="perseus-renderer perseus-renderer-responsive"
-                                                    >
-                                                      <div
-                                                        class="paragraph perseus-paragraph-centered"
-                                                        data-perseus-paragraph-index="0"
-                                                      >
-                                                        <div
-                                                          class="perseus-block-math"
-                                                        >
-                                                          <div
-                                                            class="perseus-block-math-inner"
-                                                            style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                                          >
-                                                            <span
-                                                              class="mock-TeX"
-                                                            >
-                                                              45
-                                                            </span>
-                                                          </div>
-                                                        </div>
-                                                      </div>
-                                                    </div>
-                                                  </span>
-                                                </div>
-                                              </span>
-                                            </div>
-                                          </button>
-                                        </div>
-                                      </div>
-                                    </li>
-                                    <li
-                                      class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                                    >
-                                      <div
-                                        class="description description_psmgei"
-                                        style="flex-direction: column; color: rgb(33, 36, 44);"
-                                      >
-                                        <div
-                                          style="display: flex; flex-direction: row; opacity: 1;"
-                                        >
-                                          <div
-                                            class="perseus-sr-only"
-                                          >
-                                            <input
-                                              class="perseus-radio-option-content"
-                                              id="choice-6"
-                                              tabindex="-1"
-                                              type="radio"
-                                            />
-                                            <label
-                                              for="choice-6"
-                                            >
-                                              (Choice B)
-                                                 
-                                              <span
-                                                class="mock-KatexProvider"
-                                              >
-                                                <div
-                                                  class="perseus-renderer perseus-renderer-responsive"
-                                                >
-                                                  <div
-                                                    class="paragraph perseus-paragraph-centered"
-                                                    data-perseus-paragraph-index="0"
-                                                  >
-                                                    <div
-                                                      class="perseus-block-math"
-                                                    >
-                                                      <div
-                                                        class="perseus-block-math-inner"
-                                                        style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                                      >
-                                                        <span
-                                                          class="mock-TeX"
-                                                        >
-                                                          42
-                                                        </span>
-                                                      </div>
-                                                    </div>
-                                                  </div>
-                                                </div>
-                                              </span>
-                                            </label>
-                                          </div>
-                                          <button
-                                            aria-disabled="false"
-                                            aria-hidden="true"
-                                            class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                                            type="button"
-                                          >
-                                            <div
-                                              style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                                            >
-                                              <div
-                                                class="iconWrapper_17y0hv9"
-                                              >
-                                                <span
-                                                  class="ring_ya75gi"
-                                                  data-test-id="focus-ring"
-                                                  style="border-color: transparent; border-radius: 50%;"
-                                                >
-                                                  <div
-                                                    class="circle_1tys2th"
-                                                    data-is-radio-icon="true"
-                                                    data-test-id="choice-icon__library-choice-icon"
-                                                    style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                                  >
-                                                    <div
-                                                      class="innerWrapper_177sg8x"
-                                                    >
-                                                      B
-                                                    </div>
-                                                  </div>
-                                                </span>
-                                              </div>
-                                              <span
-                                                style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                                              >
-                                                <div />
-                                                <div>
-                                                  <span
-                                                    class="mock-KatexProvider"
-                                                  >
-                                                    <div
-                                                      class="perseus-renderer perseus-renderer-responsive"
-                                                    >
-                                                      <div
-                                                        class="paragraph perseus-paragraph-centered"
-                                                        data-perseus-paragraph-index="0"
-                                                      >
-                                                        <div
-                                                          class="perseus-block-math"
-                                                        >
-                                                          <div
-                                                            class="perseus-block-math-inner"
-                                                            style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                                          >
-                                                            <span
-                                                              class="mock-TeX"
-                                                            >
-                                                              42
-                                                            </span>
-                                                          </div>
-                                                        </div>
-                                                      </div>
-                                                    </div>
-                                                  </span>
-                                                </div>
-                                              </span>
-                                            </div>
-                                          </button>
-                                        </div>
-                                      </div>
-                                    </li>
-                                    <li
-                                      class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                                    >
-                                      <div
-                                        class="description description_psmgei"
-                                        style="flex-direction: column; color: rgb(33, 36, 44);"
-                                      >
-                                        <div
-                                          style="display: flex; flex-direction: row; opacity: 1;"
-                                        >
-                                          <div
-                                            class="perseus-sr-only"
-                                          >
-                                            <input
-                                              class="perseus-radio-option-content"
-                                              id="choice-7"
-                                              tabindex="-1"
-                                              type="radio"
-                                            />
-                                            <label
-                                              for="choice-7"
-                                            >
-                                              (Choice C)
-                                                 
-                                              <span
-                                                class="mock-KatexProvider"
-                                              >
-                                                <div
-                                                  class="perseus-renderer perseus-renderer-responsive"
-                                                >
-                                                  <div
-                                                    class="paragraph perseus-paragraph-centered"
-                                                    data-perseus-paragraph-index="0"
-                                                  >
-                                                    <div
-                                                      class="perseus-block-math"
-                                                    >
-                                                      <div
-                                                        class="perseus-block-math-inner"
-                                                        style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                                      >
-                                                        <span
-                                                          class="mock-TeX"
-                                                        >
-                                                          30
-                                                        </span>
-                                                      </div>
-                                                    </div>
-                                                  </div>
-                                                </div>
-                                              </span>
-                                            </label>
-                                          </div>
-                                          <button
-                                            aria-disabled="false"
-                                            aria-hidden="true"
-                                            class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                                            type="button"
-                                          >
-                                            <div
-                                              style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                                            >
-                                              <div
-                                                class="iconWrapper_17y0hv9"
-                                              >
-                                                <span
-                                                  class="ring_ya75gi"
-                                                  data-test-id="focus-ring"
-                                                  style="border-color: transparent; border-radius: 50%;"
-                                                >
-                                                  <div
-                                                    class="circle_1tys2th"
-                                                    data-is-radio-icon="true"
-                                                    data-test-id="choice-icon__library-choice-icon"
-                                                    style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                                  >
-                                                    <div
-                                                      class="innerWrapper_177sg8x"
-                                                    >
-                                                      C
-                                                    </div>
-                                                  </div>
-                                                </span>
-                                              </div>
-                                              <span
-                                                style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                                              >
-                                                <div />
-                                                <div>
-                                                  <span
-                                                    class="mock-KatexProvider"
-                                                  >
-                                                    <div
-                                                      class="perseus-renderer perseus-renderer-responsive"
-                                                    >
-                                                      <div
-                                                        class="paragraph perseus-paragraph-centered"
-                                                        data-perseus-paragraph-index="0"
-                                                      >
-                                                        <div
-                                                          class="perseus-block-math"
-                                                        >
-                                                          <div
-                                                            class="perseus-block-math-inner"
-                                                            style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                                          >
-                                                            <span
-                                                              class="mock-TeX"
-                                                            >
-                                                              30
-                                                            </span>
-                                                          </div>
-                                                        </div>
-                                                      </div>
-                                                    </div>
-                                                  </span>
-                                                </div>
-                                              </span>
-                                            </div>
-                                          </button>
-                                        </div>
-                                      </div>
-                                    </li>
-                                    <li
-                                      class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                                    >
-                                      <div
-                                        class="description description_psmgei"
-                                        style="flex-direction: column; color: rgb(33, 36, 44);"
-                                      >
-                                        <div
-                                          style="display: flex; flex-direction: row; opacity: 1;"
-                                        >
-                                          <div
-                                            class="perseus-sr-only"
-                                          >
-                                            <input
-                                              class="perseus-radio-option-content"
-                                              id="choice-8"
-                                              tabindex="-1"
-                                              type="radio"
-                                            />
-                                            <label
-                                              for="choice-8"
-                                            >
-                                              (Choice D)
-                                                 
-                                              <span
-                                                class="mock-KatexProvider"
-                                              >
-                                                <div
-                                                  class="perseus-renderer perseus-renderer-responsive"
-                                                >
-                                                  <div
-                                                    class="paragraph perseus-paragraph-centered"
-                                                    data-perseus-paragraph-index="0"
-                                                  >
-                                                    <div
-                                                      class="perseus-block-math"
-                                                    >
-                                                      <div
-                                                        class="perseus-block-math-inner"
-                                                        style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                                      >
-                                                        <span
-                                                          class="mock-TeX"
-                                                        >
-                                                          18
-                                                        </span>
-                                                      </div>
-                                                    </div>
-                                                  </div>
-                                                </div>
-                                              </span>
-                                            </label>
-                                          </div>
-                                          <button
-                                            aria-disabled="false"
-                                            aria-hidden="true"
-                                            class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                                            type="button"
-                                          >
-                                            <div
-                                              style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                                            >
-                                              <div
-                                                class="iconWrapper_17y0hv9"
-                                              >
-                                                <span
-                                                  class="ring_ya75gi"
-                                                  data-test-id="focus-ring"
-                                                  style="border-color: transparent; border-radius: 50%;"
-                                                >
-                                                  <div
-                                                    class="circle_1tys2th"
-                                                    data-is-radio-icon="true"
-                                                    data-test-id="choice-icon__library-choice-icon"
-                                                    style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                                  >
-                                                    <div
-                                                      class="innerWrapper_177sg8x"
-                                                    >
-                                                      D
-                                                    </div>
-                                                  </div>
-                                                </span>
-                                              </div>
-                                              <span
-                                                style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                                              >
-                                                <div />
-                                                <div>
-                                                  <span
-                                                    class="mock-KatexProvider"
-                                                  >
-                                                    <div
-                                                      class="perseus-renderer perseus-renderer-responsive"
-                                                    >
-                                                      <div
-                                                        class="paragraph perseus-paragraph-centered"
-                                                        data-perseus-paragraph-index="0"
-                                                      >
-                                                        <div
-                                                          class="perseus-block-math"
-                                                        >
-                                                          <div
-                                                            class="perseus-block-math-inner"
-                                                            style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                                          >
-                                                            <span
-                                                              class="mock-TeX"
-                                                            >
-                                                              18
-                                                            </span>
-                                                          </div>
-                                                        </div>
-                                                      </div>
-                                                    </div>
-                                                  </span>
-                                                </div>
-                                              </span>
-                                            </div>
-                                          </button>
-                                        </div>
-                                      </div>
-                                    </li>
-                                    <li
-                                      class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                                    >
-                                      <div
-                                        class="description description_psmgei"
-                                        style="flex-direction: column; color: rgb(33, 36, 44);"
-                                      >
-                                        <div
-                                          style="display: flex; flex-direction: row; opacity: 1;"
-                                        >
-                                          <div
-                                            class="perseus-sr-only"
-                                          >
-                                            <input
-                                              class="perseus-radio-option-content"
-                                              id="choice-9"
-                                              tabindex="-1"
-                                              type="radio"
-                                            />
-                                            <label
-                                              for="choice-9"
-                                            >
-                                              (Choice E)
-                                                 
-                                              <span
-                                                class="mock-KatexProvider"
-                                              >
-                                                <div
-                                                  class="perseus-renderer perseus-renderer-responsive"
-                                                >
-                                                  <div
-                                                    class="paragraph perseus-paragraph-centered"
-                                                    data-perseus-paragraph-index="0"
-                                                  >
-                                                    <div
-                                                      class="perseus-block-math"
-                                                    >
-                                                      <div
-                                                        class="perseus-block-math-inner"
-                                                        style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                                      >
-                                                        <span
-                                                          class="mock-TeX"
-                                                        >
-                                                          15
-                                                        </span>
-                                                      </div>
-                                                    </div>
-                                                  </div>
-                                                </div>
-                                              </span>
-                                            </label>
-                                          </div>
-                                          <button
-                                            aria-disabled="false"
-                                            aria-hidden="true"
-                                            class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                                            type="button"
-                                          >
-                                            <div
-                                              style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                                            >
-                                              <div
-                                                class="iconWrapper_17y0hv9"
-                                              >
-                                                <span
-                                                  class="ring_ya75gi"
-                                                  data-test-id="focus-ring"
-                                                  style="border-color: transparent; border-radius: 50%;"
-                                                >
-                                                  <div
-                                                    class="circle_1tys2th"
-                                                    data-is-radio-icon="true"
-                                                    data-test-id="choice-icon__library-choice-icon"
-                                                    style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                                  >
-                                                    <div
-                                                      class="innerWrapper_177sg8x"
-                                                    >
-                                                      E
-                                                    </div>
-                                                  </div>
-                                                </span>
-                                              </div>
-                                              <span
-                                                style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                                              >
-                                                <div />
-                                                <div>
-                                                  <span
-                                                    class="mock-KatexProvider"
-                                                  >
-                                                    <div
-                                                      class="perseus-renderer perseus-renderer-responsive"
-                                                    >
-                                                      <div
-                                                        class="paragraph perseus-paragraph-centered"
-                                                        data-perseus-paragraph-index="0"
-                                                      >
-                                                        <div
-                                                          class="perseus-block-math"
-                                                        >
-                                                          <div
-                                                            class="perseus-block-math-inner"
-                                                            style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                                          >
-                                                            <span
-                                                              class="mock-TeX"
-                                                            >
-                                                              15
-                                                            </span>
-                                                          </div>
-                                                        </div>
-                                                      </div>
-                                                    </div>
-                                                  </span>
-                                                </div>
-                                              </span>
-                                            </div>
-                                          </button>
-                                        </div>
-                                      </div>
-                                    </li>
-                                  </ul>
-                                </fieldset>
+                                Choose 1 answer:
+                              </legend>
+                              <div
+                                aria-hidden="true"
+                                class="instructions instructions_125m8j1"
+                              >
+                                Choose 1 answer:
                               </div>
-                            </div>
+                              <ul
+                                class="perseus-widget-radio perseus-rendered-radio radio_1gyjybc-o_O-responsiveRadioContainer_1ybwre2"
+                                style="list-style: none;"
+                              >
+                                <li
+                                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                                >
+                                  <div
+                                    class="description description_psmgei"
+                                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                                  >
+                                    <div
+                                      style="display: flex; flex-direction: row; opacity: 1;"
+                                    >
+                                      <div
+                                        class="perseus-sr-only"
+                                      >
+                                        <input
+                                          class="perseus-radio-option-content"
+                                          id="choice-5"
+                                          tabindex="-1"
+                                          type="radio"
+                                        />
+                                        <label
+                                          for="choice-5"
+                                        >
+                                          (Choice A)
+                                             
+                                          <div
+                                            class="perseus-renderer perseus-renderer-responsive"
+                                          >
+                                            <div
+                                              class="paragraph perseus-paragraph-centered"
+                                              data-perseus-paragraph-index="0"
+                                            >
+                                              <div
+                                                class="perseus-block-math"
+                                              >
+                                                <div
+                                                  class="perseus-block-math-inner"
+                                                  style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                                >
+                                                  <span
+                                                    class="mock-TeX"
+                                                  >
+                                                    45
+                                                  </span>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </label>
+                                      </div>
+                                      <button
+                                        aria-disabled="false"
+                                        aria-hidden="true"
+                                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                                        type="button"
+                                      >
+                                        <div
+                                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                                        >
+                                          <div
+                                            class="iconWrapper_17y0hv9"
+                                          >
+                                            <span
+                                              class="ring_ya75gi"
+                                              data-test-id="focus-ring"
+                                              style="border-color: transparent; border-radius: 50%;"
+                                            >
+                                              <div
+                                                class="circle_1tys2th"
+                                                data-is-radio-icon="true"
+                                                data-test-id="choice-icon__library-choice-icon"
+                                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                                              >
+                                                <div
+                                                  class="innerWrapper_177sg8x"
+                                                >
+                                                  A
+                                                </div>
+                                              </div>
+                                            </span>
+                                          </div>
+                                          <span
+                                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                                          >
+                                            <div />
+                                            <div>
+                                              <div
+                                                class="perseus-renderer perseus-renderer-responsive"
+                                              >
+                                                <div
+                                                  class="paragraph perseus-paragraph-centered"
+                                                  data-perseus-paragraph-index="0"
+                                                >
+                                                  <div
+                                                    class="perseus-block-math"
+                                                  >
+                                                    <div
+                                                      class="perseus-block-math-inner"
+                                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                                    >
+                                                      <span
+                                                        class="mock-TeX"
+                                                      >
+                                                        45
+                                                      </span>
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </span>
+                                        </div>
+                                      </button>
+                                    </div>
+                                  </div>
+                                </li>
+                                <li
+                                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                                >
+                                  <div
+                                    class="description description_psmgei"
+                                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                                  >
+                                    <div
+                                      style="display: flex; flex-direction: row; opacity: 1;"
+                                    >
+                                      <div
+                                        class="perseus-sr-only"
+                                      >
+                                        <input
+                                          class="perseus-radio-option-content"
+                                          id="choice-6"
+                                          tabindex="-1"
+                                          type="radio"
+                                        />
+                                        <label
+                                          for="choice-6"
+                                        >
+                                          (Choice B)
+                                             
+                                          <div
+                                            class="perseus-renderer perseus-renderer-responsive"
+                                          >
+                                            <div
+                                              class="paragraph perseus-paragraph-centered"
+                                              data-perseus-paragraph-index="0"
+                                            >
+                                              <div
+                                                class="perseus-block-math"
+                                              >
+                                                <div
+                                                  class="perseus-block-math-inner"
+                                                  style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                                >
+                                                  <span
+                                                    class="mock-TeX"
+                                                  >
+                                                    42
+                                                  </span>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </label>
+                                      </div>
+                                      <button
+                                        aria-disabled="false"
+                                        aria-hidden="true"
+                                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                                        type="button"
+                                      >
+                                        <div
+                                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                                        >
+                                          <div
+                                            class="iconWrapper_17y0hv9"
+                                          >
+                                            <span
+                                              class="ring_ya75gi"
+                                              data-test-id="focus-ring"
+                                              style="border-color: transparent; border-radius: 50%;"
+                                            >
+                                              <div
+                                                class="circle_1tys2th"
+                                                data-is-radio-icon="true"
+                                                data-test-id="choice-icon__library-choice-icon"
+                                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                                              >
+                                                <div
+                                                  class="innerWrapper_177sg8x"
+                                                >
+                                                  B
+                                                </div>
+                                              </div>
+                                            </span>
+                                          </div>
+                                          <span
+                                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                                          >
+                                            <div />
+                                            <div>
+                                              <div
+                                                class="perseus-renderer perseus-renderer-responsive"
+                                              >
+                                                <div
+                                                  class="paragraph perseus-paragraph-centered"
+                                                  data-perseus-paragraph-index="0"
+                                                >
+                                                  <div
+                                                    class="perseus-block-math"
+                                                  >
+                                                    <div
+                                                      class="perseus-block-math-inner"
+                                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                                    >
+                                                      <span
+                                                        class="mock-TeX"
+                                                      >
+                                                        42
+                                                      </span>
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </span>
+                                        </div>
+                                      </button>
+                                    </div>
+                                  </div>
+                                </li>
+                                <li
+                                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                                >
+                                  <div
+                                    class="description description_psmgei"
+                                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                                  >
+                                    <div
+                                      style="display: flex; flex-direction: row; opacity: 1;"
+                                    >
+                                      <div
+                                        class="perseus-sr-only"
+                                      >
+                                        <input
+                                          class="perseus-radio-option-content"
+                                          id="choice-7"
+                                          tabindex="-1"
+                                          type="radio"
+                                        />
+                                        <label
+                                          for="choice-7"
+                                        >
+                                          (Choice C)
+                                             
+                                          <div
+                                            class="perseus-renderer perseus-renderer-responsive"
+                                          >
+                                            <div
+                                              class="paragraph perseus-paragraph-centered"
+                                              data-perseus-paragraph-index="0"
+                                            >
+                                              <div
+                                                class="perseus-block-math"
+                                              >
+                                                <div
+                                                  class="perseus-block-math-inner"
+                                                  style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                                >
+                                                  <span
+                                                    class="mock-TeX"
+                                                  >
+                                                    30
+                                                  </span>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </label>
+                                      </div>
+                                      <button
+                                        aria-disabled="false"
+                                        aria-hidden="true"
+                                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                                        type="button"
+                                      >
+                                        <div
+                                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                                        >
+                                          <div
+                                            class="iconWrapper_17y0hv9"
+                                          >
+                                            <span
+                                              class="ring_ya75gi"
+                                              data-test-id="focus-ring"
+                                              style="border-color: transparent; border-radius: 50%;"
+                                            >
+                                              <div
+                                                class="circle_1tys2th"
+                                                data-is-radio-icon="true"
+                                                data-test-id="choice-icon__library-choice-icon"
+                                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                                              >
+                                                <div
+                                                  class="innerWrapper_177sg8x"
+                                                >
+                                                  C
+                                                </div>
+                                              </div>
+                                            </span>
+                                          </div>
+                                          <span
+                                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                                          >
+                                            <div />
+                                            <div>
+                                              <div
+                                                class="perseus-renderer perseus-renderer-responsive"
+                                              >
+                                                <div
+                                                  class="paragraph perseus-paragraph-centered"
+                                                  data-perseus-paragraph-index="0"
+                                                >
+                                                  <div
+                                                    class="perseus-block-math"
+                                                  >
+                                                    <div
+                                                      class="perseus-block-math-inner"
+                                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                                    >
+                                                      <span
+                                                        class="mock-TeX"
+                                                      >
+                                                        30
+                                                      </span>
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </span>
+                                        </div>
+                                      </button>
+                                    </div>
+                                  </div>
+                                </li>
+                                <li
+                                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                                >
+                                  <div
+                                    class="description description_psmgei"
+                                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                                  >
+                                    <div
+                                      style="display: flex; flex-direction: row; opacity: 1;"
+                                    >
+                                      <div
+                                        class="perseus-sr-only"
+                                      >
+                                        <input
+                                          class="perseus-radio-option-content"
+                                          id="choice-8"
+                                          tabindex="-1"
+                                          type="radio"
+                                        />
+                                        <label
+                                          for="choice-8"
+                                        >
+                                          (Choice D)
+                                             
+                                          <div
+                                            class="perseus-renderer perseus-renderer-responsive"
+                                          >
+                                            <div
+                                              class="paragraph perseus-paragraph-centered"
+                                              data-perseus-paragraph-index="0"
+                                            >
+                                              <div
+                                                class="perseus-block-math"
+                                              >
+                                                <div
+                                                  class="perseus-block-math-inner"
+                                                  style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                                >
+                                                  <span
+                                                    class="mock-TeX"
+                                                  >
+                                                    18
+                                                  </span>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </label>
+                                      </div>
+                                      <button
+                                        aria-disabled="false"
+                                        aria-hidden="true"
+                                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                                        type="button"
+                                      >
+                                        <div
+                                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                                        >
+                                          <div
+                                            class="iconWrapper_17y0hv9"
+                                          >
+                                            <span
+                                              class="ring_ya75gi"
+                                              data-test-id="focus-ring"
+                                              style="border-color: transparent; border-radius: 50%;"
+                                            >
+                                              <div
+                                                class="circle_1tys2th"
+                                                data-is-radio-icon="true"
+                                                data-test-id="choice-icon__library-choice-icon"
+                                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                                              >
+                                                <div
+                                                  class="innerWrapper_177sg8x"
+                                                >
+                                                  D
+                                                </div>
+                                              </div>
+                                            </span>
+                                          </div>
+                                          <span
+                                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                                          >
+                                            <div />
+                                            <div>
+                                              <div
+                                                class="perseus-renderer perseus-renderer-responsive"
+                                              >
+                                                <div
+                                                  class="paragraph perseus-paragraph-centered"
+                                                  data-perseus-paragraph-index="0"
+                                                >
+                                                  <div
+                                                    class="perseus-block-math"
+                                                  >
+                                                    <div
+                                                      class="perseus-block-math-inner"
+                                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                                    >
+                                                      <span
+                                                        class="mock-TeX"
+                                                      >
+                                                        18
+                                                      </span>
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </span>
+                                        </div>
+                                      </button>
+                                    </div>
+                                  </div>
+                                </li>
+                                <li
+                                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                                >
+                                  <div
+                                    class="description description_psmgei"
+                                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                                  >
+                                    <div
+                                      style="display: flex; flex-direction: row; opacity: 1;"
+                                    >
+                                      <div
+                                        class="perseus-sr-only"
+                                      >
+                                        <input
+                                          class="perseus-radio-option-content"
+                                          id="choice-9"
+                                          tabindex="-1"
+                                          type="radio"
+                                        />
+                                        <label
+                                          for="choice-9"
+                                        >
+                                          (Choice E)
+                                             
+                                          <div
+                                            class="perseus-renderer perseus-renderer-responsive"
+                                          >
+                                            <div
+                                              class="paragraph perseus-paragraph-centered"
+                                              data-perseus-paragraph-index="0"
+                                            >
+                                              <div
+                                                class="perseus-block-math"
+                                              >
+                                                <div
+                                                  class="perseus-block-math-inner"
+                                                  style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                                >
+                                                  <span
+                                                    class="mock-TeX"
+                                                  >
+                                                    15
+                                                  </span>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </label>
+                                      </div>
+                                      <button
+                                        aria-disabled="false"
+                                        aria-hidden="true"
+                                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                                        type="button"
+                                      >
+                                        <div
+                                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                                        >
+                                          <div
+                                            class="iconWrapper_17y0hv9"
+                                          >
+                                            <span
+                                              class="ring_ya75gi"
+                                              data-test-id="focus-ring"
+                                              style="border-color: transparent; border-radius: 50%;"
+                                            >
+                                              <div
+                                                class="circle_1tys2th"
+                                                data-is-radio-icon="true"
+                                                data-test-id="choice-icon__library-choice-icon"
+                                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                                              >
+                                                <div
+                                                  class="innerWrapper_177sg8x"
+                                                >
+                                                  E
+                                                </div>
+                                              </div>
+                                            </span>
+                                          </div>
+                                          <span
+                                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                                          >
+                                            <div />
+                                            <div>
+                                              <div
+                                                class="perseus-renderer perseus-renderer-responsive"
+                                              >
+                                                <div
+                                                  class="paragraph perseus-paragraph-centered"
+                                                  data-perseus-paragraph-index="0"
+                                                >
+                                                  <div
+                                                    class="perseus-block-math"
+                                                  >
+                                                    <div
+                                                      class="perseus-block-math-inner"
+                                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                                    >
+                                                      <span
+                                                        class="mock-TeX"
+                                                      >
+                                                        15
+                                                      </span>
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </span>
+                                        </div>
+                                      </button>
+                                    </div>
+                                  </div>
+                                </li>
+                              </ul>
+                            </fieldset>
                           </div>
                         </div>
                       </div>
-                    </span>
+                    </div>
                   </div>
                 </div>
               </div>
+            </div>
+            <div
+              class="paragraph"
+            >
               <div
-                class="paragraph"
+                class="perseus-widget-container widget-nohighlight widget-block"
               >
                 <div
-                  class="perseus-widget-container widget-nohighlight widget-block"
+                  class="perseus-group perseus-group-invalid-answer"
                 >
                   <div
-                    class="perseus-group perseus-group-invalid-answer"
+                    class="perseus-renderer perseus-renderer-responsive"
                   >
-                    <span
-                      class="mock-KatexProvider"
+                    <div
+                      class="paragraph"
+                      data-perseus-paragraph-index="0"
                     >
                       <div
-                        class="perseus-renderer perseus-renderer-responsive"
+                        class="paragraph"
+                      >
+                        <strong>
+                          What is 
+                          <span
+                            style="white-space: nowrap;"
+                          >
+                            <span />
+                            <span
+                              class="mock-TeX"
+                            >
+                              \\redD{\\text{A}}
+                            </span>
+                            <span />
+                          </span>
+                           rounded to the nearest ten?
+                        </strong>
+                           
+                      </div>
+                    </div>
+                    <div
+                      class="paragraph"
+                      data-perseus-paragraph-index="1"
+                    >
+                      <div
+                        class="paragraph"
                       >
                         <div
-                          class="paragraph"
-                          data-perseus-paragraph-index="0"
+                          class="perseus-widget-container widget-nohighlight widget-inline-block"
                         >
-                          <div
-                            class="paragraph"
-                          >
-                            <strong>
-                              What is 
-                              <span
-                                style="white-space: nowrap;"
-                              >
-                                <span />
-                                <span
-                                  class="mock-TeX"
-                                >
-                                  \\redD{\\text{A}}
-                                </span>
-                                <span />
-                              </span>
-                               rounded to the nearest ten?
-                            </strong>
-                               
-                          </div>
-                        </div>
-                        <div
-                          class="paragraph"
-                          data-perseus-paragraph-index="1"
-                        >
-                          <div
-                            class="paragraph"
-                          >
-                            <div
-                              class="perseus-widget-container widget-nohighlight widget-inline-block"
-                            >
+                          <div>
+                            <span>
                               <div>
-                                <span>
-                                  <div>
-                                    <input
-                                      aria-label="value rounded to the nearest ten"
-                                      autocapitalize="off"
-                                      autocomplete="off"
-                                      autocorrect="off"
-                                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_19vw1dn"
-                                      id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
-                                      type="text"
-                                      value=""
-                                    />
-                                  </div>
-                                  <div
-                                    style="position: relative; height: 0px; display: none;"
-                                  >
-                                    <div
-                                      class="tooltipContainer"
-                                      style="position: absolute; left: 0px;"
-                                    >
-                                      <div
-                                        style="display: block; position: relative; visibility: visible; left: 0px; top: -1px; width: 12px; height: 11px; margin-top: -1px; margin-bottom: -2px; z-index: 10;"
-                                      >
-                                        <div
-                                          style="display: block; height: 0px; width: 0px; position: absolute; left: 0px; top: -1px; border-right: 12px solid transparent; border-bottom: 12px solid #ccc;"
-                                        />
-                                        <div
-                                          style="display: block; height: 0px; width: 0px; position: absolute; left: 1px; top: 1px; border-right: 10px solid transparent; border-bottom: 10px solid white;"
-                                        />
-                                      </div>
-                                      <div
-                                        class="perseus-formats-tooltip preview-measure"
-                                        style="position: relative; top: 0px; left: 0px; border: 1px solid #ccc; box-shadow: 0 1px 3px #ccc; z-index: 9;"
-                                      >
-                                        <div
-                                          id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
-                                        >
-                                          <span
-                                            class="mock-KatexProvider"
-                                          >
-                                            <div
-                                              class="perseus-renderer perseus-renderer-responsive"
-                                            >
-                                              <div
-                                                class="paragraph"
-                                                data-perseus-paragraph-index="0"
-                                              >
-                                                <ul>
-                                                  <li>
-                                                    <strong>
-                                                      Your answer should be
-                                                    </strong>
-                                                  </li>
-                                                  <li>
-                                                    an integer, like 
-                                                    <span
-                                                      style="white-space: nowrap;"
-                                                    >
-                                                      <span />
-                                                      <span
-                                                        class="mock-TeX"
-                                                      >
-                                                        6
-                                                      </span>
-                                                      <span />
-                                                    </span>
-                                                  </li>
-                                                  <li>
-                                                    a 
-                                                    <em>
-                                                      simplified proper
-                                                    </em>
-                                                     fraction, like 
-                                                    <span
-                                                      style="white-space: nowrap;"
-                                                    >
-                                                      <span />
-                                                      <span
-                                                        class="mock-TeX"
-                                                      >
-                                                        3/5
-                                                      </span>
-                                                      <span />
-                                                    </span>
-                                                  </li>
-                                                  <li>
-                                                    a 
-                                                    <em>
-                                                      simplified improper
-                                                    </em>
-                                                     fraction, like 
-                                                    <span
-                                                      style="white-space: nowrap;"
-                                                    >
-                                                      <span />
-                                                      <span
-                                                        class="mock-TeX"
-                                                      >
-                                                        7/4
-                                                      </span>
-                                                      <span />
-                                                    </span>
-                                                  </li>
-                                                  <li>
-                                                    a mixed number, like 
-                                                    <span
-                                                      style="white-space: nowrap;"
-                                                    >
-                                                      <span />
-                                                      <span
-                                                        class="mock-TeX"
-                                                      >
-                                                        1\\ 3/4
-                                                      </span>
-                                                      <span />
-                                                    </span>
-                                                  </li>
-                                                  <li>
-                                                    an 
-                                                    <em>
-                                                      exact
-                                                    </em>
-                                                     decimal, like 
-                                                    <span
-                                                      style="white-space: nowrap;"
-                                                    >
-                                                      <span />
-                                                      <span
-                                                        class="mock-TeX"
-                                                      >
-                                                        0.75
-                                                      </span>
-                                                      <span />
-                                                    </span>
-                                                  </li>
-                                                  <li>
-                                                    a multiple of pi, like 
-                                                    <span
-                                                      style="white-space: nowrap;"
-                                                    >
-                                                      <span />
-                                                      <span
-                                                        class="mock-TeX"
-                                                      >
-                                                        12\\ \\text{pi}
-                                                      </span>
-                                                      <span />
-                                                    </span>
-                                                     or 
-                                                    <span
-                                                      style="white-space: nowrap;"
-                                                    >
-                                                      <span />
-                                                      <span
-                                                        class="mock-TeX"
-                                                      >
-                                                        2/3\\ \\text{pi}
-                                                      </span>
-                                                      <span />
-                                                    </span>
-                                                  </li>
-                                                </ul>
-                                              </div>
-                                            </div>
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
+                                <input
+                                  aria-label="value rounded to the nearest ten"
+                                  autocapitalize="off"
+                                  autocomplete="off"
+                                  autocorrect="off"
+                                  class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_19vw1dn"
+                                  id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                                  type="text"
+                                  value=""
+                                />
                               </div>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="paragraph"
-                          data-perseus-paragraph-index="2"
-                        >
-                          <div
-                            class="paragraph"
-                          >
-                            <strong>
-                              What is 
-                              <span
-                                style="white-space: nowrap;"
-                              >
-                                <span />
-                                <span
-                                  class="mock-TeX"
-                                >
-                                  \\redD{\\text{A}}
-                                </span>
-                                <span />
-                              </span>
-                               rounded to the nearest hundred?
-                            </strong>
-                               
-                          </div>
-                        </div>
-                        <div
-                          class="paragraph"
-                          data-perseus-paragraph-index="3"
-                        >
-                          <div
-                            class="paragraph"
-                          >
-                            <div
-                              class="perseus-widget-container widget-nohighlight widget-inline-block"
-                            >
-                              <div>
-                                <span>
-                                  <div>
-                                    <input
-                                      aria-label="value rounded to the nearest hundred"
-                                      autocapitalize="off"
-                                      autocomplete="off"
-                                      autocorrect="off"
-                                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_19vw1dn"
-                                      id="input-with-examples-bnVtZXJpYy1pbnB1dCAy"
-                                      type="text"
-                                      value=""
-                                    />
-                                  </div>
-                                  <div
-                                    style="position: relative; height: 0px; display: none;"
-                                  >
-                                    <div
-                                      class="tooltipContainer"
-                                      style="position: absolute; left: 0px;"
-                                    >
-                                      <div
-                                        style="display: block; position: relative; visibility: visible; left: 0px; top: -1px; width: 12px; height: 11px; margin-top: -1px; margin-bottom: -2px; z-index: 10;"
-                                      >
-                                        <div
-                                          style="display: block; height: 0px; width: 0px; position: absolute; left: 0px; top: -1px; border-right: 12px solid transparent; border-bottom: 12px solid #ccc;"
-                                        />
-                                        <div
-                                          style="display: block; height: 0px; width: 0px; position: absolute; left: 1px; top: 1px; border-right: 10px solid transparent; border-bottom: 10px solid white;"
-                                        />
-                                      </div>
-                                      <div
-                                        class="perseus-formats-tooltip preview-measure"
-                                        style="position: relative; top: 0px; left: 0px; border: 1px solid #ccc; box-shadow: 0 1px 3px #ccc; z-index: 9;"
-                                      >
-                                        <div
-                                          id="input-with-examples-bnVtZXJpYy1pbnB1dCAy"
-                                        >
-                                          <span
-                                            class="mock-KatexProvider"
-                                          >
-                                            <div
-                                              class="perseus-renderer perseus-renderer-responsive"
-                                            >
-                                              <div
-                                                class="paragraph"
-                                                data-perseus-paragraph-index="0"
-                                              >
-                                                <ul>
-                                                  <li>
-                                                    <strong>
-                                                      Your answer should be
-                                                    </strong>
-                                                  </li>
-                                                  <li>
-                                                    an integer, like 
-                                                    <span
-                                                      style="white-space: nowrap;"
-                                                    >
-                                                      <span />
-                                                      <span
-                                                        class="mock-TeX"
-                                                      >
-                                                        6
-                                                      </span>
-                                                      <span />
-                                                    </span>
-                                                  </li>
-                                                  <li>
-                                                    a 
-                                                    <em>
-                                                      simplified proper
-                                                    </em>
-                                                     fraction, like 
-                                                    <span
-                                                      style="white-space: nowrap;"
-                                                    >
-                                                      <span />
-                                                      <span
-                                                        class="mock-TeX"
-                                                      >
-                                                        3/5
-                                                      </span>
-                                                      <span />
-                                                    </span>
-                                                  </li>
-                                                  <li>
-                                                    a 
-                                                    <em>
-                                                      simplified improper
-                                                    </em>
-                                                     fraction, like 
-                                                    <span
-                                                      style="white-space: nowrap;"
-                                                    >
-                                                      <span />
-                                                      <span
-                                                        class="mock-TeX"
-                                                      >
-                                                        7/4
-                                                      </span>
-                                                      <span />
-                                                    </span>
-                                                  </li>
-                                                  <li>
-                                                    a mixed number, like 
-                                                    <span
-                                                      style="white-space: nowrap;"
-                                                    >
-                                                      <span />
-                                                      <span
-                                                        class="mock-TeX"
-                                                      >
-                                                        1\\ 3/4
-                                                      </span>
-                                                      <span />
-                                                    </span>
-                                                  </li>
-                                                  <li>
-                                                    an 
-                                                    <em>
-                                                      exact
-                                                    </em>
-                                                     decimal, like 
-                                                    <span
-                                                      style="white-space: nowrap;"
-                                                    >
-                                                      <span />
-                                                      <span
-                                                        class="mock-TeX"
-                                                      >
-                                                        0.75
-                                                      </span>
-                                                      <span />
-                                                    </span>
-                                                  </li>
-                                                  <li>
-                                                    a multiple of pi, like 
-                                                    <span
-                                                      style="white-space: nowrap;"
-                                                    >
-                                                      <span />
-                                                      <span
-                                                        class="mock-TeX"
-                                                      >
-                                                        12\\ \\text{pi}
-                                                      </span>
-                                                      <span />
-                                                    </span>
-                                                     or 
-                                                    <span
-                                                      style="white-space: nowrap;"
-                                                    >
-                                                      <span />
-                                                      <span
-                                                        class="mock-TeX"
-                                                      >
-                                                        2/3\\ \\text{pi}
-                                                      </span>
-                                                      <span />
-                                                    </span>
-                                                  </li>
-                                                </ul>
-                                              </div>
-                                            </div>
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="paragraph"
-                          data-perseus-paragraph-index="4"
-                        >
-                          <div
-                            class="paragraph"
-                          >
-                            <div
-                              class="perseus-widget-container widget-nohighlight widget-block"
-                            >
                               <div
-                                class="perseus-image-widget"
+                                style="position: relative; height: 0px; display: none;"
                               >
                                 <div
-                                  class="fixed-to-responsive svg-image"
-                                  style="max-width: 380px; max-height: 80px;"
+                                  class="tooltipContainer"
+                                  style="position: absolute; left: 0px;"
                                 >
                                   <div
-                                    style="padding-bottom: 21.05%;"
-                                  />
-                                  <span
-                                    style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
+                                    style="display: block; position: relative; visibility: visible; left: 0px; top: -1px; width: 12px; height: 11px; margin-top: -1px; margin-bottom: -2px; z-index: 10;"
                                   >
                                     <div
-                                      class="default_xu2jcg-o_O-spinnerContainer_agrn11"
-                                    >
-                                      <svg
-                                        height="48"
-                                        viewBox="0 0 48 48"
-                                        width="48"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
-                                          d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
-                                          fill-rule="nonzero"
-                                        />
-                                      </svg>
-                                    </div>
-                                  </span>
-                                </div>
-                                <span
-                                  class="perseus-sr-only"
-                                >
-                                  <span
-                                    class="mock-KatexProvider"
+                                      style="display: block; height: 0px; width: 0px; position: absolute; left: 0px; top: -1px; border-right: 12px solid transparent; border-bottom: 12px solid #ccc;"
+                                    />
+                                    <div
+                                      style="display: block; height: 0px; width: 0px; position: absolute; left: 1px; top: 1px; border-right: 10px solid transparent; border-bottom: 10px solid white;"
+                                    />
+                                  </div>
+                                  <div
+                                    class="perseus-formats-tooltip preview-measure"
+                                    style="position: relative; top: 0px; left: 0px; border: 1px solid #ccc; box-shadow: 0 1px 3px #ccc; z-index: 9;"
                                   >
                                     <div
-                                      class="perseus-renderer perseus-renderer-responsive"
+                                      id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
                                     >
                                       <div
-                                        class="paragraph"
-                                        data-perseus-paragraph-index="0"
+                                        class="perseus-renderer perseus-renderer-responsive"
                                       >
                                         <div
                                           class="paragraph"
+                                          data-perseus-paragraph-index="0"
                                         >
-                                          A number line labeled 200 to 300 with tick marks at every 5 units. The tick marks at 200, 210, 220, 230, 240, 250, 260, 270, 280, 290, and 300 are labeled. A red circle labeled A is between 220 tick mark and 230 tick mark.
+                                          <ul>
+                                            <li>
+                                              <strong>
+                                                Your answer should be
+                                              </strong>
+                                            </li>
+                                            <li>
+                                              an integer, like 
+                                              <span
+                                                style="white-space: nowrap;"
+                                              >
+                                                <span />
+                                                <span
+                                                  class="mock-TeX"
+                                                >
+                                                  6
+                                                </span>
+                                                <span />
+                                              </span>
+                                            </li>
+                                            <li>
+                                              a 
+                                              <em>
+                                                simplified proper
+                                              </em>
+                                               fraction, like 
+                                              <span
+                                                style="white-space: nowrap;"
+                                              >
+                                                <span />
+                                                <span
+                                                  class="mock-TeX"
+                                                >
+                                                  3/5
+                                                </span>
+                                                <span />
+                                              </span>
+                                            </li>
+                                            <li>
+                                              a 
+                                              <em>
+                                                simplified improper
+                                              </em>
+                                               fraction, like 
+                                              <span
+                                                style="white-space: nowrap;"
+                                              >
+                                                <span />
+                                                <span
+                                                  class="mock-TeX"
+                                                >
+                                                  7/4
+                                                </span>
+                                                <span />
+                                              </span>
+                                            </li>
+                                            <li>
+                                              a mixed number, like 
+                                              <span
+                                                style="white-space: nowrap;"
+                                              >
+                                                <span />
+                                                <span
+                                                  class="mock-TeX"
+                                                >
+                                                  1\\ 3/4
+                                                </span>
+                                                <span />
+                                              </span>
+                                            </li>
+                                            <li>
+                                              an 
+                                              <em>
+                                                exact
+                                              </em>
+                                               decimal, like 
+                                              <span
+                                                style="white-space: nowrap;"
+                                              >
+                                                <span />
+                                                <span
+                                                  class="mock-TeX"
+                                                >
+                                                  0.75
+                                                </span>
+                                                <span />
+                                              </span>
+                                            </li>
+                                            <li>
+                                              a multiple of pi, like 
+                                              <span
+                                                style="white-space: nowrap;"
+                                              >
+                                                <span />
+                                                <span
+                                                  class="mock-TeX"
+                                                >
+                                                  12\\ \\text{pi}
+                                                </span>
+                                                <span />
+                                              </span>
+                                               or 
+                                              <span
+                                                style="white-space: nowrap;"
+                                              >
+                                                <span />
+                                                <span
+                                                  class="mock-TeX"
+                                                >
+                                                  2/3\\ \\text{pi}
+                                                </span>
+                                                <span />
+                                              </span>
+                                            </li>
+                                          </ul>
                                         </div>
                                       </div>
                                     </div>
-                                  </span>
-                                </span>
+                                  </div>
+                                </div>
                               </div>
-                            </div>
+                            </span>
                           </div>
                         </div>
                       </div>
-                    </span>
+                    </div>
+                    <div
+                      class="paragraph"
+                      data-perseus-paragraph-index="2"
+                    >
+                      <div
+                        class="paragraph"
+                      >
+                        <strong>
+                          What is 
+                          <span
+                            style="white-space: nowrap;"
+                          >
+                            <span />
+                            <span
+                              class="mock-TeX"
+                            >
+                              \\redD{\\text{A}}
+                            </span>
+                            <span />
+                          </span>
+                           rounded to the nearest hundred?
+                        </strong>
+                           
+                      </div>
+                    </div>
+                    <div
+                      class="paragraph"
+                      data-perseus-paragraph-index="3"
+                    >
+                      <div
+                        class="paragraph"
+                      >
+                        <div
+                          class="perseus-widget-container widget-nohighlight widget-inline-block"
+                        >
+                          <div>
+                            <span>
+                              <div>
+                                <input
+                                  aria-label="value rounded to the nearest hundred"
+                                  autocapitalize="off"
+                                  autocomplete="off"
+                                  autocorrect="off"
+                                  class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_19vw1dn"
+                                  id="input-with-examples-bnVtZXJpYy1pbnB1dCAy"
+                                  type="text"
+                                  value=""
+                                />
+                              </div>
+                              <div
+                                style="position: relative; height: 0px; display: none;"
+                              >
+                                <div
+                                  class="tooltipContainer"
+                                  style="position: absolute; left: 0px;"
+                                >
+                                  <div
+                                    style="display: block; position: relative; visibility: visible; left: 0px; top: -1px; width: 12px; height: 11px; margin-top: -1px; margin-bottom: -2px; z-index: 10;"
+                                  >
+                                    <div
+                                      style="display: block; height: 0px; width: 0px; position: absolute; left: 0px; top: -1px; border-right: 12px solid transparent; border-bottom: 12px solid #ccc;"
+                                    />
+                                    <div
+                                      style="display: block; height: 0px; width: 0px; position: absolute; left: 1px; top: 1px; border-right: 10px solid transparent; border-bottom: 10px solid white;"
+                                    />
+                                  </div>
+                                  <div
+                                    class="perseus-formats-tooltip preview-measure"
+                                    style="position: relative; top: 0px; left: 0px; border: 1px solid #ccc; box-shadow: 0 1px 3px #ccc; z-index: 9;"
+                                  >
+                                    <div
+                                      id="input-with-examples-bnVtZXJpYy1pbnB1dCAy"
+                                    >
+                                      <div
+                                        class="perseus-renderer perseus-renderer-responsive"
+                                      >
+                                        <div
+                                          class="paragraph"
+                                          data-perseus-paragraph-index="0"
+                                        >
+                                          <ul>
+                                            <li>
+                                              <strong>
+                                                Your answer should be
+                                              </strong>
+                                            </li>
+                                            <li>
+                                              an integer, like 
+                                              <span
+                                                style="white-space: nowrap;"
+                                              >
+                                                <span />
+                                                <span
+                                                  class="mock-TeX"
+                                                >
+                                                  6
+                                                </span>
+                                                <span />
+                                              </span>
+                                            </li>
+                                            <li>
+                                              a 
+                                              <em>
+                                                simplified proper
+                                              </em>
+                                               fraction, like 
+                                              <span
+                                                style="white-space: nowrap;"
+                                              >
+                                                <span />
+                                                <span
+                                                  class="mock-TeX"
+                                                >
+                                                  3/5
+                                                </span>
+                                                <span />
+                                              </span>
+                                            </li>
+                                            <li>
+                                              a 
+                                              <em>
+                                                simplified improper
+                                              </em>
+                                               fraction, like 
+                                              <span
+                                                style="white-space: nowrap;"
+                                              >
+                                                <span />
+                                                <span
+                                                  class="mock-TeX"
+                                                >
+                                                  7/4
+                                                </span>
+                                                <span />
+                                              </span>
+                                            </li>
+                                            <li>
+                                              a mixed number, like 
+                                              <span
+                                                style="white-space: nowrap;"
+                                              >
+                                                <span />
+                                                <span
+                                                  class="mock-TeX"
+                                                >
+                                                  1\\ 3/4
+                                                </span>
+                                                <span />
+                                              </span>
+                                            </li>
+                                            <li>
+                                              an 
+                                              <em>
+                                                exact
+                                              </em>
+                                               decimal, like 
+                                              <span
+                                                style="white-space: nowrap;"
+                                              >
+                                                <span />
+                                                <span
+                                                  class="mock-TeX"
+                                                >
+                                                  0.75
+                                                </span>
+                                                <span />
+                                              </span>
+                                            </li>
+                                            <li>
+                                              a multiple of pi, like 
+                                              <span
+                                                style="white-space: nowrap;"
+                                              >
+                                                <span />
+                                                <span
+                                                  class="mock-TeX"
+                                                >
+                                                  12\\ \\text{pi}
+                                                </span>
+                                                <span />
+                                              </span>
+                                               or 
+                                              <span
+                                                style="white-space: nowrap;"
+                                              >
+                                                <span />
+                                                <span
+                                                  class="mock-TeX"
+                                                >
+                                                  2/3\\ \\text{pi}
+                                                </span>
+                                                <span />
+                                              </span>
+                                            </li>
+                                          </ul>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="paragraph"
+                      data-perseus-paragraph-index="4"
+                    >
+                      <div
+                        class="paragraph"
+                      >
+                        <div
+                          class="perseus-widget-container widget-nohighlight widget-block"
+                        >
+                          <div
+                            class="perseus-image-widget"
+                          >
+                            <div
+                              class="fixed-to-responsive svg-image"
+                              style="max-width: 380px; max-height: 80px;"
+                            >
+                              <div
+                                style="padding-bottom: 21.05%;"
+                              />
+                              <span
+                                style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
+                              >
+                                <div
+                                  class="default_xu2jcg-o_O-spinnerContainer_agrn11"
+                                >
+                                  <svg
+                                    height="48"
+                                    viewBox="0 0 48 48"
+                                    width="48"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
+                                      d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
+                                      fill-rule="nonzero"
+                                    />
+                                  </svg>
+                                </div>
+                              </span>
+                            </div>
+                            <span
+                              class="perseus-sr-only"
+                            >
+                              <div
+                                class="perseus-renderer perseus-renderer-responsive"
+                              >
+                                <div
+                                  class="paragraph"
+                                  data-perseus-paragraph-index="0"
+                                >
+                                  <div
+                                    class="paragraph"
+                                  >
+                                    A number line labeled 200 to 300 with tick marks at every 5 units. The tick marks at 200, 210, 220, 230, 240, 250, 260, 270, 280, 290, and 300 are labeled. A red circle labeled A is between 220 tick mark and 230 tick mark.
+                                  </div>
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -1269,6 +1205,6 @@ exports[`group widget should snapshot: initial render 1`] = `
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/iframe.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/iframe.test.ts.snap
@@ -2,68 +2,60 @@
 
 exports[`iframe widget should snapshot on mobile: first mobile render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          Try matching the target image
+        Try matching the target image
 
-          <div
-            class="perseus-widget-container widget-nohighlight widget-block"
-          >
-            <iframe
-              allowfullscreen=""
-              sandbox="allow-same-origin allow-scripts allow-top-navigation"
-              src="https://www.khanacademy.org/computer-programming/program/4960944252/embedded?buttons=no&embed=yes&editor=no&author=no&width=410&height=410&origin=origin-test-interface&settings=%7B%22hue%22%3A%22210%22%2C%22subdivisions%22%3A%220%22%2C%22zoom%22%3A%222%22%2C%22seed%22%3A%226%22%7D"
-              style="width: 410px; height: 410px;"
-            />
-          </div>
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <iframe
+            allowfullscreen=""
+            sandbox="allow-same-origin allow-scripts allow-top-navigation"
+            src="https://www.khanacademy.org/computer-programming/program/4960944252/embedded?buttons=no&embed=yes&editor=no&author=no&width=410&height=410&origin=origin-test-interface&settings=%7B%22hue%22%3A%22210%22%2C%22subdivisions%22%3A%220%22%2C%22zoom%22%3A%222%22%2C%22seed%22%3A%226%22%7D"
+            style="width: 410px; height: 410px;"
+          />
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`iframe widget should snapshot: first render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          Try matching the target image
+        Try matching the target image
 
-          <div
-            class="perseus-widget-container widget-nohighlight widget-block"
-          >
-            <iframe
-              allowfullscreen=""
-              sandbox="allow-same-origin allow-scripts allow-top-navigation"
-              src="https://www.khanacademy.org/computer-programming/program/4960944252/embedded?buttons=no&embed=yes&editor=no&author=no&width=410&height=410&origin=origin-test-interface&settings=%7B%22hue%22%3A%22210%22%2C%22subdivisions%22%3A%220%22%2C%22zoom%22%3A%222%22%2C%22seed%22%3A%226%22%7D"
-              style="width: 410px; height: 410px;"
-            />
-          </div>
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <iframe
+            allowfullscreen=""
+            sandbox="allow-same-origin allow-scripts allow-top-navigation"
+            src="https://www.khanacademy.org/computer-programming/program/4960944252/embedded?buttons=no&embed=yes&editor=no&author=no&width=410&height=410&origin=origin-test-interface&settings=%7B%22hue%22%3A%22210%22%2C%22subdivisions%22%3A%220%22%2C%22zoom%22%3A%222%22%2C%22seed%22%3A%226%22%7D"
+            style="width: 410px; height: 410px;"
+          />
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/image.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/image.test.ts.snap
@@ -2,111 +2,99 @@
 
 exports[`image widget - isMobile %b should snapshot: first render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive perseus-renderer-two-columns"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive perseus-renderer-two-columns"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
-        class="paragraph"
-        data-perseus-paragraph-index="0"
+        class="perseus-two-columns"
       >
         <div
-          class="perseus-two-columns"
+          class="perseus-column"
         >
           <div
-            class="perseus-column"
+            class="perseus-column-content"
           >
             <div
-              class="perseus-column-content"
+              class="paragraph"
             >
               <div
-                class="paragraph"
+                class="perseus-widget-container widget-nohighlight widget-block"
               >
                 <div
-                  class="perseus-widget-container widget-nohighlight widget-block"
+                  class="perseus-image-widget"
                 >
                   <div
-                    class="perseus-image-widget"
+                    class="fixed-to-responsive svg-image"
+                    style="max-width: 420px; max-height: 345px;"
                   >
                     <div
-                      class="fixed-to-responsive svg-image"
-                      style="max-width: 420px; max-height: 345px;"
+                      style="padding-bottom: 82.14%;"
+                    />
+                    <span
+                      style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
                     >
                       <div
-                        style="padding-bottom: 82.14%;"
-                      />
-                      <span
-                        style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
+                        class="default_xu2jcg-o_O-spinnerContainer_agrn11"
                       >
-                        <div
-                          class="default_xu2jcg-o_O-spinnerContainer_agrn11"
+                        <svg
+                          height="48"
+                          viewBox="0 0 48 48"
+                          width="48"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <svg
-                            height="48"
-                            viewBox="0 0 48 48"
-                            width="48"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
-                              d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
-                              fill-rule="nonzero"
-                            />
-                          </svg>
-                        </div>
-                      </span>
-                    </div>
-                    <span
-                      class="perseus-sr-only"
+                          <path
+                            class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
+                            d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
+                            fill-rule="nonzero"
+                          />
+                        </svg>
+                      </div>
+                    </span>
+                  </div>
+                  <span
+                    class="perseus-sr-only"
+                  >
+                    <div
+                      class="perseus-renderer perseus-renderer-responsive"
                     >
-                      <span
-                        class="mock-KatexProvider"
+                      <div
+                        class="paragraph"
+                        data-perseus-paragraph-index="0"
                       >
                         <div
-                          class="perseus-renderer perseus-renderer-responsive"
+                          class="paragraph"
+                        >
+                          An array of isosceles triangles. A triangle has height A. Two smaller triangle, one with height B and one with height C, have approximately the same combined height as A.
+                        </div>
+                      </div>
+                    </div>
+                  </span>
+                  <div
+                    class="perseus-image-caption has-title"
+                  >
+                    <div
+                      class="caption_4bstk7"
+                    >
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
+                      >
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
                         >
                           <div
                             class="paragraph"
-                            data-perseus-paragraph-index="0"
                           >
-                            <div
-                              class="paragraph"
-                            >
-                              An array of isosceles triangles. A triangle has height A. Two smaller triangle, one with height B and one with height C, have approximately the same combined height as A.
-                            </div>
+                            <strong>
+                              Image Title.
+                            </strong>
+                             Image Caption
                           </div>
                         </div>
-                      </span>
-                    </span>
-                    <div
-                      class="perseus-image-caption has-title"
-                    >
-                      <div
-                        class="caption_4bstk7"
-                      >
-                        <span
-                          class="mock-KatexProvider"
-                        >
-                          <div
-                            class="perseus-renderer perseus-renderer-responsive"
-                          >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                <strong>
-                                  Image Title.
-                                </strong>
-                                 Image Caption
-                              </div>
-                            </div>
-                          </div>
-                        </span>
                       </div>
                     </div>
                   </div>
@@ -114,291 +102,275 @@ exports[`image widget - isMobile %b should snapshot: first render 1`] = `
               </div>
             </div>
           </div>
+        </div>
+        <div
+          class="perseus-column"
+        >
           <div
-            class="perseus-column"
+            class="perseus-column-content"
           >
             <div
-              class="perseus-column-content"
+              class="paragraph"
             >
-              <div
-                class="paragraph"
+              A quilter wants to make the design shown at left using the Golden Ratio. Specifically, he wants the ratio of the triangle heights 
+              <span
+                style="white-space: nowrap;"
               >
-                A quilter wants to make the design shown at left using the Golden Ratio. Specifically, he wants the ratio of the triangle heights 
+                <span />
                 <span
-                  style="white-space: nowrap;"
+                  class="mock-TeX"
                 >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    A:B
-                  </span>
-                  <span />
+                  A:B
                 </span>
-                 and 
+                <span />
+              </span>
+               and 
+              <span
+                style="white-space: nowrap;"
+              >
+                <span />
                 <span
-                  style="white-space: nowrap;"
+                  class="mock-TeX"
                 >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    B:C
-                  </span>
-                  <span />
+                  B:C
                 </span>
-                 to each equal 
+                <span />
+              </span>
+               to each equal 
+              <span
+                style="white-space: nowrap;"
+              >
+                <span />
                 <span
-                  style="white-space: nowrap;"
+                  class="mock-TeX"
                 >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    1.62
-                  </span>
-                  <span />
+                  1.62
                 </span>
-                . If the quilter makes the triangle height 
+                <span />
+              </span>
+              . If the quilter makes the triangle height 
+              <span
+                style="white-space: nowrap;"
+              >
+                <span />
                 <span
-                  style="white-space: nowrap;"
+                  class="mock-TeX"
                 >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    A=8\\ \\text{in}
-                  </span>
-                  <span />
+                  A=8\\ \\text{in}
                 </span>
-                , approximately how tall should he make triangle height 
+                <span />
+              </span>
+              , approximately how tall should he make triangle height 
+              <span
+                style="white-space: nowrap;"
+              >
+                <span />
                 <span
-                  style="white-space: nowrap;"
+                  class="mock-TeX"
                 >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    C
-                  </span>
-                  <span />
+                  C
                 </span>
-                ?
-              </div>
+                <span />
+              </span>
+              ?
             </div>
           </div>
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`image widget - isMobile %b should snapshot: first render 2`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive perseus-renderer-two-columns"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive perseus-renderer-two-columns"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
-        class="paragraph"
-        data-perseus-paragraph-index="0"
+        class="perseus-two-columns"
       >
         <div
-          class="perseus-two-columns"
+          class="perseus-column"
         >
           <div
-            class="perseus-column"
+            class="perseus-column-content"
           >
             <div
-              class="perseus-column-content"
+              class="paragraph"
             >
               <div
-                class="paragraph"
+                class="perseus-widget-container widget-nohighlight widget-block"
               >
                 <div
-                  class="perseus-widget-container widget-nohighlight widget-block"
+                  class="perseus-image-widget"
                 >
                   <div
-                    class="perseus-image-widget"
+                    class="perseus-image-title"
                   >
                     <div
-                      class="perseus-image-title"
-                    >
-                      <span
-                        class="mock-KatexProvider"
-                      >
-                        <div
-                          class="perseus-renderer perseus-renderer-responsive"
-                        >
-                          <div
-                            class="paragraph"
-                            data-perseus-paragraph-index="0"
-                          >
-                            <div
-                              class="paragraph"
-                            >
-                              Image Title
-                            </div>
-                          </div>
-                        </div>
-                      </span>
-                    </div>
-                    <div
-                      class="fixed-to-responsive svg-image"
-                      style="max-width: 420px; max-height: 345px;"
+                      class="perseus-renderer perseus-renderer-responsive"
                     >
                       <div
-                        style="padding-bottom: 82.14%;"
-                      />
-                      <span
-                        style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
+                        class="paragraph"
+                        data-perseus-paragraph-index="0"
                       >
                         <div
-                          class="default_xu2jcg-o_O-spinnerContainer_agrn11"
+                          class="paragraph"
                         >
-                          <svg
-                            height="48"
-                            viewBox="0 0 48 48"
-                            width="48"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
-                              d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
-                              fill-rule="nonzero"
-                            />
-                          </svg>
+                          Image Title
                         </div>
-                      </span>
+                      </div>
                     </div>
-                    <span
-                      class="perseus-sr-only"
-                    >
-                      <span
-                        class="mock-KatexProvider"
-                      >
-                        <div
-                          class="perseus-renderer perseus-renderer-responsive"
-                        >
-                          <div
-                            class="paragraph"
-                            data-perseus-paragraph-index="0"
-                          >
-                            <div
-                              class="paragraph"
-                            >
-                              An array of isosceles triangles. A triangle has height A. Two smaller triangle, one with height B and one with height C, have approximately the same combined height as A.
-                            </div>
-                          </div>
-                        </div>
-                      </span>
-                    </span>
+                  </div>
+                  <div
+                    class="fixed-to-responsive svg-image"
+                    style="max-width: 420px; max-height: 345px;"
+                  >
                     <div
-                      class="perseus-image-caption"
+                      style="padding-bottom: 82.14%;"
+                    />
+                    <span
+                      style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
                     >
-                      <span
-                        class="mock-KatexProvider"
+                      <div
+                        class="default_xu2jcg-o_O-spinnerContainer_agrn11"
+                      >
+                        <svg
+                          height="48"
+                          viewBox="0 0 48 48"
+                          width="48"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
+                            d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
+                            fill-rule="nonzero"
+                          />
+                        </svg>
+                      </div>
+                    </span>
+                  </div>
+                  <span
+                    class="perseus-sr-only"
+                  >
+                    <div
+                      class="perseus-renderer perseus-renderer-responsive"
+                    >
+                      <div
+                        class="paragraph"
+                        data-perseus-paragraph-index="0"
                       >
                         <div
-                          class="perseus-renderer perseus-renderer-responsive"
+                          class="paragraph"
                         >
-                          <div
-                            class="paragraph"
-                            data-perseus-paragraph-index="0"
-                          >
-                            <div
-                              class="paragraph"
-                            >
-                              Image Caption
-                            </div>
-                          </div>
+                          An array of isosceles triangles. A triangle has height A. Two smaller triangle, one with height B and one with height C, have approximately the same combined height as A.
                         </div>
-                      </span>
+                      </div>
+                    </div>
+                  </span>
+                  <div
+                    class="perseus-image-caption"
+                  >
+                    <div
+                      class="perseus-renderer perseus-renderer-responsive"
+                    >
+                      <div
+                        class="paragraph"
+                        data-perseus-paragraph-index="0"
+                      >
+                        <div
+                          class="paragraph"
+                        >
+                          Image Caption
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
+        </div>
+        <div
+          class="perseus-column"
+        >
           <div
-            class="perseus-column"
+            class="perseus-column-content"
           >
             <div
-              class="perseus-column-content"
+              class="paragraph"
             >
-              <div
-                class="paragraph"
+              A quilter wants to make the design shown at left using the Golden Ratio. Specifically, he wants the ratio of the triangle heights 
+              <span
+                style="white-space: nowrap;"
               >
-                A quilter wants to make the design shown at left using the Golden Ratio. Specifically, he wants the ratio of the triangle heights 
+                <span />
                 <span
-                  style="white-space: nowrap;"
+                  class="mock-TeX"
                 >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    A:B
-                  </span>
-                  <span />
+                  A:B
                 </span>
-                 and 
+                <span />
+              </span>
+               and 
+              <span
+                style="white-space: nowrap;"
+              >
+                <span />
                 <span
-                  style="white-space: nowrap;"
+                  class="mock-TeX"
                 >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    B:C
-                  </span>
-                  <span />
+                  B:C
                 </span>
-                 to each equal 
+                <span />
+              </span>
+               to each equal 
+              <span
+                style="white-space: nowrap;"
+              >
+                <span />
                 <span
-                  style="white-space: nowrap;"
+                  class="mock-TeX"
                 >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    1.62
-                  </span>
-                  <span />
+                  1.62
                 </span>
-                . If the quilter makes the triangle height 
+                <span />
+              </span>
+              . If the quilter makes the triangle height 
+              <span
+                style="white-space: nowrap;"
+              >
+                <span />
                 <span
-                  style="white-space: nowrap;"
+                  class="mock-TeX"
                 >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    A=8\\ \\text{in}
-                  </span>
-                  <span />
+                  A=8\\ \\text{in}
                 </span>
-                , approximately how tall should he make triangle height 
+                <span />
+              </span>
+              , approximately how tall should he make triangle height 
+              <span
+                style="white-space: nowrap;"
+              >
+                <span />
                 <span
-                  style="white-space: nowrap;"
+                  class="mock-TeX"
                 >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    C
-                  </span>
-                  <span />
+                  C
                 </span>
-                ?
-              </div>
+                <span />
+              </span>
+              ?
             </div>
           </div>
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/input-number.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/input-number.test.ts.snap
@@ -2,30 +2,140 @@
 
 exports[`rendering supports mobile rendering: mobile render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          Akshat works in a hospital lab.
-        </div>
+        Akshat works in a hospital lab.
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="1"
       >
-        <div
-          class="paragraph"
+        To project blood quantities, he wants to know the probability that more than 
+        <span
+          style="white-space: nowrap;"
         >
-          To project blood quantities, he wants to know the probability that more than 
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            1
+          </span>
+          <span />
+        </span>
+         of the next 
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            7
+          </span>
+          <span />
+        </span>
+         donors will have type-A blood. From his previous work, Sorin knows that 
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            \\dfrac14
+          </span>
+          <span />
+        </span>
+         of donors have type-A blood.
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
+    >
+      <div
+        class="paragraph"
+      >
+        Akshat uses a computer to produce many samples that simulate the next 
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            7
+          </span>
+          <span />
+        </span>
+         donors. The first 
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            8
+          </span>
+          <span />
+        </span>
+         samples are shown in the table below where "
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            \\text{\\red{A}}
+          </span>
+          <span />
+        </span>
+        " represents a donor 
+        <em>
+          with
+        </em>
+         type-A blood, and "
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            \\text{\\blue{Z}}
+          </span>
+          <span />
+        </span>
+        " represents a donor 
+        <em>
+          without
+        </em>
+         type-A blood.
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="3"
+    >
+      <div
+        class="paragraph"
+      >
+        <strong>
+          Based on the samples below, estimate the probability that  more than 
           <span
             style="white-space: nowrap;"
           >
@@ -49,449 +159,335 @@ exports[`rendering supports mobile rendering: mobile render 1`] = `
             </span>
             <span />
           </span>
-           donors will have type-A blood. From his previous work, Sorin knows that 
-          <span
-            style="white-space: nowrap;"
-          >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              \\dfrac14
-            </span>
-            <span />
-          </span>
-           of donors have type-A blood.
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="2"
-      >
+           donors will have type-A blood.
+        </strong>
+         If necessary, round your answer to the nearest hundredth. 
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-inline-block"
         >
-          Akshat uses a computer to produce many samples that simulate the next 
-          <span
-            style="white-space: nowrap;"
-          >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              7
-            </span>
-            <span />
-          </span>
-           donors. The first 
-          <span
-            style="white-space: nowrap;"
-          >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              8
-            </span>
-            <span />
-          </span>
-           samples are shown in the table below where "
-          <span
-            style="white-space: nowrap;"
-          >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              \\text{\\red{A}}
-            </span>
-            <span />
-          </span>
-          " represents a donor 
-          <em>
-            with
-          </em>
-           type-A blood, and "
-          <span
-            style="white-space: nowrap;"
-          >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              \\text{\\blue{Z}}
-            </span>
-            <span />
-          </span>
-          " represents a donor 
-          <em>
-            without
-          </em>
-           type-A blood.
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="3"
-      >
-        <div
-          class="paragraph"
-        >
-          <strong>
-            Based on the samples below, estimate the probability that  more than 
-            <span
-              style="white-space: nowrap;"
-            >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                1
-              </span>
-              <span />
-            </span>
-             of the next 
-            <span
-              style="white-space: nowrap;"
-            >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                7
-              </span>
-              <span />
-            </span>
-             donors will have type-A blood.
-          </strong>
-           If necessary, round your answer to the nearest hundredth. 
           <div
-            class="perseus-widget-container widget-nohighlight widget-inline-block"
+            aria-label="Math input box Tap with one or two fingers to open keyboard"
+            class="initial_4qg14c-o_O-input_1n1c032"
+            role="textbox"
           >
             <div
-              aria-label="Math input box Tap with one or two fingers to open keyboard"
-              class="initial_4qg14c-o_O-input_1n1c032"
-              role="textbox"
+              class="keypad-input"
+              tabindex="0"
             >
               <div
-                class="keypad-input"
-                tabindex="0"
+                class="mq-editable-field mq-math-mode"
+                style="background-color: white; min-height: 44px; min-width: 64px; max-width: 128px; box-sizing: border-box; position: relative; border-style: solid; border-color: rgba(33,36,44,0.50); border-radius: 4px; color: rgb(33, 36, 44); border-width: 1px;"
               >
-                <div
-                  class="mq-editable-field mq-math-mode"
-                  style="background-color: white; min-height: 44px; min-width: 64px; max-width: 128px; box-sizing: border-box; position: relative; border-style: solid; border-color: rgba(33,36,44,0.50); border-radius: 4px; color: rgb(33, 36, 44); border-width: 1px;"
+                <span
+                  class="mq-textarea"
                 >
-                  <span
-                    class="mq-textarea"
-                  >
-                    <span />
-                  </span>
-                  <span
-                    class="mq-root-block mq-empty"
-                    mathquill-block-id="1"
-                    style="padding: 10px 11px 8px 11px; font-size: 18pt;"
-                  />
-                </div>
+                  <span />
+                </span>
+                <span
+                  class="mq-root-block mq-empty"
+                  mathquill-block-id="1"
+                  style="padding: 10px 11px 8px 11px; font-size: 18pt;"
+                />
               </div>
             </div>
           </div>
         </div>
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="4"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="4"
       >
-        <div
-          class="paragraph"
-        >
-          <em>
-            Note: This a small sample to practice with. A larger sample could give a much better estimate.
-          </em>
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="5"
-      >
-        <table>
-          <thead>
-            <tr>
-              <th
-                scope="col"
-                style="text-align: center;"
-              />
-              <th
-                scope="col"
-                style="text-align: center;"
-              >
-                Sample
-              </th>
-              <th
-                scope="col"
-              />
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td
-                style="text-align: center;"
-              >
-                <span
-                  style="white-space: nowrap;"
-                >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    1
-                  </span>
-                  <span />
-                </span>
-              </td>
-              <td
-                style="text-align: center;"
-              >
-                <span
-                  style="white-space: nowrap;"
-                >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    \\text{\\blue{Z}, \\blue{Z}, \\blue{Z}, \\blue{Z}, \\red{A}, \\blue{Z}, \\blue{Z}}
-                  </span>
-                  <span />
-                </span>
-              </td>
-            </tr>
-            <tr>
-              <td
-                style="text-align: center;"
-              >
-                <span
-                  style="white-space: nowrap;"
-                >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    2
-                  </span>
-                  <span />
-                </span>
-              </td>
-              <td
-                style="text-align: center;"
-              >
-                <span
-                  style="white-space: nowrap;"
-                >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    \\text{\\blue{Z}, \\blue{Z}, \\blue{Z}, \\blue{Z}, \\blue{Z}, \\blue{Z}, \\blue{Z}}
-                  </span>
-                  <span />
-                </span>
-              </td>
-            </tr>
-            <tr>
-              <td
-                style="text-align: center;"
-              >
-                <span
-                  style="white-space: nowrap;"
-                >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    3
-                  </span>
-                  <span />
-                </span>
-              </td>
-              <td
-                style="text-align: center;"
-              >
-                <span
-                  style="white-space: nowrap;"
-                >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    \\text{\\blue{Z}, \\blue{Z}, \\red{A}, \\blue{Z}, \\blue{Z}, \\blue{Z}, \\blue{Z}}
-                  </span>
-                  <span />
-                </span>
-              </td>
-            </tr>
-            <tr>
-              <td
-                style="text-align: center;"
-              >
-                <span
-                  style="white-space: nowrap;"
-                >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    4
-                  </span>
-                  <span />
-                </span>
-              </td>
-              <td
-                style="text-align: center;"
-              >
-                <span
-                  style="white-space: nowrap;"
-                >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    \\text{\\red{A}, \\red{A}, \\blue{Z}, \\blue{Z}, \\blue{Z}, \\blue{Z}, \\blue{Z}}
-                  </span>
-                  <span />
-                </span>
-              </td>
-            </tr>
-            <tr>
-              <td
-                style="text-align: center;"
-              >
-                <span
-                  style="white-space: nowrap;"
-                >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    5
-                  </span>
-                  <span />
-                </span>
-              </td>
-              <td
-                style="text-align: center;"
-              >
-                <span
-                  style="white-space: nowrap;"
-                >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    \\text{\\blue{Z}, \\blue{Z}, \\blue{Z}, \\blue{Z}, \\blue{Z}, \\red{A}, \\red{A}}
-                  </span>
-                  <span />
-                </span>
-              </td>
-            </tr>
-            <tr>
-              <td
-                style="text-align: center;"
-              >
-                <span
-                  style="white-space: nowrap;"
-                >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    6
-                  </span>
-                  <span />
-                </span>
-              </td>
-              <td
-                style="text-align: center;"
-              >
-                <span
-                  style="white-space: nowrap;"
-                >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    \\text{\\blue{Z}, \\red{A}, \\red{A}, \\blue{Z}, \\blue{Z}, \\blue{Z}, \\blue{Z}}
-                  </span>
-                  <span />
-                </span>
-              </td>
-            </tr>
-            <tr>
-              <td
-                style="text-align: center;"
-              >
-                <span
-                  style="white-space: nowrap;"
-                >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    7
-                  </span>
-                  <span />
-                </span>
-              </td>
-              <td
-                style="text-align: center;"
-              >
-                <span
-                  style="white-space: nowrap;"
-                >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    \\text{\\blue{Z}, \\red{A}, \\blue{Z}, \\blue{Z}, \\blue{Z}, \\red{A}, \\blue{Z}}
-                  </span>
-                  <span />
-                </span>
-              </td>
-            </tr>
-            <tr>
-              <td
-                style="text-align: center;"
-              >
-                <span
-                  style="white-space: nowrap;"
-                >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    8
-                  </span>
-                  <span />
-                </span>
-              </td>
-              <td
-                style="text-align: center;"
-              >
-                <span
-                  style="white-space: nowrap;"
-                >
-                  <span />
-                  <span
-                    class="mock-TeX"
-                  >
-                    \\text{\\blue{Z}, \\blue{Z}, \\blue{Z}, \\blue{Z}, \\red{A}, \\blue{Z}, \\blue{Z}}
-                  </span>
-                  <span />
-                </span>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+        <em>
+          Note: This a small sample to practice with. A larger sample could give a much better estimate.
+        </em>
       </div>
     </div>
-  </span>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="5"
+    >
+      <table>
+        <thead>
+          <tr>
+            <th
+              scope="col"
+              style="text-align: center;"
+            />
+            <th
+              scope="col"
+              style="text-align: center;"
+            >
+              Sample
+            </th>
+            <th
+              scope="col"
+            />
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td
+              style="text-align: center;"
+            >
+              <span
+                style="white-space: nowrap;"
+              >
+                <span />
+                <span
+                  class="mock-TeX"
+                >
+                  1
+                </span>
+                <span />
+              </span>
+            </td>
+            <td
+              style="text-align: center;"
+            >
+              <span
+                style="white-space: nowrap;"
+              >
+                <span />
+                <span
+                  class="mock-TeX"
+                >
+                  \\text{\\blue{Z}, \\blue{Z}, \\blue{Z}, \\blue{Z}, \\red{A}, \\blue{Z}, \\blue{Z}}
+                </span>
+                <span />
+              </span>
+            </td>
+          </tr>
+          <tr>
+            <td
+              style="text-align: center;"
+            >
+              <span
+                style="white-space: nowrap;"
+              >
+                <span />
+                <span
+                  class="mock-TeX"
+                >
+                  2
+                </span>
+                <span />
+              </span>
+            </td>
+            <td
+              style="text-align: center;"
+            >
+              <span
+                style="white-space: nowrap;"
+              >
+                <span />
+                <span
+                  class="mock-TeX"
+                >
+                  \\text{\\blue{Z}, \\blue{Z}, \\blue{Z}, \\blue{Z}, \\blue{Z}, \\blue{Z}, \\blue{Z}}
+                </span>
+                <span />
+              </span>
+            </td>
+          </tr>
+          <tr>
+            <td
+              style="text-align: center;"
+            >
+              <span
+                style="white-space: nowrap;"
+              >
+                <span />
+                <span
+                  class="mock-TeX"
+                >
+                  3
+                </span>
+                <span />
+              </span>
+            </td>
+            <td
+              style="text-align: center;"
+            >
+              <span
+                style="white-space: nowrap;"
+              >
+                <span />
+                <span
+                  class="mock-TeX"
+                >
+                  \\text{\\blue{Z}, \\blue{Z}, \\red{A}, \\blue{Z}, \\blue{Z}, \\blue{Z}, \\blue{Z}}
+                </span>
+                <span />
+              </span>
+            </td>
+          </tr>
+          <tr>
+            <td
+              style="text-align: center;"
+            >
+              <span
+                style="white-space: nowrap;"
+              >
+                <span />
+                <span
+                  class="mock-TeX"
+                >
+                  4
+                </span>
+                <span />
+              </span>
+            </td>
+            <td
+              style="text-align: center;"
+            >
+              <span
+                style="white-space: nowrap;"
+              >
+                <span />
+                <span
+                  class="mock-TeX"
+                >
+                  \\text{\\red{A}, \\red{A}, \\blue{Z}, \\blue{Z}, \\blue{Z}, \\blue{Z}, \\blue{Z}}
+                </span>
+                <span />
+              </span>
+            </td>
+          </tr>
+          <tr>
+            <td
+              style="text-align: center;"
+            >
+              <span
+                style="white-space: nowrap;"
+              >
+                <span />
+                <span
+                  class="mock-TeX"
+                >
+                  5
+                </span>
+                <span />
+              </span>
+            </td>
+            <td
+              style="text-align: center;"
+            >
+              <span
+                style="white-space: nowrap;"
+              >
+                <span />
+                <span
+                  class="mock-TeX"
+                >
+                  \\text{\\blue{Z}, \\blue{Z}, \\blue{Z}, \\blue{Z}, \\blue{Z}, \\red{A}, \\red{A}}
+                </span>
+                <span />
+              </span>
+            </td>
+          </tr>
+          <tr>
+            <td
+              style="text-align: center;"
+            >
+              <span
+                style="white-space: nowrap;"
+              >
+                <span />
+                <span
+                  class="mock-TeX"
+                >
+                  6
+                </span>
+                <span />
+              </span>
+            </td>
+            <td
+              style="text-align: center;"
+            >
+              <span
+                style="white-space: nowrap;"
+              >
+                <span />
+                <span
+                  class="mock-TeX"
+                >
+                  \\text{\\blue{Z}, \\red{A}, \\red{A}, \\blue{Z}, \\blue{Z}, \\blue{Z}, \\blue{Z}}
+                </span>
+                <span />
+              </span>
+            </td>
+          </tr>
+          <tr>
+            <td
+              style="text-align: center;"
+            >
+              <span
+                style="white-space: nowrap;"
+              >
+                <span />
+                <span
+                  class="mock-TeX"
+                >
+                  7
+                </span>
+                <span />
+              </span>
+            </td>
+            <td
+              style="text-align: center;"
+            >
+              <span
+                style="white-space: nowrap;"
+              >
+                <span />
+                <span
+                  class="mock-TeX"
+                >
+                  \\text{\\blue{Z}, \\red{A}, \\blue{Z}, \\blue{Z}, \\blue{Z}, \\red{A}, \\blue{Z}}
+                </span>
+                <span />
+              </span>
+            </td>
+          </tr>
+          <tr>
+            <td
+              style="text-align: center;"
+            >
+              <span
+                style="white-space: nowrap;"
+              >
+                <span />
+                <span
+                  class="mock-TeX"
+                >
+                  8
+                </span>
+                <span />
+              </span>
+            </td>
+            <td
+              style="text-align: center;"
+            >
+              <span
+                style="white-space: nowrap;"
+              >
+                <span />
+                <span
+                  class="mock-TeX"
+                >
+                  \\text{\\blue{Z}, \\blue{Z}, \\blue{Z}, \\blue{Z}, \\red{A}, \\blue{Z}, \\blue{Z}}
+                </span>
+                <span />
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/interaction.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/interaction.test.ts.snap
@@ -2,310 +2,306 @@
 
 exports[`interaction widget should render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          Drag the dot all the way to the right.
-        </div>
+        Drag the dot all the way to the right.
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="1"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+            class="graphie-container"
           >
             <div
-              class="graphie-container"
+              class="graphie"
+              style="position: relative; width: 479.99999999999994px; height: 120.00000000000001px;"
             >
-              <div
-                class="graphie"
-                style="position: relative; width: 479.99999999999994px; height: 120.00000000000001px;"
+              <svg
+                height="120.00000000000001"
+                style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
+                version="1.1"
+                width="479.99999999999994"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  height="120.00000000000001"
-                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
-                  version="1.1"
-                  width="479.99999999999994"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <desc
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                  >
-                    Created with Raphaël
-                  </desc>
-                  <defs
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                  />
-                </svg>
-                <svg
-                  height="120.00000000000001"
+                <desc
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                  version="1.1"
-                  width="479.99999999999994"
-                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <desc
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                  >
-                    Created with Raphaël
-                  </desc>
-                  <defs
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                  />
-                  <path
-                    d="M254.59459459459455,636.5217391304348L254.5785950953643,635.6596267341514L254.53065974038762,634.8009167016342L254.45097770861094,633.9489979690746L254.33986346861047,633.1072326705054L254.19775553752822,632.2789428689938L254.02521475044523,631.467397445977L253.82292204702173,630.6757992004796L253.5916757841394,629.9072722091297L253.33238858515142,629.1648494968558L253.04608373817518,628.4514610669225L252.73389115764147,627.7699223375465L252.39704292503845,627.1229230307273L252.0368684264488,626.513016557143L251.6547891060704,625.9426099390051L251.25231285642542,625.4139543106413L250.8310280673972,624.9291360342974L250.39259735758142,624.4900684662169L249.93875101268972,624.0984844055008L249.47128015690274,623.755929255539L248.99202968412115,623.4637549250093L248.5028909770123,623.2231144925131L248.0057944425869,623.0349576558989L247.5027018937646,622.9000269842405L246.99559880699437,622.8188549872548L246.48648648648643,622.7917620137299L245.9773741659785,622.8188549872548L245.4702710792083,622.9000269842405L244.96717853038598,623.0349576558989L244.47008199596056,623.2231144925131L243.9809432888517,623.4637549250093L243.50169281607012,623.755929255539L243.03422196028313,624.0984844055008L242.58037561539143,624.4900684662169L242.14194490557566,624.9291360342974L241.72066011654746,625.4139543106413L241.31818386690247,625.9426099390051L240.9361045465241,626.513016557143L240.57593004793443,627.1229230307273L240.23908181533136,627.7699223375465L239.92688923479767,628.4514610669225L239.64058438782146,629.1648494968558L239.38129718883349,629.9072722091297L239.15005092595115,630.6757992004796L238.94775822252765,631.467397445977L238.77521743544466,632.2789428689938L238.6331095043624,633.1072326705055L238.52199526436195,633.9489979690746L238.44231323258526,634.8009167016344L238.39437787760858,635.6596267341514L238.37837837837833,636.5217391304348L238.39437787760858,637.3838515267182L238.44231323258526,638.2425615592352L238.52199526436195,639.094480291795L238.6331095043624,639.9362455903641L238.77521743544466,640.7645353918757L238.94775822252765,641.5760808148926L239.15005092595115,642.3676790603901L239.3812971888335,643.1362060517399L239.64058438782146,643.8786287640137L239.9268892347977,644.592017193947L240.23908181533142,645.2735559233231L240.57593004793446,645.9205552301422L240.93610454652412,646.5304617037265L241.3181838669025,647.1008683218645L241.7206601165475,647.6295239502281L242.14194490557568,648.1143422265723L242.5803756153915,648.5534097946527L243.03422196028316,648.9449938553686L243.50169281607015,649.2875490053307L243.98094328885173,649.5797233358603L244.47008199596058,649.8203637683565L244.96717853038598,650.0085206049705L245.4702710792083,650.1434512766289L245.9773741659785,650.2246232736147L246.48648648648643,650.2517162471395L246.99559880699437,650.2246232736147L247.5027018937646,650.1434512766289L248.0057944425869,650.0085206049705L248.5028909770123,649.8203637683565L248.99202968412115,649.5797233358603L249.47128015690274,649.2875490053307L249.93875101268972,648.9449938553686L250.3925973575814,648.5534097946527L250.8310280673972,648.1143422265723L251.2523128564254,647.6295239502281L251.65478910607038,647.1008683218645L252.03686842644876,646.5304617037265L252.39704292503842,645.9205552301422L252.73389115764144,645.2735559233231L253.04608373817516,644.5920171939471L253.3323885851514,643.8786287640137L253.59167578413937,643.1362060517399L253.82292204702173,642.3676790603901L254.0252147504452,641.5760808148926L254.1977555375282,640.7645353918758L254.33986346861045,639.9362455903643L254.45097770861094,639.094480291795L254.53065974038762,638.2425615592355L254.5785950953643,637.3838515267184L254.59459459459455,636.5217391304349"
-                    fill="none"
-                    stroke="#6495ed"
-                    stroke-dasharray="0"
-                    stroke-width="4"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 4;"
-                  />
-                  <path
-                    d="M19.459459459459445,62.60869565217392L19.459459459459445,114.78260869565217"
-                    fill="none"
-                    stroke="none"
-                    stroke-dasharray="4,3"
-                    stroke-width="1"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
-                  />
-                  <path
-                    d="M84.3243243243243,62.60869565217392L84.3243243243243,114.78260869565217"
-                    fill="none"
-                    stroke="none"
-                    stroke-dasharray="4,3"
-                    stroke-width="1"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
-                  />
-                  <path
-                    d="M149.18918918918916,62.60869565217392L149.18918918918916,114.78260869565217"
-                    fill="none"
-                    stroke="none"
-                    stroke-dasharray="4,3"
-                    stroke-width="1"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
-                  />
-                  <path
-                    d="M214.054054054054,62.60869565217392L214.054054054054,114.78260869565217"
-                    fill="none"
-                    stroke="none"
-                    stroke-dasharray="4,3"
-                    stroke-width="1"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
-                  />
-                  <path
-                    d="M278.91891891891885,62.60869565217392L278.91891891891885,114.78260869565217"
-                    fill="none"
-                    stroke="none"
-                    stroke-dasharray="4,3"
-                    stroke-width="1"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
-                  />
-                  <path
-                    d="M343.78378378378375,62.60869565217392L343.78378378378375,114.78260869565217"
-                    fill="none"
-                    stroke="none"
-                    stroke-dasharray="4,3"
-                    stroke-width="1"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
-                  />
-                  <path
-                    d="M408.6486486486486,62.60869565217392L408.6486486486486,114.78260869565217"
-                    fill="none"
-                    stroke="none"
-                    stroke-dasharray="4,3"
-                    stroke-width="1"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
-                  />
-                  <path
-                    d="M473.51351351351343,62.60869565217392L473.51351351351343,114.78260869565217"
-                    fill="none"
-                    stroke="none"
-                    stroke-dasharray="4,3"
-                    stroke-width="1"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
-                  />
-                  <path
-                    d="M19.459459459459445,10.434782608695661L149.18918918918916,10.434782608695661"
-                    fill="none"
-                    stroke="none"
-                    stroke-dasharray="0"
-                    stroke-width="2"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
-                  />
-                  <ellipse
-                    cx="278.91891891891885"
-                    cy="104.34782608695652"
-                    fill="none"
-                    rx="4"
-                    ry="4"
-                    stroke="none"
-                    stroke-width="2"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
-                  />
-                </svg>
+                  Created with Raphaël
+                </desc>
+                <defs
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                />
+              </svg>
+              <svg
+                height="120.00000000000001"
+                style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                version="1.1"
+                width="479.99999999999994"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <desc
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                >
+                  Created with Raphaël
+                </desc>
+                <defs
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                />
+                <path
+                  d="M254.59459459459455,636.5217391304348L254.5785950953643,635.6596267341514L254.53065974038762,634.8009167016342L254.45097770861094,633.9489979690746L254.33986346861047,633.1072326705054L254.19775553752822,632.2789428689938L254.02521475044523,631.467397445977L253.82292204702173,630.6757992004796L253.5916757841394,629.9072722091297L253.33238858515142,629.1648494968558L253.04608373817518,628.4514610669225L252.73389115764147,627.7699223375465L252.39704292503845,627.1229230307273L252.0368684264488,626.513016557143L251.6547891060704,625.9426099390051L251.25231285642542,625.4139543106413L250.8310280673972,624.9291360342974L250.39259735758142,624.4900684662169L249.93875101268972,624.0984844055008L249.47128015690274,623.755929255539L248.99202968412115,623.4637549250093L248.5028909770123,623.2231144925131L248.0057944425869,623.0349576558989L247.5027018937646,622.9000269842405L246.99559880699437,622.8188549872548L246.48648648648643,622.7917620137299L245.9773741659785,622.8188549872548L245.4702710792083,622.9000269842405L244.96717853038598,623.0349576558989L244.47008199596056,623.2231144925131L243.9809432888517,623.4637549250093L243.50169281607012,623.755929255539L243.03422196028313,624.0984844055008L242.58037561539143,624.4900684662169L242.14194490557566,624.9291360342974L241.72066011654746,625.4139543106413L241.31818386690247,625.9426099390051L240.9361045465241,626.513016557143L240.57593004793443,627.1229230307273L240.23908181533136,627.7699223375465L239.92688923479767,628.4514610669225L239.64058438782146,629.1648494968558L239.38129718883349,629.9072722091297L239.15005092595115,630.6757992004796L238.94775822252765,631.467397445977L238.77521743544466,632.2789428689938L238.6331095043624,633.1072326705055L238.52199526436195,633.9489979690746L238.44231323258526,634.8009167016344L238.39437787760858,635.6596267341514L238.37837837837833,636.5217391304348L238.39437787760858,637.3838515267182L238.44231323258526,638.2425615592352L238.52199526436195,639.094480291795L238.6331095043624,639.9362455903641L238.77521743544466,640.7645353918757L238.94775822252765,641.5760808148926L239.15005092595115,642.3676790603901L239.3812971888335,643.1362060517399L239.64058438782146,643.8786287640137L239.9268892347977,644.592017193947L240.23908181533142,645.2735559233231L240.57593004793446,645.9205552301422L240.93610454652412,646.5304617037265L241.3181838669025,647.1008683218645L241.7206601165475,647.6295239502281L242.14194490557568,648.1143422265723L242.5803756153915,648.5534097946527L243.03422196028316,648.9449938553686L243.50169281607015,649.2875490053307L243.98094328885173,649.5797233358603L244.47008199596058,649.8203637683565L244.96717853038598,650.0085206049705L245.4702710792083,650.1434512766289L245.9773741659785,650.2246232736147L246.48648648648643,650.2517162471395L246.99559880699437,650.2246232736147L247.5027018937646,650.1434512766289L248.0057944425869,650.0085206049705L248.5028909770123,649.8203637683565L248.99202968412115,649.5797233358603L249.47128015690274,649.2875490053307L249.93875101268972,648.9449938553686L250.3925973575814,648.5534097946527L250.8310280673972,648.1143422265723L251.2523128564254,647.6295239502281L251.65478910607038,647.1008683218645L252.03686842644876,646.5304617037265L252.39704292503842,645.9205552301422L252.73389115764144,645.2735559233231L253.04608373817516,644.5920171939471L253.3323885851514,643.8786287640137L253.59167578413937,643.1362060517399L253.82292204702173,642.3676790603901L254.0252147504452,641.5760808148926L254.1977555375282,640.7645353918758L254.33986346861045,639.9362455903643L254.45097770861094,639.094480291795L254.53065974038762,638.2425615592355L254.5785950953643,637.3838515267184L254.59459459459455,636.5217391304349"
+                  fill="none"
+                  stroke="#6495ed"
+                  stroke-dasharray="0"
+                  stroke-width="4"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 4;"
+                />
+                <path
+                  d="M19.459459459459445,62.60869565217392L19.459459459459445,114.78260869565217"
+                  fill="none"
+                  stroke="none"
+                  stroke-dasharray="4,3"
+                  stroke-width="1"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
+                />
+                <path
+                  d="M84.3243243243243,62.60869565217392L84.3243243243243,114.78260869565217"
+                  fill="none"
+                  stroke="none"
+                  stroke-dasharray="4,3"
+                  stroke-width="1"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
+                />
+                <path
+                  d="M149.18918918918916,62.60869565217392L149.18918918918916,114.78260869565217"
+                  fill="none"
+                  stroke="none"
+                  stroke-dasharray="4,3"
+                  stroke-width="1"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
+                />
+                <path
+                  d="M214.054054054054,62.60869565217392L214.054054054054,114.78260869565217"
+                  fill="none"
+                  stroke="none"
+                  stroke-dasharray="4,3"
+                  stroke-width="1"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
+                />
+                <path
+                  d="M278.91891891891885,62.60869565217392L278.91891891891885,114.78260869565217"
+                  fill="none"
+                  stroke="none"
+                  stroke-dasharray="4,3"
+                  stroke-width="1"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
+                />
+                <path
+                  d="M343.78378378378375,62.60869565217392L343.78378378378375,114.78260869565217"
+                  fill="none"
+                  stroke="none"
+                  stroke-dasharray="4,3"
+                  stroke-width="1"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
+                />
+                <path
+                  d="M408.6486486486486,62.60869565217392L408.6486486486486,114.78260869565217"
+                  fill="none"
+                  stroke="none"
+                  stroke-dasharray="4,3"
+                  stroke-width="1"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
+                />
+                <path
+                  d="M473.51351351351343,62.60869565217392L473.51351351351343,114.78260869565217"
+                  fill="none"
+                  stroke="none"
+                  stroke-dasharray="4,3"
+                  stroke-width="1"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
+                />
+                <path
+                  d="M19.459459459459445,10.434782608695661L149.18918918918916,10.434782608695661"
+                  fill="none"
+                  stroke="none"
+                  stroke-dasharray="0"
+                  stroke-width="2"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                />
+                <ellipse
+                  cx="278.91891891891885"
+                  cy="104.34782608695652"
+                  fill="none"
+                  rx="4"
+                  ry="4"
+                  stroke="none"
+                  stroke-width="2"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                />
+              </svg>
+              <div
+                style="position: absolute; left: 0px; top: 0px;"
+              >
                 <div
-                  style="position: absolute; left: 0px; top: 0px;"
+                  style="position: absolute; width: 26px; height: 26px; left: 6.459459459459445px; top: -2.565217391304339px; transform: translateX(0px) translateY(0px) translateZ(0);"
                 >
-                  <div
-                    style="position: absolute; width: 26px; height: 26px; left: 6.459459459459445px; top: -2.565217391304339px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  <svg
+                    height="26"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                    version="1.1"
+                    width="26"
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    <svg
-                      height="26"
+                    <desc
                       style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                      version="1.1"
-                      width="26"
-                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <desc
-                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                      >
-                        Created with Raphaël
-                      </desc>
-                      <defs
-                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                      />
-                      <ellipse
-                        cx="NaN"
-                        cy="NaN"
-                        fill="#71b307"
-                        r="NaN"
-                        rx="4"
-                        ry="4"
-                        stroke="#71b307"
-                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        transform=""
-                      />
-                    </svg>
-                  </div>
-                </div>
-                <div
-                  style="position: absolute; left: 0px; top: 0px; z-index: 2;"
-                >
-                  <div
-                    data-interactive-kind-for-testing="movable-point"
-                    style="position: absolute; width: 48px; height: 48px; left: -4.540540540540555px; top: -13.565217391304339px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                  >
-                    <svg
-                      height="48"
+                      Created with Raphaël
+                    </desc>
+                    <defs
                       style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                      version="1.1"
-                      width="48"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <desc
-                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                      >
-                        Created with Raphaël
-                      </desc>
-                      <defs
-                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                      />
-                      <ellipse
-                        cx="24"
-                        cy="24"
-                        fill="#000000"
-                        opacity="0"
-                        rx="24"
-                        ry="24"
-                        stroke="#000"
-                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                      />
-                    </svg>
-                  </div>
+                    />
+                    <ellipse
+                      cx="NaN"
+                      cy="NaN"
+                      fill="#71b307"
+                      r="NaN"
+                      rx="4"
+                      ry="4"
+                      stroke="#71b307"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      transform=""
+                    />
+                  </svg>
                 </div>
-                <span
-                  class="graphie-label"
-                  data-math-formula="\\Huge 2"
-                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 116.59637038983988px; top: 88.69565217391305px; fill: none;"
-                >
-                  <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
-                  />
-                </span>
-                <span
-                  class="graphie-label"
-                  data-math-formula="\\Huge 5"
-                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 181.46123525470475px; top: 88.69565217391305px; fill: none;"
-                >
-                  <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
-                  />
-                </span>
-                <span
-                  class="graphie-label"
-                  data-math-formula="\\Huge 9"
-                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 246.3261001195696px; top: 88.69565217391305px; fill: none;"
-                >
-                  <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
-                  />
-                </span>
-                <span
-                  class="graphie-label"
-                  data-math-formula="\\small 259"
-                  style="position: absolute; padding: 7px; color: gray; left: 19.459459459459445px; top: 26.08695652173914px; fill: none;"
-                >
-                  <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
-                  />
-                </span>
-                <span
-                  class="graphie-label"
-                  data-math-formula="\\small 259 \\times 10"
-                  style="position: absolute; padding: 7px; color: gray; left: 149.18918918918916px; top: 26.08695652173914px; fill: none;"
-                >
-                  <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
-                  />
-                </span>
               </div>
+              <div
+                style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+              >
+                <div
+                  data-interactive-kind-for-testing="movable-point"
+                  style="position: absolute; width: 48px; height: 48px; left: -4.540540540540555px; top: -13.565217391304339px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                >
+                  <svg
+                    height="48"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                    version="1.1"
+                    width="48"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <desc
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                    >
+                      Created with Raphaël
+                    </desc>
+                    <defs
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                    />
+                    <ellipse
+                      cx="24"
+                      cy="24"
+                      fill="#000000"
+                      opacity="0"
+                      rx="24"
+                      ry="24"
+                      stroke="#000"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <span
+                class="graphie-label"
+                data-math-formula="\\Huge 2"
+                style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 116.59637038983988px; top: 88.69565217391305px; fill: none;"
+              >
+                <span
+                  class="katex-holder"
+                />
+                <span
+                  class="mathjax-holder"
+                />
+              </span>
+              <span
+                class="graphie-label"
+                data-math-formula="\\Huge 5"
+                style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 181.46123525470475px; top: 88.69565217391305px; fill: none;"
+              >
+                <span
+                  class="katex-holder"
+                />
+                <span
+                  class="mathjax-holder"
+                />
+              </span>
+              <span
+                class="graphie-label"
+                data-math-formula="\\Huge 9"
+                style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 246.3261001195696px; top: 88.69565217391305px; fill: none;"
+              >
+                <span
+                  class="katex-holder"
+                />
+                <span
+                  class="mathjax-holder"
+                />
+              </span>
+              <span
+                class="graphie-label"
+                data-math-formula="\\small 259"
+                style="position: absolute; padding: 7px; color: gray; left: 19.459459459459445px; top: 26.08695652173914px; fill: none;"
+              >
+                <span
+                  class="katex-holder"
+                />
+                <span
+                  class="mathjax-holder"
+                />
+              </span>
+              <span
+                class="graphie-label"
+                data-math-formula="\\small 259 \\times 10"
+                style="position: absolute; padding: 7px; color: gray; left: 149.18918918918916px; top: 26.08695652173914px; fill: none;"
+              >
+                <span
+                  class="katex-holder"
+                />
+                <span
+                  class="mathjax-holder"
+                />
+              </span>
             </div>
           </div>
         </div>
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="2"
       >
-        <div
-          class="paragraph"
-        >
-          <em>
-            Notice that we add a zero to the empty place value.
-          </em>
-           
-        </div>
+        <em>
+          Notice that we add a zero to the empty place value.
+        </em>
+         
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/interactive-graph.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/interactive-graph.test.ts.snap
@@ -2,1194 +2,1182 @@
 
 exports[`interactive-graph widget question Shoud render predictably: after interaction 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          <strong>
-            Drag the vertices of the triangle below to draw a right triangle with side lengths 
+        <strong>
+          Drag the vertices of the triangle below to draw a right triangle with side lengths 
+          <span
+            style="white-space: nowrap;"
+          >
+            <span />
             <span
-              style="white-space: nowrap;"
+              class="mock-TeX"
             >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                3
-              </span>
-              <span />
+              3
             </span>
-            , 
+            <span />
+          </span>
+          , 
+          <span
+            style="white-space: nowrap;"
+          >
+            <span />
             <span
-              style="white-space: nowrap;"
+              class="mock-TeX"
             >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                4
-              </span>
-              <span />
+              4
             </span>
-            , and 
+            <span />
+          </span>
+          , and 
+          <span
+            style="white-space: nowrap;"
+          >
+            <span />
             <span
-              style="white-space: nowrap;"
+              class="mock-TeX"
             >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                5
-              </span>
-              <span />
+              5
             </span>
-            .
-          </strong>
-           
+            <span />
+          </span>
+          .
+        </strong>
+         
 
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
           <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+            class="perseus-widget perseus-widget-interactive-graph"
+            style="width: 400px; height: 400px;"
           >
             <div
-              class="perseus-widget perseus-widget-interactive-graph"
+              class="graphie-container above-scratchpad"
               style="width: 400px; height: 400px;"
             >
               <div
-                class="graphie-container above-scratchpad"
-                style="width: 400px; height: 400px;"
+                class="graphie"
+                style="position: relative; width: 400px; height: 400px;"
               >
-                <div
-                  class="graphie"
-                  style="position: relative; width: 400px; height: 400px;"
+                <svg
+                  height="400"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
+                  version="1.1"
+                  width="400"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <svg
-                    height="400"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
-                    version="1.1"
-                    width="400"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <desc
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    >
-                      Created with Raphaël
-                    </desc>
-                    <defs
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    />
-                    <path
-                      d="M371.42857142857144,228.57142857142858L142.85714285714286,57.142857142857146L142.85714285714286,228.57142857142858Z"
-                      fill="#000000"
-                      opacity="0"
-                      stroke="#000000"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                    />
-                  </svg>
-                  <svg
-                    height="400"
+                  <desc
                     style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    version="1.1"
-                    width="400"
-                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    <desc
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    >
-                      Created with Raphaël
-                    </desc>
-                    <defs
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    />
-                    <path
-                      d="M371.42857142857144,228.57142857142858L142.85714285714286,57.142857142857146L142.85714285714286,228.57142857142858Z"
-                      fill="#71b307"
-                      fill-opacity="0"
-                      stroke="#71b307"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; fill-opacity: 0;"
-                    />
-                    <path
-                      d="M156.23200184286875,228.57142857142858L156.23200184286875,215.1965695857027"
-                      fill="none"
-                      stroke="#6495ed"
-                      stroke-width="1"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
-                    />
-                    <path
-                      d="M142.85714285714286,215.1965695857027L156.23200184286875,215.1965695857027"
-                      fill="none"
-                      stroke="#6495ed"
-                      stroke-width="1"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
-                    />
-                  </svg>
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <path
+                    d="M371.42857142857144,228.57142857142858L142.85714285714286,57.142857142857146L142.85714285714286,228.57142857142858Z"
+                    fill="#000000"
+                    opacity="0"
+                    stroke="#000000"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                  />
+                </svg>
+                <svg
+                  height="400"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  version="1.1"
+                  width="400"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <path
+                    d="M371.42857142857144,228.57142857142858L142.85714285714286,57.142857142857146L142.85714285714286,228.57142857142858Z"
+                    fill="#71b307"
+                    fill-opacity="0"
+                    stroke="#71b307"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; fill-opacity: 0;"
+                  />
+                  <path
+                    d="M156.23200184286875,228.57142857142858L156.23200184286875,215.1965695857027"
+                    fill="none"
+                    stroke="#6495ed"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
+                  />
+                  <path
+                    d="M142.85714285714286,215.1965695857027L156.23200184286875,215.1965695857027"
+                    fill="none"
+                    stroke="#6495ed"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
+                  />
+                </svg>
+                <div
+                  style="position: absolute; left: 0px; top: 0px;"
+                >
                   <div
-                    style="position: absolute; left: 0px; top: 0px;"
+                    style="position: absolute; width: 26px; height: 26px; left: 358.42857142857144px; top: 215.57142857142858px; transform: translateX(0px) translateY(0px) translateZ(0);"
                   >
-                    <div
-                      style="position: absolute; width: 26px; height: 26px; left: 358.42857142857144px; top: 215.57142857142858px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                    <svg
+                      height="26"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="26"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        height="26"
+                      <desc
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="26"
-                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="NaN"
-                          cy="NaN"
-                          fill="#71b307"
-                          r="NaN"
-                          rx="4"
-                          ry="4"
-                          stroke="#71b307"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                          transform=""
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      style="position: absolute; width: 26px; height: 26px; left: 129.85714285714286px; top: 44.142857142857146px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="26"
+                        Created with Raphaël
+                      </desc>
+                      <defs
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="26"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="NaN"
-                          cy="NaN"
-                          fill="#71b307"
-                          r="NaN"
-                          rx="4"
-                          ry="4"
-                          stroke="#71b307"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                          transform=""
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      style="position: absolute; width: 26px; height: 26px; left: 129.85714285714286px; top: 215.57142857142858px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="26"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#71b307"
+                        r="NaN"
+                        rx="4"
+                        ry="4"
+                        stroke="#71b307"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="26"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="NaN"
-                          cy="NaN"
-                          fill="#71b307"
-                          r="NaN"
-                          rx="4"
-                          ry="4"
-                          stroke="#71b307"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                          transform=""
-                        />
-                      </svg>
-                    </div>
+                        transform=""
+                      />
+                    </svg>
                   </div>
                   <div
-                    style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                    style="position: absolute; width: 26px; height: 26px; left: 129.85714285714286px; top: 44.142857142857146px; transform: translateX(0px) translateY(0px) translateZ(0);"
                   >
-                    <div
-                      data-interactive-kind-for-testing="movable-point"
-                      style="position: absolute; width: 48px; height: 48px; left: 347.42857142857144px; top: 204.57142857142858px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                    <svg
+                      height="26"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="26"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        height="48"
+                      <desc
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="24"
-                          cy="24"
-                          fill="#000000"
-                          opacity="0"
-                          rx="24"
-                          ry="24"
-                          stroke="#000"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      data-interactive-kind-for-testing="movable-point"
-                      style="position: absolute; width: 48px; height: 48px; left: 118.85714285714286px; top: 33.142857142857146px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="48"
+                        Created with Raphaël
+                      </desc>
+                      <defs
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="24"
-                          cy="24"
-                          fill="#000000"
-                          opacity="0"
-                          rx="24"
-                          ry="24"
-                          stroke="#000"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      data-interactive-kind-for-testing="movable-point"
-                      style="position: absolute; width: 48px; height: 48px; left: 118.85714285714286px; top: 204.57142857142858px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="48"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#71b307"
+                        r="NaN"
+                        rx="4"
+                        ry="4"
+                        stroke="#71b307"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="24"
-                          cy="24"
-                          fill="#000000"
-                          opacity="0"
-                          rx="24"
-                          ry="24"
-                          stroke="#000"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                        />
-                      </svg>
-                    </div>
+                        transform=""
+                      />
+                    </svg>
                   </div>
-                  <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 57.142857142857146px; top: 342.8571428571429px; fill: none; stroke: #6495ED;"
+                  <div
+                    style="position: absolute; width: 26px; height: 26px; left: 129.85714285714286px; top: 215.57142857142858px; transform: translateX(0px) translateY(0px) translateZ(0);"
                   >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 57.142857142857146px; top: 342.8571428571429px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 57.142857142857146px; top: 342.8571428571429px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="5.0"
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 269.14285714285717px; top: 126.85714285714285px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="3.0"
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 122.85714285714286px; top: 142.85714285714286px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="4.0"
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 257.14285714285717px; top: 248.57142857142856px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
+                    <svg
+                      height="26"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="26"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#71b307"
+                        r="NaN"
+                        rx="4"
+                        ry="4"
+                        stroke="#71b307"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                        transform=""
+                      />
+                    </svg>
+                  </div>
                 </div>
+                <div
+                  style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                >
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 347.42857142857144px; top: 204.57142857142858px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 118.85714285714286px; top: 33.142857142857146px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 118.85714285714286px; top: 204.57142857142858px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 57.142857142857146px; top: 342.8571428571429px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 57.142857142857146px; top: 342.8571428571429px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 57.142857142857146px; top: 342.8571428571429px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="5.0"
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 269.14285714285717px; top: 126.85714285714285px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="3.0"
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 122.85714285714286px; top: 142.85714285714286px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="4.0"
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 257.14285714285717px; top: 248.57142857142856px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
               </div>
             </div>
           </div>
-           
         </div>
+         
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`interactive-graph widget question Shoud render predictably: after interaction 2`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          <strong>
-            Plot the image of triangle 
+        <strong>
+          Plot the image of triangle 
+          <span
+            style="white-space: nowrap;"
+          >
+            <span />
             <span
-              style="white-space: nowrap;"
+              class="mock-TeX"
             >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                \\triangle ABC
-              </span>
-              <span />
+              \\triangle ABC
             </span>
-             under a reflection across line 
+            <span />
+          </span>
+           under a reflection across line 
+          <span
+            style="white-space: nowrap;"
+          >
+            <span />
             <span
-              style="white-space: nowrap;"
+              class="mock-TeX"
             >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                \\ell
-              </span>
-              <span />
+              \\ell
             </span>
-            .
-          </strong>
-        </div>
+            <span />
+          </span>
+          .
+        </strong>
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="1"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+            class="perseus-widget perseus-widget-interactive-graph"
+            style="width: 400px; height: 400px;"
           >
             <div
-              class="perseus-widget perseus-widget-interactive-graph"
+              class="graphie-container above-scratchpad"
               style="width: 400px; height: 400px;"
             >
               <div
-                class="graphie-container above-scratchpad"
+                class="unresponsive-svg-image"
                 style="width: 400px; height: 400px;"
               >
-                <div
-                  class="unresponsive-svg-image"
-                  style="width: 400px; height: 400px;"
+                <span
+                  style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
                 >
-                  <span
-                    style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
+                  <div
+                    class="default_xu2jcg-o_O-spinnerContainer_agrn11"
                   >
-                    <div
-                      class="default_xu2jcg-o_O-spinnerContainer_agrn11"
+                    <svg
+                      height="48"
+                      viewBox="0 0 48 48"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        height="48"
-                        viewBox="0 0 48 48"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
-                          d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
-                          fill-rule="nonzero"
-                        />
-                      </svg>
-                    </div>
-                  </span>
-                </div>
-                <div
-                  class="graphie"
-                  style="position: relative; width: 400px; height: 400px;"
+                      <path
+                        class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
+                        d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
+                        fill-rule="nonzero"
+                      />
+                    </svg>
+                  </div>
+                </span>
+              </div>
+              <div
+                class="graphie"
+                style="position: relative; width: 400px; height: 400px;"
+              >
+                <svg
+                  height="400"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
+                  version="1.1"
+                  width="400"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <svg
-                    height="400"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
-                    version="1.1"
-                    width="400"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <desc
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    >
-                      Created with Raphaël
-                    </desc>
-                    <defs
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    />
-                    <path
-                      d="M50,375L225,300L125,300Z"
-                      fill="#000000"
-                      opacity="0"
-                      stroke="#000000"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                    />
-                  </svg>
-                  <svg
-                    height="400"
+                  <desc
                     style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    version="1.1"
-                    width="400"
-                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    <desc
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    >
-                      Created with Raphaël
-                    </desc>
-                    <defs
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    />
-                    <path
-                      d="M50,375L225,300L125,300Z"
-                      fill="#71b307"
-                      fill-opacity="0"
-                      stroke="#71b307"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; fill-opacity: 0;"
-                    />
-                  </svg>
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <path
+                    d="M50,375L225,300L125,300Z"
+                    fill="#000000"
+                    opacity="0"
+                    stroke="#000000"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                  />
+                </svg>
+                <svg
+                  height="400"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  version="1.1"
+                  width="400"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <path
+                    d="M50,375L225,300L125,300Z"
+                    fill="#71b307"
+                    fill-opacity="0"
+                    stroke="#71b307"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; fill-opacity: 0;"
+                  />
+                </svg>
+                <div
+                  style="position: absolute; left: 0px; top: 0px;"
+                >
                   <div
-                    style="position: absolute; left: 0px; top: 0px;"
+                    style="position: absolute; width: 26px; height: 26px; left: 37px; top: 362px; transform: translateX(0px) translateY(0px) translateZ(0);"
                   >
-                    <div
-                      style="position: absolute; width: 26px; height: 26px; left: 37px; top: 362px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                    <svg
+                      height="26"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="26"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        height="26"
+                      <desc
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="26"
-                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="NaN"
-                          cy="NaN"
-                          fill="#71b307"
-                          r="NaN"
-                          rx="4"
-                          ry="4"
-                          stroke="#71b307"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                          transform=""
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      style="position: absolute; width: 26px; height: 26px; left: 212px; top: 287px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="26"
+                        Created with Raphaël
+                      </desc>
+                      <defs
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="26"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="NaN"
-                          cy="NaN"
-                          fill="#71b307"
-                          r="NaN"
-                          rx="4"
-                          ry="4"
-                          stroke="#71b307"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                          transform=""
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      style="position: absolute; width: 26px; height: 26px; left: 112px; top: 287px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="26"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#71b307"
+                        r="NaN"
+                        rx="4"
+                        ry="4"
+                        stroke="#71b307"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="26"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="NaN"
-                          cy="NaN"
-                          fill="#71b307"
-                          r="NaN"
-                          rx="4"
-                          ry="4"
-                          stroke="#71b307"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                          transform=""
-                        />
-                      </svg>
-                    </div>
+                        transform=""
+                      />
+                    </svg>
                   </div>
                   <div
-                    style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                    style="position: absolute; width: 26px; height: 26px; left: 212px; top: 287px; transform: translateX(0px) translateY(0px) translateZ(0);"
                   >
-                    <div
-                      data-interactive-kind-for-testing="movable-point"
-                      style="position: absolute; width: 48px; height: 48px; left: 26px; top: 351px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                    <svg
+                      height="26"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="26"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        height="48"
+                      <desc
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="24"
-                          cy="24"
-                          fill="#000000"
-                          opacity="0"
-                          rx="24"
-                          ry="24"
-                          stroke="#000"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      data-interactive-kind-for-testing="movable-point"
-                      style="position: absolute; width: 48px; height: 48px; left: 201px; top: 276px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="48"
+                        Created with Raphaël
+                      </desc>
+                      <defs
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="24"
-                          cy="24"
-                          fill="#000000"
-                          opacity="0"
-                          rx="24"
-                          ry="24"
-                          stroke="#000"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      data-interactive-kind-for-testing="movable-point"
-                      style="position: absolute; width: 48px; height: 48px; left: 101px; top: 276px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="48"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#71b307"
+                        r="NaN"
+                        rx="4"
+                        ry="4"
+                        stroke="#71b307"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="24"
-                          cy="24"
-                          fill="#000000"
-                          opacity="0"
-                          rx="24"
-                          ry="24"
-                          stroke="#000"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                        />
-                      </svg>
-                    </div>
+                        transform=""
+                      />
+                    </svg>
                   </div>
-                  <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
+                  <div
+                    style="position: absolute; width: 26px; height: 26px; left: 112px; top: 287px; transform: translateX(0px) translateY(0px) translateZ(0);"
                   >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
+                    <svg
+                      height="26"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="26"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#71b307"
+                        r="NaN"
+                        rx="4"
+                        ry="4"
+                        stroke="#71b307"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                        transform=""
+                      />
+                    </svg>
+                  </div>
                 </div>
+                <div
+                  style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                >
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 26px; top: 351px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 201px; top: 276px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 101px; top: 276px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
               </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`interactive-graph widget question Shoud render predictably: after interaction 3`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
+      >
+        We want to find the zeros of this polynomial:
+      </div>
+    </div>
+    <div
+      class="paragraph perseus-paragraph-centered"
+      data-perseus-paragraph-index="1"
+    >
+      <div
+        class="perseus-block-math"
       >
         <div
-          class="paragraph"
+          class="perseus-block-math-inner"
+          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
         >
-          We want to find the zeros of this polynomial:
+          <span
+            class="mock-TeX"
+          >
+            p(x)=x(2x+5)(x+1)
+          </span>
         </div>
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
+    >
       <div
-        class="paragraph perseus-paragraph-centered"
-        data-perseus-paragraph-index="1"
+        class="paragraph"
       >
-        <div
-          class="perseus-block-math"
-        >
-          <div
-            class="perseus-block-math-inner"
-            style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+        <strong>
+          Plot all the zeros (
+          <span
+            style="white-space: nowrap;"
           >
+            <span />
             <span
               class="mock-TeX"
             >
-              p(x)=x(2x+5)(x+1)
+              x
             </span>
-          </div>
-        </div>
+            <span />
+          </span>
+          -intercepts) of the polynomial in the interactive graph.
+        </strong>
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="3"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="2"
       >
         <div
-          class="paragraph"
-        >
-          <strong>
-            Plot all the zeros (
-            <span
-              style="white-space: nowrap;"
-            >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                x
-              </span>
-              <span />
-            </span>
-            -intercepts) of the polynomial in the interactive graph.
-          </strong>
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="3"
-      >
-        <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+            class="perseus-widget perseus-widget-interactive-graph"
+            style="width: 400px; height: 400px;"
           >
             <div
-              class="perseus-widget perseus-widget-interactive-graph"
+              class="graphie-container above-scratchpad"
               style="width: 400px; height: 400px;"
             >
               <div
-                class="graphie-container above-scratchpad"
-                style="width: 400px; height: 400px;"
+                class="unresponsive-svg-image"
+                style="width: 425px; height: 425px;"
               >
+                <span
+                  style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
+                >
+                  <div
+                    class="default_xu2jcg-o_O-spinnerContainer_agrn11"
+                  >
+                    <svg
+                      height="48"
+                      viewBox="0 0 48 48"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
+                        d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
+                        fill-rule="nonzero"
+                      />
+                    </svg>
+                  </div>
+                </span>
+              </div>
+              <div
+                class="graphie"
+                style="position: relative; width: 400px; height: 400px;"
+              >
+                <svg
+                  height="400"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
+                  version="1.1"
+                  width="400"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <rect
+                    fill="#000000"
+                    height="400"
+                    opacity="0"
+                    r="0"
+                    rx="0"
+                    ry="0"
+                    stroke="#000"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0;"
+                    width="400"
+                    x="0"
+                    y="0"
+                  />
+                </svg>
+                <svg
+                  height="400"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  version="1.1"
+                  width="400"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <image
+                    height="40"
+                    href="https://ka-perseus-graphie.s3.amazonaws.com/b1452c0d79fd0f7ff4c3af9488474a0a0decb361.png"
+                    opacity="0.5"
+                    preserveAspectRatio="none"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0.5;"
+                    width="40"
+                    x="360"
+                    y="360"
+                  />
+                </svg>
                 <div
-                  class="unresponsive-svg-image"
-                  style="width: 425px; height: 425px;"
+                  style="font-style: italic; font-weight: bold; font-size: 32px; width: 100%; height: 100%; text-align: center; background-color: white; position: absolute; z-index: 1; transition: opacity .25s ease-in-out; opacity: 0.5;"
                 >
                   <span
-                    style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
+                    style="position: relative; top: 25%;"
                   >
-                    <div
-                      class="default_xu2jcg-o_O-spinnerContainer_agrn11"
-                    >
-                      <svg
-                        height="48"
-                        viewBox="0 0 48 48"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
-                          d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
-                          fill-rule="nonzero"
-                        />
-                      </svg>
-                    </div>
+                    Click to add points
                   </span>
                 </div>
                 <div
-                  class="graphie"
-                  style="position: relative; width: 400px; height: 400px;"
+                  style="position: absolute; left: 0px; top: 0px;"
                 >
-                  <svg
-                    height="400"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
-                    version="1.1"
-                    width="400"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <desc
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    >
-                      Created with Raphaël
-                    </desc>
-                    <defs
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    />
-                    <rect
-                      fill="#000000"
-                      height="400"
-                      opacity="0"
-                      r="0"
-                      rx="0"
-                      ry="0"
-                      stroke="#000"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0;"
-                      width="400"
-                      x="0"
-                      y="0"
-                    />
-                  </svg>
-                  <svg
-                    height="400"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    version="1.1"
-                    width="400"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <desc
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    >
-                      Created with Raphaël
-                    </desc>
-                    <defs
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    />
-                    <image
-                      height="40"
-                      href="https://ka-perseus-graphie.s3.amazonaws.com/b1452c0d79fd0f7ff4c3af9488474a0a0decb361.png"
-                      opacity="0.5"
-                      preserveAspectRatio="none"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0.5;"
-                      width="40"
-                      x="360"
-                      y="360"
-                    />
-                  </svg>
                   <div
-                    style="font-style: italic; font-weight: bold; font-size: 32px; width: 100%; height: 100%; text-align: center; background-color: white; position: absolute; z-index: 1; transition: opacity .25s ease-in-out; opacity: 0.5;"
+                    style="position: absolute; width: 26px; height: 26px; left: 187px; top: 187px; transform: translateX(0px) translateY(0px) translateZ(0);"
                   >
-                    <span
-                      style="position: relative; top: 25%;"
+                    <svg
+                      height="26"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="26"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      Click to add points
-                    </span>
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#71b307"
+                        r="NaN"
+                        rx="4"
+                        ry="4"
+                        stroke="#71b307"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                        transform=""
+                      />
+                    </svg>
                   </div>
                   <div
-                    style="position: absolute; left: 0px; top: 0px;"
+                    style="position: absolute; width: 26px; height: 26px; left: 62px; top: 187px; transform: translateX(0px) translateY(0px) translateZ(0);"
                   >
-                    <div
-                      style="position: absolute; width: 26px; height: 26px; left: 187px; top: 187px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                    <svg
+                      height="26"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="26"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        height="26"
+                      <desc
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="26"
-                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="NaN"
-                          cy="NaN"
-                          fill="#71b307"
-                          r="NaN"
-                          rx="4"
-                          ry="4"
-                          stroke="#71b307"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                          transform=""
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      style="position: absolute; width: 26px; height: 26px; left: 62px; top: 187px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="26"
+                        Created with Raphaël
+                      </desc>
+                      <defs
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="26"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="NaN"
-                          cy="NaN"
-                          fill="#71b307"
-                          r="NaN"
-                          rx="4"
-                          ry="4"
-                          stroke="#71b307"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                          transform=""
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      style="position: absolute; width: 26px; height: 26px; left: 137px; top: 187px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="26"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#71b307"
+                        r="NaN"
+                        rx="4"
+                        ry="4"
+                        stroke="#71b307"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="26"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="NaN"
-                          cy="NaN"
-                          fill="#71b307"
-                          r="NaN"
-                          rx="4"
-                          ry="4"
-                          stroke="#71b307"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                          transform=""
-                        />
-                      </svg>
-                    </div>
+                        transform=""
+                      />
+                    </svg>
                   </div>
                   <div
-                    style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                    style="position: absolute; width: 26px; height: 26px; left: 137px; top: 187px; transform: translateX(0px) translateY(0px) translateZ(0);"
                   >
-                    <div
-                      data-interactive-kind-for-testing="movable-point"
-                      style="position: absolute; width: 48px; height: 48px; left: 176px; top: 176px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                    <svg
+                      height="26"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="26"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        height="48"
+                      <desc
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="24"
-                          cy="24"
-                          fill="#000000"
-                          opacity="0"
-                          rx="24"
-                          ry="24"
-                          stroke="#000"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      data-interactive-kind-for-testing="movable-point"
-                      style="position: absolute; width: 48px; height: 48px; left: 51px; top: 176px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#71b307"
+                        r="NaN"
+                        rx="4"
+                        ry="4"
+                        stroke="#71b307"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                        transform=""
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                >
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 176px; top: 176px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        height="48"
+                      <desc
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="24"
-                          cy="24"
-                          fill="#000000"
-                          opacity="0"
-                          rx="24"
-                          ry="24"
-                          stroke="#000"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      data-interactive-kind-for-testing="movable-point"
-                      style="position: absolute; width: 48px; height: 48px; left: 126px; top: 176px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 51px; top: 176px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        height="48"
+                      <desc
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="24"
-                          cy="24"
-                          fill="#000000"
-                          opacity="0"
-                          rx="24"
-                          ry="24"
-                          stroke="#000"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                        />
-                      </svg>
-                    </div>
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 126px; top: 176px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
                   </div>
                 </div>
               </div>
@@ -1198,26 +1186,58 @@ exports[`interactive-graph widget question Shoud render predictably: after inter
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`interactive-graph widget question Shoud render predictably: after interaction 4`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
+        The graph below contains quadrilateral 
+        <span
+          style="white-space: nowrap;"
         >
-          The graph below contains quadrilateral 
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            TREK
+          </span>
+          <span />
+        </span>
+         and the point 
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            P(-8,-6)
+          </span>
+          <span />
+        </span>
+        .  
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
+      <div
+        class="paragraph"
+      >
+        <strong>
+          Draw the image of quadrilateral 
           <span
             style="white-space: nowrap;"
           >
@@ -1229,7 +1249,7 @@ exports[`interactive-graph widget question Shoud render predictably: after inter
             </span>
             <span />
           </span>
-           and the point 
+           under a dilation whose center is 
           <span
             style="white-space: nowrap;"
           >
@@ -1237,1567 +1257,1551 @@ exports[`interactive-graph widget question Shoud render predictably: after inter
             <span
               class="mock-TeX"
             >
-              P(-8,-6)
+              P
             </span>
             <span />
           </span>
-          .  
-        </div>
+           and scale factor is 
+          <span
+            style="white-space: nowrap;"
+          >
+            <span />
+            <span
+              class="mock-TeX"
+            >
+              3
+            </span>
+            <span />
+          </span>
+          .
+        </strong>
+          
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="1"
       >
         <div
-          class="paragraph"
-        >
-          <strong>
-            Draw the image of quadrilateral 
-            <span
-              style="white-space: nowrap;"
-            >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                TREK
-              </span>
-              <span />
-            </span>
-             under a dilation whose center is 
-            <span
-              style="white-space: nowrap;"
-            >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                P
-              </span>
-              <span />
-            </span>
-             and scale factor is 
-            <span
-              style="white-space: nowrap;"
-            >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                3
-              </span>
-              <span />
-            </span>
-            .
-          </strong>
-            
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="2"
-      >
-        <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+            class="perseus-widget perseus-widget-interactive-graph"
+            style="width: 400px; height: 400px;"
           >
             <div
-              class="perseus-widget perseus-widget-interactive-graph"
+              class="graphie-container above-scratchpad"
               style="width: 400px; height: 400px;"
             >
               <div
-                class="graphie-container above-scratchpad"
-                style="width: 400px; height: 400px;"
+                class="unresponsive-svg-image"
+                style="width: 425px; height: 425px;"
               >
-                <div
-                  class="unresponsive-svg-image"
-                  style="width: 425px; height: 425px;"
+                <span
+                  style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
                 >
-                  <span
-                    style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
+                  <div
+                    class="default_xu2jcg-o_O-spinnerContainer_agrn11"
                   >
-                    <div
-                      class="default_xu2jcg-o_O-spinnerContainer_agrn11"
+                    <svg
+                      height="48"
+                      viewBox="0 0 48 48"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        height="48"
-                        viewBox="0 0 48 48"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
-                          d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
-                          fill-rule="nonzero"
-                        />
-                      </svg>
-                    </div>
-                  </span>
-                </div>
-                <div
-                  class="graphie"
-                  style="position: relative; width: 400px; height: 400px;"
+                      <path
+                        class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
+                        d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
+                        fill-rule="nonzero"
+                      />
+                    </svg>
+                  </div>
+                </span>
+              </div>
+              <div
+                class="graphie"
+                style="position: relative; width: 400px; height: 400px;"
+              >
+                <svg
+                  height="400"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
+                  version="1.1"
+                  width="400"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <svg
-                    height="400"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
-                    version="1.1"
-                    width="400"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <desc
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    >
-                      Created with Raphaël
-                    </desc>
-                    <defs
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    />
-                    <rect
-                      fill="#000000"
-                      height="400"
-                      opacity="0"
-                      r="0"
-                      rx="0"
-                      ry="0"
-                      stroke="#000"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0;"
-                      width="400"
-                      x="0"
-                      y="0"
-                    />
-                    <path
-                      d="M116.66666666666667,266.6666666666667L266.6666666666667,16.666666666666668L266.6666666666667,266.6666666666667L216.66666666666669,216.66666666666669Z"
-                      fill="#000000"
-                      opacity="0"
-                      stroke="#000000"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                    />
-                  </svg>
-                  <svg
-                    height="400"
+                  <desc
                     style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    version="1.1"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <rect
+                    fill="#000000"
+                    height="400"
+                    opacity="0"
+                    r="0"
+                    rx="0"
+                    ry="0"
+                    stroke="#000"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0;"
                     width="400"
-                    xmlns="http://www.w3.org/2000/svg"
+                    x="0"
+                    y="0"
+                  />
+                  <path
+                    d="M116.66666666666667,266.6666666666667L266.6666666666667,16.666666666666668L266.6666666666667,266.6666666666667L216.66666666666669,216.66666666666669Z"
+                    fill="#000000"
+                    opacity="0"
+                    stroke="#000000"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                  />
+                </svg>
+                <svg
+                  height="400"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  version="1.1"
+                  width="400"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
                   >
-                    <desc
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    >
-                      Created with Raphaël
-                    </desc>
-                    <defs
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    />
-                    <image
-                      height="40"
-                      href="https://ka-perseus-graphie.s3.amazonaws.com/b1452c0d79fd0f7ff4c3af9488474a0a0decb361.png"
-                      opacity="0.5"
-                      preserveAspectRatio="none"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0.5;"
-                      width="40"
-                      x="360"
-                      y="360"
-                    />
-                    <path
-                      d="M116.66666666666667,266.6666666666667L266.6666666666667,16.666666666666668L266.6666666666667,266.6666666666667L216.66666666666669,216.66666666666669Z"
-                      fill="#71b307"
-                      fill-opacity="0"
-                      stroke="#71b307"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; fill-opacity: 0;"
-                    />
-                  </svg>
-                  <div
-                    style="font-style: italic; font-weight: bold; font-size: 32px; width: 100%; height: 100%; text-align: center; background-color: white; position: absolute; z-index: 1; transition: opacity .25s ease-in-out; opacity: 0.5;"
-                  >
-                    <span
-                      style="position: relative; top: 25%;"
-                    >
-                      Click to add vertices
-                    </span>
-                  </div>
-                  <div
-                    style="position: absolute; left: 0px; top: 0px;"
-                  >
-                    <div
-                      style="position: absolute; width: 26px; height: 26px; left: 103.66666666666667px; top: 253.66666666666669px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="26"
-                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="26"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="NaN"
-                          cy="NaN"
-                          fill="#71b307"
-                          r="NaN"
-                          rx="4"
-                          ry="4"
-                          stroke="#71b307"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                          transform=""
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      style="position: absolute; width: 26px; height: 26px; left: 253.66666666666669px; top: 3.666666666666668px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="26"
-                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="26"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="NaN"
-                          cy="NaN"
-                          fill="#71b307"
-                          r="NaN"
-                          rx="4"
-                          ry="4"
-                          stroke="#71b307"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                          transform=""
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      style="position: absolute; width: 26px; height: 26px; left: 253.66666666666669px; top: 253.66666666666669px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="26"
-                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="26"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="NaN"
-                          cy="NaN"
-                          fill="#71b307"
-                          r="NaN"
-                          rx="4"
-                          ry="4"
-                          stroke="#71b307"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                          transform=""
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      style="position: absolute; width: 26px; height: 26px; left: 203.66666666666669px; top: 203.66666666666669px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="26"
-                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="26"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="NaN"
-                          cy="NaN"
-                          fill="#71b307"
-                          r="NaN"
-                          rx="4"
-                          ry="4"
-                          stroke="#71b307"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                          transform=""
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    style="position: absolute; left: 0px; top: 0px; z-index: 2;"
-                  >
-                    <div
-                      data-interactive-kind-for-testing="movable-point"
-                      style="position: absolute; width: 48px; height: 48px; left: 92.66666666666667px; top: 242.66666666666669px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="48"
-                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="24"
-                          cy="24"
-                          fill="#000000"
-                          opacity="0"
-                          rx="24"
-                          ry="24"
-                          stroke="#000"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      data-interactive-kind-for-testing="movable-point"
-                      style="position: absolute; width: 48px; height: 48px; left: 242.66666666666669px; top: -7.333333333333332px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="48"
-                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="24"
-                          cy="24"
-                          fill="#000000"
-                          opacity="0"
-                          rx="24"
-                          ry="24"
-                          stroke="#000"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      data-interactive-kind-for-testing="movable-point"
-                      style="position: absolute; width: 48px; height: 48px; left: 242.66666666666669px; top: 242.66666666666669px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="48"
-                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="24"
-                          cy="24"
-                          fill="#000000"
-                          opacity="0"
-                          rx="24"
-                          ry="24"
-                          stroke="#000"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      data-interactive-kind-for-testing="movable-point"
-                      style="position: absolute; width: 48px; height: 48px; left: 192.66666666666669px; top: 192.66666666666669px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="48"
-                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="24"
-                          cy="24"
-                          fill="#000000"
-                          opacity="0"
-                          rx="24"
-                          ry="24"
-                          stroke="#000"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                        />
-                      </svg>
-                    </div>
-                  </div>
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <image
+                    height="40"
+                    href="https://ka-perseus-graphie.s3.amazonaws.com/b1452c0d79fd0f7ff4c3af9488474a0a0decb361.png"
+                    opacity="0.5"
+                    preserveAspectRatio="none"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0.5;"
+                    width="40"
+                    x="360"
+                    y="360"
+                  />
+                  <path
+                    d="M116.66666666666667,266.6666666666667L266.6666666666667,16.666666666666668L266.6666666666667,266.6666666666667L216.66666666666669,216.66666666666669Z"
+                    fill="#71b307"
+                    fill-opacity="0"
+                    stroke="#71b307"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; fill-opacity: 0;"
+                  />
+                </svg>
+                <div
+                  style="font-style: italic; font-weight: bold; font-size: 32px; width: 100%; height: 100%; text-align: center; background-color: white; position: absolute; z-index: 1; transition: opacity .25s ease-in-out; opacity: 0.5;"
+                >
                   <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 266.6666666666667px; fill: none; stroke: #6495ED;"
+                    style="position: relative; top: 25%;"
                   >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 266.6666666666667px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 266.6666666666667px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 266.6666666666667px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 266.6666666666667px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 266.6666666666667px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 266.6666666666667px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 266.6666666666667px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
+                    Click to add vertices
                   </span>
                 </div>
+                <div
+                  style="position: absolute; left: 0px; top: 0px;"
+                >
+                  <div
+                    style="position: absolute; width: 26px; height: 26px; left: 103.66666666666667px; top: 253.66666666666669px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="26"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="26"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#71b307"
+                        r="NaN"
+                        rx="4"
+                        ry="4"
+                        stroke="#71b307"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                        transform=""
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    style="position: absolute; width: 26px; height: 26px; left: 253.66666666666669px; top: 3.666666666666668px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="26"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="26"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#71b307"
+                        r="NaN"
+                        rx="4"
+                        ry="4"
+                        stroke="#71b307"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                        transform=""
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    style="position: absolute; width: 26px; height: 26px; left: 253.66666666666669px; top: 253.66666666666669px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="26"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="26"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#71b307"
+                        r="NaN"
+                        rx="4"
+                        ry="4"
+                        stroke="#71b307"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                        transform=""
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    style="position: absolute; width: 26px; height: 26px; left: 203.66666666666669px; top: 203.66666666666669px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="26"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="26"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#71b307"
+                        r="NaN"
+                        rx="4"
+                        ry="4"
+                        stroke="#71b307"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                        transform=""
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                >
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 92.66666666666667px; top: 242.66666666666669px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 242.66666666666669px; top: -7.333333333333332px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 242.66666666666669px; top: 242.66666666666669px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 192.66666666666669px; top: 192.66666666666669px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 266.6666666666667px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 266.6666666666667px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 266.6666666666667px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 266.6666666666667px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 266.6666666666667px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 266.6666666666667px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 266.6666666666667px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 266.6666666666667px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
               </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`interactive-graph widget question Shoud render predictably: first render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          <strong>
-            Drag the vertices of the triangle below to draw a right triangle with side lengths 
+        <strong>
+          Drag the vertices of the triangle below to draw a right triangle with side lengths 
+          <span
+            style="white-space: nowrap;"
+          >
+            <span />
             <span
-              style="white-space: nowrap;"
+              class="mock-TeX"
             >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                3
-              </span>
-              <span />
+              3
             </span>
-            , 
+            <span />
+          </span>
+          , 
+          <span
+            style="white-space: nowrap;"
+          >
+            <span />
             <span
-              style="white-space: nowrap;"
+              class="mock-TeX"
             >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                4
-              </span>
-              <span />
+              4
             </span>
-            , and 
+            <span />
+          </span>
+          , and 
+          <span
+            style="white-space: nowrap;"
+          >
+            <span />
             <span
-              style="white-space: nowrap;"
+              class="mock-TeX"
             >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                5
-              </span>
-              <span />
+              5
             </span>
-            .
-          </strong>
-           
+            <span />
+          </span>
+          .
+        </strong>
+         
 
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
           <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+            class="perseus-widget perseus-widget-interactive-graph"
+            style="width: 400px; height: 400px;"
           >
             <div
-              class="perseus-widget perseus-widget-interactive-graph"
+              class="graphie-container above-scratchpad"
               style="width: 400px; height: 400px;"
             >
               <div
-                class="graphie-container above-scratchpad"
-                style="width: 400px; height: 400px;"
+                class="graphie"
+                style="position: relative; width: 400px; height: 400px;"
               >
-                <div
-                  class="graphie"
-                  style="position: relative; width: 400px; height: 400px;"
+                <svg
+                  height="400"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
+                  version="1.1"
+                  width="400"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <svg
-                    height="400"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
-                    version="1.1"
-                    width="400"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <desc
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    >
-                      Created with Raphaël
-                    </desc>
-                    <defs
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    />
-                    <path
-                      d="M257.14285714285717,228.57142857142858L200,114.28571428571429L142.85714285714286,228.57142857142858Z"
-                      fill="#000000"
-                      opacity="0"
-                      stroke="#000000"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                    />
-                  </svg>
-                  <svg
-                    height="400"
+                  <desc
                     style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    version="1.1"
-                    width="400"
-                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    <desc
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    >
-                      Created with Raphaël
-                    </desc>
-                    <defs
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    />
-                    <path
-                      d="M257.14285714285717,228.57142857142858L200,114.28571428571429L142.85714285714286,228.57142857142858Z"
-                      fill="#71b307"
-                      fill-opacity="0"
-                      stroke="#71b307"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; fill-opacity: 0;"
-                    />
-                  </svg>
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <path
+                    d="M257.14285714285717,228.57142857142858L200,114.28571428571429L142.85714285714286,228.57142857142858Z"
+                    fill="#000000"
+                    opacity="0"
+                    stroke="#000000"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                  />
+                </svg>
+                <svg
+                  height="400"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  version="1.1"
+                  width="400"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <path
+                    d="M257.14285714285717,228.57142857142858L200,114.28571428571429L142.85714285714286,228.57142857142858Z"
+                    fill="#71b307"
+                    fill-opacity="0"
+                    stroke="#71b307"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; fill-opacity: 0;"
+                  />
+                </svg>
+                <div
+                  style="position: absolute; left: 0px; top: 0px;"
+                >
                   <div
-                    style="position: absolute; left: 0px; top: 0px;"
+                    style="position: absolute; width: 26px; height: 26px; left: 244.14285714285717px; top: 215.57142857142858px; transform: translateX(0px) translateY(0px) translateZ(0);"
                   >
-                    <div
-                      style="position: absolute; width: 26px; height: 26px; left: 244.14285714285717px; top: 215.57142857142858px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                    <svg
+                      height="26"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="26"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        height="26"
+                      <desc
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="26"
-                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="NaN"
-                          cy="NaN"
-                          fill="#71b307"
-                          r="NaN"
-                          rx="4"
-                          ry="4"
-                          stroke="#71b307"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                          transform=""
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      style="position: absolute; width: 26px; height: 26px; left: 187px; top: 101.28571428571429px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="26"
+                        Created with Raphaël
+                      </desc>
+                      <defs
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="26"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="NaN"
-                          cy="NaN"
-                          fill="#71b307"
-                          r="NaN"
-                          rx="4"
-                          ry="4"
-                          stroke="#71b307"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                          transform=""
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      style="position: absolute; width: 26px; height: 26px; left: 129.85714285714286px; top: 215.57142857142858px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="26"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#71b307"
+                        r="NaN"
+                        rx="4"
+                        ry="4"
+                        stroke="#71b307"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="26"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="NaN"
-                          cy="NaN"
-                          fill="#71b307"
-                          r="NaN"
-                          rx="4"
-                          ry="4"
-                          stroke="#71b307"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                          transform=""
-                        />
-                      </svg>
-                    </div>
+                        transform=""
+                      />
+                    </svg>
                   </div>
                   <div
-                    style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                    style="position: absolute; width: 26px; height: 26px; left: 187px; top: 101.28571428571429px; transform: translateX(0px) translateY(0px) translateZ(0);"
                   >
-                    <div
-                      data-interactive-kind-for-testing="movable-point"
-                      style="position: absolute; width: 48px; height: 48px; left: 233.14285714285717px; top: 204.57142857142858px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                    <svg
+                      height="26"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="26"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        height="48"
+                      <desc
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="24"
-                          cy="24"
-                          fill="#000000"
-                          opacity="0"
-                          rx="24"
-                          ry="24"
-                          stroke="#000"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      data-interactive-kind-for-testing="movable-point"
-                      style="position: absolute; width: 48px; height: 48px; left: 176px; top: 90.28571428571429px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="48"
+                        Created with Raphaël
+                      </desc>
+                      <defs
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="24"
-                          cy="24"
-                          fill="#000000"
-                          opacity="0"
-                          rx="24"
-                          ry="24"
-                          stroke="#000"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      data-interactive-kind-for-testing="movable-point"
-                      style="position: absolute; width: 48px; height: 48px; left: 118.85714285714286px; top: 204.57142857142858px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="48"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#71b307"
+                        r="NaN"
+                        rx="4"
+                        ry="4"
+                        stroke="#71b307"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="24"
-                          cy="24"
-                          fill="#000000"
-                          opacity="0"
-                          rx="24"
-                          ry="24"
-                          stroke="#000"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                        />
-                      </svg>
-                    </div>
+                        transform=""
+                      />
+                    </svg>
                   </div>
-                  <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 57.142857142857146px; top: 342.8571428571429px; fill: none; stroke: #6495ED;"
+                  <div
+                    style="position: absolute; width: 26px; height: 26px; left: 129.85714285714286px; top: 215.57142857142858px; transform: translateX(0px) translateY(0px) translateZ(0);"
                   >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 57.142857142857146px; top: 342.8571428571429px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 57.142857142857146px; top: 342.8571428571429px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="\\approx 2.2"
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 246.45997239142687px; top: 162.4842995185723px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="\\approx 2.2"
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 153.54002760857313px; top: 162.48429951857227px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="2.0"
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 248.57142857142856px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
+                    <svg
+                      height="26"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="26"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#71b307"
+                        r="NaN"
+                        rx="4"
+                        ry="4"
+                        stroke="#71b307"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                        transform=""
+                      />
+                    </svg>
+                  </div>
                 </div>
+                <div
+                  style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                >
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 233.14285714285717px; top: 204.57142857142858px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 176px; top: 90.28571428571429px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 118.85714285714286px; top: 204.57142857142858px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 57.142857142857146px; top: 342.8571428571429px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 57.142857142857146px; top: 342.8571428571429px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 57.142857142857146px; top: 342.8571428571429px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\approx 2.2"
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 246.45997239142687px; top: 162.4842995185723px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\approx 2.2"
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 153.54002760857313px; top: 162.48429951857227px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="2.0"
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 248.57142857142856px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
               </div>
             </div>
           </div>
-           
         </div>
+         
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`interactive-graph widget question Shoud render predictably: first render 2`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          <strong>
-            Plot the image of triangle 
+        <strong>
+          Plot the image of triangle 
+          <span
+            style="white-space: nowrap;"
+          >
+            <span />
             <span
-              style="white-space: nowrap;"
+              class="mock-TeX"
             >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                \\triangle ABC
-              </span>
-              <span />
+              \\triangle ABC
             </span>
-             under a reflection across line 
+            <span />
+          </span>
+           under a reflection across line 
+          <span
+            style="white-space: nowrap;"
+          >
+            <span />
             <span
-              style="white-space: nowrap;"
+              class="mock-TeX"
             >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                \\ell
-              </span>
-              <span />
+              \\ell
             </span>
-            .
-          </strong>
-        </div>
+            <span />
+          </span>
+          .
+        </strong>
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="1"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+            class="perseus-widget perseus-widget-interactive-graph"
+            style="width: 400px; height: 400px;"
           >
             <div
-              class="perseus-widget perseus-widget-interactive-graph"
+              class="graphie-container above-scratchpad"
               style="width: 400px; height: 400px;"
             >
               <div
-                class="graphie-container above-scratchpad"
+                class="unresponsive-svg-image"
                 style="width: 400px; height: 400px;"
               >
-                <div
-                  class="unresponsive-svg-image"
-                  style="width: 400px; height: 400px;"
+                <span
+                  style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
                 >
-                  <span
-                    style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
+                  <div
+                    class="default_xu2jcg-o_O-spinnerContainer_agrn11"
                   >
-                    <div
-                      class="default_xu2jcg-o_O-spinnerContainer_agrn11"
+                    <svg
+                      height="48"
+                      viewBox="0 0 48 48"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        height="48"
-                        viewBox="0 0 48 48"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
-                          d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
-                          fill-rule="nonzero"
-                        />
-                      </svg>
-                    </div>
-                  </span>
-                </div>
-                <div
-                  class="graphie"
-                  style="position: relative; width: 400px; height: 400px;"
+                      <path
+                        class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
+                        d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
+                        fill-rule="nonzero"
+                      />
+                    </svg>
+                  </div>
+                </span>
+              </div>
+              <div
+                class="graphie"
+                style="position: relative; width: 400px; height: 400px;"
+              >
+                <svg
+                  height="400"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
+                  version="1.1"
+                  width="400"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <svg
-                    height="400"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
-                    version="1.1"
-                    width="400"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <desc
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    >
-                      Created with Raphaël
-                    </desc>
-                    <defs
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    />
-                    <path
-                      d="M275,250L200,125L125,250Z"
-                      fill="#000000"
-                      opacity="0"
-                      stroke="#000000"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                    />
-                  </svg>
-                  <svg
-                    height="400"
+                  <desc
                     style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    version="1.1"
-                    width="400"
-                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    <desc
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    >
-                      Created with Raphaël
-                    </desc>
-                    <defs
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    />
-                    <path
-                      d="M275,250L200,125L125,250Z"
-                      fill="#71b307"
-                      fill-opacity="0"
-                      stroke="#71b307"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; fill-opacity: 0;"
-                    />
-                  </svg>
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <path
+                    d="M275,250L200,125L125,250Z"
+                    fill="#000000"
+                    opacity="0"
+                    stroke="#000000"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                  />
+                </svg>
+                <svg
+                  height="400"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  version="1.1"
+                  width="400"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <path
+                    d="M275,250L200,125L125,250Z"
+                    fill="#71b307"
+                    fill-opacity="0"
+                    stroke="#71b307"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; fill-opacity: 0;"
+                  />
+                </svg>
+                <div
+                  style="position: absolute; left: 0px; top: 0px;"
+                >
                   <div
-                    style="position: absolute; left: 0px; top: 0px;"
+                    style="position: absolute; width: 26px; height: 26px; left: 262px; top: 237px; transform: translateX(0px) translateY(0px) translateZ(0);"
                   >
-                    <div
-                      style="position: absolute; width: 26px; height: 26px; left: 262px; top: 237px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                    <svg
+                      height="26"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="26"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        height="26"
+                      <desc
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="26"
-                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="NaN"
-                          cy="NaN"
-                          fill="#71b307"
-                          r="NaN"
-                          rx="4"
-                          ry="4"
-                          stroke="#71b307"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                          transform=""
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      style="position: absolute; width: 26px; height: 26px; left: 187px; top: 112px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="26"
+                        Created with Raphaël
+                      </desc>
+                      <defs
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="26"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="NaN"
-                          cy="NaN"
-                          fill="#71b307"
-                          r="NaN"
-                          rx="4"
-                          ry="4"
-                          stroke="#71b307"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                          transform=""
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      style="position: absolute; width: 26px; height: 26px; left: 112px; top: 237px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="26"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#71b307"
+                        r="NaN"
+                        rx="4"
+                        ry="4"
+                        stroke="#71b307"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="26"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="NaN"
-                          cy="NaN"
-                          fill="#71b307"
-                          r="NaN"
-                          rx="4"
-                          ry="4"
-                          stroke="#71b307"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                          transform=""
-                        />
-                      </svg>
-                    </div>
+                        transform=""
+                      />
+                    </svg>
                   </div>
                   <div
-                    style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                    style="position: absolute; width: 26px; height: 26px; left: 187px; top: 112px; transform: translateX(0px) translateY(0px) translateZ(0);"
                   >
-                    <div
-                      data-interactive-kind-for-testing="movable-point"
-                      style="position: absolute; width: 48px; height: 48px; left: 251px; top: 226px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                    <svg
+                      height="26"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="26"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        height="48"
+                      <desc
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="24"
-                          cy="24"
-                          fill="#000000"
-                          opacity="0"
-                          rx="24"
-                          ry="24"
-                          stroke="#000"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      data-interactive-kind-for-testing="movable-point"
-                      style="position: absolute; width: 48px; height: 48px; left: 176px; top: 101px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="48"
+                        Created with Raphaël
+                      </desc>
+                      <defs
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="24"
-                          cy="24"
-                          fill="#000000"
-                          opacity="0"
-                          rx="24"
-                          ry="24"
-                          stroke="#000"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      data-interactive-kind-for-testing="movable-point"
-                      style="position: absolute; width: 48px; height: 48px; left: 101px; top: 226px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="48"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#71b307"
+                        r="NaN"
+                        rx="4"
+                        ry="4"
+                        stroke="#71b307"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="24"
-                          cy="24"
-                          fill="#000000"
-                          opacity="0"
-                          rx="24"
-                          ry="24"
-                          stroke="#000"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                        />
-                      </svg>
-                    </div>
+                        transform=""
+                      />
+                    </svg>
                   </div>
-                  <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
+                  <div
+                    style="position: absolute; width: 26px; height: 26px; left: 112px; top: 237px; transform: translateX(0px) translateY(0px) translateZ(0);"
                   >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula=""
-                    style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
+                    <svg
+                      height="26"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="26"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#71b307"
+                        r="NaN"
+                        rx="4"
+                        ry="4"
+                        stroke="#71b307"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                        transform=""
+                      />
+                    </svg>
+                  </div>
                 </div>
+                <div
+                  style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                >
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 251px; top: 226px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 176px; top: 101px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 101px; top: 226px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula=""
+                  style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
               </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`interactive-graph widget question Shoud render predictably: first render 3`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
+      >
+        We want to find the zeros of this polynomial:
+      </div>
+    </div>
+    <div
+      class="paragraph perseus-paragraph-centered"
+      data-perseus-paragraph-index="1"
+    >
+      <div
+        class="perseus-block-math"
       >
         <div
-          class="paragraph"
+          class="perseus-block-math-inner"
+          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
         >
-          We want to find the zeros of this polynomial:
+          <span
+            class="mock-TeX"
+          >
+            p(x)=x(2x+5)(x+1)
+          </span>
         </div>
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
+    >
       <div
-        class="paragraph perseus-paragraph-centered"
-        data-perseus-paragraph-index="1"
+        class="paragraph"
       >
-        <div
-          class="perseus-block-math"
-        >
-          <div
-            class="perseus-block-math-inner"
-            style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+        <strong>
+          Plot all the zeros (
+          <span
+            style="white-space: nowrap;"
           >
+            <span />
             <span
               class="mock-TeX"
             >
-              p(x)=x(2x+5)(x+1)
+              x
             </span>
-          </div>
-        </div>
+            <span />
+          </span>
+          -intercepts) of the polynomial in the interactive graph.
+        </strong>
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="3"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="2"
       >
         <div
-          class="paragraph"
-        >
-          <strong>
-            Plot all the zeros (
-            <span
-              style="white-space: nowrap;"
-            >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                x
-              </span>
-              <span />
-            </span>
-            -intercepts) of the polynomial in the interactive graph.
-          </strong>
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="3"
-      >
-        <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+            class="perseus-widget perseus-widget-interactive-graph"
+            style="width: 400px; height: 400px;"
           >
             <div
-              class="perseus-widget perseus-widget-interactive-graph"
+              class="graphie-container above-scratchpad"
               style="width: 400px; height: 400px;"
             >
               <div
-                class="graphie-container above-scratchpad"
-                style="width: 400px; height: 400px;"
+                class="unresponsive-svg-image"
+                style="width: 425px; height: 425px;"
               >
+                <span
+                  style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
+                >
+                  <div
+                    class="default_xu2jcg-o_O-spinnerContainer_agrn11"
+                  >
+                    <svg
+                      height="48"
+                      viewBox="0 0 48 48"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
+                        d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
+                        fill-rule="nonzero"
+                      />
+                    </svg>
+                  </div>
+                </span>
+              </div>
+              <div
+                class="graphie"
+                style="position: relative; width: 400px; height: 400px;"
+              >
+                <svg
+                  height="400"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
+                  version="1.1"
+                  width="400"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <rect
+                    fill="#000000"
+                    height="400"
+                    opacity="0"
+                    r="0"
+                    rx="0"
+                    ry="0"
+                    stroke="#000"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0;"
+                    width="400"
+                    x="0"
+                    y="0"
+                  />
+                </svg>
+                <svg
+                  height="400"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  version="1.1"
+                  width="400"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <image
+                    height="40"
+                    href="https://ka-perseus-graphie.s3.amazonaws.com/b1452c0d79fd0f7ff4c3af9488474a0a0decb361.png"
+                    opacity="0.5"
+                    preserveAspectRatio="none"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0.5;"
+                    width="40"
+                    x="360"
+                    y="360"
+                  />
+                </svg>
                 <div
-                  class="unresponsive-svg-image"
-                  style="width: 425px; height: 425px;"
+                  style="font-style: italic; font-weight: bold; font-size: 32px; width: 100%; height: 100%; text-align: center; background-color: white; position: absolute; z-index: 1; transition: opacity .25s ease-in-out; opacity: 0.5;"
                 >
                   <span
-                    style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
+                    style="position: relative; top: 25%;"
                   >
-                    <div
-                      class="default_xu2jcg-o_O-spinnerContainer_agrn11"
-                    >
-                      <svg
-                        height="48"
-                        viewBox="0 0 48 48"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
-                          d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
-                          fill-rule="nonzero"
-                        />
-                      </svg>
-                    </div>
+                    Click to add points
                   </span>
                 </div>
                 <div
-                  class="graphie"
-                  style="position: relative; width: 400px; height: 400px;"
-                >
-                  <svg
-                    height="400"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
-                    version="1.1"
-                    width="400"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <desc
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    >
-                      Created with Raphaël
-                    </desc>
-                    <defs
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    />
-                    <rect
-                      fill="#000000"
-                      height="400"
-                      opacity="0"
-                      r="0"
-                      rx="0"
-                      ry="0"
-                      stroke="#000"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0;"
-                      width="400"
-                      x="0"
-                      y="0"
-                    />
-                  </svg>
-                  <svg
-                    height="400"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    version="1.1"
-                    width="400"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <desc
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    >
-                      Created with Raphaël
-                    </desc>
-                    <defs
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    />
-                    <image
-                      height="40"
-                      href="https://ka-perseus-graphie.s3.amazonaws.com/b1452c0d79fd0f7ff4c3af9488474a0a0decb361.png"
-                      opacity="0.5"
-                      preserveAspectRatio="none"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0.5;"
-                      width="40"
-                      x="360"
-                      y="360"
-                    />
-                  </svg>
-                  <div
-                    style="font-style: italic; font-weight: bold; font-size: 32px; width: 100%; height: 100%; text-align: center; background-color: white; position: absolute; z-index: 1; transition: opacity .25s ease-in-out; opacity: 0.5;"
-                  >
-                    <span
-                      style="position: relative; top: 25%;"
-                    >
-                      Click to add points
-                    </span>
-                  </div>
-                  <div
-                    style="position: absolute; left: 0px; top: 0px;"
-                  />
-                  <div
-                    style="position: absolute; left: 0px; top: 0px; z-index: 2;"
-                  />
-                </div>
+                  style="position: absolute; left: 0px; top: 0px;"
+                />
+                <div
+                  style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                />
               </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`interactive-graph widget question Shoud render predictably: first render 4`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
+        The graph below contains quadrilateral 
+        <span
+          style="white-space: nowrap;"
         >
-          The graph below contains quadrilateral 
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            TREK
+          </span>
+          <span />
+        </span>
+         and the point 
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            P(-8,-6)
+          </span>
+          <span />
+        </span>
+        .  
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
+      <div
+        class="paragraph"
+      >
+        <strong>
+          Draw the image of quadrilateral 
           <span
             style="white-space: nowrap;"
           >
@@ -2809,7 +2813,7 @@ exports[`interactive-graph widget question Shoud render predictably: first rende
             </span>
             <span />
           </span>
-           and the point 
+           under a dilation whose center is 
           <span
             style="white-space: nowrap;"
           >
@@ -2817,201 +2821,165 @@ exports[`interactive-graph widget question Shoud render predictably: first rende
             <span
               class="mock-TeX"
             >
-              P(-8,-6)
+              P
             </span>
             <span />
           </span>
-          .  
-        </div>
+           and scale factor is 
+          <span
+            style="white-space: nowrap;"
+          >
+            <span />
+            <span
+              class="mock-TeX"
+            >
+              3
+            </span>
+            <span />
+          </span>
+          .
+        </strong>
+          
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="1"
       >
         <div
-          class="paragraph"
-        >
-          <strong>
-            Draw the image of quadrilateral 
-            <span
-              style="white-space: nowrap;"
-            >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                TREK
-              </span>
-              <span />
-            </span>
-             under a dilation whose center is 
-            <span
-              style="white-space: nowrap;"
-            >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                P
-              </span>
-              <span />
-            </span>
-             and scale factor is 
-            <span
-              style="white-space: nowrap;"
-            >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                3
-              </span>
-              <span />
-            </span>
-            .
-          </strong>
-            
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="2"
-      >
-        <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+            class="perseus-widget perseus-widget-interactive-graph"
+            style="width: 400px; height: 400px;"
           >
             <div
-              class="perseus-widget perseus-widget-interactive-graph"
+              class="graphie-container above-scratchpad"
               style="width: 400px; height: 400px;"
             >
               <div
-                class="graphie-container above-scratchpad"
-                style="width: 400px; height: 400px;"
+                class="unresponsive-svg-image"
+                style="width: 425px; height: 425px;"
               >
+                <span
+                  style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
+                >
+                  <div
+                    class="default_xu2jcg-o_O-spinnerContainer_agrn11"
+                  >
+                    <svg
+                      height="48"
+                      viewBox="0 0 48 48"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
+                        d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
+                        fill-rule="nonzero"
+                      />
+                    </svg>
+                  </div>
+                </span>
+              </div>
+              <div
+                class="graphie"
+                style="position: relative; width: 400px; height: 400px;"
+              >
+                <svg
+                  height="400"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
+                  version="1.1"
+                  width="400"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <rect
+                    fill="#000000"
+                    height="400"
+                    opacity="0"
+                    r="0"
+                    rx="0"
+                    ry="0"
+                    stroke="#000"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0;"
+                    width="400"
+                    x="0"
+                    y="0"
+                  />
+                  <path
+                    d="M0,0"
+                    fill="#000000"
+                    opacity="0"
+                    stroke="#000000"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                  />
+                </svg>
+                <svg
+                  height="400"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  version="1.1"
+                  width="400"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <image
+                    height="40"
+                    href="https://ka-perseus-graphie.s3.amazonaws.com/b1452c0d79fd0f7ff4c3af9488474a0a0decb361.png"
+                    opacity="0.5"
+                    preserveAspectRatio="none"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0.5;"
+                    width="40"
+                    x="360"
+                    y="360"
+                  />
+                  <path
+                    d="M0,0"
+                    fill="#71b307"
+                    fill-opacity="0"
+                    stroke="#71b307"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; fill-opacity: 0;"
+                  />
+                </svg>
                 <div
-                  class="unresponsive-svg-image"
-                  style="width: 425px; height: 425px;"
+                  style="font-style: italic; font-weight: bold; font-size: 32px; width: 100%; height: 100%; text-align: center; background-color: white; position: absolute; z-index: 1; transition: opacity .25s ease-in-out; opacity: 0.5;"
                 >
                   <span
-                    style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
+                    style="position: relative; top: 25%;"
                   >
-                    <div
-                      class="default_xu2jcg-o_O-spinnerContainer_agrn11"
-                    >
-                      <svg
-                        height="48"
-                        viewBox="0 0 48 48"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
-                          d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
-                          fill-rule="nonzero"
-                        />
-                      </svg>
-                    </div>
+                    Click to add vertices
                   </span>
                 </div>
                 <div
-                  class="graphie"
-                  style="position: relative; width: 400px; height: 400px;"
-                >
-                  <svg
-                    height="400"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
-                    version="1.1"
-                    width="400"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <desc
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    >
-                      Created with Raphaël
-                    </desc>
-                    <defs
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    />
-                    <rect
-                      fill="#000000"
-                      height="400"
-                      opacity="0"
-                      r="0"
-                      rx="0"
-                      ry="0"
-                      stroke="#000"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0;"
-                      width="400"
-                      x="0"
-                      y="0"
-                    />
-                    <path
-                      d="M0,0"
-                      fill="#000000"
-                      opacity="0"
-                      stroke="#000000"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                    />
-                  </svg>
-                  <svg
-                    height="400"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    version="1.1"
-                    width="400"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <desc
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    >
-                      Created with Raphaël
-                    </desc>
-                    <defs
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    />
-                    <image
-                      height="40"
-                      href="https://ka-perseus-graphie.s3.amazonaws.com/b1452c0d79fd0f7ff4c3af9488474a0a0decb361.png"
-                      opacity="0.5"
-                      preserveAspectRatio="none"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0.5;"
-                      width="40"
-                      x="360"
-                      y="360"
-                    />
-                    <path
-                      d="M0,0"
-                      fill="#71b307"
-                      fill-opacity="0"
-                      stroke="#71b307"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; fill-opacity: 0;"
-                    />
-                  </svg>
-                  <div
-                    style="font-style: italic; font-weight: bold; font-size: 32px; width: 100%; height: 100%; text-align: center; background-color: white; position: absolute; z-index: 1; transition: opacity .25s ease-in-out; opacity: 0.5;"
-                  >
-                    <span
-                      style="position: relative; top: 25%;"
-                    >
-                      Click to add vertices
-                    </span>
-                  </div>
-                  <div
-                    style="position: absolute; left: 0px; top: 0px;"
-                  />
-                  <div
-                    style="position: absolute; left: 0px; top: 0px; z-index: 2;"
-                  />
-                </div>
+                  style="position: absolute; left: 0px; top: 0px;"
+                />
+                <div
+                  style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                />
               </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/matcher.test.tsx.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/matcher.test.tsx.snap
@@ -2,46 +2,91 @@
 
 exports[`matcher widget can reorder options: moved items 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          <strong>
-            Match each claim with its supporting evidence.
-          </strong>
-        </div>
+        <strong>
+          Match each claim with its supporting evidence.
+        </strong>
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="1"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
-          <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+          <table
+            class="widget_lf609f perseus-widget-matcher"
           >
-            <table
-              class="widget_lf609f perseus-widget-matcher"
-            >
-              <tbody>
-                <tr
-                  class="row_tykfnp"
+            <tbody>
+              <tr
+                class="row_tykfnp"
+              >
+                <th
+                  class="column_4at8du-o_O-columnLabel_1wdbfym"
                 >
-                  <th
-                    class="column_4at8du-o_O-columnLabel_1wdbfym"
+                  <div
+                    class="perseus-renderer perseus-renderer-responsive"
                   >
-                    <span
-                      class="mock-KatexProvider"
+                    <div
+                      class="paragraph"
+                      data-perseus-paragraph-index="0"
+                    >
+                      <div
+                        class="paragraph"
+                      >
+                        <strong>
+                          Claims
+                        </strong>
+                      </div>
+                    </div>
+                  </div>
+                </th>
+                <th
+                  class="column_4at8du-o_O-columnRight_1wcmc4d-o_O-columnLabel_1wdbfym"
+                >
+                  <div
+                    class="perseus-renderer perseus-renderer-responsive"
+                  >
+                    <div
+                      class="paragraph"
+                      data-perseus-paragraph-index="0"
+                    >
+                      <div
+                        class="paragraph"
+                      >
+                        <strong>
+                          Evidence
+                        </strong>
+                      </div>
+                    </div>
+                  </div>
+                </th>
+              </tr>
+              <tr
+                class="row_tykfnp"
+              >
+                <td
+                  class="column_4at8du"
+                >
+                  <ul
+                    class="sortable_13d4756 perseus-sortable"
+                  >
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px 0px 5px 0px;"
                     >
                       <div
                         class="perseus-renderer perseus-renderer-responsive"
@@ -53,19 +98,14 @@ exports[`matcher widget can reorder options: moved items 1`] = `
                           <div
                             class="paragraph"
                           >
-                            <strong>
-                              Claims
-                            </strong>
+                            Average global temperatures will rise 
                           </div>
                         </div>
                       </div>
-                    </span>
-                  </th>
-                  <th
-                    class="column_4at8du-o_O-columnRight_1wcmc4d-o_O-columnLabel_1wdbfym"
-                  >
-                    <span
-                      class="mock-KatexProvider"
+                    </li>
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px 0px 5px 0px;"
                     >
                       <div
                         class="perseus-renderer perseus-renderer-responsive"
@@ -77,317 +117,270 @@ exports[`matcher widget can reorder options: moved items 1`] = `
                           <div
                             class="paragraph"
                           >
-                            <strong>
-                              Evidence
-                            </strong>
+                            Our Sun will run out of fuel and die in around 5 billion years 
                           </div>
                         </div>
                       </div>
-                    </span>
-                  </th>
-                </tr>
-                <tr
-                  class="row_tykfnp"
+                    </li>
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px 0px 5px 0px;"
+                    >
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
+                      >
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
+                        >
+                          <div
+                            class="paragraph"
+                          >
+                            Plate tectonics will rearrange the continents: the Pacific will narrow, bringing Australia closer to the Americas, and the Atlantic will expand to form the largest of the oceans 
+                          </div>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px 0px 5px 0px;"
+                    >
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
+                      >
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
+                        >
+                          <div
+                            class="paragraph"
+                          >
+                            Our Sun will run out of hydrogen, swell into a red giant, gobble up the inner rocky planets, and then collapse and die 
+                          </div>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px;"
+                    >
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
+                      >
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
+                        >
+                          <div
+                            class="paragraph"
+                          >
+                            In 3 to 4 billion years, our galaxy will begin a slow collision with its closest large neighbor, Andromeda 
+                          </div>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                </td>
+                <td
+                  class="column_4at8du-o_O-columnRight_1wcmc4d"
                 >
-                  <td
-                    class="column_4at8du"
+                  <ul
+                    class="sortable_13d4756 perseus-sortable"
                   >
-                    <ul
-                      class="sortable_13d4756 perseus-sortable"
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px 0px 5px 0px;"
                     >
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px 0px 5px 0px;"
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
                       >
-                        <span
-                          class="mock-KatexProvider"
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
                         >
                           <div
-                            class="perseus-renderer perseus-renderer-responsive"
+                            class="paragraph"
                           >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Average global temperatures will rise 
-                              </div>
-                            </div>
+                            Rapid escalation of greenhouse gas emissions
                           </div>
-                        </span>
-                      </li>
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px 0px 5px 0px;"
-                      >
-                        <span
-                          class="mock-KatexProvider"
-                        >
-                          <div
-                            class="perseus-renderer perseus-renderer-responsive"
-                          >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Our Sun will run out of fuel and die in around 5 billion years 
-                              </div>
-                            </div>
-                          </div>
-                        </span>
-                      </li>
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px 0px 5px 0px;"
-                      >
-                        <span
-                          class="mock-KatexProvider"
-                        >
-                          <div
-                            class="perseus-renderer perseus-renderer-responsive"
-                          >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Plate tectonics will rearrange the continents: the Pacific will narrow, bringing Australia closer to the Americas, and the Atlantic will expand to form the largest of the oceans 
-                              </div>
-                            </div>
-                          </div>
-                        </span>
-                      </li>
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px 0px 5px 0px;"
-                      >
-                        <span
-                          class="mock-KatexProvider"
-                        >
-                          <div
-                            class="perseus-renderer perseus-renderer-responsive"
-                          >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Our Sun will run out of hydrogen, swell into a red giant, gobble up the inner rocky planets, and then collapse and die 
-                              </div>
-                            </div>
-                          </div>
-                        </span>
-                      </li>
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px;"
-                      >
-                        <span
-                          class="mock-KatexProvider"
-                        >
-                          <div
-                            class="perseus-renderer perseus-renderer-responsive"
-                          >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                In 3 to 4 billion years, our galaxy will begin a slow collision with its closest large neighbor, Andromeda 
-                              </div>
-                            </div>
-                          </div>
-                        </span>
-                      </li>
-                    </ul>
-                  </td>
-                  <td
-                    class="column_4at8du-o_O-columnRight_1wcmc4d"
-                  >
-                    <ul
-                      class="sortable_13d4756 perseus-sortable"
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px 0px 5px 0px;"
                     >
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px 0px 5px 0px;"
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
                       >
-                        <span
-                          class="mock-KatexProvider"
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
                         >
                           <div
-                            class="perseus-renderer perseus-renderer-responsive"
+                            class="paragraph"
                           >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Rapid escalation of greenhouse gas emissions
-                              </div>
-                            </div>
+                            The current trajectory of the Milky Way galaxy and those in its immediate proximity
                           </div>
-                        </span>
-                      </li>
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px 0px 5px 0px;"
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px 0px 5px 0px;"
+                    >
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
                       >
-                        <span
-                          class="mock-KatexProvider"
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
                         >
                           <div
-                            class="perseus-renderer perseus-renderer-responsive"
+                            class="paragraph"
                           >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                The current trajectory of the Milky Way galaxy and those in its immediate proximity
-                              </div>
-                            </div>
+                            Medium-sized stars typically exist for roughly 10 billion years
                           </div>
-                        </span>
-                      </li>
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px 0px 5px 0px;"
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px 0px 5px 0px;"
+                    >
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
                       >
-                        <span
-                          class="mock-KatexProvider"
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
                         >
                           <div
-                            class="perseus-renderer perseus-renderer-responsive"
+                            class="paragraph"
                           >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Medium-sized stars typically exist for roughly 10 billion years
-                              </div>
-                            </div>
+                            The life cycle of medium-sized stars includes a red giant stage and ends in a whimper as a white dwarf
                           </div>
-                        </span>
-                      </li>
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px 0px 5px 0px;"
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px;"
+                    >
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
                       >
-                        <span
-                          class="mock-KatexProvider"
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
                         >
                           <div
-                            class="perseus-renderer perseus-renderer-responsive"
+                            class="paragraph"
                           >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                The life cycle of medium-sized stars includes a red giant stage and ends in a whimper as a white dwarf
-                              </div>
-                            </div>
+                            The current trajectory of the Earth’s tectonic plate movement
                           </div>
-                        </span>
-                      </li>
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px;"
-                      >
-                        <span
-                          class="mock-KatexProvider"
-                        >
-                          <div
-                            class="perseus-renderer perseus-renderer-responsive"
-                          >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                The current trajectory of the Earth’s tectonic plate movement
-                              </div>
-                            </div>
-                          </div>
-                        </span>
-                      </li>
-                    </ul>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                </td>
+              </tr>
+            </tbody>
+          </table>
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`matcher widget should snapshot on mobile: first mobile render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          <strong>
-            Match each claim with its supporting evidence.
-          </strong>
-        </div>
+        <strong>
+          Match each claim with its supporting evidence.
+        </strong>
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="1"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
-          <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+          <table
+            class="widget_lf609f perseus-widget-matcher"
           >
-            <table
-              class="widget_lf609f perseus-widget-matcher"
-            >
-              <tbody>
-                <tr
-                  class="row_tykfnp"
+            <tbody>
+              <tr
+                class="row_tykfnp"
+              >
+                <th
+                  class="column_4at8du-o_O-columnLabel_1wdbfym"
                 >
-                  <th
-                    class="column_4at8du-o_O-columnLabel_1wdbfym"
+                  <div
+                    class="perseus-renderer perseus-renderer-responsive"
                   >
-                    <span
-                      class="mock-KatexProvider"
+                    <div
+                      class="paragraph"
+                      data-perseus-paragraph-index="0"
+                    >
+                      <div
+                        class="paragraph"
+                      >
+                        <strong>
+                          Claims
+                        </strong>
+                      </div>
+                    </div>
+                  </div>
+                </th>
+                <th
+                  class="column_4at8du-o_O-columnRight_1wcmc4d-o_O-columnLabel_1wdbfym"
+                >
+                  <div
+                    class="perseus-renderer perseus-renderer-responsive"
+                  >
+                    <div
+                      class="paragraph"
+                      data-perseus-paragraph-index="0"
+                    >
+                      <div
+                        class="paragraph"
+                      >
+                        <strong>
+                          Evidence
+                        </strong>
+                      </div>
+                    </div>
+                  </div>
+                </th>
+              </tr>
+              <tr
+                class="row_tykfnp"
+              >
+                <td
+                  class="column_4at8du"
+                >
+                  <ul
+                    class="sortable_13d4756 perseus-sortable"
+                  >
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px 0px 8px 0px;"
                     >
                       <div
                         class="perseus-renderer perseus-renderer-responsive"
@@ -399,19 +392,14 @@ exports[`matcher widget should snapshot on mobile: first mobile render 1`] = `
                           <div
                             class="paragraph"
                           >
-                            <strong>
-                              Claims
-                            </strong>
+                            Our Sun will run out of fuel and die in around 5 billion years 
                           </div>
                         </div>
                       </div>
-                    </span>
-                  </th>
-                  <th
-                    class="column_4at8du-o_O-columnRight_1wcmc4d-o_O-columnLabel_1wdbfym"
-                  >
-                    <span
-                      class="mock-KatexProvider"
+                    </li>
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px 0px 8px 0px;"
                     >
                       <div
                         class="perseus-renderer perseus-renderer-responsive"
@@ -423,317 +411,270 @@ exports[`matcher widget should snapshot on mobile: first mobile render 1`] = `
                           <div
                             class="paragraph"
                           >
-                            <strong>
-                              Evidence
-                            </strong>
+                            Plate tectonics will rearrange the continents: the Pacific will narrow, bringing Australia closer to the Americas, and the Atlantic will expand to form the largest of the oceans 
                           </div>
                         </div>
                       </div>
-                    </span>
-                  </th>
-                </tr>
-                <tr
-                  class="row_tykfnp"
+                    </li>
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px 0px 8px 0px;"
+                    >
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
+                      >
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
+                        >
+                          <div
+                            class="paragraph"
+                          >
+                            Our Sun will run out of hydrogen, swell into a red giant, gobble up the inner rocky planets, and then collapse and die 
+                          </div>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px 0px 8px 0px;"
+                    >
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
+                      >
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
+                        >
+                          <div
+                            class="paragraph"
+                          >
+                            Average global temperatures will rise 
+                          </div>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px;"
+                    >
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
+                      >
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
+                        >
+                          <div
+                            class="paragraph"
+                          >
+                            In 3 to 4 billion years, our galaxy will begin a slow collision with its closest large neighbor, Andromeda 
+                          </div>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                </td>
+                <td
+                  class="column_4at8du-o_O-columnRight_1wcmc4d"
                 >
-                  <td
-                    class="column_4at8du"
+                  <ul
+                    class="sortable_13d4756 perseus-sortable"
                   >
-                    <ul
-                      class="sortable_13d4756 perseus-sortable"
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px 0px 8px 0px;"
                     >
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px 0px 8px 0px;"
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
                       >
-                        <span
-                          class="mock-KatexProvider"
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
                         >
                           <div
-                            class="perseus-renderer perseus-renderer-responsive"
+                            class="paragraph"
                           >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Our Sun will run out of fuel and die in around 5 billion years 
-                              </div>
-                            </div>
+                            The current trajectory of the Milky Way galaxy and those in its immediate proximity
                           </div>
-                        </span>
-                      </li>
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px 0px 8px 0px;"
-                      >
-                        <span
-                          class="mock-KatexProvider"
-                        >
-                          <div
-                            class="perseus-renderer perseus-renderer-responsive"
-                          >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Plate tectonics will rearrange the continents: the Pacific will narrow, bringing Australia closer to the Americas, and the Atlantic will expand to form the largest of the oceans 
-                              </div>
-                            </div>
-                          </div>
-                        </span>
-                      </li>
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px 0px 8px 0px;"
-                      >
-                        <span
-                          class="mock-KatexProvider"
-                        >
-                          <div
-                            class="perseus-renderer perseus-renderer-responsive"
-                          >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Our Sun will run out of hydrogen, swell into a red giant, gobble up the inner rocky planets, and then collapse and die 
-                              </div>
-                            </div>
-                          </div>
-                        </span>
-                      </li>
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px 0px 8px 0px;"
-                      >
-                        <span
-                          class="mock-KatexProvider"
-                        >
-                          <div
-                            class="perseus-renderer perseus-renderer-responsive"
-                          >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Average global temperatures will rise 
-                              </div>
-                            </div>
-                          </div>
-                        </span>
-                      </li>
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px;"
-                      >
-                        <span
-                          class="mock-KatexProvider"
-                        >
-                          <div
-                            class="perseus-renderer perseus-renderer-responsive"
-                          >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                In 3 to 4 billion years, our galaxy will begin a slow collision with its closest large neighbor, Andromeda 
-                              </div>
-                            </div>
-                          </div>
-                        </span>
-                      </li>
-                    </ul>
-                  </td>
-                  <td
-                    class="column_4at8du-o_O-columnRight_1wcmc4d"
-                  >
-                    <ul
-                      class="sortable_13d4756 perseus-sortable"
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px 0px 8px 0px;"
                     >
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px 0px 8px 0px;"
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
                       >
-                        <span
-                          class="mock-KatexProvider"
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
                         >
                           <div
-                            class="perseus-renderer perseus-renderer-responsive"
+                            class="paragraph"
                           >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                The current trajectory of the Milky Way galaxy and those in its immediate proximity
-                              </div>
-                            </div>
+                            Medium-sized stars typically exist for roughly 10 billion years
                           </div>
-                        </span>
-                      </li>
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px 0px 8px 0px;"
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px 0px 8px 0px;"
+                    >
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
                       >
-                        <span
-                          class="mock-KatexProvider"
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
                         >
                           <div
-                            class="perseus-renderer perseus-renderer-responsive"
+                            class="paragraph"
                           >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Medium-sized stars typically exist for roughly 10 billion years
-                              </div>
-                            </div>
+                            The life cycle of medium-sized stars includes a red giant stage and ends in a whimper as a white dwarf
                           </div>
-                        </span>
-                      </li>
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px 0px 8px 0px;"
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px 0px 8px 0px;"
+                    >
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
                       >
-                        <span
-                          class="mock-KatexProvider"
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
                         >
                           <div
-                            class="perseus-renderer perseus-renderer-responsive"
+                            class="paragraph"
                           >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                The life cycle of medium-sized stars includes a red giant stage and ends in a whimper as a white dwarf
-                              </div>
-                            </div>
+                            The current trajectory of the Earth’s tectonic plate movement
                           </div>
-                        </span>
-                      </li>
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px 0px 8px 0px;"
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px;"
+                    >
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
                       >
-                        <span
-                          class="mock-KatexProvider"
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
                         >
                           <div
-                            class="perseus-renderer perseus-renderer-responsive"
+                            class="paragraph"
                           >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                The current trajectory of the Earth’s tectonic plate movement
-                              </div>
-                            </div>
+                            Rapid escalation of greenhouse gas emissions
                           </div>
-                        </span>
-                      </li>
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px;"
-                      >
-                        <span
-                          class="mock-KatexProvider"
-                        >
-                          <div
-                            class="perseus-renderer perseus-renderer-responsive"
-                          >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Rapid escalation of greenhouse gas emissions
-                              </div>
-                            </div>
-                          </div>
-                        </span>
-                      </li>
-                    </ul>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                </td>
+              </tr>
+            </tbody>
+          </table>
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`matcher widget should snapshot: first render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          <strong>
-            Match each claim with its supporting evidence.
-          </strong>
-        </div>
+        <strong>
+          Match each claim with its supporting evidence.
+        </strong>
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="1"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
-          <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+          <table
+            class="widget_lf609f perseus-widget-matcher"
           >
-            <table
-              class="widget_lf609f perseus-widget-matcher"
-            >
-              <tbody>
-                <tr
-                  class="row_tykfnp"
+            <tbody>
+              <tr
+                class="row_tykfnp"
+              >
+                <th
+                  class="column_4at8du-o_O-columnLabel_1wdbfym"
                 >
-                  <th
-                    class="column_4at8du-o_O-columnLabel_1wdbfym"
+                  <div
+                    class="perseus-renderer perseus-renderer-responsive"
                   >
-                    <span
-                      class="mock-KatexProvider"
+                    <div
+                      class="paragraph"
+                      data-perseus-paragraph-index="0"
+                    >
+                      <div
+                        class="paragraph"
+                      >
+                        <strong>
+                          Claims
+                        </strong>
+                      </div>
+                    </div>
+                  </div>
+                </th>
+                <th
+                  class="column_4at8du-o_O-columnRight_1wcmc4d-o_O-columnLabel_1wdbfym"
+                >
+                  <div
+                    class="perseus-renderer perseus-renderer-responsive"
+                  >
+                    <div
+                      class="paragraph"
+                      data-perseus-paragraph-index="0"
+                    >
+                      <div
+                        class="paragraph"
+                      >
+                        <strong>
+                          Evidence
+                        </strong>
+                      </div>
+                    </div>
+                  </div>
+                </th>
+              </tr>
+              <tr
+                class="row_tykfnp"
+              >
+                <td
+                  class="column_4at8du"
+                >
+                  <ul
+                    class="sortable_13d4756 perseus-sortable"
+                  >
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px 0px 5px 0px;"
                     >
                       <div
                         class="perseus-renderer perseus-renderer-responsive"
@@ -745,19 +686,14 @@ exports[`matcher widget should snapshot: first render 1`] = `
                           <div
                             class="paragraph"
                           >
-                            <strong>
-                              Claims
-                            </strong>
+                            Our Sun will run out of fuel and die in around 5 billion years 
                           </div>
                         </div>
                       </div>
-                    </span>
-                  </th>
-                  <th
-                    class="column_4at8du-o_O-columnRight_1wcmc4d-o_O-columnLabel_1wdbfym"
-                  >
-                    <span
-                      class="mock-KatexProvider"
+                    </li>
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px 0px 5px 0px;"
                     >
                       <div
                         class="perseus-renderer perseus-renderer-responsive"
@@ -769,271 +705,179 @@ exports[`matcher widget should snapshot: first render 1`] = `
                           <div
                             class="paragraph"
                           >
-                            <strong>
-                              Evidence
-                            </strong>
+                            Plate tectonics will rearrange the continents: the Pacific will narrow, bringing Australia closer to the Americas, and the Atlantic will expand to form the largest of the oceans 
                           </div>
                         </div>
                       </div>
-                    </span>
-                  </th>
-                </tr>
-                <tr
-                  class="row_tykfnp"
+                    </li>
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px 0px 5px 0px;"
+                    >
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
+                      >
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
+                        >
+                          <div
+                            class="paragraph"
+                          >
+                            Our Sun will run out of hydrogen, swell into a red giant, gobble up the inner rocky planets, and then collapse and die 
+                          </div>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px 0px 5px 0px;"
+                    >
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
+                      >
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
+                        >
+                          <div
+                            class="paragraph"
+                          >
+                            Average global temperatures will rise 
+                          </div>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px;"
+                    >
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
+                      >
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
+                        >
+                          <div
+                            class="paragraph"
+                          >
+                            In 3 to 4 billion years, our galaxy will begin a slow collision with its closest large neighbor, Andromeda 
+                          </div>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                </td>
+                <td
+                  class="column_4at8du-o_O-columnRight_1wcmc4d"
                 >
-                  <td
-                    class="column_4at8du"
+                  <ul
+                    class="sortable_13d4756 perseus-sortable"
                   >
-                    <ul
-                      class="sortable_13d4756 perseus-sortable"
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px 0px 5px 0px;"
                     >
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px 0px 5px 0px;"
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
                       >
-                        <span
-                          class="mock-KatexProvider"
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
                         >
                           <div
-                            class="perseus-renderer perseus-renderer-responsive"
+                            class="paragraph"
                           >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Our Sun will run out of fuel and die in around 5 billion years 
-                              </div>
-                            </div>
+                            The current trajectory of the Milky Way galaxy and those in its immediate proximity
                           </div>
-                        </span>
-                      </li>
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px 0px 5px 0px;"
-                      >
-                        <span
-                          class="mock-KatexProvider"
-                        >
-                          <div
-                            class="perseus-renderer perseus-renderer-responsive"
-                          >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Plate tectonics will rearrange the continents: the Pacific will narrow, bringing Australia closer to the Americas, and the Atlantic will expand to form the largest of the oceans 
-                              </div>
-                            </div>
-                          </div>
-                        </span>
-                      </li>
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px 0px 5px 0px;"
-                      >
-                        <span
-                          class="mock-KatexProvider"
-                        >
-                          <div
-                            class="perseus-renderer perseus-renderer-responsive"
-                          >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Our Sun will run out of hydrogen, swell into a red giant, gobble up the inner rocky planets, and then collapse and die 
-                              </div>
-                            </div>
-                          </div>
-                        </span>
-                      </li>
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px 0px 5px 0px;"
-                      >
-                        <span
-                          class="mock-KatexProvider"
-                        >
-                          <div
-                            class="perseus-renderer perseus-renderer-responsive"
-                          >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Average global temperatures will rise 
-                              </div>
-                            </div>
-                          </div>
-                        </span>
-                      </li>
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px;"
-                      >
-                        <span
-                          class="mock-KatexProvider"
-                        >
-                          <div
-                            class="perseus-renderer perseus-renderer-responsive"
-                          >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                In 3 to 4 billion years, our galaxy will begin a slow collision with its closest large neighbor, Andromeda 
-                              </div>
-                            </div>
-                          </div>
-                        </span>
-                      </li>
-                    </ul>
-                  </td>
-                  <td
-                    class="column_4at8du-o_O-columnRight_1wcmc4d"
-                  >
-                    <ul
-                      class="sortable_13d4756 perseus-sortable"
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px 0px 5px 0px;"
                     >
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px 0px 5px 0px;"
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
                       >
-                        <span
-                          class="mock-KatexProvider"
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
                         >
                           <div
-                            class="perseus-renderer perseus-renderer-responsive"
+                            class="paragraph"
                           >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                The current trajectory of the Milky Way galaxy and those in its immediate proximity
-                              </div>
-                            </div>
+                            Medium-sized stars typically exist for roughly 10 billion years
                           </div>
-                        </span>
-                      </li>
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px 0px 5px 0px;"
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px 0px 5px 0px;"
+                    >
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
                       >
-                        <span
-                          class="mock-KatexProvider"
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
                         >
                           <div
-                            class="perseus-renderer perseus-renderer-responsive"
+                            class="paragraph"
                           >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Medium-sized stars typically exist for roughly 10 billion years
-                              </div>
-                            </div>
+                            The life cycle of medium-sized stars includes a red giant stage and ends in a whimper as a white dwarf
                           </div>
-                        </span>
-                      </li>
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px 0px 5px 0px;"
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px 0px 5px 0px;"
+                    >
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
                       >
-                        <span
-                          class="mock-KatexProvider"
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
                         >
                           <div
-                            class="perseus-renderer perseus-renderer-responsive"
+                            class="paragraph"
                           >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                The life cycle of medium-sized stars includes a red giant stage and ends in a whimper as a white dwarf
-                              </div>
-                            </div>
+                            The current trajectory of the Earth’s tectonic plate movement
                           </div>
-                        </span>
-                      </li>
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px 0px 5px 0px;"
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      style="position: static; margin: 0px;"
+                    >
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
                       >
-                        <span
-                          class="mock-KatexProvider"
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
                         >
                           <div
-                            class="perseus-renderer perseus-renderer-responsive"
+                            class="paragraph"
                           >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                The current trajectory of the Earth’s tectonic plate movement
-                              </div>
-                            </div>
+                            Rapid escalation of greenhouse gas emissions
                           </div>
-                        </span>
-                      </li>
-                      <li
-                        class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
-                        style="position: static; margin: 0px;"
-                      >
-                        <span
-                          class="mock-KatexProvider"
-                        >
-                          <div
-                            class="perseus-renderer perseus-renderer-responsive"
-                          >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Rapid escalation of greenhouse gas emissions
-                              </div>
-                            </div>
-                          </div>
-                        </span>
-                      </li>
-                    </ul>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                </td>
+              </tr>
+            </tbody>
+          </table>
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/matrix.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/matrix.test.ts.snap
@@ -2,309 +2,47 @@
 
 exports[`matrix widget should snapshot on mobile: first mobile render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          <strong>
-            Perform the row operation, 
-            <span
-              style="white-space: nowrap;"
-            >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                R_3 \\leftrightarrow R_2
-              </span>
-              <span />
-            </span>
-            , on the following matrix.
-          </strong>
-        </div>
-      </div>
-      <div
-        class="paragraph perseus-paragraph-centered"
-        data-perseus-paragraph-index="1"
-      >
-        <div
-          class="perseus-block-math"
-          style="margin-left: -16px; margin-right: -16px;"
-        >
-          <div
-            class="perseus-block-math-inner"
-            style="overflow-x: auto; overflow-y: hidden; margin-top: -10px; margin-bottom: -10px; transform: translate3d(0,0,0); padding: 10px 16px 10px 16px;"
+        <strong>
+          Perform the row operation, 
+          <span
+            style="white-space: nowrap;"
           >
+            <span />
             <span
-              style="display: block; width: 100%; transform: scale(1, 1)  translate(0, 8px); transform-origin: 0 0; opacity: 0;"
+              class="mock-TeX"
             >
-              <span
-                class="mock-TeX"
-              >
-                \\left[\\begin{array} {ccc}
-5 & -2 & 1 & 1 \\\\
-3 & 0 & 0 & -2 \\\\
-1 & 1 & 7 & -3 \\end{array} \\right] 
-              </span>
+              R_3 \\leftrightarrow R_2
             </span>
-          </div>
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="2"
-      >
-        <div
-          class="paragraph"
-        >
-          <div
-            class="perseus-widget-container widget-nohighlight widget-block"
-          >
-            <div
-              class="perseus-matrix"
-            >
-              
-              <div
-                class="matrix-input"
-              >
-                <div
-                  class="matrix-bracket bracket-left"
-                  style="height: 36px;"
-                />
-                <div
-                  class="matrix-bracket bracket-right"
-                  style="height: 36px; left: 46px;"
-                />
-                <div
-                  class="matrix-row"
-                >
-                  <span
-                    class="matrix-input-field"
-                  >
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1qo22fw"
-                      id="input-13"
-                      type="text"
-                      value=""
-                    />
-                  </span>
-                  <span
-                    class="matrix-input-field"
-                  >
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
-                      id="input-14"
-                      type="text"
-                      value=""
-                    />
-                  </span>
-                  <span
-                    class="matrix-input-field"
-                  >
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
-                      id="input-15"
-                      type="text"
-                      value=""
-                    />
-                  </span>
-                  <span
-                    class="matrix-input-field"
-                  >
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
-                      id="input-16"
-                      type="text"
-                      value=""
-                    />
-                  </span>
-                </div>
-                <div
-                  class="matrix-row"
-                >
-                  <span
-                    class="matrix-input-field"
-                  >
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
-                      id="input-17"
-                      type="text"
-                      value=""
-                    />
-                  </span>
-                  <span
-                    class="matrix-input-field"
-                  >
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
-                      id="input-18"
-                      type="text"
-                      value=""
-                    />
-                  </span>
-                  <span
-                    class="matrix-input-field"
-                  >
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
-                      id="input-19"
-                      type="text"
-                      value=""
-                    />
-                  </span>
-                  <span
-                    class="matrix-input-field"
-                  >
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
-                      id="input-20"
-                      type="text"
-                      value=""
-                    />
-                  </span>
-                </div>
-                <div
-                  class="matrix-row"
-                >
-                  <span
-                    class="matrix-input-field"
-                  >
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
-                      id="input-21"
-                      type="text"
-                      value=""
-                    />
-                  </span>
-                  <span
-                    class="matrix-input-field"
-                  >
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
-                      id="input-22"
-                      type="text"
-                      value=""
-                    />
-                  </span>
-                  <span
-                    class="matrix-input-field"
-                  >
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
-                      id="input-23"
-                      type="text"
-                      value=""
-                    />
-                  </span>
-                  <span
-                    class="matrix-input-field"
-                  >
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
-                      id="input-24"
-                      type="text"
-                      value=""
-                    />
-                  </span>
-                </div>
-              </div>
-              
-            </div>
-          </div>
-        </div>
+            <span />
+          </span>
+          , on the following matrix.
+        </strong>
       </div>
     </div>
-  </span>
-</div>
-`;
-
-exports[`matrix widget should snapshot: first render 1`] = `
-<div>
-  <span
-    class="mock-KatexProvider"
-  >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph perseus-paragraph-centered"
+      data-perseus-paragraph-index="1"
     >
       <div
-        class="paragraph"
-        data-perseus-paragraph-index="0"
+        class="perseus-block-math"
+        style="margin-left: -16px; margin-right: -16px;"
       >
         <div
-          class="paragraph"
+          class="perseus-block-math-inner"
+          style="overflow-x: auto; overflow-y: hidden; margin-top: -10px; margin-bottom: -10px; transform: translate3d(0,0,0); padding: 10px 16px 10px 16px;"
         >
-          <strong>
-            Perform the row operation, 
-            <span
-              style="white-space: nowrap;"
-            >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                R_3 \\leftrightarrow R_2
-              </span>
-              <span />
-            </span>
-            , on the following matrix.
-          </strong>
-        </div>
-      </div>
-      <div
-        class="paragraph perseus-paragraph-centered"
-        data-perseus-paragraph-index="1"
-      >
-        <div
-          class="perseus-block-math"
-        >
-          <div
-            class="perseus-block-math-inner"
-            style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+          <span
+            style="display: block; width: 100%; transform: scale(1, 1)  translate(0, 8px); transform-origin: 0 0; opacity: 0;"
           >
             <span
               class="mock-TeX"
@@ -314,209 +52,463 @@ exports[`matrix widget should snapshot: first render 1`] = `
 3 & 0 & 0 & -2 \\\\
 1 & 1 & 7 & -3 \\end{array} \\right] 
             </span>
-          </div>
+          </span>
         </div>
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="2"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+            class="perseus-matrix"
           >
+            
             <div
-              class="perseus-matrix"
+              class="matrix-input"
             >
-              
               <div
-                class="matrix-input"
+                class="matrix-bracket bracket-left"
+                style="height: 36px;"
+              />
+              <div
+                class="matrix-bracket bracket-right"
+                style="height: 36px; left: 46px;"
+              />
+              <div
+                class="matrix-row"
               >
-                <div
-                  class="matrix-bracket bracket-left"
-                  style="height: 36px;"
-                />
-                <div
-                  class="matrix-bracket bracket-right"
-                  style="height: 36px; left: 46px;"
-                />
-                <div
-                  class="matrix-row"
+                <span
+                  class="matrix-input-field"
                 >
-                  <span
-                    class="matrix-input-field"
-                  >
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1qo22fw"
-                      id="input-1"
-                      type="text"
-                      value=""
-                    />
-                  </span>
-                  <span
-                    class="matrix-input-field"
-                  >
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
-                      id="input-2"
-                      type="text"
-                      value=""
-                    />
-                  </span>
-                  <span
-                    class="matrix-input-field"
-                  >
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
-                      id="input-3"
-                      type="text"
-                      value=""
-                    />
-                  </span>
-                  <span
-                    class="matrix-input-field"
-                  >
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
-                      id="input-4"
-                      type="text"
-                      value=""
-                    />
-                  </span>
-                </div>
-                <div
-                  class="matrix-row"
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1qo22fw"
+                    id="input-13"
+                    type="text"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="matrix-input-field"
                 >
-                  <span
-                    class="matrix-input-field"
-                  >
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
-                      id="input-5"
-                      type="text"
-                      value=""
-                    />
-                  </span>
-                  <span
-                    class="matrix-input-field"
-                  >
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
-                      id="input-6"
-                      type="text"
-                      value=""
-                    />
-                  </span>
-                  <span
-                    class="matrix-input-field"
-                  >
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
-                      id="input-7"
-                      type="text"
-                      value=""
-                    />
-                  </span>
-                  <span
-                    class="matrix-input-field"
-                  >
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
-                      id="input-8"
-                      type="text"
-                      value=""
-                    />
-                  </span>
-                </div>
-                <div
-                  class="matrix-row"
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
+                    id="input-14"
+                    type="text"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="matrix-input-field"
                 >
-                  <span
-                    class="matrix-input-field"
-                  >
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
-                      id="input-9"
-                      type="text"
-                      value=""
-                    />
-                  </span>
-                  <span
-                    class="matrix-input-field"
-                  >
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
-                      id="input-10"
-                      type="text"
-                      value=""
-                    />
-                  </span>
-                  <span
-                    class="matrix-input-field"
-                  >
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
-                      id="input-11"
-                      type="text"
-                      value=""
-                    />
-                  </span>
-                  <span
-                    class="matrix-input-field"
-                  >
-                    <input
-                      autocapitalize="off"
-                      autocomplete="off"
-                      autocorrect="off"
-                      class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
-                      id="input-12"
-                      type="text"
-                      value=""
-                    />
-                  </span>
-                </div>
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
+                    id="input-15"
+                    type="text"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="matrix-input-field"
+                >
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
+                    id="input-16"
+                    type="text"
+                    value=""
+                  />
+                </span>
               </div>
-              
+              <div
+                class="matrix-row"
+              >
+                <span
+                  class="matrix-input-field"
+                >
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
+                    id="input-17"
+                    type="text"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="matrix-input-field"
+                >
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
+                    id="input-18"
+                    type="text"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="matrix-input-field"
+                >
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
+                    id="input-19"
+                    type="text"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="matrix-input-field"
+                >
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
+                    id="input-20"
+                    type="text"
+                    value=""
+                  />
+                </span>
+              </div>
+              <div
+                class="matrix-row"
+              >
+                <span
+                  class="matrix-input-field"
+                >
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
+                    id="input-21"
+                    type="text"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="matrix-input-field"
+                >
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
+                    id="input-22"
+                    type="text"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="matrix-input-field"
+                >
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
+                    id="input-23"
+                    type="text"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="matrix-input-field"
+                >
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
+                    id="input-24"
+                    type="text"
+                    value=""
+                  />
+                </span>
+              </div>
             </div>
+            
           </div>
         </div>
       </div>
     </div>
-  </span>
+  </div>
+</div>
+`;
+
+exports[`matrix widget should snapshot: first render 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="paragraph"
+      >
+        <strong>
+          Perform the row operation, 
+          <span
+            style="white-space: nowrap;"
+          >
+            <span />
+            <span
+              class="mock-TeX"
+            >
+              R_3 \\leftrightarrow R_2
+            </span>
+            <span />
+          </span>
+          , on the following matrix.
+        </strong>
+      </div>
+    </div>
+    <div
+      class="paragraph perseus-paragraph-centered"
+      data-perseus-paragraph-index="1"
+    >
+      <div
+        class="perseus-block-math"
+      >
+        <div
+          class="perseus-block-math-inner"
+          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+        >
+          <span
+            class="mock-TeX"
+          >
+            \\left[\\begin{array} {ccc}
+5 & -2 & 1 & 1 \\\\
+3 & 0 & 0 & -2 \\\\
+1 & 1 & 7 & -3 \\end{array} \\right] 
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <div
+            class="perseus-matrix"
+          >
+            
+            <div
+              class="matrix-input"
+            >
+              <div
+                class="matrix-bracket bracket-left"
+                style="height: 36px;"
+              />
+              <div
+                class="matrix-bracket bracket-right"
+                style="height: 36px; left: 46px;"
+              />
+              <div
+                class="matrix-row"
+              >
+                <span
+                  class="matrix-input-field"
+                >
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1qo22fw"
+                    id="input-1"
+                    type="text"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="matrix-input-field"
+                >
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
+                    id="input-2"
+                    type="text"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="matrix-input-field"
+                >
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
+                    id="input-3"
+                    type="text"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="matrix-input-field"
+                >
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
+                    id="input-4"
+                    type="text"
+                    value=""
+                  />
+                </span>
+              </div>
+              <div
+                class="matrix-row"
+              >
+                <span
+                  class="matrix-input-field"
+                >
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
+                    id="input-5"
+                    type="text"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="matrix-input-field"
+                >
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
+                    id="input-6"
+                    type="text"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="matrix-input-field"
+                >
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
+                    id="input-7"
+                    type="text"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="matrix-input-field"
+                >
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
+                    id="input-8"
+                    type="text"
+                    value=""
+                  />
+                </span>
+              </div>
+              <div
+                class="matrix-row"
+              >
+                <span
+                  class="matrix-input-field"
+                >
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
+                    id="input-9"
+                    type="text"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="matrix-input-field"
+                >
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
+                    id="input-10"
+                    type="text"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="matrix-input-field"
+                >
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
+                    id="input-11"
+                    type="text"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="matrix-input-field"
+                >
+                  <input
+                    autocapitalize="off"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_1simu8f"
+                    id="input-12"
+                    type="text"
+                    value=""
+                  />
+                </span>
+              </div>
+            </div>
+            
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/number-line.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/number-line.test.ts.snap
@@ -2,887 +2,879 @@
 
 exports[`number-line widget should snapshot on mobile: first mobile render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph perseus-paragraph-centered"
+      data-perseus-paragraph-index="0"
     >
       <div
-        class="paragraph perseus-paragraph-centered"
-        data-perseus-paragraph-index="0"
+        class="perseus-block-math"
+        style="margin-left: -16px; margin-right: -16px;"
       >
         <div
-          class="perseus-block-math"
-          style="margin-left: -16px; margin-right: -16px;"
+          class="perseus-block-math-inner"
+          style="overflow-x: auto; overflow-y: hidden; margin-top: -10px; margin-bottom: -10px; transform: translate3d(0,0,0); padding: 10px 16px 10px 16px;"
         >
-          <div
-            class="perseus-block-math-inner"
-            style="overflow-x: auto; overflow-y: hidden; margin-top: -10px; margin-bottom: -10px; transform: translate3d(0,0,0); padding: 10px 16px 10px 16px;"
-          >
-            <span
-              style="display: block; width: 100%; transform: scale(1, 1)  translate(0, 8px); transform-origin: 0 0; opacity: 0;"
-            >
-              <span
-                class="mock-TeX"
-              >
-                E=2.5
-              </span>
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="1"
-      >
-        <div
-          class="paragraph"
-        >
-          <strong>
-            Move the dot to 
-            <span
-              style="white-space: nowrap;"
-            >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                -E
-              </span>
-              <span />
-            </span>
-             on the number line.
-          </strong>
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="2"
-      >
-        <div
-          class="paragraph"
-        >
-          <div
-            class="perseus-widget-container widget-nohighlight widget-block"
-          >
-            <div
-              class="perseus-widget perseus-widget-interactive-number-line"
-            >
-              <div
-                class="graphie-container"
-              >
-                <div
-                  class="graphie"
-                  style="position: relative; width: 288px; height: 80px;"
-                >
-                  <svg
-                    height="80"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
-                    version="1.1"
-                    width="288"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <desc
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    >
-                      Created with Raphaël
-                    </desc>
-                    <defs
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    />
-                    <rect
-                      fill="#000000"
-                      height="80"
-                      opacity="0"
-                      r="0"
-                      rx="0"
-                      ry="0"
-                      stroke="#000"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0;"
-                      width="288"
-                      x="0"
-                      y="0"
-                    />
-                  </svg>
-                  <svg
-                    height="80"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    version="1.1"
-                    width="288"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <desc
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    >
-                      Created with Raphaël
-                    </desc>
-                    <defs
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    />
-                    <path
-                      d="M281.05,45.6C281.05,45.6,286.3,40,286.3,40C286.3,40,281.05,34.4,281.05,34.4"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; stroke-linejoin: round; stroke-linecap: round;"
-                      transform=""
-                    />
-                    <path
-                      d="M144,40C144,40,144,40,286.95,40"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
-                    />
-                    <path
-                      d="M-4.849999999999988,45.6C-4.849999999999988,45.6,0.4000000000000119,40,0.4000000000000119,40C0.4000000000000119,40,-4.849999999999988,34.4,-4.849999999999988,34.4"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; stroke-linejoin: round; stroke-linecap: round;"
-                      transform="rotate(180 1.0500100000000114 40)"
-                    />
-                    <path
-                      d="M144,40C144,40,144,40,1.0500000000000114,40"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
-                    />
-                    <path
-                      d="M29.999999999999993,48L29.999999999999993,32"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 2;"
-                    />
-                    <path
-                      d="M58.49999999999999,48L58.49999999999999,32"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 2;"
-                    />
-                    <path
-                      d="M86.99999999999999,48L86.99999999999999,32"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 2;"
-                    />
-                    <path
-                      d="M115.49999999999999,48L115.49999999999999,32"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 2;"
-                    />
-                    <path
-                      d="M144,48L144,32"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 2;"
-                    />
-                    <path
-                      d="M172.5,48L172.5,32"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 2;"
-                    />
-                    <path
-                      d="M201,48L201,32"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 2;"
-                    />
-                    <path
-                      d="M229.5,48L229.5,32"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 2;"
-                    />
-                    <path
-                      d="M258,48L258,32"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 2;"
-                    />
-                    <path
-                      d="M29.999999999999993,48L29.999999999999993,32"
-                      fill="none"
-                      stroke="#11accd"
-                      stroke-width="3.5"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 3.5;"
-                    />
-                    <path
-                      d="M258,48L258,32"
-                      fill="none"
-                      stroke="#11accd"
-                      stroke-width="3.5"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 3.5;"
-                    />
-                  </svg>
-                  <div
-                    style="position: absolute; left: 0px; top: 0px;"
-                  >
-                    <div
-                      style="position: absolute; width: 24px; height: 24px; left: 17.999999999999993px; top: 28px; filter: drop-shadow(0px 0px 5px rgba(0, 0, 0, 0.5)); transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="24"
-                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="NaN"
-                          cy="NaN"
-                          fill="#71b307"
-                          r="NaN"
-                          rx="7"
-                          ry="7"
-                          stroke="#ffffff"
-                          stroke-width="3"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 3;"
-                          transform=""
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    style="position: absolute; left: 0px; top: 0px; z-index: 2;"
-                  >
-                    <div
-                      data-interactive-kind-for-testing="movable-point"
-                      style="position: absolute; width: 48px; height: 48px; left: 5.999999999999993px; top: 16px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="48"
-                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="24"
-                          cy="24"
-                          fill="#000000"
-                          opacity="0"
-                          rx="24"
-                          ry="24"
-                          stroke="#000"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="-4"
-                    style="position: absolute; padding: 7px; color: black; left: 29.999999999999993px; top: 61.2px; fill: none;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="-3"
-                    style="position: absolute; padding: 7px; color: black; left: 58.49999999999999px; top: 61.2px; fill: none;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="-2"
-                    style="position: absolute; padding: 7px; color: black; left: 86.99999999999999px; top: 61.2px; fill: none;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="-1"
-                    style="position: absolute; padding: 7px; color: black; left: 115.49999999999999px; top: 61.2px; fill: none;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="0"
-                    style="position: absolute; padding: 7px; color: black; left: 144px; top: 61.2px; fill: none;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="1"
-                    style="position: absolute; padding: 7px; color: black; left: 172.5px; top: 61.2px; fill: none;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="2"
-                    style="position: absolute; padding: 7px; color: black; left: 201px; top: 61.2px; fill: none;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="3"
-                    style="position: absolute; padding: 7px; color: black; left: 229.5px; top: 61.2px; fill: none;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="4"
-                    style="position: absolute; padding: 7px; color: black; left: 258px; top: 61.2px; fill: none;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="-4"
-                    style="position: absolute; padding: 7px; color: rgb(17, 172, 205); left: 29.999999999999993px; top: 61.2px; fill: none;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="4"
-                    style="position: absolute; padding: 7px; color: rgb(17, 172, 205); left: 258px; top: 61.2px; fill: none;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </span>
-</div>
-`;
-
-exports[`number-line widget should snapshot: first render 1`] = `
-<div>
-  <span
-    class="mock-KatexProvider"
-  >
-    <div
-      class="perseus-renderer perseus-renderer-responsive"
-    >
-      <div
-        class="paragraph perseus-paragraph-centered"
-        data-perseus-paragraph-index="0"
-      >
-        <div
-          class="perseus-block-math"
-        >
-          <div
-            class="perseus-block-math-inner"
-            style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+          <span
+            style="display: block; width: 100%; transform: scale(1, 1)  translate(0, 8px); transform-origin: 0 0; opacity: 0;"
           >
             <span
               class="mock-TeX"
             >
               E=2.5
             </span>
-          </div>
+          </span>
         </div>
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="1"
       >
-        <div
-          class="paragraph"
-        >
-          <strong>
-            Move the dot to 
+        <strong>
+          Move the dot to 
+          <span
+            style="white-space: nowrap;"
+          >
+            <span />
             <span
-              style="white-space: nowrap;"
+              class="mock-TeX"
             >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                -E
-              </span>
-              <span />
+              -E
             </span>
-             on the number line.
-          </strong>
-        </div>
+            <span />
+          </span>
+           on the number line.
+        </strong>
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="2"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+            class="perseus-widget perseus-widget-interactive-number-line"
           >
             <div
-              class="perseus-widget perseus-widget-interactive-number-line"
+              class="graphie-container"
             >
               <div
-                class="graphie-container"
+                class="graphie"
+                style="position: relative; width: 288px; height: 80px;"
               >
-                <div
-                  class="graphie"
-                  style="position: relative; width: 459.99999999999994px; height: 80px;"
+                <svg
+                  height="80"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
+                  version="1.1"
+                  width="288"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <svg
-                    height="80"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
-                    version="1.1"
-                    width="460"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <desc
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    >
-                      Created with Raphaël
-                    </desc>
-                    <defs
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    />
-                    <rect
-                      fill="#000000"
-                      height="80"
-                      opacity="0"
-                      r="0"
-                      rx="0"
-                      ry="0"
-                      stroke="#000"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0;"
-                      width="460"
-                      x="0"
-                      y="0"
-                    />
-                  </svg>
-                  <svg
-                    height="80"
+                  <desc
                     style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    version="1.1"
-                    width="459.99999999999994"
-                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    <desc
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    >
-                      Created with Raphaël
-                    </desc>
-                    <defs
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                    />
-                    <path
-                      d="M454.44999999999993,45.6C454.79999999999995,43.5,458.6499999999999,40.35,459.69999999999993,40C458.6499999999999,39.65,454.79999999999995,36.5,454.44999999999993,34.4"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; stroke-linejoin: round; stroke-linecap: round;"
-                      transform=""
-                    />
-                    <path
-                      d="M229.99999999999997,40C229.99999999999997,40,229.99999999999997,40,458.94999999999993,40"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
-                    />
-                    <path
-                      d="M-3.4499999999999886,45.6C-3.0999999999999885,43.5,0.7500000000000115,40.35,1.8000000000000114,40C0.7500000000000113,39.65,-3.099999999999989,36.5,-3.4499999999999886,34.4"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; stroke-linejoin: round; stroke-linecap: round;"
-                      transform="rotate(180 1.8000000000000114 40)"
-                    />
-                    <path
-                      d="M229.99999999999997,40C229.99999999999997,40,229.99999999999997,40,1.0500000000000114,40"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
-                    />
-                    <path
-                      d="M29.999999999999982,48L29.999999999999982,32"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
-                    />
-                    <path
-                      d="M79.99999999999999,48L79.99999999999999,32"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
-                    />
-                    <path
-                      d="M129.99999999999997,48L129.99999999999997,32"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
-                    />
-                    <path
-                      d="M179.99999999999997,48L179.99999999999997,32"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
-                    />
-                    <path
-                      d="M229.99999999999997,48L229.99999999999997,32"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
-                    />
-                    <path
-                      d="M280,48L280,32"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
-                    />
-                    <path
-                      d="M330,48L330,32"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
-                    />
-                    <path
-                      d="M380,48L380,32"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
-                    />
-                    <path
-                      d="M430,48L430,32"
-                      fill="none"
-                      stroke="#000000"
-                      stroke-width="2"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
-                    />
-                    <path
-                      d="M29.999999999999982,48L29.999999999999982,32"
-                      fill="none"
-                      stroke="#6495ed"
-                      stroke-width="3.5"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 3.5;"
-                    />
-                    <path
-                      d="M430,48L430,32"
-                      fill="none"
-                      stroke="#6495ed"
-                      stroke-width="3.5"
-                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 3.5;"
-                    />
-                  </svg>
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <rect
+                    fill="#000000"
+                    height="80"
+                    opacity="0"
+                    r="0"
+                    rx="0"
+                    ry="0"
+                    stroke="#000"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0;"
+                    width="288"
+                    x="0"
+                    y="0"
+                  />
+                </svg>
+                <svg
+                  height="80"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  version="1.1"
+                  width="288"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <path
+                    d="M281.05,45.6C281.05,45.6,286.3,40,286.3,40C286.3,40,281.05,34.4,281.05,34.4"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; stroke-linejoin: round; stroke-linecap: round;"
+                    transform=""
+                  />
+                  <path
+                    d="M144,40C144,40,144,40,286.95,40"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M-4.849999999999988,45.6C-4.849999999999988,45.6,0.4000000000000119,40,0.4000000000000119,40C0.4000000000000119,40,-4.849999999999988,34.4,-4.849999999999988,34.4"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; stroke-linejoin: round; stroke-linecap: round;"
+                    transform="rotate(180 1.0500100000000114 40)"
+                  />
+                  <path
+                    d="M144,40C144,40,144,40,1.0500000000000114,40"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M29.999999999999993,48L29.999999999999993,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 2;"
+                  />
+                  <path
+                    d="M58.49999999999999,48L58.49999999999999,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 2;"
+                  />
+                  <path
+                    d="M86.99999999999999,48L86.99999999999999,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 2;"
+                  />
+                  <path
+                    d="M115.49999999999999,48L115.49999999999999,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 2;"
+                  />
+                  <path
+                    d="M144,48L144,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 2;"
+                  />
+                  <path
+                    d="M172.5,48L172.5,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 2;"
+                  />
+                  <path
+                    d="M201,48L201,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 2;"
+                  />
+                  <path
+                    d="M229.5,48L229.5,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 2;"
+                  />
+                  <path
+                    d="M258,48L258,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 2;"
+                  />
+                  <path
+                    d="M29.999999999999993,48L29.999999999999993,32"
+                    fill="none"
+                    stroke="#11accd"
+                    stroke-width="3.5"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 3.5;"
+                  />
+                  <path
+                    d="M258,48L258,32"
+                    fill="none"
+                    stroke="#11accd"
+                    stroke-width="3.5"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 3.5;"
+                  />
+                </svg>
+                <div
+                  style="position: absolute; left: 0px; top: 0px;"
+                >
                   <div
-                    style="position: absolute; left: 0px; top: 0px;"
+                    style="position: absolute; width: 24px; height: 24px; left: 17.999999999999993px; top: 28px; filter: drop-shadow(0px 0px 5px rgba(0, 0, 0, 0.5)); transform: translateX(0px) translateY(0px) translateZ(0);"
                   >
-                    <div
-                      style="position: absolute; width: 34px; height: 34px; left: 12.999999999999982px; top: 23px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                    <svg
+                      height="24"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        height="34"
+                      <desc
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="34"
-                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="NaN"
-                          cy="NaN"
-                          fill="#71b307"
-                          r="NaN"
-                          rx="6"
-                          ry="6"
-                          stroke="#71b307"
-                          stroke-width="1"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
-                          transform=""
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    style="position: absolute; left: 0px; top: 0px; z-index: 2;"
-                  >
-                    <div
-                      data-interactive-kind-for-testing="movable-point"
-                      style="position: absolute; width: 48px; height: 48px; left: 5.999999999999982px; top: 16px; transform: translateX(0px) translateY(0px) translateZ(0);"
-                    >
-                      <svg
-                        height="48"
+                        Created with Raphaël
+                      </desc>
+                      <defs
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        version="1.1"
-                        width="48"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <desc
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        >
-                          Created with Raphaël
-                        </desc>
-                        <defs
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
-                        />
-                        <ellipse
-                          cx="24"
-                          cy="24"
-                          fill="#000000"
-                          opacity="0"
-                          rx="24"
-                          ry="24"
-                          stroke="#000"
-                          style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
-                        />
-                      </svg>
-                    </div>
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#71b307"
+                        r="NaN"
+                        rx="7"
+                        ry="7"
+                        stroke="#ffffff"
+                        stroke-width="3"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 3;"
+                        transform=""
+                      />
+                    </svg>
                   </div>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="-4"
-                    style="position: absolute; padding: 7px; color: black; left: 29.999999999999982px; top: 61.2px; fill: none;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="-3"
-                    style="position: absolute; padding: 7px; color: black; left: 79.99999999999999px; top: 61.2px; fill: none;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="-2"
-                    style="position: absolute; padding: 7px; color: black; left: 129.99999999999997px; top: 61.2px; fill: none;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="-1"
-                    style="position: absolute; padding: 7px; color: black; left: 179.99999999999997px; top: 61.2px; fill: none;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="0"
-                    style="position: absolute; padding: 7px; color: black; left: 229.99999999999997px; top: 61.2px; fill: none;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="1"
-                    style="position: absolute; padding: 7px; color: black; left: 280px; top: 61.2px; fill: none;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="2"
-                    style="position: absolute; padding: 7px; color: black; left: 330px; top: 61.2px; fill: none;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="3"
-                    style="position: absolute; padding: 7px; color: black; left: 380px; top: 61.2px; fill: none;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="4"
-                    style="position: absolute; padding: 7px; color: black; left: 430px; top: 61.2px; fill: none;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="-4"
-                    style="position: absolute; padding: 7px; color: black; left: 29.999999999999982px; top: 61.2px; fill: none;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
-                  <span
-                    class="graphie-label"
-                    data-math-formula="4"
-                    style="position: absolute; padding: 7px; color: black; left: 430px; top: 61.2px; fill: none;"
-                  >
-                    <span
-                      class="katex-holder"
-                    />
-                    <span
-                      class="mathjax-holder"
-                    />
-                  </span>
                 </div>
+                <div
+                  style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                >
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 5.999999999999993px; top: 16px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-4"
+                  style="position: absolute; padding: 7px; color: black; left: 29.999999999999993px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-3"
+                  style="position: absolute; padding: 7px; color: black; left: 58.49999999999999px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-2"
+                  style="position: absolute; padding: 7px; color: black; left: 86.99999999999999px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-1"
+                  style="position: absolute; padding: 7px; color: black; left: 115.49999999999999px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="0"
+                  style="position: absolute; padding: 7px; color: black; left: 144px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="1"
+                  style="position: absolute; padding: 7px; color: black; left: 172.5px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="2"
+                  style="position: absolute; padding: 7px; color: black; left: 201px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="3"
+                  style="position: absolute; padding: 7px; color: black; left: 229.5px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="4"
+                  style="position: absolute; padding: 7px; color: black; left: 258px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-4"
+                  style="position: absolute; padding: 7px; color: rgb(17, 172, 205); left: 29.999999999999993px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="4"
+                  style="position: absolute; padding: 7px; color: rgb(17, 172, 205); left: 258px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
               </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </span>
+  </div>
+</div>
+`;
+
+exports[`number-line widget should snapshot: first render 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph perseus-paragraph-centered"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="perseus-block-math"
+      >
+        <div
+          class="perseus-block-math-inner"
+          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+        >
+          <span
+            class="mock-TeX"
+          >
+            E=2.5
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
+      <div
+        class="paragraph"
+      >
+        <strong>
+          Move the dot to 
+          <span
+            style="white-space: nowrap;"
+          >
+            <span />
+            <span
+              class="mock-TeX"
+            >
+              -E
+            </span>
+            <span />
+          </span>
+           on the number line.
+        </strong>
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <div
+            class="perseus-widget perseus-widget-interactive-number-line"
+          >
+            <div
+              class="graphie-container"
+            >
+              <div
+                class="graphie"
+                style="position: relative; width: 459.99999999999994px; height: 80px;"
+              >
+                <svg
+                  height="80"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
+                  version="1.1"
+                  width="460"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <rect
+                    fill="#000000"
+                    height="80"
+                    opacity="0"
+                    r="0"
+                    rx="0"
+                    ry="0"
+                    stroke="#000"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0;"
+                    width="460"
+                    x="0"
+                    y="0"
+                  />
+                </svg>
+                <svg
+                  height="80"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  version="1.1"
+                  width="459.99999999999994"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <path
+                    d="M454.44999999999993,45.6C454.79999999999995,43.5,458.6499999999999,40.35,459.69999999999993,40C458.6499999999999,39.65,454.79999999999995,36.5,454.44999999999993,34.4"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; stroke-linejoin: round; stroke-linecap: round;"
+                    transform=""
+                  />
+                  <path
+                    d="M229.99999999999997,40C229.99999999999997,40,229.99999999999997,40,458.94999999999993,40"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M-3.4499999999999886,45.6C-3.0999999999999885,43.5,0.7500000000000115,40.35,1.8000000000000114,40C0.7500000000000113,39.65,-3.099999999999989,36.5,-3.4499999999999886,34.4"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; stroke-linejoin: round; stroke-linecap: round;"
+                    transform="rotate(180 1.8000000000000114 40)"
+                  />
+                  <path
+                    d="M229.99999999999997,40C229.99999999999997,40,229.99999999999997,40,1.0500000000000114,40"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M29.999999999999982,48L29.999999999999982,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M79.99999999999999,48L79.99999999999999,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M129.99999999999997,48L129.99999999999997,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M179.99999999999997,48L179.99999999999997,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M229.99999999999997,48L229.99999999999997,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M280,48L280,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M330,48L330,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M380,48L380,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M430,48L430,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M29.999999999999982,48L29.999999999999982,32"
+                    fill="none"
+                    stroke="#6495ed"
+                    stroke-width="3.5"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 3.5;"
+                  />
+                  <path
+                    d="M430,48L430,32"
+                    fill="none"
+                    stroke="#6495ed"
+                    stroke-width="3.5"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 3.5;"
+                  />
+                </svg>
+                <div
+                  style="position: absolute; left: 0px; top: 0px;"
+                >
+                  <div
+                    style="position: absolute; width: 34px; height: 34px; left: 12.999999999999982px; top: 23px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="34"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="34"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#71b307"
+                        r="NaN"
+                        rx="6"
+                        ry="6"
+                        stroke="#71b307"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
+                        transform=""
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                >
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 5.999999999999982px; top: 16px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-4"
+                  style="position: absolute; padding: 7px; color: black; left: 29.999999999999982px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-3"
+                  style="position: absolute; padding: 7px; color: black; left: 79.99999999999999px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-2"
+                  style="position: absolute; padding: 7px; color: black; left: 129.99999999999997px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-1"
+                  style="position: absolute; padding: 7px; color: black; left: 179.99999999999997px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="0"
+                  style="position: absolute; padding: 7px; color: black; left: 229.99999999999997px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="1"
+                  style="position: absolute; padding: 7px; color: black; left: 280px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="2"
+                  style="position: absolute; padding: 7px; color: black; left: 330px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="3"
+                  style="position: absolute; padding: 7px; color: black; left: 380px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="4"
+                  style="position: absolute; padding: 7px; color: black; left: 430px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-4"
+                  style="position: absolute; padding: 7px; color: black; left: 29.999999999999982px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="4"
+                  style="position: absolute; padding: 7px; color: black; left: 430px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="katex-holder"
+                  />
+                  <span
+                    class="mathjax-holder"
+                  />
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/numeric-input.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/numeric-input.test.ts.snap
@@ -2,487 +2,467 @@
 
 exports[`Numeric input widget styles differently on mobile: mobile render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
+        <span
+          style="white-space: nowrap;"
         >
+          <span />
           <span
-            style="white-space: nowrap;"
+            class="mock-TeX"
           >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              5008 \\div 4 =
-            </span>
-            <span />
+            5008 \\div 4 =
           </span>
-           
+          <span />
+        </span>
+         
+        <div
+          class="perseus-widget-container widget-nohighlight widget-inline-block"
+        >
           <div
-            class="perseus-widget-container widget-nohighlight widget-inline-block"
+            aria-label="Math input box Tap with one or two fingers to open keyboard"
+            class="initial_4qg14c-o_O-input_1n1c032"
+            role="textbox"
           >
             <div
-              aria-label="Math input box Tap with one or two fingers to open keyboard"
-              class="initial_4qg14c-o_O-input_1n1c032"
-              role="textbox"
+              class="keypad-input"
+              tabindex="0"
             >
               <div
-                class="keypad-input"
-                tabindex="0"
+                class="mq-editable-field mq-math-mode"
+                style="background-color: white; min-height: 44px; min-width: 64px; max-width: 128px; box-sizing: border-box; position: relative; border-style: solid; border-color: rgba(33,36,44,0.50); border-radius: 4px; color: rgb(33, 36, 44); border-width: 1px;"
               >
-                <div
-                  class="mq-editable-field mq-math-mode"
-                  style="background-color: white; min-height: 44px; min-width: 64px; max-width: 128px; box-sizing: border-box; position: relative; border-style: solid; border-color: rgba(33,36,44,0.50); border-radius: 4px; color: rgb(33, 36, 44); border-width: 1px;"
+                <span
+                  class="mq-textarea"
                 >
-                  <span
-                    class="mq-textarea"
-                  >
-                    <span />
-                  </span>
-                  <span
-                    class="mq-root-block mq-empty"
-                    mathquill-block-id="1"
-                    style="padding: 10px 11px 8px 11px; font-size: 18pt;"
-                  />
-                </div>
+                  <span />
+                </span>
+                <span
+                  class="mq-root-block mq-empty"
+                  mathquill-block-id="1"
+                  style="padding: 10px 11px 8px 11px; font-size: 18pt;"
+                />
               </div>
             </div>
           </div>
-           
         </div>
+         
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`numeric-input widget Should render predictably: after interaction 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
+        <span
+          style="white-space: nowrap;"
         >
+          <span />
           <span
-            style="white-space: nowrap;"
+            class="mock-TeX"
           >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              5008 \\div 4 =
-            </span>
-            <span />
+            5008 \\div 4 =
           </span>
-           
-          <div
-            class="perseus-widget-container widget-nohighlight widget-inline-block"
-          >
-            <div>
-              <span>
-                <div>
-                  <input
-                    aria-label="Your answer:"
-                    autocapitalize="off"
-                    autocomplete="off"
-                    autocorrect="off"
-                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-focused_1z0d9ul-o_O-input_19vw1dn"
-                    id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
-                    type="text"
-                    value="1252"
-                  />
-                </div>
+          <span />
+        </span>
+         
+        <div
+          class="perseus-widget-container widget-nohighlight widget-inline-block"
+        >
+          <div>
+            <span>
+              <div>
+                <input
+                  aria-label="Your answer:"
+                  autocapitalize="off"
+                  autocomplete="off"
+                  autocorrect="off"
+                  class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-focused_1z0d9ul-o_O-input_19vw1dn"
+                  id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                  type="text"
+                  value="1252"
+                />
+              </div>
+              <div
+                style="position: relative; height: 0px; display: none;"
+              >
                 <div
-                  style="position: relative; height: 0px; display: none;"
+                  class="tooltipContainer"
+                  style="position: absolute; left: 0px;"
                 >
                   <div
-                    class="tooltipContainer"
-                    style="position: absolute; left: 0px;"
+                    style="display: block; position: relative; visibility: visible; left: 0px; top: -1px; width: 12px; height: 11px; margin-top: -1px; margin-bottom: -2px; z-index: 10;"
                   >
                     <div
-                      style="display: block; position: relative; visibility: visible; left: 0px; top: -1px; width: 12px; height: 11px; margin-top: -1px; margin-bottom: -2px; z-index: 10;"
-                    >
-                      <div
-                        style="display: block; height: 0px; width: 0px; position: absolute; left: 0px; top: -1px; border-right: 12px solid transparent; border-bottom: 12px solid #ccc;"
-                      />
-                      <div
-                        style="display: block; height: 0px; width: 0px; position: absolute; left: 1px; top: 1px; border-right: 10px solid transparent; border-bottom: 10px solid white;"
-                      />
-                    </div>
+                      style="display: block; height: 0px; width: 0px; position: absolute; left: 0px; top: -1px; border-right: 12px solid transparent; border-bottom: 12px solid #ccc;"
+                    />
                     <div
-                      class="perseus-formats-tooltip preview-measure"
-                      style="position: relative; top: 0px; left: 0px; border: 1px solid #ccc; box-shadow: 0 1px 3px #ccc; z-index: 9;"
+                      style="display: block; height: 0px; width: 0px; position: absolute; left: 1px; top: 1px; border-right: 10px solid transparent; border-bottom: 10px solid white;"
+                    />
+                  </div>
+                  <div
+                    class="perseus-formats-tooltip preview-measure"
+                    style="position: relative; top: 0px; left: 0px; border: 1px solid #ccc; box-shadow: 0 1px 3px #ccc; z-index: 9;"
+                  >
+                    <div
+                      id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
                     >
                       <div
-                        id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                        class="perseus-renderer perseus-renderer-responsive"
                       >
-                        <span
-                          class="mock-KatexProvider"
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
                         >
-                          <div
-                            class="perseus-renderer perseus-renderer-responsive"
-                          >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <ul>
-                                <li>
-                                  <strong>
-                                    Your answer should be
-                                  </strong>
-                                </li>
-                                <li>
-                                  an integer, like 
-                                  <span
-                                    style="white-space: nowrap;"
-                                  >
-                                    <span />
-                                    <span
-                                      class="mock-TeX"
-                                    >
-                                      6
-                                    </span>
-                                    <span />
-                                  </span>
-                                </li>
-                                <li>
-                                  a 
-                                  <em>
-                                    simplified proper
-                                  </em>
-                                   fraction, like 
-                                  <span
-                                    style="white-space: nowrap;"
-                                  >
-                                    <span />
-                                    <span
-                                      class="mock-TeX"
-                                    >
-                                      3/5
-                                    </span>
-                                    <span />
-                                  </span>
-                                </li>
-                                <li>
-                                  a 
-                                  <em>
-                                    simplified improper
-                                  </em>
-                                   fraction, like 
-                                  <span
-                                    style="white-space: nowrap;"
-                                  >
-                                    <span />
-                                    <span
-                                      class="mock-TeX"
-                                    >
-                                      7/4
-                                    </span>
-                                    <span />
-                                  </span>
-                                </li>
-                                <li>
-                                  a mixed number, like 
-                                  <span
-                                    style="white-space: nowrap;"
-                                  >
-                                    <span />
-                                    <span
-                                      class="mock-TeX"
-                                    >
-                                      1\\ 3/4
-                                    </span>
-                                    <span />
-                                  </span>
-                                </li>
-                                <li>
-                                  an 
-                                  <em>
-                                    exact
-                                  </em>
-                                   decimal, like 
-                                  <span
-                                    style="white-space: nowrap;"
-                                  >
-                                    <span />
-                                    <span
-                                      class="mock-TeX"
-                                    >
-                                      0.75
-                                    </span>
-                                    <span />
-                                  </span>
-                                </li>
-                                <li>
-                                  a multiple of pi, like 
-                                  <span
-                                    style="white-space: nowrap;"
-                                  >
-                                    <span />
-                                    <span
-                                      class="mock-TeX"
-                                    >
-                                      12\\ \\text{pi}
-                                    </span>
-                                    <span />
-                                  </span>
-                                   or 
-                                  <span
-                                    style="white-space: nowrap;"
-                                  >
-                                    <span />
-                                    <span
-                                      class="mock-TeX"
-                                    >
-                                      2/3\\ \\text{pi}
-                                    </span>
-                                    <span />
-                                  </span>
-                                </li>
-                              </ul>
-                            </div>
-                          </div>
-                        </span>
+                          <ul>
+                            <li>
+                              <strong>
+                                Your answer should be
+                              </strong>
+                            </li>
+                            <li>
+                              an integer, like 
+                              <span
+                                style="white-space: nowrap;"
+                              >
+                                <span />
+                                <span
+                                  class="mock-TeX"
+                                >
+                                  6
+                                </span>
+                                <span />
+                              </span>
+                            </li>
+                            <li>
+                              a 
+                              <em>
+                                simplified proper
+                              </em>
+                               fraction, like 
+                              <span
+                                style="white-space: nowrap;"
+                              >
+                                <span />
+                                <span
+                                  class="mock-TeX"
+                                >
+                                  3/5
+                                </span>
+                                <span />
+                              </span>
+                            </li>
+                            <li>
+                              a 
+                              <em>
+                                simplified improper
+                              </em>
+                               fraction, like 
+                              <span
+                                style="white-space: nowrap;"
+                              >
+                                <span />
+                                <span
+                                  class="mock-TeX"
+                                >
+                                  7/4
+                                </span>
+                                <span />
+                              </span>
+                            </li>
+                            <li>
+                              a mixed number, like 
+                              <span
+                                style="white-space: nowrap;"
+                              >
+                                <span />
+                                <span
+                                  class="mock-TeX"
+                                >
+                                  1\\ 3/4
+                                </span>
+                                <span />
+                              </span>
+                            </li>
+                            <li>
+                              an 
+                              <em>
+                                exact
+                              </em>
+                               decimal, like 
+                              <span
+                                style="white-space: nowrap;"
+                              >
+                                <span />
+                                <span
+                                  class="mock-TeX"
+                                >
+                                  0.75
+                                </span>
+                                <span />
+                              </span>
+                            </li>
+                            <li>
+                              a multiple of pi, like 
+                              <span
+                                style="white-space: nowrap;"
+                              >
+                                <span />
+                                <span
+                                  class="mock-TeX"
+                                >
+                                  12\\ \\text{pi}
+                                </span>
+                                <span />
+                              </span>
+                               or 
+                              <span
+                                style="white-space: nowrap;"
+                              >
+                                <span />
+                                <span
+                                  class="mock-TeX"
+                                >
+                                  2/3\\ \\text{pi}
+                                </span>
+                                <span />
+                              </span>
+                            </li>
+                          </ul>
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </span>
-            </div>
+              </div>
+            </span>
           </div>
-           
         </div>
+         
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`numeric-input widget Should render predictably: first render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
+        <span
+          style="white-space: nowrap;"
         >
+          <span />
           <span
-            style="white-space: nowrap;"
+            class="mock-TeX"
           >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              5008 \\div 4 =
-            </span>
-            <span />
+            5008 \\div 4 =
           </span>
-           
-          <div
-            class="perseus-widget-container widget-nohighlight widget-inline-block"
-          >
-            <div>
-              <span>
-                <div>
-                  <input
-                    aria-label="Your answer:"
-                    autocapitalize="off"
-                    autocomplete="off"
-                    autocorrect="off"
-                    class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_19vw1dn"
-                    id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
-                    type="text"
-                    value=""
-                  />
-                </div>
+          <span />
+        </span>
+         
+        <div
+          class="perseus-widget-container widget-nohighlight widget-inline-block"
+        >
+          <div>
+            <span>
+              <div>
+                <input
+                  aria-label="Your answer:"
+                  autocapitalize="off"
+                  autocomplete="off"
+                  autocorrect="off"
+                  class="input_1t4b01j-o_O-LabelMedium_1rew30o-o_O-default_1r2dwp3-o_O-input_19vw1dn"
+                  id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                  type="text"
+                  value=""
+                />
+              </div>
+              <div
+                style="position: relative; height: 0px; display: none;"
+              >
                 <div
-                  style="position: relative; height: 0px; display: none;"
+                  class="tooltipContainer"
+                  style="position: absolute; left: 0px;"
                 >
                   <div
-                    class="tooltipContainer"
-                    style="position: absolute; left: 0px;"
+                    style="display: block; position: relative; visibility: visible; left: 0px; top: -1px; width: 12px; height: 11px; margin-top: -1px; margin-bottom: -2px; z-index: 10;"
                   >
                     <div
-                      style="display: block; position: relative; visibility: visible; left: 0px; top: -1px; width: 12px; height: 11px; margin-top: -1px; margin-bottom: -2px; z-index: 10;"
-                    >
-                      <div
-                        style="display: block; height: 0px; width: 0px; position: absolute; left: 0px; top: -1px; border-right: 12px solid transparent; border-bottom: 12px solid #ccc;"
-                      />
-                      <div
-                        style="display: block; height: 0px; width: 0px; position: absolute; left: 1px; top: 1px; border-right: 10px solid transparent; border-bottom: 10px solid white;"
-                      />
-                    </div>
+                      style="display: block; height: 0px; width: 0px; position: absolute; left: 0px; top: -1px; border-right: 12px solid transparent; border-bottom: 12px solid #ccc;"
+                    />
                     <div
-                      class="perseus-formats-tooltip preview-measure"
-                      style="position: relative; top: 0px; left: 0px; border: 1px solid #ccc; box-shadow: 0 1px 3px #ccc; z-index: 9;"
+                      style="display: block; height: 0px; width: 0px; position: absolute; left: 1px; top: 1px; border-right: 10px solid transparent; border-bottom: 10px solid white;"
+                    />
+                  </div>
+                  <div
+                    class="perseus-formats-tooltip preview-measure"
+                    style="position: relative; top: 0px; left: 0px; border: 1px solid #ccc; box-shadow: 0 1px 3px #ccc; z-index: 9;"
+                  >
+                    <div
+                      id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
                     >
                       <div
-                        id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                        class="perseus-renderer perseus-renderer-responsive"
                       >
-                        <span
-                          class="mock-KatexProvider"
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
                         >
-                          <div
-                            class="perseus-renderer perseus-renderer-responsive"
-                          >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <ul>
-                                <li>
-                                  <strong>
-                                    Your answer should be
-                                  </strong>
-                                </li>
-                                <li>
-                                  an integer, like 
-                                  <span
-                                    style="white-space: nowrap;"
-                                  >
-                                    <span />
-                                    <span
-                                      class="mock-TeX"
-                                    >
-                                      6
-                                    </span>
-                                    <span />
-                                  </span>
-                                </li>
-                                <li>
-                                  a 
-                                  <em>
-                                    simplified proper
-                                  </em>
-                                   fraction, like 
-                                  <span
-                                    style="white-space: nowrap;"
-                                  >
-                                    <span />
-                                    <span
-                                      class="mock-TeX"
-                                    >
-                                      3/5
-                                    </span>
-                                    <span />
-                                  </span>
-                                </li>
-                                <li>
-                                  a 
-                                  <em>
-                                    simplified improper
-                                  </em>
-                                   fraction, like 
-                                  <span
-                                    style="white-space: nowrap;"
-                                  >
-                                    <span />
-                                    <span
-                                      class="mock-TeX"
-                                    >
-                                      7/4
-                                    </span>
-                                    <span />
-                                  </span>
-                                </li>
-                                <li>
-                                  a mixed number, like 
-                                  <span
-                                    style="white-space: nowrap;"
-                                  >
-                                    <span />
-                                    <span
-                                      class="mock-TeX"
-                                    >
-                                      1\\ 3/4
-                                    </span>
-                                    <span />
-                                  </span>
-                                </li>
-                                <li>
-                                  an 
-                                  <em>
-                                    exact
-                                  </em>
-                                   decimal, like 
-                                  <span
-                                    style="white-space: nowrap;"
-                                  >
-                                    <span />
-                                    <span
-                                      class="mock-TeX"
-                                    >
-                                      0.75
-                                    </span>
-                                    <span />
-                                  </span>
-                                </li>
-                                <li>
-                                  a multiple of pi, like 
-                                  <span
-                                    style="white-space: nowrap;"
-                                  >
-                                    <span />
-                                    <span
-                                      class="mock-TeX"
-                                    >
-                                      12\\ \\text{pi}
-                                    </span>
-                                    <span />
-                                  </span>
-                                   or 
-                                  <span
-                                    style="white-space: nowrap;"
-                                  >
-                                    <span />
-                                    <span
-                                      class="mock-TeX"
-                                    >
-                                      2/3\\ \\text{pi}
-                                    </span>
-                                    <span />
-                                  </span>
-                                </li>
-                              </ul>
-                            </div>
-                          </div>
-                        </span>
+                          <ul>
+                            <li>
+                              <strong>
+                                Your answer should be
+                              </strong>
+                            </li>
+                            <li>
+                              an integer, like 
+                              <span
+                                style="white-space: nowrap;"
+                              >
+                                <span />
+                                <span
+                                  class="mock-TeX"
+                                >
+                                  6
+                                </span>
+                                <span />
+                              </span>
+                            </li>
+                            <li>
+                              a 
+                              <em>
+                                simplified proper
+                              </em>
+                               fraction, like 
+                              <span
+                                style="white-space: nowrap;"
+                              >
+                                <span />
+                                <span
+                                  class="mock-TeX"
+                                >
+                                  3/5
+                                </span>
+                                <span />
+                              </span>
+                            </li>
+                            <li>
+                              a 
+                              <em>
+                                simplified improper
+                              </em>
+                               fraction, like 
+                              <span
+                                style="white-space: nowrap;"
+                              >
+                                <span />
+                                <span
+                                  class="mock-TeX"
+                                >
+                                  7/4
+                                </span>
+                                <span />
+                              </span>
+                            </li>
+                            <li>
+                              a mixed number, like 
+                              <span
+                                style="white-space: nowrap;"
+                              >
+                                <span />
+                                <span
+                                  class="mock-TeX"
+                                >
+                                  1\\ 3/4
+                                </span>
+                                <span />
+                              </span>
+                            </li>
+                            <li>
+                              an 
+                              <em>
+                                exact
+                              </em>
+                               decimal, like 
+                              <span
+                                style="white-space: nowrap;"
+                              >
+                                <span />
+                                <span
+                                  class="mock-TeX"
+                                >
+                                  0.75
+                                </span>
+                                <span />
+                              </span>
+                            </li>
+                            <li>
+                              a multiple of pi, like 
+                              <span
+                                style="white-space: nowrap;"
+                              >
+                                <span />
+                                <span
+                                  class="mock-TeX"
+                                >
+                                  12\\ \\text{pi}
+                                </span>
+                                <span />
+                              </span>
+                               or 
+                              <span
+                                style="white-space: nowrap;"
+                              >
+                                <span />
+                                <span
+                                  class="mock-TeX"
+                                >
+                                  2/3\\ \\text{pi}
+                                </span>
+                                <span />
+                              </span>
+                            </li>
+                          </ul>
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </span>
-            </div>
+              </div>
+            </span>
           </div>
-           
         </div>
+         
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/orderer.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/orderer.test.ts.snap
@@ -2,274 +2,242 @@
 
 exports[`orderer widget should snapshot on mobile: first mobile render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          <strong>
-            Without using a calculator, put the numbers in order  from least to greatest.
-          </strong>
-            
-        </div>
+        <strong>
+          Without using a calculator, put the numbers in order  from least to greatest.
+        </strong>
+          
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="1"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+            class="draggy-boxy-thing orderer height-normal layout-horizontal above-scratchpad blank-background perseus-clearfix perseus-interactive"
           >
             <div
-              class="draggy-boxy-thing orderer height-normal layout-horizontal above-scratchpad blank-background perseus-clearfix perseus-interactive"
+              class="bank perseus-clearfix"
             >
               <div
-                class="bank perseus-clearfix"
+                class="card-wrap perseus-interactive"
               >
                 <div
-                  class="card-wrap perseus-interactive"
+                  class="card stack"
                 >
                   <div
-                    class="card stack"
+                    class="perseus-renderer perseus-renderer-responsive"
                   >
-                    <span
-                      class="mock-KatexProvider"
+                    <div
+                      class="paragraph"
+                      data-perseus-paragraph-index="0"
                     >
                       <div
-                        class="perseus-renderer perseus-renderer-responsive"
+                        class="paragraph"
                       >
-                        <div
-                          class="paragraph"
-                          data-perseus-paragraph-index="0"
-                        >
-                          <div
-                            class="paragraph"
-                          >
-                            1
-                          </div>
-                        </div>
+                        1
                       </div>
-                    </span>
-                  </div>
-                </div>
-                <div
-                  class="card-wrap perseus-interactive"
-                >
-                  <div
-                    class="card stack"
-                  >
-                    <span
-                      class="mock-KatexProvider"
-                    >
-                      <div
-                        class="perseus-renderer perseus-renderer-responsive"
-                      >
-                        <div
-                          class="paragraph"
-                          data-perseus-paragraph-index="0"
-                        >
-                          <div
-                            class="paragraph"
-                          >
-                            3
-                          </div>
-                        </div>
-                      </div>
-                    </span>
-                  </div>
-                </div>
-                <div
-                  class="card-wrap perseus-interactive"
-                >
-                  <div
-                    class="card stack"
-                  >
-                    <span
-                      class="mock-KatexProvider"
-                    >
-                      <div
-                        class="perseus-renderer perseus-renderer-responsive"
-                      >
-                        <div
-                          class="paragraph"
-                          data-perseus-paragraph-index="0"
-                        >
-                          <div
-                            class="paragraph"
-                          >
-                            2
-                          </div>
-                        </div>
-                      </div>
-                    </span>
+                    </div>
                   </div>
                 </div>
               </div>
               <div
-                class="perseus-clearfix draggable-box"
+                class="card-wrap perseus-interactive"
               >
                 <div
-                  class="card-wrap perseus-interactive"
+                  class="card stack"
                 >
                   <div
-                    class="card drag-hint"
-                  />
+                    class="perseus-renderer perseus-renderer-responsive"
+                  >
+                    <div
+                      class="paragraph"
+                      data-perseus-paragraph-index="0"
+                    >
+                      <div
+                        class="paragraph"
+                      >
+                        3
+                      </div>
+                    </div>
+                  </div>
                 </div>
-                <div />
               </div>
+              <div
+                class="card-wrap perseus-interactive"
+              >
+                <div
+                  class="card stack"
+                >
+                  <div
+                    class="perseus-renderer perseus-renderer-responsive"
+                  >
+                    <div
+                      class="paragraph"
+                      data-perseus-paragraph-index="0"
+                    >
+                      <div
+                        class="paragraph"
+                      >
+                        2
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="perseus-clearfix draggable-box"
+            >
+              <div
+                class="card-wrap perseus-interactive"
+              >
+                <div
+                  class="card drag-hint"
+                />
+              </div>
+              <div />
             </div>
           </div>
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`orderer widget should snapshot: first render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          <strong>
-            Without using a calculator, put the numbers in order  from least to greatest.
-          </strong>
-            
-        </div>
+        <strong>
+          Without using a calculator, put the numbers in order  from least to greatest.
+        </strong>
+          
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="1"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+            class="draggy-boxy-thing orderer height-normal layout-horizontal above-scratchpad blank-background perseus-clearfix perseus-interactive"
           >
             <div
-              class="draggy-boxy-thing orderer height-normal layout-horizontal above-scratchpad blank-background perseus-clearfix perseus-interactive"
+              class="bank perseus-clearfix"
             >
               <div
-                class="bank perseus-clearfix"
+                class="card-wrap perseus-interactive"
               >
                 <div
-                  class="card-wrap perseus-interactive"
+                  class="card stack"
                 >
                   <div
-                    class="card stack"
+                    class="perseus-renderer perseus-renderer-responsive"
                   >
-                    <span
-                      class="mock-KatexProvider"
+                    <div
+                      class="paragraph"
+                      data-perseus-paragraph-index="0"
                     >
                       <div
-                        class="perseus-renderer perseus-renderer-responsive"
+                        class="paragraph"
                       >
-                        <div
-                          class="paragraph"
-                          data-perseus-paragraph-index="0"
-                        >
-                          <div
-                            class="paragraph"
-                          >
-                            1
-                          </div>
-                        </div>
+                        1
                       </div>
-                    </span>
-                  </div>
-                </div>
-                <div
-                  class="card-wrap perseus-interactive"
-                >
-                  <div
-                    class="card stack"
-                  >
-                    <span
-                      class="mock-KatexProvider"
-                    >
-                      <div
-                        class="perseus-renderer perseus-renderer-responsive"
-                      >
-                        <div
-                          class="paragraph"
-                          data-perseus-paragraph-index="0"
-                        >
-                          <div
-                            class="paragraph"
-                          >
-                            3
-                          </div>
-                        </div>
-                      </div>
-                    </span>
-                  </div>
-                </div>
-                <div
-                  class="card-wrap perseus-interactive"
-                >
-                  <div
-                    class="card stack"
-                  >
-                    <span
-                      class="mock-KatexProvider"
-                    >
-                      <div
-                        class="perseus-renderer perseus-renderer-responsive"
-                      >
-                        <div
-                          class="paragraph"
-                          data-perseus-paragraph-index="0"
-                        >
-                          <div
-                            class="paragraph"
-                          >
-                            2
-                          </div>
-                        </div>
-                      </div>
-                    </span>
+                    </div>
                   </div>
                 </div>
               </div>
               <div
-                class="perseus-clearfix draggable-box"
+                class="card-wrap perseus-interactive"
               >
                 <div
-                  class="card-wrap perseus-interactive"
+                  class="card stack"
                 >
                   <div
-                    class="card drag-hint"
-                  />
+                    class="perseus-renderer perseus-renderer-responsive"
+                  >
+                    <div
+                      class="paragraph"
+                      data-perseus-paragraph-index="0"
+                    >
+                      <div
+                        class="paragraph"
+                      >
+                        3
+                      </div>
+                    </div>
+                  </div>
                 </div>
-                <div />
               </div>
+              <div
+                class="card-wrap perseus-interactive"
+              >
+                <div
+                  class="card stack"
+                >
+                  <div
+                    class="perseus-renderer perseus-renderer-responsive"
+                  >
+                    <div
+                      class="paragraph"
+                      data-perseus-paragraph-index="0"
+                    >
+                      <div
+                        class="paragraph"
+                      >
+                        2
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="perseus-clearfix draggable-box"
+            >
+              <div
+                class="card-wrap perseus-interactive"
+              >
+                <div
+                  class="card drag-hint"
+                />
+              </div>
+              <div />
             </div>
           </div>
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/passage-ref.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/passage-ref.test.ts.snap
@@ -2,445 +2,433 @@
 
 exports[`passage-ref widget should render with invalid reference 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
-          <div
-            class="perseus-widget-container widget-nohighlight widget-block"
-          >
-            <div>
+          <div>
+            <div
+              class="perseus-widget-passage-container"
+            >
               <div
-                class="perseus-widget-passage-container"
+                class="perseus-widget-passage-instructions"
               >
-                <div
-                  class="perseus-widget-passage-instructions"
-                >
-                  
+                
 
-                </div>
-                <div
-                  class="perseus-widget-passage"
+              </div>
+              <div
+                class="perseus-widget-passage"
+              >
+                <h3
+                  class="perseus-sr-only"
                 >
-                  <h3
-                    class="perseus-sr-only"
-                  >
-                    Beginning of reading passage.
-                  </h3>
+                  Beginning of reading passage.
+                </h3>
+                <div
+                  class="passage-text"
+                >
                   <div
-                    class="passage-text"
+                    class="container_6htn2u"
                   >
+                    <div>
+                      <div>
+                        <div>
+                          <div />
+                        </div>
+                      </div>
+                    </div>
                     <div
-                      class="container_6htn2u"
+                      class="content_gor68n"
                     >
                       <div>
                         <div>
-                          <div>
-                            <div />
-                          </div>
-                        </div>
-                      </div>
-                      <div
-                        class="content_gor68n"
-                      >
-                        <div>
-                          <div>
-                            <div
-                              aria-hidden="true"
-                              class="measurer_225hir"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Line Height Measurement
-                              </div>
-                            </div>
+                          <div
+                            aria-hidden="true"
+                            class="measurer_225hir"
+                          >
                             <div
                               class="paragraph"
                             >
-                              <span>
-                                Our electronic devices are keeping us awake—not just because we spend time using them when we should be sleeping
-                              </span>
-                              <span>
-                                , but also because they emit a blue light that keeps our brains awake
-                              </span>
-                              <span>
-                                . One study showed that people who used screens that emitted blue light were unable to produce sufficient melatonin
-                              </span>
-                              <span>
-                                , a hormone that 
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                promotes
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                 sleep
-                              </span>
-                              <span>
-                                . In order to enjoy a more restful night
-                              </span>
-                              <span>
-                                , experts recommend shutting off screens at least two hours before bed
-                              </span>
-                              <span>
-                                . 
-                              </span>
+                              Line Height Measurement
                             </div>
+                          </div>
+                          <div
+                            class="paragraph"
+                          >
+                            <span>
+                              Our electronic devices are keeping us awake—not just because we spend time using them when we should be sleeping
+                            </span>
+                            <span>
+                              , but also because they emit a blue light that keeps our brains awake
+                            </span>
+                            <span>
+                              . One study showed that people who used screens that emitted blue light were unable to produce sufficient melatonin
+                            </span>
+                            <span>
+                              , a hormone that 
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                              promotes
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                               sleep
+                            </span>
+                            <span>
+                              . In order to enjoy a more restful night
+                            </span>
+                            <span>
+                              , experts recommend shutting off screens at least two hours before bed
+                            </span>
+                            <span>
+                              . 
+                            </span>
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
-                  <div
-                    class="perseus-sr-only"
-                  >
-                    End of reading passage.
-                  </div>
+                </div>
+                <div
+                  class="perseus-sr-only"
+                >
+                  End of reading passage.
                 </div>
               </div>
             </div>
           </div>
         </div>
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="1"
       >
+        We can see the word “promotes” is used in 
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-inline"
         >
-          We can see the word “promotes” is used in 
-          <div
-            class="perseus-widget-container widget-nohighlight widget-inline"
-          >
-            <span>
-              lines 
-              ?–?
-              
-            </span>
-          </div>
+          <span>
+            lines 
+            ?–?
+            
+          </span>
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`passage-ref widget should render with multi-line reference 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
-          <div
-            class="perseus-widget-container widget-nohighlight widget-block"
-          >
-            <div>
+          <div>
+            <div
+              class="perseus-widget-passage-container"
+            >
               <div
-                class="perseus-widget-passage-container"
+                class="perseus-widget-passage-instructions"
               >
-                <div
-                  class="perseus-widget-passage-instructions"
-                >
-                  
+                
 
-                </div>
-                <div
-                  class="perseus-widget-passage"
+              </div>
+              <div
+                class="perseus-widget-passage"
+              >
+                <h3
+                  class="perseus-sr-only"
                 >
-                  <h3
-                    class="perseus-sr-only"
-                  >
-                    Beginning of reading passage.
-                  </h3>
+                  Beginning of reading passage.
+                </h3>
+                <div
+                  class="passage-text"
+                >
                   <div
-                    class="passage-text"
+                    class="container_6htn2u"
                   >
+                    <div>
+                      <div>
+                        <div>
+                          <div />
+                        </div>
+                      </div>
+                    </div>
                     <div
-                      class="container_6htn2u"
+                      class="content_gor68n"
                     >
                       <div>
                         <div>
-                          <div>
-                            <div />
-                          </div>
-                        </div>
-                      </div>
-                      <div
-                        class="content_gor68n"
-                      >
-                        <div>
-                          <div>
-                            <div
-                              aria-hidden="true"
-                              class="measurer_225hir"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Line Height Measurement
-                              </div>
-                            </div>
+                          <div
+                            aria-hidden="true"
+                            class="measurer_225hir"
+                          >
                             <div
                               class="paragraph"
                             >
-                              <span>
-                                Our electronic devices are keeping us awake—not just because we spend time using them when we should be sleeping
-                              </span>
-                              <span>
-                                , but also because they emit a blue light that keeps our brains awake
-                              </span>
-                              <span>
-                                . One study showed that people who used screens that emitted blue light were unable to produce sufficient melatonin
-                              </span>
-                              <span>
-                                , a hormone that 
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                promotes
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                 sleep
-                              </span>
-                              <span>
-                                . In order to enjoy a more restful night
-                              </span>
-                              <span>
-                                , experts recommend shutting off screens at least two hours before bed
-                              </span>
-                              <span>
-                                . 
-                              </span>
+                              Line Height Measurement
                             </div>
+                          </div>
+                          <div
+                            class="paragraph"
+                          >
+                            <span>
+                              Our electronic devices are keeping us awake—not just because we spend time using them when we should be sleeping
+                            </span>
+                            <span>
+                              , but also because they emit a blue light that keeps our brains awake
+                            </span>
+                            <span>
+                              . One study showed that people who used screens that emitted blue light were unable to produce sufficient melatonin
+                            </span>
+                            <span>
+                              , a hormone that 
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                              promotes
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                               sleep
+                            </span>
+                            <span>
+                              . In order to enjoy a more restful night
+                            </span>
+                            <span>
+                              , experts recommend shutting off screens at least two hours before bed
+                            </span>
+                            <span>
+                              . 
+                            </span>
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
-                  <div
-                    class="perseus-sr-only"
-                  >
-                    End of reading passage.
-                  </div>
+                </div>
+                <div
+                  class="perseus-sr-only"
+                >
+                  End of reading passage.
                 </div>
               </div>
             </div>
           </div>
         </div>
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="1"
       >
+        We can see the word “promotes” is used in 
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-inline"
         >
-          We can see the word “promotes” is used in 
-          <div
-            class="perseus-widget-container widget-nohighlight widget-inline"
-          >
-            <span>
-              lines 
-              4–6
-              
-              <div
-                class="perseus-sr-only"
-              >
-                mocked reference content
-              </div>
-            </span>
-          </div>
+          <span>
+            lines 
+            4–6
+            
+            <div
+              class="perseus-sr-only"
+            >
+              mocked reference content
+            </div>
+          </span>
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`passage-ref widget should render with single-line reference 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
-          <div
-            class="perseus-widget-container widget-nohighlight widget-block"
-          >
-            <div>
+          <div>
+            <div
+              class="perseus-widget-passage-container"
+            >
               <div
-                class="perseus-widget-passage-container"
+                class="perseus-widget-passage-instructions"
               >
-                <div
-                  class="perseus-widget-passage-instructions"
-                >
-                  
+                
 
-                </div>
-                <div
-                  class="perseus-widget-passage"
+              </div>
+              <div
+                class="perseus-widget-passage"
+              >
+                <h3
+                  class="perseus-sr-only"
                 >
-                  <h3
-                    class="perseus-sr-only"
-                  >
-                    Beginning of reading passage.
-                  </h3>
+                  Beginning of reading passage.
+                </h3>
+                <div
+                  class="passage-text"
+                >
                   <div
-                    class="passage-text"
+                    class="container_6htn2u"
                   >
+                    <div>
+                      <div>
+                        <div>
+                          <div />
+                        </div>
+                      </div>
+                    </div>
                     <div
-                      class="container_6htn2u"
+                      class="content_gor68n"
                     >
                       <div>
                         <div>
-                          <div>
-                            <div />
-                          </div>
-                        </div>
-                      </div>
-                      <div
-                        class="content_gor68n"
-                      >
-                        <div>
-                          <div>
-                            <div
-                              aria-hidden="true"
-                              class="measurer_225hir"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Line Height Measurement
-                              </div>
-                            </div>
+                          <div
+                            aria-hidden="true"
+                            class="measurer_225hir"
+                          >
                             <div
                               class="paragraph"
                             >
-                              <span>
-                                Our electronic devices are keeping us awake—not just because we spend time using them when we should be sleeping
-                              </span>
-                              <span>
-                                , but also because they emit a blue light that keeps our brains awake
-                              </span>
-                              <span>
-                                . One study showed that people who used screens that emitted blue light were unable to produce sufficient melatonin
-                              </span>
-                              <span>
-                                , a hormone that 
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                promotes
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                 sleep
-                              </span>
-                              <span>
-                                . In order to enjoy a more restful night
-                              </span>
-                              <span>
-                                , experts recommend shutting off screens at least two hours before bed
-                              </span>
-                              <span>
-                                . 
-                              </span>
+                              Line Height Measurement
                             </div>
+                          </div>
+                          <div
+                            class="paragraph"
+                          >
+                            <span>
+                              Our electronic devices are keeping us awake—not just because we spend time using them when we should be sleeping
+                            </span>
+                            <span>
+                              , but also because they emit a blue light that keeps our brains awake
+                            </span>
+                            <span>
+                              . One study showed that people who used screens that emitted blue light were unable to produce sufficient melatonin
+                            </span>
+                            <span>
+                              , a hormone that 
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                              promotes
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                               sleep
+                            </span>
+                            <span>
+                              . In order to enjoy a more restful night
+                            </span>
+                            <span>
+                              , experts recommend shutting off screens at least two hours before bed
+                            </span>
+                            <span>
+                              . 
+                            </span>
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
-                  <div
-                    class="perseus-sr-only"
-                  >
-                    End of reading passage.
-                  </div>
+                </div>
+                <div
+                  class="perseus-sr-only"
+                >
+                  End of reading passage.
                 </div>
               </div>
             </div>
           </div>
         </div>
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="1"
       >
+        We can see the word “promotes” is used in 
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-inline"
         >
-          We can see the word “promotes” is used in 
-          <div
-            class="perseus-widget-container widget-nohighlight widget-inline"
-          >
-            <span>
-              line 
-              4
-              
-              <div
-                class="perseus-sr-only"
-              >
-                mocked reference content
-              </div>
-            </span>
-          </div>
+          <span>
+            line 
+            4
+            
+            <div
+              class="perseus-sr-only"
+            >
+              mocked reference content
+            </div>
+          </span>
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/passage.test.tsx.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/passage.test.tsx.snap
@@ -45,864 +45,532 @@ exports[`passage widget should be able to return a valid reference 1`] = `
 
 exports[`passage widget should snapshot multiple passages (mobile: false) 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
+    >
+      <blockquote>
+        <div
+          class="paragraph"
+        >
+          Select text to highlight it. 
+          <em>
+            (Laptop/desktop only)
+          </em>
+        </div>
+      </blockquote>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
+      <blockquote>
+        <div
+          class="paragraph"
+        >
+          <strong>
+            Passage 1 is adapted from 
+            <em>
+              "Ancient DNA Tells Story of Giant Eagle Evolution,"
+            </em>
+             © 2005 by Public Library of Science. Passage 2 is adapted from Tim Heupink, et al. 
+            <em>
+              "Dodos and Spotted Green Pigeons are Descendants of an Island Hopping Bird,"
+            </em>
+             © 2014 by BioMed Central. 
+          </strong>
+        </div>
+      </blockquote>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
-      >
-        <blockquote>
-          <div
-            class="paragraph"
-          >
-            Select text to highlight it. 
-            <em>
-              (Laptop/desktop only)
-            </em>
-          </div>
-        </blockquote>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="1"
-      >
-        <blockquote>
-          <div
-            class="paragraph"
-          >
-            <strong>
-              Passage 1 is adapted from 
-              <em>
-                "Ancient DNA Tells Story of Giant Eagle Evolution,"
-              </em>
-               © 2005 by Public Library of Science. Passage 2 is adapted from Tim Heupink, et al. 
-              <em>
-                "Dodos and Spotted Green Pigeons are Descendants of an Island Hopping Bird,"
-              </em>
-               © 2014 by BioMed Central. 
-            </strong>
-          </div>
-        </blockquote>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="2"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
-          <div
-            class="perseus-widget-container widget-nohighlight widget-block"
-          >
-            <div>
+          <div>
+            <div
+              class="perseus-widget-passage-container"
+            >
               <div
-                class="perseus-widget-passage-container"
+                class="perseus-widget-passage-instructions"
               >
                 <div
-                  class="perseus-widget-passage-instructions"
+                  class="paragraph"
                 >
-                  <div
-                    class="paragraph"
-                  >
-                    <span>
-                      The symbol 
-                    </span>
-                    <span
-                      aria-hidden="true"
-                      class="perseus-passage-square-label"
-                      style="display: inline; white-space: nowrap;"
-                    >
-                      <span
-                        style="display: inline-block; color: rgb(255, 255, 255); background-color: rgb(90, 90, 90); padding-left: 10px; padding-right: 10px; user-select: none;"
-                      >
-                        1
-                      </span>
-                    </span>
-                    <span
-                      class="perseus-sr-only"
-                    >
-                      [Marker for question 
-                      1
-                      ]
-                    </span>
-                     
-                    <span>
-                      indicates that question 1 references this portion of the passage
-                    </span>
-                    <span>
-                      .
-                    </span>
-                  </div>
-                </div>
-                <div
-                  class="perseus-widget-passage"
-                >
-                  <h3
-                    class="passage-title"
-                  >
-                    <span
-                      class="mock-KatexProvider"
-                    >
-                      <div
-                        class="perseus-renderer perseus-renderer-responsive"
-                      >
-                        <div
-                          class="paragraph"
-                          data-perseus-paragraph-index="0"
-                        >
-                          <div
-                            class="paragraph"
-                          >
-                            Passage 1
-                          </div>
-                        </div>
-                      </div>
-                    </span>
-                  </h3>
-                  <div
+                  <span>
+                    The symbol 
+                  </span>
+                  <span
                     aria-hidden="true"
-                    class="line-numbers"
+                    class="perseus-passage-square-label"
+                    style="display: inline; white-space: nowrap;"
                   >
-                    <span>
+                    <span
+                      style="display: inline-block; color: rgb(255, 255, 255); background-color: rgb(90, 90, 90); padding-left: 10px; padding-right: 10px; user-select: none;"
+                    >
                       1
                     </span>
-                    <span>
-                      2
-                    </span>
-                    <span>
-                      3
-                    </span>
-                    <span
-                      class="line-marker"
-                    >
-                      Line 
-                    </span>
-                    <span>
-                      5
-                    </span>
-                    <span>
-                      6
-                    </span>
-                    <span>
-                      7
-                    </span>
-                    <span>
-                      8
-                    </span>
-                    <span>
-                      9
-                    </span>
-                    <span>
-                      10
-                    </span>
-                  </div>
-                  <div
-                    class="passage-text"
-                  >
-                    <div
-                      class="container_6htn2u"
-                    >
-                      <div>
-                        <div>
-                          <div>
-                            <div />
-                          </div>
-                        </div>
-                      </div>
-                      <div
-                        class="content_gor68n"
-                      >
-                        <div>
-                          <div>
-                            <div
-                              aria-hidden="true"
-                              class="measurer_225hir"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Line Height Measurement
-                              </div>
-                            </div>
-                            <div
-                              class="paragraph"
-                            >
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                For reasons that are not entirely clear
-                              </span>
-                              <span>
-                                , when animals make their way to isolated islands 
-                              </span>
-                              <span
-                                aria-hidden="true"
-                                class="perseus-passage-square-label"
-                                style="display: inline; white-space: nowrap;"
-                              >
-                                <span
-                                  style="display: inline-block; color: rgb(255, 255, 255); background-color: rgb(90, 90, 90); padding-left: 10px; padding-right: 10px; user-select: none;"
-                                >
-                                  1
-                                </span>
-                              </span>
-                              <span
-                                class="perseus-sr-only"
-                              >
-                                [Marker for question 
-                                1
-                                ]
-                              </span>
-                              <span>
-                                , they tend to evolve relatively quickly toward an outsized or pint
-                              </span>
-                              <span>
-                                -sized version of their mainland counterpart
-                              </span>
-                              <span>
-                                .
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                 
-                              </span>
-                            </div>
-                            <div
-                              class="paragraph"
-                            >
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                Perhaps the most famous example of an island giant—and
-                              </span>
-                              <span>
-                                , sadly
-                              </span>
-                              <span>
-                                , of species extinction—is the dodo
-                              </span>
-                              <span>
-                                , once found on the Indian Ocean island of Mauritius
-                              </span>
-                              <span>
-                                .
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                 
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                When the dodo
-                              </span>
-                              <span>
-                                's ancestor 
-                              </span>
-                              <span>
-                                (thought to be a migratory pigeon
-                              </span>
-                              <span>
-                                ) settled on this island with abundant food
-                              </span>
-                              <span>
-                                , no competition from terrestrial mammals
-                              </span>
-                              <span>
-                                , and no predators
-                              </span>
-                              <span>
-                                , it could survive without flying
-                              </span>
-                              <span>
-                                , and thus was freed from the energetic and size constraints of flight
-                              </span>
-                              <span>
-                                .
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                 
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                New Zealand also had avian giants
-                              </span>
-                              <span>
-                                , now extinct
-                              </span>
-                              <span>
-                                , including the flightless moa
-                              </span>
-                              <span>
-                                , an ostrich
-                              </span>
-                              <span>
-                                -like bird
-                              </span>
-                              <span>
-                                , and Haast
-                              </span>
-                              <span>
-                                's eagle 
-                              </span>
-                              <span>
-                                (
-                              </span>
-                              <em>
-                                <span>
-                                  Harpagornis moorei
-                                </span>
-                              </em>
-                              <span>
-                                )
-                              </span>
-                              <span>
-                                , which had a wingspan up to 3 meters
-                              </span>
-                              <span>
-                                .
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                 
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                Though Haast
-                              </span>
-                              <span>
-                                's eagle could fly—and presumably used its wings to 
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                launch
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                 brutal attacks on the hapless moa—its body mass 
-                              </span>
-                              <span>
-                                (10–14 kilograms
-                              </span>
-                              <span>
-                                ) pushed the limits for self
-                              </span>
-                              <span>
-                                -propelled flight
-                              </span>
-                              <span>
-                                .
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                            </div>
-                            <div
-                              class="paragraph"
-                            >
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                As extreme evolutionary examples
-                              </span>
-                              <span>
-                                , these island birds can offer insights into the forces and events shaping evolutionary change
-                              </span>
-                              <span>
-                                .
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                 In a new study
-                              </span>
-                              <span>
-                                , Michael Bunce et al
-                              </span>
-                              <span>
-                                . compared ancient mitochondrial DNA extracted from Haast
-                              </span>
-                              <span>
-                                's eagle bones with DNA sequences of 16 living eagle species to better characterize the evolutionary history of the extinct giant raptor
-                              </span>
-                              <span>
-                                . 
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                Their results suggest the extinct raptor underwent a rapid evolutionary transformation that belies its kinship to some of the world
-                              </span>
-                              <span>
-                                's smallest eagle species
-                              </span>
-                              <span>
-                                .
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                            </div>
-                            <div
-                              class="paragraph"
-                            >
-                              <span>
-                                The authors characterized the rates of sequence evolution within mitochondrial DNA to establish the evolutionary relationships between the different eagle species
-                              </span>
-                              <span>
-                                . Their analysis places Haast
-                              </span>
-                              <span>
-                                's eagle in the same evolutionary lineage as a group of small eagle species in the genus 
-                              </span>
-                              <em>
-                                <span>
-                                  Hieraaetus
-                                </span>
-                              </em>
-                              <span>
-                                . Surprisingly
-                              </span>
-                              <span>
-                                , the genetic distance separating the giant eagle and its more diminutive 
-                              </span>
-                              <em>
-                                <span>
-                                  Hieraaetus
-                                </span>
-                              </em>
-                              <span>
-                                 cousins from their last 
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                common
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                 ancestor is relatively small
-                              </span>
-                              <span>
-                                .
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <h4
+                  </span>
+                  <span
                     class="perseus-sr-only"
                   >
-                    Beginning of reading passage footnotes.
-                  </h4>
+                    [Marker for question 
+                    1
+                    ]
+                  </span>
+                   
+                  <span>
+                    indicates that question 1 references this portion of the passage
+                  </span>
+                  <span>
+                    .
+                  </span>
+                </div>
+              </div>
+              <div
+                class="perseus-widget-passage"
+              >
+                <h3
+                  class="passage-title"
+                >
                   <div
-                    class="footnotes"
+                    class="perseus-renderer perseus-renderer-responsive"
                   >
                     <div
                       class="paragraph"
+                      data-perseus-paragraph-index="0"
                     >
-                      <span>
-                        An example footnote
-                      </span>
+                      <div
+                        class="paragraph"
+                      >
+                        Passage 1
+                      </div>
                     </div>
                   </div>
-                  <div
-                    class="perseus-sr-only"
+                </h3>
+                <div
+                  aria-hidden="true"
+                  class="line-numbers"
+                >
+                  <span>
+                    1
+                  </span>
+                  <span>
+                    2
+                  </span>
+                  <span>
+                    3
+                  </span>
+                  <span
+                    class="line-marker"
                   >
-                    End of reading passage.
+                    Line 
+                  </span>
+                  <span>
+                    5
+                  </span>
+                  <span>
+                    6
+                  </span>
+                  <span>
+                    7
+                  </span>
+                  <span>
+                    8
+                  </span>
+                  <span>
+                    9
+                  </span>
+                  <span>
+                    10
+                  </span>
+                </div>
+                <div
+                  class="passage-text"
+                >
+                  <div
+                    class="container_6htn2u"
+                  >
+                    <div>
+                      <div>
+                        <div>
+                          <div />
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="content_gor68n"
+                    >
+                      <div>
+                        <div>
+                          <div
+                            aria-hidden="true"
+                            class="measurer_225hir"
+                          >
+                            <div
+                              class="paragraph"
+                            >
+                              Line Height Measurement
+                            </div>
+                          </div>
+                          <div
+                            class="paragraph"
+                          >
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                              For reasons that are not entirely clear
+                            </span>
+                            <span>
+                              , when animals make their way to isolated islands 
+                            </span>
+                            <span
+                              aria-hidden="true"
+                              class="perseus-passage-square-label"
+                              style="display: inline; white-space: nowrap;"
+                            >
+                              <span
+                                style="display: inline-block; color: rgb(255, 255, 255); background-color: rgb(90, 90, 90); padding-left: 10px; padding-right: 10px; user-select: none;"
+                              >
+                                1
+                              </span>
+                            </span>
+                            <span
+                              class="perseus-sr-only"
+                            >
+                              [Marker for question 
+                              1
+                              ]
+                            </span>
+                            <span>
+                              , they tend to evolve relatively quickly toward an outsized or pint
+                            </span>
+                            <span>
+                              -sized version of their mainland counterpart
+                            </span>
+                            <span>
+                              .
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                               
+                            </span>
+                          </div>
+                          <div
+                            class="paragraph"
+                          >
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                              Perhaps the most famous example of an island giant—and
+                            </span>
+                            <span>
+                              , sadly
+                            </span>
+                            <span>
+                              , of species extinction—is the dodo
+                            </span>
+                            <span>
+                              , once found on the Indian Ocean island of Mauritius
+                            </span>
+                            <span>
+                              .
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                               
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                              When the dodo
+                            </span>
+                            <span>
+                              's ancestor 
+                            </span>
+                            <span>
+                              (thought to be a migratory pigeon
+                            </span>
+                            <span>
+                              ) settled on this island with abundant food
+                            </span>
+                            <span>
+                              , no competition from terrestrial mammals
+                            </span>
+                            <span>
+                              , and no predators
+                            </span>
+                            <span>
+                              , it could survive without flying
+                            </span>
+                            <span>
+                              , and thus was freed from the energetic and size constraints of flight
+                            </span>
+                            <span>
+                              .
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                               
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                              New Zealand also had avian giants
+                            </span>
+                            <span>
+                              , now extinct
+                            </span>
+                            <span>
+                              , including the flightless moa
+                            </span>
+                            <span>
+                              , an ostrich
+                            </span>
+                            <span>
+                              -like bird
+                            </span>
+                            <span>
+                              , and Haast
+                            </span>
+                            <span>
+                              's eagle 
+                            </span>
+                            <span>
+                              (
+                            </span>
+                            <em>
+                              <span>
+                                Harpagornis moorei
+                              </span>
+                            </em>
+                            <span>
+                              )
+                            </span>
+                            <span>
+                              , which had a wingspan up to 3 meters
+                            </span>
+                            <span>
+                              .
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                               
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                              Though Haast
+                            </span>
+                            <span>
+                              's eagle could fly—and presumably used its wings to 
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                              launch
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                               brutal attacks on the hapless moa—its body mass 
+                            </span>
+                            <span>
+                              (10–14 kilograms
+                            </span>
+                            <span>
+                              ) pushed the limits for self
+                            </span>
+                            <span>
+                              -propelled flight
+                            </span>
+                            <span>
+                              .
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                          </div>
+                          <div
+                            class="paragraph"
+                          >
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                              As extreme evolutionary examples
+                            </span>
+                            <span>
+                              , these island birds can offer insights into the forces and events shaping evolutionary change
+                            </span>
+                            <span>
+                              .
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                               In a new study
+                            </span>
+                            <span>
+                              , Michael Bunce et al
+                            </span>
+                            <span>
+                              . compared ancient mitochondrial DNA extracted from Haast
+                            </span>
+                            <span>
+                              's eagle bones with DNA sequences of 16 living eagle species to better characterize the evolutionary history of the extinct giant raptor
+                            </span>
+                            <span>
+                              . 
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                              Their results suggest the extinct raptor underwent a rapid evolutionary transformation that belies its kinship to some of the world
+                            </span>
+                            <span>
+                              's smallest eagle species
+                            </span>
+                            <span>
+                              .
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                          </div>
+                          <div
+                            class="paragraph"
+                          >
+                            <span>
+                              The authors characterized the rates of sequence evolution within mitochondrial DNA to establish the evolutionary relationships between the different eagle species
+                            </span>
+                            <span>
+                              . Their analysis places Haast
+                            </span>
+                            <span>
+                              's eagle in the same evolutionary lineage as a group of small eagle species in the genus 
+                            </span>
+                            <em>
+                              <span>
+                                Hieraaetus
+                              </span>
+                            </em>
+                            <span>
+                              . Surprisingly
+                            </span>
+                            <span>
+                              , the genetic distance separating the giant eagle and its more diminutive 
+                            </span>
+                            <em>
+                              <span>
+                                Hieraaetus
+                              </span>
+                            </em>
+                            <span>
+                               cousins from their last 
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                              common
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                               ancestor is relatively small
+                            </span>
+                            <span>
+                              .
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="3"
-      >
-        <div
-          class="paragraph"
-        >
-          <div
-            class="perseus-widget-container widget-nohighlight widget-block"
-          >
-            <div>
-              <div
-                class="perseus-widget-passage-container"
-              >
+                <h4
+                  class="perseus-sr-only"
+                >
+                  Beginning of reading passage footnotes.
+                </h4>
                 <div
-                  class="perseus-widget-passage-instructions"
+                  class="footnotes"
                 >
                   <div
                     class="paragraph"
                   >
                     <span>
-                       The symbol 
-                    </span>
-                    <span
-                      aria-hidden="true"
-                      class="perseus-passage-bracket-label"
-                    >
-                      [
-                      1
-                      ]
-                    </span>
-                    <span
-                      class="perseus-sr-only"
-                    >
-                      [Sentence 
-                      1
-                      ]
-                    </span>
-                     
-                    <span>
-                      indicates that the following sentence is referenced in a question
-                    </span>
-                    <span>
-                      .
+                      An example footnote
                     </span>
                   </div>
                 </div>
                 <div
-                  class="perseus-widget-passage"
+                  class="perseus-sr-only"
                 >
-                  <h3
-                    class="passage-title"
-                  >
-                    <span
-                      class="mock-KatexProvider"
-                    >
-                      <div
-                        class="perseus-renderer perseus-renderer-responsive"
-                      >
-                        <div
-                          class="paragraph"
-                          data-perseus-paragraph-index="0"
-                        >
-                          <div
-                            class="paragraph"
-                          >
-                            Passage 2
-                          </div>
-                        </div>
-                      </div>
-                    </span>
-                  </h3>
-                  <div
-                    aria-hidden="true"
-                    class="line-numbers"
-                  >
-                    <span>
-                      11
-                    </span>
-                    <span>
-                      12
-                    </span>
-                    <span>
-                      13
-                    </span>
-                    <span>
-                      14
-                    </span>
-                    <span>
-                      15
-                    </span>
-                    <span>
-                      16
-                    </span>
-                    <span>
-                      17
-                    </span>
-                    <span>
-                      18
-                    </span>
-                    <span>
-                      19
-                    </span>
-                    <span>
-                      20
-                    </span>
-                  </div>
-                  <div
-                    class="passage-text"
-                  >
-                    <div
-                      class="container_6htn2u"
-                    >
-                      <div>
-                        <div>
-                          <div>
-                            <div />
-                          </div>
-                        </div>
-                      </div>
-                      <div
-                        class="content_gor68n"
-                      >
-                        <div>
-                          <div>
-                            <div
-                              aria-hidden="true"
-                              class="measurer_225hir"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Line Height Measurement
-                              </div>
-                            </div>
-                            <div
-                              class="paragraph"
-                            >
-                              <span>
-                                The mysterious spotted green pigeon 
-                              </span>
-                              <span>
-                                (
-                              </span>
-                              <em>
-                                <span>
-                                  Caloenas maculata
-                                </span>
-                              </em>
-                              <span>
-                                ) was a relative of the dodo
-                              </span>
-                              <span>
-                                , according to scientists who have examined its genetic make
-                              </span>
-                              <span>
-                                -up 
-                              </span>
-                              <span
-                                aria-hidden="true"
-                                class="perseus-passage-bracket-label"
-                              >
-                                [
-                                1
-                                ]
-                              </span>
-                              <span
-                                class="perseus-sr-only"
-                              >
-                                [Sentence 
-                                1
-                                ]
-                              </span>
-                              <span>
-                                . The authors say their results
-                              </span>
-                              <span>
-                                , published in the open access journal BMC Evolutionary Biology
-                              </span>
-                              <span>
-                                , support a theory that both birds are descended from “island hopping” ancestors
-                              </span>
-                              <span>
-                                .
-                              </span>
-                            </div>
-                            <div
-                              class="paragraph"
-                            >
-                              <span>
-                                The scientists took DNA from two feathers of the spotted green pigeon
-                              </span>
-                              <span>
-                                . Because of its age
-                              </span>
-                              <span>
-                                , the DNA was highly fragmented
-                              </span>
-                              <span>
-                                , so they focused in on three DNA “mini barcodes” – small sections of DNA which are unique for most bird species
-                              </span>
-                              <span>
-                                . They looked at these sections of the pigeon
-                              </span>
-                              <span>
-                                's DNA
-                              </span>
-                              <span>
-                                , and compared it to other species
-                              </span>
-                              <span>
-                                .
-                              </span>
-                            </div>
-                            <div
-                              class="paragraph"
-                            >
-                              <span>
-                                This showed that the spotted green pigeon is indeed a separate species
-                              </span>
-                              <span>
-                                , showing a unique DNA barcode compared to other pigeons
-                              </span>
-                              <span>
-                                . The pigeon is genetically most closely related to the Nicobar pigeon and the dodo and Rodrigues solitaire
-                              </span>
-                              <span>
-                                , both extinct birds from islands near Madagascar
-                              </span>
-                              <span>
-                                . The spotted green pigeon shows signs of a semi
-                              </span>
-                              <span>
-                                -terrestrial island lifestyle and the ability to fly
-                              </span>
-                              <span>
-                                . The closely related Nicobar pigeon shows similar habits and has a preference for travelling between small islands
-                              </span>
-                              <span>
-                                .
-                              </span>
-                            </div>
-                            <div
-                              class="paragraph"
-                            >
-                              <span>
-                                The scientists say this lifestyle
-                              </span>
-                              <span>
-                                , together with the relationship of both pigeons to the dodo and Rodrigues solitaire
-                              </span>
-                              <span>
-                                , supports an evolutionary theory that the ancestors of these birds were “island hoppers
-                              </span>
-                              <span>
-                                ,” moving between islands around India and Southeast Asia
-                              </span>
-                              <span>
-                                . The birds that settled on particular islands then evolved into the individual species
-                              </span>
-                              <span>
-                                . The dodo
-                              </span>
-                              <span>
-                                's ancestor managed to hop as far as the island of Mauritius near Madagascar where it then lost the ability to fly
-                              </span>
-                              <span>
-                                .
-                              </span>
-                            </div>
-                            <div
-                              class="paragraph"
-                            >
-                              <span>
-                                Dr
-                              </span>
-                              <span>
-                                . Tim Heupink
-                              </span>
-                              <span>
-                                , Griffith University Australia says
-                              </span>
-                              <span>
-                                : 
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                “This study improves our ability to identify novel species from historic remains
-                              </span>
-                              <span>
-                                , and also those that are not novel after all
-                              </span>
-                              <span>
-                                . Ultimately this will help us to measure and understand the extinction of local populations and entire species
-                              </span>
-                              <span>
-                                .”
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="perseus-sr-only"
-                  >
-                    End of reading passage.
-                  </div>
+                  End of reading passage.
                 </div>
               </div>
             </div>
@@ -910,870 +578,858 @@ exports[`passage widget should snapshot multiple passages (mobile: false) 1`] = 
         </div>
       </div>
     </div>
-  </span>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="3"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <div>
+            <div
+              class="perseus-widget-passage-container"
+            >
+              <div
+                class="perseus-widget-passage-instructions"
+              >
+                <div
+                  class="paragraph"
+                >
+                  <span>
+                     The symbol 
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    class="perseus-passage-bracket-label"
+                  >
+                    [
+                    1
+                    ]
+                  </span>
+                  <span
+                    class="perseus-sr-only"
+                  >
+                    [Sentence 
+                    1
+                    ]
+                  </span>
+                   
+                  <span>
+                    indicates that the following sentence is referenced in a question
+                  </span>
+                  <span>
+                    .
+                  </span>
+                </div>
+              </div>
+              <div
+                class="perseus-widget-passage"
+              >
+                <h3
+                  class="passage-title"
+                >
+                  <div
+                    class="perseus-renderer perseus-renderer-responsive"
+                  >
+                    <div
+                      class="paragraph"
+                      data-perseus-paragraph-index="0"
+                    >
+                      <div
+                        class="paragraph"
+                      >
+                        Passage 2
+                      </div>
+                    </div>
+                  </div>
+                </h3>
+                <div
+                  aria-hidden="true"
+                  class="line-numbers"
+                >
+                  <span>
+                    11
+                  </span>
+                  <span>
+                    12
+                  </span>
+                  <span>
+                    13
+                  </span>
+                  <span>
+                    14
+                  </span>
+                  <span>
+                    15
+                  </span>
+                  <span>
+                    16
+                  </span>
+                  <span>
+                    17
+                  </span>
+                  <span>
+                    18
+                  </span>
+                  <span>
+                    19
+                  </span>
+                  <span>
+                    20
+                  </span>
+                </div>
+                <div
+                  class="passage-text"
+                >
+                  <div
+                    class="container_6htn2u"
+                  >
+                    <div>
+                      <div>
+                        <div>
+                          <div />
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="content_gor68n"
+                    >
+                      <div>
+                        <div>
+                          <div
+                            aria-hidden="true"
+                            class="measurer_225hir"
+                          >
+                            <div
+                              class="paragraph"
+                            >
+                              Line Height Measurement
+                            </div>
+                          </div>
+                          <div
+                            class="paragraph"
+                          >
+                            <span>
+                              The mysterious spotted green pigeon 
+                            </span>
+                            <span>
+                              (
+                            </span>
+                            <em>
+                              <span>
+                                Caloenas maculata
+                              </span>
+                            </em>
+                            <span>
+                              ) was a relative of the dodo
+                            </span>
+                            <span>
+                              , according to scientists who have examined its genetic make
+                            </span>
+                            <span>
+                              -up 
+                            </span>
+                            <span
+                              aria-hidden="true"
+                              class="perseus-passage-bracket-label"
+                            >
+                              [
+                              1
+                              ]
+                            </span>
+                            <span
+                              class="perseus-sr-only"
+                            >
+                              [Sentence 
+                              1
+                              ]
+                            </span>
+                            <span>
+                              . The authors say their results
+                            </span>
+                            <span>
+                              , published in the open access journal BMC Evolutionary Biology
+                            </span>
+                            <span>
+                              , support a theory that both birds are descended from “island hopping” ancestors
+                            </span>
+                            <span>
+                              .
+                            </span>
+                          </div>
+                          <div
+                            class="paragraph"
+                          >
+                            <span>
+                              The scientists took DNA from two feathers of the spotted green pigeon
+                            </span>
+                            <span>
+                              . Because of its age
+                            </span>
+                            <span>
+                              , the DNA was highly fragmented
+                            </span>
+                            <span>
+                              , so they focused in on three DNA “mini barcodes” – small sections of DNA which are unique for most bird species
+                            </span>
+                            <span>
+                              . They looked at these sections of the pigeon
+                            </span>
+                            <span>
+                              's DNA
+                            </span>
+                            <span>
+                              , and compared it to other species
+                            </span>
+                            <span>
+                              .
+                            </span>
+                          </div>
+                          <div
+                            class="paragraph"
+                          >
+                            <span>
+                              This showed that the spotted green pigeon is indeed a separate species
+                            </span>
+                            <span>
+                              , showing a unique DNA barcode compared to other pigeons
+                            </span>
+                            <span>
+                              . The pigeon is genetically most closely related to the Nicobar pigeon and the dodo and Rodrigues solitaire
+                            </span>
+                            <span>
+                              , both extinct birds from islands near Madagascar
+                            </span>
+                            <span>
+                              . The spotted green pigeon shows signs of a semi
+                            </span>
+                            <span>
+                              -terrestrial island lifestyle and the ability to fly
+                            </span>
+                            <span>
+                              . The closely related Nicobar pigeon shows similar habits and has a preference for travelling between small islands
+                            </span>
+                            <span>
+                              .
+                            </span>
+                          </div>
+                          <div
+                            class="paragraph"
+                          >
+                            <span>
+                              The scientists say this lifestyle
+                            </span>
+                            <span>
+                              , together with the relationship of both pigeons to the dodo and Rodrigues solitaire
+                            </span>
+                            <span>
+                              , supports an evolutionary theory that the ancestors of these birds were “island hoppers
+                            </span>
+                            <span>
+                              ,” moving between islands around India and Southeast Asia
+                            </span>
+                            <span>
+                              . The birds that settled on particular islands then evolved into the individual species
+                            </span>
+                            <span>
+                              . The dodo
+                            </span>
+                            <span>
+                              's ancestor managed to hop as far as the island of Mauritius near Madagascar where it then lost the ability to fly
+                            </span>
+                            <span>
+                              .
+                            </span>
+                          </div>
+                          <div
+                            class="paragraph"
+                          >
+                            <span>
+                              Dr
+                            </span>
+                            <span>
+                              . Tim Heupink
+                            </span>
+                            <span>
+                              , Griffith University Australia says
+                            </span>
+                            <span>
+                              : 
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                              “This study improves our ability to identify novel species from historic remains
+                            </span>
+                            <span>
+                              , and also those that are not novel after all
+                            </span>
+                            <span>
+                              . Ultimately this will help us to measure and understand the extinction of local populations and entire species
+                            </span>
+                            <span>
+                              .”
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="perseus-sr-only"
+                >
+                  End of reading passage.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;
 
 exports[`passage widget should snapshot multiple passages (mobile: true) 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
+    >
+      <blockquote>
+        <div
+          class="paragraph"
+        >
+          Select text to highlight it. 
+          <em>
+            (Laptop/desktop only)
+          </em>
+        </div>
+      </blockquote>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
+      <blockquote>
+        <div
+          class="paragraph"
+        >
+          <strong>
+            Passage 1 is adapted from 
+            <em>
+              "Ancient DNA Tells Story of Giant Eagle Evolution,"
+            </em>
+             © 2005 by Public Library of Science. Passage 2 is adapted from Tim Heupink, et al. 
+            <em>
+              "Dodos and Spotted Green Pigeons are Descendants of an Island Hopping Bird,"
+            </em>
+             © 2014 by BioMed Central. 
+          </strong>
+        </div>
+      </blockquote>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
-      >
-        <blockquote>
-          <div
-            class="paragraph"
-          >
-            Select text to highlight it. 
-            <em>
-              (Laptop/desktop only)
-            </em>
-          </div>
-        </blockquote>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="1"
-      >
-        <blockquote>
-          <div
-            class="paragraph"
-          >
-            <strong>
-              Passage 1 is adapted from 
-              <em>
-                "Ancient DNA Tells Story of Giant Eagle Evolution,"
-              </em>
-               © 2005 by Public Library of Science. Passage 2 is adapted from Tim Heupink, et al. 
-              <em>
-                "Dodos and Spotted Green Pigeons are Descendants of an Island Hopping Bird,"
-              </em>
-               © 2014 by BioMed Central. 
-            </strong>
-          </div>
-        </blockquote>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="2"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
-          <div
-            class="perseus-widget-container widget-nohighlight widget-block"
-          >
-            <div>
+          <div>
+            <div
+              class="perseus-widget-passage-container"
+            >
               <div
-                class="perseus-widget-passage-container"
+                class="perseus-widget-passage-instructions"
               >
                 <div
-                  class="perseus-widget-passage-instructions"
+                  class="paragraph"
                 >
-                  <div
-                    class="paragraph"
-                  >
-                    <span>
-                      The symbol 
-                    </span>
-                    <span
-                      aria-hidden="true"
-                      class="perseus-passage-square-label"
-                      style="display: inline; white-space: nowrap;"
-                    >
-                      <span
-                        style="display: inline-block; color: rgb(255, 255, 255); background-color: rgb(90, 90, 90); padding-left: 10px; padding-right: 10px; user-select: none;"
-                      >
-                        1
-                      </span>
-                    </span>
-                    <span
-                      class="perseus-sr-only"
-                    >
-                      [Marker for question 
-                      1
-                      ]
-                    </span>
-                     
-                    <span>
-                      indicates that question 1 references this portion of the passage
-                    </span>
-                    <span>
-                      .
-                    </span>
-                  </div>
-                </div>
-                <div
-                  class="perseus-widget-passage"
-                >
-                  <h3
-                    class="passage-title"
-                  >
-                    <span
-                      class="mock-KatexProvider"
-                    >
-                      <div
-                        class="perseus-renderer perseus-renderer-responsive"
-                      >
-                        <div
-                          class="paragraph"
-                          data-perseus-paragraph-index="0"
-                        >
-                          <div
-                            class="paragraph"
-                          >
-                            Passage 1
-                          </div>
-                        </div>
-                      </div>
-                    </span>
-                  </h3>
-                  <div
+                  <span>
+                    The symbol 
+                  </span>
+                  <span
                     aria-hidden="true"
-                    class="line-numbers"
+                    class="perseus-passage-square-label"
+                    style="display: inline; white-space: nowrap;"
                   >
-                    <span>
+                    <span
+                      style="display: inline-block; color: rgb(255, 255, 255); background-color: rgb(90, 90, 90); padding-left: 10px; padding-right: 10px; user-select: none;"
+                    >
                       1
                     </span>
-                    <span>
-                      2
-                    </span>
-                    <span>
-                      3
-                    </span>
-                    <span
-                      class="line-marker"
-                    >
-                      Line 
-                    </span>
-                    <span>
-                      5
-                    </span>
-                    <span>
-                      6
-                    </span>
-                    <span>
-                      7
-                    </span>
-                    <span>
-                      8
-                    </span>
-                    <span>
-                      9
-                    </span>
-                    <span>
-                      10
-                    </span>
-                  </div>
-                  <div
-                    class="passage-text"
-                  >
-                    <div
-                      class="container_6htn2u"
-                    >
-                      <div>
-                        <div>
-                          <div>
-                            <div />
-                          </div>
-                        </div>
-                      </div>
-                      <div
-                        class="content_gor68n"
-                      >
-                        <div>
-                          <div>
-                            <div
-                              aria-hidden="true"
-                              class="measurer_225hir"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Line Height Measurement
-                              </div>
-                            </div>
-                            <div
-                              class="paragraph"
-                            >
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                For reasons that are not entirely clear
-                              </span>
-                              <span>
-                                , when animals make their way to isolated islands 
-                              </span>
-                              <span
-                                aria-hidden="true"
-                                class="perseus-passage-square-label"
-                                style="display: inline; white-space: nowrap;"
-                              >
-                                <span
-                                  style="display: inline-block; color: rgb(255, 255, 255); background-color: rgb(90, 90, 90); padding-left: 10px; padding-right: 10px; user-select: none;"
-                                >
-                                  1
-                                </span>
-                              </span>
-                              <span
-                                class="perseus-sr-only"
-                              >
-                                [Marker for question 
-                                1
-                                ]
-                              </span>
-                              <span>
-                                , they tend to evolve relatively quickly toward an outsized or pint
-                              </span>
-                              <span>
-                                -sized version of their mainland counterpart
-                              </span>
-                              <span>
-                                .
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                 
-                              </span>
-                            </div>
-                            <div
-                              class="paragraph"
-                            >
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                Perhaps the most famous example of an island giant—and
-                              </span>
-                              <span>
-                                , sadly
-                              </span>
-                              <span>
-                                , of species extinction—is the dodo
-                              </span>
-                              <span>
-                                , once found on the Indian Ocean island of Mauritius
-                              </span>
-                              <span>
-                                .
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                 
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                When the dodo
-                              </span>
-                              <span>
-                                's ancestor 
-                              </span>
-                              <span>
-                                (thought to be a migratory pigeon
-                              </span>
-                              <span>
-                                ) settled on this island with abundant food
-                              </span>
-                              <span>
-                                , no competition from terrestrial mammals
-                              </span>
-                              <span>
-                                , and no predators
-                              </span>
-                              <span>
-                                , it could survive without flying
-                              </span>
-                              <span>
-                                , and thus was freed from the energetic and size constraints of flight
-                              </span>
-                              <span>
-                                .
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                 
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                New Zealand also had avian giants
-                              </span>
-                              <span>
-                                , now extinct
-                              </span>
-                              <span>
-                                , including the flightless moa
-                              </span>
-                              <span>
-                                , an ostrich
-                              </span>
-                              <span>
-                                -like bird
-                              </span>
-                              <span>
-                                , and Haast
-                              </span>
-                              <span>
-                                's eagle 
-                              </span>
-                              <span>
-                                (
-                              </span>
-                              <em>
-                                <span>
-                                  Harpagornis moorei
-                                </span>
-                              </em>
-                              <span>
-                                )
-                              </span>
-                              <span>
-                                , which had a wingspan up to 3 meters
-                              </span>
-                              <span>
-                                .
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                 
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                Though Haast
-                              </span>
-                              <span>
-                                's eagle could fly—and presumably used its wings to 
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                launch
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                 brutal attacks on the hapless moa—its body mass 
-                              </span>
-                              <span>
-                                (10–14 kilograms
-                              </span>
-                              <span>
-                                ) pushed the limits for self
-                              </span>
-                              <span>
-                                -propelled flight
-                              </span>
-                              <span>
-                                .
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                            </div>
-                            <div
-                              class="paragraph"
-                            >
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                As extreme evolutionary examples
-                              </span>
-                              <span>
-                                , these island birds can offer insights into the forces and events shaping evolutionary change
-                              </span>
-                              <span>
-                                .
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                 In a new study
-                              </span>
-                              <span>
-                                , Michael Bunce et al
-                              </span>
-                              <span>
-                                . compared ancient mitochondrial DNA extracted from Haast
-                              </span>
-                              <span>
-                                's eagle bones with DNA sequences of 16 living eagle species to better characterize the evolutionary history of the extinct giant raptor
-                              </span>
-                              <span>
-                                . 
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                Their results suggest the extinct raptor underwent a rapid evolutionary transformation that belies its kinship to some of the world
-                              </span>
-                              <span>
-                                's smallest eagle species
-                              </span>
-                              <span>
-                                .
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                            </div>
-                            <div
-                              class="paragraph"
-                            >
-                              <span>
-                                The authors characterized the rates of sequence evolution within mitochondrial DNA to establish the evolutionary relationships between the different eagle species
-                              </span>
-                              <span>
-                                . Their analysis places Haast
-                              </span>
-                              <span>
-                                's eagle in the same evolutionary lineage as a group of small eagle species in the genus 
-                              </span>
-                              <em>
-                                <span>
-                                  Hieraaetus
-                                </span>
-                              </em>
-                              <span>
-                                . Surprisingly
-                              </span>
-                              <span>
-                                , the genetic distance separating the giant eagle and its more diminutive 
-                              </span>
-                              <em>
-                                <span>
-                                  Hieraaetus
-                                </span>
-                              </em>
-                              <span>
-                                 cousins from their last 
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                common
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                 ancestor is relatively small
-                              </span>
-                              <span>
-                                .
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <h4
+                  </span>
+                  <span
                     class="perseus-sr-only"
                   >
-                    Beginning of reading passage footnotes.
-                  </h4>
+                    [Marker for question 
+                    1
+                    ]
+                  </span>
+                   
+                  <span>
+                    indicates that question 1 references this portion of the passage
+                  </span>
+                  <span>
+                    .
+                  </span>
+                </div>
+              </div>
+              <div
+                class="perseus-widget-passage"
+              >
+                <h3
+                  class="passage-title"
+                >
                   <div
-                    class="footnotes"
+                    class="perseus-renderer perseus-renderer-responsive"
                   >
                     <div
                       class="paragraph"
+                      data-perseus-paragraph-index="0"
                     >
-                      <span>
-                        An example footnote
-                      </span>
+                      <div
+                        class="paragraph"
+                      >
+                        Passage 1
+                      </div>
                     </div>
                   </div>
-                  <div
-                    class="perseus-sr-only"
+                </h3>
+                <div
+                  aria-hidden="true"
+                  class="line-numbers"
+                >
+                  <span>
+                    1
+                  </span>
+                  <span>
+                    2
+                  </span>
+                  <span>
+                    3
+                  </span>
+                  <span
+                    class="line-marker"
                   >
-                    End of reading passage.
+                    Line 
+                  </span>
+                  <span>
+                    5
+                  </span>
+                  <span>
+                    6
+                  </span>
+                  <span>
+                    7
+                  </span>
+                  <span>
+                    8
+                  </span>
+                  <span>
+                    9
+                  </span>
+                  <span>
+                    10
+                  </span>
+                </div>
+                <div
+                  class="passage-text"
+                >
+                  <div
+                    class="container_6htn2u"
+                  >
+                    <div>
+                      <div>
+                        <div>
+                          <div />
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="content_gor68n"
+                    >
+                      <div>
+                        <div>
+                          <div
+                            aria-hidden="true"
+                            class="measurer_225hir"
+                          >
+                            <div
+                              class="paragraph"
+                            >
+                              Line Height Measurement
+                            </div>
+                          </div>
+                          <div
+                            class="paragraph"
+                          >
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                              For reasons that are not entirely clear
+                            </span>
+                            <span>
+                              , when animals make their way to isolated islands 
+                            </span>
+                            <span
+                              aria-hidden="true"
+                              class="perseus-passage-square-label"
+                              style="display: inline; white-space: nowrap;"
+                            >
+                              <span
+                                style="display: inline-block; color: rgb(255, 255, 255); background-color: rgb(90, 90, 90); padding-left: 10px; padding-right: 10px; user-select: none;"
+                              >
+                                1
+                              </span>
+                            </span>
+                            <span
+                              class="perseus-sr-only"
+                            >
+                              [Marker for question 
+                              1
+                              ]
+                            </span>
+                            <span>
+                              , they tend to evolve relatively quickly toward an outsized or pint
+                            </span>
+                            <span>
+                              -sized version of their mainland counterpart
+                            </span>
+                            <span>
+                              .
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                               
+                            </span>
+                          </div>
+                          <div
+                            class="paragraph"
+                          >
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                              Perhaps the most famous example of an island giant—and
+                            </span>
+                            <span>
+                              , sadly
+                            </span>
+                            <span>
+                              , of species extinction—is the dodo
+                            </span>
+                            <span>
+                              , once found on the Indian Ocean island of Mauritius
+                            </span>
+                            <span>
+                              .
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                               
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                              When the dodo
+                            </span>
+                            <span>
+                              's ancestor 
+                            </span>
+                            <span>
+                              (thought to be a migratory pigeon
+                            </span>
+                            <span>
+                              ) settled on this island with abundant food
+                            </span>
+                            <span>
+                              , no competition from terrestrial mammals
+                            </span>
+                            <span>
+                              , and no predators
+                            </span>
+                            <span>
+                              , it could survive without flying
+                            </span>
+                            <span>
+                              , and thus was freed from the energetic and size constraints of flight
+                            </span>
+                            <span>
+                              .
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                               
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                              New Zealand also had avian giants
+                            </span>
+                            <span>
+                              , now extinct
+                            </span>
+                            <span>
+                              , including the flightless moa
+                            </span>
+                            <span>
+                              , an ostrich
+                            </span>
+                            <span>
+                              -like bird
+                            </span>
+                            <span>
+                              , and Haast
+                            </span>
+                            <span>
+                              's eagle 
+                            </span>
+                            <span>
+                              (
+                            </span>
+                            <em>
+                              <span>
+                                Harpagornis moorei
+                              </span>
+                            </em>
+                            <span>
+                              )
+                            </span>
+                            <span>
+                              , which had a wingspan up to 3 meters
+                            </span>
+                            <span>
+                              .
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                               
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                              Though Haast
+                            </span>
+                            <span>
+                              's eagle could fly—and presumably used its wings to 
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                              launch
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                               brutal attacks on the hapless moa—its body mass 
+                            </span>
+                            <span>
+                              (10–14 kilograms
+                            </span>
+                            <span>
+                              ) pushed the limits for self
+                            </span>
+                            <span>
+                              -propelled flight
+                            </span>
+                            <span>
+                              .
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                          </div>
+                          <div
+                            class="paragraph"
+                          >
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                              As extreme evolutionary examples
+                            </span>
+                            <span>
+                              , these island birds can offer insights into the forces and events shaping evolutionary change
+                            </span>
+                            <span>
+                              .
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                               In a new study
+                            </span>
+                            <span>
+                              , Michael Bunce et al
+                            </span>
+                            <span>
+                              . compared ancient mitochondrial DNA extracted from Haast
+                            </span>
+                            <span>
+                              's eagle bones with DNA sequences of 16 living eagle species to better characterize the evolutionary history of the extinct giant raptor
+                            </span>
+                            <span>
+                              . 
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                              Their results suggest the extinct raptor underwent a rapid evolutionary transformation that belies its kinship to some of the world
+                            </span>
+                            <span>
+                              's smallest eagle species
+                            </span>
+                            <span>
+                              .
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                          </div>
+                          <div
+                            class="paragraph"
+                          >
+                            <span>
+                              The authors characterized the rates of sequence evolution within mitochondrial DNA to establish the evolutionary relationships between the different eagle species
+                            </span>
+                            <span>
+                              . Their analysis places Haast
+                            </span>
+                            <span>
+                              's eagle in the same evolutionary lineage as a group of small eagle species in the genus 
+                            </span>
+                            <em>
+                              <span>
+                                Hieraaetus
+                              </span>
+                            </em>
+                            <span>
+                              . Surprisingly
+                            </span>
+                            <span>
+                              , the genetic distance separating the giant eagle and its more diminutive 
+                            </span>
+                            <em>
+                              <span>
+                                Hieraaetus
+                              </span>
+                            </em>
+                            <span>
+                               cousins from their last 
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                              common
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                               ancestor is relatively small
+                            </span>
+                            <span>
+                              .
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="3"
-      >
-        <div
-          class="paragraph"
-        >
-          <div
-            class="perseus-widget-container widget-nohighlight widget-block"
-          >
-            <div>
-              <div
-                class="perseus-widget-passage-container"
-              >
+                <h4
+                  class="perseus-sr-only"
+                >
+                  Beginning of reading passage footnotes.
+                </h4>
                 <div
-                  class="perseus-widget-passage-instructions"
+                  class="footnotes"
                 >
                   <div
                     class="paragraph"
                   >
                     <span>
-                       The symbol 
-                    </span>
-                    <span
-                      aria-hidden="true"
-                      class="perseus-passage-bracket-label"
-                    >
-                      [
-                      1
-                      ]
-                    </span>
-                    <span
-                      class="perseus-sr-only"
-                    >
-                      [Sentence 
-                      1
-                      ]
-                    </span>
-                     
-                    <span>
-                      indicates that the following sentence is referenced in a question
-                    </span>
-                    <span>
-                      .
+                      An example footnote
                     </span>
                   </div>
                 </div>
                 <div
-                  class="perseus-widget-passage"
+                  class="perseus-sr-only"
                 >
-                  <h3
-                    class="passage-title"
-                  >
-                    <span
-                      class="mock-KatexProvider"
-                    >
-                      <div
-                        class="perseus-renderer perseus-renderer-responsive"
-                      >
-                        <div
-                          class="paragraph"
-                          data-perseus-paragraph-index="0"
-                        >
-                          <div
-                            class="paragraph"
-                          >
-                            Passage 2
-                          </div>
-                        </div>
-                      </div>
-                    </span>
-                  </h3>
-                  <div
-                    aria-hidden="true"
-                    class="line-numbers"
-                  >
-                    <span>
-                      11
-                    </span>
-                    <span>
-                      12
-                    </span>
-                    <span>
-                      13
-                    </span>
-                    <span>
-                      14
-                    </span>
-                    <span>
-                      15
-                    </span>
-                    <span>
-                      16
-                    </span>
-                    <span>
-                      17
-                    </span>
-                    <span>
-                      18
-                    </span>
-                    <span>
-                      19
-                    </span>
-                    <span>
-                      20
-                    </span>
-                  </div>
-                  <div
-                    class="passage-text"
-                  >
-                    <div
-                      class="container_6htn2u"
-                    >
-                      <div>
-                        <div>
-                          <div>
-                            <div />
-                          </div>
-                        </div>
-                      </div>
-                      <div
-                        class="content_gor68n"
-                      >
-                        <div>
-                          <div>
-                            <div
-                              aria-hidden="true"
-                              class="measurer_225hir"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Line Height Measurement
-                              </div>
-                            </div>
-                            <div
-                              class="paragraph"
-                            >
-                              <span>
-                                The mysterious spotted green pigeon 
-                              </span>
-                              <span>
-                                (
-                              </span>
-                              <em>
-                                <span>
-                                  Caloenas maculata
-                                </span>
-                              </em>
-                              <span>
-                                ) was a relative of the dodo
-                              </span>
-                              <span>
-                                , according to scientists who have examined its genetic make
-                              </span>
-                              <span>
-                                -up 
-                              </span>
-                              <span
-                                aria-hidden="true"
-                                class="perseus-passage-bracket-label"
-                              >
-                                [
-                                1
-                                ]
-                              </span>
-                              <span
-                                class="perseus-sr-only"
-                              >
-                                [Sentence 
-                                1
-                                ]
-                              </span>
-                              <span>
-                                . The authors say their results
-                              </span>
-                              <span>
-                                , published in the open access journal BMC Evolutionary Biology
-                              </span>
-                              <span>
-                                , support a theory that both birds are descended from “island hopping” ancestors
-                              </span>
-                              <span>
-                                .
-                              </span>
-                            </div>
-                            <div
-                              class="paragraph"
-                            >
-                              <span>
-                                The scientists took DNA from two feathers of the spotted green pigeon
-                              </span>
-                              <span>
-                                . Because of its age
-                              </span>
-                              <span>
-                                , the DNA was highly fragmented
-                              </span>
-                              <span>
-                                , so they focused in on three DNA “mini barcodes” – small sections of DNA which are unique for most bird species
-                              </span>
-                              <span>
-                                . They looked at these sections of the pigeon
-                              </span>
-                              <span>
-                                's DNA
-                              </span>
-                              <span>
-                                , and compared it to other species
-                              </span>
-                              <span>
-                                .
-                              </span>
-                            </div>
-                            <div
-                              class="paragraph"
-                            >
-                              <span>
-                                This showed that the spotted green pigeon is indeed a separate species
-                              </span>
-                              <span>
-                                , showing a unique DNA barcode compared to other pigeons
-                              </span>
-                              <span>
-                                . The pigeon is genetically most closely related to the Nicobar pigeon and the dodo and Rodrigues solitaire
-                              </span>
-                              <span>
-                                , both extinct birds from islands near Madagascar
-                              </span>
-                              <span>
-                                . The spotted green pigeon shows signs of a semi
-                              </span>
-                              <span>
-                                -terrestrial island lifestyle and the ability to fly
-                              </span>
-                              <span>
-                                . The closely related Nicobar pigeon shows similar habits and has a preference for travelling between small islands
-                              </span>
-                              <span>
-                                .
-                              </span>
-                            </div>
-                            <div
-                              class="paragraph"
-                            >
-                              <span>
-                                The scientists say this lifestyle
-                              </span>
-                              <span>
-                                , together with the relationship of both pigeons to the dodo and Rodrigues solitaire
-                              </span>
-                              <span>
-                                , supports an evolutionary theory that the ancestors of these birds were “island hoppers
-                              </span>
-                              <span>
-                                ,” moving between islands around India and Southeast Asia
-                              </span>
-                              <span>
-                                . The birds that settled on particular islands then evolved into the individual species
-                              </span>
-                              <span>
-                                . The dodo
-                              </span>
-                              <span>
-                                's ancestor managed to hop as far as the island of Mauritius near Madagascar where it then lost the ability to fly
-                              </span>
-                              <span>
-                                .
-                              </span>
-                            </div>
-                            <div
-                              class="paragraph"
-                            >
-                              <span>
-                                Dr
-                              </span>
-                              <span>
-                                . Tim Heupink
-                              </span>
-                              <span>
-                                , Griffith University Australia says
-                              </span>
-                              <span>
-                                : 
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                              <span>
-                                “This study improves our ability to identify novel species from historic remains
-                              </span>
-                              <span>
-                                , and also those that are not novel after all
-                              </span>
-                              <span>
-                                . Ultimately this will help us to measure and understand the extinction of local populations and entire species
-                              </span>
-                              <span>
-                                .”
-                              </span>
-                              <span
-                                style="display: inline-block; width: 0px; visibility: hidden;"
-                              >
-                                _
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="perseus-sr-only"
-                  >
-                    End of reading passage.
-                  </div>
+                  End of reading passage.
                 </div>
               </div>
             </div>
@@ -1781,100 +1437,416 @@ exports[`passage widget should snapshot multiple passages (mobile: true) 1`] = `
         </div>
       </div>
     </div>
-  </span>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="3"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <div>
+            <div
+              class="perseus-widget-passage-container"
+            >
+              <div
+                class="perseus-widget-passage-instructions"
+              >
+                <div
+                  class="paragraph"
+                >
+                  <span>
+                     The symbol 
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    class="perseus-passage-bracket-label"
+                  >
+                    [
+                    1
+                    ]
+                  </span>
+                  <span
+                    class="perseus-sr-only"
+                  >
+                    [Sentence 
+                    1
+                    ]
+                  </span>
+                   
+                  <span>
+                    indicates that the following sentence is referenced in a question
+                  </span>
+                  <span>
+                    .
+                  </span>
+                </div>
+              </div>
+              <div
+                class="perseus-widget-passage"
+              >
+                <h3
+                  class="passage-title"
+                >
+                  <div
+                    class="perseus-renderer perseus-renderer-responsive"
+                  >
+                    <div
+                      class="paragraph"
+                      data-perseus-paragraph-index="0"
+                    >
+                      <div
+                        class="paragraph"
+                      >
+                        Passage 2
+                      </div>
+                    </div>
+                  </div>
+                </h3>
+                <div
+                  aria-hidden="true"
+                  class="line-numbers"
+                >
+                  <span>
+                    11
+                  </span>
+                  <span>
+                    12
+                  </span>
+                  <span>
+                    13
+                  </span>
+                  <span>
+                    14
+                  </span>
+                  <span>
+                    15
+                  </span>
+                  <span>
+                    16
+                  </span>
+                  <span>
+                    17
+                  </span>
+                  <span>
+                    18
+                  </span>
+                  <span>
+                    19
+                  </span>
+                  <span>
+                    20
+                  </span>
+                </div>
+                <div
+                  class="passage-text"
+                >
+                  <div
+                    class="container_6htn2u"
+                  >
+                    <div>
+                      <div>
+                        <div>
+                          <div />
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="content_gor68n"
+                    >
+                      <div>
+                        <div>
+                          <div
+                            aria-hidden="true"
+                            class="measurer_225hir"
+                          >
+                            <div
+                              class="paragraph"
+                            >
+                              Line Height Measurement
+                            </div>
+                          </div>
+                          <div
+                            class="paragraph"
+                          >
+                            <span>
+                              The mysterious spotted green pigeon 
+                            </span>
+                            <span>
+                              (
+                            </span>
+                            <em>
+                              <span>
+                                Caloenas maculata
+                              </span>
+                            </em>
+                            <span>
+                              ) was a relative of the dodo
+                            </span>
+                            <span>
+                              , according to scientists who have examined its genetic make
+                            </span>
+                            <span>
+                              -up 
+                            </span>
+                            <span
+                              aria-hidden="true"
+                              class="perseus-passage-bracket-label"
+                            >
+                              [
+                              1
+                              ]
+                            </span>
+                            <span
+                              class="perseus-sr-only"
+                            >
+                              [Sentence 
+                              1
+                              ]
+                            </span>
+                            <span>
+                              . The authors say their results
+                            </span>
+                            <span>
+                              , published in the open access journal BMC Evolutionary Biology
+                            </span>
+                            <span>
+                              , support a theory that both birds are descended from “island hopping” ancestors
+                            </span>
+                            <span>
+                              .
+                            </span>
+                          </div>
+                          <div
+                            class="paragraph"
+                          >
+                            <span>
+                              The scientists took DNA from two feathers of the spotted green pigeon
+                            </span>
+                            <span>
+                              . Because of its age
+                            </span>
+                            <span>
+                              , the DNA was highly fragmented
+                            </span>
+                            <span>
+                              , so they focused in on three DNA “mini barcodes” – small sections of DNA which are unique for most bird species
+                            </span>
+                            <span>
+                              . They looked at these sections of the pigeon
+                            </span>
+                            <span>
+                              's DNA
+                            </span>
+                            <span>
+                              , and compared it to other species
+                            </span>
+                            <span>
+                              .
+                            </span>
+                          </div>
+                          <div
+                            class="paragraph"
+                          >
+                            <span>
+                              This showed that the spotted green pigeon is indeed a separate species
+                            </span>
+                            <span>
+                              , showing a unique DNA barcode compared to other pigeons
+                            </span>
+                            <span>
+                              . The pigeon is genetically most closely related to the Nicobar pigeon and the dodo and Rodrigues solitaire
+                            </span>
+                            <span>
+                              , both extinct birds from islands near Madagascar
+                            </span>
+                            <span>
+                              . The spotted green pigeon shows signs of a semi
+                            </span>
+                            <span>
+                              -terrestrial island lifestyle and the ability to fly
+                            </span>
+                            <span>
+                              . The closely related Nicobar pigeon shows similar habits and has a preference for travelling between small islands
+                            </span>
+                            <span>
+                              .
+                            </span>
+                          </div>
+                          <div
+                            class="paragraph"
+                          >
+                            <span>
+                              The scientists say this lifestyle
+                            </span>
+                            <span>
+                              , together with the relationship of both pigeons to the dodo and Rodrigues solitaire
+                            </span>
+                            <span>
+                              , supports an evolutionary theory that the ancestors of these birds were “island hoppers
+                            </span>
+                            <span>
+                              ,” moving between islands around India and Southeast Asia
+                            </span>
+                            <span>
+                              . The birds that settled on particular islands then evolved into the individual species
+                            </span>
+                            <span>
+                              . The dodo
+                            </span>
+                            <span>
+                              's ancestor managed to hop as far as the island of Mauritius near Madagascar where it then lost the ability to fly
+                            </span>
+                            <span>
+                              .
+                            </span>
+                          </div>
+                          <div
+                            class="paragraph"
+                          >
+                            <span>
+                              Dr
+                            </span>
+                            <span>
+                              . Tim Heupink
+                            </span>
+                            <span>
+                              , Griffith University Australia says
+                            </span>
+                            <span>
+                              : 
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                            <span>
+                              “This study improves our ability to identify novel species from historic remains
+                            </span>
+                            <span>
+                              , and also those that are not novel after all
+                            </span>
+                            <span>
+                              . Ultimately this will help us to measure and understand the extinction of local populations and entire species
+                            </span>
+                            <span>
+                              .”
+                            </span>
+                            <span
+                              style="display: inline-block; width: 0px; visibility: hidden;"
+                            >
+                              _
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="perseus-sr-only"
+                >
+                  End of reading passage.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;
 
 exports[`passage widget should snapshot simple passage (mobile: false) 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
-          <div
-            class="perseus-widget-container widget-nohighlight widget-block"
-          >
-            <div>
+          <div>
+            <div
+              class="perseus-widget-passage-container"
+            >
               <div
-                class="perseus-widget-passage-container"
+                class="perseus-widget-passage-instructions"
               >
-                <div
-                  class="perseus-widget-passage-instructions"
-                >
-                  
+                
 
-                </div>
-                <div
-                  class="perseus-widget-passage"
+              </div>
+              <div
+                class="perseus-widget-passage"
+              >
+                <h3
+                  class="perseus-sr-only"
                 >
-                  <h3
-                    class="perseus-sr-only"
-                  >
-                    Beginning of reading passage.
-                  </h3>
+                  Beginning of reading passage.
+                </h3>
+                <div
+                  class="passage-text"
+                >
                   <div
-                    class="passage-text"
+                    class="container_6htn2u"
                   >
+                    <div>
+                      <div>
+                        <div>
+                          <div />
+                        </div>
+                      </div>
+                    </div>
                     <div
-                      class="container_6htn2u"
+                      class="content_gor68n"
                     >
                       <div>
                         <div>
-                          <div>
-                            <div />
-                          </div>
-                        </div>
-                      </div>
-                      <div
-                        class="content_gor68n"
-                      >
-                        <div>
-                          <div>
-                            <div
-                              aria-hidden="true"
-                              class="measurer_225hir"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Line Height Measurement
-                              </div>
-                            </div>
+                          <div
+                            aria-hidden="true"
+                            class="measurer_225hir"
+                          >
                             <div
                               class="paragraph"
                             >
-                              <span>
-                                Sociologists study folktales because they provide a means of understanding the distinctive values of a culture
-                              </span>
-                              <span>
-                                . However
-                              </span>
-                              <span>
-                                , the folktales in almost all cultures are adaptations of the same ancient narratives to the local milieu
-                              </span>
-                              <span>
-                                .
-                              </span>
+                              Line Height Measurement
                             </div>
+                          </div>
+                          <div
+                            class="paragraph"
+                          >
+                            <span>
+                              Sociologists study folktales because they provide a means of understanding the distinctive values of a culture
+                            </span>
+                            <span>
+                              . However
+                            </span>
+                            <span>
+                              , the folktales in almost all cultures are adaptations of the same ancient narratives to the local milieu
+                            </span>
+                            <span>
+                              .
+                            </span>
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
-                  <div
-                    class="perseus-sr-only"
-                  >
-                    End of reading passage.
-                  </div>
+                </div>
+                <div
+                  class="perseus-sr-only"
+                >
+                  End of reading passage.
                 </div>
               </div>
             </div>
@@ -1882,100 +1854,96 @@ exports[`passage widget should snapshot simple passage (mobile: false) 1`] = `
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`passage widget should snapshot simple passage (mobile: true) 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
-          <div
-            class="perseus-widget-container widget-nohighlight widget-block"
-          >
-            <div>
+          <div>
+            <div
+              class="perseus-widget-passage-container"
+            >
               <div
-                class="perseus-widget-passage-container"
+                class="perseus-widget-passage-instructions"
               >
-                <div
-                  class="perseus-widget-passage-instructions"
-                >
-                  
+                
 
-                </div>
-                <div
-                  class="perseus-widget-passage"
+              </div>
+              <div
+                class="perseus-widget-passage"
+              >
+                <h3
+                  class="perseus-sr-only"
                 >
-                  <h3
-                    class="perseus-sr-only"
-                  >
-                    Beginning of reading passage.
-                  </h3>
+                  Beginning of reading passage.
+                </h3>
+                <div
+                  class="passage-text"
+                >
                   <div
-                    class="passage-text"
+                    class="container_6htn2u"
                   >
+                    <div>
+                      <div>
+                        <div>
+                          <div />
+                        </div>
+                      </div>
+                    </div>
                     <div
-                      class="container_6htn2u"
+                      class="content_gor68n"
                     >
                       <div>
                         <div>
-                          <div>
-                            <div />
-                          </div>
-                        </div>
-                      </div>
-                      <div
-                        class="content_gor68n"
-                      >
-                        <div>
-                          <div>
-                            <div
-                              aria-hidden="true"
-                              class="measurer_225hir"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                Line Height Measurement
-                              </div>
-                            </div>
+                          <div
+                            aria-hidden="true"
+                            class="measurer_225hir"
+                          >
                             <div
                               class="paragraph"
                             >
-                              <span>
-                                Sociologists study folktales because they provide a means of understanding the distinctive values of a culture
-                              </span>
-                              <span>
-                                . However
-                              </span>
-                              <span>
-                                , the folktales in almost all cultures are adaptations of the same ancient narratives to the local milieu
-                              </span>
-                              <span>
-                                .
-                              </span>
+                              Line Height Measurement
                             </div>
+                          </div>
+                          <div
+                            class="paragraph"
+                          >
+                            <span>
+                              Sociologists study folktales because they provide a means of understanding the distinctive values of a culture
+                            </span>
+                            <span>
+                              . However
+                            </span>
+                            <span>
+                              , the folktales in almost all cultures are adaptations of the same ancient narratives to the local milieu
+                            </span>
+                            <span>
+                              .
+                            </span>
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
-                  <div
-                    class="perseus-sr-only"
-                  >
-                    End of reading passage.
-                  </div>
+                </div>
+                <div
+                  class="perseus-sr-only"
+                >
+                  End of reading passage.
                 </div>
               </div>
             </div>
@@ -1983,6 +1951,6 @@ exports[`passage widget should snapshot simple passage (mobile: true) 1`] = `
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/radio.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/radio.test.ts.snap
@@ -2,94 +2,149 @@
 
 exports[`multi-choice question should snapshot the same when invalid: invalid state 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          <strong>
-            Select all input values for which 
+        <strong>
+          Select all input values for which 
+          <span
+            style="white-space: nowrap;"
+          >
+            <span />
             <span
-              style="white-space: nowrap;"
+              class="mock-TeX"
             >
-              <span />
-              <span
-                class="mock-TeX"
-              >
-                g(x)=2
-              </span>
-              <span />
+              g(x)=2
             </span>
-            .
-          </strong>
-        </div>
+            <span />
+          </span>
+          .
+        </strong>
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="1"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+            class="responsiveContainer_vq37gq"
           >
-            <div
-              class="responsiveContainer_vq37gq"
+            <fieldset
+              class="perseus-widget-radio-fieldset responsiveFieldset_c0l5kf"
             >
-              <fieldset
-                class="perseus-widget-radio-fieldset responsiveFieldset_c0l5kf"
+              <legend
+                class="perseus-sr-only"
               >
-                <legend
-                  class="perseus-sr-only"
+                Choose all answers that apply:
+              </legend>
+              <div
+                aria-hidden="true"
+                class="instructions instructions_125m8j1"
+              >
+                Choose all answers that apply:
+              </div>
+              <ul
+                class="perseus-widget-radio perseus-rendered-radio radio_1gyjybc-o_O-responsiveRadioContainer_1ybwre2"
+                style="list-style: none;"
+              >
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd-o_O-selectedItem_p6cyk0 perseus-radio-option perseus-radio-selected"
                 >
-                  Choose all answers that apply:
-                </legend>
-                <div
-                  aria-hidden="true"
-                  class="instructions instructions_125m8j1"
-                >
-                  Choose all answers that apply:
-                </div>
-                <ul
-                  class="perseus-widget-radio perseus-rendered-radio radio_1gyjybc-o_O-responsiveRadioContainer_1ybwre2"
-                  style="list-style: none;"
-                >
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd-o_O-selectedItem_p6cyk0 perseus-radio-option perseus-radio-selected"
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
                   >
                     <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
+                      style="display: flex; flex-direction: row; opacity: 1;"
                     >
                       <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-318"
+                          tabindex="-1"
+                          type="checkbox"
+                        />
+                        <label
+                          for="choice-318"
+                        >
+                          (Choice A, Checked)
+                             
+                          <div
+                            class="perseus-renderer perseus-renderer-responsive"
+                          >
+                            <div
+                              class="paragraph perseus-paragraph-centered"
+                              data-perseus-paragraph-index="0"
+                            >
+                              <div
+                                class="perseus-block-math"
+                              >
+                                <div
+                                  class="perseus-block-math-inner"
+                                  style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                >
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    x=-6
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
                       >
                         <div
-                          class="perseus-sr-only"
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
                         >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-318"
-                            tabindex="-1"
-                            type="checkbox"
-                          />
-                          <label
-                            for="choice-318"
+                          <div
+                            class="iconWrapper_17y0hv9"
                           >
-                            (Choice A, Checked)
-                               
                             <span
-                              class="mock-KatexProvider"
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 5px;"
                             >
+                              <div
+                                class="circle_1tys2th"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: #1865f2; color: rgb(255, 255, 255); border-radius: 3px; background-color: rgb(24, 101, 242);"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
+                                >
+                                  A
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                          >
+                            <div />
+                            <div>
                               <div
                                 class="perseus-renderer perseus-renderer-responsive"
                               >
@@ -113,106 +168,98 @@ exports[`multi-choice question should snapshot the same when invalid: invalid st
                                   </div>
                                 </div>
                               </div>
-                            </span>
-                          </label>
+                            </div>
+                          </span>
                         </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
+                      </button>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
+                      <div
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-319"
+                          tabindex="-1"
+                          type="checkbox"
+                        />
+                        <label
+                          for="choice-319"
                         >
+                          (Choice B)
+                             
                           <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                            class="perseus-renderer perseus-renderer-responsive"
                           >
                             <div
-                              class="iconWrapper_17y0hv9"
+                              class="paragraph perseus-paragraph-centered"
+                              data-perseus-paragraph-index="0"
                             >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 5px;"
+                              <div
+                                class="perseus-block-math"
                               >
                                 <div
-                                  class="circle_1tys2th"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: #1865f2; color: rgb(255, 255, 255); border-radius: 3px; background-color: rgb(24, 101, 242);"
+                                  class="perseus-block-math-inner"
+                                  style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
                                 >
-                                  <div
-                                    class="innerWrapper_177sg8x"
+                                  <span
+                                    class="mock-TeX"
                                   >
-                                    A
-                                  </div>
+                                    x=4
+                                  </span>
                                 </div>
-                              </span>
+                              </div>
                             </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
                             <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 5px;"
                             >
-                              <div />
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
+                              <div
+                                class="circle_1tys2th"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 3px;"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
                                 >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph perseus-paragraph-centered"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="perseus-block-math"
-                                      >
-                                        <div
-                                          class="perseus-block-math-inner"
-                                          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                        >
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            x=-6
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
+                                  B
+                                </div>
                               </div>
                             </span>
                           </div>
-                        </button>
-                      </div>
-                    </div>
-                  </li>
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
-                      >
-                        <div
-                          class="perseus-sr-only"
-                        >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-319"
-                            tabindex="-1"
-                            type="checkbox"
-                          />
-                          <label
-                            for="choice-319"
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
                           >
-                            (Choice B)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
+                            <div />
+                            <div>
                               <div
                                 class="perseus-renderer perseus-renderer-responsive"
                               >
@@ -236,106 +283,98 @@ exports[`multi-choice question should snapshot the same when invalid: invalid st
                                   </div>
                                 </div>
                               </div>
-                            </span>
-                          </label>
+                            </div>
+                          </span>
                         </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
+                      </button>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
+                      <div
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-320"
+                          tabindex="-1"
+                          type="checkbox"
+                        />
+                        <label
+                          for="choice-320"
                         >
+                          (Choice C)
+                             
                           <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                            class="perseus-renderer perseus-renderer-responsive"
                           >
                             <div
-                              class="iconWrapper_17y0hv9"
+                              class="paragraph perseus-paragraph-centered"
+                              data-perseus-paragraph-index="0"
                             >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 5px;"
+                              <div
+                                class="perseus-block-math"
                               >
                                 <div
-                                  class="circle_1tys2th"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 3px;"
+                                  class="perseus-block-math-inner"
+                                  style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
                                 >
-                                  <div
-                                    class="innerWrapper_177sg8x"
+                                  <span
+                                    class="mock-TeX"
                                   >
-                                    B
-                                  </div>
+                                    x=7
+                                  </span>
                                 </div>
-                              </span>
+                              </div>
                             </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
                             <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 5px;"
                             >
-                              <div />
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
+                              <div
+                                class="circle_1tys2th"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 3px;"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
                                 >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph perseus-paragraph-centered"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="perseus-block-math"
-                                      >
-                                        <div
-                                          class="perseus-block-math-inner"
-                                          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                        >
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            x=4
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
+                                  C
+                                </div>
                               </div>
                             </span>
                           </div>
-                        </button>
-                      </div>
-                    </div>
-                  </li>
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
-                      >
-                        <div
-                          class="perseus-sr-only"
-                        >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-320"
-                            tabindex="-1"
-                            type="checkbox"
-                          />
-                          <label
-                            for="choice-320"
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
                           >
-                            (Choice C)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
+                            <div />
+                            <div>
                               <div
                                 class="perseus-renderer perseus-renderer-responsive"
                               >
@@ -359,106 +398,89 @@ exports[`multi-choice question should snapshot the same when invalid: invalid st
                                   </div>
                                 </div>
                               </div>
-                            </span>
-                          </label>
+                            </div>
+                          </span>
                         </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
+                      </button>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
+                      <div
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-321"
+                          tabindex="-1"
+                          type="checkbox"
+                        />
+                        <label
+                          for="choice-321"
                         >
+                          (Choice D)
+                             
                           <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                            class="perseus-renderer perseus-renderer-responsive"
                           >
                             <div
-                              class="iconWrapper_17y0hv9"
+                              class="paragraph"
+                              data-perseus-paragraph-index="0"
                             >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 5px;"
+                              <div
+                                class="paragraph"
+                              >
+                                None of the above
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
+                            <span
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 5px;"
+                            >
+                              <div
+                                class="circle_1tys2th"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 3px;"
                               >
                                 <div
-                                  class="circle_1tys2th"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 3px;"
+                                  class="innerWrapper_177sg8x"
                                 >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    C
-                                  </div>
+                                  D
                                 </div>
-                              </span>
-                            </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div />
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph perseus-paragraph-centered"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="perseus-block-math"
-                                      >
-                                        <div
-                                          class="perseus-block-math-inner"
-                                          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                        >
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            x=7
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
                               </div>
                             </span>
                           </div>
-                        </button>
-                      </div>
-                    </div>
-                  </li>
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
-                      >
-                        <div
-                          class="perseus-sr-only"
-                        >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-321"
-                            tabindex="-1"
-                            type="checkbox"
-                          />
-                          <label
-                            for="choice-321"
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
                           >
-                            (Choice D)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
+                            <div />
+                            <div>
                               <div
                                 class="perseus-renderer perseus-renderer-responsive"
                               >
@@ -473,3404 +495,155 @@ exports[`multi-choice question should snapshot the same when invalid: invalid st
                                   </div>
                                 </div>
                               </div>
-                            </span>
-                          </label>
-                        </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                          >
-                            <div
-                              class="iconWrapper_17y0hv9"
-                            >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 5px;"
-                              >
-                                <div
-                                  class="circle_1tys2th"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 3px;"
-                                >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    D
-                                  </div>
-                                </div>
-                              </span>
                             </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div />
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="paragraph"
-                                      >
-                                        None of the above
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </span>
-                          </div>
-                        </button>
-                      </div>
+                          </span>
+                        </div>
+                      </button>
                     </div>
-                  </li>
-                </ul>
-              </fieldset>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="paragraph perseus-paragraph-centered"
-        data-perseus-paragraph-index="2"
-      >
-        <div
-          class="paragraph"
-        >
-           
-          <div
-            class="fixed-to-responsive svg-image"
-            style="max-width: 428px; max-height: 428px;"
-          >
-            <div
-              style="padding-bottom: 100%;"
-            />
-            <span
-              style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
-            >
-              <div
-                class="default_xu2jcg-o_O-spinnerContainer_agrn11"
-              >
-                <svg
-                  height="48"
-                  viewBox="0 0 48 48"
-                  width="48"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
-                    d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
-                    fill-rule="nonzero"
-                  />
-                </svg>
-              </div>
-            </span>
+                  </div>
+                </li>
+              </ul>
+            </fieldset>
           </div>
         </div>
       </div>
     </div>
-  </span>
+    <div
+      class="paragraph perseus-paragraph-centered"
+      data-perseus-paragraph-index="2"
+    >
+      <div
+        class="paragraph"
+      >
+         
+        <div
+          class="fixed-to-responsive svg-image"
+          style="max-width: 428px; max-height: 428px;"
+        >
+          <div
+            style="padding-bottom: 100%;"
+          />
+          <span
+            style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
+          >
+            <div
+              class="default_xu2jcg-o_O-spinnerContainer_agrn11"
+            >
+              <svg
+                height="48"
+                viewBox="0 0 48 48"
+                width="48"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  class="loadingSpinner_1dvgeb3-o_O-inlineStyles_1kzk0y9"
+                  d="M44.19 23.455a1.91 1.91 0 1 1 3.801 0h.003c.004.18.006.363.006.545 0 13.255-10.745 24-24 24S0 37.255 0 24 10.745 0 24 0c.182 0 .364.002.545.006V.01a1.91 1.91 0 1 1 0 3.801v.015A20.564 20.564 0 0 0 24 3.818C12.854 3.818 3.818 12.854 3.818 24c0 11.146 9.036 20.182 20.182 20.182 11.146 0 20.182-9.036 20.182-20.182 0-.182-.003-.364-.007-.545h.015z"
+                  fill-rule="nonzero"
+                />
+              </svg>
+            </div>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;
 
 exports[`single-choice question reviewMode: false should snapshot the same with correct answer: correct answer 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
+        Which of the following values of 
+        <span
+          style="white-space: nowrap;"
         >
-          Which of the following values of 
+          <span />
           <span
-            style="white-space: nowrap;"
+            class="mock-TeX"
           >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              x
-            </span>
-            <span />
+            x
           </span>
-           satisfies the equation 
-          <span
-            style="white-space: nowrap;"
-          >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              \\sqrt{64}=x
-            </span>
-            <span />
-          </span>
-           ?
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="1"
-      >
-        <div
-          class="paragraph"
+          <span />
+        </span>
+         satisfies the equation 
+        <span
+          style="white-space: nowrap;"
         >
-          <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+          <span />
+          <span
+            class="mock-TeX"
           >
-            <div
-              class="responsiveContainer_vq37gq"
-            >
-              <fieldset
-                class="perseus-widget-radio-fieldset responsiveFieldset_c0l5kf"
-              >
-                <legend
-                  class="perseus-sr-only"
-                >
-                  Choose 1 answer:
-                </legend>
-                <div
-                  aria-hidden="true"
-                  class="instructions instructions_125m8j1"
-                >
-                  Choose 1 answer:
-                </div>
-                <ul
-                  class="perseus-widget-radio perseus-rendered-radio radio_1gyjybc-o_O-responsiveRadioContainer_1ybwre2"
-                  style="list-style: none;"
-                >
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
-                      >
-                        <div
-                          class="perseus-sr-only"
-                        >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-88"
-                            tabindex="-1"
-                            type="radio"
-                          />
-                          <label
-                            for="choice-88"
-                          >
-                            (Choice A)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
-                              <div
-                                class="perseus-renderer perseus-renderer-responsive"
-                              >
-                                <div
-                                  class="paragraph"
-                                  data-perseus-paragraph-index="0"
-                                >
-                                  <div
-                                    class="paragraph"
-                                  >
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        -8
-                                      </span>
-                                      <span />
-                                    </span>
-                                     and 
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        8
-                                      </span>
-                                      <span />
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </span>
-                          </label>
-                        </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                          >
-                            <div
-                              class="iconWrapper_17y0hv9"
-                            >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 50%;"
-                              >
-                                <div
-                                  class="circle_1tys2th"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    A
-                                  </div>
-                                </div>
-                              </span>
-                            </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div />
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="paragraph"
-                                      >
-                                        <span
-                                          style="white-space: nowrap;"
-                                        >
-                                          <span />
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            -8
-                                          </span>
-                                          <span />
-                                        </span>
-                                         and 
-                                        <span
-                                          style="white-space: nowrap;"
-                                        >
-                                          <span />
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            8
-                                          </span>
-                                          <span />
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </span>
-                          </div>
-                        </button>
-                      </div>
-                    </div>
-                  </li>
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
-                      >
-                        <div
-                          class="perseus-sr-only"
-                        >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-89"
-                            tabindex="-1"
-                            type="radio"
-                          />
-                          <label
-                            for="choice-89"
-                          >
-                            (Choice B)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
-                              <div
-                                class="perseus-renderer perseus-renderer-responsive"
-                              >
-                                <div
-                                  class="paragraph perseus-paragraph-centered"
-                                  data-perseus-paragraph-index="0"
-                                >
-                                  <div
-                                    class="perseus-block-math"
-                                  >
-                                    <div
-                                      class="perseus-block-math-inner"
-                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                    >
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        -8
-                                      </span>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </span>
-                          </label>
-                        </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                          >
-                            <div
-                              class="iconWrapper_17y0hv9"
-                            >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 50%;"
-                              >
-                                <div
-                                  class="circle_1tys2th"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    B
-                                  </div>
-                                </div>
-                              </span>
-                            </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div />
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph perseus-paragraph-centered"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="perseus-block-math"
-                                      >
-                                        <div
-                                          class="perseus-block-math-inner"
-                                          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                        >
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            -8
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </span>
-                          </div>
-                        </button>
-                      </div>
-                    </div>
-                  </li>
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd-o_O-selectedItem_p6cyk0 perseus-radio-option perseus-radio-selected"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
-                      >
-                        <div
-                          class="perseus-sr-only"
-                        >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-90"
-                            tabindex="-1"
-                            type="radio"
-                          />
-                          <label
-                            for="choice-90"
-                          >
-                            (Choice C, Checked)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
-                              <div
-                                class="perseus-renderer perseus-renderer-responsive"
-                              >
-                                <div
-                                  class="paragraph perseus-paragraph-centered"
-                                  data-perseus-paragraph-index="0"
-                                >
-                                  <div
-                                    class="perseus-block-math"
-                                  >
-                                    <div
-                                      class="perseus-block-math-inner"
-                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                    >
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        8
-                                      </span>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </span>
-                          </label>
-                        </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                          >
-                            <div
-                              class="iconWrapper_17y0hv9"
-                            >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 50%;"
-                              >
-                                <div
-                                  class="circle_1tys2th"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: #1865f2; color: rgb(255, 255, 255); border-radius: 24px; background-color: rgb(24, 101, 242);"
-                                >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    C
-                                  </div>
-                                </div>
-                              </span>
-                            </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div />
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph perseus-paragraph-centered"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="perseus-block-math"
-                                      >
-                                        <div
-                                          class="perseus-block-math-inner"
-                                          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                        >
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            8
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </span>
-                          </div>
-                        </button>
-                      </div>
-                    </div>
-                  </li>
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
-                      >
-                        <div
-                          class="perseus-sr-only"
-                        >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-91"
-                            tabindex="-1"
-                            type="radio"
-                          />
-                          <label
-                            for="choice-91"
-                          >
-                            (Choice D)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
-                              <div
-                                class="perseus-renderer perseus-renderer-responsive"
-                              >
-                                <div
-                                  class="paragraph"
-                                  data-perseus-paragraph-index="0"
-                                >
-                                  <div
-                                    class="paragraph"
-                                  >
-                                    No value of 
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        x
-                                      </span>
-                                      <span />
-                                    </span>
-                                     satisfies the equation.
-                                  </div>
-                                </div>
-                              </div>
-                            </span>
-                          </label>
-                        </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                          >
-                            <div
-                              class="iconWrapper_17y0hv9"
-                            >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 50%;"
-                              >
-                                <div
-                                  class="circle_1tys2th"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    D
-                                  </div>
-                                </div>
-                              </span>
-                            </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div />
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="paragraph"
-                                      >
-                                        No value of 
-                                        <span
-                                          style="white-space: nowrap;"
-                                        >
-                                          <span />
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            x
-                                          </span>
-                                          <span />
-                                        </span>
-                                         satisfies the equation.
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </span>
-                          </div>
-                        </button>
-                      </div>
-                    </div>
-                  </li>
-                </ul>
-              </fieldset>
-            </div>
-          </div>
-        </div>
+            \\sqrt{64}=x
+          </span>
+          <span />
+        </span>
+         ?
       </div>
     </div>
-  </span>
-</div>
-`;
-
-exports[`single-choice question reviewMode: false should snapshot the same with incorrect answer: incorrect answer 1`] = `
-<div>
-  <span
-    class="mock-KatexProvider"
-  >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="1"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
         <div
-          class="paragraph"
-        >
-          Which of the following values of 
-          <span
-            style="white-space: nowrap;"
-          >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              x
-            </span>
-            <span />
-          </span>
-           satisfies the equation 
-          <span
-            style="white-space: nowrap;"
-          >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              \\sqrt{64}=x
-            </span>
-            <span />
-          </span>
-           ?
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="1"
-      >
-        <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+            class="responsiveContainer_vq37gq"
           >
-            <div
-              class="responsiveContainer_vq37gq"
+            <fieldset
+              class="perseus-widget-radio-fieldset responsiveFieldset_c0l5kf"
             >
-              <fieldset
-                class="perseus-widget-radio-fieldset responsiveFieldset_c0l5kf"
+              <legend
+                class="perseus-sr-only"
               >
-                <legend
-                  class="perseus-sr-only"
-                >
-                  Choose 1 answer:
-                </legend>
-                <div
-                  aria-hidden="true"
-                  class="instructions instructions_125m8j1"
-                >
-                  Choose 1 answer:
-                </div>
-                <ul
-                  class="perseus-widget-radio perseus-rendered-radio radio_1gyjybc-o_O-responsiveRadioContainer_1ybwre2"
-                  style="list-style: none;"
-                >
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd-o_O-selectedItem_p6cyk0 perseus-radio-option perseus-radio-selected"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
-                      >
-                        <div
-                          class="perseus-sr-only"
-                        >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-96"
-                            tabindex="-1"
-                            type="radio"
-                          />
-                          <label
-                            for="choice-96"
-                          >
-                            (Choice A, Checked)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
-                              <div
-                                class="perseus-renderer perseus-renderer-responsive"
-                              >
-                                <div
-                                  class="paragraph"
-                                  data-perseus-paragraph-index="0"
-                                >
-                                  <div
-                                    class="paragraph"
-                                  >
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        -8
-                                      </span>
-                                      <span />
-                                    </span>
-                                     and 
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        8
-                                      </span>
-                                      <span />
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </span>
-                          </label>
-                        </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                          >
-                            <div
-                              class="iconWrapper_17y0hv9"
-                            >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 50%;"
-                              >
-                                <div
-                                  class="circle_1tys2th"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: #1865f2; color: rgb(255, 255, 255); border-radius: 24px; background-color: rgb(24, 101, 242);"
-                                >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    A
-                                  </div>
-                                </div>
-                              </span>
-                            </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div />
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="paragraph"
-                                      >
-                                        <span
-                                          style="white-space: nowrap;"
-                                        >
-                                          <span />
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            -8
-                                          </span>
-                                          <span />
-                                        </span>
-                                         and 
-                                        <span
-                                          style="white-space: nowrap;"
-                                        >
-                                          <span />
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            8
-                                          </span>
-                                          <span />
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </span>
-                          </div>
-                        </button>
-                      </div>
-                    </div>
-                  </li>
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
-                      >
-                        <div
-                          class="perseus-sr-only"
-                        >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-97"
-                            tabindex="-1"
-                            type="radio"
-                          />
-                          <label
-                            for="choice-97"
-                          >
-                            (Choice B)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
-                              <div
-                                class="perseus-renderer perseus-renderer-responsive"
-                              >
-                                <div
-                                  class="paragraph perseus-paragraph-centered"
-                                  data-perseus-paragraph-index="0"
-                                >
-                                  <div
-                                    class="perseus-block-math"
-                                  >
-                                    <div
-                                      class="perseus-block-math-inner"
-                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                    >
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        -8
-                                      </span>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </span>
-                          </label>
-                        </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                          >
-                            <div
-                              class="iconWrapper_17y0hv9"
-                            >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 50%;"
-                              >
-                                <div
-                                  class="circle_1tys2th"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    B
-                                  </div>
-                                </div>
-                              </span>
-                            </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div />
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph perseus-paragraph-centered"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="perseus-block-math"
-                                      >
-                                        <div
-                                          class="perseus-block-math-inner"
-                                          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                        >
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            -8
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </span>
-                          </div>
-                        </button>
-                      </div>
-                    </div>
-                  </li>
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
-                      >
-                        <div
-                          class="perseus-sr-only"
-                        >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-98"
-                            tabindex="-1"
-                            type="radio"
-                          />
-                          <label
-                            for="choice-98"
-                          >
-                            (Choice C)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
-                              <div
-                                class="perseus-renderer perseus-renderer-responsive"
-                              >
-                                <div
-                                  class="paragraph perseus-paragraph-centered"
-                                  data-perseus-paragraph-index="0"
-                                >
-                                  <div
-                                    class="perseus-block-math"
-                                  >
-                                    <div
-                                      class="perseus-block-math-inner"
-                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                    >
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        8
-                                      </span>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </span>
-                          </label>
-                        </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                          >
-                            <div
-                              class="iconWrapper_17y0hv9"
-                            >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 50%;"
-                              >
-                                <div
-                                  class="circle_1tys2th"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    C
-                                  </div>
-                                </div>
-                              </span>
-                            </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div />
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph perseus-paragraph-centered"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="perseus-block-math"
-                                      >
-                                        <div
-                                          class="perseus-block-math-inner"
-                                          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                        >
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            8
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </span>
-                          </div>
-                        </button>
-                      </div>
-                    </div>
-                  </li>
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
-                      >
-                        <div
-                          class="perseus-sr-only"
-                        >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-99"
-                            tabindex="-1"
-                            type="radio"
-                          />
-                          <label
-                            for="choice-99"
-                          >
-                            (Choice D)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
-                              <div
-                                class="perseus-renderer perseus-renderer-responsive"
-                              >
-                                <div
-                                  class="paragraph"
-                                  data-perseus-paragraph-index="0"
-                                >
-                                  <div
-                                    class="paragraph"
-                                  >
-                                    No value of 
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        x
-                                      </span>
-                                      <span />
-                                    </span>
-                                     satisfies the equation.
-                                  </div>
-                                </div>
-                              </div>
-                            </span>
-                          </label>
-                        </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                          >
-                            <div
-                              class="iconWrapper_17y0hv9"
-                            >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 50%;"
-                              >
-                                <div
-                                  class="circle_1tys2th"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    D
-                                  </div>
-                                </div>
-                              </span>
-                            </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div />
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="paragraph"
-                                      >
-                                        No value of 
-                                        <span
-                                          style="white-space: nowrap;"
-                                        >
-                                          <span />
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            x
-                                          </span>
-                                          <span />
-                                        </span>
-                                         satisfies the equation.
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </span>
-                          </div>
-                        </button>
-                      </div>
-                    </div>
-                  </li>
-                </ul>
-              </fieldset>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </span>
-</div>
-`;
-
-exports[`single-choice question reviewMode: false should snapshot the same: first render 1`] = `
-<div>
-  <span
-    class="mock-KatexProvider"
-  >
-    <div
-      class="perseus-renderer perseus-renderer-responsive"
-    >
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="0"
-      >
-        <div
-          class="paragraph"
-        >
-          Which of the following values of 
-          <span
-            style="white-space: nowrap;"
-          >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              x
-            </span>
-            <span />
-          </span>
-           satisfies the equation 
-          <span
-            style="white-space: nowrap;"
-          >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              \\sqrt{64}=x
-            </span>
-            <span />
-          </span>
-           ?
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="1"
-      >
-        <div
-          class="paragraph"
-        >
-          <div
-            class="perseus-widget-container widget-nohighlight widget-block"
-          >
-            <div
-              class="responsiveContainer_vq37gq"
-            >
-              <fieldset
-                class="perseus-widget-radio-fieldset responsiveFieldset_c0l5kf"
+                Choose 1 answer:
+              </legend>
+              <div
+                aria-hidden="true"
+                class="instructions instructions_125m8j1"
               >
-                <legend
-                  class="perseus-sr-only"
-                >
-                  Choose 1 answer:
-                </legend>
-                <div
-                  aria-hidden="true"
-                  class="instructions instructions_125m8j1"
-                >
-                  Choose 1 answer:
-                </div>
-                <ul
-                  class="perseus-widget-radio perseus-rendered-radio radio_1gyjybc-o_O-responsiveRadioContainer_1ybwre2"
-                  style="list-style: none;"
-                >
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
-                      >
-                        <div
-                          class="perseus-sr-only"
-                        >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-80"
-                            tabindex="-1"
-                            type="radio"
-                          />
-                          <label
-                            for="choice-80"
-                          >
-                            (Choice A)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
-                              <div
-                                class="perseus-renderer perseus-renderer-responsive"
-                              >
-                                <div
-                                  class="paragraph"
-                                  data-perseus-paragraph-index="0"
-                                >
-                                  <div
-                                    class="paragraph"
-                                  >
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        -8
-                                      </span>
-                                      <span />
-                                    </span>
-                                     and 
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        8
-                                      </span>
-                                      <span />
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </span>
-                          </label>
-                        </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                          >
-                            <div
-                              class="iconWrapper_17y0hv9"
-                            >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 50%;"
-                              >
-                                <div
-                                  class="circle_1tys2th"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    A
-                                  </div>
-                                </div>
-                              </span>
-                            </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div />
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="paragraph"
-                                      >
-                                        <span
-                                          style="white-space: nowrap;"
-                                        >
-                                          <span />
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            -8
-                                          </span>
-                                          <span />
-                                        </span>
-                                         and 
-                                        <span
-                                          style="white-space: nowrap;"
-                                        >
-                                          <span />
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            8
-                                          </span>
-                                          <span />
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </span>
-                          </div>
-                        </button>
-                      </div>
-                    </div>
-                  </li>
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
-                      >
-                        <div
-                          class="perseus-sr-only"
-                        >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-81"
-                            tabindex="-1"
-                            type="radio"
-                          />
-                          <label
-                            for="choice-81"
-                          >
-                            (Choice B)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
-                              <div
-                                class="perseus-renderer perseus-renderer-responsive"
-                              >
-                                <div
-                                  class="paragraph perseus-paragraph-centered"
-                                  data-perseus-paragraph-index="0"
-                                >
-                                  <div
-                                    class="perseus-block-math"
-                                  >
-                                    <div
-                                      class="perseus-block-math-inner"
-                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                    >
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        -8
-                                      </span>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </span>
-                          </label>
-                        </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                          >
-                            <div
-                              class="iconWrapper_17y0hv9"
-                            >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 50%;"
-                              >
-                                <div
-                                  class="circle_1tys2th"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    B
-                                  </div>
-                                </div>
-                              </span>
-                            </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div />
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph perseus-paragraph-centered"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="perseus-block-math"
-                                      >
-                                        <div
-                                          class="perseus-block-math-inner"
-                                          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                        >
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            -8
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </span>
-                          </div>
-                        </button>
-                      </div>
-                    </div>
-                  </li>
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
-                      >
-                        <div
-                          class="perseus-sr-only"
-                        >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-82"
-                            tabindex="-1"
-                            type="radio"
-                          />
-                          <label
-                            for="choice-82"
-                          >
-                            (Choice C)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
-                              <div
-                                class="perseus-renderer perseus-renderer-responsive"
-                              >
-                                <div
-                                  class="paragraph perseus-paragraph-centered"
-                                  data-perseus-paragraph-index="0"
-                                >
-                                  <div
-                                    class="perseus-block-math"
-                                  >
-                                    <div
-                                      class="perseus-block-math-inner"
-                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                    >
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        8
-                                      </span>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </span>
-                          </label>
-                        </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                          >
-                            <div
-                              class="iconWrapper_17y0hv9"
-                            >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 50%;"
-                              >
-                                <div
-                                  class="circle_1tys2th"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    C
-                                  </div>
-                                </div>
-                              </span>
-                            </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div />
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph perseus-paragraph-centered"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="perseus-block-math"
-                                      >
-                                        <div
-                                          class="perseus-block-math-inner"
-                                          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                        >
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            8
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </span>
-                          </div>
-                        </button>
-                      </div>
-                    </div>
-                  </li>
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
-                      >
-                        <div
-                          class="perseus-sr-only"
-                        >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-83"
-                            tabindex="-1"
-                            type="radio"
-                          />
-                          <label
-                            for="choice-83"
-                          >
-                            (Choice D)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
-                              <div
-                                class="perseus-renderer perseus-renderer-responsive"
-                              >
-                                <div
-                                  class="paragraph"
-                                  data-perseus-paragraph-index="0"
-                                >
-                                  <div
-                                    class="paragraph"
-                                  >
-                                    No value of 
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        x
-                                      </span>
-                                      <span />
-                                    </span>
-                                     satisfies the equation.
-                                  </div>
-                                </div>
-                              </div>
-                            </span>
-                          </label>
-                        </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                          >
-                            <div
-                              class="iconWrapper_17y0hv9"
-                            >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 50%;"
-                              >
-                                <div
-                                  class="circle_1tys2th"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    D
-                                  </div>
-                                </div>
-                              </span>
-                            </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div />
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="paragraph"
-                                      >
-                                        No value of 
-                                        <span
-                                          style="white-space: nowrap;"
-                                        >
-                                          <span />
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            x
-                                          </span>
-                                          <span />
-                                        </span>
-                                         satisfies the equation.
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </span>
-                          </div>
-                        </button>
-                      </div>
-                    </div>
-                  </li>
-                </ul>
-              </fieldset>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </span>
-</div>
-`;
-
-exports[`single-choice question reviewMode: true should snapshot the same with correct answer: correct answer 1`] = `
-<div>
-  <span
-    class="mock-KatexProvider"
-  >
-    <div
-      class="perseus-renderer perseus-renderer-responsive"
-    >
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="0"
-      >
-        <div
-          class="paragraph"
-        >
-          Which of the following values of 
-          <span
-            style="white-space: nowrap;"
-          >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              x
-            </span>
-            <span />
-          </span>
-           satisfies the equation 
-          <span
-            style="white-space: nowrap;"
-          >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              \\sqrt{64}=x
-            </span>
-            <span />
-          </span>
-           ?
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="1"
-      >
-        <div
-          class="paragraph"
-        >
-          <div
-            class="perseus-widget-container widget-nohighlight widget-block"
-          >
-            <div
-              class="responsiveContainer_vq37gq"
-            >
-              <fieldset
-                class="perseus-widget-radio-fieldset responsiveFieldset_c0l5kf"
+                Choose 1 answer:
+              </div>
+              <ul
+                class="perseus-widget-radio perseus-rendered-radio radio_1gyjybc-o_O-responsiveRadioContainer_1ybwre2"
+                style="list-style: none;"
               >
-                <legend
-                  class="perseus-sr-only"
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                 >
-                  Choose 1 answer:
-                </legend>
-                <div
-                  aria-hidden="true"
-                  class="instructions instructions_125m8j1"
-                >
-                  Choose 1 answer:
-                </div>
-                <ul
-                  class="perseus-widget-radio perseus-rendered-radio radio_1gyjybc-o_O-responsiveRadioContainer_1ybwre2"
-                  style="list-style: none;"
-                >
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
                   >
                     <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
+                      style="display: flex; flex-direction: row; opacity: 1;"
                     >
                       <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
+                        class="perseus-sr-only"
                       >
-                        <div
-                          class="perseus-sr-only"
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-88"
+                          tabindex="-1"
+                          type="radio"
+                        />
+                        <label
+                          for="choice-88"
                         >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-8"
-                            tabindex="-1"
-                            type="radio"
-                          />
-                          <label
-                            for="choice-8"
-                          >
-                            (Choice A)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
-                              <div
-                                class="perseus-renderer perseus-renderer-responsive"
-                              >
-                                <div
-                                  class="paragraph"
-                                  data-perseus-paragraph-index="0"
-                                >
-                                  <div
-                                    class="paragraph"
-                                  >
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        -8
-                                      </span>
-                                      <span />
-                                    </span>
-                                     and 
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        8
-                                      </span>
-                                      <span />
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </span>
-                          </label>
-                        </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                          >
-                            <div
-                              class="iconWrapper_17y0hv9"
-                            >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 50%;"
-                              >
-                                <div
-                                  class="circle_1tys2th"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    A
-                                  </div>
-                                </div>
-                              </span>
-                            </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div />
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="paragraph"
-                                      >
-                                        <span
-                                          style="white-space: nowrap;"
-                                        >
-                                          <span />
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            -8
-                                          </span>
-                                          <span />
-                                        </span>
-                                         and 
-                                        <span
-                                          style="white-space: nowrap;"
-                                        >
-                                          <span />
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            8
-                                          </span>
-                                          <span />
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </span>
-                          </div>
-                        </button>
-                      </div>
-                    </div>
-                  </li>
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
-                      >
-                        <div
-                          class="perseus-sr-only"
-                        >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-9"
-                            tabindex="-1"
-                            type="radio"
-                          />
-                          <label
-                            for="choice-9"
-                          >
-                            (Choice B)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
-                              <div
-                                class="perseus-renderer perseus-renderer-responsive"
-                              >
-                                <div
-                                  class="paragraph perseus-paragraph-centered"
-                                  data-perseus-paragraph-index="0"
-                                >
-                                  <div
-                                    class="perseus-block-math"
-                                  >
-                                    <div
-                                      class="perseus-block-math-inner"
-                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                    >
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        -8
-                                      </span>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </span>
-                          </label>
-                        </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                          >
-                            <div
-                              class="iconWrapper_17y0hv9"
-                            >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 50%;"
-                              >
-                                <div
-                                  class="circle_1tys2th"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    B
-                                  </div>
-                                </div>
-                              </span>
-                            </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div />
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph perseus-paragraph-centered"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="perseus-block-math"
-                                      >
-                                        <div
-                                          class="perseus-block-math-inner"
-                                          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                        >
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            -8
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </span>
-                          </div>
-                        </button>
-                      </div>
-                    </div>
-                  </li>
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd-o_O-selectedItem_p6cyk0 perseus-radio-option perseus-radio-selected"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
-                      >
-                        <div
-                          class="perseus-sr-only"
-                        >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-10"
-                            tabindex="-1"
-                            type="radio"
-                          />
-                          <label
-                            for="choice-10"
-                          >
-                            (Choice C, Checked)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
-                              <div
-                                class="perseus-renderer perseus-renderer-responsive"
-                              >
-                                <div
-                                  class="paragraph perseus-paragraph-centered"
-                                  data-perseus-paragraph-index="0"
-                                >
-                                  <div
-                                    class="perseus-block-math"
-                                  >
-                                    <div
-                                      class="perseus-block-math-inner"
-                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                    >
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        8
-                                      </span>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </span>
-                          </label>
-                        </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                          >
-                            <div
-                              class="iconWrapper_17y0hv9"
-                            >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 50%;"
-                              >
-                                <div
-                                  class="circle_1tys2th"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: #1865f2; color: rgb(255, 255, 255); border-radius: 24px; background-color: rgb(24, 101, 242);"
-                                >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    C
-                                  </div>
-                                </div>
-                              </span>
-                            </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div />
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph perseus-paragraph-centered"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="perseus-block-math"
-                                      >
-                                        <div
-                                          class="perseus-block-math-inner"
-                                          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                        >
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            8
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </span>
-                          </div>
-                        </button>
-                      </div>
-                    </div>
-                  </li>
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
-                      >
-                        <div
-                          class="perseus-sr-only"
-                        >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-11"
-                            tabindex="-1"
-                            type="radio"
-                          />
-                          <label
-                            for="choice-11"
-                          >
-                            (Choice D)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
-                              <div
-                                class="perseus-renderer perseus-renderer-responsive"
-                              >
-                                <div
-                                  class="paragraph"
-                                  data-perseus-paragraph-index="0"
-                                >
-                                  <div
-                                    class="paragraph"
-                                  >
-                                    No value of 
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        x
-                                      </span>
-                                      <span />
-                                    </span>
-                                     satisfies the equation.
-                                  </div>
-                                </div>
-                              </div>
-                            </span>
-                          </label>
-                        </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                          >
-                            <div
-                              class="iconWrapper_17y0hv9"
-                            >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 50%;"
-                              >
-                                <div
-                                  class="circle_1tys2th"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    D
-                                  </div>
-                                </div>
-                              </span>
-                            </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div />
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="paragraph"
-                                      >
-                                        No value of 
-                                        <span
-                                          style="white-space: nowrap;"
-                                        >
-                                          <span />
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            x
-                                          </span>
-                                          <span />
-                                        </span>
-                                         satisfies the equation.
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </span>
-                          </div>
-                        </button>
-                      </div>
-                    </div>
-                  </li>
-                </ul>
-              </fieldset>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </span>
-</div>
-`;
-
-exports[`single-choice question reviewMode: true should snapshot the same with incorrect answer: incorrect answer 1`] = `
-<div>
-  <span
-    class="mock-KatexProvider"
-  >
-    <div
-      class="perseus-renderer perseus-renderer-responsive"
-    >
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="0"
-      >
-        <div
-          class="paragraph"
-        >
-          Which of the following values of 
-          <span
-            style="white-space: nowrap;"
-          >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              x
-            </span>
-            <span />
-          </span>
-           satisfies the equation 
-          <span
-            style="white-space: nowrap;"
-          >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              \\sqrt{64}=x
-            </span>
-            <span />
-          </span>
-           ?
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="1"
-      >
-        <div
-          class="paragraph"
-        >
-          <div
-            class="perseus-widget-container widget-nohighlight widget-block"
-          >
-            <div
-              class="responsiveContainer_vq37gq"
-            >
-              <fieldset
-                class="perseus-widget-radio-fieldset responsiveFieldset_c0l5kf"
-              >
-                <legend
-                  class="perseus-sr-only"
-                >
-                  Choose 1 answer:
-                </legend>
-                <div
-                  aria-hidden="true"
-                  class="instructions instructions_125m8j1"
-                >
-                  Choose 1 answer:
-                </div>
-                <ul
-                  class="perseus-widget-radio perseus-rendered-radio radio_1gyjybc-o_O-responsiveRadioContainer_1ybwre2"
-                  style="list-style: none;"
-                >
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd-o_O-selectedItem_p6cyk0 perseus-radio-option perseus-radio-selected"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
-                      >
-                        <div
-                          class="perseus-sr-only"
-                        >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-16"
-                            tabindex="-1"
-                            type="radio"
-                          />
-                          <label
-                            for="choice-16"
-                          >
-                            (Choice A, Checked)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
-                              <div
-                                class="perseus-renderer perseus-renderer-responsive"
-                              >
-                                <div
-                                  class="paragraph"
-                                  data-perseus-paragraph-index="0"
-                                >
-                                  <div
-                                    class="paragraph"
-                                  >
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        -8
-                                      </span>
-                                      <span />
-                                    </span>
-                                     and 
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        8
-                                      </span>
-                                      <span />
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </span>
-                          </label>
-                        </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                          >
-                            <div
-                              class="iconWrapper_17y0hv9"
-                            >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 50%;"
-                              >
-                                <div
-                                  class="circle_1tys2th"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: #1865f2; color: rgb(255, 255, 255); border-radius: 24px; background-color: rgb(24, 101, 242);"
-                                >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    A
-                                  </div>
-                                </div>
-                              </span>
-                            </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div />
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="paragraph"
-                                      >
-                                        <span
-                                          style="white-space: nowrap;"
-                                        >
-                                          <span />
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            -8
-                                          </span>
-                                          <span />
-                                        </span>
-                                         and 
-                                        <span
-                                          style="white-space: nowrap;"
-                                        >
-                                          <span />
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            8
-                                          </span>
-                                          <span />
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </span>
-                          </div>
-                        </button>
-                      </div>
-                    </div>
-                  </li>
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
-                      >
-                        <div
-                          class="perseus-sr-only"
-                        >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-17"
-                            tabindex="-1"
-                            type="radio"
-                          />
-                          <label
-                            for="choice-17"
-                          >
-                            (Choice B)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
-                              <div
-                                class="perseus-renderer perseus-renderer-responsive"
-                              >
-                                <div
-                                  class="paragraph perseus-paragraph-centered"
-                                  data-perseus-paragraph-index="0"
-                                >
-                                  <div
-                                    class="perseus-block-math"
-                                  >
-                                    <div
-                                      class="perseus-block-math-inner"
-                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                    >
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        -8
-                                      </span>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </span>
-                          </label>
-                        </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                          >
-                            <div
-                              class="iconWrapper_17y0hv9"
-                            >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 50%;"
-                              >
-                                <div
-                                  class="circle_1tys2th"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    B
-                                  </div>
-                                </div>
-                              </span>
-                            </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div />
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph perseus-paragraph-centered"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="perseus-block-math"
-                                      >
-                                        <div
-                                          class="perseus-block-math-inner"
-                                          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                        >
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            -8
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </span>
-                          </div>
-                        </button>
-                      </div>
-                    </div>
-                  </li>
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
-                      >
-                        <div
-                          class="perseus-sr-only"
-                        >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-18"
-                            tabindex="-1"
-                            type="radio"
-                          />
-                          <label
-                            for="choice-18"
-                          >
-                            (Choice C)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
-                              <div
-                                class="perseus-renderer perseus-renderer-responsive"
-                              >
-                                <div
-                                  class="paragraph perseus-paragraph-centered"
-                                  data-perseus-paragraph-index="0"
-                                >
-                                  <div
-                                    class="perseus-block-math"
-                                  >
-                                    <div
-                                      class="perseus-block-math-inner"
-                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                    >
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        8
-                                      </span>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </span>
-                          </label>
-                        </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                          >
-                            <div
-                              class="iconWrapper_17y0hv9"
-                            >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 50%;"
-                              >
-                                <div
-                                  class="circle_1tys2th"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    C
-                                  </div>
-                                </div>
-                              </span>
-                            </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div />
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph perseus-paragraph-centered"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="perseus-block-math"
-                                      >
-                                        <div
-                                          class="perseus-block-math-inner"
-                                          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                        >
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            8
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </span>
-                          </div>
-                        </button>
-                      </div>
-                    </div>
-                  </li>
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
-                      >
-                        <div
-                          class="perseus-sr-only"
-                        >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-19"
-                            tabindex="-1"
-                            type="radio"
-                          />
-                          <label
-                            for="choice-19"
-                          >
-                            (Choice D)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
-                              <div
-                                class="perseus-renderer perseus-renderer-responsive"
-                              >
-                                <div
-                                  class="paragraph"
-                                  data-perseus-paragraph-index="0"
-                                >
-                                  <div
-                                    class="paragraph"
-                                  >
-                                    No value of 
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        x
-                                      </span>
-                                      <span />
-                                    </span>
-                                     satisfies the equation.
-                                  </div>
-                                </div>
-                              </div>
-                            </span>
-                          </label>
-                        </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                          >
-                            <div
-                              class="iconWrapper_17y0hv9"
-                            >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 50%;"
-                              >
-                                <div
-                                  class="circle_1tys2th"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    D
-                                  </div>
-                                </div>
-                              </span>
-                            </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div />
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="paragraph"
-                                      >
-                                        No value of 
-                                        <span
-                                          style="white-space: nowrap;"
-                                        >
-                                          <span />
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            x
-                                          </span>
-                                          <span />
-                                        </span>
-                                         satisfies the equation.
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </span>
-                          </div>
-                        </button>
-                      </div>
-                    </div>
-                  </li>
-                </ul>
-              </fieldset>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </span>
-</div>
-`;
-
-exports[`single-choice question reviewMode: true should snapshot the same: first render 1`] = `
-<div>
-  <span
-    class="mock-KatexProvider"
-  >
-    <div
-      class="perseus-renderer perseus-renderer-responsive"
-    >
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="0"
-      >
-        <div
-          class="paragraph"
-        >
-          Which of the following values of 
-          <span
-            style="white-space: nowrap;"
-          >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              x
-            </span>
-            <span />
-          </span>
-           satisfies the equation 
-          <span
-            style="white-space: nowrap;"
-          >
-            <span />
-            <span
-              class="mock-TeX"
-            >
-              \\sqrt{64}=x
-            </span>
-            <span />
-          </span>
-           ?
-        </div>
-      </div>
-      <div
-        class="paragraph"
-        data-perseus-paragraph-index="1"
-      >
-        <div
-          class="paragraph"
-        >
-          <div
-            class="perseus-widget-container widget-nohighlight widget-block"
-          >
-            <div
-              class="responsiveContainer_vq37gq"
-            >
-              <fieldset
-                class="perseus-widget-radio-fieldset responsiveFieldset_c0l5kf"
-              >
-                <legend
-                  class="perseus-sr-only"
-                >
-                  Choose 1 answer:
-                </legend>
-                <div
-                  aria-hidden="true"
-                  class="instructions instructions_125m8j1"
-                >
-                  Choose 1 answer:
-                </div>
-                <ul
-                  class="perseus-widget-radio perseus-rendered-radio radio_1gyjybc-o_O-responsiveRadioContainer_1ybwre2"
-                  style="list-style: none;"
-                >
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option perseus-incorrect"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
-                      >
-                        <div
-                          class="perseus-sr-only"
-                        >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-0"
-                            tabindex="-1"
-                            type="radio"
-                          />
-                          <label
-                            for="choice-0"
-                          >
-                            (Choice A, Incorrect)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
-                              <div
-                                class="perseus-renderer perseus-renderer-responsive"
-                              >
-                                <div
-                                  class="paragraph"
-                                  data-perseus-paragraph-index="0"
-                                >
-                                  <div
-                                    class="paragraph"
-                                  >
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        -8
-                                      </span>
-                                      <span />
-                                    </span>
-                                     and 
-                                    <span
-                                      style="white-space: nowrap;"
-                                    >
-                                      <span />
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        8
-                                      </span>
-                                      <span />
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </span>
-                          </label>
-                        </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                          >
-                            <div
-                              class="iconWrapper_17y0hv9"
-                            >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 50%;"
-                              >
-                                <div
-                                  class="circle_1tys2th-o_O-circleIncorrect_gxqnr9"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      height="1em"
-                                      role="img"
-                                      style="vertical-align: middle;"
-                                      viewBox="0 0 24 24"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M8,13 L16,13 C16.5522847,13 17,12.5522847 17,12 C17,11.4477153 16.5522847,11 16,11 L8,11 C7.44771525,11 7,11.4477153 7,12 C7,12.5522847 7.44771525,13 8,13 Z"
-                                        fill="currentColor"
-                                      />
-                                    </svg>
-                                  </div>
-                                </div>
-                              </span>
-                            </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div>
-                                <div
-                                  class="text_1tb4z7c-o_O-incorrect_7sq9ra"
-                                >
-                                  Incorrect
-                                </div>
-                              </div>
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="paragraph"
-                                      >
-                                        <span
-                                          style="white-space: nowrap;"
-                                        >
-                                          <span />
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            -8
-                                          </span>
-                                          <span />
-                                        </span>
-                                         and 
-                                        <span
-                                          style="white-space: nowrap;"
-                                        >
-                                          <span />
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            8
-                                          </span>
-                                          <span />
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </span>
-                          </div>
-                        </button>
-                      </div>
-                      <div
-                        class="perseus-radio-rationale-content rationale_1w3tmyh"
-                        data-test-id="perseus-radio-rationale-content-0"
-                      >
-                        <span
-                          class="mock-KatexProvider"
-                        >
+                          (Choice A)
+                             
                           <div
                             class="perseus-renderer perseus-renderer-responsive"
                           >
@@ -3881,7 +654,6 @@ exports[`single-choice question reviewMode: true should snapshot the same: first
                               <div
                                 class="paragraph"
                               >
-                                The square root operation (
                                 <span
                                   style="white-space: nowrap;"
                                 >
@@ -3889,15 +661,371 @@ exports[`single-choice question reviewMode: true should snapshot the same: first
                                   <span
                                     class="mock-TeX"
                                   >
-                                    \\sqrt{\\phantom{x}}
+                                    -8
                                   </span>
                                   <span />
                                 </span>
-                                ) calculates 
-                                <em>
-                                  only
-                                </em>
-                                 the positive square root when performed on a number, so 
+                                 and 
+                                <span
+                                  style="white-space: nowrap;"
+                                >
+                                  <span />
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    8
+                                  </span>
+                                  <span />
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
+                            <span
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 50%;"
+                            >
+                              <div
+                                class="circle_1tys2th"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
+                                >
+                                  A
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                          >
+                            <div />
+                            <div>
+                              <div
+                                class="perseus-renderer perseus-renderer-responsive"
+                              >
+                                <div
+                                  class="paragraph"
+                                  data-perseus-paragraph-index="0"
+                                >
+                                  <div
+                                    class="paragraph"
+                                  >
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        -8
+                                      </span>
+                                      <span />
+                                    </span>
+                                     and 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        8
+                                      </span>
+                                      <span />
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
+                      <div
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-89"
+                          tabindex="-1"
+                          type="radio"
+                        />
+                        <label
+                          for="choice-89"
+                        >
+                          (Choice B)
+                             
+                          <div
+                            class="perseus-renderer perseus-renderer-responsive"
+                          >
+                            <div
+                              class="paragraph perseus-paragraph-centered"
+                              data-perseus-paragraph-index="0"
+                            >
+                              <div
+                                class="perseus-block-math"
+                              >
+                                <div
+                                  class="perseus-block-math-inner"
+                                  style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                >
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    -8
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
+                            <span
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 50%;"
+                            >
+                              <div
+                                class="circle_1tys2th"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
+                                >
+                                  B
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                          >
+                            <div />
+                            <div>
+                              <div
+                                class="perseus-renderer perseus-renderer-responsive"
+                              >
+                                <div
+                                  class="paragraph perseus-paragraph-centered"
+                                  data-perseus-paragraph-index="0"
+                                >
+                                  <div
+                                    class="perseus-block-math"
+                                  >
+                                    <div
+                                      class="perseus-block-math-inner"
+                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                    >
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        -8
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd-o_O-selectedItem_p6cyk0 perseus-radio-option perseus-radio-selected"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
+                      <div
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-90"
+                          tabindex="-1"
+                          type="radio"
+                        />
+                        <label
+                          for="choice-90"
+                        >
+                          (Choice C, Checked)
+                             
+                          <div
+                            class="perseus-renderer perseus-renderer-responsive"
+                          >
+                            <div
+                              class="paragraph perseus-paragraph-centered"
+                              data-perseus-paragraph-index="0"
+                            >
+                              <div
+                                class="perseus-block-math"
+                              >
+                                <div
+                                  class="perseus-block-math-inner"
+                                  style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                >
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    8
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
+                            <span
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 50%;"
+                            >
+                              <div
+                                class="circle_1tys2th"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: #1865f2; color: rgb(255, 255, 255); border-radius: 24px; background-color: rgb(24, 101, 242);"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
+                                >
+                                  C
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                          >
+                            <div />
+                            <div>
+                              <div
+                                class="perseus-renderer perseus-renderer-responsive"
+                              >
+                                <div
+                                  class="paragraph perseus-paragraph-centered"
+                                  data-perseus-paragraph-index="0"
+                                >
+                                  <div
+                                    class="perseus-block-math"
+                                  >
+                                    <div
+                                      class="perseus-block-math-inner"
+                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                    >
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        8
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
+                      <div
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-91"
+                          tabindex="-1"
+                          type="radio"
+                        />
+                        <label
+                          for="choice-91"
+                        >
+                          (Choice D)
+                             
+                          <div
+                            class="perseus-renderer perseus-renderer-responsive"
+                          >
+                            <div
+                              class="paragraph"
+                              data-perseus-paragraph-index="0"
+                            >
+                              <div
+                                class="paragraph"
+                              >
+                                No value of 
                                 <span
                                   style="white-space: nowrap;"
                                 >
@@ -3909,436 +1037,48 @@ exports[`single-choice question reviewMode: true should snapshot the same: first
                                   </span>
                                   <span />
                                 </span>
-                                 is equal to 
-                                <em>
-                                  only
-                                </em>
-                                 
-                                <span
-                                  style="white-space: nowrap;"
-                                >
-                                  <span />
-                                  <span
-                                    class="mock-TeX"
-                                  >
-                                    8
-                                  </span>
-                                  <span />
-                                </span>
-                                .
+                                 satisfies the equation.
                               </div>
                             </div>
                           </div>
-                        </span>
+                        </label>
                       </div>
-                    </div>
-                  </li>
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option perseus-incorrect"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
                       >
                         <div
-                          class="perseus-sr-only"
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
                         >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-1"
-                            tabindex="-1"
-                            type="radio"
-                          />
-                          <label
-                            for="choice-1"
+                          <div
+                            class="iconWrapper_17y0hv9"
                           >
-                            (Choice B, Incorrect)
-                               
                             <span
-                              class="mock-KatexProvider"
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 50%;"
                             >
                               <div
-                                class="perseus-renderer perseus-renderer-responsive"
+                                class="circle_1tys2th"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
                               >
                                 <div
-                                  class="paragraph perseus-paragraph-centered"
-                                  data-perseus-paragraph-index="0"
+                                  class="innerWrapper_177sg8x"
                                 >
-                                  <div
-                                    class="perseus-block-math"
-                                  >
-                                    <div
-                                      class="perseus-block-math-inner"
-                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                    >
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        -8
-                                      </span>
-                                    </div>
-                                  </div>
+                                  D
                                 </div>
                               </div>
                             </span>
-                          </label>
-                        </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                          >
-                            <div
-                              class="iconWrapper_17y0hv9"
-                            >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 50%;"
-                              >
-                                <div
-                                  class="circle_1tys2th-o_O-circleIncorrect_gxqnr9"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      height="1em"
-                                      role="img"
-                                      style="vertical-align: middle;"
-                                      viewBox="0 0 24 24"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M8,13 L16,13 C16.5522847,13 17,12.5522847 17,12 C17,11.4477153 16.5522847,11 16,11 L8,11 C7.44771525,11 7,11.4477153 7,12 C7,12.5522847 7.44771525,13 8,13 Z"
-                                        fill="currentColor"
-                                      />
-                                    </svg>
-                                  </div>
-                                </div>
-                              </span>
-                            </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div>
-                                <div
-                                  class="text_1tb4z7c-o_O-incorrect_7sq9ra"
-                                >
-                                  Incorrect
-                                </div>
-                              </div>
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph perseus-paragraph-centered"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="perseus-block-math"
-                                      >
-                                        <div
-                                          class="perseus-block-math-inner"
-                                          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                        >
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            -8
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </span>
                           </div>
-                        </button>
-                      </div>
-                      <div
-                        class="perseus-radio-rationale-content rationale_1w3tmyh"
-                        data-test-id="perseus-radio-rationale-content-1"
-                      >
-                        <span
-                          class="mock-KatexProvider"
-                        >
-                          <div
-                            class="perseus-renderer perseus-renderer-responsive"
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
                           >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                While 
-                                <span
-                                  style="white-space: nowrap;"
-                                >
-                                  <span />
-                                  <span
-                                    class="mock-TeX"
-                                  >
-                                    (-8)^2=64
-                                  </span>
-                                  <span />
-                                </span>
-                                , the square root operation (
-                                <span
-                                  style="white-space: nowrap;"
-                                >
-                                  <span />
-                                  <span
-                                    class="mock-TeX"
-                                  >
-                                    \\sqrt{\\phantom{x}}
-                                  </span>
-                                  <span />
-                                </span>
-                                ) calculates 
-                                <em>
-                                  only
-                                </em>
-                                 the positive square root when performed on a number.
-                              </div>
-                            </div>
-                          </div>
-                        </span>
-                      </div>
-                    </div>
-                  </li>
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option perseus-correct"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
-                      >
-                        <div
-                          class="perseus-sr-only"
-                        >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-2"
-                            tabindex="-1"
-                            type="radio"
-                          />
-                          <label
-                            for="choice-2"
-                          >
-                            (Choice C, Correct)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
-                              <div
-                                class="perseus-renderer perseus-renderer-responsive"
-                              >
-                                <div
-                                  class="paragraph perseus-paragraph-centered"
-                                  data-perseus-paragraph-index="0"
-                                >
-                                  <div
-                                    class="perseus-block-math"
-                                  >
-                                    <div
-                                      class="perseus-block-math-inner"
-                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                    >
-                                      <span
-                                        class="mock-TeX"
-                                      >
-                                        8
-                                      </span>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </span>
-                          </label>
-                        </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                          >
-                            <div
-                              class="iconWrapper_17y0hv9"
-                            >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 50%;"
-                              >
-                                <div
-                                  class="circle_1tys2th-o_O-circleCorrect_ifnw95"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      height="1em"
-                                      role="img"
-                                      style="vertical-align: middle; position: relative; top: -1px;"
-                                      viewBox="0 0 24 24"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M8.70710678,12.2928932 C8.31658249,11.9023689 7.68341751,11.9023689 7.29289322,12.2928932 C6.90236893,12.6834175 6.90236893,13.3165825 7.29289322,13.7071068 L9.82842712,16.2426407 C10.2207367,16.6349502 10.8574274,16.6328935 11.2471942,16.2380576 L16.7116603,10.7025237 C17.0996535,10.3094846 17.0955629,9.67633279 16.7025237,9.28833966 C16.3094846,8.90034653 15.6763328,8.90443714 15.2883397,9.29747629 L10.5309507,14.1167372 L8.70710678,12.2928932 Z"
-                                        fill="currentColor"
-                                      />
-                                    </svg>
-                                  </div>
-                                </div>
-                              </span>
-                            </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div>
-                                <div
-                                  class="text_1tb4z7c-o_O-correct_udbdnp"
-                                >
-                                  Correct
-                                </div>
-                              </div>
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph perseus-paragraph-centered"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="perseus-block-math"
-                                      >
-                                        <div
-                                          class="perseus-block-math-inner"
-                                          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
-                                        >
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            8
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </span>
-                          </div>
-                        </button>
-                      </div>
-                      <div
-                        class="perseus-radio-rationale-content rationale_1w3tmyh"
-                        data-test-id="perseus-radio-rationale-content-2"
-                      >
-                        <span
-                          class="mock-KatexProvider"
-                        >
-                          <div
-                            class="perseus-renderer perseus-renderer-responsive"
-                          >
-                            <div
-                              class="paragraph"
-                              data-perseus-paragraph-index="0"
-                            >
-                              <div
-                                class="paragraph"
-                              >
-                                <span
-                                  style="white-space: nowrap;"
-                                >
-                                  <span />
-                                  <span
-                                    class="mock-TeX"
-                                  >
-                                    8
-                                  </span>
-                                  <span />
-                                </span>
-                                 is the positive square root of 
-                                <span
-                                  style="white-space: nowrap;"
-                                >
-                                  <span />
-                                  <span
-                                    class="mock-TeX"
-                                  >
-                                    64
-                                  </span>
-                                  <span />
-                                </span>
-                                .
-                              </div>
-                            </div>
-                          </div>
-                        </span>
-                      </div>
-                    </div>
-                  </li>
-                  <li
-                    class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option perseus-incorrect"
-                  >
-                    <div
-                      class="description description_psmgei"
-                      style="flex-direction: column; color: rgb(33, 36, 44);"
-                    >
-                      <div
-                        style="display: flex; flex-direction: row; opacity: 1;"
-                      >
-                        <div
-                          class="perseus-sr-only"
-                        >
-                          <input
-                            class="perseus-radio-option-content"
-                            id="choice-3"
-                            tabindex="-1"
-                            type="radio"
-                          />
-                          <label
-                            for="choice-3"
-                          >
-                            (Choice D, Incorrect)
-                               
-                            <span
-                              class="mock-KatexProvider"
-                            >
+                            <div />
+                            <div>
                               <div
                                 class="perseus-renderer perseus-renderer-responsive"
                               >
@@ -4365,105 +1105,117 @@ exports[`single-choice question reviewMode: true should snapshot the same: first
                                   </div>
                                 </div>
                               </div>
-                            </span>
-                          </label>
-                        </div>
-                        <button
-                          aria-disabled="false"
-                          aria-hidden="true"
-                          class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
-                          type="button"
-                        >
-                          <div
-                            style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
-                          >
-                            <div
-                              class="iconWrapper_17y0hv9"
-                            >
-                              <span
-                                class="ring_ya75gi"
-                                data-test-id="focus-ring"
-                                style="border-color: transparent; border-radius: 50%;"
-                              >
-                                <div
-                                  class="circle_1tys2th-o_O-circleIncorrect_gxqnr9"
-                                  data-is-radio-icon="true"
-                                  data-test-id="choice-icon__library-choice-icon"
-                                  style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
-                                >
-                                  <div
-                                    class="innerWrapper_177sg8x"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      height="1em"
-                                      role="img"
-                                      style="vertical-align: middle;"
-                                      viewBox="0 0 24 24"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M8,13 L16,13 C16.5522847,13 17,12.5522847 17,12 C17,11.4477153 16.5522847,11 16,11 L8,11 C7.44771525,11 7,11.4477153 7,12 C7,12.5522847 7.44771525,13 8,13 Z"
-                                        fill="currentColor"
-                                      />
-                                    </svg>
-                                  </div>
-                                </div>
-                              </span>
                             </div>
-                            <span
-                              style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
-                            >
-                              <div>
-                                <div
-                                  class="text_1tb4z7c-o_O-incorrect_7sq9ra"
-                                >
-                                  Incorrect
-                                </div>
-                              </div>
-                              <div>
-                                <span
-                                  class="mock-KatexProvider"
-                                >
-                                  <div
-                                    class="perseus-renderer perseus-renderer-responsive"
-                                  >
-                                    <div
-                                      class="paragraph"
-                                      data-perseus-paragraph-index="0"
-                                    >
-                                      <div
-                                        class="paragraph"
-                                      >
-                                        No value of 
-                                        <span
-                                          style="white-space: nowrap;"
-                                        >
-                                          <span />
-                                          <span
-                                            class="mock-TeX"
-                                          >
-                                            x
-                                          </span>
-                                          <span />
-                                        </span>
-                                         satisfies the equation.
-                                      </div>
-                                    </div>
-                                  </div>
-                                </span>
-                              </div>
-                            </span>
-                          </div>
-                        </button>
-                      </div>
+                          </span>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </li>
+              </ul>
+            </fieldset>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`single-choice question reviewMode: false should snapshot the same with incorrect answer: incorrect answer 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="paragraph"
+      >
+        Which of the following values of 
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            x
+          </span>
+          <span />
+        </span>
+         satisfies the equation 
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            \\sqrt{64}=x
+          </span>
+          <span />
+        </span>
+         ?
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <div
+            class="responsiveContainer_vq37gq"
+          >
+            <fieldset
+              class="perseus-widget-radio-fieldset responsiveFieldset_c0l5kf"
+            >
+              <legend
+                class="perseus-sr-only"
+              >
+                Choose 1 answer:
+              </legend>
+              <div
+                aria-hidden="true"
+                class="instructions instructions_125m8j1"
+              >
+                Choose 1 answer:
+              </div>
+              <ul
+                class="perseus-widget-radio perseus-rendered-radio radio_1gyjybc-o_O-responsiveRadioContainer_1ybwre2"
+                style="list-style: none;"
+              >
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd-o_O-selectedItem_p6cyk0 perseus-radio-option perseus-radio-selected"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
                       <div
-                        class="perseus-radio-rationale-content rationale_1w3tmyh"
-                        data-test-id="perseus-radio-rationale-content-3"
+                        class="perseus-sr-only"
                       >
-                        <span
-                          class="mock-KatexProvider"
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-96"
+                          tabindex="-1"
+                          type="radio"
+                        />
+                        <label
+                          for="choice-96"
                         >
+                          (Choice A, Checked)
+                             
                           <div
                             class="perseus-renderer perseus-renderer-responsive"
                           >
@@ -4481,7 +1233,379 @@ exports[`single-choice question reviewMode: true should snapshot the same: first
                                   <span
                                     class="mock-TeX"
                                   >
+                                    -8
+                                  </span>
+                                  <span />
+                                </span>
+                                 and 
+                                <span
+                                  style="white-space: nowrap;"
+                                >
+                                  <span />
+                                  <span
+                                    class="mock-TeX"
+                                  >
                                     8
+                                  </span>
+                                  <span />
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
+                            <span
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 50%;"
+                            >
+                              <div
+                                class="circle_1tys2th"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: #1865f2; color: rgb(255, 255, 255); border-radius: 24px; background-color: rgb(24, 101, 242);"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
+                                >
+                                  A
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                          >
+                            <div />
+                            <div>
+                              <div
+                                class="perseus-renderer perseus-renderer-responsive"
+                              >
+                                <div
+                                  class="paragraph"
+                                  data-perseus-paragraph-index="0"
+                                >
+                                  <div
+                                    class="paragraph"
+                                  >
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        -8
+                                      </span>
+                                      <span />
+                                    </span>
+                                     and 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        8
+                                      </span>
+                                      <span />
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
+                      <div
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-97"
+                          tabindex="-1"
+                          type="radio"
+                        />
+                        <label
+                          for="choice-97"
+                        >
+                          (Choice B)
+                             
+                          <div
+                            class="perseus-renderer perseus-renderer-responsive"
+                          >
+                            <div
+                              class="paragraph perseus-paragraph-centered"
+                              data-perseus-paragraph-index="0"
+                            >
+                              <div
+                                class="perseus-block-math"
+                              >
+                                <div
+                                  class="perseus-block-math-inner"
+                                  style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                >
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    -8
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
+                            <span
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 50%;"
+                            >
+                              <div
+                                class="circle_1tys2th"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
+                                >
+                                  B
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                          >
+                            <div />
+                            <div>
+                              <div
+                                class="perseus-renderer perseus-renderer-responsive"
+                              >
+                                <div
+                                  class="paragraph perseus-paragraph-centered"
+                                  data-perseus-paragraph-index="0"
+                                >
+                                  <div
+                                    class="perseus-block-math"
+                                  >
+                                    <div
+                                      class="perseus-block-math-inner"
+                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                    >
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        -8
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
+                      <div
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-98"
+                          tabindex="-1"
+                          type="radio"
+                        />
+                        <label
+                          for="choice-98"
+                        >
+                          (Choice C)
+                             
+                          <div
+                            class="perseus-renderer perseus-renderer-responsive"
+                          >
+                            <div
+                              class="paragraph perseus-paragraph-centered"
+                              data-perseus-paragraph-index="0"
+                            >
+                              <div
+                                class="perseus-block-math"
+                              >
+                                <div
+                                  class="perseus-block-math-inner"
+                                  style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                >
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    8
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
+                            <span
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 50%;"
+                            >
+                              <div
+                                class="circle_1tys2th"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
+                                >
+                                  C
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                          >
+                            <div />
+                            <div>
+                              <div
+                                class="perseus-renderer perseus-renderer-responsive"
+                              >
+                                <div
+                                  class="paragraph perseus-paragraph-centered"
+                                  data-perseus-paragraph-index="0"
+                                >
+                                  <div
+                                    class="perseus-block-math"
+                                  >
+                                    <div
+                                      class="perseus-block-math-inner"
+                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                    >
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        8
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
+                      <div
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-99"
+                          tabindex="-1"
+                          type="radio"
+                        />
+                        <label
+                          for="choice-99"
+                        >
+                          (Choice D)
+                             
+                          <div
+                            class="perseus-renderer perseus-renderer-responsive"
+                          >
+                            <div
+                              class="paragraph"
+                              data-perseus-paragraph-index="0"
+                            >
+                              <div
+                                class="paragraph"
+                              >
+                                No value of 
+                                <span
+                                  style="white-space: nowrap;"
+                                >
+                                  <span />
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    x
                                   </span>
                                   <span />
                                 </span>
@@ -4489,17 +1613,2625 @@ exports[`single-choice question reviewMode: true should snapshot the same: first
                               </div>
                             </div>
                           </div>
-                        </span>
+                        </label>
                       </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
+                            <span
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 50%;"
+                            >
+                              <div
+                                class="circle_1tys2th"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
+                                >
+                                  D
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                          >
+                            <div />
+                            <div>
+                              <div
+                                class="perseus-renderer perseus-renderer-responsive"
+                              >
+                                <div
+                                  class="paragraph"
+                                  data-perseus-paragraph-index="0"
+                                >
+                                  <div
+                                    class="paragraph"
+                                  >
+                                    No value of 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        x
+                                      </span>
+                                      <span />
+                                    </span>
+                                     satisfies the equation.
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                        </div>
+                      </button>
                     </div>
-                  </li>
-                </ul>
-              </fieldset>
-            </div>
+                  </div>
+                </li>
+              </ul>
+            </fieldset>
           </div>
         </div>
       </div>
     </div>
-  </span>
+  </div>
+</div>
+`;
+
+exports[`single-choice question reviewMode: false should snapshot the same: first render 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="paragraph"
+      >
+        Which of the following values of 
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            x
+          </span>
+          <span />
+        </span>
+         satisfies the equation 
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            \\sqrt{64}=x
+          </span>
+          <span />
+        </span>
+         ?
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <div
+            class="responsiveContainer_vq37gq"
+          >
+            <fieldset
+              class="perseus-widget-radio-fieldset responsiveFieldset_c0l5kf"
+            >
+              <legend
+                class="perseus-sr-only"
+              >
+                Choose 1 answer:
+              </legend>
+              <div
+                aria-hidden="true"
+                class="instructions instructions_125m8j1"
+              >
+                Choose 1 answer:
+              </div>
+              <ul
+                class="perseus-widget-radio perseus-rendered-radio radio_1gyjybc-o_O-responsiveRadioContainer_1ybwre2"
+                style="list-style: none;"
+              >
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
+                      <div
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-80"
+                          tabindex="-1"
+                          type="radio"
+                        />
+                        <label
+                          for="choice-80"
+                        >
+                          (Choice A)
+                             
+                          <div
+                            class="perseus-renderer perseus-renderer-responsive"
+                          >
+                            <div
+                              class="paragraph"
+                              data-perseus-paragraph-index="0"
+                            >
+                              <div
+                                class="paragraph"
+                              >
+                                <span
+                                  style="white-space: nowrap;"
+                                >
+                                  <span />
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    -8
+                                  </span>
+                                  <span />
+                                </span>
+                                 and 
+                                <span
+                                  style="white-space: nowrap;"
+                                >
+                                  <span />
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    8
+                                  </span>
+                                  <span />
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
+                            <span
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 50%;"
+                            >
+                              <div
+                                class="circle_1tys2th"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
+                                >
+                                  A
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                          >
+                            <div />
+                            <div>
+                              <div
+                                class="perseus-renderer perseus-renderer-responsive"
+                              >
+                                <div
+                                  class="paragraph"
+                                  data-perseus-paragraph-index="0"
+                                >
+                                  <div
+                                    class="paragraph"
+                                  >
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        -8
+                                      </span>
+                                      <span />
+                                    </span>
+                                     and 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        8
+                                      </span>
+                                      <span />
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
+                      <div
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-81"
+                          tabindex="-1"
+                          type="radio"
+                        />
+                        <label
+                          for="choice-81"
+                        >
+                          (Choice B)
+                             
+                          <div
+                            class="perseus-renderer perseus-renderer-responsive"
+                          >
+                            <div
+                              class="paragraph perseus-paragraph-centered"
+                              data-perseus-paragraph-index="0"
+                            >
+                              <div
+                                class="perseus-block-math"
+                              >
+                                <div
+                                  class="perseus-block-math-inner"
+                                  style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                >
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    -8
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
+                            <span
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 50%;"
+                            >
+                              <div
+                                class="circle_1tys2th"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
+                                >
+                                  B
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                          >
+                            <div />
+                            <div>
+                              <div
+                                class="perseus-renderer perseus-renderer-responsive"
+                              >
+                                <div
+                                  class="paragraph perseus-paragraph-centered"
+                                  data-perseus-paragraph-index="0"
+                                >
+                                  <div
+                                    class="perseus-block-math"
+                                  >
+                                    <div
+                                      class="perseus-block-math-inner"
+                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                    >
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        -8
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
+                      <div
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-82"
+                          tabindex="-1"
+                          type="radio"
+                        />
+                        <label
+                          for="choice-82"
+                        >
+                          (Choice C)
+                             
+                          <div
+                            class="perseus-renderer perseus-renderer-responsive"
+                          >
+                            <div
+                              class="paragraph perseus-paragraph-centered"
+                              data-perseus-paragraph-index="0"
+                            >
+                              <div
+                                class="perseus-block-math"
+                              >
+                                <div
+                                  class="perseus-block-math-inner"
+                                  style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                >
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    8
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
+                            <span
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 50%;"
+                            >
+                              <div
+                                class="circle_1tys2th"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
+                                >
+                                  C
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                          >
+                            <div />
+                            <div>
+                              <div
+                                class="perseus-renderer perseus-renderer-responsive"
+                              >
+                                <div
+                                  class="paragraph perseus-paragraph-centered"
+                                  data-perseus-paragraph-index="0"
+                                >
+                                  <div
+                                    class="perseus-block-math"
+                                  >
+                                    <div
+                                      class="perseus-block-math-inner"
+                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                    >
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        8
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
+                      <div
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-83"
+                          tabindex="-1"
+                          type="radio"
+                        />
+                        <label
+                          for="choice-83"
+                        >
+                          (Choice D)
+                             
+                          <div
+                            class="perseus-renderer perseus-renderer-responsive"
+                          >
+                            <div
+                              class="paragraph"
+                              data-perseus-paragraph-index="0"
+                            >
+                              <div
+                                class="paragraph"
+                              >
+                                No value of 
+                                <span
+                                  style="white-space: nowrap;"
+                                >
+                                  <span />
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    x
+                                  </span>
+                                  <span />
+                                </span>
+                                 satisfies the equation.
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
+                            <span
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 50%;"
+                            >
+                              <div
+                                class="circle_1tys2th"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
+                                >
+                                  D
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                          >
+                            <div />
+                            <div>
+                              <div
+                                class="perseus-renderer perseus-renderer-responsive"
+                              >
+                                <div
+                                  class="paragraph"
+                                  data-perseus-paragraph-index="0"
+                                >
+                                  <div
+                                    class="paragraph"
+                                  >
+                                    No value of 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        x
+                                      </span>
+                                      <span />
+                                    </span>
+                                     satisfies the equation.
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </li>
+              </ul>
+            </fieldset>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`single-choice question reviewMode: true should snapshot the same with correct answer: correct answer 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="paragraph"
+      >
+        Which of the following values of 
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            x
+          </span>
+          <span />
+        </span>
+         satisfies the equation 
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            \\sqrt{64}=x
+          </span>
+          <span />
+        </span>
+         ?
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <div
+            class="responsiveContainer_vq37gq"
+          >
+            <fieldset
+              class="perseus-widget-radio-fieldset responsiveFieldset_c0l5kf"
+            >
+              <legend
+                class="perseus-sr-only"
+              >
+                Choose 1 answer:
+              </legend>
+              <div
+                aria-hidden="true"
+                class="instructions instructions_125m8j1"
+              >
+                Choose 1 answer:
+              </div>
+              <ul
+                class="perseus-widget-radio perseus-rendered-radio radio_1gyjybc-o_O-responsiveRadioContainer_1ybwre2"
+                style="list-style: none;"
+              >
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
+                      <div
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-8"
+                          tabindex="-1"
+                          type="radio"
+                        />
+                        <label
+                          for="choice-8"
+                        >
+                          (Choice A)
+                             
+                          <div
+                            class="perseus-renderer perseus-renderer-responsive"
+                          >
+                            <div
+                              class="paragraph"
+                              data-perseus-paragraph-index="0"
+                            >
+                              <div
+                                class="paragraph"
+                              >
+                                <span
+                                  style="white-space: nowrap;"
+                                >
+                                  <span />
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    -8
+                                  </span>
+                                  <span />
+                                </span>
+                                 and 
+                                <span
+                                  style="white-space: nowrap;"
+                                >
+                                  <span />
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    8
+                                  </span>
+                                  <span />
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
+                            <span
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 50%;"
+                            >
+                              <div
+                                class="circle_1tys2th"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
+                                >
+                                  A
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                          >
+                            <div />
+                            <div>
+                              <div
+                                class="perseus-renderer perseus-renderer-responsive"
+                              >
+                                <div
+                                  class="paragraph"
+                                  data-perseus-paragraph-index="0"
+                                >
+                                  <div
+                                    class="paragraph"
+                                  >
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        -8
+                                      </span>
+                                      <span />
+                                    </span>
+                                     and 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        8
+                                      </span>
+                                      <span />
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
+                      <div
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-9"
+                          tabindex="-1"
+                          type="radio"
+                        />
+                        <label
+                          for="choice-9"
+                        >
+                          (Choice B)
+                             
+                          <div
+                            class="perseus-renderer perseus-renderer-responsive"
+                          >
+                            <div
+                              class="paragraph perseus-paragraph-centered"
+                              data-perseus-paragraph-index="0"
+                            >
+                              <div
+                                class="perseus-block-math"
+                              >
+                                <div
+                                  class="perseus-block-math-inner"
+                                  style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                >
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    -8
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
+                            <span
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 50%;"
+                            >
+                              <div
+                                class="circle_1tys2th"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
+                                >
+                                  B
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                          >
+                            <div />
+                            <div>
+                              <div
+                                class="perseus-renderer perseus-renderer-responsive"
+                              >
+                                <div
+                                  class="paragraph perseus-paragraph-centered"
+                                  data-perseus-paragraph-index="0"
+                                >
+                                  <div
+                                    class="perseus-block-math"
+                                  >
+                                    <div
+                                      class="perseus-block-math-inner"
+                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                    >
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        -8
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd-o_O-selectedItem_p6cyk0 perseus-radio-option perseus-radio-selected"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
+                      <div
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-10"
+                          tabindex="-1"
+                          type="radio"
+                        />
+                        <label
+                          for="choice-10"
+                        >
+                          (Choice C, Checked)
+                             
+                          <div
+                            class="perseus-renderer perseus-renderer-responsive"
+                          >
+                            <div
+                              class="paragraph perseus-paragraph-centered"
+                              data-perseus-paragraph-index="0"
+                            >
+                              <div
+                                class="perseus-block-math"
+                              >
+                                <div
+                                  class="perseus-block-math-inner"
+                                  style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                >
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    8
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
+                            <span
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 50%;"
+                            >
+                              <div
+                                class="circle_1tys2th"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: #1865f2; color: rgb(255, 255, 255); border-radius: 24px; background-color: rgb(24, 101, 242);"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
+                                >
+                                  C
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                          >
+                            <div />
+                            <div>
+                              <div
+                                class="perseus-renderer perseus-renderer-responsive"
+                              >
+                                <div
+                                  class="paragraph perseus-paragraph-centered"
+                                  data-perseus-paragraph-index="0"
+                                >
+                                  <div
+                                    class="perseus-block-math"
+                                  >
+                                    <div
+                                      class="perseus-block-math-inner"
+                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                    >
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        8
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
+                      <div
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-11"
+                          tabindex="-1"
+                          type="radio"
+                        />
+                        <label
+                          for="choice-11"
+                        >
+                          (Choice D)
+                             
+                          <div
+                            class="perseus-renderer perseus-renderer-responsive"
+                          >
+                            <div
+                              class="paragraph"
+                              data-perseus-paragraph-index="0"
+                            >
+                              <div
+                                class="paragraph"
+                              >
+                                No value of 
+                                <span
+                                  style="white-space: nowrap;"
+                                >
+                                  <span />
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    x
+                                  </span>
+                                  <span />
+                                </span>
+                                 satisfies the equation.
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
+                            <span
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 50%;"
+                            >
+                              <div
+                                class="circle_1tys2th"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
+                                >
+                                  D
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                          >
+                            <div />
+                            <div>
+                              <div
+                                class="perseus-renderer perseus-renderer-responsive"
+                              >
+                                <div
+                                  class="paragraph"
+                                  data-perseus-paragraph-index="0"
+                                >
+                                  <div
+                                    class="paragraph"
+                                  >
+                                    No value of 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        x
+                                      </span>
+                                      <span />
+                                    </span>
+                                     satisfies the equation.
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </li>
+              </ul>
+            </fieldset>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`single-choice question reviewMode: true should snapshot the same with incorrect answer: incorrect answer 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="paragraph"
+      >
+        Which of the following values of 
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            x
+          </span>
+          <span />
+        </span>
+         satisfies the equation 
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            \\sqrt{64}=x
+          </span>
+          <span />
+        </span>
+         ?
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <div
+            class="responsiveContainer_vq37gq"
+          >
+            <fieldset
+              class="perseus-widget-radio-fieldset responsiveFieldset_c0l5kf"
+            >
+              <legend
+                class="perseus-sr-only"
+              >
+                Choose 1 answer:
+              </legend>
+              <div
+                aria-hidden="true"
+                class="instructions instructions_125m8j1"
+              >
+                Choose 1 answer:
+              </div>
+              <ul
+                class="perseus-widget-radio perseus-rendered-radio radio_1gyjybc-o_O-responsiveRadioContainer_1ybwre2"
+                style="list-style: none;"
+              >
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd-o_O-selectedItem_p6cyk0 perseus-radio-option perseus-radio-selected"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
+                      <div
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-16"
+                          tabindex="-1"
+                          type="radio"
+                        />
+                        <label
+                          for="choice-16"
+                        >
+                          (Choice A, Checked)
+                             
+                          <div
+                            class="perseus-renderer perseus-renderer-responsive"
+                          >
+                            <div
+                              class="paragraph"
+                              data-perseus-paragraph-index="0"
+                            >
+                              <div
+                                class="paragraph"
+                              >
+                                <span
+                                  style="white-space: nowrap;"
+                                >
+                                  <span />
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    -8
+                                  </span>
+                                  <span />
+                                </span>
+                                 and 
+                                <span
+                                  style="white-space: nowrap;"
+                                >
+                                  <span />
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    8
+                                  </span>
+                                  <span />
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
+                            <span
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 50%;"
+                            >
+                              <div
+                                class="circle_1tys2th"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: #1865f2; color: rgb(255, 255, 255); border-radius: 24px; background-color: rgb(24, 101, 242);"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
+                                >
+                                  A
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                          >
+                            <div />
+                            <div>
+                              <div
+                                class="perseus-renderer perseus-renderer-responsive"
+                              >
+                                <div
+                                  class="paragraph"
+                                  data-perseus-paragraph-index="0"
+                                >
+                                  <div
+                                    class="paragraph"
+                                  >
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        -8
+                                      </span>
+                                      <span />
+                                    </span>
+                                     and 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        8
+                                      </span>
+                                      <span />
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
+                      <div
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-17"
+                          tabindex="-1"
+                          type="radio"
+                        />
+                        <label
+                          for="choice-17"
+                        >
+                          (Choice B)
+                             
+                          <div
+                            class="perseus-renderer perseus-renderer-responsive"
+                          >
+                            <div
+                              class="paragraph perseus-paragraph-centered"
+                              data-perseus-paragraph-index="0"
+                            >
+                              <div
+                                class="perseus-block-math"
+                              >
+                                <div
+                                  class="perseus-block-math-inner"
+                                  style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                >
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    -8
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
+                            <span
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 50%;"
+                            >
+                              <div
+                                class="circle_1tys2th"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
+                                >
+                                  B
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                          >
+                            <div />
+                            <div>
+                              <div
+                                class="perseus-renderer perseus-renderer-responsive"
+                              >
+                                <div
+                                  class="paragraph perseus-paragraph-centered"
+                                  data-perseus-paragraph-index="0"
+                                >
+                                  <div
+                                    class="perseus-block-math"
+                                  >
+                                    <div
+                                      class="perseus-block-math-inner"
+                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                    >
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        -8
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
+                      <div
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-18"
+                          tabindex="-1"
+                          type="radio"
+                        />
+                        <label
+                          for="choice-18"
+                        >
+                          (Choice C)
+                             
+                          <div
+                            class="perseus-renderer perseus-renderer-responsive"
+                          >
+                            <div
+                              class="paragraph perseus-paragraph-centered"
+                              data-perseus-paragraph-index="0"
+                            >
+                              <div
+                                class="perseus-block-math"
+                              >
+                                <div
+                                  class="perseus-block-math-inner"
+                                  style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                >
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    8
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
+                            <span
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 50%;"
+                            >
+                              <div
+                                class="circle_1tys2th"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
+                                >
+                                  C
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                          >
+                            <div />
+                            <div>
+                              <div
+                                class="perseus-renderer perseus-renderer-responsive"
+                              >
+                                <div
+                                  class="paragraph perseus-paragraph-centered"
+                                  data-perseus-paragraph-index="0"
+                                >
+                                  <div
+                                    class="perseus-block-math"
+                                  >
+                                    <div
+                                      class="perseus-block-math-inner"
+                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                    >
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        8
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
+                      <div
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-19"
+                          tabindex="-1"
+                          type="radio"
+                        />
+                        <label
+                          for="choice-19"
+                        >
+                          (Choice D)
+                             
+                          <div
+                            class="perseus-renderer perseus-renderer-responsive"
+                          >
+                            <div
+                              class="paragraph"
+                              data-perseus-paragraph-index="0"
+                            >
+                              <div
+                                class="paragraph"
+                              >
+                                No value of 
+                                <span
+                                  style="white-space: nowrap;"
+                                >
+                                  <span />
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    x
+                                  </span>
+                                  <span />
+                                </span>
+                                 satisfies the equation.
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
+                            <span
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 50%;"
+                            >
+                              <div
+                                class="circle_1tys2th"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
+                                >
+                                  D
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                          >
+                            <div />
+                            <div>
+                              <div
+                                class="perseus-renderer perseus-renderer-responsive"
+                              >
+                                <div
+                                  class="paragraph"
+                                  data-perseus-paragraph-index="0"
+                                >
+                                  <div
+                                    class="paragraph"
+                                  >
+                                    No value of 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        x
+                                      </span>
+                                      <span />
+                                    </span>
+                                     satisfies the equation.
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </li>
+              </ul>
+            </fieldset>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`single-choice question reviewMode: true should snapshot the same: first render 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="paragraph"
+      >
+        Which of the following values of 
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            x
+          </span>
+          <span />
+        </span>
+         satisfies the equation 
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            \\sqrt{64}=x
+          </span>
+          <span />
+        </span>
+         ?
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <div
+            class="responsiveContainer_vq37gq"
+          >
+            <fieldset
+              class="perseus-widget-radio-fieldset responsiveFieldset_c0l5kf"
+            >
+              <legend
+                class="perseus-sr-only"
+              >
+                Choose 1 answer:
+              </legend>
+              <div
+                aria-hidden="true"
+                class="instructions instructions_125m8j1"
+              >
+                Choose 1 answer:
+              </div>
+              <ul
+                class="perseus-widget-radio perseus-rendered-radio radio_1gyjybc-o_O-responsiveRadioContainer_1ybwre2"
+                style="list-style: none;"
+              >
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option perseus-incorrect"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
+                      <div
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-0"
+                          tabindex="-1"
+                          type="radio"
+                        />
+                        <label
+                          for="choice-0"
+                        >
+                          (Choice A, Incorrect)
+                             
+                          <div
+                            class="perseus-renderer perseus-renderer-responsive"
+                          >
+                            <div
+                              class="paragraph"
+                              data-perseus-paragraph-index="0"
+                            >
+                              <div
+                                class="paragraph"
+                              >
+                                <span
+                                  style="white-space: nowrap;"
+                                >
+                                  <span />
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    -8
+                                  </span>
+                                  <span />
+                                </span>
+                                 and 
+                                <span
+                                  style="white-space: nowrap;"
+                                >
+                                  <span />
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    8
+                                  </span>
+                                  <span />
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
+                            <span
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 50%;"
+                            >
+                              <div
+                                class="circle_1tys2th-o_O-circleIncorrect_gxqnr9"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    height="1em"
+                                    role="img"
+                                    style="vertical-align: middle;"
+                                    viewBox="0 0 24 24"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M8,13 L16,13 C16.5522847,13 17,12.5522847 17,12 C17,11.4477153 16.5522847,11 16,11 L8,11 C7.44771525,11 7,11.4477153 7,12 C7,12.5522847 7.44771525,13 8,13 Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                          >
+                            <div>
+                              <div
+                                class="text_1tb4z7c-o_O-incorrect_7sq9ra"
+                              >
+                                Incorrect
+                              </div>
+                            </div>
+                            <div>
+                              <div
+                                class="perseus-renderer perseus-renderer-responsive"
+                              >
+                                <div
+                                  class="paragraph"
+                                  data-perseus-paragraph-index="0"
+                                >
+                                  <div
+                                    class="paragraph"
+                                  >
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        -8
+                                      </span>
+                                      <span />
+                                    </span>
+                                     and 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        8
+                                      </span>
+                                      <span />
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                        </div>
+                      </button>
+                    </div>
+                    <div
+                      class="perseus-radio-rationale-content rationale_1w3tmyh"
+                      data-test-id="perseus-radio-rationale-content-0"
+                    >
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
+                      >
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
+                        >
+                          <div
+                            class="paragraph"
+                          >
+                            The square root operation (
+                            <span
+                              style="white-space: nowrap;"
+                            >
+                              <span />
+                              <span
+                                class="mock-TeX"
+                              >
+                                \\sqrt{\\phantom{x}}
+                              </span>
+                              <span />
+                            </span>
+                            ) calculates 
+                            <em>
+                              only
+                            </em>
+                             the positive square root when performed on a number, so 
+                            <span
+                              style="white-space: nowrap;"
+                            >
+                              <span />
+                              <span
+                                class="mock-TeX"
+                              >
+                                x
+                              </span>
+                              <span />
+                            </span>
+                             is equal to 
+                            <em>
+                              only
+                            </em>
+                             
+                            <span
+                              style="white-space: nowrap;"
+                            >
+                              <span />
+                              <span
+                                class="mock-TeX"
+                              >
+                                8
+                              </span>
+                              <span />
+                            </span>
+                            .
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option perseus-incorrect"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
+                      <div
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-1"
+                          tabindex="-1"
+                          type="radio"
+                        />
+                        <label
+                          for="choice-1"
+                        >
+                          (Choice B, Incorrect)
+                             
+                          <div
+                            class="perseus-renderer perseus-renderer-responsive"
+                          >
+                            <div
+                              class="paragraph perseus-paragraph-centered"
+                              data-perseus-paragraph-index="0"
+                            >
+                              <div
+                                class="perseus-block-math"
+                              >
+                                <div
+                                  class="perseus-block-math-inner"
+                                  style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                >
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    -8
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
+                            <span
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 50%;"
+                            >
+                              <div
+                                class="circle_1tys2th-o_O-circleIncorrect_gxqnr9"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    height="1em"
+                                    role="img"
+                                    style="vertical-align: middle;"
+                                    viewBox="0 0 24 24"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M8,13 L16,13 C16.5522847,13 17,12.5522847 17,12 C17,11.4477153 16.5522847,11 16,11 L8,11 C7.44771525,11 7,11.4477153 7,12 C7,12.5522847 7.44771525,13 8,13 Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                          >
+                            <div>
+                              <div
+                                class="text_1tb4z7c-o_O-incorrect_7sq9ra"
+                              >
+                                Incorrect
+                              </div>
+                            </div>
+                            <div>
+                              <div
+                                class="perseus-renderer perseus-renderer-responsive"
+                              >
+                                <div
+                                  class="paragraph perseus-paragraph-centered"
+                                  data-perseus-paragraph-index="0"
+                                >
+                                  <div
+                                    class="perseus-block-math"
+                                  >
+                                    <div
+                                      class="perseus-block-math-inner"
+                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                    >
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        -8
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                        </div>
+                      </button>
+                    </div>
+                    <div
+                      class="perseus-radio-rationale-content rationale_1w3tmyh"
+                      data-test-id="perseus-radio-rationale-content-1"
+                    >
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
+                      >
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
+                        >
+                          <div
+                            class="paragraph"
+                          >
+                            While 
+                            <span
+                              style="white-space: nowrap;"
+                            >
+                              <span />
+                              <span
+                                class="mock-TeX"
+                              >
+                                (-8)^2=64
+                              </span>
+                              <span />
+                            </span>
+                            , the square root operation (
+                            <span
+                              style="white-space: nowrap;"
+                            >
+                              <span />
+                              <span
+                                class="mock-TeX"
+                              >
+                                \\sqrt{\\phantom{x}}
+                              </span>
+                              <span />
+                            </span>
+                            ) calculates 
+                            <em>
+                              only
+                            </em>
+                             the positive square root when performed on a number.
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option perseus-correct"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
+                      <div
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-2"
+                          tabindex="-1"
+                          type="radio"
+                        />
+                        <label
+                          for="choice-2"
+                        >
+                          (Choice C, Correct)
+                             
+                          <div
+                            class="perseus-renderer perseus-renderer-responsive"
+                          >
+                            <div
+                              class="paragraph perseus-paragraph-centered"
+                              data-perseus-paragraph-index="0"
+                            >
+                              <div
+                                class="perseus-block-math"
+                              >
+                                <div
+                                  class="perseus-block-math-inner"
+                                  style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                >
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    8
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
+                            <span
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 50%;"
+                            >
+                              <div
+                                class="circle_1tys2th-o_O-circleCorrect_ifnw95"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    height="1em"
+                                    role="img"
+                                    style="vertical-align: middle; position: relative; top: -1px;"
+                                    viewBox="0 0 24 24"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M8.70710678,12.2928932 C8.31658249,11.9023689 7.68341751,11.9023689 7.29289322,12.2928932 C6.90236893,12.6834175 6.90236893,13.3165825 7.29289322,13.7071068 L9.82842712,16.2426407 C10.2207367,16.6349502 10.8574274,16.6328935 11.2471942,16.2380576 L16.7116603,10.7025237 C17.0996535,10.3094846 17.0955629,9.67633279 16.7025237,9.28833966 C16.3094846,8.90034653 15.6763328,8.90443714 15.2883397,9.29747629 L10.5309507,14.1167372 L8.70710678,12.2928932 Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                          >
+                            <div>
+                              <div
+                                class="text_1tb4z7c-o_O-correct_udbdnp"
+                              >
+                                Correct
+                              </div>
+                            </div>
+                            <div>
+                              <div
+                                class="perseus-renderer perseus-renderer-responsive"
+                              >
+                                <div
+                                  class="paragraph perseus-paragraph-centered"
+                                  data-perseus-paragraph-index="0"
+                                >
+                                  <div
+                                    class="perseus-block-math"
+                                  >
+                                    <div
+                                      class="perseus-block-math-inner"
+                                      style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+                                    >
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        8
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                        </div>
+                      </button>
+                    </div>
+                    <div
+                      class="perseus-radio-rationale-content rationale_1w3tmyh"
+                      data-test-id="perseus-radio-rationale-content-2"
+                    >
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
+                      >
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
+                        >
+                          <div
+                            class="paragraph"
+                          >
+                            <span
+                              style="white-space: nowrap;"
+                            >
+                              <span />
+                              <span
+                                class="mock-TeX"
+                              >
+                                8
+                              </span>
+                              <span />
+                            </span>
+                             is the positive square root of 
+                            <span
+                              style="white-space: nowrap;"
+                            >
+                              <span />
+                              <span
+                                class="mock-TeX"
+                              >
+                                64
+                              </span>
+                              <span />
+                            </span>
+                            .
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option perseus-incorrect"
+                >
+                  <div
+                    class="description description_psmgei"
+                    style="flex-direction: column; color: rgb(33, 36, 44);"
+                  >
+                    <div
+                      style="display: flex; flex-direction: row; opacity: 1;"
+                    >
+                      <div
+                        class="perseus-sr-only"
+                      >
+                        <input
+                          class="perseus-radio-option-content"
+                          id="choice-3"
+                          tabindex="-1"
+                          type="radio"
+                        />
+                        <label
+                          for="choice-3"
+                        >
+                          (Choice D, Incorrect)
+                             
+                          <div
+                            class="perseus-renderer perseus-renderer-responsive"
+                          >
+                            <div
+                              class="paragraph"
+                              data-perseus-paragraph-index="0"
+                            >
+                              <div
+                                class="paragraph"
+                              >
+                                No value of 
+                                <span
+                                  style="white-space: nowrap;"
+                                >
+                                  <span />
+                                  <span
+                                    class="mock-TeX"
+                                  >
+                                    x
+                                  </span>
+                                  <span />
+                                </span>
+                                 satisfies the equation.
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <button
+                        aria-disabled="false"
+                        aria-hidden="true"
+                        class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-inlineStyles_1jvwfht"
+                        type="button"
+                      >
+                        <div
+                          style="display: flex; flex-direction: row; justify-content: center; align-content: center; padding-top: 8px; padding-bottom: 8px; padding-left: 8px;"
+                        >
+                          <div
+                            class="iconWrapper_17y0hv9"
+                          >
+                            <span
+                              class="ring_ya75gi"
+                              data-test-id="focus-ring"
+                              style="border-color: transparent; border-radius: 50%;"
+                            >
+                              <div
+                                class="circle_1tys2th-o_O-circleIncorrect_gxqnr9"
+                                data-is-radio-icon="true"
+                                data-test-id="choice-icon__library-choice-icon"
+                                style="border-color: rgba(33,36,44,0.64); color: rgba(33, 36, 44, 0.64); border-radius: 24px;"
+                              >
+                                <div
+                                  class="innerWrapper_177sg8x"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    height="1em"
+                                    role="img"
+                                    style="vertical-align: middle;"
+                                    viewBox="0 0 24 24"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M8,13 L16,13 C16.5522847,13 17,12.5522847 17,12 C17,11.4477153 16.5522847,11 16,11 L8,11 C7.44771525,11 7,11.4477153 7,12 C7,12.5522847 7.44771525,13 8,13 Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <span
+                            style="padding-left: 12px; text-align: left; flex: 1; padding-top: 4px;"
+                          >
+                            <div>
+                              <div
+                                class="text_1tb4z7c-o_O-incorrect_7sq9ra"
+                              >
+                                Incorrect
+                              </div>
+                            </div>
+                            <div>
+                              <div
+                                class="perseus-renderer perseus-renderer-responsive"
+                              >
+                                <div
+                                  class="paragraph"
+                                  data-perseus-paragraph-index="0"
+                                >
+                                  <div
+                                    class="paragraph"
+                                  >
+                                    No value of 
+                                    <span
+                                      style="white-space: nowrap;"
+                                    >
+                                      <span />
+                                      <span
+                                        class="mock-TeX"
+                                      >
+                                        x
+                                      </span>
+                                      <span />
+                                    </span>
+                                     satisfies the equation.
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                        </div>
+                      </button>
+                    </div>
+                    <div
+                      class="perseus-radio-rationale-content rationale_1w3tmyh"
+                      data-test-id="perseus-radio-rationale-content-3"
+                    >
+                      <div
+                        class="perseus-renderer perseus-renderer-responsive"
+                      >
+                        <div
+                          class="paragraph"
+                          data-perseus-paragraph-index="0"
+                        >
+                          <div
+                            class="paragraph"
+                          >
+                            <span
+                              style="white-space: nowrap;"
+                            >
+                              <span />
+                              <span
+                                class="mock-TeX"
+                              >
+                                8
+                              </span>
+                              <span />
+                            </span>
+                             satisfies the equation.
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </li>
+              </ul>
+            </fieldset>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/video.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/video.test.ts.snap
@@ -2,160 +2,152 @@
 
 exports[`video widget should snapshot on mobile: first mobile render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          Watch the Biogeography: Where Life Lives video to find the answer.
-        </div>
+        Watch the Biogeography: Where Life Lives video to find the answer.
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="1"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+            class="default_xu2jcg"
           >
             <div
-              class="default_xu2jcg"
+              class="fixed-to-responsive"
+              style="max-width: 1280px; max-height: 720px;"
             >
               <div
-                class="fixed-to-responsive"
-                style="max-width: 1280px; max-height: 720px;"
-              >
-                <div
-                  style="padding-bottom: 56.25%;"
-                />
-                <div
-                  class="default_xu2jcg-o_O-srOnly_19bpjuy"
-                >
-                  Khan Academy video wrapper
-                </div>
-                <iframe
-                  allowfullscreen=""
-                  class="perseus-video-widget"
-                  height="720"
-                  sandbox="allow-same-origin allow-scripts"
-                  src="https://www.khanacademy.org/embed_video?slug=biogeography-where-life-lives&internal_video_only=1"
-                  width="1280"
-                />
-              </div>
+                style="padding-bottom: 56.25%;"
+              />
               <div
-                class="default_xu2jcg-o_O-transcriptLink_18xwqfz"
+                class="default_xu2jcg-o_O-srOnly_19bpjuy"
               >
-                <span
-                  class="text_f1191h"
-                />
-                <div
-                  aria-hidden="true"
-                  class="default_xu2jcg-o_O-inlineStyles_sc01dy"
-                />
-                <a
-                  class="shared_htyo3s-o_O-resting_nelfll visited-no-recolor"
-                  href="/transcript/videoNotFound"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  See video transcript
-                </a>
+                Khan Academy video wrapper
               </div>
+              <iframe
+                allowfullscreen=""
+                class="perseus-video-widget"
+                height="720"
+                sandbox="allow-same-origin allow-scripts"
+                src="https://www.khanacademy.org/embed_video?slug=biogeography-where-life-lives&internal_video_only=1"
+                width="1280"
+              />
+            </div>
+            <div
+              class="default_xu2jcg-o_O-transcriptLink_18xwqfz"
+            >
+              <span
+                class="text_f1191h"
+              />
+              <div
+                aria-hidden="true"
+                class="default_xu2jcg-o_O-inlineStyles_sc01dy"
+              />
+              <a
+                class="shared_htyo3s-o_O-resting_nelfll visited-no-recolor"
+                href="/transcript/videoNotFound"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                See video transcript
+              </a>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`video widget should snapshot: first render 1`] = `
 <div>
-  <span
-    class="mock-KatexProvider"
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
   >
     <div
-      class="perseus-renderer perseus-renderer-responsive"
+      class="paragraph"
+      data-perseus-paragraph-index="0"
     >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="0"
       >
-        <div
-          class="paragraph"
-        >
-          Watch the Biogeography: Where Life Lives video to find the answer.
-        </div>
+        Watch the Biogeography: Where Life Lives video to find the answer.
       </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
       <div
         class="paragraph"
-        data-perseus-paragraph-index="1"
       >
         <div
-          class="paragraph"
+          class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="perseus-widget-container widget-nohighlight widget-block"
+            class="default_xu2jcg"
           >
             <div
-              class="default_xu2jcg"
+              class="fixed-to-responsive"
+              style="max-width: 1280px; max-height: 720px;"
             >
               <div
-                class="fixed-to-responsive"
-                style="max-width: 1280px; max-height: 720px;"
-              >
-                <div
-                  style="padding-bottom: 56.25%;"
-                />
-                <div
-                  class="default_xu2jcg-o_O-srOnly_19bpjuy"
-                >
-                  Khan Academy video wrapper
-                </div>
-                <iframe
-                  allowfullscreen=""
-                  class="perseus-video-widget"
-                  height="720"
-                  sandbox="allow-same-origin allow-scripts"
-                  src="https://www.khanacademy.org/embed_video?slug=biogeography-where-life-lives&internal_video_only=1"
-                  width="1280"
-                />
-              </div>
+                style="padding-bottom: 56.25%;"
+              />
               <div
-                class="default_xu2jcg-o_O-transcriptLink_18xwqfz"
+                class="default_xu2jcg-o_O-srOnly_19bpjuy"
               >
-                <span
-                  class="text_f1191h"
-                />
-                <div
-                  aria-hidden="true"
-                  class="default_xu2jcg-o_O-inlineStyles_sc01dy"
-                />
-                <a
-                  class="shared_htyo3s-o_O-resting_nelfll visited-no-recolor"
-                  href="/transcript/videoNotFound"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  See video transcript
-                </a>
+                Khan Academy video wrapper
               </div>
+              <iframe
+                allowfullscreen=""
+                class="perseus-video-widget"
+                height="720"
+                sandbox="allow-same-origin allow-scripts"
+                src="https://www.khanacademy.org/embed_video?slug=biogeography-where-life-lives&internal_video_only=1"
+                width="1280"
+              />
+            </div>
+            <div
+              class="default_xu2jcg-o_O-transcriptLink_18xwqfz"
+            >
+              <span
+                class="text_f1191h"
+              />
+              <div
+                aria-hidden="true"
+                class="default_xu2jcg-o_O-inlineStyles_sc01dy"
+              />
+              <a
+                class="shared_htyo3s-o_O-resting_nelfll visited-no-recolor"
+                href="/transcript/videoNotFound"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                See video transcript
+              </a>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;

--- a/packages/perseus/src/widgets/__tests__/matcher.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/matcher.test.tsx
@@ -31,7 +31,6 @@ describe("matcher widget", () => {
             TeX: ({children}: {children: React.ReactNode}) => (
                 <span className="tex-mock">{children}</span>
             ),
-            shouldUseFutureKaTeX: (flag: boolean) => {},
         });
     });
 

--- a/packages/perseus/src/widgets/__tests__/matcher.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/matcher.test.tsx
@@ -1,4 +1,3 @@
-import getRenderA11yString from "katex/dist/contrib/render-a11y-string";
 import * as React from "react";
 import "@testing-library/jest-dom";
 
@@ -32,8 +31,6 @@ describe("matcher widget", () => {
             TeX: ({children}: {children: React.ReactNode}) => (
                 <span className="tex-mock">{children}</span>
             ),
-            // @ts-expect-error [FEI-5003] - TS2322 - Type 'Promise<any>' is not assignable to type '() => Promise<katexA11y>'.
-            getRenderA11yString: Promise.resolve(getRenderA11yString),
             shouldUseFutureKaTeX: (flag: boolean) => {},
         });
     });

--- a/testing/test-dependencies.tsx
+++ b/testing/test-dependencies.tsx
@@ -37,7 +37,6 @@ export const testDependencies: PerseusDependencies = {
 
     // KaTeX
     getKaTeX: () => Promise.resolve(katex),
-    loadMathjax: () => Promise.resolve(),
     // The KaTeX used in the 'should replace deprecated alignment tags in inline
     // math' test uses the `align` environment. This results in `array` nodes in
     // the parsed KaTeX node tree. When the Tex component tries to build an a11y

--- a/testing/test-dependencies.tsx
+++ b/testing/test-dependencies.tsx
@@ -48,9 +48,6 @@ export const testDependencies: PerseusDependencies = {
     // Mocking this here so that we don't fail because of this issue.
     logKaTeXError: (expression: string, error: Error): Promise<any> =>
         Promise.resolve({}),
-    KatexProvider: ({children}: {children: React.ReactNode}) => (
-        <span className="mock-KatexProvider">{children}</span>
-    ),
     shouldUseFutureKaTeX: (flag: boolean) => {},
     TeX: ({children}: {children: React.ReactNode}) => (
         <span className="mock-TeX">{children}</span>

--- a/testing/test-dependencies.tsx
+++ b/testing/test-dependencies.tsx
@@ -47,7 +47,6 @@ export const testDependencies: PerseusDependencies = {
     // Mocking this here so that we don't fail because of this issue.
     logKaTeXError: (expression: string, error: Error): Promise<any> =>
         Promise.resolve({}),
-    shouldUseFutureKaTeX: (flag: boolean) => {},
     TeX: ({children}: {children: React.ReactNode}) => (
         <span className="mock-TeX">{children}</span>
     ),

--- a/testing/test-dependencies.tsx
+++ b/testing/test-dependencies.tsx
@@ -1,7 +1,6 @@
 // This defines a version of PerseusDependencies that is suitable for use in tests.
 // It should not make network requests, for example.
 import katex from "katex";
-import renderA11yString from "katex/dist/contrib/render-a11y-string";
 import * as React from "react";
 
 import {registerAllWidgetsForTesting} from "../packages/perseus/src/util/register-all-widgets-for-testing";
@@ -38,7 +37,6 @@ export const testDependencies: PerseusDependencies = {
 
     // KaTeX
     getKaTeX: () => Promise.resolve(katex),
-    getRenderA11yString: () => Promise.resolve(renderA11yString),
     loadMathjax: () => Promise.resolve(),
     // The KaTeX used in the 'should replace deprecated alignment tags in inline
     // math' test uses the `align` environment. This results in `array` nodes in


### PR DESCRIPTION
We are replacing KaTeX with MathJax 3 in webapp and the mobile app. Before we
can do that, Perseus needs to not depend on KaTeX at all.

This PR doesn't fully remove references to KaTeX from Perseus. It is just the
first step.

Issue: https://khanacademy.atlassian.net/browse/LC-459

## Test plan:

Inspect all Storybook stories and verify that e.g. the Graphie graphs with
rendered math expressions look good.