### PR TITLE
Remove all uses of React.FC<> and other misc TS changes

### DIFF
--- a/.changeset/red-badgers-fry.md
+++ b/.changeset/red-badgers-fry.md
@@ -1,0 +1,8 @@
+---
+"@khanacademy/math-input": patch
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+"@khanacademy/simple-markdown": patch
+---
+
+Remove the use of React.FC<> and use types named Props/State in more components

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -242,6 +242,11 @@ module.exports = {
             ...banImportExtension("jsx"),
             ...banImportExtension("ts"),
             ...banImportExtension("tsx"),
+            {
+                selector: "TSQualifiedName[left.name='React'][right.name='FC']",
+                message:
+                    "Use of React.FC<Props> is disallowed, use the following alternative: https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/2201682693/TypeScript+for+Flow+Developers#Functional-Components",
+            },
         ],
 
         /**

--- a/packages/math-input/src/components/keypad/button-assets.tsx
+++ b/packages/math-input/src/components/keypad/button-assets.tsx
@@ -15,9 +15,7 @@ import * as React from "react";
 // TODO: This should be an enumeration of all of the possible legal values
 type KeyId = string;
 
-const buttonAsset: React.FC<{
-    id: KeyId;
-}> = function ({id}): React.ReactElement {
+const buttonAsset = function ({id}: {id: KeyId}): React.ReactElement {
     switch (id) {
         case "NUM_0":
             return (

--- a/packages/math-input/src/components/keypad/button-assets.tsx
+++ b/packages/math-input/src/components/keypad/button-assets.tsx
@@ -15,7 +15,9 @@ import * as React from "react";
 // TODO: This should be an enumeration of all of the possible legal values
 type KeyId = string;
 
-const buttonAsset = function ({id}: {id: KeyId}): React.ReactElement {
+type Props = {id: KeyId};
+
+export default function ButtonAsset({id}: Props): React.ReactElement {
     switch (id) {
         case "NUM_0":
             return (
@@ -487,5 +489,4 @@ const buttonAsset = function ({id}: {id: KeyId}): React.ReactElement {
         default:
             throw new Error(`Invalid asset ${id}`);
     }
-};
-export default buttonAsset;
+}

--- a/packages/math-input/src/components/keypad/index.tsx
+++ b/packages/math-input/src/components/keypad/index.tsx
@@ -18,7 +18,7 @@ type State = {
     selectedPage: TabbarItemType;
 };
 
-const allPages: React.FC<Props> = function (props): React.ReactElement {
+const allPages = function (props: Props): React.ReactElement {
     const pages: Array<TabbarItemType> = ["Numbers"];
 
     if (props.preAlgebra) {

--- a/packages/math-input/src/components/keypad/keypad-page-items.tsx
+++ b/packages/math-input/src/components/keypad/keypad-page-items.tsx
@@ -7,9 +7,13 @@ import ButtonAsset from "./button-assets";
 import type {KeyConfig} from "../../data/key-configs";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
-export const KeypadPageContainer: React.FC<{
+type KeypadPageContainerProps = {
     children: React.ReactNode;
-}> = ({children}): React.ReactElement => (
+};
+
+export const KeypadPageContainer = ({
+    children,
+}: KeypadPageContainerProps): React.ReactElement => (
     <View
         style={{
             backgroundColor: "#DBDCDD",
@@ -25,12 +29,19 @@ export const KeypadPageContainer: React.FC<{
     </View>
 );
 
-export const KeypadButton: React.FC<{
+type KeypadButtonProps = {
     keyConfig: KeyConfig;
     tintColor?: string;
     style?: StyleType;
     onClickKey: (keyConfig: string) => void;
-}> = ({keyConfig, onClickKey, tintColor, style}): React.ReactElement => (
+};
+
+export const KeypadButton = ({
+    keyConfig,
+    onClickKey,
+    tintColor,
+    style,
+}: KeypadButtonProps): React.ReactElement => (
     <Button
         onPress={() => onClickKey(keyConfig.id)}
         tintColor={tintColor}
@@ -40,11 +51,17 @@ export const KeypadButton: React.FC<{
     </Button>
 );
 
-export const SecondaryKeypadButton: React.FC<{
+type SecondaryKeypadButtonProps = {
     keyConfig: KeyConfig;
     style?: any;
     onClickKey: (keyConfig: string) => void;
-}> = ({keyConfig, onClickKey, style}): React.ReactElement => (
+};
+
+export const SecondaryKeypadButton = ({
+    keyConfig,
+    onClickKey,
+    style,
+}: SecondaryKeypadButtonProps): React.ReactElement => (
     <KeypadButton
         keyConfig={keyConfig}
         onClickKey={onClickKey}
@@ -53,11 +70,17 @@ export const SecondaryKeypadButton: React.FC<{
     />
 );
 
-export const KeypadActionButton: React.FC<{
+type KeypadActionButtonProps = {
     keyConfig: KeyConfig;
     style?: any;
     onClickKey: (keyConfig: string) => void;
-}> = ({keyConfig, onClickKey, style}): React.ReactElement => (
+};
+
+export const KeypadActionButton = ({
+    keyConfig,
+    onClickKey,
+    style,
+}: KeypadActionButtonProps): React.ReactElement => (
     <KeypadButton
         keyConfig={keyConfig}
         onClickKey={onClickKey}

--- a/packages/math-input/src/components/tabbar/icons.tsx
+++ b/packages/math-input/src/components/tabbar/icons.tsx
@@ -2,10 +2,12 @@ import * as React from "react";
 
 import type {TabbarItemType} from "./types";
 
-const IconAsset: React.FC<{
+type Props = {
     tintColor: string;
     type: TabbarItemType;
-}> = function ({tintColor, type}): React.ReactElement {
+};
+
+const IconAsset = function ({tintColor, type}: Props): React.ReactElement {
     if (type === "Geometry") {
         return (
             <svg

--- a/packages/math-input/src/components/tabbar/tabbar.tsx
+++ b/packages/math-input/src/components/tabbar/tabbar.tsx
@@ -23,12 +23,12 @@ type TabbarState = {
     selectedItem: number;
 };
 
-type TabbarProps = {
+type Props = {
     items: Array<TabbarItemType>;
     onSelect: (item: TabbarItemType) => void;
 };
 
-class Tabbar extends React.Component<TabbarProps, TabbarState> {
+class Tabbar extends React.Component<Props, TabbarState> {
     state: TabbarState = {
         selectedItem: 0,
     };

--- a/packages/perseus-editor/src/__stories__/section-control-button.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/section-control-button.stories.tsx
@@ -13,9 +13,9 @@ export default {
     title: "Perseus Editor/Widgets/Section Control Button",
 } as Story;
 
-export const ButtonForEditingSectionsOfContentWithInArticleEditor: React.FC<
-    StoryArgs
-> = (args): React.ReactElement => {
+export const ButtonForEditingSectionsOfContentWithInArticleEditor = (
+    args: StoryArgs,
+): React.ReactElement => {
     return (
         <SectionControlButton
             icon={icons.iconTrash}

--- a/packages/perseus-editor/src/article-editor.tsx
+++ b/packages/perseus-editor/src/article-editor.tsx
@@ -44,7 +44,7 @@ type DefaultProps = {
     ) => React.ReactElement<React.ComponentProps<"span">>;
     useNewStyles: boolean;
 };
-type PerseusArticleEditorProps = DefaultProps & {
+type Props = DefaultProps & {
     apiOptions?: APIOptions;
     imageUploader?: (arg1: string, arg2: (arg1: string) => unknown) => unknown;
     // URL of the route to show on initial load of the preview frames.
@@ -54,10 +54,7 @@ type PerseusArticleEditorProps = DefaultProps & {
 type State = {
     highlightLint: boolean;
 };
-export default class ArticleEditor extends React.Component<
-    PerseusArticleEditorProps,
-    State
-> {
+export default class ArticleEditor extends React.Component<Props, State> {
     static defaultProps: DefaultProps = {
         contentPaths: [],
         json: [{}],

--- a/packages/perseus-editor/src/components/dropdown-option.tsx
+++ b/packages/perseus-editor/src/components/dropdown-option.tsx
@@ -31,7 +31,7 @@ const findAndFocusElement = (component?: Element | null) => {
     }
 };
 
-type OptionProps = {
+type Props = {
     // The value to use when the option is selected
     value: string;
     // The display of the option
@@ -65,7 +65,7 @@ const check = `M10,3.8C10,4,9.9,4.2,9.8,4.3L5.1,8.9L4.3,9.8C4.2,9.9,4,10,3.8,10
 
 export const optionHeight = 30;
 
-class Option extends React.Component<OptionProps> {
+class Option extends React.Component<Props> {
     // @ts-expect-error [FEI-5003] - TS2564 - Property 'node' has no initializer and is not definitely assigned in the constructor.
     node: HTMLDivElement;
 

--- a/packages/perseus-editor/src/components/link.ts
+++ b/packages/perseus-editor/src/components/link.ts
@@ -24,7 +24,7 @@ type DefaultProps = {
     style: CSSProperties | Array<CSSProperties>;
 };
 
-type LinkProps = DefaultProps & {
+type Props = DefaultProps & {
     children?: React.ReactNode;
     // An additional class name to add. This is supported so-as to allow
     // Perseus to add class-based styles to links when using this
@@ -66,7 +66,7 @@ type LinkProps = DefaultProps & {
 /**
  * A wrapper that creates an anchor tag with normalized styles
  */
-class Link extends React.Component<LinkProps> {
+class Link extends React.Component<Props> {
     static defaultProps: DefaultProps = {
         highlighted: false,
         href: DEFAULT_HREF,

--- a/packages/perseus-editor/src/diffs/__stories__/perseus-diff-wrapper.tsx
+++ b/packages/perseus-editor/src/diffs/__stories__/perseus-diff-wrapper.tsx
@@ -1,8 +1,10 @@
 import * as React from "react";
 
-const Wrapper: React.FC<{
+type Props = {
     children: React.ReactNode;
-}> = ({children}): React.ReactElement => {
+};
+
+const Wrapper = ({children}: Props): React.ReactElement => {
     return <div className="perseus-diff">{children}</div>;
 };
 

--- a/packages/perseus-editor/src/diffs/__stories__/structured-item-diff.stories.tsx
+++ b/packages/perseus-editor/src/diffs/__stories__/structured-item-diff.stories.tsx
@@ -33,7 +33,7 @@ const tags = {
     c: "c tag",
 } as const;
 
-export const ContentAdded: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const ContentAdded = (args: StoryArgs): React.ReactElement => {
     const props = {
         before: {
             _multi: {
@@ -175,8 +175,8 @@ export const ContentAdded: React.FC<StoryArgs> = (args): React.ReactElement => {
 };
 
 // second instance
-export const ContentAddedRemovedAndChanged: React.FC<StoryArgs> = (
-    args,
+export const ContentAddedRemovedAndChanged = (
+    args: StoryArgs,
 ): React.ReactElement => {
     const props = {
         before: {
@@ -383,9 +383,7 @@ export const ContentAddedRemovedAndChanged: React.FC<StoryArgs> = (
 };
 
 // third instance
-export const MiscContentChanges: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const MiscContentChanges = (args: StoryArgs): React.ReactElement => {
     const props = {
         before: {
             _multi: {
@@ -681,9 +679,7 @@ export const MiscContentChanges: React.FC<StoryArgs> = (
 };
 
 // fourth
-export const ContentRemoved: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const ContentRemoved = (args: StoryArgs): React.ReactElement => {
     const props = {
         before: {
             _multi: {

--- a/packages/perseus-editor/src/diffs/__stories__/tags-diff.stories.tsx
+++ b/packages/perseus-editor/src/diffs/__stories__/tags-diff.stories.tsx
@@ -24,7 +24,7 @@ export default {
     ],
 } as Story;
 
-export const Example: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Example = (args: StoryArgs): React.ReactElement => {
     return (
         <TagsDiff
             title="tags"

--- a/packages/perseus-editor/src/diffs/__stories__/text-diff.stories.tsx
+++ b/packages/perseus-editor/src/diffs/__stories__/text-diff.stories.tsx
@@ -24,7 +24,7 @@ export default {
     ],
 } as Story;
 
-export const Example: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Example = (args: StoryArgs): React.ReactElement => {
     return (
         <TextDiff
             title="A day in the life of a text diff"

--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -127,9 +127,7 @@ type WidgetEditorState = {
     widgetInfo: WidgetInfo;
 };
 
-const _upgradeWidgetInfo: React.FC<WidgetEditorProps> = (
-    props,
-): React.ReactElement => {
+const _upgradeWidgetInfo = (props: WidgetEditorProps): React.ReactElement => {
     // We can't call serialize here because this.refs.widget
     // doesn't exist before this component is mounted.
     const filteredProps = _.omit(props, WIDGET_PROP_DENYLIST);
@@ -368,7 +366,7 @@ const imageUrlsFromContent = function (content: string) {
     return _.map(allMatches(IMAGE_REGEX, content), (capture) => capture[1]);
 };
 
-type EditorProps = Readonly<{
+type Props = Readonly<{
     apiOptions: any;
     className?: string;
     content: string;
@@ -406,14 +404,14 @@ type DeafultProps = {
     };
 };
 
-type EditorState = {
+type State = {
     showKatexErrors: boolean;
     textAreaValue: string;
     katex?: katex;
 };
 
 // eslint-disable-next-line react/no-unsafe
-class Editor extends React.Component<EditorProps, EditorState> {
+class Editor extends React.Component<Props, State> {
     lastUserValue: string | null | undefined;
     deferredChange: any | null | undefined;
     widgetIds: any | null | undefined;
@@ -431,7 +429,7 @@ class Editor extends React.Component<EditorProps, EditorState> {
         warnNoWidgets: false,
     };
 
-    state: EditorState = {
+    state: State = {
         katex: undefined,
         showKatexErrors: false,
         textAreaValue: this.props.content,
@@ -463,13 +461,13 @@ class Editor extends React.Component<EditorProps, EditorState> {
     }
 
     // TODO(arun): This is a deprecated method, use the appropriate replacement
-    UNSAFE_componentWillReceiveProps(nextProps: EditorProps) {
+    UNSAFE_componentWillReceiveProps(nextProps: Props) {
         if (this.props.content !== nextProps.content) {
             this.setState({textAreaValue: nextProps.content});
         }
     }
 
-    componentDidUpdate(prevProps: EditorProps) {
+    componentDidUpdate(prevProps: Props) {
         // TODO(alpert): Maybe fix React so this isn't necessary
         // eslint-disable-next-line react/no-string-refs
         const textarea = ReactDOM.findDOMNode(this.refs.textarea);
@@ -574,7 +572,7 @@ class Editor extends React.Component<EditorProps, EditorState> {
      * Calculate the size of all the images in props.content, and send
      * those sizes to this.props.images using props.onChange.
      */
-    _sizeImages: (props: EditorProps) => void = (props: EditorProps) => {
+    _sizeImages: (props: Props) => void = (props: Props) => {
         const imageUrls = imageUrlsFromContent(props.content);
 
         // Discard any images in our dimension table that no

--- a/packages/perseus-editor/src/multirenderer-editor.tsx
+++ b/packages/perseus-editor/src/multirenderer-editor.tsx
@@ -141,13 +141,9 @@ type HeaderProps = {
     depth: number;
 };
 
-const Header: React.FC<HeaderProps> = ({
-    depth,
-    ...props
-}): React.ReactElement => {
+const Header = ({depth, ...props}: HeaderProps): React.ReactElement => {
     const headerLevel = Math.min(depth, 5) + 1;
     const HeaderTag = `h${headerLevel}`;
-    // @ts-expect-error [FEI-5003] - TS2559 - Type '{ children?: ReactNode; }' has no properties in common with type 'IntrinsicAttributes'.
     return <HeaderTag {...props} />;
 };
 
@@ -268,13 +264,13 @@ type LeafContainerProps = {
     path: Path;
     shape: Shape;
 };
-const LeafContainer: React.FC<LeafContainerProps> = ({
+const LeafContainer = ({
     name,
     controls,
     children,
     path,
     shape,
-}): React.ReactElement => {
+}: LeafContainerProps): React.ReactElement => {
     const hasPreviewHeading = shape.type === "content" || shape.type === "hint";
     const previewHeading = hasPreviewHeading && (
         <div className={css(styles.containerHeader)}>
@@ -314,9 +310,7 @@ type ArrayContainerProps = {
     shape: ArrayShape;
     actions: ArrayContainerActions;
 };
-const ArrayContainer: React.FC<ArrayContainerProps> = (
-    props,
-): React.ReactElement => {
+const ArrayContainer = (props: ArrayContainerProps): React.ReactElement => {
     const {name, controls, children, path, shape, actions} = props;
     return (
         <div className={css(styles.container)}>
@@ -347,12 +341,12 @@ type ObjectContainerProps = {
     children?: React.ReactNode;
     path: Path;
 };
-const ObjectContainer: React.FC<ObjectContainerProps> = ({
+const ObjectContainer = ({
     name,
     controls,
     children,
     path,
-}): React.ReactElement => {
+}: ObjectContainerProps): React.ReactElement => {
     const headingEditor = (
         <div className={css(styles.containerHeader)}>
             {/* @ts-expect-error [FEI-5003] - TS2322 - Type '{ children: string; depth: number; className: string; }' is not assignable to type 'IntrinsicAttributes & HeaderProps & { children?: ReactNode; }'. */}

--- a/packages/perseus-editor/src/widgets/__stories__/label-image-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/label-image-editor.stories.tsx
@@ -93,6 +93,6 @@ class WithState extends React.Component<Empty, State> {
     }
 }
 
-export const Default: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Default = (args: StoryArgs): React.ReactElement => {
     return <WithState />;
 };

--- a/packages/perseus-editor/src/widgets/__stories__/radio-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/radio-editor.stories.tsx
@@ -110,6 +110,6 @@ class WithState extends React.Component<Empty, PerseusRadioWidgetOptions> {
     }
 }
 
-export const Default: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Default = (args: StoryArgs): React.ReactElement => {
     return <WithState />;
 };

--- a/packages/perseus-editor/src/widgets/label-image-editor.tsx
+++ b/packages/perseus-editor/src/widgets/label-image-editor.tsx
@@ -19,7 +19,7 @@ import SelectImage from "./label-image/select-image";
 
 import type {MarkerType} from "@khanacademy/perseus";
 
-type LabelImageEditorProps = {
+type Props = {
     // List of answer choices to label question image with.
     choices: ReadonlyArray<string>;
     // The question image properties.
@@ -37,7 +37,7 @@ type LabelImageEditorProps = {
     onChange: (options: any) => void;
 };
 
-class LabelImageEditor extends React.Component<LabelImageEditorProps> {
+class LabelImageEditor extends React.Component<Props> {
     _questionMarkers: QuestionMarkers | null | undefined;
 
     static defaultProps: {
@@ -62,7 +62,7 @@ class LabelImageEditor extends React.Component<LabelImageEditorProps> {
 
     static widgetName = "label-image" as const;
 
-    componentDidUpdate(prevProps: LabelImageEditorProps) {
+    componentDidUpdate(prevProps: Props) {
         const coordsToMarkers: Record<string, any> = {};
 
         prevProps.markers.forEach(

--- a/packages/perseus-editor/src/widgets/label-image/__stories__/answer-choices.stories.tsx
+++ b/packages/perseus-editor/src/widgets/label-image/__stories__/answer-choices.stories.tsx
@@ -57,16 +57,12 @@ class WithState extends React.Component<
     }
 }
 
-export const EmptyNonInteractive: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const EmptyNonInteractive = (args: StoryArgs): React.ReactElement => {
     const props = {choices: [], onChange: (...args) => {}} as const;
     return <Wrapper {...props} />;
 };
 
-export const FilledNonInteractive: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const FilledNonInteractive = (args: StoryArgs): React.ReactElement => {
     const props = {
         choices: [
             "Lamborghini",
@@ -81,6 +77,6 @@ export const FilledNonInteractive: React.FC<StoryArgs> = (
     return <Wrapper {...props} />;
 };
 
-export const Interactive: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Interactive = (args: StoryArgs): React.ReactElement => {
     return <WithState />;
 };

--- a/packages/perseus-editor/src/widgets/label-image/__stories__/behavior.stories.tsx
+++ b/packages/perseus-editor/src/widgets/label-image/__stories__/behavior.stories.tsx
@@ -13,7 +13,7 @@ export default {
     title: "Perseus/Editor/Widgets/Label Image/Behavior",
 } as Story;
 
-export const Default: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Default = (args: StoryArgs): React.ReactElement => {
     const [state, setState] = React.useState({
         multipleAnswers: false,
         hideChoicesFromInstructions: false,

--- a/packages/perseus-editor/src/widgets/label-image/__stories__/marker.stories.tsx
+++ b/packages/perseus-editor/src/widgets/label-image/__stories__/marker.stories.tsx
@@ -33,7 +33,7 @@ const Wrapper = (props) => (
     </div>
 );
 
-export const Empty: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Empty = (args: StoryArgs): React.ReactElement => {
     const props = {
         answers: [],
         choices: [],
@@ -50,7 +50,7 @@ export const Empty: React.FC<StoryArgs> = (args): React.ReactElement => {
     return <Wrapper {...props} />;
 };
 
-export const WithAnswers: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const WithAnswers = (args: StoryArgs): React.ReactElement => {
     const props = {
         answers: ["BMW", "Ferrari"],
         choices: [

--- a/packages/perseus-editor/src/widgets/label-image/__stories__/question-markers.stories.tsx
+++ b/packages/perseus-editor/src/widgets/label-image/__stories__/question-markers.stories.tsx
@@ -70,7 +70,7 @@ class WithState extends React.Component<
     }
 }
 
-export const Empty: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Empty = (args: StoryArgs): React.ReactElement => {
     const props = {
         choices: [],
         imageUrl: "",
@@ -82,7 +82,7 @@ export const Empty: React.FC<StoryArgs> = (args): React.ReactElement => {
     return <Wrapper {...props} />;
 };
 
-export const Filled: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Filled = (args: StoryArgs): React.ReactElement => {
     const props = {
         choices: [],
         imageUrl:
@@ -102,6 +102,6 @@ export const Filled: React.FC<StoryArgs> = (args): React.ReactElement => {
     return <Wrapper {...props} />;
 };
 
-export const Interactive: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Interactive = (args: StoryArgs): React.ReactElement => {
     return <WithState />;
 };

--- a/packages/perseus-editor/src/widgets/label-image/__stories__/select-image.stories.tsx
+++ b/packages/perseus-editor/src/widgets/label-image/__stories__/select-image.stories.tsx
@@ -36,7 +36,7 @@ const WithState = () => {
     );
 };
 
-export const Empty: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Empty = (args: StoryArgs): React.ReactElement => {
     const props = {
         url: "",
         onChange: () => {},
@@ -45,7 +45,7 @@ export const Empty: React.FC<StoryArgs> = (args): React.ReactElement => {
     return <Wrapper {...props} />;
 };
 
-export const Filled: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Filled = (args: StoryArgs): React.ReactElement => {
     const props = {
         url: "https://ka-perseus-images.s3.amazonaws.com/2ee5fc32e35c5178373b39fd304b325b2994c913.png",
         onChange: () => {},
@@ -54,6 +54,6 @@ export const Filled: React.FC<StoryArgs> = (args): React.ReactElement => {
     return <Wrapper {...props} />;
 };
 
-export const Interactive: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Interactive = (args: StoryArgs): React.ReactElement => {
     return <WithState />;
 };

--- a/packages/perseus-editor/src/widgets/label-image/answer-choices.tsx
+++ b/packages/perseus-editor/src/widgets/label-image/answer-choices.tsx
@@ -89,7 +89,7 @@ const DraggableGripIcon = () => (
 /**
  * A button link to add a new answer.
  */
-const AddAnswer: React.FC<AddAnswerProps> = ({onClick}): React.ReactElement => (
+const AddAnswer = ({onClick}: AddAnswerProps): React.ReactElement => (
     <Link
         className={css(styles.addAnswer, editorStyles.addAnswer)}
         onClick={onClick}
@@ -105,11 +105,11 @@ const AddAnswer: React.FC<AddAnswerProps> = ({onClick}): React.ReactElement => (
  *
  * TODO(michaelpolyak): Implement answer reordering, CP-117
  */
-const Answer: React.FC<AnswerProps> = ({
+const Answer = ({
     answer,
     onChange,
     onRemove,
-}): React.ReactElement => (
+}: AnswerProps): React.ReactElement => (
     <li className={css(styles.answer)}>
         <Link onClick={onRemove}>
             <Icon icon={removeIcon} size={24} color="#D92916" />
@@ -137,10 +137,10 @@ const Answer: React.FC<AnswerProps> = ({
 /**
  * The list of choices, handles adding, removing and reording of answers.
  */
-const AnswerChoices: React.FC<AnswerChoicesProps> = ({
+const AnswerChoices = ({
     choices,
     onChange,
-}): React.ReactElement => (
+}: AnswerChoicesProps): React.ReactElement => (
     <div>
         <div className={css(styles.title)}>Answer Choices</div>
 

--- a/packages/perseus-editor/src/widgets/label-image/behavior.tsx
+++ b/packages/perseus-editor/src/widgets/label-image/behavior.tsx
@@ -10,7 +10,7 @@ import Checkbox from "../../components/checkbox";
 
 const {colors, typography} = globalStyles;
 
-type BehaviorProps = {
+type Props = {
     // Whether multiple answer choices may be selected for markers.
     multipleAnswers: boolean;
     // Whether to hide answer choices from user instructions.
@@ -22,11 +22,11 @@ type BehaviorProps = {
     }) => void;
 };
 
-const Behavior: React.FC<BehaviorProps> = ({
+const Behavior = ({
     multipleAnswers,
     hideChoicesFromInstructions,
     onChange,
-}): React.ReactElement => (
+}: Props): React.ReactElement => (
     <div>
         <div className={css(styles.title)}>Behavior</div>
 

--- a/packages/perseus-editor/src/widgets/label-image/marker.tsx
+++ b/packages/perseus-editor/src/widgets/label-image/marker.tsx
@@ -17,7 +17,7 @@ import type {MarkerType} from "@khanacademy/perseus";
 
 const {colors, borderRadius} = globalStyles;
 
-type MarkerProps = MarkerType & {
+type Props = MarkerType & {
     // The list of possible answer choices.
     choices: ReadonlyArray<string>;
     // Callback for when any of the marker props are changed.
@@ -26,16 +26,16 @@ type MarkerProps = MarkerType & {
     onRemove: () => void;
 };
 
-type MarkerState = {
+type State = {
     // Whether answer choices dropdown is shown, controlled by the user clicking
     // on the marker icon.
     showDropdown: boolean;
 };
 
-export default class Marker extends React.Component<MarkerProps, MarkerState> {
+export default class Marker extends React.Component<Props, State> {
     _marker: HTMLElement | null | undefined;
 
-    constructor(props: MarkerProps) {
+    constructor(props: Props) {
         super(props);
 
         this.state = {
@@ -47,7 +47,7 @@ export default class Marker extends React.Component<MarkerProps, MarkerState> {
         document.addEventListener("click", this.handleClick, true);
     }
 
-    UNSAFE_componentWillReceiveProps(nextProps: MarkerProps) {
+    UNSAFE_componentWillReceiveProps(nextProps: Props) {
         const {answers} = this.props;
 
         // Exclude those answers that are no longer present in choices.

--- a/packages/perseus-editor/src/widgets/label-image/question-markers.tsx
+++ b/packages/perseus-editor/src/widgets/label-image/question-markers.tsx
@@ -13,7 +13,7 @@ import type {MarkerType} from "@khanacademy/perseus";
 
 const {colors, typography} = globalStyles;
 
-type QuestionMarkersProps = {
+type Props = {
     // The list of possible answers in a specific order.
     choices: ReadonlyArray<string>;
     // The question image properties.
@@ -26,7 +26,7 @@ type QuestionMarkersProps = {
     onChange: (markers: ReadonlyArray<MarkerType>) => void;
 };
 
-export default class QuestionMarkers extends React.Component<QuestionMarkersProps> {
+export default class QuestionMarkers extends React.Component<Props> {
     _markers: Array<Marker | null | undefined> = [];
 
     openDropdownForMarkerIndices(indices: ReadonlyArray<number>) {

--- a/packages/perseus-editor/src/widgets/label-image/select-image.tsx
+++ b/packages/perseus-editor/src/widgets/label-image/select-image.tsx
@@ -11,17 +11,14 @@ import FormWrappedTextField from "../../components/form-wrapped-text-field";
 
 const {colors, typography} = globalStyles;
 
-type SelectImageProps = {
+type Props = {
     // Callback for when image URL is changed.
     onChange: (url: string) => void;
     // The selected image URL.
     url: string;
 };
 
-const SelectImage: React.FC<SelectImageProps> = ({
-    onChange,
-    url,
-}): React.ReactElement => (
+const SelectImage = ({onChange, url}: Props): React.ReactElement => (
     <div>
         <div className={css(styles.title)}>Image</div>
 

--- a/packages/perseus/src/__stories__/item-renderer.stories.tsx
+++ b/packages/perseus/src/__stories__/item-renderer.stories.tsx
@@ -16,14 +16,10 @@ export default {
     title: "Perseus/Renderers/Item Renderer",
 } as Story;
 
-export const InputNumberItem: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const InputNumberItem = (args: StoryArgs): React.ReactElement => {
     return <ItemRendererWithDebugUI item={itemWithInput} />;
 };
 
-export const LabelImageItem: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const LabelImageItem = (args: StoryArgs): React.ReactElement => {
     return <ItemRendererWithDebugUI item={labelImageItem} />;
 };

--- a/packages/perseus/src/__stories__/server-item-renderer.stories.tsx
+++ b/packages/perseus/src/__stories__/server-item-renderer.stories.tsx
@@ -16,14 +16,10 @@ export default {
     title: "Perseus/Renderers/Server Item Renderer",
 } as Story;
 
-export const InputNumberItem: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const InputNumberItem = (args: StoryArgs): React.ReactElement => {
     return <ServerItemRendererWithDebugUI item={itemWithInput} />;
 };
 
-export const LabelImageItem: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const LabelImageItem = (args: StoryArgs): React.ReactElement => {
     return <ServerItemRendererWithDebugUI item={labelImageItem} />;
 };

--- a/packages/perseus/src/components/__stories__/button-group.stories.tsx
+++ b/packages/perseus/src/components/__stories__/button-group.stories.tsx
@@ -30,9 +30,7 @@ const HarnassedButtonGroup = (
     );
 };
 
-export const ButtonsWithNoTitles: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const ButtonsWithNoTitles = (args: StoryArgs): React.ReactElement => {
     return (
         <HarnassedButtonGroup
             buttons={[
@@ -44,9 +42,7 @@ export const ButtonsWithNoTitles: React.FC<StoryArgs> = (
     );
 };
 
-export const ButtonsWithTitles: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const ButtonsWithTitles = (args: StoryArgs): React.ReactElement => {
     return (
         <HarnassedButtonGroup
             buttons={[

--- a/packages/perseus/src/components/__stories__/fixed-to-responsive.stories.tsx
+++ b/packages/perseus/src/components/__stories__/fixed-to-responsive.stories.tsx
@@ -21,8 +21,8 @@ export default {
     title: "Perseus/Components/Fixed to Responsive",
 } as Story;
 
-export const SmallImageWithSmallContainer: React.FC<StoryArgs> = (
-    args,
+export const SmallImageWithSmallContainer = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return (
         <FixedToResponsive width={width} height={sizeSmall}>
@@ -36,8 +36,8 @@ export const SmallImageWithSmallContainer: React.FC<StoryArgs> = (
     );
 };
 
-export const SmallImageWithMediumContainer: React.FC<StoryArgs> = (
-    args,
+export const SmallImageWithMediumContainer = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return (
         <FixedToResponsive width={width} height={sizeMedium}>
@@ -51,8 +51,8 @@ export const SmallImageWithMediumContainer: React.FC<StoryArgs> = (
     );
 };
 
-export const LargeImageWithLargeContainer: React.FC<StoryArgs> = (
-    args,
+export const LargeImageWithLargeContainer = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return (
         <FixedToResponsive width={width} height={sizeLarge}>
@@ -66,8 +66,8 @@ export const LargeImageWithLargeContainer: React.FC<StoryArgs> = (
     );
 };
 
-export const LargeImageWithSmallerContainer: React.FC<StoryArgs> = (
-    args,
+export const LargeImageWithSmallerContainer = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return (
         <FixedToResponsive width={width} height={sizeSmall}>
@@ -81,9 +81,9 @@ export const LargeImageWithSmallerContainer: React.FC<StoryArgs> = (
     );
 };
 
-export const TwoOverlayedImagesInsteadOneResponsiveContainer: React.FC<
-    StoryArgs
-> = (args): React.ReactElement => {
+export const TwoOverlayedImagesInsteadOneResponsiveContainer = (
+    args: StoryArgs,
+): React.ReactElement => {
     return (
         <FixedToResponsive width={width} height={sizeSmall}>
             <img
@@ -104,8 +104,8 @@ export const TwoOverlayedImagesInsteadOneResponsiveContainer: React.FC<
     );
 };
 
-export const HeightConstrainingAnImage: React.FC<StoryArgs> = (
-    args,
+export const HeightConstrainingAnImage = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return (
         <FixedToResponsive
@@ -123,9 +123,7 @@ export const HeightConstrainingAnImage: React.FC<StoryArgs> = (
     );
 };
 
-export const AllowingFullBleed: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const AllowingFullBleed = (args: StoryArgs): React.ReactElement => {
     return (
         <FixedToResponsive
             width={width}

--- a/packages/perseus/src/components/__stories__/graph.stories.tsx
+++ b/packages/perseus/src/components/__stories__/graph.stories.tsx
@@ -15,15 +15,13 @@ export default {
     title: "Perseus/Components/Graph",
 } as Story;
 
-export const SquareBoxSizeAndOtherwiseEmpty: React.FC<StoryArgs> = (
-    args,
+export const SquareBoxSizeAndOtherwiseEmpty = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return <Graph box={[size, size]} />;
 };
 
-export const LabeledSquaredBox: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const LabeledSquaredBox = (args: StoryArgs): React.ReactElement => {
     return (
         <Graph box={[size, size]} labels={["First label", "Second label"]} />
     );

--- a/packages/perseus/src/components/__stories__/graphie.stories.tsx
+++ b/packages/perseus/src/components/__stories__/graphie.stories.tsx
@@ -16,8 +16,8 @@ export default {
     title: "Perseus/Components/Graphie",
 } as Story;
 
-export const SquareBoxSizeAndOtherwiseEmpty: React.FC<StoryArgs> = (
-    args,
+export const SquareBoxSizeAndOtherwiseEmpty = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return (
         <Graphie
@@ -28,8 +28,6 @@ export const SquareBoxSizeAndOtherwiseEmpty: React.FC<StoryArgs> = (
     );
 };
 
-export const PieChartGraphieLabels: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const PieChartGraphieLabels = (args: StoryArgs): React.ReactElement => {
     return <ItemRendererWithDebugUI item={itemWithPieChart} />;
 };

--- a/packages/perseus/src/components/__stories__/hud.stories.tsx
+++ b/packages/perseus/src/components/__stories__/hud.stories.tsx
@@ -12,9 +12,7 @@ export default {
     title: "Perseus/Components/HUD",
 } as Story;
 
-export const TestMessageDisabled: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const TestMessageDisabled = (args: StoryArgs): React.ReactElement => {
     return (
         <Hud
             fixedPosition={false}
@@ -25,9 +23,7 @@ export const TestMessageDisabled: React.FC<StoryArgs> = (
     );
 };
 
-export const TestMessageEnabled: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const TestMessageEnabled = (args: StoryArgs): React.ReactElement => {
     return (
         <Hud
             fixedPosition={false}

--- a/packages/perseus/src/components/__stories__/icon.stories.tsx
+++ b/packages/perseus/src/components/__stories__/icon.stories.tsx
@@ -54,7 +54,7 @@ export default {
     },
 } as Story;
 
-export const Icon: React.FC<StoryArgs> = (args): React.ReactElement => (
+export const Icon = (args: StoryArgs): React.ReactElement => (
     <IconComponent
         style={{display: "block"}}
         icon={IconPaths.iconCheck}

--- a/packages/perseus/src/components/__stories__/image-loader.stories.tsx
+++ b/packages/perseus/src/components/__stories__/image-loader.stories.tsx
@@ -15,7 +15,7 @@ export default {
     title: "Perseus/Components/Image Loader",
 } as Story;
 
-export const SvgImage: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const SvgImage = (args: StoryArgs): React.ReactElement => {
     return (
         <ImageLoader
             src={svgUrl}
@@ -29,7 +29,7 @@ export const SvgImage: React.FC<StoryArgs> = (args): React.ReactElement => {
     );
 };
 
-export const PngImage: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const PngImage = (args: StoryArgs): React.ReactElement => {
     return (
         <ImageLoader
             src={imgUrl}
@@ -43,8 +43,8 @@ export const PngImage: React.FC<StoryArgs> = (args): React.ReactElement => {
     );
 };
 
-export const InvalidImageWithChildrenForFailedLoading: React.FC<StoryArgs> = (
-    args,
+export const InvalidImageWithChildrenForFailedLoading = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return (
         <ImageLoader

--- a/packages/perseus/src/components/__stories__/info-tip.stories.tsx
+++ b/packages/perseus/src/components/__stories__/info-tip.stories.tsx
@@ -14,9 +14,7 @@ export default {
 
 const svgUrl = "http://www.khanacademy.org/images/ohnoes-concerned.svg";
 
-export const TextOnMouseover: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const TextOnMouseover = (args: StoryArgs): React.ReactElement => {
     return (
         <InfoTip>
             <span>Sample text</span>
@@ -24,9 +22,7 @@ export const TextOnMouseover: React.FC<StoryArgs> = (
     );
 };
 
-export const ImageOnMouseover: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const ImageOnMouseover = (args: StoryArgs): React.ReactElement => {
     return (
         <InfoTip>
             <img alt="" src={svgUrl} />

--- a/packages/perseus/src/components/__stories__/inline-icon.stories.tsx
+++ b/packages/perseus/src/components/__stories__/inline-icon.stories.tsx
@@ -18,14 +18,12 @@ export default {
     title: "Perseus/Components/Inline Icon",
 } as Story;
 
-export const BasicIconPathAndSizing: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const BasicIconPathAndSizing = (args: StoryArgs): React.ReactElement => {
     return <InlineIcon {...defaultPath} />;
 };
 
-export const BasicIconWithAdditionalStyling: React.FC<StoryArgs> = (
-    args,
+export const BasicIconWithAdditionalStyling = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return (
         <InlineIcon
@@ -37,8 +35,6 @@ export const BasicIconWithAdditionalStyling: React.FC<StoryArgs> = (
     );
 };
 
-export const BasicIconWithAriaTitle: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const BasicIconWithAriaTitle = (args: StoryArgs): React.ReactElement => {
     return <InlineIcon {...defaultPath} title="Sample ARIA title" />;
 };

--- a/packages/perseus/src/components/__stories__/input-with-examples.stories.tsx
+++ b/packages/perseus/src/components/__stories__/input-with-examples.stories.tsx
@@ -20,20 +20,18 @@ const defaultObject = {
 } as const;
 const testExamples = ["Sample 1", "Sample 2", "Sample 3"];
 
-export const DefaultAndMostlyEmptyProps: React.FC<StoryArgs> = (
-    args,
+export const DefaultAndMostlyEmptyProps = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return <InputWithExamples {...defaultObject} />;
 };
 
-export const ListOfExamples: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const ListOfExamples = (args: StoryArgs): React.ReactElement => {
     return <InputWithExamples {...defaultObject} examples={testExamples} />;
 };
 
-export const AriaLabelTextWithListOfExamples: React.FC<StoryArgs> = (
-    args,
+export const AriaLabelTextWithListOfExamples = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return (
         <InputWithExamples
@@ -44,9 +42,7 @@ export const AriaLabelTextWithListOfExamples: React.FC<StoryArgs> = (
     );
 };
 
-export const DisabledInput: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const DisabledInput = (args: StoryArgs): React.ReactElement => {
     return (
         <InputWithExamples
             {...defaultObject}

--- a/packages/perseus/src/components/__stories__/lint.stories.tsx
+++ b/packages/perseus/src/components/__stories__/lint.stories.tsx
@@ -19,33 +19,33 @@ const defaultObject = {
     ruleName: "Test rule",
 } as const;
 
-export const DefaultLintContainerAndMessage: React.FC<StoryArgs> = (
-    args,
+export const DefaultLintContainerAndMessage = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return <Lint {...defaultObject} />;
 };
-export const Severity1DefaultLintAndMessage: React.FC<StoryArgs> = (
-    args,
+export const Severity1DefaultLintAndMessage = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return <Lint {...defaultObject} severity={1} />;
 };
-export const Severity2DefaultLintAndMessage: React.FC<StoryArgs> = (
-    args,
+export const Severity2DefaultLintAndMessage = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return <Lint {...defaultObject} severity={2} />;
 };
-export const Severity3DefaultLintAndMessage: React.FC<StoryArgs> = (
-    args,
+export const Severity3DefaultLintAndMessage = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return <Lint {...defaultObject} severity={3} />;
 };
-export const Severity4DefaultLintAndMessage: React.FC<StoryArgs> = (
-    args,
+export const Severity4DefaultLintAndMessage = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return <Lint {...defaultObject} severity={4} />;
 };
-export const InlineLintContainerAndMessage: React.FC<StoryArgs> = (
-    args,
+export const InlineLintContainerAndMessage = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return <Lint {...defaultObject} inline={true} />;
 };

--- a/packages/perseus/src/components/__stories__/math-input.stories.tsx
+++ b/packages/perseus/src/components/__stories__/math-input.stories.tsx
@@ -17,18 +17,14 @@ const defaultObject = {
     onChange: () => {},
 } as const;
 
-export const DefaultWithBasicButtonSet: React.FC<StoryArgs> = (
-    args,
+export const DefaultWithBasicButtonSet = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return <MathInput {...defaultObject} />;
 };
-export const AlwaysVisibleButtonSet: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const AlwaysVisibleButtonSet = (args: StoryArgs): React.ReactElement => {
     return <MathInput {...defaultObject} buttonsVisible="always" />;
 };
-export const DefaultWithAriaLabel: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const DefaultWithAriaLabel = (args: StoryArgs): React.ReactElement => {
     return <MathInput {...defaultObject} labelText="Sample label" />;
 };

--- a/packages/perseus/src/components/__stories__/math-output.stories.tsx
+++ b/packages/perseus/src/components/__stories__/math-output.stories.tsx
@@ -12,14 +12,12 @@ export default {
     title: "Perseus/Components/Math Ouput",
 } as Story;
 
-export const EmptyPropsObject: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const EmptyPropsObject = (args: StoryArgs): React.ReactElement => {
     return <MathOutput />;
 };
-export const StringValue: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const StringValue = (args: StoryArgs): React.ReactElement => {
     return <MathOutput value="Test string value" />;
 };
-export const NumericValue: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const NumericValue = (args: StoryArgs): React.ReactElement => {
     return <MathOutput value={1234567890} />;
 };

--- a/packages/perseus/src/components/__stories__/multi-button-group.stories.tsx
+++ b/packages/perseus/src/components/__stories__/multi-button-group.stories.tsx
@@ -39,9 +39,7 @@ const HarnassedButtonGroup = (
     );
 };
 
-export const ButtonsWithNoTitles: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const ButtonsWithNoTitles = (args: StoryArgs): React.ReactElement => {
     return (
         <HarnassedButtonGroup
             {...args}
@@ -54,9 +52,7 @@ export const ButtonsWithNoTitles: React.FC<StoryArgs> = (
     );
 };
 
-export const ButtonsWithTitles: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const ButtonsWithTitles = (args: StoryArgs): React.ReactElement => {
     return (
         <HarnassedButtonGroup
             {...args}

--- a/packages/perseus/src/components/__stories__/number-input.stories.tsx
+++ b/packages/perseus/src/components/__stories__/number-input.stories.tsx
@@ -16,28 +16,26 @@ export default {
     title: "Perseus/Components/Number Input",
 } as Story;
 
-export const EmptyPropsObject: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const EmptyPropsObject = (args: StoryArgs): React.ReactElement => {
     return <NumberInput {...defaultObject} />;
 };
 
-export const SampleValue: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const SampleValue = (args: StoryArgs): React.ReactElement => {
     return <NumberInput {...defaultObject} value={1234567890} />;
 };
 
-export const Placeholder: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Placeholder = (args: StoryArgs): React.ReactElement => {
     return <NumberInput {...defaultObject} placeholder="Sample placeholder" />;
 };
 
-export const SizeMini: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const SizeMini = (args: StoryArgs): React.ReactElement => {
     return <NumberInput {...defaultObject} placeholder="Sample placeholder" />;
 };
 
-export const SizeSmall: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const SizeSmall = (args: StoryArgs): React.ReactElement => {
     return <NumberInput {...defaultObject} size="small" />;
 };
 
-export const SizeNormal: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const SizeNormal = (args: StoryArgs): React.ReactElement => {
     return <NumberInput {...defaultObject} size="normal" />;
 };

--- a/packages/perseus/src/components/__stories__/prop-check-box.stories.tsx
+++ b/packages/perseus/src/components/__stories__/prop-check-box.stories.tsx
@@ -12,8 +12,8 @@ export default {
     title: "Perseus/Components/Prop Check Box",
 } as Story;
 
-export const TestLabelWithCheckedObject: React.FC<StoryArgs> = (
-    args,
+export const TestLabelWithCheckedObject = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return (
         <PropCheckBox
@@ -25,8 +25,8 @@ export const TestLabelWithCheckedObject: React.FC<StoryArgs> = (
     );
 };
 
-export const TestLabelWithUncheckedObject: React.FC<StoryArgs> = (
-    args,
+export const TestLabelWithUncheckedObject = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return (
         <PropCheckBox
@@ -38,8 +38,8 @@ export const TestLabelWithUncheckedObject: React.FC<StoryArgs> = (
     );
 };
 
-export const TestLabelWithCheckedObjectLabelOnTheRight: React.FC<StoryArgs> = (
-    args,
+export const TestLabelWithCheckedObjectLabelOnTheRight = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return (
         <PropCheckBox
@@ -51,9 +51,9 @@ export const TestLabelWithCheckedObjectLabelOnTheRight: React.FC<StoryArgs> = (
     );
 };
 
-export const TestLabelWithUncheckedObjectLabelOnTheRight: React.FC<
-    StoryArgs
-> = (args): React.ReactElement => {
+export const TestLabelWithUncheckedObjectLabelOnTheRight = (
+    args: StoryArgs,
+): React.ReactElement => {
     return (
         <PropCheckBox
             test={false}

--- a/packages/perseus/src/components/__stories__/range-input.stories.tsx
+++ b/packages/perseus/src/components/__stories__/range-input.stories.tsx
@@ -12,19 +12,17 @@ export default {
     title: "Perseus/Components/Range Input",
 } as Story;
 
-export const EmptyValueArray: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const EmptyValueArray = (args: StoryArgs): React.ReactElement => {
     return <RangeInput onChange={() => {}} value={[]} />;
 };
 
-export const SimpleWithSmallValueRanges: React.FC<StoryArgs> = (
-    args,
+export const SimpleWithSmallValueRanges = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return <RangeInput onChange={() => {}} value={[-10, 10]} />;
 };
 
-export const Placeholders: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Placeholders = (args: StoryArgs): React.ReactElement => {
     return (
         <RangeInput onChange={() => {}} placeholder={["?", "!"]} value={[]} />
     );

--- a/packages/perseus/src/components/__stories__/simple-keypad-input.stories.tsx
+++ b/packages/perseus/src/components/__stories__/simple-keypad-input.stories.tsx
@@ -18,12 +18,10 @@ export default {
     title: "Perseus/Components/Simple Keypad Input",
 } as Story;
 
-export const EmptyPropsObject: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const EmptyPropsObject = (args: StoryArgs): React.ReactElement => {
     return <SimpleKeypadInput {...defaultObject} />;
 };
 
-export const CustomValue: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const CustomValue = (args: StoryArgs): React.ReactElement => {
     return <SimpleKeypadInput {...defaultObject} value="Test value" />;
 };

--- a/packages/perseus/src/components/__stories__/sortable.stories.tsx
+++ b/packages/perseus/src/components/__stories__/sortable.stories.tsx
@@ -14,8 +14,8 @@ export default {
     title: "Perseus/Components/Sortable",
 } as Story;
 
-export const SortableHorizontalExample: React.FC<StoryArgs> = (
-    args,
+export const SortableHorizontalExample = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return (
         <Sortable
@@ -26,8 +26,8 @@ export const SortableHorizontalExample: React.FC<StoryArgs> = (
     );
 };
 
-export const SortableVerticalExample: React.FC<StoryArgs> = (
-    args,
+export const SortableVerticalExample = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return (
         <Sortable
@@ -38,33 +38,33 @@ export const SortableVerticalExample: React.FC<StoryArgs> = (
     );
 };
 
-export const BasicSortableOptionsTest: React.FC<StoryArgs> = (
-    args,
+export const BasicSortableOptionsTest = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return <Sortable options={defaultOptions} />;
 };
 
-export const BasicSortableOptionsTestWithNoPadding: React.FC<StoryArgs> = (
-    args,
+export const BasicSortableOptionsTestWithNoPadding = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return <Sortable options={defaultOptions} padding={false} />;
 };
 
-export const BasicSortableOptionsTestWithLargeMargin: React.FC<StoryArgs> = (
-    args,
+export const BasicSortableOptionsTestWithLargeMargin = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return <Sortable options={defaultOptions} margin={64} />;
 };
 
-export const BasicSortableOptionsTestDisabled: React.FC<StoryArgs> = (
-    args,
+export const BasicSortableOptionsTestDisabled = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return <Sortable options={defaultOptions} disabled={true} />;
 };
 
-export const BasicSortableOptionsTestWithWidthAndHeightConstraints: React.FC<
-    StoryArgs
-> = (args): React.ReactElement => {
+export const BasicSortableOptionsTestWithWidthAndHeightConstraints = (
+    args: StoryArgs,
+): React.ReactElement => {
     return (
         <Sortable
             options={defaultOptions}

--- a/packages/perseus/src/components/__stories__/stub-tag-editor.stories.tsx
+++ b/packages/perseus/src/components/__stories__/stub-tag-editor.stories.tsx
@@ -14,19 +14,15 @@ export default {
 
 const defaultValues = ["Test value 1", "Test value 2", "Test value 3"];
 
-export const ShowingTitle: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const ShowingTitle = (args: StoryArgs): React.ReactElement => {
     return <StubTagEditor onChange={() => {}} showTitle={true} />;
 };
 
-export const NotShowingTitle: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const NotShowingTitle = (args: StoryArgs): React.ReactElement => {
     return <StubTagEditor onChange={() => {}} showTitle={false} />;
 };
 
-export const ShowingTitleWithValue: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const ShowingTitleWithValue = (args: StoryArgs): React.ReactElement => {
     return (
         <StubTagEditor
             onChange={() => {}}
@@ -36,8 +32,8 @@ export const ShowingTitleWithValue: React.FC<StoryArgs> = (
     );
 };
 
-export const NotShowingTitleWithValue: React.FC<StoryArgs> = (
-    args,
+export const NotShowingTitleWithValue = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return (
         <StubTagEditor

--- a/packages/perseus/src/components/__stories__/svg-image.stories.tsx
+++ b/packages/perseus/src/components/__stories__/svg-image.stories.tsx
@@ -17,15 +17,11 @@ const imgUrl = "https://www.khanacademy.org/images/hand-tree.new.png";
 const graphieUrl =
     "web+graphie://ka-perseus-graphie.s3.amazonaws.com/1e06f6d4071f30cee2cc3ccb7435b3a66a62fe3f";
 
-export const MostlyEmptyPropsObject: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const MostlyEmptyPropsObject = (args: StoryArgs): React.ReactElement => {
     return <SvgImage alt="ALT" />;
 };
 
-export const SvgImageThatDoesntLoad: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const SvgImageThatDoesntLoad = (args: StoryArgs): React.ReactElement => {
     return (
         <SvgImage
             alt="ALT"
@@ -36,26 +32,22 @@ export const SvgImageThatDoesntLoad: React.FC<StoryArgs> = (
     );
 };
 
-export const SvgImageBasic: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const SvgImageBasic = (args: StoryArgs): React.ReactElement => {
     return <SvgImage src={svgUrl} alt="ALT" />;
 };
 
-export const SvgImageWithFixedHeight: React.FC<StoryArgs> = (
-    args,
+export const SvgImageWithFixedHeight = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return <SvgImage height={50} src={svgUrl} alt="ALT" />;
 };
 
-export const SvgImageWithFixedWidth: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const SvgImageWithFixedWidth = (args: StoryArgs): React.ReactElement => {
     return <SvgImage src={svgUrl} width={50} alt="ALT" />;
 };
 
-export const SvgImageWithExtraGraphieProps: React.FC<StoryArgs> = (
-    args,
+export const SvgImageWithExtraGraphieProps = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return (
         <SvgImage
@@ -73,10 +65,10 @@ export const SvgImageWithExtraGraphieProps: React.FC<StoryArgs> = (
     );
 };
 
-export const PngImage: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const PngImage = (args: StoryArgs): React.ReactElement => {
     return <SvgImage src={imgUrl} alt="ALT" />;
 };
 
-export const GraphieImage: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const GraphieImage = (args: StoryArgs): React.ReactElement => {
     return <SvgImage src={graphieUrl} alt="ALT" />;
 };

--- a/packages/perseus/src/components/__stories__/tex.stories.tsx
+++ b/packages/perseus/src/components/__stories__/tex.stories.tsx
@@ -18,8 +18,6 @@ export default {
     },
 } as Story;
 
-export const BasicOperation: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const BasicOperation = (args: StoryArgs): React.ReactElement => {
     return <TeX setAssetStatus={() => {}} children={args.equation} />;
 };

--- a/packages/perseus/src/components/__stories__/text-buttons.stories.tsx
+++ b/packages/perseus/src/components/__stories__/text-buttons.stories.tsx
@@ -12,51 +12,39 @@ export default {
     title: "Perseus/Components/Tex Buttons",
 } as Story;
 
-export const ButtonSetBasic: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const ButtonSetBasic = (args: StoryArgs): React.ReactElement => {
     return <TexButtons sets={["basic"]} onInsert={() => {}} />;
 };
 
-export const ButtonSetBasicDiv: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const ButtonSetBasicDiv = (args: StoryArgs): React.ReactElement => {
     return <TexButtons sets={["basic+div"]} onInsert={() => {}} />;
 };
 
-export const ButtonSetTrig: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const ButtonSetTrig = (args: StoryArgs): React.ReactElement => {
     return <TexButtons sets={["trig"]} onInsert={() => {}} />;
 };
 
-export const ButtonSetPrealgebra: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const ButtonSetPrealgebra = (args: StoryArgs): React.ReactElement => {
     return <TexButtons sets={["prealgebra"]} onInsert={() => {}} />;
 };
 
-export const ButtonSetLogarithms: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const ButtonSetLogarithms = (args: StoryArgs): React.ReactElement => {
     return <TexButtons sets={["logarithms"]} onInsert={() => {}} />;
 };
 
-export const ButtonSetBasicRelations: React.FC<StoryArgs> = (
-    args,
+export const ButtonSetBasicRelations = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return <TexButtons sets={["basic relations"]} onInsert={() => {}} />;
 };
 
-export const ButtonSetAdvancedRelations: React.FC<StoryArgs> = (
-    args,
+export const ButtonSetAdvancedRelations = (
+    args: StoryArgs,
 ): React.ReactElement => {
     return <TexButtons sets={["advanced relations"]} onInsert={() => {}} />;
 };
 
-export const ButtonSetMultiple: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const ButtonSetMultiple = (args: StoryArgs): React.ReactElement => {
     return (
         <TexButtons
             sets={["basic", "trig", "advanced relations"]}

--- a/packages/perseus/src/components/__stories__/text-input.stories.tsx
+++ b/packages/perseus/src/components/__stories__/text-input.stories.tsx
@@ -16,24 +16,18 @@ const defaultObject = {
     onChange: () => {},
 } as const;
 
-export const EmptyPropsObject: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const EmptyPropsObject = (args: StoryArgs): React.ReactElement => {
     return <TextInput {...defaultObject} />;
 };
 
-export const TestValueProvided: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const TestValueProvided = (args: StoryArgs): React.ReactElement => {
     return <TextInput {...defaultObject} value="Test value" />;
 };
 
-export const AriaLabelTextProvided: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const AriaLabelTextProvided = (args: StoryArgs): React.ReactElement => {
     return <TextInput {...defaultObject} labelText="Test label" />;
 };
 
-export const Disabled: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Disabled = (args: StoryArgs): React.ReactElement => {
     return <TextInput {...defaultObject} disabled={true} />;
 };

--- a/packages/perseus/src/components/__stories__/text-list-editor.stories.tsx
+++ b/packages/perseus/src/components/__stories__/text-list-editor.stories.tsx
@@ -22,9 +22,7 @@ const defaultObject = {
 
 const ClassName = "framework-perseus orderer";
 
-export const SimpleListOfOptions: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const SimpleListOfOptions = (args: StoryArgs): React.ReactElement => {
     return (
         // @ts-expect-error [FEI-5003] - TS2322 - Type '{ children: Element; class: string; }' is not assignable to type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>'.
         <div class={ClassName}>

--- a/packages/perseus/src/components/__stories__/zoomable-tex.stories.tsx
+++ b/packages/perseus/src/components/__stories__/zoomable-tex.stories.tsx
@@ -12,16 +12,18 @@ export default {
     title: "Perseus/Components/Zoomable Tex",
 } as Story;
 
-const ForceZoomWrapper: React.FC<{
+type Props = {
     children: React.ReactNode;
-}> = ({children}): React.ReactElement => (
+};
+
+const ForceZoomWrapper = ({children}: Props): React.ReactElement => (
     <>
         <h1>Click on equation to zoom/unzoom</h1>
         <div style={{width: "50px"}}>{children}</div>
     </>
 );
 
-export const KaTeX: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const KaTeX = (args: StoryArgs): React.ReactElement => {
     return (
         <ForceZoomWrapper>
             <ZoomableTex children="\sum_{i=1}^\infty\frac{1}{n^2} =\frac{\pi^2}{6}" />
@@ -29,7 +31,7 @@ export const KaTeX: React.FC<StoryArgs> = (args): React.ReactElement => {
     );
 };
 
-export const ComplexKaTeX: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const ComplexKaTeX = (args: StoryArgs): React.ReactElement => {
     return (
         <ForceZoomWrapper>
             {" "}

--- a/packages/perseus/src/components/__stories__/zoomable.stories.tsx
+++ b/packages/perseus/src/components/__stories__/zoomable.stories.tsx
@@ -27,9 +27,7 @@ const computeChildBounds = (
     };
 };
 
-export const ZoomableExample: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const ZoomableExample = (args: StoryArgs): React.ReactElement => {
     return (
         <Zoomable computeChildBounds={computeChildBounds}>
             <span>

--- a/packages/perseus/src/components/highlighting/highlightable-content.tsx
+++ b/packages/perseus/src/components/highlighting/highlightable-content.tsx
@@ -31,7 +31,7 @@ import type {
     DOMRange,
 } from "./types";
 
-type HighlightableContentProps = {
+type Props = {
     // The highlightable content itself. Highlights will be defined relative to
     // the content specified here.
     children?: React.ReactElement<any>;
@@ -57,21 +57,18 @@ type HighlightableContentProps = {
     serializedHighlights: SerializedHighlightSet;
 };
 
-type HighlightableContentState = {
+type State = {
     // A cached list of DOMRanges, each representing one of the content's
     // semantic words. Sorted in document order.
     wordRanges: ReadonlyArray<DOMRange>;
 };
 
-class HighlightableContent extends React.PureComponent<
-    HighlightableContentProps,
-    HighlightableContentState
-> {
+class HighlightableContent extends React.PureComponent<Props, State> {
     // References to the mounted container and content divs.
     _container: HTMLElement | null | undefined;
     _content: HTMLElement | null | undefined;
 
-    state: HighlightableContentState = {
+    state: State = {
         wordRanges: [],
     };
 

--- a/packages/perseus/src/components/highlighting/ui/highlight-renderer.tsx
+++ b/packages/perseus/src/components/highlighting/ui/highlight-renderer.tsx
@@ -21,7 +21,7 @@ import {
 
 import type {DOMHighlight, Position, Rect, ZIndexes} from "./types";
 
-type HighlightRendererProps = {
+type Props = {
     // The DOMHighlight to render.
     highlight: DOMHighlight;
     // A unique key corresponding to the given `highlight`.
@@ -36,7 +36,7 @@ type HighlightRendererProps = {
     zIndexes: ZIndexes;
 };
 
-type HighlightRendererState = {
+type State = {
     // The set of rectangles that cover this highlight's content, relative to
     // the offset parent. This cache is updated on mount and on changes to
     // the `highlight` and `offsetParent` props.
@@ -50,17 +50,14 @@ type HighlightRendererState = {
     cachedHighlightRects: ReadonlyArray<Rect>;
 };
 
-class HighlightRenderer extends React.PureComponent<
-    HighlightRendererProps,
-    HighlightRendererState
-> {
-    state: HighlightRendererState = {
+class HighlightRenderer extends React.PureComponent<Props, State> {
+    state: State = {
         cachedHighlightRects: this._computeRects(this.props),
         // @ts-expect-error [FEI-5003] - TS2322 - Type '{ cachedHighlightRects: readonly Rect[]; tooltipIsHovered: boolean; }' is not assignable to type 'HighlightRendererState'.
         tooltipIsHovered: false,
     };
 
-    UNSAFE_componentWillReceiveProps(nextProps: HighlightRendererProps) {
+    UNSAFE_componentWillReceiveProps(nextProps: Props) {
         if (
             this.props.highlight !== nextProps.highlight ||
             this.props.offsetParent !== nextProps.offsetParent
@@ -76,7 +73,7 @@ class HighlightRenderer extends React.PureComponent<
      * coordinates relative to the offset parent. That way, we can use them
      * for CSS positioning.
      */
-    _computeRects(props: HighlightRendererProps): ReadonlyArray<Rect> {
+    _computeRects(props: Props): ReadonlyArray<Rect> {
         const {highlight, offsetParent} = props;
 
         // Get the set of rectangles that covers the range's text, relative to

--- a/packages/perseus/src/components/highlighting/ui/highlight-set-renderer.tsx
+++ b/packages/perseus/src/components/highlighting/ui/highlight-set-renderer.tsx
@@ -15,7 +15,7 @@ import HighlightTooltip from "./highlight-tooltip";
 
 import type {DOMHighlightSet, Position, ZIndexes} from "./types";
 
-type HighlightSetRendererProps = {
+type Props = {
     // Whether the highlights are user-editable. If false, highlights are
     // read-only.
     editable: boolean;
@@ -33,7 +33,7 @@ type HighlightSetRendererProps = {
     // highlights below content.
     zIndexes: ZIndexes;
 };
-type HighlightSetRendererState = {
+type State = {
     // If the user is currently hovering over a highlight, this field contains
     // its key.
     hoveredHighlightKey: string | null | undefined;
@@ -42,11 +42,8 @@ type HighlightSetRendererState = {
     hoveringTooltipFor: string | null | undefined;
 };
 
-class HighlightSetRenderer extends React.PureComponent<
-    HighlightSetRendererProps,
-    HighlightSetRendererState
-> {
-    state: HighlightSetRendererState = {
+class HighlightSetRenderer extends React.PureComponent<Props, State> {
+    state: State = {
         hoveredHighlightKey: null,
         hoveringTooltipFor: null,
     };
@@ -60,7 +57,7 @@ class HighlightSetRenderer extends React.PureComponent<
         this._updateEditListeners(false, this.props.editable);
     }
 
-    UNSAFE_componentWillReceiveProps(nextProps: HighlightSetRendererProps) {
+    UNSAFE_componentWillReceiveProps(nextProps: Props) {
         this._updateEditListeners(this.props.editable, nextProps.editable);
 
         // If we were previously hovering over a highlight that has been

--- a/packages/perseus/src/components/highlighting/ui/highlight-tooltip.tsx
+++ b/packages/perseus/src/components/highlighting/ui/highlight-tooltip.tsx
@@ -23,7 +23,7 @@ import {getRelativeRect} from "./util";
 
 import type {Rect} from "./types";
 
-type HighlightTooltipProps = {
+type Props = {
     label: string;
     onClick: () => unknown;
     onMouseEnter?: () => unknown;
@@ -33,7 +33,7 @@ type HighlightTooltipProps = {
     offsetParent: Element;
 };
 
-class HighlightTooltip extends React.PureComponent<HighlightTooltipProps> {
+class HighlightTooltip extends React.PureComponent<Props> {
     _getFocusRect(): Rect | null | undefined {
         const {focusNode, focusOffset, offsetParent} = this.props;
 

--- a/packages/perseus/src/components/highlighting/ui/highlighting-ui.tsx
+++ b/packages/perseus/src/components/highlighting/ui/highlighting-ui.tsx
@@ -21,7 +21,7 @@ import SelectionTracker from "./selection-tracker";
 import type {TrackedSelection} from "./selection-tracker";
 import type {DOMHighlight, DOMHighlightSet, DOMRange, ZIndexes} from "./types";
 
-type HighlightingUIProps = {
+type Props = {
     // A function that builds a DOMHighlight from the given DOMRange, if
     // possible. If it would not currently be valid to add a highlight over the
     // given DOMRange, returns null.
@@ -49,7 +49,7 @@ type HighlightingUIProps = {
     zIndexes: ZIndexes;
 };
 
-class HighlightingUI extends React.PureComponent<HighlightingUIProps> {
+class HighlightingUI extends React.PureComponent<Props> {
     _handleAddHighlight(highlightToAdd: DOMHighlight) {
         this.props.onAddHighlight(highlightToAdd);
 

--- a/packages/perseus/src/components/highlighting/ui/selection-tracker.tsx
+++ b/packages/perseus/src/components/highlighting/ui/selection-tracker.tsx
@@ -22,7 +22,7 @@ export type TrackedSelection = {
     proposedHighlight: DOMHighlight;
 };
 
-type SelectionTrackerProps = {
+type Props = {
     // A function that builds a DOMHighlight from the given DOMRange, if
     // possible. If it would not currently be valid to add a highlight over the
     // given DOMRange, returns null.
@@ -38,7 +38,7 @@ type SelectionTrackerProps = {
     enabled: boolean;
 };
 
-type SelectionTrackerState = {
+type State = {
     // The current state of the mouse button. We distinguish between down,
     // down and the selection has changed since going down, and up.
     mouseState: "down" | "down-and-selecting" | "up";
@@ -46,11 +46,8 @@ type SelectionTrackerState = {
     trackedSelection: TrackedSelection | null | undefined;
 };
 
-class SelectionTracker extends React.PureComponent<
-    SelectionTrackerProps,
-    SelectionTrackerState
-> {
-    state: SelectionTrackerState = {
+class SelectionTracker extends React.PureComponent<Props, State> {
+    state: State = {
         mouseState: "up",
         trackedSelection: null,
     };
@@ -59,7 +56,7 @@ class SelectionTracker extends React.PureComponent<
         this._updateListeners(false, this.props.enabled);
     }
 
-    componentDidUpdate(prevProps: SelectionTrackerProps) {
+    componentDidUpdate(prevProps: Props) {
         if (this.props.buildHighlight !== prevProps.buildHighlight) {
             // The highlight-building function changed, so the
             // proposedHighlight we built with it might be different, or no

--- a/packages/perseus/src/components/highlighting/word-indexer.tsx
+++ b/packages/perseus/src/components/highlighting/word-indexer.tsx
@@ -18,7 +18,7 @@ import {PerseusError} from "../../perseus-error";
 
 import type {DOMRange} from "./types";
 
-type WordIndexerProps = {
+type Props = {
     // The content to display and traverse in search of words.
     children?: React.ReactElement<any>;
     // After each mount and update, this callback is called with the list of
@@ -26,7 +26,7 @@ type WordIndexerProps = {
     onWordsUpdate: (wordRanges: ReadonlyArray<DOMRange>) => unknown;
 };
 
-class WordIndexer extends React.PureComponent<WordIndexerProps> {
+class WordIndexer extends React.PureComponent<Props> {
     _container: HTMLElement | null | undefined;
     /* eslint-enable react/sort-comp */
 

--- a/packages/perseus/src/components/inline-icon.tsx
+++ b/packages/perseus/src/components/inline-icon.tsx
@@ -26,13 +26,13 @@
 import PropTypes from "prop-types";
 import * as React from "react";
 
-const InlineIcon: React.FC<InlineIconProps> = ({
+const InlineIcon = ({
     path,
     width,
     height,
     style = {},
     title,
-}): React.ReactElement => (
+}: InlineIconProps): React.ReactElement => (
     <svg
         role="img"
         aria-hidden={!title}

--- a/packages/perseus/src/components/tex-buttons.tsx
+++ b/packages/perseus/src/components/tex-buttons.tsx
@@ -253,7 +253,7 @@ const buttonSets: ButtonSets = {
 
 export type ButtonSetsType = ReadonlyArray<keyof typeof buttonSets>;
 
-type TexButtonProps = {
+type Props = {
     sets: ButtonSetsType;
     onInsert: (arg1: Inserter) => void;
     className?: string;
@@ -264,7 +264,7 @@ const buttonSetsPropType = PropTypes.arrayOf(
     PropTypes.oneOf(_(buttonSets).keys()),
 );
 
-class TexButtons extends React.Component<TexButtonProps> {
+class TexButtons extends React.Component<Props> {
     static buttonSets: typeof buttonSets = buttonSets;
     static buttonSetsType: any = buttonSetsPropType;
 

--- a/packages/perseus/src/components/visibility-observer/__stories__/visibility-observer.stories.tsx
+++ b/packages/perseus/src/components/visibility-observer/__stories__/visibility-observer.stories.tsx
@@ -136,8 +136,6 @@ class VisibilityTest extends React.Component<Props, State> {
     }
 }
 
-export const AlertWhenNotVisible: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const AlertWhenNotVisible = (args: StoryArgs): React.ReactElement => {
     return <VisibilityTest />;
 };

--- a/packages/perseus/src/error-boundary.tsx
+++ b/packages/perseus/src/error-boundary.tsx
@@ -2,18 +2,15 @@ import * as React from "react";
 
 import {Errors, Log} from "./logging/log";
 
-type ErrorBoundaryProps = {
+type Props = {
     children: React.ReactNode;
 };
-type ErrorBoundaryState = {
+type State = {
     error: string;
 };
 
-class ErrorBoundary extends React.Component<
-    ErrorBoundaryProps,
-    ErrorBoundaryState
-> {
-    constructor(props: ErrorBoundaryProps) {
+class ErrorBoundary extends React.Component<Props, State> {
+    constructor(props: Props) {
         super(props);
         this.state = {error: ""};
     }

--- a/packages/perseus/src/multi-items/__stories__/multi-renderer.stories.tsx
+++ b/packages/perseus/src/multi-items/__stories__/multi-renderer.stories.tsx
@@ -13,7 +13,7 @@ type Story = {
     title: string;
 };
 
-export const SingleItem: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const SingleItem = (args: StoryArgs): React.ReactElement => {
     const item = {
         _multi: {
             ...question1._multi,

--- a/packages/perseus/src/multi-items/__tests__/multi-renderer.test.tsx
+++ b/packages/perseus/src/multi-items/__tests__/multi-renderer.test.tsx
@@ -23,9 +23,8 @@ import type {Item} from "../item-types";
 import type {Tree} from "../tree-types";
 
 // A little helper used in the render callback of a MultiRenderer.
-const SimpleLayout: React.FC<{
-    renderers: any;
-}> = ({renderers}): React.ReactElement => {
+type Props = {renderers: any};
+const SimpleLayout = ({renderers}: Props): React.ReactElement => {
     if (renderers == null) {
         throw new Error("renderers was null");
     }

--- a/packages/perseus/src/widgets/__stories__/categorizer.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/categorizer.stories.tsx
@@ -9,6 +9,6 @@ export default {
 
 type StoryArgs = Record<any, any>;
 
-export const Question1: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Question1 = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={question1} />;
 };

--- a/packages/perseus/src/widgets/__stories__/cs-program.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/cs-program.stories.tsx
@@ -9,6 +9,6 @@ export default {
 
 type StoryArgs = Record<any, any>;
 
-export const Question1: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Question1 = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={question1} />;
 };

--- a/packages/perseus/src/widgets/__stories__/definition.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/definition.stories.tsx
@@ -94,18 +94,14 @@ const article = {
 
 type StoryArgs = Record<any, any>;
 
-export const Question1: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Question1 = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={question1} />;
 };
 
-export const MultipleDefinitions: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const MultipleDefinitions = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={question2} />;
 };
 
-export const ArticleDefintion: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const ArticleDefintion = (args: StoryArgs): React.ReactElement => {
     return <ArticleRenderer json={article} useNewStyles />;
 };

--- a/packages/perseus/src/widgets/__stories__/dropdown.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/dropdown.stories.tsx
@@ -9,6 +9,6 @@ export default {
 
 type StoryArgs = Record<any, any>;
 
-export const Question1: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Question1 = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={question1} />;
 };

--- a/packages/perseus/src/widgets/__stories__/explanation.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/explanation.stories.tsx
@@ -9,10 +9,10 @@ export default {
 
 type StoryArgs = Record<any, any>;
 
-export const Question1: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Question1 = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={question1} />;
 };
 
-export const Question2: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Question2 = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={question2} />;
 };

--- a/packages/perseus/src/widgets/__stories__/expression.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/expression.stories.tsx
@@ -45,9 +45,7 @@ const WrappedKeypadContext = (props: WrappedKeypadContextProps) => {
     );
 };
 
-export const DesktopKitchenSink: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const DesktopKitchenSink = (args: StoryArgs): React.ReactElement => {
     const reviewModeRubric = {
         functions: ["f", "g", "h"],
         times: true,
@@ -88,11 +86,11 @@ export const DesktopKitchenSink: React.FC<StoryArgs> = (
     );
 };
 
-export const Desktop: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Desktop = (args: StoryArgs): React.ReactElement => {
     return <WrappedKeypadContext item={expressionItem3} customKeypad={false} />;
 };
 
-export const Mobile: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Mobile = (args: StoryArgs): React.ReactElement => {
     return (
         <div>
             <p>
@@ -107,9 +105,7 @@ export const Mobile: React.FC<StoryArgs> = (args): React.ReactElement => {
     );
 };
 
-export const ExpressionItem2: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const ExpressionItem2 = (args: StoryArgs): React.ReactElement => {
     return (
         <WrappedKeypadContext
             item={expressionItem2}
@@ -118,9 +114,7 @@ export const ExpressionItem2: React.FC<StoryArgs> = (
     );
 };
 
-export const ExpressionItem3: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const ExpressionItem3 = (args: StoryArgs): React.ReactElement => {
     return (
         <WrappedKeypadContext
             item={expressionItem3}

--- a/packages/perseus/src/widgets/__stories__/graded-group-set.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/graded-group-set.stories.tsx
@@ -12,7 +12,7 @@ type GradedGroupSetStory = {
     args: StoryArgs;
 };
 
-export const Article1: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Article1 = (args: StoryArgs): React.ReactElement => {
     return (
         <RendererWithDebugUI
             apiOptions={{

--- a/packages/perseus/src/widgets/__stories__/graded-group.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/graded-group.stories.tsx
@@ -12,7 +12,7 @@ type Story = {
     args: StoryArgs;
 };
 
-export const Question1: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Question1 = (args: StoryArgs): React.ReactElement => {
     return (
         <RendererWithDebugUI
             question={question1}

--- a/packages/perseus/src/widgets/__stories__/grapher.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/grapher.stories.tsx
@@ -17,44 +17,30 @@ export default {
 
 type StoryArgs = Record<any, any>;
 
-export const AbsoluteValueQuestion: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const AbsoluteValueQuestion = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={absoluteValueQuestion} />;
 };
 
-export const ExponentialQuestion: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const ExponentialQuestion = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={exponentialQuestion} />;
 };
 
-export const LinearQuestion: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const LinearQuestion = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={linearQuestion} />;
 };
 
-export const LogarithmQuestion: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const LogarithmQuestion = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={logarithmQuestion} />;
 };
 
-export const QuadraticQuestion: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const QuadraticQuestion = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={quadraticQuestion} />;
 };
 
-export const SinusoidQuestion: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const SinusoidQuestion = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={sinusoidQuestion} />;
 };
 
-export const ComplexQuestion: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const ComplexQuestion = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={multipleAvailableTypesQuestion} />;
 };

--- a/packages/perseus/src/widgets/__stories__/group.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/group.stories.tsx
@@ -9,6 +9,6 @@ export default {
 
 type StoryArgs = Record<any, any>;
 
-export const Question1: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Question1 = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={question1} />;
 };

--- a/packages/perseus/src/widgets/__stories__/iframe.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/iframe.stories.tsx
@@ -9,6 +9,6 @@ export default {
 
 type StoryArgs = Record<any, any>;
 
-export const Question1: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Question1 = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={question1} />;
 };

--- a/packages/perseus/src/widgets/__stories__/image.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/image.stories.tsx
@@ -16,7 +16,7 @@ type ImageStory = {
     args: StoryArgs;
 };
 
-export const Question1: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Question1 = (args: StoryArgs): React.ReactElement => {
     const apiOptions: APIOptions = {
         isMobile: args.isMobile,
     };

--- a/packages/perseus/src/widgets/__stories__/input-number.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/input-number.stories.tsx
@@ -82,29 +82,20 @@ const updateWidgetOptions = (
     };
 };
 
-export const Rational: React.FC<InputNumberOptions> = (
-    args,
-): React.ReactElement => {
+export const Rational = (args: InputNumberOptions): React.ReactElement => {
     const question = updateWidgetOptions(question1, "input-number 1", args);
     return <RendererWithDebugUI question={question} />;
 };
-// @ts-expect-error [FEI-5003] - TS2339 - Property 'args' does not exist on type 'FC<PerseusInputNumberWidgetOptions>'.
 Rational.args = question1.widgets["input-number 1"].options;
 
-export const PiSimplify: React.FC<InputNumberOptions> = (
-    args,
-): React.ReactElement => {
+export const PiSimplify = (args: InputNumberOptions): React.ReactElement => {
     const question = updateWidgetOptions(question2, "input-number 1", args);
     return <RendererWithDebugUI question={question} />;
 };
-// @ts-expect-error [FEI-5003] - TS2339 - Property 'args' does not exist on type 'FC<PerseusInputNumberWidgetOptions>'.
 PiSimplify.args = question2.widgets["input-number 1"].options;
 
-export const Percent: React.FC<InputNumberOptions> = (
-    args,
-): React.ReactElement => {
+export const Percent = (args: InputNumberOptions): React.ReactElement => {
     const question = updateWidgetOptions(question3, "input-number 1", args);
     return <RendererWithDebugUI question={question} />;
 };
-// @ts-expect-error [FEI-5003] - TS2339 - Property 'args' does not exist on type 'FC<PerseusInputNumberWidgetOptions>'.
 Percent.args = question3.widgets["input-number 1"].options;

--- a/packages/perseus/src/widgets/__stories__/interaction.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/interaction.stories.tsx
@@ -9,6 +9,6 @@ export default {
 
 type StoryArgs = Record<any, any>;
 
-export const Question1: React.FC<StoryArgs> = (args): React.ReactElement => (
+export const Question1 = (args: StoryArgs): React.ReactElement => (
     <RendererWithDebugUI question={question1} />
 );

--- a/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
@@ -19,39 +19,39 @@ export default {
 
 type StoryArgs = Record<any, any>;
 
-export const Angle: React.FC<StoryArgs> = (args): React.ReactElement => (
+export const Angle = (args: StoryArgs): React.ReactElement => (
     <RendererWithDebugUI question={angleQuestion} />
 );
 
-export const Circle: React.FC<StoryArgs> = (args): React.ReactElement => (
+export const Circle = (args: StoryArgs): React.ReactElement => (
     <RendererWithDebugUI question={circleQuestion} />
 );
 
-export const Linear: React.FC<StoryArgs> = (args): React.ReactElement => (
+export const Linear = (args: StoryArgs): React.ReactElement => (
     <RendererWithDebugUI question={linearQuestion} />
 );
 
-export const LinearSystem: React.FC<StoryArgs> = (args): React.ReactElement => (
+export const LinearSystem = (args: StoryArgs): React.ReactElement => (
     <RendererWithDebugUI question={linearSystemQuestion} />
 );
 
-export const Point: React.FC<StoryArgs> = (args): React.ReactElement => (
+export const Point = (args: StoryArgs): React.ReactElement => (
     <RendererWithDebugUI question={pointQuestion} />
 );
 
-export const Polygon: React.FC<StoryArgs> = (args): React.ReactElement => (
+export const Polygon = (args: StoryArgs): React.ReactElement => (
     <RendererWithDebugUI question={polygonQuestion} />
 );
 
-export const Ray: React.FC<StoryArgs> = (args): React.ReactElement => (
+export const Ray = (args: StoryArgs): React.ReactElement => (
     <RendererWithDebugUI question={rayQuestion} />
 );
 
-export const Segment: React.FC<StoryArgs> = (args): React.ReactElement => (
+export const Segment = (args: StoryArgs): React.ReactElement => (
     <RendererWithDebugUI question={segmentQuestion} />
 );
 
-export const Sinusoid: React.FC<StoryArgs> = (args): React.ReactElement => (
+export const Sinusoid = (args: StoryArgs): React.ReactElement => (
     <RendererWithDebugUI question={sinusoidQuestion} />
 );
 

--- a/packages/perseus/src/widgets/__stories__/matcher.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/matcher.stories.tsx
@@ -9,6 +9,6 @@ export default {
 
 type StoryArgs = Record<any, any>;
 
-export const Question1: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Question1 = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={question1} />;
 };

--- a/packages/perseus/src/widgets/__stories__/matrix.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/matrix.stories.tsx
@@ -9,6 +9,6 @@ export default {
 
 type StoryArgs = Record<any, any>;
 
-export const Question1: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Question1 = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={question1} />;
 };

--- a/packages/perseus/src/widgets/__stories__/number-line.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/number-line.stories.tsx
@@ -9,6 +9,6 @@ export default {
 
 type StoryArgs = Record<any, any>;
 
-export const Question1: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Question1 = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={question1} />;
 };

--- a/packages/perseus/src/widgets/__stories__/numeric-input.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/numeric-input.stories.tsx
@@ -62,13 +62,13 @@ export const Question1 = (): React.ReactElement => {
     return <RendererWithDebugUI question={question1} />;
 };
 
-export const Interactive: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Interactive = (args: StoryArgs): React.ReactElement => {
     const props = generateProps(args);
 
     return <NumericInput {...props} />;
 };
 
-export const Sizes: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Sizes = (args: StoryArgs): React.ReactElement => {
     const smallProps = generateProps({...args, size: "small"});
     const normalProps = generateProps({...args, size: "normal"});
 
@@ -86,9 +86,7 @@ export const Sizes: React.FC<StoryArgs> = (args): React.ReactElement => {
     );
 };
 
-export const TextAlignment: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const TextAlignment = (args: StoryArgs): React.ReactElement => {
     const leftProps = generateProps({...args, rightAlign: false});
     const rightProps = generateProps({...args, rightAlign: true});
 

--- a/packages/perseus/src/widgets/__stories__/orderer.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/orderer.stories.tsx
@@ -9,6 +9,6 @@ export default {
 
 type StoryArgs = Record<any, any>;
 
-export const Question1: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Question1 = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={question1} />;
 };

--- a/packages/perseus/src/widgets/__stories__/passage-ref.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/passage-ref.stories.tsx
@@ -13,10 +13,10 @@ export default {
     title: "Perseus/Widgets/PassageRef",
 } as Story;
 
-export const ShortPassage: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const ShortPassage = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={question1} />;
 };
 
-export const LongPassage: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const LongPassage = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={question2} />;
 };

--- a/packages/perseus/src/widgets/__stories__/passage.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/passage.stories.tsx
@@ -13,20 +13,14 @@ export default {
 
 type StoryArgs = Record<any, any>;
 
-export const SimpleQuestion: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const SimpleQuestion = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={question1} />;
 };
 
-export const MultiPassageQuestion: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const MultiPassageQuestion = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={question2} />;
 };
 
-export const SingleNumberedPassage: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const SingleNumberedPassage = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={question3} />;
 };

--- a/packages/perseus/src/widgets/__stories__/radio.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/radio.stories.tsx
@@ -55,7 +55,7 @@ const buildApiOptions = (args: StoryArgs): APIOptions => {
     };
 };
 
-export const SingleSelect: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const SingleSelect = (args: StoryArgs): React.ReactElement => {
     return (
         <RendererWithDebugUI
             question={applyStoryArgs(questionWithPassage, args)}
@@ -65,9 +65,7 @@ export const SingleSelect: React.FC<StoryArgs> = (args): React.ReactElement => {
     );
 };
 
-export const MultiSelectSimple: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const MultiSelectSimple = (args: StoryArgs): React.ReactElement => {
     return (
         <RendererWithDebugUI
             question={applyStoryArgs(multiChoiceQuestionSimple, args)}
@@ -77,7 +75,7 @@ export const MultiSelectSimple: React.FC<StoryArgs> = (
     );
 };
 
-export const MultiSelect: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const MultiSelect = (args: StoryArgs): React.ReactElement => {
     return (
         <RendererWithDebugUI
             question={applyStoryArgs(multiChoiceQuestion, args)}

--- a/packages/perseus/src/widgets/__stories__/sorter.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/sorter.stories.tsx
@@ -9,6 +9,6 @@ export default {
 
 type StoryArgs = Record<any, any>;
 
-export const Question1: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Question1 = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={question1} />;
 };

--- a/packages/perseus/src/widgets/__stories__/test-keypad-context-wrapper.tsx
+++ b/packages/perseus/src/widgets/__stories__/test-keypad-context-wrapper.tsx
@@ -21,13 +21,11 @@ const Footer = (): React.ReactElement => {
     );
 };
 
-type TestKeypadContextWrapperProps = {
+type Props = {
     children: React.ReactElement;
 };
 
-const TestKeypadContextWrapper = (
-    props: TestKeypadContextWrapperProps,
-): React.ReactElement => {
+const TestKeypadContextWrapper = (props: Props): React.ReactElement => {
     const [keypadElement, setKeypadElement] = React.useState(null);
     const [renderer, setRenderer] = React.useState(null);
     const [scrollableElement, setScrollableElement] = React.useState(

--- a/packages/perseus/src/widgets/__stories__/transformer.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/transformer.stories.tsx
@@ -9,6 +9,6 @@ export default {
 
 type StoryArgs = Record<any, any>;
 
-export const Question: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Question = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={question} />;
 };

--- a/packages/perseus/src/widgets/__stories__/unit.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/unit.stories.tsx
@@ -13,9 +13,7 @@ export default {
     title: "Perseus/Widgets/Unit",
 } as Story;
 
-export const NonStaticRender: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const NonStaticRender = (args: StoryArgs): React.ReactElement => {
     return (
         <OldUnitInput
             apiOptions={{

--- a/packages/perseus/src/widgets/__stories__/video-transcript-link.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/video-transcript-link.stories.tsx
@@ -12,16 +12,12 @@ export default {
     title: "Perseus/Components/Video Transcript Link",
 } as Story;
 
-export const YoutubeVideoLink: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const YoutubeVideoLink = (args: StoryArgs): React.ReactElement => {
     return (
         <VideoTranscriptLink location="https://www.youtube.com/watch?v=YoutubeId" />
     );
 };
 
-export const SlugVideoLink: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const SlugVideoLink = (args: StoryArgs): React.ReactElement => {
     return <VideoTranscriptLink location="slug-video-id" />;
 };

--- a/packages/perseus/src/widgets/__stories__/video.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/video.stories.tsx
@@ -9,6 +9,6 @@ export default {
 
 type StoryArgs = Record<any, any>;
 
-export const Question1: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Question1 = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={question1} />;
 };

--- a/packages/perseus/src/widgets/__tests__/radio/focus-ring.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/radio/focus-ring.test.tsx
@@ -10,7 +10,6 @@ describe("choice icon", () => {
     describe.each([[true], [false]])("multipleSelect: %s", (multipleSelect) => {
         it("renders with the correct border radius", () => {
             // Arrange/Act
-            // @ts-expect-error [FEI-5003] - TS2739 - Type '{ multipleSelect: any; }' is missing the following properties from type 'Props': visible, color
             render(<FocusRing multipleSelect={multipleSelect} />);
 
             const focusRing = screen.getByTestId("focus-ring");

--- a/packages/perseus/src/widgets/interaction/element-container.tsx
+++ b/packages/perseus/src/widgets/interaction/element-container.tsx
@@ -10,7 +10,7 @@ import {
     iconTrash,
 } from "../../icon-paths";
 
-type ElementContainerProps = {
+type Props = {
     children: React.ReactElement<any> | ReadonlyArray<React.ReactElement<any>>;
     initiallyVisible: boolean;
     onDelete?: () => void | null | undefined;
@@ -19,12 +19,11 @@ type ElementContainerProps = {
     title: string | React.ReactElement<any>;
 };
 
-class ElementContainer extends React.Component<
-    ElementContainerProps,
-    {
-        show: boolean;
-    }
-> {
+type State = {
+    show: boolean;
+};
+
+class ElementContainer extends React.Component<Props, State> {
     static defaultProps: {
         initiallyVisible: boolean;
         title: string;
@@ -33,7 +32,7 @@ class ElementContainer extends React.Component<
         title: "More",
     };
 
-    constructor(props: ElementContainerProps) {
+    constructor(props: Props) {
         super(props);
 
         this.state = {

--- a/packages/perseus/src/widgets/label-image/__stories__/answer-choices.stories.tsx
+++ b/packages/perseus/src/widgets/label-image/__stories__/answer-choices.stories.tsx
@@ -87,12 +87,10 @@ class WithState extends React.Component<
     }
 }
 
-export const SingleSelect: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const SingleSelect = (args: StoryArgs): React.ReactElement => {
     return <WithState />;
 };
 
-export const MultipleSelect: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const MultipleSelect = (args: StoryArgs): React.ReactElement => {
     return <WithState multipleSelect={true} />;
 };

--- a/packages/perseus/src/widgets/label-image/__stories__/marker.stories.tsx
+++ b/packages/perseus/src/widgets/label-image/__stories__/marker.stories.tsx
@@ -31,7 +31,7 @@ const Wrapper = (props) => (
 // TODO(jeremy): There are a bunch of props that we have to pass to the Marker
 // that are not used by it, but required because we share a props type.
 
-export const Unfilled: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Unfilled = (args: StoryArgs): React.ReactElement => {
     const props = {
         answers: ["BMW", "Ferrari"],
         selected: [],
@@ -46,9 +46,7 @@ export const Unfilled: React.FC<StoryArgs> = (args): React.ReactElement => {
     return <Wrapper {...props} />;
 };
 
-export const UnfilledPulsate: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const UnfilledPulsate = (args: StoryArgs): React.ReactElement => {
     const props = {
         answers: ["BMW", "Ferrari"],
         selected: [],
@@ -63,9 +61,7 @@ export const UnfilledPulsate: React.FC<StoryArgs> = (
     return <Wrapper {...props} />;
 };
 
-export const UnfilledSelected: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const UnfilledSelected = (args: StoryArgs): React.ReactElement => {
     const props = {
         answers: ["BMW", "Ferrari"],
         selected: [],
@@ -80,7 +76,7 @@ export const UnfilledSelected: React.FC<StoryArgs> = (
     return <Wrapper {...props} />;
 };
 
-export const Filled: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Filled = (args: StoryArgs): React.ReactElement => {
     const props = {
         answers: ["BMW", "Ferrari"],
         selected: ["Fiat"],
@@ -95,9 +91,7 @@ export const Filled: React.FC<StoryArgs> = (args): React.ReactElement => {
     return <Wrapper {...props} />;
 };
 
-export const FilledSelected: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const FilledSelected = (args: StoryArgs): React.ReactElement => {
     const props = {
         answers: ["BMW", "Ferrari"],
         selected: ["Fiat"],
@@ -112,7 +106,7 @@ export const FilledSelected: React.FC<StoryArgs> = (
     return <Wrapper {...props} />;
 };
 
-export const Incorrect: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Incorrect = (args: StoryArgs): React.ReactElement => {
     const props = {
         answers: ["BMW", "Ferrari"],
         selected: ["Fiat"],
@@ -128,9 +122,7 @@ export const Incorrect: React.FC<StoryArgs> = (args): React.ReactElement => {
     return <Wrapper {...props} />;
 };
 
-export const IncorrectSelected: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const IncorrectSelected = (args: StoryArgs): React.ReactElement => {
     const props = {
         answers: ["BMW", "Ferrari"],
         selected: ["Fiat"],
@@ -146,7 +138,7 @@ export const IncorrectSelected: React.FC<StoryArgs> = (
     return <Wrapper {...props} />;
 };
 
-export const Correct: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Correct = (args: StoryArgs): React.ReactElement => {
     const props = {
         answers: ["BMW", "Ferrari"],
         selected: ["BMW", "Ferrari"],
@@ -162,9 +154,7 @@ export const Correct: React.FC<StoryArgs> = (args): React.ReactElement => {
     return <Wrapper {...props} />;
 };
 
-export const CorrectSelected: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const CorrectSelected = (args: StoryArgs): React.ReactElement => {
     const props = {
         answers: ["BMW", "Ferrari"],
         selected: ["BMW", "Ferrari"],

--- a/packages/perseus/src/widgets/label-image/marker.tsx
+++ b/packages/perseus/src/widgets/label-image/marker.tsx
@@ -13,7 +13,7 @@ import {iconCheck, iconMinus} from "../../icon-paths";
 
 import type {InteractiveMarkerType} from "./types";
 
-type MarkerProps = InteractiveMarkerType & {
+type Props = InteractiveMarkerType & {
     // Whether this marker has been selected by user.
     showSelected: boolean;
     // Whether this marker should pulsate to draw user attention.
@@ -23,12 +23,12 @@ type MarkerProps = InteractiveMarkerType & {
     onKeyDown: (e: KeyboardEvent) => void;
 };
 
-type MarkerState = {
+type State = {
     // Whether the marker button has input focus.
     isFocused: boolean;
 };
 
-export default class Marker extends React.Component<MarkerProps, MarkerState> {
+export default class Marker extends React.Component<Props, State> {
     // The marker icon element.
     _icon: HTMLElement | null | undefined;
 
@@ -38,7 +38,7 @@ export default class Marker extends React.Component<MarkerProps, MarkerState> {
         selected: [],
     };
 
-    state: MarkerState = {
+    state: State = {
         isFocused: false,
     };
 

--- a/packages/perseus/src/widgets/passage/passage-markdown.tsx
+++ b/packages/perseus/src/widgets/passage/passage-markdown.tsx
@@ -48,7 +48,7 @@ type HighlightNode = {
     content: string;
 };
 
-type RefStartProps = {
+type Props = {
     refContent: React.ReactNode;
 };
 
@@ -63,7 +63,7 @@ function getInitialParseState(): ParseState {
     };
 }
 
-class RefStart extends React.Component<RefStartProps> {
+class RefStart extends React.Component<Props> {
     render(): React.ReactNode {
         return <span style={REF_STYLE}>{i18n.doNotTranslate("_")}</span>;
     }

--- a/packages/perseus/src/widgets/radio/__stories__/base-radio.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__stories__/base-radio.stories.tsx
@@ -60,27 +60,27 @@ const defaultProps = {
     isLastUsedWidget: false,
 } as const;
 
-export const Interactive: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Interactive = (args: StoryArgs): React.ReactElement => {
     const overwrittenProps = {...defaultProps, ...args} as const;
     return <BaseRadio {...overwrittenProps} />;
 };
 
-export const SingleSelectWithNothingSelected: React.FC<StoryArgs> = (
-    args,
+export const SingleSelectWithNothingSelected = (
+    args: StoryArgs,
 ): React.ReactElement => {
     const overwrittenProps = {...defaultProps, multipleSelect: false} as const;
     return <BaseRadio {...overwrittenProps} />;
 };
 
-export const MultipleSelectWithNothingSelected: React.FC<StoryArgs> = (
-    args,
+export const MultipleSelectWithNothingSelected = (
+    args: StoryArgs,
 ): React.ReactElement => {
     const overwrittenProps = {...defaultProps, multipleSelect: true} as const;
     return <BaseRadio {...overwrittenProps} />;
 };
 
-export const MultipleSelectWithCountChoicesLabel: React.FC<StoryArgs> = (
-    args,
+export const MultipleSelectWithCountChoicesLabel = (
+    args: StoryArgs,
 ): React.ReactElement => {
     const overwrittenProps = {
         ...defaultProps,
@@ -91,9 +91,7 @@ export const MultipleSelectWithCountChoicesLabel: React.FC<StoryArgs> = (
     return <BaseRadio {...overwrittenProps} />;
 };
 
-export const SingleSelected: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const SingleSelected = (args: StoryArgs): React.ReactElement => {
     const choices = Array(4)
         .fill(null)
         .map((_, i) => generateChoice({content: `Choice ${i + 1}`}));
@@ -107,9 +105,7 @@ export const SingleSelected: React.FC<StoryArgs> = (
     return <BaseRadio {...overwrittenProps} />;
 };
 
-export const MultipleSelected: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const MultipleSelected = (args: StoryArgs): React.ReactElement => {
     const choices = Array(4)
         .fill(null)
         .map((_, i) => generateChoice({content: `Choice ${i + 1}`}));
@@ -124,9 +120,7 @@ export const MultipleSelected: React.FC<StoryArgs> = (
     return <BaseRadio {...overwrittenProps} />;
 };
 
-export const SingleKitchenSink: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const SingleKitchenSink = (args: StoryArgs): React.ReactElement => {
     const choices = Array(4)
         .fill(null)
         .map((_, i) => {
@@ -162,9 +156,7 @@ export const SingleKitchenSink: React.FC<StoryArgs> = (
     return <BaseRadio {...overwrittenProps} />;
 };
 
-export const MultipleKitchenSink: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const MultipleKitchenSink = (args: StoryArgs): React.ReactElement => {
     const choices = Array(4)
         .fill(null)
         .map((_, i) => {

--- a/packages/perseus/src/widgets/radio/__stories__/choice-icon.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__stories__/choice-icon.stories.tsx
@@ -40,13 +40,11 @@ export default {
     args: defaultProps,
 };
 
-const Panel: React.FC<{
-    children: React.ReactNode;
-}> = (props): React.ReactElement => {
+const Panel = (props: {children: React.ReactNode}): React.ReactElement => {
     return <div style={{padding: "10px"}}>{props.children}</div>;
 };
 
-export const Interactive: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Interactive = (args: StoryArgs): React.ReactElement => {
     return (
         <Panel>
             <ChoiceIcon {...args} />
@@ -54,7 +52,7 @@ export const Interactive: React.FC<StoryArgs> = (args): React.ReactElement => {
     );
 };
 
-export const Default: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Default = (args: StoryArgs): React.ReactElement => {
     return (
         <Panel>
             <ChoiceIcon {...defaultProps} />
@@ -63,7 +61,7 @@ export const Default: React.FC<StoryArgs> = (args): React.ReactElement => {
     );
 };
 
-export const Focused: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Focused = (args: StoryArgs): React.ReactElement => {
     return (
         <Panel>
             <ChoiceIcon {...defaultProps} focused={true} />
@@ -76,7 +74,7 @@ export const Focused: React.FC<StoryArgs> = (args): React.ReactElement => {
     );
 };
 
-export const Checked: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Checked = (args: StoryArgs): React.ReactElement => {
     return (
         <Panel>
             <ChoiceIcon {...defaultProps} checked={true} />
@@ -89,7 +87,7 @@ export const Checked: React.FC<StoryArgs> = (args): React.ReactElement => {
     );
 };
 
-export const CrossedOut: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const CrossedOut = (args: StoryArgs): React.ReactElement => {
     return (
         <Panel>
             <ChoiceIcon {...defaultProps} crossedOut={true} />
@@ -102,7 +100,7 @@ export const CrossedOut: React.FC<StoryArgs> = (args): React.ReactElement => {
     );
 };
 
-export const Correct: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Correct = (args: StoryArgs): React.ReactElement => {
     return (
         <Panel>
             <ChoiceIcon
@@ -124,7 +122,7 @@ export const Correct: React.FC<StoryArgs> = (args): React.ReactElement => {
     );
 };
 
-export const Incorrect: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Incorrect = (args: StoryArgs): React.ReactElement => {
     return (
         <Panel>
             <ChoiceIcon
@@ -146,7 +144,7 @@ export const Incorrect: React.FC<StoryArgs> = (args): React.ReactElement => {
     );
 };
 
-export const AllPositions: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const AllPositions = (args: StoryArgs): React.ReactElement => {
     // @ts-expect-error [FEI-5003] - TS2554 - Expected 1-3 arguments, but got 0.
     const allLetters = Array(26).fill();
     return (

--- a/packages/perseus/src/widgets/radio/__stories__/choice-none-above.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__stories__/choice-none-above.stories.tsx
@@ -34,7 +34,7 @@ const ChoiceDefaults = {
     onChange: action("changed"),
 } as const;
 
-export const Example: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Example = (args: StoryArgs): React.ReactElement => {
     const combineProps = {...ChoiceDefaults, ...args} as const;
     return <ChoiceNoneAbove {...combineProps} />;
 };

--- a/packages/perseus/src/widgets/radio/__stories__/choice.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__stories__/choice.stories.tsx
@@ -45,11 +45,11 @@ export default {
     args: defaultProps,
 } as Story;
 
-export const Interactive: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Interactive = (args: StoryArgs): React.ReactElement => {
     return <Choice {...args} />;
 };
 
-export const Checked: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Checked = (args: StoryArgs): React.ReactElement => {
     const sharedProps = {
         ...defaultProps,
         checked: true,
@@ -73,7 +73,7 @@ export const Checked: React.FC<StoryArgs> = (args): React.ReactElement => {
     );
 };
 
-export const ReviewMode: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const ReviewMode = (args: StoryArgs): React.ReactElement => {
     const sharedProps = {
         ...defaultProps,
         showCorrectness: true,
@@ -108,7 +108,7 @@ export const ReviewMode: React.FC<StoryArgs> = (args): React.ReactElement => {
     );
 };
 
-export const Rationale: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Rationale = (args: StoryArgs): React.ReactElement => {
     const sharedProps = {
         ...defaultProps,
         checked: true,

--- a/packages/perseus/src/widgets/radio/__stories__/focus-ring.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__stories__/focus-ring.stories.tsx
@@ -25,7 +25,7 @@ export default {
     },
 } as Story;
 
-export const Interactive: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Interactive = (args: StoryArgs): React.ReactElement => {
     // faux choice is just for demonstration
     const fauxChoiceStyles = {
         height: "20px",

--- a/packages/perseus/src/widgets/radio/__stories__/option-status.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__stories__/option-status.stories.tsx
@@ -26,13 +26,11 @@ export default {
     },
 } as Story;
 
-export const Interactive: React.FC<StoryArgs> = (args): React.ReactElement => {
+export const Interactive = (args: StoryArgs): React.ReactElement => {
     return <OptionStatus {...args} />;
 };
 
-export const AllPossibleOutputs: React.FC<StoryArgs> = (
-    args,
-): React.ReactElement => {
+export const AllPossibleOutputs = (args: StoryArgs): React.ReactElement => {
     return (
         <>
             <div>

--- a/packages/perseus/src/widgets/radio/base-radio.tsx
+++ b/packages/perseus/src/widgets/radio/base-radio.tsx
@@ -86,7 +86,7 @@ function getInstructionsText(
     return i18n._("Choose 1 answer:");
 }
 
-const BaseRadio: React.FC<Props> = function (props): React.ReactElement {
+const BaseRadio = function (props: Props): React.ReactElement {
     const {
         apiOptions,
         reviewModeRubric,

--- a/packages/perseus/src/widgets/radio/choice-icon/choice-icon.tsx
+++ b/packages/perseus/src/widgets/radio/choice-icon/choice-icon.tsx
@@ -27,11 +27,13 @@ type ChoiceIconProps = {
     previouslyAnswered: boolean;
 };
 
-function ChoiceInner(props: {
+type ChoiceInnerProps = {
     pos: number;
     showCorrectness: boolean;
     correct: boolean | null | undefined;
-}) {
+};
+
+function ChoiceInner(props: ChoiceInnerProps) {
     const {pos, showCorrectness, correct} = props;
     const letter = getChoiceLetter(pos);
 
@@ -96,9 +98,7 @@ function getDynamicStyles(
     return {backgroundColor, borderColor, color, borderRadius};
 }
 
-const ChoiceIcon: React.FC<ChoiceIconProps> = function (
-    props,
-): React.ReactElement {
+const ChoiceIcon = function (props: ChoiceIconProps): React.ReactElement {
     const {
         checked,
         crossedOut,

--- a/packages/perseus/src/widgets/radio/choice-icon/cross-out-line.tsx
+++ b/packages/perseus/src/widgets/radio/choice-icon/cross-out-line.tsx
@@ -14,9 +14,7 @@ const CROSS_OUT_LINE_SIZE = CHOICE_ICON_SIZE + CROSS_OUT_LINE_PADDING * 2;
  * The "cross-out line" that appears over the icon when the choice has been
  * `crossedOut`.
  */
-const CrossOutLine: React.FC<{
-    color: string;
-}> = function (props): React.ReactElement {
+const CrossOutLine = function (props: {color: string}): React.ReactElement {
     return (
         <svg
             width={CROSS_OUT_LINE_SIZE}

--- a/packages/perseus/src/widgets/radio/choice-none-above.tsx
+++ b/packages/perseus/src/widgets/radio/choice-none-above.tsx
@@ -17,8 +17,8 @@ type WithForwardRef = {
 
 type PropsWithForwardRef = Props & WithForwardRef;
 
-const ChoiceNoneAbove: React.FC<PropsWithForwardRef> = function (
-    props,
+const ChoiceNoneAbove = function (
+    props: PropsWithForwardRef,
 ): React.ReactElement {
     const {showContent, content, forwardedRef, ...rest} = props;
 

--- a/packages/perseus/src/widgets/radio/choice.tsx
+++ b/packages/perseus/src/widgets/radio/choice.tsx
@@ -78,9 +78,7 @@ function uniqueId() {
     return `choice-${id++}`;
 }
 
-const Choice: React.FC<ChoicePropsWithForwardRef> = function (
-    props,
-): React.ReactElement {
+const Choice = function (props: ChoicePropsWithForwardRef): React.ReactElement {
     const {
         disabled = false,
         checked = false,

--- a/packages/perseus/src/widgets/radio/focus-ring.tsx
+++ b/packages/perseus/src/widgets/radio/focus-ring.tsx
@@ -18,7 +18,7 @@ type Props = {
     multipleSelect: boolean;
 };
 
-const FocusRing: React.FC<Props> = function (props): React.ReactElement {
+const FocusRing = function (props: Props): React.ReactElement {
     const {visible, color, children, multipleSelect} = props;
 
     const borderColor = visible ? color : "transparent";

--- a/packages/perseus/src/widgets/radio/option-status.tsx
+++ b/packages/perseus/src/widgets/radio/option-status.tsx
@@ -11,7 +11,7 @@ import * as i18n from "@khanacademy/wonder-blocks-i18n";
 import {StyleSheet, css} from "aphrodite";
 import * as React from "react";
 
-type OptionStatusProps = {
+type Props = {
     // Was this option the correct answer?
     correct: boolean;
     // Did the user select this option as the answer?
@@ -47,9 +47,7 @@ function renderText(
     return i18n._("Incorrect");
 }
 
-const OptionStatus: React.FC<OptionStatusProps> = function (
-    props,
-): React.ReactElement {
+const OptionStatus = function (props: Props): React.ReactElement {
     const {checked, correct, crossedOut, previouslyAnswered, reviewMode} =
         props;
 

--- a/packages/perseus/src/widgets/radio/widget.tsx
+++ b/packages/perseus/src/widgets/radio/widget.tsx
@@ -502,7 +502,6 @@ class Radio extends React.Component<Props> {
         return (
             <BaseRadio
                 labelWrap={true}
-                // @ts-expect-error [FEI-5003] - TS2322 - Type 'boolean | undefined' is not assignable to type 'boolean'.
                 multipleSelect={this.props.multipleSelect}
                 countChoices={this.props.countChoices}
                 numCorrect={this.props.numCorrect}

--- a/packages/perseus/src/widgets/video-transcript-link.tsx
+++ b/packages/perseus/src/widgets/video-transcript-link.tsx
@@ -31,7 +31,7 @@ type Props = {
 /**
  * Video Transcript Link Component.
  */
-const VideoTranscriptLink: React.FC<Props> = (props): React.ReactElement => {
+const VideoTranscriptLink = (props: Props): React.ReactElement => {
     const {location} = props;
     const {useVideo} = getDependencies();
     const [id, kind] = IS_URL.test(location)

--- a/packages/simple-markdown/src/index.ts
+++ b/packages/simple-markdown/src/index.ts
@@ -1899,10 +1899,8 @@ var markdownToHtml = function (source: string, state?: State | null): string {
 };
 
 // TODO: This needs definition
-type ReactMarkdownProps = any;
-var ReactMarkdown: React.FC<ReactMarkdownProps> = function (
-    props,
-): React.ReactElement {
+type Props = any;
+var ReactMarkdown = function (props): React.ReactElement {
     var divProps: Record<string, any> = {};
 
     for (var prop in props) {
@@ -2000,6 +1998,16 @@ type Exports = {
             [key: string]: any;
         },
     ) => ReactElement;
+    /**
+     * defaultParse is deprecated, please use `defaultImplicitParse`
+     * @deprecated
+     */
+    readonly defaultParse: (...args: any[]) => any;
+    /**
+     * defaultOutput is deprecated, please use `defaultReactOutput`
+     * @deprecated
+     */
+    readonly defaultOutput: (...args: any[]) => any;
 };
 
 export type {
@@ -2048,7 +2056,6 @@ var SimpleMarkdown: Exports = {
     // default wrappers:
     markdownToReact: markdownToReact,
     markdownToHtml: markdownToHtml,
-    // @ts-expect-error [FEI-5003] - TS2322 - Type 'FC<any>' is not assignable to type '(props: { [key: string]: any; source: string; }) => ReactElement'.
     ReactMarkdown: ReactMarkdown,
 
     defaultBlockParse: defaultBlockParse,

--- a/testing/item-renderer-with-debug-ui.tsx
+++ b/testing/item-renderer-with-debug-ui.tsx
@@ -16,10 +16,10 @@ type Props = {
     apiOptions?: APIOptions;
 };
 
-export const ItemRendererWithDebugUI: React.FC<Props> = ({
+export const ItemRendererWithDebugUI = ({
     item,
     apiOptions,
-}): React.ReactElement => {
+}: Props): React.ReactElement => {
     const ref = React.useRef<ItemRenderer | null | undefined>(null);
     const [state, setState] = React.useState<KEScore | null | undefined>(null);
 

--- a/testing/ke-score-ui.tsx
+++ b/testing/ke-score-ui.tsx
@@ -4,11 +4,11 @@ import ReactJson from "react-json-view";
 
 import type {KEScore} from "../packages/perseus/src/types";
 
-export default ({
-    score,
-}: {
+type Props = {
     score: KEScore | null | undefined;
-}): React.ReactElement | null => {
+};
+
+export default ({score}: Props): React.ReactElement | null => {
     if (score == null) {
         return null;
     }

--- a/testing/multi-item-renderer-with-debug-ui.tsx
+++ b/testing/multi-item-renderer-with-debug-ui.tsx
@@ -27,11 +27,11 @@ type Props = {
 
 // Renders an assessment item (aka {_multi: ...} that conforms to the
 // sample data simpleQuestionShape.
-export const MultiItemRendererWithDebugUI: React.FC<Props> = ({
+export const MultiItemRendererWithDebugUI = ({
     children,
     simpleItem,
     apiOptions,
-}): React.ReactElement => {
+}: Props): React.ReactElement => {
     // @ts-expect-error [FEI-5003] - TS2530 - Cannot find namespace 'MultiItems'.
     const ref = React.useRef<MultiItems.MultiRenderer>(null);
     const [state, setState] = React.useState<KEScore | null | undefined>(null);

--- a/testing/renderer-with-debug-ui.tsx
+++ b/testing/renderer-with-debug-ui.tsx
@@ -19,11 +19,11 @@ type Props = {
     reviewMode?: boolean;
 };
 
-export const RendererWithDebugUI: React.FC<Props> = ({
+export const RendererWithDebugUI = ({
     question,
     apiOptions,
     reviewMode = false,
-}): React.ReactElement => {
+}: Props): React.ReactElement => {
     registerAllWidgetsForTesting();
     const ref = React.useRef<Renderer | null | undefined>(null);
     const [state, setState] = React.useState<any>(null);

--- a/testing/server-item-renderer-with-debug-ui.tsx
+++ b/testing/server-item-renderer-with-debug-ui.tsx
@@ -16,10 +16,10 @@ type Props = {
     apiOptions?: APIOptions;
 };
 
-export const ServerItemRendererWithDebugUI: React.FC<Props> = ({
+export const ServerItemRendererWithDebugUI = ({
     item,
     apiOptions,
-}): React.ReactElement => {
+}: Props): React.ReactElement => {
     const ref = React.useRef<Perseus.ServerItemRendererComponent>(null);
     const [state, setState] = React.useState<KEScore | null | undefined>(null);
     const options = apiOptions || Object.freeze({});

--- a/testing/side-by-side.tsx
+++ b/testing/side-by-side.tsx
@@ -3,11 +3,17 @@ import {HeadingMedium} from "@khanacademy/wonder-blocks-typography";
 import * as React from "react";
 import ReactJson from "react-json-view";
 
-const SideBySide: React.FC<{
+type Props = {
     leftTitle: string;
     left: React.ReactNode;
     perseusObject: any;
-}> = ({leftTitle = "Renderer", left, perseusObject}): React.ReactElement => {
+};
+
+const SideBySide = ({
+    leftTitle = "Renderer",
+    left,
+    perseusObject,
+}: Props): React.ReactElement => {
     return (
         <View style={styles.sideBySide}>
             {/* @ts-expect-error [FEI-5003] - TS2769 - No overload matches this call. */}

--- a/testing/test-tex.tsx
+++ b/testing/test-tex.tsx
@@ -17,7 +17,7 @@ type Props = JSX.LibraryManagedAttributes<
  * renderToString/renderA11yString.  If KaTeX can't process `children`
  * an empty string is rendered instead.
  */
-export const TestTeX: React.FC<Props> = (props): React.ReactElement => {
+export const TestTeX = (props: Props): React.ReactElement => {
     const {children, katexOptions, onRender} = props;
 
     const katexHtml = React.useMemo(() => {


### PR DESCRIPTION
## Summary:
There are issues with React.FC<> (e.g. it adds an implicit "children" prop) so we'd like to avoid its use.  I've already update wonder-blocks to no use it.  This PR updates the perseus repo to not user it either.

In addition to getting rid of React.FC<> I've also made the following additional changes:
- created type aliases for all inline prop types outside of test files
- rename FooProps to Props and FooState to State in files containing only a single component

This brings the prop types closer inline with our best practices.

Issue: None

## Test plan:
- yarn lint
- yarn tsc