### PR TITLE
POC: pulling redux up out of v1 keypad

### DIFF
--- a/packages/math-input/src/components/__tests__/two-page-keypad.test.tsx
+++ b/packages/math-input/src/components/__tests__/two-page-keypad.test.tsx
@@ -11,6 +11,10 @@ describe("<TwoPageKeyPage />", () => {
                 currentPage={1}
                 leftPage={<p>Left Page</p>}
                 rightPage={<p>Right Page</p>}
+                paginationEnabled={true}
+                active={true}
+                echoes={[]}
+                popover={null}
             />,
         );
 
@@ -26,6 +30,10 @@ describe("<TwoPageKeyPage />", () => {
                 currentPage={0}
                 leftPage={<p>Left Page</p>}
                 rightPage={<p>Right Page</p>}
+                paginationEnabled={true}
+                active={true}
+                echoes={[]}
+                popover={null}
             />,
         );
 

--- a/packages/math-input/src/components/__tests__/two-page-keypad.test.tsx
+++ b/packages/math-input/src/components/__tests__/two-page-keypad.test.tsx
@@ -15,6 +15,8 @@ describe("<TwoPageKeyPage />", () => {
                 active={true}
                 echoes={[]}
                 popover={null}
+                heightPx={40}
+                widthPx={40}
             />,
         );
 
@@ -34,6 +36,8 @@ describe("<TwoPageKeyPage />", () => {
                 active={true}
                 echoes={[]}
                 popover={null}
+                heightPx={40}
+                widthPx={40}
             />,
         );
 

--- a/packages/math-input/src/components/echo-manager.tsx
+++ b/packages/math-input/src/components/echo-manager.tsx
@@ -19,6 +19,8 @@ type EchoProps = {
     borders: Border;
     id: Key;
     initialBounds: Bound;
+    heightPx: number;
+    widthPx: number;
     onAnimationFinish: () => void;
 };
 
@@ -34,7 +36,7 @@ class Echo extends React.Component<EchoProps> {
     }
 
     render() {
-        const {borders, id, initialBounds} = this.props;
+        const {borders, id, initialBounds, heightPx, widthPx} = this.props;
         const {icon} = KeyConfigs[id];
 
         const containerStyle: any = {
@@ -55,6 +57,8 @@ class Echo extends React.Component<EchoProps> {
                     icon={icon}
                     type={KeyTypes.ECHO}
                     borders={borders}
+                    heightPx={heightPx}
+                    widthPx={widthPx}
                 />
             </div>
         );
@@ -71,6 +75,8 @@ type EchoPropType = {
 
 type EchoManagerProps = {
     echoes: ReadonlyArray<EchoPropType>;
+    heightPx: number;
+    widthPx: number;
     onAnimationFinish?: (animationId: string) => void;
 };
 
@@ -110,7 +116,7 @@ class EchoManager extends React.Component<EchoManagerProps> {
     };
 
     render() {
-        const {echoes, onAnimationFinish} = this.props;
+        const {echoes, heightPx, widthPx, onAnimationFinish} = this.props;
 
         return (
             <span>
@@ -143,6 +149,8 @@ class EchoManager extends React.Component<EchoManagerProps> {
                                         key={animationId}
                                     >
                                         <Echo
+                                            heightPx={heightPx}
+                                            widthPx={widthPx}
                                             animationDurationMs={
                                                 animationDurationMs
                                             }

--- a/packages/math-input/src/components/empty-keypad-button.tsx
+++ b/packages/math-input/src/components/empty-keypad-button.tsx
@@ -3,22 +3,19 @@
  */
 
 import * as React from "react";
-import {connect} from "react-redux";
 
 import KeyConfigs from "../data/key-configs";
 
 import GestureManager from "./gesture-manager";
 import KeypadButton from "./keypad-button";
 
-import type {State} from "../store/types";
-
-interface ReduxProps {
+interface Props {
     gestureManager: GestureManager;
 }
 
-class EmptyKeypadButton extends React.Component<ReduxProps> {
+class EmptyKeypadButton extends React.Component<Props> {
     render() {
-        const {gestureManager, ...rest} = this.props;
+        const {gestureManager} = this.props;
 
         // Register touch events on the button, but don't register its DOM node
         // or compute focus state or anything like that. We want the gesture
@@ -38,19 +35,9 @@ class EmptyKeypadButton extends React.Component<ReduxProps> {
                     gestureManager.onTouchCancel(evt)
                 }
                 {...KeyConfigs.NOOP}
-                {...rest}
             />
         );
     }
 }
 
-const mapStateToProps = (state: State): ReduxProps => {
-    const {gestures} = state;
-    return {
-        gestureManager: gestures.gestureManager,
-    };
-};
-
-export default connect(mapStateToProps, null, null, {forwardRef: true})(
-    EmptyKeypadButton,
-);
+export default EmptyKeypadButton;

--- a/packages/math-input/src/components/expression-keypad.tsx
+++ b/packages/math-input/src/components/expression-keypad.tsx
@@ -28,6 +28,7 @@ interface ReduxProps {
     currentPage: number;
     cursorContext?: CursorContext;
     dynamicJumpOut: boolean;
+    paginationEnabled: boolean;
 }
 
 interface Props extends ReduxProps {
@@ -55,6 +56,7 @@ class ExpressionKeypad extends React.Component<Props> {
             extraKeys,
             roundTopLeft,
             roundTopRight,
+            paginationEnabled,
         } = this.props;
 
         let dismissOrJumpOutKey;
@@ -292,6 +294,7 @@ class ExpressionKeypad extends React.Component<Props> {
                 currentPage={currentPage}
                 rightPage={rightPage}
                 leftPage={leftPage}
+                paginationEnabled={paginationEnabled}
             />
         );
     }
@@ -317,6 +320,7 @@ const mapStateToProps = (state: State): ReduxProps => {
         currentPage: state.pager.currentPage,
         cursorContext: state.input.cursor?.context,
         dynamicJumpOut: !state.layout.navigationPadEnabled,
+        paginationEnabled: state.layout.paginationEnabled,
     };
 };
 

--- a/packages/math-input/src/components/expression-keypad.tsx
+++ b/packages/math-input/src/components/expression-keypad.tsx
@@ -16,9 +16,10 @@ import ManyKeypadButton from "./many-keypad-button";
 import Styles from "./styles";
 import TouchableKeypadButton from "./touchable-keypad-button";
 import TwoPageKeypad from "./two-page-keypad";
+import {removeEcho} from "../actions/index";
 
 import type {State} from "../store/types";
-import type {KeypadLayout} from "../types";
+import type {KeypadLayout, Popover, Echo} from "../types";
 import type {CursorContext} from "./input/cursor-contexts";
 
 const {row, column, oneColumn, fullWidth, roundedTopLeft, roundedTopRight} =
@@ -29,12 +30,16 @@ interface ReduxProps {
     cursorContext?: CursorContext;
     dynamicJumpOut: boolean;
     paginationEnabled: boolean;
+    active: boolean;
+    echoes: ReadonlyArray<Echo>;
+    popover: Popover | null;
 }
 
 interface Props extends ReduxProps {
     extraKeys?: ReadonlyArray<string>;
     roundTopLeft: boolean;
     roundTopRight: boolean;
+    removeEcho?: (animationId: string) => void;
 }
 
 export const expressionKeypadLayout: KeypadLayout = {
@@ -57,6 +62,10 @@ class ExpressionKeypad extends React.Component<Props> {
             roundTopLeft,
             roundTopRight,
             paginationEnabled,
+            active,
+            echoes,
+            popover,
+            removeEcho,
         } = this.props;
 
         let dismissOrJumpOutKey;
@@ -295,6 +304,10 @@ class ExpressionKeypad extends React.Component<Props> {
                 rightPage={rightPage}
                 leftPage={leftPage}
                 paginationEnabled={paginationEnabled}
+                active={active}
+                echoes={echoes}
+                popover={popover}
+                removeEcho={removeEcho}
             />
         );
     }
@@ -321,9 +334,20 @@ const mapStateToProps = (state: State): ReduxProps => {
         cursorContext: state.input.cursor?.context,
         dynamicJumpOut: !state.layout.navigationPadEnabled,
         paginationEnabled: state.layout.paginationEnabled,
+        echoes: state.echoes.echoes,
+        active: state.keypad.active,
+        popover: state.gestures.popover,
     };
 };
 
-export default connect(mapStateToProps, null, null, {forwardRef: true})(
-    ExpressionKeypad,
-);
+const mapDispatchToProps = (dispatch) => {
+    return {
+        removeEcho: (animationId) => {
+            dispatch(removeEcho(animationId));
+        },
+    };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps, null, {
+    forwardRef: true,
+})(ExpressionKeypad);

--- a/packages/math-input/src/components/expression-keypad.tsx
+++ b/packages/math-input/src/components/expression-keypad.tsx
@@ -4,7 +4,6 @@
 
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
-import {connect} from "react-redux";
 
 import {BorderStyles} from "../consts";
 import KeyConfigs from "../data/key-configs";
@@ -16,16 +15,16 @@ import ManyKeypadButton from "./many-keypad-button";
 import Styles from "./styles";
 import TouchableKeypadButton from "./touchable-keypad-button";
 import TwoPageKeypad from "./two-page-keypad";
-import {removeEcho} from "../actions/index";
-
-import type {State} from "../store/types";
 import type {KeypadLayout, Popover, Echo} from "../types";
 import type {CursorContext} from "./input/cursor-contexts";
 
 const {row, column, oneColumn, fullWidth, roundedTopLeft, roundedTopRight} =
     Styles;
 
-interface ReduxProps {
+type Props = {
+    extraKeys?: ReadonlyArray<string>;
+    roundTopLeft: boolean;
+    roundTopRight: boolean;
     currentPage: number;
     cursorContext?: CursorContext;
     dynamicJumpOut: boolean;
@@ -33,14 +32,8 @@ interface ReduxProps {
     active: boolean;
     echoes: ReadonlyArray<Echo>;
     popover: Popover | null;
-}
-
-interface Props extends ReduxProps {
-    extraKeys?: ReadonlyArray<string>;
-    roundTopLeft: boolean;
-    roundTopRight: boolean;
     removeEcho?: (animationId: string) => void;
-}
+};
 
 export const expressionKeypadLayout: KeypadLayout = {
     rows: 4,
@@ -328,26 +321,4 @@ const styles = StyleSheet.create({
     },
 });
 
-const mapStateToProps = (state: State): ReduxProps => {
-    return {
-        currentPage: state.pager.currentPage,
-        cursorContext: state.input.cursor?.context,
-        dynamicJumpOut: !state.layout.navigationPadEnabled,
-        paginationEnabled: state.layout.paginationEnabled,
-        echoes: state.echoes.echoes,
-        active: state.keypad.active,
-        popover: state.gestures.popover,
-    };
-};
-
-const mapDispatchToProps = (dispatch) => {
-    return {
-        removeEcho: (animationId) => {
-            dispatch(removeEcho(animationId));
-        },
-    };
-};
-
-export default connect(mapStateToProps, mapDispatchToProps, null, {
-    forwardRef: true,
-})(ExpressionKeypad);
+export default ExpressionKeypad;

--- a/packages/math-input/src/components/expression-keypad.tsx
+++ b/packages/math-input/src/components/expression-keypad.tsx
@@ -33,6 +33,8 @@ type Props = {
     active: boolean;
     echoes: ReadonlyArray<Echo>;
     popover: Popover | null;
+    heightPx: number;
+    widthPx: number;
     gestureManager: GestureManager;
     removeEcho?: (animationId: string) => void;
 };
@@ -60,6 +62,8 @@ class ExpressionKeypad extends React.Component<Props> {
             active,
             echoes,
             popover,
+            heightPx,
+            widthPx,
             gestureManager,
             removeEcho,
         } = this.props;
@@ -306,6 +310,8 @@ class ExpressionKeypad extends React.Component<Props> {
                 active={active}
                 echoes={echoes}
                 popover={popover}
+                heightPx={heightPx}
+                widthPx={widthPx}
                 removeEcho={removeEcho}
             />
         );

--- a/packages/math-input/src/components/expression-keypad.tsx
+++ b/packages/math-input/src/components/expression-keypad.tsx
@@ -10,15 +10,16 @@ import KeyConfigs from "../data/key-configs";
 import {View} from "../fake-react-native-web/index";
 
 import {valueGrey, controlGrey} from "./common-style";
+import GestureManager from "./gesture-manager";
 import * as CursorContexts from "./input/cursor-contexts";
 import ManyKeypadButton from "./many-keypad-button";
 import Styles from "./styles";
 import TouchableKeypadButton from "./touchable-keypad-button";
 import TwoPageKeypad from "./two-page-keypad";
+
+import type {Key} from "../data/keys";
 import type {KeypadLayout, Popover, Echo} from "../types";
 import type {CursorContext} from "./input/cursor-contexts";
-import type {Key} from "../data/keys";
-import GestureManager from "./gesture-manager";
 
 const {row, column, oneColumn, fullWidth, roundedTopLeft, roundedTopRight} =
     Styles;

--- a/packages/math-input/src/components/expression-keypad.tsx
+++ b/packages/math-input/src/components/expression-keypad.tsx
@@ -17,6 +17,7 @@ import TouchableKeypadButton from "./touchable-keypad-button";
 import TwoPageKeypad from "./two-page-keypad";
 import type {KeypadLayout, Popover, Echo} from "../types";
 import type {CursorContext} from "./input/cursor-contexts";
+import GestureManager from "./gesture-manager";
 
 const {row, column, oneColumn, fullWidth, roundedTopLeft, roundedTopRight} =
     Styles;
@@ -32,6 +33,7 @@ type Props = {
     active: boolean;
     echoes: ReadonlyArray<Echo>;
     popover: Popover | null;
+    gestureManager: GestureManager;
     removeEcho?: (animationId: string) => void;
 };
 
@@ -58,6 +60,7 @@ class ExpressionKeypad extends React.Component<Props> {
             active,
             echoes,
             popover,
+            gestureManager,
             removeEcho,
         } = this.props;
 
@@ -118,7 +121,10 @@ class ExpressionKeypad extends React.Component<Props> {
                         keyConfig={KeyConfigs.NUM_1}
                         borders={BorderStyles.BOTTOM}
                     />
-                    <ManyKeypadButton keys={extraKeys} />
+                    <ManyKeypadButton
+                        keys={extraKeys}
+                        gestureManager={gestureManager}
+                    />
                 </View>
                 <View style={[column, oneColumn]}>
                     <TouchableKeypadButton

--- a/packages/math-input/src/components/expression-keypad.tsx
+++ b/packages/math-input/src/components/expression-keypad.tsx
@@ -17,6 +17,7 @@ import TouchableKeypadButton from "./touchable-keypad-button";
 import TwoPageKeypad from "./two-page-keypad";
 import type {KeypadLayout, Popover, Echo} from "../types";
 import type {CursorContext} from "./input/cursor-contexts";
+import type {Key} from "../data/keys";
 import GestureManager from "./gesture-manager";
 
 const {row, column, oneColumn, fullWidth, roundedTopLeft, roundedTopRight} =
@@ -36,6 +37,7 @@ type Props = {
     heightPx: number;
     widthPx: number;
     gestureManager: GestureManager;
+    gestureFocus: Key | null;
     removeEcho?: (animationId: string) => void;
 };
 
@@ -65,8 +67,17 @@ class ExpressionKeypad extends React.Component<Props> {
             heightPx,
             widthPx,
             gestureManager,
+            gestureFocus,
             removeEcho,
         } = this.props;
+
+        const sharedButtonProps = {
+            gestureFocus,
+            popover,
+            heightPx,
+            widthPx,
+            gestureManager,
+        };
 
         let dismissOrJumpOutKey;
         if (dynamicJumpOut) {
@@ -116,87 +127,105 @@ class ExpressionKeypad extends React.Component<Props> {
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.NUM_7}
                         borders={BorderStyles.NONE}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.NUM_4}
                         borders={BorderStyles.NONE}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.NUM_1}
                         borders={BorderStyles.BOTTOM}
+                        {...sharedButtonProps}
                     />
-                    <ManyKeypadButton
-                        keys={extraKeys}
-                        gestureManager={gestureManager}
-                    />
+                    <ManyKeypadButton keys={extraKeys} {...sharedButtonProps} />
                 </View>
                 <View style={[column, oneColumn]}>
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.NUM_8}
                         borders={BorderStyles.NONE}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.NUM_5}
                         borders={BorderStyles.NONE}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.NUM_2}
                         borders={BorderStyles.NONE}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.NUM_0}
                         borders={BorderStyles.LEFT}
+                        {...sharedButtonProps}
                     />
                 </View>
                 <View style={[column, oneColumn]}>
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.NUM_9}
                         borders={BorderStyles.NONE}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.NUM_6}
                         borders={BorderStyles.NONE}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.NUM_3}
                         borders={BorderStyles.BOTTOM}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.DECIMAL}
                         borders={BorderStyles.LEFT}
+                        {...sharedButtonProps}
                     />
                 </View>
                 <View style={[column, oneColumn]}>
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.DIVIDE}
                         borders={BorderStyles.LEFT}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.TIMES}
                         borders={BorderStyles.LEFT}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.MINUS}
                         borders={BorderStyles.LEFT}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.PLUS}
                         borders={BorderStyles.LEFT}
+                        {...sharedButtonProps}
                     />
                 </View>
                 <View style={[column, oneColumn]}>
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.FRAC}
                         style={roundTopRight && roundedTopRight}
+                        {...sharedButtonProps}
                     />
-                    <TouchableKeypadButton keyConfig={KeyConfigs.CDOT} />
+                    <TouchableKeypadButton
+                        keyConfig={KeyConfigs.CDOT}
+                        {...sharedButtonProps}
+                    />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.BACKSPACE}
                         borders={BorderStyles.LEFT}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={dismissOrJumpOutKey}
                         borders={BorderStyles.LEFT}
+                        {...sharedButtonProps}
                     />
                 </View>
             </View>
@@ -215,87 +244,109 @@ class ExpressionKeypad extends React.Component<Props> {
                         keyConfig={KeyConfigs.EXP_2}
                         borders={BorderStyles.NONE}
                         style={roundTopLeft && roundedTopLeft}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.SQRT}
                         borders={BorderStyles.NONE}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.LOG}
                         borders={BorderStyles.BOTTOM}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.SIN}
                         borders={BorderStyles.NONE}
+                        {...sharedButtonProps}
                     />
                 </View>
                 <View style={[column, oneColumn]}>
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.EXP_3}
                         borders={BorderStyles.NONE}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.CUBE_ROOT}
                         borders={BorderStyles.NONE}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.LN}
                         borders={BorderStyles.BOTTOM}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.COS}
                         borders={BorderStyles.NONE}
+                        {...sharedButtonProps}
                     />
                 </View>
                 <View style={[column, oneColumn]}>
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.EXP}
                         borders={BorderStyles.NONE}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.RADICAL}
                         borders={BorderStyles.NONE}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.LOG_N}
                         borders={BorderStyles.BOTTOM}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.TAN}
                         borders={BorderStyles.NONE}
+                        {...sharedButtonProps}
                     />
                 </View>
                 <View style={[column, oneColumn]}>
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.GEQ}
                         borders={BorderStyles.LEFT}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.EQUAL}
                         borders={BorderStyles.LEFT}
+                        {...sharedButtonProps}
                     />
-                    <TouchableKeypadButton keyConfig={KeyConfigs.LEQ} />
+                    <TouchableKeypadButton
+                        keyConfig={KeyConfigs.LEQ}
+                        {...sharedButtonProps}
+                    />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.LEFT_PAREN}
                         borders={BorderStyles.LEFT}
+                        {...sharedButtonProps}
                     />
                 </View>
                 <View style={[column, oneColumn]}>
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.GT}
                         borders={BorderStyles.NONE}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.NEQ}
                         borders={BorderStyles.NONE}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.LT}
                         borders={BorderStyles.BOTTOM}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.RIGHT_PAREN}
                         borders={BorderStyles.NONE}
+                        {...sharedButtonProps}
                     />
                 </View>
             </View>
@@ -312,6 +363,8 @@ class ExpressionKeypad extends React.Component<Props> {
                 popover={popover}
                 heightPx={heightPx}
                 widthPx={widthPx}
+                gestureManager={gestureManager}
+                gestureFocus={gestureFocus}
                 removeEcho={removeEcho}
             />
         );

--- a/packages/math-input/src/components/fraction-keypad.tsx
+++ b/packages/math-input/src/components/fraction-keypad.tsx
@@ -15,6 +15,8 @@ import Styles from "./styles";
 import TouchableKeypadButton from "./touchable-keypad-button";
 import type {KeypadLayout, Popover, Echo} from "../types";
 import type {CursorContext} from "./input/cursor-contexts";
+import type {Key} from "../data/keys";
+import GestureManager from "./gesture-manager";
 
 const {row, roundedTopLeft, roundedTopRight} = Styles;
 
@@ -28,6 +30,8 @@ type Props = {
     popover: Popover | null;
     heightPx: number;
     widthPx: number;
+    gestureManager: GestureManager;
+    gestureFocus: Key | null;
     removeEcho?: (animationId: string) => void;
 };
 
@@ -54,7 +58,17 @@ class FractionKeypad extends React.Component<Props> {
             removeEcho,
             heightPx,
             widthPx,
+            gestureManager,
+            gestureFocus,
         } = this.props;
+
+        const sharedButtonProps = {
+            popover,
+            heightPx,
+            widthPx,
+            gestureManager,
+            gestureFocus,
+        };
 
         let dismissOrJumpOutKey;
         if (dynamicJumpOut) {
@@ -100,20 +114,25 @@ class FractionKeypad extends React.Component<Props> {
                 removeEcho={removeEcho}
                 heightPx={heightPx}
                 widthPx={widthPx}
+                gestureManager={gestureManager}
+                gestureFocus={gestureFocus}
             >
                 <View style={row}>
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.NUM_7}
                         borders={BorderStyles.NONE}
                         style={roundTopLeft && roundedTopLeft}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.NUM_8}
                         borders={BorderStyles.NONE}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.NUM_9}
                         borders={BorderStyles.NONE}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.FRAC}
@@ -128,57 +147,72 @@ class FractionKeypad extends React.Component<Props> {
                             cursorContext === CursorContexts.IN_DENOMINATOR
                         }
                         style={roundTopRight && roundedTopRight}
+                        {...sharedButtonProps}
                     />
                 </View>
                 <View style={row}>
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.NUM_4}
                         borders={BorderStyles.NONE}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.NUM_5}
                         borders={BorderStyles.NONE}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.NUM_6}
                         borders={BorderStyles.NONE}
+                        {...sharedButtonProps}
                     />
-                    <TouchableKeypadButton keyConfig={KeyConfigs.PERCENT} />
+                    <TouchableKeypadButton
+                        keyConfig={KeyConfigs.PERCENT}
+                        {...sharedButtonProps}
+                    />
                 </View>
                 <View style={row}>
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.NUM_1}
                         borders={BorderStyles.BOTTOM}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.NUM_2}
                         borders={BorderStyles.NONE}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.NUM_3}
                         borders={BorderStyles.BOTTOM}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.BACKSPACE}
                         borders={BorderStyles.LEFT}
+                        {...sharedButtonProps}
                     />
                 </View>
                 <View style={row}>
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.NEGATIVE}
                         borders={BorderStyles.NONE}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.NUM_0}
                         borders={BorderStyles.LEFT}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.DECIMAL}
                         borders={BorderStyles.LEFT}
+                        {...sharedButtonProps}
                     />
                     <TouchableKeypadButton
                         keyConfig={dismissOrJumpOutKey}
                         borders={BorderStyles.LEFT}
+                        {...sharedButtonProps}
                     />
                 </View>
             </Keypad>

--- a/packages/math-input/src/components/fraction-keypad.tsx
+++ b/packages/math-input/src/components/fraction-keypad.tsx
@@ -14,9 +14,10 @@ import * as CursorContexts from "./input/cursor-contexts";
 import Keypad from "./keypad";
 import Styles from "./styles";
 import TouchableKeypadButton from "./touchable-keypad-button";
+import {removeEcho} from "../actions/index";
 
 import type {State} from "../store/types";
-import type {KeypadLayout} from "../types";
+import type {KeypadLayout, Popover, Echo} from "../types";
 import type {CursorContext} from "./input/cursor-contexts";
 
 const {row, roundedTopLeft, roundedTopRight} = Styles;
@@ -24,11 +25,15 @@ const {row, roundedTopLeft, roundedTopRight} = Styles;
 interface ReduxProps {
     cursorContext?: CursorContext;
     dynamicJumpOut: boolean;
+    active: boolean;
+    echoes: ReadonlyArray<Echo>;
+    popover: Popover | null;
 }
 
 interface Props extends ReduxProps {
     roundTopLeft: boolean;
     roundTopRight: boolean;
+    removeEcho?: (animationId: string) => void;
 }
 
 export const fractionKeypadLayout: KeypadLayout = {
@@ -43,8 +48,16 @@ export const fractionKeypadLayout: KeypadLayout = {
 
 class FractionKeypad extends React.Component<Props> {
     render() {
-        const {cursorContext, dynamicJumpOut, roundTopLeft, roundTopRight} =
-            this.props;
+        const {
+            cursorContext,
+            dynamicJumpOut,
+            roundTopLeft,
+            roundTopRight,
+            active,
+            echoes,
+            popover,
+            removeEcho,
+        } = this.props;
 
         let dismissOrJumpOutKey;
         if (dynamicJumpOut) {
@@ -83,7 +96,12 @@ class FractionKeypad extends React.Component<Props> {
         }
 
         return (
-            <Keypad>
+            <Keypad
+                active={active}
+                echoes={echoes}
+                popover={popover}
+                removeEcho={removeEcho}
+            >
                 <View style={row}>
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.NUM_7}
@@ -173,9 +191,20 @@ const mapStateToProps = (state: State): ReduxProps => {
     return {
         cursorContext: state.input.cursor?.context,
         dynamicJumpOut: !state.layout.navigationPadEnabled,
+        echoes: state.echoes.echoes,
+        active: state.keypad.active,
+        popover: state.gestures.popover,
     };
 };
 
-export default connect(mapStateToProps, null, null, {forwardRef: true})(
-    FractionKeypad,
-);
+const mapDispatchToProps = (dispatch) => {
+    return {
+        removeEcho: (animationId) => {
+            dispatch(removeEcho(animationId));
+        },
+    };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps, null, {
+    forwardRef: true,
+})(FractionKeypad);

--- a/packages/math-input/src/components/fraction-keypad.tsx
+++ b/packages/math-input/src/components/fraction-keypad.tsx
@@ -26,6 +26,8 @@ type Props = {
     active: boolean;
     echoes: ReadonlyArray<Echo>;
     popover: Popover | null;
+    heightPx: number;
+    widthPx: number;
     removeEcho?: (animationId: string) => void;
 };
 
@@ -50,6 +52,8 @@ class FractionKeypad extends React.Component<Props> {
             echoes,
             popover,
             removeEcho,
+            heightPx,
+            widthPx,
         } = this.props;
 
         let dismissOrJumpOutKey;
@@ -94,6 +98,8 @@ class FractionKeypad extends React.Component<Props> {
                 echoes={echoes}
                 popover={popover}
                 removeEcho={removeEcho}
+                heightPx={heightPx}
+                widthPx={widthPx}
             >
                 <View style={row}>
                     <TouchableKeypadButton

--- a/packages/math-input/src/components/fraction-keypad.tsx
+++ b/packages/math-input/src/components/fraction-keypad.tsx
@@ -4,7 +4,6 @@
  */
 
 import * as React from "react";
-import {connect} from "react-redux";
 
 import {BorderStyles} from "../consts";
 import KeyConfigs from "../data/key-configs";
@@ -14,27 +13,21 @@ import * as CursorContexts from "./input/cursor-contexts";
 import Keypad from "./keypad";
 import Styles from "./styles";
 import TouchableKeypadButton from "./touchable-keypad-button";
-import {removeEcho} from "../actions/index";
-
-import type {State} from "../store/types";
 import type {KeypadLayout, Popover, Echo} from "../types";
 import type {CursorContext} from "./input/cursor-contexts";
 
 const {row, roundedTopLeft, roundedTopRight} = Styles;
 
-interface ReduxProps {
+type Props = {
+    roundTopLeft: boolean;
+    roundTopRight: boolean;
     cursorContext?: CursorContext;
     dynamicJumpOut: boolean;
     active: boolean;
     echoes: ReadonlyArray<Echo>;
     popover: Popover | null;
-}
-
-interface Props extends ReduxProps {
-    roundTopLeft: boolean;
-    roundTopRight: boolean;
     removeEcho?: (animationId: string) => void;
-}
+};
 
 export const fractionKeypadLayout: KeypadLayout = {
     rows: 4,
@@ -187,24 +180,4 @@ class FractionKeypad extends React.Component<Props> {
     }
 }
 
-const mapStateToProps = (state: State): ReduxProps => {
-    return {
-        cursorContext: state.input.cursor?.context,
-        dynamicJumpOut: !state.layout.navigationPadEnabled,
-        echoes: state.echoes.echoes,
-        active: state.keypad.active,
-        popover: state.gestures.popover,
-    };
-};
-
-const mapDispatchToProps = (dispatch) => {
-    return {
-        removeEcho: (animationId) => {
-            dispatch(removeEcho(animationId));
-        },
-    };
-};
-
-export default connect(mapStateToProps, mapDispatchToProps, null, {
-    forwardRef: true,
-})(FractionKeypad);
+export default FractionKeypad;

--- a/packages/math-input/src/components/fraction-keypad.tsx
+++ b/packages/math-input/src/components/fraction-keypad.tsx
@@ -9,14 +9,15 @@ import {BorderStyles} from "../consts";
 import KeyConfigs from "../data/key-configs";
 import {View} from "../fake-react-native-web/index";
 
+import GestureManager from "./gesture-manager";
 import * as CursorContexts from "./input/cursor-contexts";
 import Keypad from "./keypad";
 import Styles from "./styles";
 import TouchableKeypadButton from "./touchable-keypad-button";
+
+import type {Key} from "../data/keys";
 import type {KeypadLayout, Popover, Echo} from "../types";
 import type {CursorContext} from "./input/cursor-contexts";
-import type {Key} from "../data/keys";
-import GestureManager from "./gesture-manager";
 
 const {row, roundedTopLeft, roundedTopRight} = Styles;
 

--- a/packages/math-input/src/components/keypad-button.tsx
+++ b/packages/math-input/src/components/keypad-button.tsx
@@ -4,7 +4,6 @@
 
 import {StyleSheet, css} from "aphrodite";
 import * as React from "react";
-import {connect} from "react-redux";
 
 import {KeyTypes, BorderDirections, BorderStyles} from "../consts";
 import {View} from "../fake-react-native-web/index";
@@ -24,16 +23,10 @@ import Icon from "./icon";
 import MultiSymbolGrid from "./multi-symbol-grid";
 
 import type {KeyType} from "../consts";
-import type {State} from "../store/types";
 import type {Border, KeyConfig, Icon as IconType} from "../types";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
-interface ReduxProps {
-    heightPx: number;
-    widthPx: number;
-}
-
-interface Props extends ReduxProps {
+type Props = {
     ariaLabel?: string;
     borders: Border;
     childKeys: ReadonlyArray<KeyConfig>;
@@ -42,6 +35,8 @@ interface Props extends ReduxProps {
     popoverEnabled: boolean;
     type: KeyType;
     icon: IconType;
+    heightPx: number;
+    widthPx: number;
     style?: StyleType;
     onTouchCancel?: (evt: React.TouchEvent<HTMLDivElement>) => void;
     onTouchEnd?: (evt: React.TouchEvent<HTMLDivElement>) => void;
@@ -50,7 +45,7 @@ interface Props extends ReduxProps {
     // NOTE(matthewc)[LC-754] this is a normal React thing, but TS
     // gets mad if I don't explicitly set it as a prop
     ref?: (any) => void;
-}
+};
 
 // eslint-disable-next-line react/no-unsafe
 class KeypadButton extends React.PureComponent<Props> {
@@ -355,13 +350,4 @@ const styleForButtonDimensions = (heightPx, widthPx) => {
     }).buttonSize;
 };
 
-const mapStateToProps = (state: State): ReduxProps => {
-    return {
-        heightPx: state.layout.buttonDimensions.heightPx,
-        widthPx: state.layout.buttonDimensions.widthPx,
-    };
-};
-
-export default connect(mapStateToProps, null, null, {forwardRef: true})(
-    KeypadButton,
-);
+export default KeypadButton;

--- a/packages/math-input/src/components/keypad-button.tsx
+++ b/packages/math-input/src/components/keypad-button.tsx
@@ -34,7 +34,7 @@ type Props = {
     focused: boolean;
     popoverEnabled: boolean;
     type: KeyType;
-    icon: IconType;
+    icon?: IconType;
     heightPx: number;
     widthPx: number;
     style?: StyleType;
@@ -223,9 +223,11 @@ class KeypadButton extends React.PureComponent<Props> {
                 role: "button",
                 ariaLabel: childKeys[0].ariaLabel,
             };
-            const icons = childKeys.map((keyConfig) => {
-                return keyConfig.icon;
-            });
+            const icons: ReadonlyArray<IconType> = childKeys.map(
+                (keyConfig) => {
+                    return keyConfig.icon;
+                },
+            ) as any;
             return (
                 <View
                     style={buttonStyle}
@@ -252,7 +254,7 @@ class KeypadButton extends React.PureComponent<Props> {
                 <View style={buttonStyle} {...eventHandlers} {...a11yMarkup}>
                     {maybeFocusBox}
                     <View style={iconWrapperStyle}>
-                        <Icon icon={icon} focused={renderFocused} />
+                        <Icon icon={icon as IconType} focused={renderFocused} />
                     </View>
                     {maybeCornerDecal}
                 </View>

--- a/packages/math-input/src/components/keypad-container.tsx
+++ b/packages/math-input/src/components/keypad-container.tsx
@@ -14,17 +14,17 @@ import {
 } from "./common-style";
 import ExpressionKeypad from "./expression-keypad";
 import FractionKeypad from "./fraction-keypad";
+import GestureManager from "./gesture-manager";
 import NavigationPad from "./navigation-pad";
 import Styles from "./styles";
 import * as zIndexes from "./z-indexes";
-import GestureManager from "./gesture-manager";
 
 import type {KeypadType} from "../consts";
+import type {Key} from "../data/keys";
 import type {State as ReduxState} from "../store/types";
 import type {Popover, Echo} from "../types";
 import type {CursorContext} from "./input/cursor-contexts";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
-import type {Key} from "../data/keys";
 
 const {row, centered, fullWidth} = Styles;
 

--- a/packages/math-input/src/components/keypad-container.tsx
+++ b/packages/math-input/src/components/keypad-container.tsx
@@ -39,6 +39,8 @@ interface ReduxProps {
     paginationEnabled: boolean;
     echoes: ReadonlyArray<Echo>;
     popover: Popover | null;
+    heightPx: number;
+    widthPx: number;
     gestureManager: GestureManager;
 }
 
@@ -143,6 +145,8 @@ class KeypadContainer extends React.Component<Props, State> {
             currentPage,
             gestureManager,
             paginationEnabled,
+            heightPx,
+            widthPx,
         } = this.props;
 
         const keypadProps = {
@@ -159,6 +163,8 @@ class KeypadContainer extends React.Component<Props, State> {
             active,
             echoes,
             popover,
+            heightPx,
+            widthPx,
             removeEcho,
         };
 
@@ -345,6 +351,8 @@ const mapStateToProps = (state: ReduxState): ReduxProps => {
         echoes: state.echoes.echoes,
         popover: state.gestures.popover,
         gestureManager: state.gestures.gestureManager,
+        heightPx: state.layout.buttonDimensions.heightPx,
+        widthPx: state.layout.buttonDimensions.widthPx,
     };
 };
 

--- a/packages/math-input/src/components/keypad-container.tsx
+++ b/packages/math-input/src/components/keypad-container.tsx
@@ -24,6 +24,7 @@ import type {State as ReduxState} from "../store/types";
 import type {Popover, Echo} from "../types";
 import type {CursorContext} from "./input/cursor-contexts";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
+import type {Key} from "../data/keys";
 
 const {row, centered, fullWidth} = Styles;
 
@@ -42,6 +43,7 @@ interface ReduxProps {
     heightPx: number;
     widthPx: number;
     gestureManager: GestureManager;
+    gestureFocus: Key | null;
 }
 
 interface Props extends ReduxProps {
@@ -144,6 +146,7 @@ class KeypadContainer extends React.Component<Props, State> {
             removeEcho,
             currentPage,
             gestureManager,
+            gestureFocus,
             paginationEnabled,
             heightPx,
             widthPx,
@@ -165,6 +168,8 @@ class KeypadContainer extends React.Component<Props, State> {
             popover,
             heightPx,
             widthPx,
+            gestureManager,
+            gestureFocus,
             removeEcho,
         };
 
@@ -185,7 +190,6 @@ class KeypadContainer extends React.Component<Props, State> {
                         {...keypadProps}
                         currentPage={currentPage}
                         paginationEnabled={paginationEnabled}
-                        gestureManager={gestureManager}
                     />
                 );
 
@@ -201,6 +205,11 @@ class KeypadContainer extends React.Component<Props, State> {
             navigationPadEnabled,
             onElementMounted,
             style,
+            gestureManager,
+            gestureFocus,
+            popover,
+            heightPx,
+            widthPx,
         } = this.props;
         const {hasBeenActivated} = this.state;
 
@@ -256,6 +265,11 @@ class KeypadContainer extends React.Component<Props, State> {
                         <NavigationPad
                             roundTopLeft={layoutMode === LayoutModes.COMPACT}
                             style={styles.navigationPadContainer}
+                            gestureManager={gestureManager}
+                            gestureFocus={gestureFocus}
+                            popover={popover}
+                            heightPx={heightPx}
+                            widthPx={widthPx}
                         />
                     )}
                     <View style={styles.keypadLayout}>
@@ -351,6 +365,7 @@ const mapStateToProps = (state: ReduxState): ReduxProps => {
         echoes: state.echoes.echoes,
         popover: state.gestures.popover,
         gestureManager: state.gestures.gestureManager,
+        gestureFocus: state.gestures.focus,
         heightPx: state.layout.buttonDimensions.heightPx,
         widthPx: state.layout.buttonDimensions.widthPx,
     };

--- a/packages/math-input/src/components/keypad-container.tsx
+++ b/packages/math-input/src/components/keypad-container.tsx
@@ -17,6 +17,7 @@ import FractionKeypad from "./fraction-keypad";
 import NavigationPad from "./navigation-pad";
 import Styles from "./styles";
 import * as zIndexes from "./z-indexes";
+import GestureManager from "./gesture-manager";
 
 import type {KeypadType} from "../consts";
 import type {State as ReduxState} from "../store/types";
@@ -38,6 +39,7 @@ interface ReduxProps {
     paginationEnabled: boolean;
     echoes: ReadonlyArray<Echo>;
     popover: Popover | null;
+    gestureManager: GestureManager;
 }
 
 interface Props extends ReduxProps {
@@ -139,6 +141,7 @@ class KeypadContainer extends React.Component<Props, State> {
             popover,
             removeEcho,
             currentPage,
+            gestureManager,
             paginationEnabled,
         } = this.props;
 
@@ -176,6 +179,7 @@ class KeypadContainer extends React.Component<Props, State> {
                         {...keypadProps}
                         currentPage={currentPage}
                         paginationEnabled={paginationEnabled}
+                        gestureManager={gestureManager}
                     />
                 );
 
@@ -340,6 +344,7 @@ const mapStateToProps = (state: ReduxState): ReduxProps => {
         paginationEnabled: state.layout.paginationEnabled,
         echoes: state.echoes.echoes,
         popover: state.gestures.popover,
+        gestureManager: state.gestures.gestureManager,
     };
 };
 

--- a/packages/math-input/src/components/keypad.tsx
+++ b/packages/math-input/src/components/keypad.tsx
@@ -5,29 +5,23 @@
 
 import * as React from "react";
 import ReactDOM from "react-dom";
-import {connect} from "react-redux";
 
-import {removeEcho} from "../actions/index";
 import {View} from "../fake-react-native-web/index";
 
 import EchoManager from "./echo-manager";
 import PopoverManager from "./popover-manager";
 
-import type {State} from "../store/types";
 import type {Popover, Echo} from "../types";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
-interface ReduxProps {
-    active: boolean;
-    echoes: ReadonlyArray<Echo>;
-    popover: Popover | null;
-}
-
-interface Props extends ReduxProps {
+type Props = {
     children: React.ReactNode;
     style?: StyleType;
     removeEcho?: (animationId: string) => void;
-}
+    active: boolean;
+    echoes: ReadonlyArray<Echo>;
+    popover: Popover | null;
+};
 
 // eslint-disable-next-line react/no-unsafe
 class Keypad extends React.Component<Props> {
@@ -141,22 +135,4 @@ class Keypad extends React.Component<Props> {
     }
 }
 
-const mapStateToProps = (state: State): ReduxProps => {
-    return {
-        echoes: state.echoes.echoes,
-        active: state.keypad.active,
-        popover: state.gestures.popover,
-    };
-};
-
-const mapDispatchToProps = (dispatch) => {
-    return {
-        removeEcho: (animationId) => {
-            dispatch(removeEcho(animationId));
-        },
-    };
-};
-
-export default connect(mapStateToProps, mapDispatchToProps, null, {
-    forwardRef: true,
-})(Keypad);
+export default Keypad;

--- a/packages/math-input/src/components/keypad.tsx
+++ b/packages/math-input/src/components/keypad.tsx
@@ -13,6 +13,7 @@ import PopoverManager from "./popover-manager";
 
 import type {Popover, Echo} from "../types";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
+import GestureManager from "./gesture-manager";
 
 type Props = {
     children: React.ReactNode;
@@ -20,6 +21,8 @@ type Props = {
     removeEcho?: (animationId: string) => void;
     active: boolean;
     echoes: ReadonlyArray<Echo>;
+    gestureManager: GestureManager;
+    gestureFocus: any;
     popover: Popover | null;
     heightPx: number;
     widthPx: number;
@@ -92,6 +95,8 @@ class Keypad extends React.Component<Props> {
             style,
             heightPx,
             widthPx,
+            gestureManager,
+            gestureFocus,
         } = this.props;
 
         // Translate the echo boxes, as they'll be positioned absolutely to
@@ -141,7 +146,13 @@ class Keypad extends React.Component<Props> {
                     heightPx={heightPx}
                     widthPx={widthPx}
                 />
-                <PopoverManager popover={relativePopover} />
+                <PopoverManager
+                    popover={relativePopover}
+                    heightPx={heightPx}
+                    widthPx={widthPx}
+                    gestureManager={gestureManager}
+                    gestureFocus={gestureFocus}
+                />
             </View>
         );
     }

--- a/packages/math-input/src/components/keypad.tsx
+++ b/packages/math-input/src/components/keypad.tsx
@@ -9,11 +9,11 @@ import ReactDOM from "react-dom";
 import {View} from "../fake-react-native-web/index";
 
 import EchoManager from "./echo-manager";
+import GestureManager from "./gesture-manager";
 import PopoverManager from "./popover-manager";
 
 import type {Popover, Echo} from "../types";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
-import GestureManager from "./gesture-manager";
 
 type Props = {
     children: React.ReactNode;

--- a/packages/math-input/src/components/keypad.tsx
+++ b/packages/math-input/src/components/keypad.tsx
@@ -21,6 +21,8 @@ type Props = {
     active: boolean;
     echoes: ReadonlyArray<Echo>;
     popover: Popover | null;
+    heightPx: number;
+    widthPx: number;
 };
 
 // eslint-disable-next-line react/no-unsafe
@@ -82,7 +84,15 @@ class Keypad extends React.Component<Props> {
     };
 
     render() {
-        const {children, echoes, removeEcho, popover, style} = this.props;
+        const {
+            children,
+            echoes,
+            removeEcho,
+            popover,
+            style,
+            heightPx,
+            widthPx,
+        } = this.props;
 
         // Translate the echo boxes, as they'll be positioned absolutely to
         // this relative container.
@@ -128,6 +138,8 @@ class Keypad extends React.Component<Props> {
                 <EchoManager
                     echoes={relativeEchoes}
                     onAnimationFinish={removeEcho}
+                    heightPx={heightPx}
+                    widthPx={widthPx}
                 />
                 <PopoverManager popover={relativePopover} />
             </View>

--- a/packages/math-input/src/components/many-keypad-button.tsx
+++ b/packages/math-input/src/components/many-keypad-button.tsx
@@ -10,8 +10,9 @@ import KeyConfigs from "../data/key-configs";
 import Keys from "../data/keys";
 
 import EmptyKeypadButton from "./empty-keypad-button";
-import TouchableKeypadButton from "./touchable-keypad-button";
 import GestureManager from "./gesture-manager";
+import TouchableKeypadButton from "./touchable-keypad-button";
+
 import type {Popover} from "../types";
 
 type Props = {

--- a/packages/math-input/src/components/many-keypad-button.tsx
+++ b/packages/math-input/src/components/many-keypad-button.tsx
@@ -12,10 +12,15 @@ import Keys from "../data/keys";
 import EmptyKeypadButton from "./empty-keypad-button";
 import TouchableKeypadButton from "./touchable-keypad-button";
 import GestureManager from "./gesture-manager";
+import type {Popover} from "../types";
 
 type Props = {
     keys: ReadonlyArray<string>;
     gestureManager: GestureManager;
+    gestureFocus: any;
+    popover: Popover | null;
+    heightPx: number;
+    widthPx: number;
 };
 
 class ManyKeypadButton extends React.Component<Props> {
@@ -24,23 +29,33 @@ class ManyKeypadButton extends React.Component<Props> {
     };
 
     render() {
-        const {keys, gestureManager, ...rest} = this.props;
+        const {keys, gestureManager, gestureFocus, popover, heightPx, widthPx} =
+            this.props;
 
         // If we have no extra symbols, render an empty button. If we have just
         // one, render a standard button. Otherwise, capture them all in a
         // single button.
         if (keys.length === 0) {
             return <EmptyKeypadButton gestureManager={gestureManager} />;
-        } else if (keys.length === 1) {
-            const keyConfig = KeyConfigs[keys[0]];
-            return <TouchableKeypadButton keyConfig={keyConfig} {...rest} />;
         } else {
-            const keyConfig = {
-                id: Keys.MANY,
-                type: KeyTypes.MANY,
-                childKeyIds: keys,
-            };
-            return <TouchableKeypadButton keyConfig={keyConfig} {...rest} />;
+            const keyConfig =
+                keys.length === 1
+                    ? KeyConfigs[keys[0]]
+                    : {
+                          id: Keys.MANY,
+                          type: KeyTypes.MANY,
+                          childKeyIds: keys,
+                      };
+            return (
+                <TouchableKeypadButton
+                    keyConfig={keyConfig}
+                    gestureManager={gestureManager}
+                    gestureFocus={gestureFocus}
+                    popover={popover}
+                    heightPx={heightPx}
+                    widthPx={widthPx}
+                />
+            );
         }
     }
 }

--- a/packages/math-input/src/components/many-keypad-button.tsx
+++ b/packages/math-input/src/components/many-keypad-button.tsx
@@ -11,9 +11,11 @@ import Keys from "../data/keys";
 
 import EmptyKeypadButton from "./empty-keypad-button";
 import TouchableKeypadButton from "./touchable-keypad-button";
+import GestureManager from "./gesture-manager";
 
 type Props = {
     keys: ReadonlyArray<string>;
+    gestureManager: GestureManager;
 };
 
 class ManyKeypadButton extends React.Component<Props> {
@@ -22,13 +24,13 @@ class ManyKeypadButton extends React.Component<Props> {
     };
 
     render() {
-        const {keys, ...rest} = this.props;
+        const {keys, gestureManager, ...rest} = this.props;
 
         // If we have no extra symbols, render an empty button. If we have just
         // one, render a standard button. Otherwise, capture them all in a
         // single button.
         if (keys.length === 0) {
-            return <EmptyKeypadButton />;
+            return <EmptyKeypadButton gestureManager={gestureManager} />;
         } else if (keys.length === 1) {
             const keyConfig = KeyConfigs[keys[0]];
             return <TouchableKeypadButton keyConfig={keyConfig} {...rest} />;

--- a/packages/math-input/src/components/multi-symbol-popover.tsx
+++ b/packages/math-input/src/components/multi-symbol-popover.tsx
@@ -11,14 +11,22 @@ import {KeyConfig} from "../types";
 
 import TouchableKeypadButton from "./touchable-keypad-button";
 import * as zIndexes from "./z-indexes";
+import GestureManager from "./gesture-manager";
+import type {Popover} from "../types";
 
 type Prop = {
     keys: ReadonlyArray<KeyConfig>;
+    gestureManager: GestureManager;
+    gestureFocus: any;
+    popover: Popover | null;
+    heightPx: number;
+    widthPx: number;
 };
 
 class MultiSymbolPopover extends React.Component<Prop> {
     render() {
-        const {keys} = this.props;
+        const {keys, gestureManager, gestureFocus, popover, heightPx, widthPx} =
+            this.props;
 
         // TODO(charlie): We have to require this lazily because of a cyclic
         // dependence in our components.
@@ -30,6 +38,11 @@ class MultiSymbolPopover extends React.Component<Prop> {
                             key={key.id}
                             keyConfig={key}
                             borders={BorderStyles.NONE}
+                            gestureManager={gestureManager}
+                            gestureFocus={gestureFocus}
+                            popover={popover}
+                            heightPx={heightPx}
+                            widthPx={widthPx}
                         />
                     );
                 })}

--- a/packages/math-input/src/components/multi-symbol-popover.tsx
+++ b/packages/math-input/src/components/multi-symbol-popover.tsx
@@ -9,9 +9,10 @@ import {BorderStyles} from "../consts";
 import {View} from "../fake-react-native-web/index";
 import {KeyConfig} from "../types";
 
+import GestureManager from "./gesture-manager";
 import TouchableKeypadButton from "./touchable-keypad-button";
 import * as zIndexes from "./z-indexes";
-import GestureManager from "./gesture-manager";
+
 import type {Popover} from "../types";
 
 type Prop = {

--- a/packages/math-input/src/components/navigation-pad.tsx
+++ b/packages/math-input/src/components/navigation-pad.tsx
@@ -18,6 +18,8 @@ import {
 } from "./common-style";
 import Styles from "./styles";
 import TouchableKeypadButton from "./touchable-keypad-button";
+import GestureManager from "./gesture-manager";
+import type {Popover} from "../types";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
@@ -26,13 +28,34 @@ const {row, column, centered, stretch, roundedTopLeft} = Styles;
 type Props = {
     roundTopLeft: boolean;
     style: StyleType;
+    gestureManager: GestureManager;
+    gestureFocus: any;
+    popover: Popover | null;
+    heightPx: number;
+    widthPx: number;
 };
 
 class NavigationPad extends React.Component<Props> {
     render() {
         // TODO(charlie): Disable the navigational arrows depending on the
         // cursor context.
-        const {roundTopLeft, style} = this.props;
+        const {
+            roundTopLeft,
+            style,
+            gestureManager,
+            gestureFocus,
+            popover,
+            heightPx,
+            widthPx,
+        } = this.props;
+
+        const sharedButtonProps = {
+            gestureManager,
+            gestureFocus,
+            popover,
+            heightPx,
+            widthPx,
+        };
 
         const containerStyle = [
             column,
@@ -49,6 +72,7 @@ class NavigationPad extends React.Component<Props> {
                         keyConfig={KeyConfigs.UP}
                         borders={BorderStyles.NONE}
                         style={[styles.navigationKey, styles.topArrow]}
+                        {...sharedButtonProps}
                     />
                 </View>
                 <View style={[row, centered, stretch]}>
@@ -56,12 +80,14 @@ class NavigationPad extends React.Component<Props> {
                         keyConfig={KeyConfigs.LEFT}
                         borders={BorderStyles.NONE}
                         style={[styles.navigationKey, styles.leftArrow]}
+                        {...sharedButtonProps}
                     />
                     <View style={styles.horizontalSpacer} />
                     <TouchableKeypadButton
                         keyConfig={KeyConfigs.RIGHT}
                         borders={BorderStyles.NONE}
                         style={[styles.navigationKey, styles.rightArrow]}
+                        {...sharedButtonProps}
                     />
                 </View>
                 <View style={[row, centered]}>
@@ -69,6 +95,7 @@ class NavigationPad extends React.Component<Props> {
                         keyConfig={KeyConfigs.DOWN}
                         borders={BorderStyles.NONE}
                         style={[styles.navigationKey, styles.bottomArrow]}
+                        {...sharedButtonProps}
                     />
                 </View>
             </View>

--- a/packages/math-input/src/components/navigation-pad.tsx
+++ b/packages/math-input/src/components/navigation-pad.tsx
@@ -16,11 +16,11 @@ import {
     valueGrey,
     offBlack16,
 } from "./common-style";
+import GestureManager from "./gesture-manager";
 import Styles from "./styles";
 import TouchableKeypadButton from "./touchable-keypad-button";
-import GestureManager from "./gesture-manager";
-import type {Popover} from "../types";
 
+import type {Popover} from "../types";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 const {row, column, centered, stretch, roundedTopLeft} = Styles;

--- a/packages/math-input/src/components/popover-manager.tsx
+++ b/packages/math-input/src/components/popover-manager.tsx
@@ -11,6 +11,7 @@ import KeyConfigs from "../data/key-configs";
 import MultiSymbolPopover from "./multi-symbol-popover";
 
 import type {Popover, KeyConfig} from "../types";
+import GestureManager from "./gesture-manager";
 
 // NOTE(charlie): These must be kept in sync with the transition durations and
 // classnames specified in popover.less.
@@ -21,13 +22,26 @@ type Props = {
     // TODO(matthewc) should be something like Bound, but couldn't fix errors
     bounds: any;
     childKeys: ReadonlyArray<KeyConfig>;
+    gestureManager: GestureManager;
+    gestureFocus: any;
+    popover: Popover | null;
+    heightPx: number;
+    widthPx: number;
 };
 
 // A container component used to position a popover absolutely at a specific
 // position.
 class PopoverContainer extends React.Component<Props> {
     render() {
-        const {bounds, childKeys} = this.props;
+        const {
+            bounds,
+            childKeys,
+            gestureManager,
+            gestureFocus,
+            popover,
+            heightPx,
+            widthPx,
+        } = this.props;
 
         const containerStyle = {
             position: "absolute",
@@ -36,7 +50,14 @@ class PopoverContainer extends React.Component<Props> {
 
         return (
             <div style={containerStyle}>
-                <MultiSymbolPopover keys={childKeys} />
+                <MultiSymbolPopover
+                    keys={childKeys}
+                    gestureManager={gestureManager}
+                    gestureFocus={gestureFocus}
+                    popover={popover}
+                    heightPx={heightPx}
+                    widthPx={widthPx}
+                />
             </div>
         );
     }
@@ -44,11 +65,16 @@ class PopoverContainer extends React.Component<Props> {
 
 type PopoverManagerProps = {
     popover: Popover | null;
+    gestureManager: GestureManager;
+    gestureFocus: any;
+    heightPx: number;
+    widthPx: number;
 };
 
 class PopoverManager extends React.Component<PopoverManagerProps> {
     render() {
-        const {popover} = this.props;
+        const {popover, gestureManager, gestureFocus, heightPx, widthPx} =
+            this.props;
 
         return popover ? (
             <CSSTransition
@@ -64,6 +90,11 @@ class PopoverManager extends React.Component<PopoverManagerProps> {
                     key={popover.childKeyIds[0]}
                     bounds={popover.bounds}
                     childKeys={popover.childKeyIds.map((id) => KeyConfigs[id])}
+                    popover={popover}
+                    gestureManager={gestureManager}
+                    gestureFocus={gestureFocus}
+                    heightPx={heightPx}
+                    widthPx={widthPx}
                 />
             </CSSTransition>
         ) : null;

--- a/packages/math-input/src/components/popover-manager.tsx
+++ b/packages/math-input/src/components/popover-manager.tsx
@@ -8,10 +8,10 @@ import {CSSTransition} from "react-transition-group";
 
 import KeyConfigs from "../data/key-configs";
 
+import GestureManager from "./gesture-manager";
 import MultiSymbolPopover from "./multi-symbol-popover";
 
 import type {Popover, KeyConfig} from "../types";
-import GestureManager from "./gesture-manager";
 
 // NOTE(charlie): These must be kept in sync with the transition durations and
 // classnames specified in popover.less.

--- a/packages/math-input/src/components/touchable-keypad-button.tsx
+++ b/packages/math-input/src/components/touchable-keypad-button.tsx
@@ -30,6 +30,8 @@ type Props = {
     style: StyleType;
     type: KeyType;
     icon: Icon;
+    heightPx: number;
+    widthPx: number;
 };
 
 class TouchableKeypadButton extends React.Component<Props> {
@@ -132,6 +134,8 @@ const mapStateToProps = (state, ownProps) => {
 
         // Pass down the child keys and any extracted props.
         childKeys,
+        heightPx: state.layout.buttonDimensions.heightPx,
+        widthPx: state.layout.buttonDimensions.widthPx,
         ...extractProps(useFirstChildProps ? childKeys[0] : keyConfig),
     };
 };

--- a/packages/math-input/src/components/two-page-keypad.tsx
+++ b/packages/math-input/src/components/two-page-keypad.tsx
@@ -16,6 +16,7 @@ import {
 import Keypad from "./keypad";
 import Styles from "./styles";
 import Tabbar from "./tabbar/tabbar";
+import type {Popover, Echo} from "../types";
 
 const {column, row, fullWidth} = Styles;
 
@@ -24,6 +25,10 @@ interface Props {
     leftPage: React.ReactNode;
     rightPage: React.ReactNode;
     paginationEnabled: boolean;
+    active: boolean;
+    echoes: ReadonlyArray<Echo>;
+    popover: Popover | null;
+    removeEcho?: (animationId: string) => void;
 }
 
 class TwoPageKeypad extends React.Component<Props> {
@@ -32,13 +37,27 @@ class TwoPageKeypad extends React.Component<Props> {
     };
 
     render() {
-        const {leftPage, paginationEnabled, rightPage} = this.props;
+        const {
+            leftPage,
+            paginationEnabled,
+            rightPage,
+            active,
+            echoes,
+            popover,
+            removeEcho,
+        } = this.props;
 
         const {selectedPage} = this.state;
 
         if (paginationEnabled) {
             return (
-                <Keypad style={[column, styles.keypad]}>
+                <Keypad
+                    style={[column, styles.keypad]}
+                    active={active}
+                    echoes={echoes}
+                    popover={popover}
+                    removeEcho={removeEcho}
+                >
                     <Tabbar
                         items={["Numbers", "Operators"]}
                         onSelect={(selectedItem) => {
@@ -53,7 +72,13 @@ class TwoPageKeypad extends React.Component<Props> {
             );
         } else {
             return (
-                <Keypad style={styles.keypad}>
+                <Keypad
+                    style={styles.keypad}
+                    active={active}
+                    echoes={echoes}
+                    popover={popover}
+                    removeEcho={removeEcho}
+                >
                     <View style={row}>
                         <View style={fullWidth}>{leftPage}</View>
                         <View style={[styles.borderLeft, fullWidth]}>

--- a/packages/math-input/src/components/two-page-keypad.tsx
+++ b/packages/math-input/src/components/two-page-keypad.tsx
@@ -28,6 +28,8 @@ interface Props {
     active: boolean;
     echoes: ReadonlyArray<Echo>;
     popover: Popover | null;
+    heightPx: number;
+    widthPx: number;
     removeEcho?: (animationId: string) => void;
 }
 
@@ -44,6 +46,8 @@ class TwoPageKeypad extends React.Component<Props> {
             active,
             echoes,
             popover,
+            heightPx,
+            widthPx,
             removeEcho,
         } = this.props;
 
@@ -56,6 +60,8 @@ class TwoPageKeypad extends React.Component<Props> {
                     active={active}
                     echoes={echoes}
                     popover={popover}
+                    heightPx={heightPx}
+                    widthPx={widthPx}
                     removeEcho={removeEcho}
                 >
                     <Tabbar
@@ -77,6 +83,8 @@ class TwoPageKeypad extends React.Component<Props> {
                     active={active}
                     echoes={echoes}
                     popover={popover}
+                    heightPx={heightPx}
+                    widthPx={widthPx}
                     removeEcho={removeEcho}
                 >
                     <View style={row}>

--- a/packages/math-input/src/components/two-page-keypad.tsx
+++ b/packages/math-input/src/components/two-page-keypad.tsx
@@ -13,12 +13,13 @@ import {
     innerBorderWidthPx,
     offBlack16,
 } from "./common-style";
+import GestureManager from "./gesture-manager";
 import Keypad from "./keypad";
 import Styles from "./styles";
 import Tabbar from "./tabbar/tabbar";
-import type {Popover, Echo} from "../types";
+
 import type {Key} from "../data/keys";
-import GestureManager from "./gesture-manager";
+import type {Popover, Echo} from "../types";
 
 const {column, row, fullWidth} = Styles;
 

--- a/packages/math-input/src/components/two-page-keypad.tsx
+++ b/packages/math-input/src/components/two-page-keypad.tsx
@@ -4,7 +4,6 @@
 
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
-import {connect} from "react-redux";
 
 import {View} from "../fake-react-native-web/index";
 
@@ -18,18 +17,13 @@ import Keypad from "./keypad";
 import Styles from "./styles";
 import Tabbar from "./tabbar/tabbar";
 
-import type {State} from "../store/types";
-
 const {column, row, fullWidth} = Styles;
 
-interface ReduxProps {
-    paginationEnabled: boolean;
-}
-
-interface Props extends ReduxProps {
+interface Props {
     currentPage: number;
     leftPage: React.ReactNode;
     rightPage: React.ReactNode;
+    paginationEnabled: boolean;
 }
 
 class TwoPageKeypad extends React.Component<Props> {
@@ -92,12 +86,4 @@ const styles = StyleSheet.create({
     },
 });
 
-const mapStateToProps = (state: State): ReduxProps => {
-    return {
-        paginationEnabled: state.layout.paginationEnabled,
-    };
-};
-
-export default connect(mapStateToProps, null, null, {forwardRef: true})(
-    TwoPageKeypad,
-);
+export default TwoPageKeypad;

--- a/packages/math-input/src/components/two-page-keypad.tsx
+++ b/packages/math-input/src/components/two-page-keypad.tsx
@@ -17,6 +17,8 @@ import Keypad from "./keypad";
 import Styles from "./styles";
 import Tabbar from "./tabbar/tabbar";
 import type {Popover, Echo} from "../types";
+import type {Key} from "../data/keys";
+import GestureManager from "./gesture-manager";
 
 const {column, row, fullWidth} = Styles;
 
@@ -30,6 +32,8 @@ interface Props {
     popover: Popover | null;
     heightPx: number;
     widthPx: number;
+    gestureManager: GestureManager;
+    gestureFocus: Key | null;
     removeEcho?: (animationId: string) => void;
 }
 
@@ -48,6 +52,8 @@ class TwoPageKeypad extends React.Component<Props> {
             popover,
             heightPx,
             widthPx,
+            gestureManager,
+            gestureFocus,
             removeEcho,
         } = this.props;
 
@@ -63,6 +69,8 @@ class TwoPageKeypad extends React.Component<Props> {
                     heightPx={heightPx}
                     widthPx={widthPx}
                     removeEcho={removeEcho}
+                    gestureManager={gestureManager}
+                    gestureFocus={gestureFocus}
                 >
                     <Tabbar
                         items={["Numbers", "Operators"]}
@@ -86,6 +94,8 @@ class TwoPageKeypad extends React.Component<Props> {
                     heightPx={heightPx}
                     widthPx={widthPx}
                     removeEcho={removeEcho}
+                    gestureManager={gestureManager}
+                    gestureFocus={gestureFocus}
                 >
                     <View style={row}>
                         <View style={fullWidth}>{leftPage}</View>

--- a/packages/math-input/src/types.ts
+++ b/packages/math-input/src/types.ts
@@ -9,7 +9,7 @@ import type {CursorContext} from "./components/input/cursor-contexts";
 import type {KeypadType} from "./consts";
 import type {Key} from "./data/keys";
 
-export type Border = Partial<Array<keyof typeof BorderDirections>>;
+export type Border = Partial<ReadonlyArray<keyof typeof BorderDirections>>;
 
 export type Bound = {
     top: number;
@@ -40,11 +40,11 @@ export type Icon = {
 };
 
 export type KeyConfig = {
-    ariaLabel: string;
+    ariaLabel?: string;
     id: Key;
     type: keyof typeof KeyTypes;
-    childKeyIds: Array<Key>;
-    icon: Icon;
+    childKeyIds: ReadonlyArray<string>;
+    icon?: Icon;
 };
 
 export type KeypadConfiguration = {


### PR DESCRIPTION
## Summary:
This is a WIP/POC of what things might look like if we were to pull Redux up out of the v1 keypad.

It's not working as-is and at this point I think it's a dead end (and a mistake on my part to have pursued it).

Thoughts:
- I don't think we're doing anything that really necessitates using Redux and we violate come of the core rules of Redux (such as having side-effects or having complex state machines _within_ the Redux store).
- As far as I understand it, we're basically using it to avoid prop drilling. There's also some GestureManager logic that's tied to the store, but this is part of the Redux anti-pattern and shouldn't be there anyway.
- Redux mostly seems to be just for the Keypad. The highest component using Redux was the KeypadContainer component.

I think we could clean this up quite a bit using Context/Hooks, but given that this all seems to be for the Keypad and we're going to look at replacing the Keypad with v2...I'm not sure we need to keep trying to refactor this.

Issue: LC-729

## Test plan: