### PR TITLE
Remove prop-types from graphie.tsx

### DIFF
--- a/.changeset/rude-lamps-itch.md
+++ b/.changeset/rude-lamps-itch.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Upgraded Graphie component to use TypeScript types for props

--- a/packages/perseus/src/components/graphie.tsx
+++ b/packages/perseus/src/components/graphie.tsx
@@ -12,30 +12,31 @@ import GraphUtils from "../util/graph-utils";
 import GraphieClasses from "./graphie-classes";
 import Movables from "./graphie-movables";
 
+import type {Range, Size} from "../perseus-types";
+
 const GraphieMovable = GraphieClasses.GraphieMovable;
 
 const createGraphie = GraphUtils.createGraphie;
 const {deepEq, nestedMap} = Util;
 const {assert} = InteractiveUtil;
 
-type Size = [width: number, height: number];
-
 type Props = {
     addMouseLayer?: boolean;
     box: Size;
-    children: React.ReactNode;
-    isMobile?: boolean;
-    onClick: (at: Coord) => void;
-    onMouseDown: (at: Coord) => void;
-    onMouseMove: (at: Coord) => void;
-    onMouseUp: (at: Coord) => void;
-    options: {
-        snapStep?: [x: number, y: number];
-        labels?: ReadonlyArray<any>;
-    };
     range: [Coord, Coord];
+    ranges?: [Range, Range];
+    gridStep?: [number, number];
+    step?: [number, number];
+    scale?: [number, number];
+
+    isMobile?: boolean;
     responsive?: boolean;
-    setDrawingAreaAvailable?: () => void;
+
+    children?: React.ReactNode;
+
+    options: any;
+
+    setDrawingAreaAvailable?: (boolean) => void;
     setup: (
         graphie: any,
         options: {
@@ -43,6 +44,11 @@ type Props = {
             scale: [xScale: number, yScale: number];
         },
     ) => void;
+
+    onClick?: (at: Coord) => void;
+    onMouseDown?: (at: Coord) => void;
+    onMouseMove?: (at: Coord) => void;
+    onMouseUp?: (at: Coord) => void;
 };
 
 type DefaultProps = {

--- a/packages/perseus/src/components/graphie.tsx
+++ b/packages/perseus/src/components/graphie.tsx
@@ -42,7 +42,7 @@ type Props = {
         graphie: any,
         options: {
             range: [Coord, Coord];
-            scale: [xScale: number, yScale: number];
+            scale: [number, number];
         },
     ) => void;
 

--- a/packages/perseus/src/components/graphie.tsx
+++ b/packages/perseus/src/components/graphie.tsx
@@ -4,7 +4,6 @@ import ReactDOM from "react-dom";
 import _ from "underscore";
 
 import InteractiveUtil from "../interactive2/interactive-util";
-import {Coord} from "../interactive2/types";
 import {Errors, Log} from "../logging/log";
 import Util from "../util";
 import GraphUtils from "../util/graph-utils";
@@ -12,6 +11,7 @@ import GraphUtils from "../util/graph-utils";
 import GraphieClasses from "./graphie-classes";
 import Movables from "./graphie-movables";
 
+import type {Coord} from "../interactive2/types";
 import type {Range, Size} from "../perseus-types";
 
 const GraphieMovable = GraphieClasses.GraphieMovable;
@@ -34,6 +34,7 @@ type Props = {
 
     children?: React.ReactNode;
 
+    // TODO(LC-772) - type this prop!
     options: any;
 
     setDrawingAreaAvailable?: (boolean) => void;

--- a/packages/perseus/src/components/svg-image.tsx
+++ b/packages/perseus/src/components/svg-image.tsx
@@ -718,6 +718,10 @@ class SvgImage extends React.Component<Props, State> {
                 );
             }
 
+            const x = this.state.range[0][1];
+
+            // TODO: the "40" scale factor was introduced in D14974 but is not
+            // documented where it came from.
             graphie = (
                 <Graphie
                     // eslint-disable-next-line react/no-string-refs

--- a/packages/perseus/src/components/svg-image.tsx
+++ b/packages/perseus/src/components/svg-image.tsx
@@ -6,6 +6,7 @@ import * as React from "react";
 import _ from "underscore";
 
 import {getDependencies} from "../dependencies";
+import {Coord} from "../interactive2/types";
 import {Errors, Log} from "../logging/log";
 import {PerseusError} from "../perseus-error";
 import Util from "../util";
@@ -15,7 +16,7 @@ import FixedToResponsive from "./fixed-to-responsive";
 import Graphie from "./graphie";
 import ImageLoader from "./image-loader";
 
-import type {Range, Size} from "../perseus-types";
+import type {Size} from "../perseus-types";
 import type {Alignment, Dimensions} from "../types";
 import type {ImageProps} from "./image-loader";
 
@@ -143,7 +144,7 @@ type Props = {
     constrainHeight?: boolean;
     extraGraphie?: {
         box: Size;
-        range: [x: Range, y: Range];
+        range: [x: Coord, y: Coord];
         labels: ReadonlyArray<any>;
     };
     height?: number;
@@ -204,7 +205,7 @@ type State = {
     labelsRendered: LabelsRenderedMap;
     labelDataIsLocalized: boolean;
     labels: ReadonlyArray<Label>;
-    range: [x: Range, y: Range];
+    range: [Coord, Coord];
 };
 
 class SvgImage extends React.Component<Props, State> {
@@ -241,7 +242,7 @@ class SvgImage extends React.Component<Props, State> {
             labelDataIsLocalized: false,
             labels: [],
             labelsRendered: {},
-            range: [[0, 0], [0, 0] as [number, number]],
+            range: [[0, 0], [0, 0] as Coord],
         };
     }
 
@@ -403,7 +404,7 @@ class SvgImage extends React.Component<Props, State> {
     ) => void = (
         data: {
             labels: ReadonlyArray<any>;
-            range: [Range, Range];
+            range: [Coord, Coord];
         },
         localized: boolean,
     ) => {

--- a/packages/perseus/src/components/svg-image.tsx
+++ b/packages/perseus/src/components/svg-image.tsx
@@ -718,8 +718,6 @@ class SvgImage extends React.Component<Props, State> {
                 );
             }
 
-            const x = this.state.range[0][1];
-
             // TODO: the "40" scale factor was introduced in D14974 but is not
             // documented where it came from.
             graphie = (

--- a/packages/perseus/src/components/svg-image.tsx
+++ b/packages/perseus/src/components/svg-image.tsx
@@ -144,7 +144,7 @@ type Props = {
     constrainHeight?: boolean;
     extraGraphie?: {
         box: Size;
-        range: [x: Coord, y: Coord];
+        range: [Coord, Coord];
         labels: ReadonlyArray<any>;
     };
     height?: number;

--- a/packages/perseus/src/components/svg-image.tsx
+++ b/packages/perseus/src/components/svg-image.tsx
@@ -15,6 +15,7 @@ import FixedToResponsive from "./fixed-to-responsive";
 import Graphie from "./graphie";
 import ImageLoader from "./image-loader";
 
+import type {Range, Size} from "../perseus-types";
 import type {Alignment, Dimensions} from "../types";
 import type {ImageProps} from "./image-loader";
 
@@ -141,8 +142,8 @@ type Props = {
     alt: string;
     constrainHeight?: boolean;
     extraGraphie?: {
-        box: ReadonlyArray<any>;
-        range: ReadonlyArray<any>;
+        box: Size;
+        range: [x: Range, y: Range];
         labels: ReadonlyArray<any>;
     };
     height?: number;
@@ -203,7 +204,7 @@ type State = {
     labelsRendered: LabelsRenderedMap;
     labelDataIsLocalized: boolean;
     labels: ReadonlyArray<Label>;
-    range: ReadonlyArray<any>;
+    range: [x: Range, y: Range];
 };
 
 class SvgImage extends React.Component<Props, State> {
@@ -240,10 +241,7 @@ class SvgImage extends React.Component<Props, State> {
             labelDataIsLocalized: false,
             labels: [],
             labelsRendered: {},
-            range: [
-                [0, 0],
-                [0, 0],
-            ],
+            range: [[0, 0], [0, 0] as [number, number]],
         };
     }
 
@@ -405,7 +403,7 @@ class SvgImage extends React.Component<Props, State> {
     ) => void = (
         data: {
             labels: ReadonlyArray<any>;
-            range: ReadonlyArray<any>;
+            range: [Range, Range];
         },
         localized: boolean,
     ) => {
@@ -719,14 +717,12 @@ class SvgImage extends React.Component<Props, State> {
                 );
             }
 
-            const scale = [40 * this.props.scale, 40 * this.props.scale];
-
             graphie = (
                 <Graphie
                     // eslint-disable-next-line react/no-string-refs
                     ref="graphie"
                     box={box}
-                    scale={scale}
+                    scale={[40 * this.props.scale, 40 * this.props.scale]}
                     range={this.state.range}
                     options={_.pick(this.state, "labels")}
                     responsive={responsive}

--- a/packages/perseus/src/interactive2/types.ts
+++ b/packages/perseus/src/interactive2/types.ts
@@ -1,2 +1,2 @@
-export type Coord = [number, number];
-export type Line = [Coord, Coord];
+export type Coord = [x: number, y: number];
+export type Line = [from: Coord, to: Coord];

--- a/packages/perseus/src/interactive2/types.ts
+++ b/packages/perseus/src/interactive2/types.ts
@@ -1,2 +1,2 @@
-export type Coord = [x: number, y: number];
-export type Line = [from: Coord, to: Coord];
+export type Coord = [number, number]; // x, y
+export type Line = [Coord, Coord]; // start, end

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -1141,13 +1141,13 @@ export type PerseusInteractionGraph = {
     // The Axis labels.  e.g. ["x", "y"]
     labels: ReadonlyArray<string>;
     // The Axis ranges. e.g. [[-10, 10], [-10, 10]]
-    range: [x: Range, y: Range];
+    range: [Range, Range];
     // The steps in the grid. default [1, 1]
-    gridStep: Readonly<[xStep: number, yStep: number]>;
+    gridStep: Readonly<[number, number]>;
     // What to show on the graph.  "graph", "grid", or "none"
     markings: string;
     // The snap steps. default [0.5, 0.5]
-    snapStep?: Readonly<[xStep: number, yStep: number]>;
+    snapStep?: Readonly<[number, number]>;
     // Whether the grid is valid or not.  Do the numbers all make sense?
     // NOTE(jeremy) The editor for this widget sometimes stores the graph
     // editor validation error message into this field. It seems innocuous
@@ -1165,7 +1165,7 @@ export type PerseusInteractionGraph = {
     // How many ticks to show on the ruler.  e.g. 1, 2, 4, 8, 10, 16
     rulerTicks?: number;
     // This controls the number (and position) of the tick marks for the X and Y axis. e.g. [1, 1]
-    tickStep: Readonly<[xStep: number, yStep: number]>;
+    tickStep: Readonly<[number, number]>;
 };
 
 export type PerseusInteractionElement =

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -3,8 +3,8 @@
 
 import type {Coord} from "./interactive2/types";
 
-export type Range = [min: number, max: number];
-export type Size = [width: number, height: number];
+export type Range = [number, number];
+export type Size = [number, number];
 
 // TODO(FEI-5054): Figure out how to get global .d.ts files working with monorepos
 type Empty = Record<string, never>;

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -3,6 +3,9 @@
 
 import type {Coord} from "./interactive2/types";
 
+export type Range = [min: number, max: number];
+export type Size = [width: number, height: number];
+
 // TODO(FEI-5054): Figure out how to get global .d.ts files working with monorepos
 type Empty = Record<string, never>;
 
@@ -475,10 +478,10 @@ export type PerseusImageWidgetOptions = {
     labels?: ReadonlyArray<PerseusImageLabel>;
     // The range on the image render for labels
     // NOTE: perseus_data.go says this is required even though it isn't necessary.
-    range?: ReadonlyArray<ReadonlyArray<number>>;
+    range?: [Range, Range];
     // The box on the image render for labels. The same as backgroundImage.width and backgroundImage.height
     // NOTE: perseus_data.go says this is required even though it isn't necessary.
-    box?: ReadonlyArray<number>;
+    box?: Size;
 };
 
 export type PerseusImageLabel = {
@@ -1134,17 +1137,17 @@ export type PerseusInteractionGraph = {
     // "canvas", "graph"
     editableSettings?: ReadonlyArray<"canvas" | "graph">;
     // The Grid Canvas size. e.g. [400, 140]
-    box: ReadonlyArray<number>;
+    box: Size;
     // The Axis labels.  e.g. ["x", "y"]
     labels: ReadonlyArray<string>;
     // The Axis ranges. e.g. [[-10, 10], [-10, 10]]
-    range: ReadonlyArray<ReadonlyArray<number>>;
+    range: [x: Range, y: Range];
     // The steps in the grid. default [1, 1]
-    gridStep: ReadonlyArray<number>;
+    gridStep: [x: number, y: number];
     // What to show on the graph.  "graph", "grid", or "none"
     markings: string;
     // The snap steps. default [0.5, 0.5]
-    snapStep?: ReadonlyArray<number>;
+    snapStep?: [x: number, y: number];
     // Whether the grid is valid or not.  Do the numbers all make sense?
     // NOTE(jeremy) The editor for this widget sometimes stores the graph
     // editor validation error message into this field. It seems innocuous
@@ -1162,7 +1165,7 @@ export type PerseusInteractionGraph = {
     // How many ticks to show on the ruler.  e.g. 1, 2, 4, 8, 10, 16
     rulerTicks?: number;
     // This controls the number (and position) of the tick marks for the X and Y axis. e.g. [1, 1]
-    tickStep: ReadonlyArray<number>;
+    tickStep: [x: number, y: number];
 };
 
 export type PerseusInteractionElement =

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -1143,11 +1143,11 @@ export type PerseusInteractionGraph = {
     // The Axis ranges. e.g. [[-10, 10], [-10, 10]]
     range: [x: Range, y: Range];
     // The steps in the grid. default [1, 1]
-    gridStep: [x: number, y: number];
+    gridStep: Readonly<[xStep: number, yStep: number]>;
     // What to show on the graph.  "graph", "grid", or "none"
     markings: string;
     // The snap steps. default [0.5, 0.5]
-    snapStep?: [x: number, y: number];
+    snapStep?: Readonly<[xStep: number, yStep: number]>;
     // Whether the grid is valid or not.  Do the numbers all make sense?
     // NOTE(jeremy) The editor for this widget sometimes stores the graph
     // editor validation error message into this field. It seems innocuous
@@ -1165,7 +1165,7 @@ export type PerseusInteractionGraph = {
     // How many ticks to show on the ruler.  e.g. 1, 2, 4, 8, 10, 16
     rulerTicks?: number;
     // This controls the number (and position) of the tick marks for the X and Y axis. e.g. [1, 1]
-    tickStep: [x: number, y: number];
+    tickStep: Readonly<[xStep: number, yStep: number]>;
 };
 
 export type PerseusInteractionElement =

--- a/packages/perseus/src/util.ts
+++ b/packages/perseus/src/util.ts
@@ -5,6 +5,7 @@ import {Errors} from "./logging/log";
 import {PerseusError} from "./perseus-error";
 import KhanAnswerTypes from "./util/answer-types";
 
+import type {Range} from "./perseus-types";
 import type {Widget, PerseusScore, KEScore} from "./types";
 
 type WordPosition = {
@@ -495,8 +496,6 @@ function tickStepFromNumTicks(span: number, numTicks: number): number {
     return step;
 }
 
-type Range = [number, number]; // [min, max]
-
 const constrainTickStep = (step: number, range: Range): number => {
     const span = range[1] - range[0];
     const numTicks = span / step;
@@ -519,7 +518,7 @@ const constrainTickStep = (step: number, range: Range): number => {
  * Specifically, we aim for 10 or fewer ticks per graph axis.
  */
 function constrainedTickStepsFromTickSteps(
-    tickSteps: Coordinates,
+    tickSteps: [x: number, y: number],
     ranges: [Range, Range],
 ): Coordinates {
     return [

--- a/packages/perseus/src/util.ts
+++ b/packages/perseus/src/util.ts
@@ -518,7 +518,7 @@ const constrainTickStep = (step: number, range: Range): number => {
  * Specifically, we aim for 10 or fewer ticks per graph axis.
  */
 function constrainedTickStepsFromTickSteps(
-    tickSteps: [x: number, y: number],
+    tickSteps: [number, number],
     ranges: [Range, Range],
 ): Coordinates {
     return [

--- a/packages/perseus/src/widgets/grapher.tsx
+++ b/packages/perseus/src/widgets/grapher.tsx
@@ -476,15 +476,15 @@ class Grapher extends React.Component<Props> {
     _calculateMobileTickStep(
         gridStep: JSX.LibraryManagedAttributes<
             typeof Graphie,
-            React.ComponentProps<typeof Graphie>
+            Required<React.ComponentProps<typeof Graphie>>
         >["gridStep"],
         step: JSX.LibraryManagedAttributes<
             typeof Graphie,
-            React.ComponentProps<typeof Graphie>
+            Required<React.ComponentProps<typeof Graphie>>
         >["step"],
         ranges: JSX.LibraryManagedAttributes<
             typeof Graphie,
-            React.ComponentProps<typeof Graphie>
+            Required<React.ComponentProps<typeof Graphie>>
         >["ranges"],
     ): any {
         const tickStep = Util.constrainedTickStepsFromTickSteps(step, ranges);

--- a/packages/perseus/src/widgets/image.tsx
+++ b/packages/perseus/src/widgets/image.tsx
@@ -12,7 +12,7 @@ import Renderer from "../renderer";
 import {baseUnitPx} from "../styles/constants";
 import mediaQueries from "../styles/media-queries";
 
-import type {PerseusImageWidgetOptions} from "../perseus-types";
+import type {Range, PerseusImageWidgetOptions} from "../perseus-types";
 import type {
     ChangeFn,
     PerseusScore,
@@ -21,7 +21,7 @@ import type {
 } from "../types";
 
 const defaultBoxSize = 400;
-const defaultRange = [0, 10];
+const defaultRange: Range = [0, 10];
 const defaultBackgroundImage = {
     url: null,
     width: 0,

--- a/packages/perseus/src/widgets/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line.tsx
@@ -192,7 +192,7 @@ const TickMarks: any = Graphie.createSimpleClass((graphie, props) => {
 });
 
 type Props = ChangeableProps & {
-    range: ReadonlyArray<number>;
+    range: [number, number];
     labelRange: ReadonlyArray<number | null>;
     labelStyle: string;
     labelTicks: boolean;

--- a/packages/perseus/src/widgets/simulator.tsx
+++ b/packages/perseus/src/widgets/simulator.tsx
@@ -8,7 +8,6 @@ import _ from "underscore";
 
 import Graphie from "../components/graphie";
 import InfoTip from "../components/info-tip";
-import MathOutput from "../components/math-output";
 import NumberInput from "../components/number-input";
 import InteractiveUtil from "../interactive2/interactive-util";
 import * as Changeable from "../mixins/changeable";
@@ -17,6 +16,7 @@ import Util from "../util";
 import KhanColors from "../util/colors";
 import KhanMath from "../util/math";
 
+import type {Range} from "../perseus-types";
 import type {WidgetExports} from "../types";
 
 const {assert} = InteractiveUtil;
@@ -231,9 +231,7 @@ class Histogram extends React.Component<any, any> {
             range: range,
             data: data,
             scale: [
-                // @ts-expect-error [FEI-5003] - TS2345 - Argument of type 'any[]' is not assignable to parameter of type 'Coordinates'.
                 Util.scaleFromExtent(range[0], this.props.box[0]),
-                // @ts-expect-error [FEI-5003] - TS2345 - Argument of type 'any[]' is not assignable to parameter of type 'Coordinates'.
                 Util.scaleFromExtent(range[1], this.props.box[1]),
             ],
         } as const;
@@ -352,8 +350,8 @@ class Histogram extends React.Component<any, any> {
     };
 
     /* Convenience functions that help calculate props based on other props. */
-    _range = (props) => {
-        const defaultRange = [
+    _range = (props): [Range, Range] => {
+        const defaultRange: [Range, Range] = [
             [0, 100],
             [-1, 10],
         ];
@@ -361,7 +359,7 @@ class Histogram extends React.Component<any, any> {
         return props.data ? this._getRangeForData(props.data) : defaultRange;
     };
 
-    _getRangeForData = (data: any) => {
+    _getRangeForData = (data: any): [Range, Range] => {
         // Find first/last non-zero entry and add some padding
         const padding = 10;
         const firstIndex = _.indexOf(


### PR DESCRIPTION
## Summary:

Switches to true TypeScript types for `graphie.tsx`.

<img width="500" alt="Screenshot 2023-04-24 at 12 46 37 PM" src="https://user-images.githubusercontent.com/77138/234100598-9bdebae8-ed8f-4414-94a1-efcf0813813c.png">

Issue: "none"

## Test plan:

Viewed the Graphie stories in storybook.