### PR TITLE
Type and modernize math-output.tsx

### DIFF
--- a/.changeset/gorgeous-games-collect.md
+++ b/.changeset/gorgeous-games-collect.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Upgraded <MathOutput> component to use TypeScript types for props

--- a/packages/perseus/src/components/math-output.tsx
+++ b/packages/perseus/src/components/math-output.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/sort-comp */
 import $ from "jquery";
-import PropTypes from "prop-types";
 import * as React from "react";
 import ReactDOM from "react-dom";
 import _ from "underscore";
@@ -11,22 +10,33 @@ import TexWrangler from "../tex-wrangler";
 
 const ModifyTex = TexWrangler.modifyTex;
 
-class MathOutput extends React.Component<any, any> {
-    static propTypes = {
-        value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-        className: PropTypes.string,
-        labelText: PropTypes.string,
-        onFocus: PropTypes.func,
-        onBlur: PropTypes.func,
-    };
+type Props = {
+    value: string | number;
+    className?: string;
+    labelText?: string;
+    onFocus: () => void;
+    onBlur: () => void;
+};
 
-    static defaultProps: any = {
+type DefaultProps = {
+    value: Props["value"];
+    onFocus: Props["onFocus"];
+    onBlur: Props["onBlur"];
+};
+
+type State = {
+    focused: boolean;
+    selectorNamespace: string;
+};
+
+class MathOutput extends React.Component<Props, State> {
+    static defaultProps: DefaultProps = {
         value: "",
         onFocus: function () {},
         onBlur: function () {},
     };
 
-    state: any = {
+    state: State = {
         focused: false,
         selectorNamespace: _.uniqueId("math-output"),
     };

--- a/packages/perseus/src/components/math-output.tsx
+++ b/packages/perseus/src/components/math-output.tsx
@@ -18,11 +18,7 @@ type Props = {
     onBlur: () => void;
 };
 
-type DefaultProps = {
-    value: Props["value"];
-    onFocus: Props["onFocus"];
-    onBlur: Props["onBlur"];
-};
+type DefaultProps = Pick<Props, "value" | "onFocus" | "onBlur">;
 
 type State = {
     focused: boolean;


### PR DESCRIPTION
## Summary:

Switches to true TypeScript types for `math-output.tsx`

Issue: None

## Test plan:

Reviewed changes in Storybook

<img width="500" alt="image" src="https://user-images.githubusercontent.com/77138/234124962-be3e3503-1727-457c-acbd-c5c8bcf262c2.png">
