### PR TITLE
Removed archaic style that is no longer affecting anything so that it doesn't cause future confusion should we move away from katex.

### DIFF
--- a/.changeset/shaggy-cheetahs-promise.md
+++ b/.changeset/shaggy-cheetahs-promise.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Removal of an unused keypad style

--- a/packages/math-input/less/overrides.less
+++ b/packages/math-input/less/overrides.less
@@ -121,9 +121,3 @@
         display: inline-block !important;
     }
 }
-
-// The keypad sets its own color styles for KaTeX elements that are rendered in
-// its keys, so prevent any external styling.
-.keypad-container .katex {
-    color: inherit !important;
-}


### PR DESCRIPTION
## Summary:
This style was found as part of our MathJax investigation. It's currently not affecting anything, and could cause future confusion should we switch over to MathJax. This simple PR just removes the unused style. 

Issue: LC-670

## Test plan:
Manual Testing