### PR TITLE
Hook Redux up to the v2 keypad

### DIFF
--- a/packages/math-input/src/components/empty-keypad-button.tsx
+++ b/packages/math-input/src/components/empty-keypad-button.tsx
@@ -27,14 +27,16 @@ class EmptyKeypadButton extends React.Component<ReduxProps> {
         // to focus them or trigger presses.
         return (
             <KeypadButton
-                onTouchStart={(evt: TouchEvent) =>
+                onTouchStart={(evt: React.TouchEvent<Element>) =>
                     gestureManager.onTouchStart(evt)
                 }
-                onTouchEnd={(evt: TouchEvent) => gestureManager.onTouchEnd(evt)}
-                onTouchMove={(evt: TouchEvent) =>
+                onTouchEnd={(evt: React.TouchEvent<Element>) =>
+                    gestureManager.onTouchEnd(evt)
+                }
+                onTouchMove={(evt: React.TouchEvent<Element>) =>
                     gestureManager.onTouchMove(evt)
                 }
-                onTouchCancel={(evt: TouchEvent) =>
+                onTouchCancel={(evt: React.TouchEvent<Element>) =>
                     gestureManager.onTouchCancel(evt)
                 }
                 {...KeyConfigs.NOOP}

--- a/packages/math-input/src/components/gesture-manager.ts
+++ b/packages/math-input/src/components/gesture-manager.ts
@@ -3,6 +3,7 @@
  * connects our various bits of logic for managing gestures and interactions,
  * and links them together.
  */
+import * as React from "react";
 
 import GestureStateMachine from "./gesture-state-machine";
 import NodeManager from "./node-manager";
@@ -100,7 +101,7 @@ class GestureManager {
      * @param {string} id - the identifier of the DOM node in which the touch
      *                      occurred
      */
-    onTouchStart(evt: TouchEvent, id?) {
+    onTouchStart(evt: React.TouchEvent<Element>, id?: string) {
         if (!this.trackEvents) {
             return;
         }
@@ -130,7 +131,7 @@ class GestureManager {
      *
      * @param {TouchEvent} evt - the raw touch event from the browser
      */
-    onTouchMove(evt: TouchEvent) {
+    onTouchMove(evt: React.TouchEvent<Element>) {
         if (!this.trackEvents) {
             return;
         }
@@ -154,7 +155,7 @@ class GestureManager {
      *
      * @param {TouchEvent} evt - the raw touch event from the browser
      */
-    onTouchEnd(evt: TouchEvent) {
+    onTouchEnd(evt: React.TouchEvent<Element>) {
         if (!this.trackEvents) {
             return;
         }
@@ -175,7 +176,7 @@ class GestureManager {
      *
      * @param {TouchEvent} evt - the raw touch event from the browser
      */
-    onTouchCancel(evt: TouchEvent) {
+    onTouchCancel(evt: React.TouchEvent<Element>) {
         if (!this.trackEvents) {
             return;
         }

--- a/packages/math-input/src/components/gesture-manager.ts
+++ b/packages/math-input/src/components/gesture-manager.ts
@@ -25,7 +25,7 @@ class GestureManager {
         this.swipeEnabled = swipeEnabled;
 
         // Events aren't tracked until event tracking is enabled.
-        this.trackEvents = false;
+        this.trackEvents = true;
 
         this.nodeManager = new NodeManager();
         this.popoverStateMachine = new PopoverStateMachine({

--- a/packages/math-input/src/components/keypad/button.tsx
+++ b/packages/math-input/src/components/keypad/button.tsx
@@ -1,4 +1,3 @@
-import Clickable from "@khanacademy/wonder-blocks-clickable";
 import Color from "@khanacademy/wonder-blocks-color";
 import {View, StyleType} from "@khanacademy/wonder-blocks-core";
 import {StyleSheet} from "aphrodite";
@@ -6,6 +5,8 @@ import * as React from "react";
 import {connect} from "react-redux";
 
 import {State} from "../../store/types";
+import {KeyConfig} from "../../types";
+import GestureManager from "../gesture-manager";
 
 const styles = StyleSheet.create({
     base: {
@@ -52,52 +53,60 @@ const styles = StyleSheet.create({
     outerBoxPressed: {
         border: "2px solid #1B50B3",
     },
-    clickable: {
-        width: "100%",
-        height: "100%",
-        boxSizing: "border-box",
-    },
 });
 
-export type Props = {
+type OwnProps = {
     onPress: () => void;
     children: React.ReactNode;
     style?: StyleType;
     tintColor?: string;
+    keyConfig: KeyConfig;
 };
+
+type ReduxProps = {
+    gestureManager: GestureManager;
+};
+
+export type Props = OwnProps & ReduxProps;
 
 class Button extends React.Component<Props> {
     render(): React.ReactNode {
-        const {onPress, children, style, tintColor} = this.props;
+        const {children, style, tintColor, gestureManager, keyConfig} =
+            this.props;
+        const hovered = false;
+        const focused = false;
+        const pressed = false;
         return (
-            <View style={style}>
-                <Clickable onClick={onPress} style={styles.clickable}>
-                    {({hovered, focused, pressed}) => {
-                        return (
-                            <View
-                                style={[
-                                    styles.outerBoxBase,
-                                    hovered && styles.outerBoxHover,
-                                    pressed && styles.outerBoxPressed,
-                                ]}
-                            >
-                                <View
-                                    style={[
-                                        styles.base,
-                                        tintColor != null
-                                            ? {background: tintColor}
-                                            : undefined,
-                                        hovered && styles.hovered,
-                                        focused && styles.focused,
-                                        pressed && styles.pressed,
-                                    ]}
-                                >
-                                    {children}
-                                </View>
-                            </View>
-                        );
-                    }}
-                </Clickable>
+            <View
+                style={style}
+                onTouchStart={(evt) =>
+                    gestureManager.onTouchStart(evt, keyConfig.id)
+                }
+                onTouchEnd={(evt) => gestureManager.onTouchEnd(evt)}
+                onTouchMove={(evt) => gestureManager.onTouchMove(evt)}
+                onTouchCancel={(evt) => gestureManager.onTouchCancel(evt)}
+            >
+                <View
+                    style={[
+                        styles.outerBoxBase,
+                        hovered && styles.outerBoxHover,
+                        pressed && styles.outerBoxPressed,
+                    ]}
+                >
+                    <View
+                        style={[
+                            styles.base,
+                            tintColor != null
+                                ? {background: tintColor}
+                                : undefined,
+                            hovered && styles.hovered,
+                            focused && styles.focused,
+                            pressed && styles.pressed,
+                        ]}
+                    >
+                        {children}
+                    </View>
+                </View>
             </View>
         );
     }

--- a/packages/math-input/src/components/keypad/button.tsx
+++ b/packages/math-input/src/components/keypad/button.tsx
@@ -22,22 +22,25 @@ const styles = StyleSheet.create({
         minHeight: 42,
         minWidth: 42,
         padding: 1,
-    },
-    hovered: {
-        border: `1px solid ${Color.blue}`,
-        padding: 1,
-        boxShadow: "none",
-    },
-    focused: {
-        border: `2px solid ${Color.blue}`,
-        padding: 0,
-        boxShadow: "none",
-    },
-    pressed: {
-        border: "2px solid #1B50B3",
-        padding: 0,
-        background: `linear-gradient(0deg, rgba(24, 101, 242, 0.32), rgba(24, 101, 242, 0.32)), ${Color.white}`,
-        boxShadow: "none",
+
+        ":hover": {
+            border: `1px solid ${Color.blue}`,
+            padding: 1,
+            boxShadow: "none",
+        },
+
+        ":focus": {
+            border: `2px solid ${Color.blue}`,
+            padding: 0,
+            boxShadow: "none",
+        },
+
+        ":active": {
+            border: "2px solid #1B50B3",
+            padding: 0,
+            background: `linear-gradient(0deg, rgba(24, 101, 242, 0.32), rgba(24, 101, 242, 0.32)), ${Color.white}`,
+            boxShadow: "none",
+        },
     },
     outerBoxBase: {
         padding: 1,
@@ -46,12 +49,12 @@ const styles = StyleSheet.create({
         boxSizing: "border-box",
         borderRadius: 7,
         border: "2px solid transparent",
-    },
-    outerBoxHover: {
-        border: `2px solid ${Color.blue}`,
-    },
-    outerBoxPressed: {
-        border: "2px solid #1B50B3",
+        ":hover": {
+            border: `2px solid ${Color.blue}`,
+        },
+        ":active": {
+            border: "2px solid #1B50B3",
+        },
     },
 });
 

--- a/packages/math-input/src/components/keypad/button.tsx
+++ b/packages/math-input/src/components/keypad/button.tsx
@@ -1,10 +1,11 @@
 import Clickable from "@khanacademy/wonder-blocks-clickable";
 import Color from "@khanacademy/wonder-blocks-color";
-import {View} from "@khanacademy/wonder-blocks-core";
+import {View, StyleType} from "@khanacademy/wonder-blocks-core";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
+import {connect} from "react-redux";
 
-import type {StyleType} from "@khanacademy/wonder-blocks-core";
+import {State} from "../../store/types";
 
 const styles = StyleSheet.create({
     base: {
@@ -65,7 +66,7 @@ export type Props = {
     tintColor?: string;
 };
 
-export default class Button extends React.Component<Props> {
+class Button extends React.Component<Props> {
     render(): React.ReactNode {
         const {onPress, children, style, tintColor} = this.props;
         return (
@@ -101,3 +102,11 @@ export default class Button extends React.Component<Props> {
         );
     }
 }
+
+function mapStateToProps(state: State) {
+    return {
+        gestureManager: state.gestures.gestureManager,
+    };
+}
+
+export default connect(mapStateToProps, null, null, {forwardRef: true})(Button);

--- a/packages/math-input/src/components/keypad/keypad-page-items.tsx
+++ b/packages/math-input/src/components/keypad/keypad-page-items.tsx
@@ -43,6 +43,7 @@ export const KeypadButton = ({
     style,
 }: KeypadButtonProps): React.ReactElement => (
     <Button
+        keyConfig={keyConfig}
         onPress={() => onClickKey(keyConfig.id)}
         tintColor={tintColor}
         style={style}

--- a/packages/math-input/src/components/keypad/keypad-page-items.tsx
+++ b/packages/math-input/src/components/keypad/keypad-page-items.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import Button from "./button";
 import ButtonAsset from "./button-assets";
 
-import type {KeyConfig} from "../../data/key-configs";
+import type {KeyConfig} from "../../types";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 type KeypadPageContainerProps = {

--- a/packages/math-input/src/components/keypad/stateful-keypad.stories.tsx
+++ b/packages/math-input/src/components/keypad/stateful-keypad.stories.tsx
@@ -1,3 +1,4 @@
+import {action} from "@storybook/addon-actions";
 import * as React from "react";
 
 import StatefulKeypad from "./stateful-keypad";
@@ -6,23 +7,6 @@ export default {
     title: "Stateful v2 Keypad",
 };
 
-function KeypadContainer({children}) {
-    return (
-        <div
-            style={{
-                width: "400px",
-                margin: "5em",
-            }}
-        >
-            {children}
-        </div>
-    );
-}
-
 export function Base() {
-    return (
-        <KeypadContainer>
-            <StatefulKeypad />
-        </KeypadContainer>
-    );
+    return <StatefulKeypad handleClickKey={action("handleClickKey")} />;
 }

--- a/packages/math-input/src/components/keypad/stateful-keypad.stories.tsx
+++ b/packages/math-input/src/components/keypad/stateful-keypad.stories.tsx
@@ -15,6 +15,13 @@ export function Base() {
                 console.log(key);
                 action("handleClickKey");
             }}
+            trigonometry
+            preAlgebra
+            logarithms
+            basicRelations
+            advancedRelations
+            multiplicationDot
+            divisionKey
             showKeypad
         />
     );

--- a/packages/math-input/src/components/keypad/stateful-keypad.stories.tsx
+++ b/packages/math-input/src/components/keypad/stateful-keypad.stories.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+
+import StatefulKeypad from "./stateful-keypad";
+
+export default {
+    title: "Stateful v2 Keypad",
+};
+
+function KeypadContainer({children}) {
+    return (
+        <div
+            style={{
+                width: "400px",
+                margin: "5em",
+            }}
+        >
+            {children}
+        </div>
+    );
+}
+
+export function Base() {
+    return (
+        <KeypadContainer>
+            <StatefulKeypad />
+        </KeypadContainer>
+    );
+}

--- a/packages/math-input/src/components/keypad/stateful-keypad.stories.tsx
+++ b/packages/math-input/src/components/keypad/stateful-keypad.stories.tsx
@@ -8,5 +8,14 @@ export default {
 };
 
 export function Base() {
-    return <StatefulKeypad handleClickKey={action("handleClickKey")} />;
+    return (
+        <StatefulKeypad
+            handleClickKey={(key) => {
+                // eslint-disable-next-line no-console
+                console.log(key);
+                action("handleClickKey");
+            }}
+            showKeypad
+        />
+    );
 }

--- a/packages/math-input/src/components/keypad/stateful-keypad.tsx
+++ b/packages/math-input/src/components/keypad/stateful-keypad.tsx
@@ -1,18 +1,28 @@
 import * as React from "react";
 import {Provider} from "react-redux";
 
+import {setKeyHandler} from "../../store/actions";
 import {createStore} from "../../store/index";
+import {KeyHandler} from "../../types";
 
 import Keypad from "./index";
 
-function StatefulKeypad({handleClickKey}) {
-    const [store, setStore] = React.useState();
+type Props = {
+    handleClickKey: KeyHandler;
+};
+
+function StatefulKeypad({handleClickKey}: Props) {
+    const [store, setStore] = React.useState<any>();
 
     React.useEffect(() => {
         if (!store) {
             setStore(createStore());
         }
     }, [store, setStore]);
+
+    React.useEffect(() => {
+        store?.dispatch(setKeyHandler(handleClickKey));
+    }, [store, handleClickKey]);
 
     if (!store) {
         return null;

--- a/packages/math-input/src/components/keypad/stateful-keypad.tsx
+++ b/packages/math-input/src/components/keypad/stateful-keypad.tsx
@@ -5,7 +5,7 @@ import {createStore} from "../../store/index";
 
 import Keypad from "./index";
 
-function StatefulKeypad() {
+function StatefulKeypad({handleClickKey}) {
     const [store, setStore] = React.useState();
 
     React.useEffect(() => {
@@ -21,7 +21,7 @@ function StatefulKeypad() {
     return (
         <Provider store={store}>
             <Keypad
-                onClickKey={console.log}
+                onClickKey={handleClickKey}
                 trigonometry
                 preAlgebra
                 logarithms

--- a/packages/math-input/src/components/keypad/stateful-keypad.tsx
+++ b/packages/math-input/src/components/keypad/stateful-keypad.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import {Provider} from "react-redux";
+
+import {createStore} from "../../store/index";
+
+import Keypad from "./index";
+
+function StatefulKeypad() {
+    const [store, setStore] = React.useState();
+
+    React.useEffect(() => {
+        if (!store) {
+            setStore(createStore());
+        }
+    }, [store, setStore]);
+
+    if (!store) {
+        return null;
+    }
+
+    return (
+        <Provider store={store}>
+            <Keypad
+                onClickKey={console.log}
+                trigonometry
+                preAlgebra
+                logarithms
+                basicRelations
+                advancedRelations
+                multiplicationDot
+                divisionKey
+            />
+        </Provider>
+    );
+}
+
+export default StatefulKeypad;

--- a/packages/math-input/src/components/keypad/stateful-keypad.tsx
+++ b/packages/math-input/src/components/keypad/stateful-keypad.tsx
@@ -1,7 +1,11 @@
 import * as React from "react";
 import {Provider} from "react-redux";
 
-import {setKeyHandler} from "../../store/actions";
+import {
+    activateKeypad,
+    dismissKeypad,
+    setKeyHandler,
+} from "../../store/actions";
 import {createStore} from "../../store/index";
 import {KeyHandler} from "../../types";
 
@@ -9,9 +13,10 @@ import Keypad from "./index";
 
 type Props = {
     handleClickKey: KeyHandler;
+    showKeypad: boolean;
 };
 
-function StatefulKeypad({handleClickKey}: Props) {
+function StatefulKeypad({handleClickKey, showKeypad}: Props) {
     const [store, setStore] = React.useState<any>();
 
     React.useEffect(() => {
@@ -23,6 +28,11 @@ function StatefulKeypad({handleClickKey}: Props) {
     React.useEffect(() => {
         store?.dispatch(setKeyHandler(handleClickKey));
     }, [store, handleClickKey]);
+
+    React.useEffect(() => {
+        const action = showKeypad ? activateKeypad : dismissKeypad;
+        store?.dispatch(action());
+    }, [store, showKeypad]);
 
     if (!store) {
         return null;

--- a/packages/math-input/src/components/keypad/stateful-keypad.tsx
+++ b/packages/math-input/src/components/keypad/stateful-keypad.tsx
@@ -14,9 +14,26 @@ import Keypad from "./index";
 type Props = {
     handleClickKey: KeyHandler;
     showKeypad: boolean;
+    trigonometry: boolean;
+    preAlgebra: boolean;
+    logarithms: boolean;
+    basicRelations: boolean;
+    advancedRelations: boolean;
+    multiplicationDot: boolean;
+    divisionKey: boolean;
 };
 
-function StatefulKeypad({handleClickKey, showKeypad}: Props) {
+function StatefulKeypad({
+    handleClickKey,
+    showKeypad,
+    trigonometry,
+    preAlgebra,
+    logarithms,
+    basicRelations,
+    advancedRelations,
+    multiplicationDot,
+    divisionKey,
+}: Props) {
     const [store, setStore] = React.useState<any>();
 
     React.useEffect(() => {
@@ -42,13 +59,13 @@ function StatefulKeypad({handleClickKey, showKeypad}: Props) {
         <Provider store={store}>
             <Keypad
                 onClickKey={handleClickKey}
-                trigonometry
-                preAlgebra
-                logarithms
-                basicRelations
-                advancedRelations
-                multiplicationDot
-                divisionKey
+                trigonometry={trigonometry}
+                preAlgebra={preAlgebra}
+                logarithms={logarithms}
+                basicRelations={basicRelations}
+                advancedRelations={advancedRelations}
+                multiplicationDot={multiplicationDot}
+                divisionKey={divisionKey}
             />
         </Provider>
     );

--- a/packages/math-input/src/store/index.ts
+++ b/packages/math-input/src/store/index.ts
@@ -60,7 +60,6 @@ export const createStore = () => {
         state: GestureState = initialGestureState,
         action: Action,
     ): GestureState {
-        console.log(action);
         switch (action.type) {
             case "DismissKeypad":
                 // NOTE(charlie): In the past, we enforced the "gesture manager

--- a/packages/math-input/src/store/index.ts
+++ b/packages/math-input/src/store/index.ts
@@ -60,6 +60,7 @@ export const createStore = () => {
         state: GestureState = initialGestureState,
         action: Action,
     ): GestureState {
+        console.log(action);
         switch (action.type) {
             case "DismissKeypad":
                 // NOTE(charlie): In the past, we enforced the "gesture manager

--- a/packages/math-input/src/store/types.ts
+++ b/packages/math-input/src/store/types.ts
@@ -14,7 +14,7 @@ export interface InputState {
     // Information about where the cursor is, which we use to
     // conditionally render buttons to help navigate
     // where the cursor should go next
-    cursor: Cursor | undefined;
+    cursor: Cursor | undefined | void;
 }
 
 // Managing high-level keypad state

--- a/packages/math-input/src/types.ts
+++ b/packages/math-input/src/types.ts
@@ -59,7 +59,7 @@ export type KeypadConfiguration = {
     extraKeys?: ReadonlyArray<Keys>;
 };
 
-export type KeyHandler = (key: Keys) => Cursor;
+export type KeyHandler = (key: Keys) => Cursor | void;
 
 export type Cursor = {
     context: CursorContext;


### PR DESCRIPTION
## Summary:
The idea of this PR/ticket is to connect the v2 keypad to Redux so we can leverage existing state management.

One of the things I realized while doing this PR is that GestureManager is really only equipped to handle mobile (all event callbacks are for touch). Either we're going to have to replace GestureManager or we're going to have to get it working with a mouse/keyboard.

So far this PR:
- Wraps v2 keypad in a provider (`StatefulKeypad`)
  - Adds a story for this
- Lets `StatefulKeypad` accept a key press callback
- Connects v2 keypad button to the gesture manager for key presses

Issue: LC-803

## Test plan: