### PR TITLE
Export v2 keypad

### DIFF
--- a/.changeset/plenty-pans-help.md
+++ b/.changeset/plenty-pans-help.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/math-input": major
+"@khanacademy/perseus": patch
+---
+
+Export v2 keypad, rename v1 keypad to ProvidedKeypad

--- a/packages/math-input/src/index.ts
+++ b/packages/math-input/src/index.ts
@@ -7,7 +7,9 @@ import "../less/main.less";
 export {CursorContext} from "./components/input/cursor-contexts";
 export {default as KeypadInput} from "./components/input/math-input";
 export {keypadElementPropType} from "./components/prop-types";
-export {default as Keypad} from "./components/keypad-legacy/provided-keypad";
+export {default as LegacyKeypad} from "./components/keypad-legacy/provided-keypad";
 export {default as KeyConfigs} from "./data/key-configs";
 export {default as Keys} from "./data/keys";
 export {KeyType, KeypadType} from "./enums";
+
+export {default as Keypad} from "./components/keypad/index";

--- a/packages/math-input/src/math-input.stories.tsx
+++ b/packages/math-input/src/math-input.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import {Keypad, KeypadInput, KeypadType} from "./index";
+import {LegacyKeypad, KeypadInput, KeypadType} from "./index";
 
 export default {
     title: "Full MathInput",
@@ -55,7 +55,7 @@ export const Basic = () => {
                 }}
             />
 
-            <Keypad
+            <LegacyKeypad
                 onElementMounted={(node) => {
                     if (node && !keypadElement) {
                         setKeypadElement(node);

--- a/packages/perseus/src/mixins/provide-keypad.tsx
+++ b/packages/perseus/src/mixins/provide-keypad.tsx
@@ -10,7 +10,7 @@
  * extend a `ProvideKeypad` component instead of using this mixin.
  */
 
-import {Keypad} from "@khanacademy/math-input";
+import {LegacyKeypad} from "@khanacademy/math-input";
 import PropTypes from "prop-types";
 import * as React from "react";
 import ReactDOM from "react-dom";
@@ -90,7 +90,7 @@ const ProvideKeypad = {
             document.body?.appendChild(_this._keypadContainer);
 
             reactRender(
-                <Keypad
+                <LegacyKeypad
                     onElementMounted={(element) => {
                         // NOTE(kevinb): The reason why this setState works is
                         // b/c we're calling it manually from item-renderer.jsx

--- a/packages/perseus/src/widgets/__stories__/test-keypad-context-wrapper.tsx
+++ b/packages/perseus/src/widgets/__stories__/test-keypad-context-wrapper.tsx
@@ -1,4 +1,4 @@
-import {Keypad} from "@khanacademy/math-input";
+import {LegacyKeypad} from "@khanacademy/math-input";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
@@ -10,7 +10,7 @@ const Footer = (): React.ReactElement => {
         <View style={styles.keypadContainer}>
             <KeypadContext.Consumer>
                 {({keypadElement, setKeypadElement, renderer}) => (
-                    <Keypad
+                    <LegacyKeypad
                         onElementMounted={setKeypadElement}
                         onDismiss={() => renderer && renderer.blur()}
                         style={styles.keypad}


### PR DESCRIPTION
## Summary:
- Export the v2 keypad as `Keypad`
- Rename the v1 keypad as `ProvidedKeypad` (this is going to require a change in Webapp!)

## Test plan:
Functionality shouldn't change, the v2 keypad should be exported now