### PR TITLE
Removes uses of Record<string, empty>

### DIFF
--- a/.changeset/pink-ears-fold.md
+++ b/.changeset/pink-ears-fold.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Remove the use of Record<string, never> which is unsafe

--- a/packages/perseus/src/components/__tests__/sortable.test.tsx
+++ b/packages/perseus/src/components/__tests__/sortable.test.tsx
@@ -181,7 +181,6 @@ describe("Sortable.itemsFromProps", () => {
         expect(items).toMatchInlineSnapshot(`
             [
               {
-                "endPosition": {},
                 "height": 0,
                 "key": 0,
                 "option": "a",
@@ -189,7 +188,6 @@ describe("Sortable.itemsFromProps", () => {
                 "width": 0,
               },
               {
-                "endPosition": {},
                 "height": 0,
                 "key": 1,
                 "option": "b",
@@ -197,7 +195,6 @@ describe("Sortable.itemsFromProps", () => {
                 "width": 0,
               },
               {
-                "endPosition": {},
                 "height": 0,
                 "key": 2,
                 "option": "c",

--- a/packages/perseus/src/components/sortable.tsx
+++ b/packages/perseus/src/components/sortable.tsx
@@ -72,7 +72,7 @@ class Placeholder extends React.Component<PlaceholderProps> {
 
 type DraggableProps = {
     content: string;
-    endPosition: {left: number; top: number} | Record<string, never>;
+    endPosition?: {left: number; top: number};
     includePadding: boolean;
     layout: Layout;
     width?: number;
@@ -251,7 +251,10 @@ class Draggable extends React.Component<DraggableProps, DraggableState> {
             return;
         }
 
-        if (this.props.state === ItemState.ANIMATING) {
+        if (
+            this.props.state === ItemState.ANIMATING &&
+            this.props.endPosition
+        ) {
             // Start animating
             const current = this.getCurrentPosition();
             const duration =
@@ -433,7 +436,7 @@ type SortableItem = {
     option: SortableOption;
     key: number;
     state: ItemState;
-    endPosition: Position | Record<string, never>;
+    endPosition?: Position;
     width: number;
     height: number;
 };
@@ -513,7 +516,6 @@ class Sortable extends React.Component<SortableProps, SortableState> {
                 option: option,
                 key: i,
                 state,
-                endPosition: {},
                 width: 0,
                 height: 0,
             };

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -7,7 +7,7 @@ export type Range = [number, number];
 export type Size = [number, number];
 
 // TODO(FEI-5054): Figure out how to get global .d.ts files working with monorepos
-type Empty = Record<string, never>;
+type Empty = Record<never, never>;
 
 export type PerseusItem = {
     // The details of the question being asked to the user.

--- a/packages/perseus/src/widgets/definition.tsx
+++ b/packages/perseus/src/widgets/definition.tsx
@@ -13,7 +13,7 @@ import type {
 import type {PerseusScore, WidgetExports, WidgetProps} from "../types";
 
 // TODO(FEI-5054): Figure out how to get global .d.ts files working with monorepos
-type Empty = Record<string, never>;
+type Empty = Record<never, never>;
 
 type RenderProps = PerseusDefinitionWidgetOptions;
 

--- a/packages/perseus/src/widgets/explanation.tsx
+++ b/packages/perseus/src/widgets/explanation.tsx
@@ -13,7 +13,7 @@ import type {PerseusExplanationWidgetOptions} from "../perseus-types";
 import type {PerseusScore, WidgetExports, WidgetProps} from "../types";
 
 // TODO(FEI-5054): Figure out how to get global .d.ts files working with monorepos
-type Empty = Record<string, never>;
+type Empty = Record<never, never>;
 
 type RenderProps = PerseusExplanationWidgetOptions; // transform = _.identity
 

--- a/types/utility.d.ts
+++ b/types/utility.d.ts
@@ -3,4 +3,4 @@
  */
 declare type SpreadType<A, B> = Omit<A, keyof B> & B;
 
-declare type Empty = Record<string, never>;
+declare type Empty = Record<never, never>;


### PR DESCRIPTION
## Summary:
@jaredly raised how unsafe Record<string, empty> is since in https://khanacademy.slack.com/archives/C04KJCRM8QN/p1684345906827579.  This PR removes all uses of this unsafe type.  I'll work on creating a lint rule for it our lint config/plugin in wonder-stuff separately.

In most cases `Record<string, empty>` can be replaced with `Record<empty, empty>`.

Issue: None

## Test plan:
- yarn tsc