### PR TITLE
Allow editor to configure 'points' graph type

### DIFF
--- a/.changeset/bright-gifts-change.md
+++ b/.changeset/bright-gifts-change.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+Restore point count selector in `interactive-graph` widget editor

--- a/packages/perseus-editor/src/components/graph-points-count-selector.tsx
+++ b/packages/perseus-editor/src/components/graph-points-count-selector.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+
+const UNLIMITED = "unlimited" as const;
+type PointValue = number | typeof UNLIMITED;
+
+const GraphPointsCountSelector = ({
+    numPoints = 1,
+    onChange,
+}: {
+    numPoints?: PointValue;
+    onChange: (points: PointValue) => void;
+}) => {
+    return (
+        <select
+            key="point-select"
+            value={numPoints}
+            onChange={(e) => {
+                // Convert numbers, leave UNLIMITED intact:
+                const num = +e.target.value || UNLIMITED;
+                onChange(num);
+            }}
+        >
+            {[...Array(7).keys()].map((n) => (
+                <option key={n} value={n}>
+                    {`${n} point${n > 1 ? "s" : ""}`}
+                </option>
+            ))}
+            <option value={UNLIMITED}>unlimited</option>
+        </select>
+    );
+};
+
+export default GraphPointsCountSelector;

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
@@ -7,6 +7,7 @@ import {
     SizingUtils,
     Util,
     PerseusImageBackground,
+    PerseusInteractiveGraphWidgetOptions,
     APIOptionsWithDefaults,
 } from "@khanacademy/perseus";
 import {StyleType, View} from "@khanacademy/wonder-blocks-core";
@@ -357,7 +358,7 @@ class InteractiveGraphEditor extends React.Component<Props> {
         this.props.onChange({correct: correct});
     }
 
-    serialize() /* STOPSHIP : PerseusInteractiveGraphWidgetOptions */ {
+    serialize(): PerseusInteractiveGraphWidgetOptions {
         const json = _.pick(
             this.props,
             "step",

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
@@ -8,13 +8,13 @@ import {
     Util,
     PerseusImageBackground,
     APIOptionsWithDefaults,
-    PerseusInteractiveGraphWidgetOptions,
 } from "@khanacademy/perseus";
 import {StyleType, View} from "@khanacademy/wonder-blocks-core";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
 import * as React from "react";
 import _ from "underscore";
 
+import GraphPointsCountSelector from "../components/graph-points-count-selector";
 import GraphSettings from "../components/graph-settings";
 import GraphTypeSelector from "../components/graph-type-selector";
 
@@ -191,7 +191,9 @@ class InteractiveGraphEditor extends React.Component<Props> {
         return (
             <View>
                 <Row>
-                    <span>Type of Graph:</span>
+                    <span style={{marginRight: Spacing.xSmall_8}}>
+                        Type of Graph:
+                    </span>
                     <GraphTypeSelector
                         graphType={
                             this.props.graph?.type ??
@@ -207,6 +209,24 @@ class InteractiveGraphEditor extends React.Component<Props> {
                         }}
                     />
                 </Row>
+                {this.props.graph?.type === "point" && (
+                    <Row>
+                        <span style={{marginRight: Spacing.xSmall_8}}>
+                            Number of Points:
+                        </span>
+                        <GraphPointsCountSelector
+                            numPoints={this.props.graph?.numPoints}
+                            onChange={(points) => {
+                                this.props.onChange({
+                                    correct: {
+                                        type: "point",
+                                        numPoints: points,
+                                    },
+                                });
+                            }}
+                        />
+                    </Row>
+                )}
 
                 <Row>
                     Correct answer{" "}
@@ -337,7 +357,7 @@ class InteractiveGraphEditor extends React.Component<Props> {
         this.props.onChange({correct: correct});
     }
 
-    serialize(): PerseusInteractiveGraphWidgetOptions {
+    serialize() /* STOPSHIP : PerseusInteractiveGraphWidgetOptions */ {
         const json = _.pick(
             this.props,
             "step",


### PR DESCRIPTION
## Summary:

This is PR 6 in a series of PRs that restore some editor functionality that I [deleted](https://github.com/Khan/webapp/pull/3144) back in January of 2022. It obviously isn't used often, but it's [still needed](https://khanacademy.slack.com/archives/C6NS8DWJU/p1683664865635869)!

Previous PRs:
  * #536
  * #537
  * #539
  * #540
  * #542

In this PR I re-introduce UI to configure the number of points in the graph

<img width="500" alt="image" src="https://github.com/Khan/perseus/assets/77138/62501e86-443b-4fed-ae20-af645200974d">

Issue: LC-813

## Test plan:

Start storybook and select the "Point(s)" graph type. Now change the "Number of Points" selector and verify the right side output display to compare that it's updating the widget options correctly.