### PR TITLE
Improve Chanegable's types [prototype]

### DIFF
--- a/.changeset/grumpy-windows-doubt.md
+++ b/.changeset/grumpy-windows-doubt.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Improve static typing of Changeable and the components that use it

--- a/packages/perseus-editor/src/components/graph-settings.tsx
+++ b/packages/perseus-editor/src/components/graph-settings.tsx
@@ -502,7 +502,13 @@ const GraphSettings = createReactClass({
                                     {value: "grid", content: "Grid"},
                                     {value: "none", content: "None"},
                                 ]}
-                                onChange={this.change("markings")}
+                                onChange={(value) =>
+                                    Changeable.changeSingleProp(
+                                        this,
+                                        "markings",
+                                        value,
+                                    )
+                                }
                             />
                         </div>
                         <div className="perseus-widget-left-col">

--- a/packages/perseus-editor/src/widgets/categorizer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/categorizer-editor.tsx
@@ -1,40 +1,33 @@
 import {
     components,
-    ApiOptions,
+    APIOptionsWithDefaults,
     Categorizer as CategorizerWidget,
     Changeable,
     EditorJsonify,
 } from "@khanacademy/perseus";
-import PropTypes from "prop-types";
 import * as React from "react";
 import _ from "underscore";
 
 const {PropCheckBox, TextListEditor} = components;
 const Categorizer = CategorizerWidget.widget;
 
-type Props = any;
-
-class CategorizerEditor extends React.Component<Props> {
-    static propTypes = {
-        ...Changeable.propTypes,
-        apiOptions: ApiOptions.propTypes,
-        items: PropTypes.arrayOf(PropTypes.string),
-        categories: PropTypes.arrayOf(PropTypes.string),
-        values: PropTypes.arrayOf(PropTypes.number),
-        randomizeItems: PropTypes.bool,
+type Props = typeof CategorizerEditor.defaultProps &
+    Changeable.ChangeableProps & {
+        apiOptions: APIOptionsWithDefaults;
+        items: Array<string>;
+        categories: Array<string>;
+        values: Array<number>;
+        randomizeItems: boolean;
     };
 
+class CategorizerEditor extends React.Component<Props> {
     static widgetName = "categorizer" as const;
 
-    static defaultProps: Props = {
+    static defaultProps = {
         items: [],
         categories: [],
         values: [],
         randomizeItems: false,
-    };
-
-    change: (arg1: any, arg2: any, arg3: any) => any = (...args) => {
-        return Changeable.change.apply(this, args);
     };
 
     serialize: () => any = () => {
@@ -56,8 +49,7 @@ class CategorizerEditor extends React.Component<Props> {
                 <TextListEditor
                     options={this.props.categories}
                     onChange={(cat) => {
-                        // @ts-expect-error [FEI-5003] - TS2554 - Expected 3 arguments, but got 2.
-                        this.change("categories", cat);
+                        Changeable.changeSingleProp(this, "categories", cat);
                     }}
                     layout="horizontal"
                 />

--- a/packages/perseus-editor/src/widgets/cs-program-editor.tsx
+++ b/packages/perseus-editor/src/widgets/cs-program-editor.tsx
@@ -23,16 +23,16 @@ const {InfoTip, PropCheckBox} = components;
 const DEFAULT_WIDTH = 400;
 const DEFAULT_HEIGHT = 400;
 
+type Props = typeof PairEditor.defaultProps &
+    Changeable.ChangeableProps & {
+        name: string;
+        value: string;
+    };
+
 /**
  * This is used for editing a name/value pair.
  */
-class PairEditor extends React.Component<any> {
-    static propTypes = {
-        ...Changeable.propTypes,
-        name: PropTypes.string,
-        value: PropTypes.string,
-    };
-
+class PairEditor extends React.Component<Props> {
     static defaultProps = {
         name: "",
         value: "",
@@ -53,7 +53,9 @@ class PairEditor extends React.Component<any> {
                     Name:{" "}
                     <BlurInput
                         value={this.props.name}
-                        onChange={this.change("name")}
+                        onChange={(value) =>
+                            Changeable.changeSingleProp(this, "name", value)
+                        }
                     />
                 </label>
                 <label>
@@ -61,7 +63,9 @@ class PairEditor extends React.Component<any> {
                     Value:{" "}
                     <BlurInput
                         value={this.props.value}
-                        onChange={this.change("value")}
+                        onChange={(value) =>
+                            Changeable.changeSingleProp(this, "name", value)
+                        }
                     />
                 </label>
             </fieldset>

--- a/packages/perseus-editor/src/widgets/cs-program-editor.tsx
+++ b/packages/perseus-editor/src/widgets/cs-program-editor.tsx
@@ -12,7 +12,6 @@ import {
     Log,
 } from "@khanacademy/perseus";
 import $ from "jquery";
-import PropTypes from "prop-types";
 import * as React from "react";
 import _ from "underscore";
 
@@ -23,7 +22,7 @@ const {InfoTip, PropCheckBox} = components;
 const DEFAULT_WIDTH = 400;
 const DEFAULT_HEIGHT = 400;
 
-type Props = typeof PairEditor.defaultProps &
+type PairEditorProps = typeof PairEditor.defaultProps &
     Changeable.ChangeableProps & {
         name: string;
         value: string;
@@ -32,14 +31,10 @@ type Props = typeof PairEditor.defaultProps &
 /**
  * This is used for editing a name/value pair.
  */
-class PairEditor extends React.Component<Props> {
+class PairEditor extends React.Component<PairEditorProps> {
     static defaultProps = {
         name: "",
         value: "",
-    };
-
-    change = (...args) => {
-        return Changeable.change.apply(this, args);
     };
 
     serialize = () => {
@@ -73,20 +68,15 @@ class PairEditor extends React.Component<Props> {
     }
 }
 
+type Props = Changeable.ChangeableProps & {
+    name: string;
+    pairs: Array<{name: string; value: string}>;
+};
+
 /**
  * This is used for editing a set of name/value pairs.
  */
-class PairsEditor extends React.Component<any> {
-    static propTypes = {
-        ...Changeable.propTypes,
-        pairs: PropTypes.arrayOf(
-            PropTypes.shape({
-                name: PropTypes.string,
-                value: PropTypes.string,
-            }),
-        ).isRequired,
-    };
-
+class PairsEditor extends React.Component<Props> {
     change = (...args) => {
         return Changeable.change.apply(this, args);
     };
@@ -100,7 +90,7 @@ class PairsEditor extends React.Component<any> {
         if (lastPair.name && lastPair.value) {
             pairs.push({name: "", value: ""});
         }
-        this.change("pairs", pairs);
+        Changeable.changeSingleProp(this, "pairs", pairs);
     };
 
     serialize = () => {
@@ -139,17 +129,24 @@ function isolateProgramID(programUrl: string) {
     return programUrl;
 }
 
+type CSProgramEditorProps = typeof CSProgramEditor.defaultProps &
+    Changeable.ChangeableProps & {
+        programID: string;
+        programType: any; // TODO
+        settings: Array<{name: string; value: string}>;
+        showEditor: boolean;
+        showButtons: boolean;
+        width: number;
+        height: number;
+    };
+
 /**
  * This is the main editor for this widget, to specify all the options.
  */
-class CSProgramEditor extends React.Component<any> {
-    static propTypes = {
-        ...Changeable.propTypes,
-    };
-
+class CSProgramEditor extends React.Component<CSProgramEditorProps> {
     static widgetName = "cs-program" as const;
 
-    static defaultProps: any = {
+    static defaultProps = {
         programID: "",
         programType: null,
         settings: [{name: "", value: ""}],
@@ -159,13 +156,8 @@ class CSProgramEditor extends React.Component<any> {
         height: DEFAULT_HEIGHT,
     };
 
-    change: (...args: ReadonlyArray<unknown>) => any = (...args) => {
-        // @ts-expect-error [FEI-5003] - TS2345 - Argument of type 'readonly unknown[]' is not assignable to parameter of type 'any[]'.
-        return Changeable.change.apply(this, args);
-    };
-
     _handleSettingsChange: (arg1: any) => void = (settings) => {
-        this.change({settings: settings.pairs});
+        Changeable.changeMultipleProps(this, {settings: settings.pairs});
     };
 
     _handleProgramIDChange: (arg1: string) => void = (programID) => {
@@ -180,7 +172,7 @@ class CSProgramEditor extends React.Component<any> {
         $.getJSON(baseUrl)
             .done((programInfo) => {
                 const programType = programInfo.userAuthoredContentType;
-                this.change({
+                Changeable.changeMultipleProps(this, {
                     width: programInfo.width,
                     height: programInfo.height,
                     programID: programID,
@@ -200,7 +192,7 @@ class CSProgramEditor extends React.Component<any> {
                         },
                     },
                 );
-                this.change({
+                Changeable.changeMultipleProps(this, {
                     width: DEFAULT_WIDTH,
                     height: DEFAULT_HEIGHT,
                     programID: programID,

--- a/packages/perseus/src/mixins/changeable.ts
+++ b/packages/perseus/src/mixins/changeable.ts
@@ -31,14 +31,9 @@ const USAGE =
  * figured out which way it was called.
  */
 const _changeMultiple = function (
-    component: any,
-    newProps:
-        | string
-        | Record<any, any>
-        | {
-              [key: string]: any;
-          },
-    callback,
+    component: {props: ChangeableProps},
+    newProps: Record<any, any>,
+    callback?: () => unknown,
 ) {
     // Omit "default" props:
     // ref and key come from react, and don't actually represent
@@ -54,7 +49,7 @@ const _changeMultiple = function (
  * Helper function for changing a single prop
  */
 const _changeSingle = function (
-    component: any,
+    component: {props: ChangeableProps},
     propName: string,
     value: any,
     callback,
@@ -118,6 +113,15 @@ export const change: ChangeFn = function (
     );
 };
 
+export function changeSingleProp(
+    component: {props: ChangeableProps},
+    name: string,
+    value: any,
+    callback?: () => unknown,
+) {
+    _changeMultiple(component, {[name]: value}, callback);
+}
+
 export const propTypes = {
     onChange: PropTypes.func.isRequired,
 } as const;
@@ -127,7 +131,7 @@ export type ChangeableProps = {
         values: {
             [key: string]: any;
         },
-        callback?: () => unknown | null | undefined,
+        callback?: () => unknown,
         silent?: boolean,
     ) => unknown;
 };

--- a/packages/perseus/src/mixins/changeable.ts
+++ b/packages/perseus/src/mixins/changeable.ts
@@ -32,7 +32,7 @@ const USAGE =
  */
 const _changeMultiple = function (
     component: {props: ChangeableProps},
-    newProps: Record<any, any>,
+    newProps: Record<string, any>,
     callback?: () => unknown,
 ) {
     // Omit "default" props:
@@ -113,13 +113,24 @@ export const change: ChangeFn = function (
     );
 };
 
-export function changeSingleProp(
-    component: {props: ChangeableProps},
-    name: string,
-    value: any,
+export function changeSingleProp<
+    Props extends ChangeableProps,
+    Name extends keyof Props,
+>(
+    component: {props: Props},
+    name: Name,
+    value: Props[Name],
     callback?: () => unknown,
 ) {
     _changeMultiple(component, {[name]: value}, callback);
+}
+
+export function changeMultipleProps<Props extends ChangeableProps>(
+    component: {props: Props},
+    props: Partial<Props>,
+    callback?: () => unknown,
+) {
+    _changeMultiple(component, props, callback);
 }
 
 export const propTypes = {

--- a/packages/perseus/src/widgets/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer.tsx
@@ -50,11 +50,6 @@ export class Categorizer extends React.Component<Props, State> {
         uniqueId: _.uniqueId("perseus_radio_"),
     };
 
-    change: (...args: ReadonlyArray<unknown>) => any = (...args) => {
-        // @ts-expect-error [FEI-5003] - TS2345 - Argument of type 'readonly unknown[]' is not assignable to parameter of type 'any[]'.
-        return Changeable.change.apply(this, args);
-    };
-
     getUserInput: () => UserInput = () => {
         return Categorizer.getUserInputFromProps(this.props);
     };
@@ -213,7 +208,7 @@ export class Categorizer extends React.Component<Props, State> {
         const values = [...this.props.values];
         // @ts-expect-error [FEI-5003] - TS2322 - Type 'number' is not assignable to type 'never'.
         values[itemNum] = catNum;
-        this.change("values", values);
+        Changeable.changeSingleProp(this, "values", values);
         this.props.trackInteraction();
     };
 

--- a/packages/perseus/src/widgets/expression.tsx
+++ b/packages/perseus/src/widgets/expression.tsx
@@ -352,10 +352,6 @@ export class Expression extends React.Component<Props, ExpressionState> {
         return Expression.getUserInputFromProps(this.props);
     };
 
-    change: (...args: any) => any | undefined = (...args: any) => {
-        return Changeable.change.apply(this, args);
-    };
-
     parse: (value: string, props: Props) => any = (
         value: string,
         props: Props,
@@ -369,11 +365,8 @@ export class Expression extends React.Component<Props, ExpressionState> {
         return KAS.parse(insertBraces(value), options);
     };
 
-    changeAndTrack: (e: any, cb: () => void) => void = (
-        e: any,
-        cb: () => void,
-    ) => {
-        this.change("value", e, cb);
+    changeAndTrack = (e: any, cb: () => void) => {
+        Changeable.changeSingleProp(this, "value", e, cb);
         this.props.trackInteraction();
     };
 

--- a/packages/perseus/src/widgets/expression.tsx
+++ b/packages/perseus/src/widgets/expression.tsx
@@ -365,8 +365,8 @@ export class Expression extends React.Component<Props, ExpressionState> {
         return KAS.parse(insertBraces(value), options);
     };
 
-    changeAndTrack = (e: any, cb: () => void) => {
-        Changeable.changeSingleProp(this, "value", e, cb);
+    changeAndTrack = (value: string, cb: () => void) => {
+        Changeable.changeSingleProp(this, "value", value, cb);
         this.props.trackInteraction();
     };
 

--- a/packages/perseus/src/widgets/graded-group.tsx
+++ b/packages/perseus/src/widgets/graded-group.tsx
@@ -112,11 +112,6 @@ export class GradedGroup extends React.Component<Props, State> {
         return nextProps !== this.props || nextState !== this.state;
     }
 
-    change: (...args: ReadonlyArray<unknown>) => any = (...args) => {
-        // @ts-expect-error [FEI-5003] - TS2345 - Argument of type 'readonly unknown[]' is not assignable to parameter of type 'any[]'.
-        return Changeable.change.apply(this, args);
-    };
-
     // This is a little strange because the id of the widget that actually
     // changed is going to be lost in favor of the group widget's id. The
     // widgets prop also wasn't actually changed, and this only serves to
@@ -131,7 +126,7 @@ export class GradedGroup extends React.Component<Props, State> {
 
         // eslint-disable-next-line react/no-string-refs
         if (this.refs.renderer) {
-            this.change("widgets", this.props.widgets);
+            Changeable.changeSingleProp(this, "widgets", this.props.widgets);
             // eslint-disable-next-line react/no-string-refs
             // @ts-expect-error [FEI-5003] - TS2339 - Property 'emptyWidgets' does not exist on type 'ReactInstance'.
             const emptyWidgets = this.refs.renderer.emptyWidgets();

--- a/packages/perseus/src/widgets/group.tsx
+++ b/packages/perseus/src/widgets/group.tsx
@@ -10,7 +10,6 @@ import type {PerseusGroupWidgetOptions} from "../perseus-types";
 import type {Widget} from "../renderer";
 import type {
     APIOptions,
-    ChangeFn,
     FocusPath,
     PerseusScore,
     WidgetExports,
@@ -43,10 +42,6 @@ class Group extends React.Component<Props> {
         // the group with the correct number.
         this.forceUpdate();
     }
-
-    change: ChangeFn = (...args) => {
-        return Changeable.change.apply(this, args);
-    };
 
     getUserInput: () => any = () => {
         return this.rendererRef?.getUserInput();
@@ -141,7 +136,11 @@ class Group extends React.Component<Props> {
         // has occurred.
         const onInteractWithWidget = (id) => {
             if (this.rendererRef) {
-                this.change("widgets", this.rendererRef.props.widgets);
+                Changeable.changeSingleProp(
+                    this,
+                    "widgets",
+                    this.rendererRef.props.widgets,
+                );
             }
         };
 


### PR DESCRIPTION
## Summary:
Changeable.change's signature makes it more difficult to use unsafely.  This PR creates separate functions with better type signatures.

Issue: None

## Test plan:
- yarn flow
- yarn storybook
- check that the the expression widget is working as expected
- let CI run the tests
- misspell one of the prop names when using `changeSingleProp` to see that the new types catch this issue

<img width="938" alt="Screen Shot 2023-05-19 at 4 53 08 PM" src="https://github.com/Khan/perseus/assets/1044413/1ece4034-0e50-466e-b0a0-5c966c2c6d91">
