### PR TITLE
Tabbar accepts style, create demo of using v2 keypad in popover

### DIFF
--- a/.changeset/stale-rabbits-wink.md
+++ b/.changeset/stale-rabbits-wink.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": minor
+---
+
+Make tabbar accept styles, create v2 keypad popover example

--- a/packages/math-input/.eslintrc.js
+++ b/packages/math-input/.eslintrc.js
@@ -8,6 +8,9 @@ module.exports = {
             "error",
             {
                 packageDir: [__dirname, path.join(__dirname, "../../")],
+                // note(matthewc): I changed this in a time pinch and I'm not sure
+                // it's right so I made a ticket to circle back to it
+                // https://khanacademy.atlassian.net/browse/LC-864
                 devDependencies: ["**/*.stories.tsx", "**/*.test.tsx"],
             },
         ],

--- a/packages/math-input/.eslintrc.js
+++ b/packages/math-input/.eslintrc.js
@@ -6,7 +6,10 @@ module.exports = {
     rules: {
         "import/no-extraneous-dependencies": [
             "error",
-            {packageDir: [__dirname, path.join(__dirname, "../../")]},
+            {
+                packageDir: [__dirname, path.join(__dirname, "../../")],
+                devDependencies: ['**/*.stories.tsx'],
+            },
         ],
     },
 };

--- a/packages/math-input/.eslintrc.js
+++ b/packages/math-input/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
             "error",
             {
                 packageDir: [__dirname, path.join(__dirname, "../../")],
-                devDependencies: ['**/*.stories.tsx'],
+                devDependencies: ["**/*.stories.tsx", "**/*.test.tsx"],
             },
         ],
     },

--- a/packages/math-input/package.json
+++ b/packages/math-input/package.json
@@ -26,6 +26,7 @@
         "@khanacademy/wonder-blocks-color": "^2.0.1",
         "@khanacademy/wonder-blocks-core": "^5.0.4",
         "@khanacademy/wonder-blocks-i18n": "^2.0.2",
+        "@khanacademy/wonder-blocks-popover": "^2.0.11",
         "@khanacademy/wonder-stuff-core": "^1.2.2",
         "aphrodite": "^1.1.0",
         "jquery": "^2.1.1",

--- a/packages/math-input/src/components/keypad-legacy/two-page-keypad.tsx
+++ b/packages/math-input/src/components/keypad-legacy/two-page-keypad.tsx
@@ -2,6 +2,7 @@
  * A keypad with two pages of keys.
  */
 
+import Color from "@khanacademy/wonder-blocks-color";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 import {connect} from "react-redux";
@@ -54,6 +55,11 @@ class TwoPageKeypad extends React.Component<Props, State> {
                         onSelectItem={(selectedItem) => {
                             this.setState({selectedPage: selectedItem});
                         }}
+                        style={{
+                            background: Color.offWhite,
+                            borderTop: `1px solid ${Color.offBlack50}`,
+                            borderBottom: `1px solid ${Color.offBlack50}`,
+                        }}
                     />
                     <View style={styles.borderTop}>
                         {selectedPage === "Numbers" && rightPage}
@@ -94,6 +100,7 @@ const styles = StyleSheet.create({
             `${innerBorderColor}`,
         boxSizing: "content-box",
     },
+    tabbarWrapper: {},
 });
 
 const mapStateToProps = (state: ReduxState): ReduxProps => {

--- a/packages/math-input/src/components/keypad-legacy/two-page-keypad.tsx
+++ b/packages/math-input/src/components/keypad-legacy/two-page-keypad.tsx
@@ -55,11 +55,7 @@ class TwoPageKeypad extends React.Component<Props, State> {
                         onSelectItem={(selectedItem) => {
                             this.setState({selectedPage: selectedItem});
                         }}
-                        style={{
-                            background: Color.offWhite,
-                            borderTop: `1px solid ${Color.offBlack50}`,
-                            borderBottom: `1px solid ${Color.offBlack50}`,
-                        }}
+                        style={styles.tabbar}
                     />
                     <View style={styles.borderTop}>
                         {selectedPage === "Numbers" && rightPage}
@@ -100,7 +96,11 @@ const styles = StyleSheet.create({
             `${innerBorderColor}`,
         boxSizing: "content-box",
     },
-    tabbarWrapper: {},
+    tabbar: {
+        background: Color.offWhite,
+        borderTop: `1px solid ${Color.offBlack50}`,
+        borderBottom: `1px solid ${Color.offBlack50}`,
+    },
 });
 
 const mapStateToProps = (state: ReduxState): ReduxProps => {

--- a/packages/math-input/src/components/keypad/index.tsx
+++ b/packages/math-input/src/components/keypad/index.tsx
@@ -1,4 +1,5 @@
 import Color from "@khanacademy/wonder-blocks-color";
+import {StyleSheet} from "aphrodite";
 import {View} from "@khanacademy/wonder-blocks-core";
 import * as React from "react";
 
@@ -75,10 +76,7 @@ export default class Keypad extends React.Component<Props, State> {
                     onSelectItem={(tabbarItem: TabbarItemType) => {
                         this.setState({selectedPage: tabbarItem});
                     }}
-                    style={{
-                        background: Color.white,
-                        border: `1px solid ${Color.offBlack16}`,
-                    }}
+                    style={styles.tabbar}
                 />
                 {selectedPage === "Numbers" && <NumbersPage {...this.props} />}
                 {selectedPage === "Extras" && <ExtrasPage {...this.props} />}
@@ -92,3 +90,10 @@ export default class Keypad extends React.Component<Props, State> {
         );
     }
 }
+
+const styles = StyleSheet.create({
+    tabbar: {
+        background: Color.white,
+        border: `1px solid ${Color.offBlack16}`,
+    },
+});

--- a/packages/math-input/src/components/keypad/index.tsx
+++ b/packages/math-input/src/components/keypad/index.tsx
@@ -1,10 +1,11 @@
 import Color from "@khanacademy/wonder-blocks-color";
-import {StyleSheet} from "aphrodite";
 import {View} from "@khanacademy/wonder-blocks-core";
+import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 import Key from "../../data/keys";
 import Tabbar from "../tabbar/tabbar";
+import {TabbarItemType} from "../tabbar/types";
 
 import ExtrasPage from "./extras-page";
 import GeometryPage from "./geometry-page";
@@ -12,8 +13,6 @@ import NumbersPage from "./numbers-page";
 import {NumbersPageOptions} from "./numbers-page/types";
 import OperatorsPage from "./operators-page";
 import {OperatorsButtonSets} from "./operators-page/types";
-
-import type {TabbarItemType} from "../tabbar/types";
 
 export type Props = {
     onClickKey: (keyConfig: string) => void;
@@ -30,7 +29,7 @@ type DefaultProps = {
     extraKeys: Props["extraKeys"];
 };
 
-const allPages = function (props: Props): ReadonlyArray<TabbarItemType> {
+function allPages(props: Props): ReadonlyArray<TabbarItemType> {
     const pages: Array<TabbarItemType> = ["Numbers"];
 
     if (props.extraKeys?.length) {
@@ -52,7 +51,7 @@ const allPages = function (props: Props): ReadonlyArray<TabbarItemType> {
     }
 
     return pages;
-};
+}
 
 export default class Keypad extends React.Component<Props, State> {
     state: State = {

--- a/packages/math-input/src/components/keypad/index.tsx
+++ b/packages/math-input/src/components/keypad/index.tsx
@@ -1,3 +1,4 @@
+import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import * as React from "react";
 
@@ -73,6 +74,10 @@ export default class Keypad extends React.Component<Props, State> {
                     selectedItem={selectedPage}
                     onSelectItem={(tabbarItem: TabbarItemType) => {
                         this.setState({selectedPage: tabbarItem});
+                    }}
+                    style={{
+                        background: Color.white,
+                        border: `1px solid ${Color.offBlack16}`,
                     }}
                 />
                 {selectedPage === "Numbers" && <NumbersPage {...this.props} />}

--- a/packages/math-input/src/components/keypad/index.tsx
+++ b/packages/math-input/src/components/keypad/index.tsx
@@ -93,6 +93,5 @@ export default class Keypad extends React.Component<Props, State> {
 const styles = StyleSheet.create({
     tabbar: {
         background: Color.white,
-        border: `1px solid ${Color.offBlack16}`,
     },
 });

--- a/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
+++ b/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
@@ -1,3 +1,4 @@
+import Color from "@khanacademy/wonder-blocks-color";
 import {Popover} from "@khanacademy/wonder-blocks-popover";
 import MathQuill from "mathquill";
 import * as React from "react";
@@ -68,7 +69,11 @@ export function V2KeypadWithMathquill() {
                 dismissEnabled
             >
                 <div
-                    style={{width: "100%", marginBottom: "1em"}}
+                    style={{
+                        width: "100%",
+                        marginBottom: "1em",
+                        border: `1px solid ${Color.offBlack16}`,
+                    }}
                     ref={mathquillWrapperRef}
                 />
             </Popover>

--- a/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
+++ b/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
@@ -1,3 +1,4 @@
+import {Popover} from "@khanacademy/wonder-blocks-popover";
 import MathQuill from "mathquill";
 import * as React from "react";
 
@@ -18,6 +19,7 @@ const mathQuillConfig = {
 };
 
 export function V2KeypadWithMathquill() {
+    const containerRef = React.useRef<HTMLDivElement>(null);
     const mathquillWrapperRef = React.useRef<HTMLDivElement>(null);
     const [mathQuill, setMathQuill] = React.useState<MathQuill>();
 
@@ -47,24 +49,30 @@ export function V2KeypadWithMathquill() {
     }
 
     return (
-        <div style={{maxWidth: "400px", margin: "2em"}}>
-            <div
-                ref={mathquillWrapperRef}
-                style={{width: "100%", marginBottom: "1em"}}
-            />
-            <div>
-                <Keypad
-                    extraKeys={["a", "b", "c"]}
-                    onClickKey={handleClickKey}
-                    advancedRelations
-                    basicRelations
-                    divisionKey
-                    logarithms
-                    multiplicationDot
-                    preAlgebra
-                    trigonometry
+        <div style={{maxWidth: "400px", margin: "2em"}} ref={containerRef}>
+            <Popover
+                content={
+                    <div>
+                        <Keypad
+                            extraKeys={["a", "b", "c"]}
+                            onClickKey={handleClickKey}
+                            advancedRelations
+                            basicRelations
+                            divisionKey
+                            logarithms
+                            multiplicationDot
+                            preAlgebra
+                            trigonometry
+                        />
+                    </div>
+                }
+                dismissEnabled
+            >
+                <div
+                    ref={mathquillWrapperRef}
+                    style={{width: "100%", marginBottom: "1em"}}
                 />
-            </div>
+            </Popover>
         </div>
     );
 }

--- a/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
+++ b/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
@@ -19,7 +19,6 @@ const mathQuillConfig = {
 };
 
 export function V2KeypadWithMathquill() {
-    const containerRef = React.useRef<HTMLDivElement>(null);
     const mathquillWrapperRef = React.useRef<HTMLDivElement>(null);
     const [mathQuill, setMathQuill] = React.useState<MathQuill>();
 
@@ -49,7 +48,7 @@ export function V2KeypadWithMathquill() {
     }
 
     return (
-        <div style={{maxWidth: "400px", margin: "2em"}} ref={containerRef}>
+        <div style={{maxWidth: "400px", margin: "2em"}}>
             <Popover
                 content={
                     <div>
@@ -69,8 +68,8 @@ export function V2KeypadWithMathquill() {
                 dismissEnabled
             >
                 <div
-                    ref={mathquillWrapperRef}
                     style={{width: "100%", marginBottom: "1em"}}
+                    ref={mathquillWrapperRef}
                 />
             </Popover>
         </div>

--- a/packages/math-input/src/components/tabbar/tabbar.tsx
+++ b/packages/math-input/src/components/tabbar/tabbar.tsx
@@ -1,20 +1,18 @@
-import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 import TabbarItem from "./item";
 
-import type {TabbarItemType} from "./types";
+import {TabbarItemType} from "./types";
+import {StyleType} from "@khanacademy/wonder-blocks-core";
 
 const styles = StyleSheet.create({
     tabbar: {
         display: "flex",
         flexDirection: "row",
-        background: Color.white,
         paddingTop: 2,
         paddingBottom: 2,
-        border: `1px solid ${Color.offBlack16}`,
     },
 });
 
@@ -22,13 +20,14 @@ type Props = {
     items: ReadonlyArray<TabbarItemType>;
     selectedItem: TabbarItemType;
     onSelectItem: (item: TabbarItemType) => void;
+    style?: StyleType;
 };
 
 function Tabbar(props: Props): React.ReactElement {
-    const {items, selectedItem, onSelectItem} = props;
+    const {items, selectedItem, onSelectItem, style} = props;
 
     return (
-        <View style={styles.tabbar}>
+        <View style={[styles.tabbar, style]}>
             {items.map((item) => (
                 <TabbarItem
                     key={`tabbar-item-${item}`}

--- a/packages/math-input/src/components/tabbar/tabbar.tsx
+++ b/packages/math-input/src/components/tabbar/tabbar.tsx
@@ -1,11 +1,9 @@
-import {View} from "@khanacademy/wonder-blocks-core";
+import {View, StyleType} from "@khanacademy/wonder-blocks-core";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 import TabbarItem from "./item";
-
 import {TabbarItemType} from "./types";
-import {StyleType} from "@khanacademy/wonder-blocks-core";
 
 const styles = StyleSheet.create({
     tabbar: {

--- a/packages/math-input/src/components/tabbar/tabbar.tsx
+++ b/packages/math-input/src/components/tabbar/tabbar.tsx
@@ -11,11 +11,10 @@ const styles = StyleSheet.create({
     tabbar: {
         display: "flex",
         flexDirection: "row",
-        background: Color.offWhite,
+        background: Color.white,
         paddingTop: 2,
         paddingBottom: 2,
-        borderTop: `1px solid ${Color.offBlack50}`,
-        borderBottom: `1px solid ${Color.offBlack50}`,
+        border: `1px solid ${Color.offBlack16}`,
     },
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2628,6 +2628,15 @@
   resolved "https://registry.yarnpkg.com/@khanacademy/eslint-config/-/eslint-config-1.3.0.tgz#4c23870083f73382a4bcb76503a85eb010acf47c"
   integrity sha512-87iKqX20sfEIjJXuEUamf8tPToY8+1qyZKRwNRlWphhvjjK2mqFoRxxG+BTVehHlpMVqrya4FtFZwi7zk4bRGQ==
 
+"@khanacademy/wonder-blocks-breadcrumbs@^2.0.10":
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-breadcrumbs/-/wonder-blocks-breadcrumbs-2.0.10.tgz#a5896c7c2f76feb778f1b407e3a39ee28d887ba9"
+  integrity sha512-K++P/Dtc3Ho7AHdziZ77/jWldC5moRKdJ+x0yiGIbWksgCb/8ZYvZ+3obzNyetY0e1YD6pmTgvUNhtAxXG32fg==
+  dependencies:
+    "@babel/runtime" "^7.18.6"
+    "@khanacademy/wonder-blocks-core" "^5.2.0"
+    "@khanacademy/wonder-blocks-spacing" "^4.0.1"
+
 "@khanacademy/wonder-blocks-breadcrumbs@^2.0.8":
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-breadcrumbs/-/wonder-blocks-breadcrumbs-2.0.8.tgz#1ae3218af68c0aff488db06bbf38969ccf77a35c"
@@ -2651,6 +2660,15 @@
     "@khanacademy/wonder-blocks-spacing" "^4.0.1"
     "@khanacademy/wonder-blocks-typography" "^2.0.8"
 
+"@khanacademy/wonder-blocks-clickable@^3.0.10":
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-clickable/-/wonder-blocks-clickable-3.0.10.tgz#925179feec5756c2669df671536cfc4430a6d171"
+  integrity sha512-FBrgLhTAFW5imcpGumPk5jZ+YnDh6WtOD4cHRim7y+kb2c6vmcEpkozm76Ex7mWEv3eQrafTUA0cZtX4Qw78vQ==
+  dependencies:
+    "@babel/runtime" "^7.18.6"
+    "@khanacademy/wonder-blocks-color" "^2.0.1"
+    "@khanacademy/wonder-blocks-core" "^5.2.0"
+
 "@khanacademy/wonder-blocks-clickable@^3.0.8":
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-clickable/-/wonder-blocks-clickable-3.0.8.tgz#c4fb259c3783fca11bcf2573be42f1663ac2fc8a"
@@ -2669,6 +2687,13 @@
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-core/-/wonder-blocks-core-5.0.4.tgz#82703e0c7f207835462889b21ab03e28a8022313"
   integrity sha512-i1/XzbPMYN8G5q448JK/Ljhsb4/af0pnQmBbokiNVlR+tTWyBXpOk8Bs7cB0QgSuZHjdQCeJY+D96XMJtWOS6g==
+  dependencies:
+    "@babel/runtime" "^7.18.6"
+
+"@khanacademy/wonder-blocks-core@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-core/-/wonder-blocks-core-5.2.0.tgz#0072c2f89abb92dd7522883167b18e2c25a3b845"
+  integrity sha512-yQAPptILmuMYWn2Q6Dq6g5TrDfAr6AHsYFnVZYSdXWrm0EYCQc3AvXfF32vz3+AnOEv+lkgs/zUsIIy91VBJQg==
   dependencies:
     "@babel/runtime" "^7.18.6"
 
@@ -2718,6 +2743,17 @@
   dependencies:
     "@babel/runtime" "^7.18.6"
 
+"@khanacademy/wonder-blocks-icon-button@^4.0.10":
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-icon-button/-/wonder-blocks-icon-button-4.0.10.tgz#6074f2d92bbd3df2a4fc354433aa19fa09ee4d1d"
+  integrity sha512-wu8JbdWvfYZXg2fOKDymNnnQDGHhW8kVy9qPa+Mxwvcr3nzD613c7Ccl/UqKwsSUf0qOmKgzTEjnaE9Xx9jrVg==
+  dependencies:
+    "@babel/runtime" "^7.18.6"
+    "@khanacademy/wonder-blocks-clickable" "^3.0.10"
+    "@khanacademy/wonder-blocks-color" "^2.0.1"
+    "@khanacademy/wonder-blocks-core" "^5.2.0"
+    "@khanacademy/wonder-blocks-icon" "^2.0.10"
+
 "@khanacademy/wonder-blocks-icon-button@^4.0.8":
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-icon-button/-/wonder-blocks-icon-button-4.0.8.tgz#cb6a87ff6a1f7237d0b43e18a14fa9631b43506e"
@@ -2729,6 +2765,14 @@
     "@khanacademy/wonder-blocks-core" "^5.0.4"
     "@khanacademy/wonder-blocks-icon" "^2.0.8"
 
+"@khanacademy/wonder-blocks-icon@^2.0.10":
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-icon/-/wonder-blocks-icon-2.0.10.tgz#34bad79571d92fe703117037db6e98296cde8259"
+  integrity sha512-D065mDsxmwuDp/ERftK6RhSbhgMTNCsLIZ3fLb2owc7Eh8fUuZ9VSrG3ruAAiObji/BsFCYopNLlzUC5YOIzOQ==
+  dependencies:
+    "@babel/runtime" "^7.18.6"
+    "@khanacademy/wonder-blocks-core" "^5.2.0"
+
 "@khanacademy/wonder-blocks-icon@^2.0.8":
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-icon/-/wonder-blocks-icon-2.0.8.tgz#253515216d0747b6e974192548d9564670a1b890"
@@ -2736,6 +2780,15 @@
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@khanacademy/wonder-blocks-core" "^5.0.4"
+
+"@khanacademy/wonder-blocks-layout@^2.0.10":
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-layout/-/wonder-blocks-layout-2.0.10.tgz#25160fb15882dab47f83cf4c8ca5b9062f9f83bb"
+  integrity sha512-aWhP4QEicxsUurZ5zkUEdujgP6zpyoM6KkVqOiwDhnKEYkRXUWHl8F+Mm6nYyelNYmCaNxhpBPJ+jYAt0NYYUg==
+  dependencies:
+    "@babel/runtime" "^7.18.6"
+    "@khanacademy/wonder-blocks-core" "^5.2.0"
+    "@khanacademy/wonder-blocks-spacing" "^4.0.1"
 
 "@khanacademy/wonder-blocks-layout@^2.0.8":
   version "2.0.8"
@@ -2756,6 +2809,22 @@
     "@khanacademy/wonder-blocks-color" "^2.0.1"
     "@khanacademy/wonder-blocks-core" "^5.0.4"
 
+"@khanacademy/wonder-blocks-modal@^4.0.11":
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-modal/-/wonder-blocks-modal-4.0.11.tgz#66bd284744e3fab4c977986fc3b1227c03e7ea10"
+  integrity sha512-qiHJzUrFTkb5XATt5fmxySkaMVdFA1l4WDCkqoeICoqwHejl/ueac+5jYtrfoSVkla0WpvjOXkm28XF7jAbFqQ==
+  dependencies:
+    "@babel/runtime" "^7.18.6"
+    "@khanacademy/wonder-blocks-breadcrumbs" "^2.0.10"
+    "@khanacademy/wonder-blocks-color" "^2.0.1"
+    "@khanacademy/wonder-blocks-core" "^5.2.0"
+    "@khanacademy/wonder-blocks-icon" "^2.0.10"
+    "@khanacademy/wonder-blocks-icon-button" "^4.0.10"
+    "@khanacademy/wonder-blocks-layout" "^2.0.10"
+    "@khanacademy/wonder-blocks-spacing" "^4.0.1"
+    "@khanacademy/wonder-blocks-timing" "^4.0.0"
+    "@khanacademy/wonder-blocks-typography" "^2.0.10"
+
 "@khanacademy/wonder-blocks-modal@^4.0.8":
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-modal/-/wonder-blocks-modal-4.0.8.tgz#da6a28fbaadcd9b3d6bdded8353b330898e5fddb"
@@ -2771,6 +2840,21 @@
     "@khanacademy/wonder-blocks-spacing" "^4.0.1"
     "@khanacademy/wonder-blocks-timing" "^3.0.2"
     "@khanacademy/wonder-blocks-typography" "^2.0.8"
+
+"@khanacademy/wonder-blocks-popover@^2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-popover/-/wonder-blocks-popover-2.0.11.tgz#590f39afa5c8580bcdf40ab65603f71bc6af6cbd"
+  integrity sha512-P3vDEl/j5tKTYJWwLme7OXVun7EPcWCyDexoCsejPRlxDNfUYKhChdTPGvFDejpdBrL1pqWqoIwZq0PM0UhiEw==
+  dependencies:
+    "@babel/runtime" "^7.18.6"
+    "@khanacademy/wonder-blocks-color" "^2.0.1"
+    "@khanacademy/wonder-blocks-core" "^5.2.0"
+    "@khanacademy/wonder-blocks-icon" "^2.0.10"
+    "@khanacademy/wonder-blocks-icon-button" "^4.0.10"
+    "@khanacademy/wonder-blocks-modal" "^4.0.11"
+    "@khanacademy/wonder-blocks-spacing" "^4.0.1"
+    "@khanacademy/wonder-blocks-tooltip" "^2.0.11"
+    "@khanacademy/wonder-blocks-typography" "^2.0.10"
 
 "@khanacademy/wonder-blocks-popover@^2.0.8":
   version "2.0.8"
@@ -2825,6 +2909,24 @@
   resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-timing/-/wonder-blocks-timing-3.0.2.tgz#54713390dfe27ab19d3581e829d2b6c780449a0b"
   integrity sha512-7duBBYseUdOrMJwxJ+dlDc7iiNR2g22ZidosjzXIUt/8bC3T7eJ3m+45snCs2yTMON+9GZ73MiXE2QrNVI/HMQ==
 
+"@khanacademy/wonder-blocks-timing@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-timing/-/wonder-blocks-timing-4.0.0.tgz#fb9d22afa2c630cb8df4439a4290c074f9120659"
+  integrity sha512-ugswnxzX20WSrXMXR50z/UHoH4LIadd+lb1cltQyY7/h2ZDrWFP3FBESiUypZXNyfqFuSFFDOLYSCNYYLRqZJw==
+
+"@khanacademy/wonder-blocks-tooltip@^2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-tooltip/-/wonder-blocks-tooltip-2.0.11.tgz#12b01d4808faf45ded33341e1a88e992f38c8333"
+  integrity sha512-W8izcPXe0mtoQ5qDaBrEiIBsnuIPhLZwlL6fNhgHjIyVpbFllurOrXbHxc30tWL9zTbNHd0Piq+fIviGFCYEIw==
+  dependencies:
+    "@babel/runtime" "^7.18.6"
+    "@khanacademy/wonder-blocks-color" "^2.0.1"
+    "@khanacademy/wonder-blocks-core" "^5.2.0"
+    "@khanacademy/wonder-blocks-layout" "^2.0.10"
+    "@khanacademy/wonder-blocks-modal" "^4.0.11"
+    "@khanacademy/wonder-blocks-spacing" "^4.0.1"
+    "@khanacademy/wonder-blocks-typography" "^2.0.10"
+
 "@khanacademy/wonder-blocks-tooltip@^2.0.8":
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-tooltip/-/wonder-blocks-tooltip-2.0.8.tgz#10d423598fdc47ef7eddf3fa2ec341df3e0560f5"
@@ -2837,6 +2939,14 @@
     "@khanacademy/wonder-blocks-modal" "^4.0.8"
     "@khanacademy/wonder-blocks-spacing" "^4.0.1"
     "@khanacademy/wonder-blocks-typography" "^2.0.8"
+
+"@khanacademy/wonder-blocks-typography@^2.0.10":
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-typography/-/wonder-blocks-typography-2.0.10.tgz#ef376672102d2f9ac34b88540c93aaf23c01c97c"
+  integrity sha512-LVDgZAgA+m8ByrJaN1EBT+ssaZteNGvaci/YIXjxjLXKu3JMCOYjdDW7pQwXu+whnRPKDRXYGfctEAxJXQnx1A==
+  dependencies:
+    "@babel/runtime" "^7.18.6"
+    "@khanacademy/wonder-blocks-core" "^5.2.0"
 
 "@khanacademy/wonder-blocks-typography@^2.0.5", "@khanacademy/wonder-blocks-typography@^2.0.8":
   version "2.0.8"


### PR DESCRIPTION
## Summary:
- Adds a story with an example of the v2 keypad in a popover, which is the final goal for desktop
- I needed to style tabbar in v2 differently, but I didn't want to break prod so I added a style prop

https://github.com/Khan/perseus/assets/16308368/724c1612-bf02-47bd-a388-4ad3c584acb1
