### PR TITLE
Allow editor to configure 'line segment' graph type

### DIFF
--- a/.changeset/stupid-shrimps-marry.md
+++ b/.changeset/stupid-shrimps-marry.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+Re-enable editing of 'line segment' graph type in interactive-graph-editor

--- a/packages/perseus-editor/src/components/segment-count-selector.tsx
+++ b/packages/perseus-editor/src/components/segment-count-selector.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import _ from "underscore";
+
+const SegmentCountSelector = ({
+    numSegments = 1,
+    onChange,
+}: {
+    numSegments?: number;
+    onChange: (numSegments: number) => void;
+}) => (
+    <select
+        key="segment-select"
+        value={numSegments}
+        onChange={(e) => {
+            const num = +e.target.value;
+            onChange(num);
+        }}
+    >
+        {_.map(_.range(1, 7), function (n) {
+            return (
+                <option key={n} value={n}>
+                    {`${n} segment${n > 1 ? "s" : ""}`}
+                </option>
+            );
+        })}
+    </select>
+);
+
+export default SegmentCountSelector;

--- a/packages/perseus-editor/src/components/segment-count-selector.tsx
+++ b/packages/perseus-editor/src/components/segment-count-selector.tsx
@@ -16,13 +16,11 @@ const SegmentCountSelector = ({
             onChange(num);
         }}
     >
-        {_.map(_.range(1, 7), function (n) {
-            return (
-                <option key={n} value={n}>
-                    {`${n} segment${n > 1 ? "s" : ""}`}
-                </option>
-            );
-        })}
+        {_.range(1, 7).map((n) => (
+            <option key={n} value={n}>
+                {`${n} segment${n > 1 ? "s" : ""}`}
+            </option>
+        ))}
     </select>
 );
 

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
@@ -19,6 +19,7 @@ import _ from "underscore";
 import GraphPointsCountSelector from "../components/graph-points-count-selector";
 import GraphSettings from "../components/graph-settings";
 import GraphTypeSelector from "../components/graph-type-selector";
+import SegmentCountSelector from "../components/segment-count-selector";
 
 const {InfoTip} = components;
 const {containerSizeClass, getInteractiveBoxFromSizeClass} = SizingUtils;
@@ -234,7 +235,7 @@ class InteractiveGraphEditor extends React.Component<Props> {
                     </Row>
                 )}
                 {this.props.correct?.type === "polygon" && (
-                    <View>
+                    <>
                         <Row>
                             <FieldLabel>Number of sides:</FieldLabel>
                             <select
@@ -355,7 +356,24 @@ class InteractiveGraphEditor extends React.Component<Props> {
                                 <p>Displays the side lengths.</p>
                             </InfoTip>
                         </Row>
-                    </View>
+                    </>
+                )}
+                {this.props.correct?.type === "segment" && (
+                    <Row>
+                        <FieldLabel>Number of segments: </FieldLabel>
+                        <SegmentCountSelector
+                            numSegments={this.props.correct?.numSegments}
+                            onChange={(sides) => {
+                                this.props.onChange({
+                                    correct: {
+                                        type: "segment",
+                                        numSegments: sides,
+                                        coords: null,
+                                    },
+                                });
+                            }}
+                        />
+                    </Row>
                 )}
 
                 <Row>
@@ -369,7 +387,6 @@ class InteractiveGraphEditor extends React.Component<Props> {
                     </InfoTip>
                     : {equationString}
                 </Row>
-
                 <GraphSettings
                     box={getInteractiveBoxFromSizeClass(sizeClass)}
                     range={this.props.range}
@@ -387,7 +404,6 @@ class InteractiveGraphEditor extends React.Component<Props> {
                     rulerTicks={this.props.rulerTicks}
                     onChange={this.props.onChange}
                 />
-
                 {this.props.correct.type === "polygon" && (
                     <div className="type-settings">
                         <label>

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -1679,16 +1679,6 @@ class InteractiveGraph extends React.Component<Props, State> {
         this.angle?.remove();
     };
 
-    toggleShowAngles: () => void = () => {
-        if (this.props.graph.type !== "polygon") {
-            throw makeInvalidTypeError("toggleShowAngles", "polygon");
-        }
-        const graph = _.extend({}, this.props.graph, {
-            showAngles: !this.props.graph.showAngles,
-        });
-        this.onChange({graph: graph});
-    };
-
     toggleShowSides: () => void = () => {
         if (this.props.graph.type !== "polygon") {
             throw makeInvalidTypeError("toggleShowSides", "polygon");


### PR DESCRIPTION
This is PR 8 in a series of PRs that restore some editor functionality that I [deleted](https://github.com/Khan/webapp/pull/3144) back in January of 2022. It obviously isn't used often, but it's [still needed](https://khanacademy.slack.com/archives/C6NS8DWJU/p1683664865635869)!

Previous PRs:
  * #536
  * #537
  * #539
  * #540
  * #542
  * #543
  * #544

In this PR I re-introduce UI to configure the details of the 'segment' graph type.

Issue: LC-813

<img width="500" alt="image" src="https://github.com/Khan/perseus/assets/77138/3b3c9bc8-2d8b-4f24-a94a-f2ea9bf837ec">


## Test plan:

Start storybook and select the "Line (segments)" graph type. 
Change the "Number of segments" field.
Drag the segment start/end "knobs" around (ie. configure the line segments).
Verify the right side output display to compare that it's updating the widget options correctly.