### PR TITLE
Tweak formatting of 'correct answer' in interactive-graph-editor

### DIFF
--- a/.changeset/strong-parrots-live.md
+++ b/.changeset/strong-parrots-live.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Enhance formatting of the 'Correct answer' field on interactive-graph widget editor (to be more legible)

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
@@ -377,7 +377,19 @@ class InteractiveGraphEditor extends React.Component<Props> {
                 )}
 
                 <Row>
-                    <FieldLabel>Correct answer</FieldLabel>
+                    <FieldLabel>Correct answer:</FieldLabel>
+                    <Typography.BodyMonospace
+                        style={{
+                            fontSize: 12,
+                            backgroundColor: "#eee",
+                            paddingInline: Spacing.xxSmall_6,
+                            borderColor: "#ccc",
+                            borderStyle: "solid",
+                            borderWidth: 1,
+                        }}
+                    >
+                        {equationString}
+                    </Typography.BodyMonospace>
                     <InfoTip>
                         <p>
                             Graph the correct answer in the graph below and
@@ -385,7 +397,6 @@ class InteractiveGraphEditor extends React.Component<Props> {
                             represent the correct answer.
                         </p>
                     </InfoTip>
-                    : {equationString}
                 </Row>
                 <GraphSettings
                     box={getInteractiveBoxFromSizeClass(sizeClass)}


### PR DESCRIPTION
## Summary:

A small PR to make the correct answer area more legible. Switched to have a background and border and use a monospace font so it's more legible.

Issue: LC-813

## Test plan:

Check the design in storybook (or look at the screenshot).

| Before | After | 
| --- | --- |
| <img width="378" alt="image" src="https://github.com/Khan/perseus/assets/77138/767cc110-599e-443c-b687-2869bcba92f5">  | <img width="390" alt="image" src="https://github.com/Khan/perseus/assets/77138/6788479e-ec32-4dc2-860d-4572cb67afd5"> |
