### PR TITLE
add KeypadButton, Button tests

### DIFF
--- a/.changeset/cuddly-buckets-rush.md
+++ b/.changeset/cuddly-buckets-rush.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Add math-input v2 keypad tests

--- a/packages/math-input/src/components/keypad/__tests__/Button.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/Button.test.tsx
@@ -9,7 +9,7 @@ describe("<Button />", () => {
     it("uses the aria label", () => {
         // Arrange
         render(
-            <Button onPress={jest.fn()} ariaLabel="Oranges">
+            <Button onPress={() => {}} ariaLabel="Oranges">
                 <p />
             </Button>,
         );
@@ -29,43 +29,23 @@ describe("<Button />", () => {
             </Button>,
         );
 
-        // Assert
+        // Act
         userEvent.click(screen.getByRole("button", {name: "Oranges"}));
+
+        // Assert
         expect(mockPressCallback).toHaveBeenCalled();
     });
 
     it("renders child", () => {
         // Arrange
-
         render(
-            <Button onPress={jest.fn()} ariaLabel="Test">
+            <Button onPress={() => {}} ariaLabel="Test">
                 <img aria-label="child1" />
             </Button>,
         );
 
         // Assert
-        expect(screen.getByRole("button", {})).toBeInTheDocument();
-
-        expect(screen.getByRole("img", {name: "child1"})).toBeInTheDocument();
-    });
-
-    it("renders children", () => {
-        // Arrange
-
-        render(
-            <Button onPress={jest.fn()} ariaLabel="Test">
-                <>
-                    <img aria-label="child1" />
-                    <img aria-label="child2" />
-                </>
-            </Button>,
-        );
-
-        // Assert
         expect(screen.getByRole("button", {name: "Test"})).toBeInTheDocument();
-
         expect(screen.getByRole("img", {name: "child1"})).toBeInTheDocument();
-
-        expect(screen.getByRole("img", {name: "child2"})).toBeInTheDocument();
     });
 });

--- a/packages/math-input/src/components/keypad/__tests__/Button.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/Button.test.tsx
@@ -1,0 +1,71 @@
+import {render, screen} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as React from "react";
+import "@testing-library/jest-dom";
+
+import Button from "../button";
+
+describe("<Button />", () => {
+    it("uses the aria label", () => {
+        // Arrange
+        render(
+            <Button onPress={jest.fn()} ariaLabel="Oranges">
+                <p />
+            </Button>,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Oranges"}),
+        ).toBeInTheDocument();
+    });
+
+    it("handles callback on press", () => {
+        // Arrange
+        const mockPressCallback = jest.fn();
+        render(
+            <Button onPress={mockPressCallback} ariaLabel="Oranges">
+                <p />
+            </Button>,
+        );
+
+        // Assert
+        userEvent.click(screen.getByRole("button", {name: "Oranges"}));
+        expect(mockPressCallback).toHaveBeenCalled();
+    });
+
+    it("renders child", () => {
+        // Arrange
+
+        render(
+            <Button onPress={jest.fn()} ariaLabel="Test">
+                <img aria-label="child1" />
+            </Button>,
+        );
+
+        // Assert
+        expect(screen.getByRole("button", {})).toBeInTheDocument();
+
+        expect(screen.getByRole("img", {name: "child1"})).toBeInTheDocument();
+    });
+
+    it("renders children", () => {
+        // Arrange
+
+        render(
+            <Button onPress={jest.fn()} ariaLabel="Test">
+                <>
+                    <img aria-label="child1" />
+                    <img aria-label="child2" />
+                </>
+            </Button>,
+        );
+
+        // Assert
+        expect(screen.getByRole("button", {name: "Test"})).toBeInTheDocument();
+
+        expect(screen.getByRole("img", {name: "child1"})).toBeInTheDocument();
+
+        expect(screen.getByRole("img", {name: "child2"})).toBeInTheDocument();
+    });
+});

--- a/packages/math-input/src/components/keypad/__tests__/KeypadButton.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/KeypadButton.test.tsx
@@ -7,11 +7,11 @@ import Keys from "../../../data/key-configs";
 import {KeypadButton} from "../keypad-page-items";
 
 describe("<KeypadButton />", () => {
-    it("uses the aria label", () => {
+    it("uses the aria label from the key config", () => {
         // Arrange
         render(
             <KeypadButton
-                onClickKey={(config) => jest.fn()}
+                onClickKey={(config) => {}}
                 keyConfig={Keys.LEFT_PAREN}
             />,
         );
@@ -32,8 +32,10 @@ describe("<KeypadButton />", () => {
             />,
         );
 
-        // Assert
+        // Act
         userEvent.click(screen.getByRole("button", {name: "LEFT_PAREN"}));
+
+        // Assert
         expect(mockClickKeyCallback).toHaveBeenCalled();
     });
 });

--- a/packages/math-input/src/components/keypad/__tests__/KeypadButton.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/KeypadButton.test.tsx
@@ -1,0 +1,39 @@
+import {render, screen} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as React from "react";
+import "@testing-library/jest-dom";
+
+import Keys from "../../../data/key-configs";
+import {KeypadButton} from "../keypad-page-items";
+
+describe("<KeypadButton />", () => {
+    it("uses the aria label", () => {
+        // Arrange
+        render(
+            <KeypadButton
+                onClickKey={(config) => jest.fn()}
+                keyConfig={Keys.LEFT_PAREN}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "LEFT_PAREN"}),
+        ).toBeInTheDocument();
+    });
+
+    it("handles onClickKey callback", () => {
+        // Arrange
+        const mockClickKeyCallback = jest.fn();
+        render(
+            <KeypadButton
+                onClickKey={mockClickKeyCallback}
+                keyConfig={Keys.LEFT_PAREN}
+            />,
+        );
+
+        // Assert
+        userEvent.click(screen.getByRole("button", {name: "LEFT_PAREN"}));
+        expect(mockClickKeyCallback).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary:
Created Jest tests for the Button and KeypadButton components within math-input/src/keypad. Test for correct rendering of aria-label, callbacks, correct rendering of children.

Issue: LC-869 and LC-868

## Test plan:

- Ran the tests locally via `yarn test`.