### PR TITLE
Remove pi as a default answer form in numeric-input

### DIFF
--- a/.changeset/khaki-chairs-attack.md
+++ b/.changeset/khaki-chairs-attack.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Remove pi as a default answerForm for numeric-input

--- a/packages/perseus/src/widgets/__tests__/numeric-input.test.ts
+++ b/packages/perseus/src/widgets/__tests__/numeric-input.test.ts
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
+import {errors} from "../../util/answer-types";
 import {
     question1AndAnswer,
     multipleAnswers,
@@ -210,6 +211,40 @@ describe("static function validate", () => {
               "type": "invalid",
             }
         `);
+    });
+
+    // Don't default to validating the answer as a pi answer
+    // if answerForm isn't set on the answer.
+    // The answer value, userInput.currentValue, and
+    // the omission of answerForms in the answer are
+    // important to the test.
+    // https://khanacademy.atlassian.net/browse/LC-691
+    it("doesn't default to validating pi", () => {
+        const rubric: Rubric = {
+            answers: [
+                {
+                    maxError: null,
+                    message: "",
+                    simplify: "required",
+                    status: "correct",
+                    strict: true,
+                    value: 45.289,
+                },
+            ],
+            labelText: "",
+            size: "normal",
+            static: false,
+            coefficient: false,
+        };
+
+        const useInput = {
+            currentValue: "45.282",
+        } as const;
+
+        const score = NumericInput.validate(useInput, rubric);
+
+        expect(score.message).not.toBe(errors.APPROXIMATED_PI_ERROR);
+        expect(score.message?.includes("pi")).toBeFalsy();
     });
 
     it("with a strict answer", () => {

--- a/packages/perseus/src/widgets/__tests__/numeric-input.test.ts
+++ b/packages/perseus/src/widgets/__tests__/numeric-input.test.ts
@@ -237,11 +237,14 @@ describe("static function validate", () => {
             coefficient: false,
         };
 
-        const useInput = {
+        const userInput = {
+            // (pi / 12) * 173 = 45.291
+            // within the 0.01 margin of error
+            // to trigger the pi validation flow
             currentValue: "45.282",
         } as const;
 
-        const score = NumericInput.validate(useInput, rubric);
+        const score = NumericInput.validate(userInput, rubric);
 
         expect(score.message).not.toBe(errors.APPROXIMATED_PI_ERROR);
         expect(score.message?.includes("pi")).toBeFalsy();

--- a/packages/perseus/src/widgets/numeric-input.tsx
+++ b/packages/perseus/src/widgets/numeric-input.tsx
@@ -150,7 +150,12 @@ export class NumericInput extends React.Component<Props, State> {
     }
 
     static validate(useInput: UserInput, rubric: Rubric): PerseusScore {
-        const allAnswerForms = answerFormButtons.map((e) => e["value"]);
+        const allAnswerForms = answerFormButtons
+            .map((e) => e["value"])
+            // Don't default to validating the answer as a pi answer
+            // if answerForm isn't set on the answer
+            // https://khanacademy.atlassian.net/browse/LC-691
+            .filter((e) => e !== "pi");
 
         const createValidator = (answer: PerseusNumericInputAnswer) => {
             const stringAnswer = `${answer.value}`;


### PR DESCRIPTION
## Summary:
This is kind of complicated and a super edge-case.

- IF a content creator didn't set an explicit answer form for a question using numeric-input
- AND the correct answer was close to a multiple of `pi/12`
- AND the submitted answer was within a small margin of error to the correct answer
- THEN the validator would think the learner was approximating pi - even if the question had nothing to do with pi

There's a lot of conversation in the ticket, but the tl;dr is we decided not to validate against pi unless it was explicitly set as an option.

Issue: LC-691

## Test plan:

Original steps to repro:
1. Access Khan Academy.
2. Go to the exercise "Subtracting decimals: thousandths"
3. Look for this specific question: 52.389 – 7.1
4. Type anything between 45.282 and 45.288 as its answer.
5. This notification will come from the check button: `Your answer is close, but may have approximated pi. Enter your answer as a multiple of pi, like <code>12\ \text{pi}</code> or <code>2/3\ \text{pi}</code>.`

Thankfully for the learners and unfortunately for those who want to manual test this, Charlie explicitly set the answerForm for this question so we can't reproduce with those steps anymore. It's so edge-case that I'm not sure how we'd intentionally find a live example of the problem, so I wrote a unit test.