### PR TITLE
Update MathInput v2 keypad layout

### DIFF
--- a/.changeset/slimy-gorillas-return.md
+++ b/.changeset/slimy-gorillas-return.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": minor
+---
+
+Rearrange buttons in MathInput v2 keypad

--- a/packages/math-input/src/components/keypad/button-assets.tsx
+++ b/packages/math-input/src/components/keypad/button-assets.tsx
@@ -713,9 +713,9 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
                 >
                     <path
                         fill="currentColor"
-                        fill-rule="evenodd"
+                        fillRule="evenodd"
                         d="M24.447 11.106a1 1 0 0 1 .447 1.341l-8 16a1 1 0 1 1-1.788-.894l8-16a1 1 0 0 1 1.341-.447ZM15 13a2 2 0 1 0 0 4 2 2 0 0 0 0-4Zm-4 2a4 4 0 1 1 8 0 4 4 0 0 1-8 0Zm12 10a2 2 0 1 1 4 0 2 2 0 0 1-4 0Zm2-4a4 4 0 1 0 0 8 4 4 0 0 0 0-8Z"
-                        clip-rule="evenodd"
+                        clipRule="evenodd"
                     />
                 </svg>
             );

--- a/packages/math-input/src/components/keypad/button-assets.tsx
+++ b/packages/math-input/src/components/keypad/button-assets.tsx
@@ -706,12 +706,17 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="20"
-                    height="20"
-                    fill="currentColor"
-                    viewBox="0 0 256 256"
+                    width="40"
+                    height="40"
+                    fill="none"
+                    viewBox="0 0 40 40"
                 >
-                    <path d="M205.66,61.64l-144,144a8,8,0,0,1-11.32-11.32l144-144a8,8,0,0,1,11.32,11.31ZM50.54,101.44a36,36,0,0,1,50.92-50.91h0a36,36,0,0,1-50.92,50.91ZM56,76A20,20,0,1,0,90.14,61.84h0A20,20,0,0,0,56,76ZM216,180a36,36,0,1,1-10.54-25.46h0A35.76,35.76,0,0,1,216,180Zm-16,0a20,20,0,1,0-5.86,14.14A19.87,19.87,0,0,0,200,180Z" />
+                    <path
+                        fill="currentColor"
+                        fill-rule="evenodd"
+                        d="M24.447 11.106a1 1 0 0 1 .447 1.341l-8 16a1 1 0 1 1-1.788-.894l8-16a1 1 0 0 1 1.341-.447ZM15 13a2 2 0 1 0 0 4 2 2 0 0 0 0-4Zm-4 2a4 4 0 1 1 8 0 4 4 0 0 1-8 0Zm12 10a2 2 0 1 1 4 0 2 2 0 0 1-4 0Zm2-4a4 4 0 1 0 0 8 4 4 0 0 0 0-8Z"
+                        clip-rule="evenodd"
+                    />
                 </svg>
             );
         case "PI":

--- a/packages/math-input/src/components/keypad/index.tsx
+++ b/packages/math-input/src/components/keypad/index.tsx
@@ -121,6 +121,7 @@ export default function Keypad(props: Props) {
                     cursorContext={cursorContext}
                     multiplicationDot={multiplicationDot}
                     divisionKey={divisionKey}
+                    selectedPage={selectedPage}
                 />
             </View>
         </View>

--- a/packages/math-input/src/components/keypad/keypad-pages/extras-page.tsx
+++ b/packages/math-input/src/components/keypad/keypad-pages/extras-page.tsx
@@ -10,7 +10,7 @@ type Props = {
     onClickKey: ClickKeyCallback;
 };
 
-const columns = 4;
+const columns = 3;
 
 export default function ExtrasPage(props: Props) {
     const {extraKeys, onClickKey} = props;

--- a/packages/math-input/src/components/keypad/keypad-pages/numbers-page.tsx
+++ b/packages/math-input/src/components/keypad/keypad-pages/numbers-page.tsx
@@ -82,6 +82,12 @@ export default function NumbersPage(props: Props) {
                 onClickKey={onClickKey}
                 coord={[2, 3]}
             />
+            <KeypadButton
+                keyConfig={Keys.PERCENT}
+                onClickKey={onClickKey}
+                coord={[3, 0]}
+                secondary
+            />
         </>
     );
 }

--- a/packages/math-input/src/components/keypad/shared-keys.tsx
+++ b/packages/math-input/src/components/keypad/shared-keys.tsx
@@ -3,11 +3,13 @@ import * as React from "react";
 import Keys from "../../data/key-configs";
 import {ClickKeyCallback} from "../../types";
 import {CursorContext} from "../input/cursor-contexts";
+import {TabbarItemType} from "../tabbar/types";
 
 import {KeypadButton} from "./keypad-button";
 
 type Props = {
     onClickKey: ClickKeyCallback;
+    selectedPage: TabbarItemType;
     cursorContext?: CursorContext;
     multiplicationDot?: boolean;
     divisionKey?: boolean;
@@ -37,9 +39,19 @@ function getCursorContextConfig(cursorContext?: CursorContext) {
 }
 
 export default function SharedKeys(props: Props) {
-    const {onClickKey, cursorContext, divisionKey, multiplicationDot} = props;
+    const {
+        onClickKey,
+        cursorContext,
+        divisionKey,
+        multiplicationDot,
+        selectedPage,
+    } = props;
 
     const cursorKeyConfig = getCursorContextConfig(cursorContext);
+    const fracCoord: readonly [number, number] =
+        selectedPage === "Numbers" || selectedPage === "Operators"
+            ? [3, 1]
+            : [3, 0];
 
     return (
         <>
@@ -76,7 +88,7 @@ export default function SharedKeys(props: Props) {
             <KeypadButton
                 keyConfig={Keys.FRAC_INCLUSIVE}
                 onClickKey={onClickKey}
-                coord={[3, 2]}
+                coord={fracCoord}
                 secondary
             />
             <KeypadButton

--- a/packages/math-input/src/components/keypad/shared-keys.tsx
+++ b/packages/math-input/src/components/keypad/shared-keys.tsx
@@ -67,6 +67,12 @@ export default function SharedKeys(props: Props) {
                 coord={[5, 0]}
                 secondary
             />
+            <KeypadButton
+                keyConfig={Keys.FRAC_INCLUSIVE}
+                onClickKey={onClickKey}
+                coord={fracCoord}
+                secondary
+            />
 
             {/* Row 2 */}
             <KeypadButton
@@ -85,12 +91,6 @@ export default function SharedKeys(props: Props) {
             )}
 
             {/* Row 3 */}
-            <KeypadButton
-                keyConfig={Keys.FRAC_INCLUSIVE}
-                onClickKey={onClickKey}
-                coord={fracCoord}
-                secondary
-            />
             <KeypadButton
                 keyConfig={Keys.LEFT_PAREN}
                 onClickKey={onClickKey}

--- a/packages/math-input/src/components/keypad/shared-keys.tsx
+++ b/packages/math-input/src/components/keypad/shared-keys.tsx
@@ -48,7 +48,9 @@ export default function SharedKeys(props: Props) {
     } = props;
 
     const cursorKeyConfig = getCursorContextConfig(cursorContext);
-    const fracCoord: readonly [number, number] =
+
+    // Fraction position depends on the page
+    const fractionCoord: readonly [number, number] =
         selectedPage === "Numbers" || selectedPage === "Operators"
             ? [3, 1]
             : [3, 0];
@@ -70,7 +72,7 @@ export default function SharedKeys(props: Props) {
             <KeypadButton
                 keyConfig={Keys.FRAC_INCLUSIVE}
                 onClickKey={onClickKey}
-                coord={fracCoord}
+                coord={fractionCoord}
                 secondary
             />
 


### PR DESCRIPTION
## Summary:
Updates the layout of the v2 keypad per the ticket:

Changes to the keypad layout, explained as 0-indexed coordinates (top left button is x:0, y:0)
- On all pages movement key will be 4, 3
- On the Numbers page, add “Percent” to 3, 0 (only on Numbers page)
- On the Numbers / Pre-Algebra page, move “Fraction” to 3, 1
- On Geometry / Extras page, move “Fraction” to 3, 0
- Make “extras” key a 3x4 grid vs a 4x4 grid, to accommodate “Fraction” key

https://github.com/Khan/perseus/assets/16308368/a3127504-168d-49f4-bdc3-660670c95237

Issue: LC-976