### PR TITLE
Make dismiss button optional

### DIFF
--- a/.changeset/spotty-radios-warn.md
+++ b/.changeset/spotty-radios-warn.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": major
+---
+
+Make v2 keypad dismiss button optional, hidden by default

--- a/packages/math-input/src/components/keypad/__tests__/keypad.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/keypad.test.tsx
@@ -1,5 +1,6 @@
 import {render, screen} from "@testing-library/react";
 import * as React from "react";
+import "@testing-library/jest-dom";
 
 import keyConfigs from "../../../data/key-configs";
 import {CursorContext} from "../../input/cursor-contexts";
@@ -35,8 +36,40 @@ describe("keypad", () => {
                     screen.getByRole("button", {
                         name: ariaLabel,
                     }),
-                );
+                ).toBeInTheDocument();
             });
         });
+    });
+
+    it(`shows optional dismiss button`, () => {
+        // Arrange
+        // Act
+        render(
+            <Keypad
+                onClickKey={() => {}}
+                sendEvent={async () => {}}
+                showDismiss
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("tab", {
+                name: "Dismiss",
+            }),
+        ).toBeInTheDocument();
+    });
+
+    it(`hides optional dismiss button`, () => {
+        // Arrange
+        // Act
+        render(<Keypad onClickKey={() => {}} sendEvent={async () => {}} />);
+
+        // Assert
+        expect(
+            screen.queryByRole("tab", {
+                name: "Dismiss",
+            }),
+        ).not.toBeInTheDocument();
     });
 });

--- a/packages/math-input/src/components/keypad/index.tsx
+++ b/packages/math-input/src/components/keypad/index.tsx
@@ -18,17 +18,20 @@ import SharedKeys from "./shared-keys";
 import type {SendEventFn} from "@khanacademy/perseus-core";
 
 export type Props = {
-    onClickKey: ClickKeyCallback;
-    cursorContext?: CursorContext;
-    trigonometry?: boolean;
     extraKeys: ReadonlyArray<Key>;
+    cursorContext?: CursorContext;
+    showDismiss?: boolean;
+
     multiplicationDot?: boolean;
     divisionKey?: boolean;
+
+    trigonometry?: boolean;
     preAlgebra?: boolean;
     logarithms?: boolean;
     basicRelations?: boolean;
     advancedRelations?: boolean;
 
+    onClickKey: ClickKeyCallback;
     sendEvent: SendEventFn;
 };
 
@@ -78,6 +81,7 @@ export default function Keypad(props: Props) {
         logarithms,
         basicRelations,
         advancedRelations,
+        showDismiss,
     } = props;
 
     return (
@@ -89,7 +93,9 @@ export default function Keypad(props: Props) {
                     setSelectedPage(tabbarItem);
                 }}
                 style={styles.tabbar}
-                onClickClose={() => onClickKey("DISMISS")}
+                onClickClose={
+                    showDismiss ? () => onClickKey("DISMISS") : undefined
+                }
             />
 
             <View


### PR DESCRIPTION
## Summary:
We decided to use the native popover button to dismiss the keypad in desktop. Will likely need this v2 keypad dismiss button in mobile. Making it optional using a prop.

https://khanacademy.slack.com/archives/C01AZ9H8TTQ/p1687960633274759