### PR TITLE
Convert CursorContext TS enum to POJO

### DIFF
--- a/.changeset/thick-donuts-sell.md
+++ b/.changeset/thick-donuts-sell.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Fix issue with uses of CursorContext not being converted by flowgen

--- a/packages/math-input/src/components/input/cursor-contexts.ts
+++ b/packages/math-input/src/components/input/cursor-contexts.ts
@@ -10,28 +10,28 @@
  * the radical.
  */
 
-export enum CursorContext {
+export const CursorContext = {
     // The cursor is not in any of the other viable contexts.
-    NONE = "NONE",
+    NONE: "NONE",
 
     // The cursor is within a set of parentheses.
-    IN_PARENS = "IN_PARENS",
+    IN_PARENS: "IN_PARENS",
 
     // The cursor is within a superscript (e.g., an exponent).
-    IN_SUPER_SCRIPT = "IN_SUPER_SCRIPT",
+    IN_SUPER_SCRIPT: "IN_SUPER_SCRIPT",
 
     // The cursor is within a subscript (e.g., the base of a custom logarithm).
-    IN_SUB_SCRIPT = "IN_SUB_SCRIPT",
+    IN_SUB_SCRIPT: "IN_SUB_SCRIPT",
 
     // The cursor is in the numerator of a fraction.
-    IN_NUMERATOR = "IN_NUMERATOR",
+    IN_NUMERATOR: "IN_NUMERATOR",
 
     // The cursor is in the denominator of a fraction.
-    IN_DENOMINATOR = "IN_DENOMINATOR",
+    IN_DENOMINATOR: "IN_DENOMINATOR",
 
     // The cursor is sitting before a fraction; that is, the cursor is within
     // what looks to be a mixed number preceding a fraction. This will only be
     // the case when the only math between the cursor and the fraction to its
     // write is non-leaf math (numbers and variables).
-    BEFORE_FRACTION = "BEFORE_FRACTION",
-}
+    BEFORE_FRACTION: "BEFORE_FRACTION",
+} as const;

--- a/packages/math-input/src/components/input/mathquill-helpers.ts
+++ b/packages/math-input/src/components/input/mathquill-helpers.ts
@@ -240,7 +240,7 @@ export function maybeFindCommandBeforeParens(leftParenNode) {
 
 export function getCursorContext(
     mathField?: MathFieldInterface,
-): CursorContext {
+): typeof CursorContext[keyof typeof CursorContext] {
     if (!mathField) {
         return CursorContext.NONE;
     }

--- a/packages/math-input/src/components/keypad-legacy/expression-keypad.tsx
+++ b/packages/math-input/src/components/keypad-legacy/expression-keypad.tsx
@@ -24,7 +24,7 @@ const {row, column, oneColumn, fullWidth, roundedTopLeft, roundedTopRight} =
     Styles;
 
 interface ReduxProps {
-    cursorContext?: CursorContext;
+    cursorContext?: typeof CursorContext[keyof typeof CursorContext];
     dynamicJumpOut: boolean;
 }
 

--- a/packages/math-input/src/components/keypad-legacy/fraction-keypad.tsx
+++ b/packages/math-input/src/components/keypad-legacy/fraction-keypad.tsx
@@ -21,7 +21,7 @@ import type {State} from "./store/types";
 const {row, roundedTopLeft, roundedTopRight} = Styles;
 
 interface ReduxProps {
-    cursorContext?: CursorContext;
+    cursorContext?: typeof CursorContext[keyof typeof CursorContext];
     dynamicJumpOut: boolean;
 }
 

--- a/packages/math-input/src/components/keypad/__tests__/keypad.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/keypad.test.tsx
@@ -24,7 +24,9 @@ describe("keypad", () => {
                 render(
                     <Keypad
                         onClickKey={() => {}}
-                        cursorContext={context as CursorContext}
+                        cursorContext={
+                            context as typeof CursorContext[keyof typeof CursorContext]
+                        }
                         sendEvent={async () => {
                             /* TODO: verify correct analytics event sent */
                         }}

--- a/packages/math-input/src/components/keypad/index.tsx
+++ b/packages/math-input/src/components/keypad/index.tsx
@@ -19,7 +19,7 @@ import type {SendEventFn} from "@khanacademy/perseus-core";
 
 export type Props = {
     extraKeys: ReadonlyArray<Key>;
-    cursorContext?: CursorContext;
+    cursorContext?: typeof CursorContext[keyof typeof CursorContext];
     showDismiss?: boolean;
 
     multiplicationDot?: boolean;

--- a/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
+++ b/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
@@ -18,9 +18,9 @@ export default {
 export function V2KeypadWithMathquill() {
     const mathFieldWrapperRef = React.useRef<HTMLDivElement>(null);
     const [mathField, setMathField] = React.useState<MathFieldInterface>();
-    const [cursorContext, setCursorContext] = React.useState<CursorContext>(
-        CursorContext.NONE,
-    );
+    const [cursorContext, setCursorContext] = React.useState<
+        typeof CursorContext[keyof typeof CursorContext]
+    >(CursorContext.NONE);
 
     React.useEffect(() => {
         if (!mathField && mathFieldWrapperRef.current) {

--- a/packages/math-input/src/components/keypad/shared-keys.tsx
+++ b/packages/math-input/src/components/keypad/shared-keys.tsx
@@ -10,12 +10,14 @@ import {KeypadButton} from "./keypad-button";
 type Props = {
     onClickKey: ClickKeyCallback;
     selectedPage: TabbarItemType;
-    cursorContext?: CursorContext;
+    cursorContext?: typeof CursorContext[keyof typeof CursorContext];
     multiplicationDot?: boolean;
     divisionKey?: boolean;
 };
 
-function getCursorContextConfig(cursorContext?: CursorContext) {
+function getCursorContextConfig(
+    cursorContext?: typeof CursorContext[keyof typeof CursorContext],
+) {
     if (!cursorContext) {
         return null;
     }

--- a/packages/math-input/src/types.ts
+++ b/packages/math-input/src/types.ts
@@ -1,3 +1,4 @@
+import {CursorContext} from "./components/input/cursor-contexts";
 import Key from "./data/keys";
 import {
     BorderDirection,
@@ -6,8 +7,6 @@ import {
     KeyType,
     KeypadType,
 } from "./enums";
-
-import type {CursorContext} from "./components/input/cursor-contexts";
 
 export type Border = Partial<ReadonlyArray<BorderDirection>>;
 
@@ -60,7 +59,7 @@ export type KeypadConfiguration = {
 export type KeyHandler = (key: Key) => Cursor;
 
 export type Cursor = {
-    context: CursorContext;
+    context: typeof CursorContext[keyof typeof CursorContext];
 };
 
 export type KeypadLayout = {


### PR DESCRIPTION
## Summary:
While flowgen is capable of converting TS enums to the appropriate POJO, it doesn't know how to update the uses of the enum.  It'll be difficult to update the tool to do this properly because it currently only converts a file at a time without looking at other files, but it would need to find the definition of the enum to know whether it has to do extra work to convert the usage properly.

TODO: Convert any other enums that are causing issues.

Issue: None

## Test plan:
- yarn build:types
- yarn build:flowtypes
- check that the generated flow types work as expected in the [flow playground](https://flow.org/try/#1N4Igxg9gdgZglgcxALlAJwKYEMwBcD6aArlLnALYYrgA2WAzvXGCADQgYAeOBARgJ74AJhhhYiNXClzEM7DFCLl602e0hQhcMtCw18ufgAcqyMTXpyQ5LEZNCDx0+cvzOJtBQW49AOkMm+AhEWGhCKmZ6lgC+6hAi1AD0AFQABAACMDQQAO6pyYkAOlDFImB0mKlcRhBouKkAbqGpAMJEaPS1LdC4XLjIqcAAPsWpqQDUAHIA8pMAogOFIDPzS6yjEwCSk-gACgCCAEpzkwDKiyDbe0cnp2sb41enAKq7c4f4py2Hm7sAKhcnq93p9vr8-vcoGNHjsXgAhUE-f6A2HPBFfJEQtgPK6TZ4AWXe+z+00OKPweMJh2JpMh0KuABETtN8dsaWTUktGczWZN2XSJnC5gAxUlzfDC6ktP6bWYXIWi44SqUy2aQobRADcxWKAQwqWFEAgqQAvKkACRzGgYSikP5OAA8Gz1EBgrXanTQ3VIfXWUItAGkMPx6A6XW62h0uj0+gA+Yqx7UlZM6qDW+owI0ARgGhuNZqWKzmSyT6dSmYgACZc0bTZzltAMCXimwQA0MB04NBqA0AAy+StZ-tZkDRIA)

<img width="468" alt="Screen Shot 2023-06-28 at 3 43 03 PM" src="https://github.com/Khan/perseus/assets/1044413/834de7a2-93ea-4980-86b0-cd76c33ea4e6">
