### PR TITLE
Fix positioning of Graphie labels when MathJax is used to render TeX

### DIFF
--- a/.changeset/witty-singers-check.md
+++ b/.changeset/witty-singers-check.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix an issue where Graphie labels were sometimes incorrectly positioned when
+MathJax 3 was injected as the TeX renderer.

--- a/packages/perseus/src/util/tex.ts
+++ b/packages/perseus/src/util/tex.ts
@@ -100,13 +100,15 @@ export default {
             // We use createElement instead of JSX here because we can't name this file tex.tsx;
             // that name is already taken.
             reactRender(
-                React.createElement(TeX, {children: text}),
+                React.createElement(TeX, {
+                    children: text,
+                    onRender: () => {
+                        if (callback) {
+                            doCallback(elem, callback);
+                        }
+                    },
+                }),
                 $katexHolder[0],
-                () => {
-                    if (callback) {
-                        doCallback(elem, callback);
-                    }
-                },
             );
         }
     },


### PR DESCRIPTION
## Summary:
There was a race between the code in Perseus that positions Graphie
labels and the code in webapp that updates MathJax CSS. If Perseus
measured the label's dimensions before MathJax updated its CSS, then the
measured dimensions of the label would be wrong and the label would get
positioned incorrectly.

To fix this, we measure and position the label when the TeX component
calls its onRender callback. The MathJax component doesn't call this
callback until the CSS is up to date.

Issue: https://khanacademy.atlassian.net/browse/LC-934

Test plan:

Follow the instructions in webapp to install a dev build of Perseus.

Visit
/math/arithmetic-home/multiply-divide/division-intro/e/dividing-with-visuals?devflagk=mathjax3
and run through the exercise several times. You should not see the
duplicated label problem described in the issue linked above.  (Note
that the labels are still duplicated; that's a problem in the content
that we can't fix.  But now they are positioned exactly on top of each
other, so the duplication is not visible.)