### PR TITLE
[Perseus] [Khanmigo] Adjust the focus styling on the keypad buttons

### DIFF
--- a/.changeset/tidy-timers-unite.md
+++ b/.changeset/tidy-timers-unite.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Removed double focus outline from keypad buttons

--- a/packages/math-input/src/components/keypad/keypad-button.tsx
+++ b/packages/math-input/src/components/keypad/keypad-button.tsx
@@ -47,13 +47,7 @@ export const KeypadButton = ({
             >
                 {({hovered, focused, pressed}) => {
                     return (
-                        <View
-                            style={[
-                                styles.outerBoxBase,
-                                hovered && styles.outerBoxHover,
-                                pressed && styles.outerBoxPressed,
-                            ]}
-                        >
+                        <View style={[styles.outerBoxBase]}>
                             <View
                                 style={[
                                     styles.base,
@@ -91,7 +85,7 @@ const styles = StyleSheet.create({
         padding: 1,
     },
     hovered: {
-        border: `1px solid ${Color.blue}`,
+        border: `2px solid ${Color.blue}`,
         padding: 1,
         boxShadow: "none",
     },
@@ -114,15 +108,13 @@ const styles = StyleSheet.create({
         borderRadius: 7,
         border: "2px solid transparent",
     },
-    outerBoxHover: {
-        border: `2px solid ${Color.blue}`,
-    },
-    outerBoxPressed: {
-        border: "2px solid #1B50B3",
-    },
     clickable: {
         width: "100%",
         height: "100%",
         boxSizing: "border-box",
+
+        ":focus": {
+            outline: `none`,
+        },
     },
 });

--- a/packages/math-input/src/components/tabbar/item.tsx
+++ b/packages/math-input/src/components/tabbar/item.tsx
@@ -50,6 +50,11 @@ const styles = StyleSheet.create({
         height: 3,
         marginLeft: 3,
     },
+    clickable: {
+        ":focus": {
+            outline: `none`,
+        },
+    },
 });
 
 function imageTintColor(
@@ -84,6 +89,7 @@ class TabbarItem extends React.Component<Props> {
                 onClick={onClick}
                 disabled={itemState === "disabled"}
                 aria-label={itemType}
+                style={styles.clickable}
                 aria-selected={itemState === "active"}
                 role="tab"
             >


### PR DESCRIPTION
## Summary:
This is a minor PR to remove the doubled blue outline on the keypad buttons during hover/pressed/focused states. You should now see only a single blue outline around the buttons during hover/pressed/focused. This required overriding the clickable focus styling, but we've already come up with a custom (and cleaner) solution. 

BEFORE
![image](https://github.com/Khan/perseus/assets/12463099/cef447e3-c864-4f7c-9efd-2a93e82a2cf7)

AFTER
![Screenshot 2023-06-29 at 2 09 50 PM](https://github.com/Khan/perseus/assets/12463099/4dc79598-fb09-404c-a144-02f4a8475424)

Issue: LC-999

## Test plan:
manual testing