### PR TITLE
Introduce and use a new Perseus Dependencies type provided through a React Context

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,7 +2,12 @@ import * as React from "react";
 import Color from "@khanacademy/wonder-blocks-color";
 import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 import {Dependencies} from "@khanacademy/perseus";
-import {storybookTestDependencies} from "../testing/test-dependencies";
+
+import {DependenciesContext} from "../packages/perseus/src/dependencies";
+import {
+    storybookTestDependencies,
+    storybookDependenciesV2,
+} from "../testing/test-dependencies";
 
 // IMPORTANT: This code runs ONCE per story file, not per story within that file.
 // If you want code to run once per story, see `StorybookWrapper`.
@@ -14,7 +19,9 @@ Dependencies.setDependencies(storybookTestDependencies);
 export const decorators = [
     (Story) => (
         <RenderStateRoot>
-            <Story />
+            <DependenciesContext.Provider value={storybookDependenciesV2}>
+                <Story />
+            </DependenciesContext.Provider>
         </RenderStateRoot>
     ),
 ];

--- a/packages/perseus-editor/src/multirenderer-editor.tsx
+++ b/packages/perseus-editor/src/multirenderer-editor.tsx
@@ -867,6 +867,10 @@ class MultiRendererEditor extends React.Component<MultiRendererEditorProps> {
                     item={item}
                     shape={itemShape}
                     apiOptions={apiOptions}
+                    // Today, with analytics being the only thing in
+                    // dependencies, we send in a dummy function as we don't
+                    // want to gather analytics events from within the editor.
+                    dependencies={{analytics: {sendEvent: async () => {}}}}
                 >
                     {({renderers}) => (
                         <NodeContainer

--- a/packages/perseus/src/__stories__/article-renderer.stories.tsx
+++ b/packages/perseus/src/__stories__/article-renderer.stories.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+
+import {storybookDependenciesV2} from "../../../../testing/test-dependencies";
+import {
+    singleSectionArticle,
+    multiSectionArticle,
+} from "../__testdata__/article-renderer.testdata";
+import ArticleRenderer from "../article-renderer";
+
+type StoryArgs = Record<any, any>;
+
+type Story = {
+    title: string;
+};
+
+export default {
+    title: "Perseus/Renderers/Article Renderer",
+} as Story;
+
+export const ASingleSectionArticle = (args: StoryArgs): React.ReactElement => {
+    return (
+        <ArticleRenderer
+            json={singleSectionArticle}
+            dependencies={storybookDependenciesV2}
+        />
+    );
+};
+
+export const BMultiSectionArticle = (args: StoryArgs): React.ReactElement => {
+    return (
+        <ArticleRenderer
+            json={multiSectionArticle}
+            dependencies={storybookDependenciesV2}
+        />
+    );
+};

--- a/packages/perseus/src/__testdata__/article-renderer.testdata.ts
+++ b/packages/perseus/src/__testdata__/article-renderer.testdata.ts
@@ -1,0 +1,72 @@
+import type {PerseusRenderer} from "../perseus-types";
+
+export const singleSectionArticle: PerseusRenderer = {
+    content:
+        "[[☃ image 2]]\n\n**Part A:** Return to the main characters from your three favorite films. \n\n- What was one important choice they had to make where the stakes were **high**?\n\n-  What were the **stakes**?\n\n- Can you identify them as internal, external or philosophical?\n\n**Part B:** Think about a difficult choice you had to make in your own life.  What was at stake? \n\n**Part C:** Return to one of the obstacles your character might face from the previous exercise. Now think of the **choice** this obstacle forces them to make. Answer the following:\n\n- What are the possible stakes of this choice?\n\n- Can you come up with an internal, external or philosophical stake which applies to this choice? \n",
+    images: {},
+    widgets: {
+        "image 2": {
+            type: "image",
+            alignment: "block",
+            static: false,
+            graded: true,
+            options: {
+                static: false,
+                title: "",
+                range: [
+                    [0, 10],
+                    [0, 10],
+                ],
+                box: [1258, 703],
+                backgroundImage: {
+                    url: "https://ka-perseus-images.s3.amazonaws.com/b08029bc1786fbe54468a2ddc96aaa20be7a663a.png",
+                    width: 1258,
+                    height: 703,
+                },
+                labels: [],
+                alt: 'A scene from Pixar\'s film "Toy Story 3" where the characters are swimming in a sea of trash and look very afraid.',
+                caption: "",
+            },
+            version: {major: 0, minor: 0},
+        },
+    },
+};
+
+export const multiSectionArticle: ReadonlyArray<PerseusRenderer> = [
+    {
+        content:
+            "## What is a matrix?\n\nA matrix is a rectangular array of numbers arranged in rows and columns.\n\nMatrices can be useful for organizing and manipulating data. They can also be used as a tool to help solve systems of equations.",
+        images: {},
+        widgets: {},
+    },
+    {
+        content:
+            "## How do we multiply a matrix by a scalar?\n\nTo multiply a matrix by a scalar, we multiply each entry in the matrix by the scalar. For example, if \n\n$A = \\begin{bmatrix} \n2 & 3 \\\\\n1 & 4 \\\\\n\\end{bmatrix}$\n\nand we want to multiply $A$ by $2$, we can multiply each entry by $2$ to get:\n\n$2A = \\begin{bmatrix} \n4 & 6 \\\\\n2 & 8 \\\\\n\\end{bmatrix}$",
+        images: {},
+        widgets: {},
+    },
+    {
+        content:
+            "## How do we add or subtract two matrices?\n\nTo add or subtract two matrices, we add or subtract corresponding entries. So if \n\n$A = \\begin{bmatrix} \n2 & 3 \\\\\n1 & 4 \\\\\n\\end{bmatrix}$ \n\nand \n\n$B = \\begin{bmatrix} \n5 & 2 \\\\\n3 & 1 \\\\\n\\end{bmatrix}$,\n\nthen \n\n$A+B = \\begin{bmatrix} \n7 & 5 \\\\\n4 & 5 \\\\\n\\end{bmatrix}$\n\nand \n\n$A-B = \\begin{bmatrix} \n-3 & 1 \\\\\n-2 & 3 \\\\\n\\end{bmatrix}$",
+        images: {},
+        widgets: {},
+    },
+    {
+        content:
+            "## How do we multiply two matrices together?\n\nThis one's a bit trickier. To multiply two matrices together, we take the dot product of the rows from the first matrix with the columns from the second matrix. The result is a new matrix. For example, if \n\n$A = \\begin{bmatrix} \n2 & 3 \\\\\n1 & 4 \\\\\n\\end{bmatrix}$ \n\nand \n\n$B = \\begin{bmatrix} \n5 & 2 \\\\\n3 & 1 \\\\\n\\end{bmatrix}$,\n\nthen \n\n$AB = \\begin{bmatrix} \n2\\cdot5+3\\cdot3 & 2\\cdot2+3\\cdot1 \\\\\n1\\cdot5+4\\cdot3 & 1\\cdot2+4\\cdot1 \\\\\n\\end{bmatrix} = \\begin{bmatrix} \n19 & 7 \\\\\n17 & 6 \\\\\n\\end{bmatrix}.$",
+        images: {},
+        widgets: {},
+    },
+    {
+        content:
+            "## What can we do with the inverse of a matrix?\n\nFinding the inverse of a matrix can be useful for solving linear systems of equations. If $A$ is the matrix representing the system of equations, and $b$ is the vector of solutions, then $Ax=b$. If we can find the inverse of $A$, we can multiply both sides of the equation by it to isolate $x$:\n\n$A^{-1}Ax=A^{-1}b \\Rightarrow x=A^{-1}b.$",
+        images: {},
+        widgets: {},
+    },
+    {
+        content:
+            "## Where are matrices used in the real world?\n\nMatrices have tons of real-world applications! They can be used in computer graphics to perform transformations on images, in physics to model physical systems, and in statistics to analyze data, just to name a few.",
+        images: {},
+        widgets: {},
+    },
+];

--- a/packages/perseus/src/__tests__/item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/item-renderer.test.tsx
@@ -4,7 +4,10 @@ import userEvent from "@testing-library/user-event";
 import * as React from "react";
 import "@testing-library/jest-dom"; // Imports custom matchers
 
-import {testDependencies} from "../../../../testing/test-dependencies";
+import {
+    testDependencies,
+    testDependenciesV2,
+} from "../../../../testing/test-dependencies";
 import {
     itemWithInput,
     labelImageItem,
@@ -76,6 +79,7 @@ export const renderQuestion = (
                 reviewMode={false}
                 savedState=""
                 controlPeripherals={false}
+                dependencies={testDependenciesV2}
                 {...optionalProps}
             />
             {/* The ItemRenderer _requires_ two divs: a work area and hints

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -4,7 +4,10 @@ import userEvent from "@testing-library/user-event";
 import * as React from "react";
 import "@testing-library/jest-dom"; // Imports custom matchers
 
-import {testDependencies} from "../../../../testing/test-dependencies";
+import {
+    testDependencies,
+    testDependenciesV2,
+} from "../../../../testing/test-dependencies";
 import {
     itemWithInput,
     mockedItem,
@@ -51,6 +54,7 @@ const renderQuestion = (
                 item={question}
                 problemNum={0}
                 reviewMode={false}
+                dependencies={testDependenciesV2}
                 {...optionalProps}
             />
         </RenderStateRoot>,
@@ -228,6 +232,7 @@ describe("server item renderer", () => {
                     item={itemWithInput}
                     problemNum={0}
                     reviewMode={false}
+                    dependencies={testDependenciesV2}
                 />
             </RenderStateRoot>,
         );
@@ -243,6 +248,7 @@ describe("server item renderer", () => {
                     item={itemWithInput}
                     problemNum={1} // to force componentDidUpdate
                     reviewMode={false}
+                    dependencies={testDependenciesV2}
                 />
                 ,
             </RenderStateRoot>,
@@ -272,6 +278,7 @@ describe("server item renderer", () => {
                     problemNum={0}
                     reviewMode={false}
                     onRendered={onRendered}
+                    dependencies={testDependenciesV2}
                 />
             </RenderStateRoot>,
         );
@@ -293,6 +300,7 @@ describe("server item renderer", () => {
                     problemNum={1}
                     reviewMode={false}
                     onRendered={onRendered}
+                    dependencies={testDependenciesV2}
                 />
             </RenderStateRoot>,
         );

--- a/packages/perseus/src/dependencies.ts
+++ b/packages/perseus/src/dependencies.ts
@@ -1,4 +1,6 @@
-import type {PerseusDependencies} from "./types";
+import * as React from "react";
+
+import type {PerseusDependencies, PerseusDependenciesV2} from "./types";
 
 let _dependencies: PerseusDependencies | null | undefined = null;
 
@@ -18,4 +20,17 @@ export const getDependencies = (): PerseusDependencies => {
             "Make sure Perseus is being imported from javascript/perseus/perseus.js.",
         ].join("\n"),
     );
+};
+
+export const DependenciesContext = React.createContext<PerseusDependenciesV2>({
+    analytics: {sendEvent: async () => {}},
+});
+
+/**
+ * useDependencies provides easy access to the current Perseus dependencies.
+ */
+export const useDependencies = (): PerseusDependenciesV2 => {
+    const deps = React.useContext(DependenciesContext);
+
+    return deps;
 };

--- a/packages/perseus/src/multi-items/__tests__/multi-renderer.test.tsx
+++ b/packages/perseus/src/multi-items/__tests__/multi-renderer.test.tsx
@@ -4,7 +4,10 @@ import userEvent from "@testing-library/user-event";
 import * as React from "react";
 import "@testing-library/jest-dom"; // Imports custom mathers
 
-import {testDependencies} from "../../../../../testing/test-dependencies";
+import {
+    testDependencies,
+    testDependenciesV2,
+} from "../../../../../testing/test-dependencies";
 import MockWidgetExport from "../../__tests__/mock-widget";
 import * as Dependencies from "../../dependencies";
 import {registerAllWidgetsForTesting} from "../../util/register-all-widgets-for-testing";
@@ -50,6 +53,7 @@ const renderSimpleQuestion = (question: Item) => {
                 item={question}
                 shape={simpleQuestionShape}
                 ref={(r) => (renderer = r)}
+                dependencies={testDependenciesV2}
             >
                 {({renderers}) => <SimpleLayout renderers={renderers} />}
             </MultiRenderer>
@@ -119,6 +123,7 @@ describe("multi-item renderer", () => {
                 <MultiRenderer
                     item={question1}
                     shape={shapes.shape({broken: shapes.content})}
+                    dependencies={testDependenciesV2}
                 >
                     {({renderers}) => {
                         return <div />;

--- a/packages/perseus/src/multi-items/multi-renderer.tsx
+++ b/packages/perseus/src/multi-items/multi-renderer.tsx
@@ -40,6 +40,7 @@ import {StyleSheet, css} from "aphrodite"; // eslint-disable-line import/no-extr
 import lens from "hubble"; // eslint-disable-line import/no-extraneous-dependencies
 import * as React from "react";
 
+import {DependenciesContext} from "../dependencies";
 import HintsRenderer from "../hints-renderer";
 import {Errors, Log} from "../logging/log";
 import Renderer from "../renderer";
@@ -49,7 +50,12 @@ import {itemToTree} from "./items";
 import {buildMapper} from "./trees";
 
 import type {Widget} from "../renderer";
-import type {APIOptions, FilterCriterion, PerseusScore} from "../types";
+import type {
+    APIOptions,
+    FilterCriterion,
+    PerseusDependenciesV2,
+    PerseusScore,
+} from "../types";
 import type {Item, ContentNode, HintNode, TagsNode} from "./item-types";
 import type {Shape, ArrayShape} from "./shape-types";
 import type {Tree} from "./tree-types";
@@ -108,6 +114,8 @@ type Props = {
     onInteractWithWidget?: (id: string) => void;
     apiOptions?: APIOptions;
     reviewMode?: boolean | null | undefined;
+
+    dependencies: PerseusDependenciesV2;
 };
 type State = {
     // We cache functions to generate renderers and refs in `rendererDataTree`,
@@ -546,9 +554,13 @@ class MultiRenderer extends React.Component<Props, State> {
 
         // Pass the renderer tree to the `children` function, which will
         // determine the actual content of this component.
-        return this.props.children({
-            renderers: this._getRenderers(),
-        });
+        return (
+            <DependenciesContext.Provider value={this.props.dependencies}>
+                {this.props.children({
+                    renderers: this._getRenderers(),
+                })}
+            </DependenciesContext.Provider>
+        );
     }
 }
 

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -11,6 +11,7 @@ import * as React from "react";
 import _ from "underscore";
 
 import AssetContext from "./asset-context";
+import {DependenciesContext} from "./dependencies";
 import HintsRenderer from "./hints-renderer";
 import Objective from "./interactive2/objective_";
 import LoadingContext from "./loading-context";
@@ -19,7 +20,13 @@ import Renderer from "./renderer";
 import Util from "./util";
 
 import type {KeypadProps} from "./mixins/provide-keypad";
-import type {APIOptions, KEScore, FocusPath, RendererInterface} from "./types";
+import type {
+    APIOptions,
+    KEScore,
+    FocusPath,
+    RendererInterface,
+    PerseusDependenciesV2,
+} from "./types";
 
 const {mapObject} = Objective;
 
@@ -35,6 +42,8 @@ type OwnProps = // These props are used by the ProvideKeypad mixin.
         reviewMode?: boolean;
         // from KeypadContext
         keypadElement?: any | null | undefined;
+
+        dependencies: PerseusDependenciesV2;
     };
 
 type HOCProps = {
@@ -423,22 +432,24 @@ export class ServerItemRenderer
         );
 
         return (
-            <div>
-                <div>{questionRenderer}</div>
-                <div
-                    className={
-                        // Avoid adding any horizontal padding when applying the
-                        // mobile hint styles, which are flush to the left.
-                        // NOTE(charlie): We may still want to apply this
-                        // padding for desktop exercises.
-                        apiOptions.isMobile
-                            ? undefined
-                            : css(styles.hintsContainer)
-                    }
-                >
-                    {hintsRenderer}
+            <DependenciesContext.Provider value={this.props.dependencies}>
+                <div>
+                    <div>{questionRenderer}</div>
+                    <div
+                        className={
+                            // Avoid adding any horizontal padding when applying the
+                            // mobile hint styles, which are flush to the left.
+                            // NOTE(charlie): We may still want to apply this
+                            // padding for desktop exercises.
+                            apiOptions.isMobile
+                                ? undefined
+                                : css(styles.hintsContainer)
+                        }
+                    >
+                        {hintsRenderer}
+                    </div>
                 </div>
-            </div>
+            </DependenciesContext.Provider>
         );
     }
 }

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -319,7 +319,6 @@ export type PerseusDependencies = {
     //misc
     staticUrl: StaticUrlFn;
     InitialRequestUrl: InitialRequestUrlInterface;
-    analytics: SendEventFn;
 
     // video widget
     // This is used as a hook to fetch data about a video which is used to
@@ -339,6 +338,18 @@ export type PerseusDependencies = {
     isDevServer: boolean;
     kaLocale: string;
     isMobile: boolean;
+};
+
+/**
+ * The modern iteration of Perseus Depedndencies. These dependencies are
+ * provided to Perseus through its entrypoints (for example:
+ * ServerItemRenderer) and then attached to the DependenciesContext so they are
+ * available anywhere down the React render tree.
+ *
+ * Prefer using this type over `PerseusDependencies` when possible.
+ */
+export type PerseusDependenciesV2 = {
+    analytics: {sendEvent: SendEventFn};
 };
 
 export type APIOptionsWithDefaults = Readonly<

--- a/packages/perseus/src/widgets/__stories__/definition.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/definition.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui";
+import {storybookDependenciesV2} from "../../../../../testing/test-dependencies";
 import ArticleRenderer from "../../article-renderer";
 
 export default {
@@ -103,5 +104,11 @@ export const MultipleDefinitions = (args: StoryArgs): React.ReactElement => {
 };
 
 export const ArticleDefintion = (args: StoryArgs): React.ReactElement => {
-    return <ArticleRenderer json={article} useNewStyles />;
+    return (
+        <ArticleRenderer
+            json={article}
+            useNewStyles
+            dependencies={storybookDependenciesV2}
+        />
+    );
 };

--- a/packages/perseus/src/widgets/__stories__/expression.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/expression.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import {ItemRendererWithDebugUI} from "../../../../../testing/item-renderer-with-debug-ui";
+import {KeypadType} from "../../../../math-input/src/enums";
 import KeypadContext from "../../keypad-context";
 import {
     expressionItem2,
@@ -62,7 +63,7 @@ export const DesktopKitchenSink = (args: StoryArgs): React.ReactElement => {
     };
 
     const keypadConfiguration = {
-        keypadType: "EXPRESSION",
+        keypadType: KeypadType.EXPRESSION,
         extraKeys: ["x", "y", "z"],
     };
 

--- a/packages/perseus/src/widgets/__tests__/expression.test.ts
+++ b/packages/perseus/src/widgets/__tests__/expression.test.ts
@@ -3,7 +3,10 @@ import {screen, fireEvent} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
-import {testDependencies} from "../../../../../testing/test-dependencies";
+import {
+    testDependencies,
+    testDependenciesV2,
+} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
 import {PerseusItem} from "../../perseus-types";
 import {
@@ -15,7 +18,11 @@ import {Expression} from "../expression";
 
 import {renderQuestion} from "./renderQuestion";
 
-const assertComplete = (itemData: PerseusItem, input, isCorrect: boolean) => {
+const assertComplete = (
+    itemData: PerseusItem,
+    input: string,
+    isCorrect: boolean,
+) => {
     const {renderer} = renderQuestion(itemData.question);
     userEvent.type(screen.getByRole("textbox"), input);
     const [_, score] = renderer.guessAndScore();
@@ -26,10 +33,10 @@ const assertComplete = (itemData: PerseusItem, input, isCorrect: boolean) => {
     });
 };
 
-const assertCorrect = (itemData: PerseusItem, input) => {
+const assertCorrect = (itemData: PerseusItem, input: string) => {
     assertComplete(itemData, input, true);
 
-    expect(testDependencies.analytics).toHaveBeenCalledWith({
+    expect(testDependenciesV2.analytics.sendEvent).toHaveBeenCalledWith({
         type: "perseus:expression-evaluated",
         payload: {
             result: "correct",
@@ -40,7 +47,7 @@ const assertCorrect = (itemData: PerseusItem, input) => {
 const assertIncorrect = (itemData: PerseusItem, input: string) => {
     assertComplete(itemData, input, false);
 
-    expect(testDependencies.analytics).toHaveBeenCalledWith({
+    expect(testDependenciesV2.analytics.sendEvent).toHaveBeenCalledWith({
         type: "perseus:expression-evaluated",
         payload: {
             result: "incorrect",
@@ -49,7 +56,11 @@ const assertIncorrect = (itemData: PerseusItem, input: string) => {
 };
 
 // TODO: actually Assert that message is being set on the score object.
-const assertInvalid = (itemData: PerseusItem, input, message?: string) => {
+const assertInvalid = (
+    itemData: PerseusItem,
+    input: string,
+    message?: string,
+) => {
     const {renderer} = renderQuestion(itemData.question);
     if (input.length) {
         userEvent.type(screen.getByRole("textbox"), input);
@@ -57,7 +68,7 @@ const assertInvalid = (itemData: PerseusItem, input, message?: string) => {
     const [_, score] = renderer.guessAndScore();
     expect(score).toMatchObject({type: "invalid"});
 
-    expect(testDependencies.analytics).toHaveBeenCalledWith({
+    expect(testDependenciesV2.analytics.sendEvent).toHaveBeenCalledWith({
         type: "perseus:expression-evaluated",
         payload: {
             result: "invalid",
@@ -67,7 +78,7 @@ const assertInvalid = (itemData: PerseusItem, input, message?: string) => {
 
 describe("Expression Widget", function () {
     beforeEach(() => {
-        jest.spyOn(testDependencies, "analytics");
+        jest.spyOn(testDependenciesV2.analytics, "sendEvent");
         jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
             testDependencies,
         );

--- a/packages/perseus/src/widgets/__tests__/renderQuestion.tsx
+++ b/packages/perseus/src/widgets/__tests__/renderQuestion.tsx
@@ -2,6 +2,9 @@ import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 import {render} from "@testing-library/react";
 import * as React from "react";
 
+// eslint-disable-next-line import/no-relative-packages
+import {testDependenciesV2} from "../../../../../testing/test-dependencies";
+import {DependenciesContext} from "../../dependencies";
 import * as Perseus from "../../index";
 import {registerAllWidgetsForTesting} from "../../util/register-all-widgets-for-testing";
 
@@ -32,18 +35,21 @@ export const renderQuestion = (
     unmount: RenderResult["unmount"];
 } => {
     registerAllWidgetsForTesting();
+
     let renderer: Perseus.Renderer | null = null;
     const {container, rerender, unmount} = render(
         <RenderStateRoot>
-            <Perseus.Renderer
-                ref={(node) => (renderer = node)}
-                content={question.content}
-                images={question.images}
-                widgets={question.widgets}
-                problemNum={0}
-                apiOptions={apiOptions}
-                {...extraProps}
-            />
+            <DependenciesContext.Provider value={testDependenciesV2}>
+                <Perseus.Renderer
+                    ref={(node) => (renderer = node)}
+                    content={question.content}
+                    images={question.images}
+                    widgets={question.widgets}
+                    problemNum={0}
+                    apiOptions={apiOptions}
+                    {...extraProps}
+                />
+            </DependenciesContext.Provider>
         </RenderStateRoot>,
     );
     if (!renderer) {
@@ -56,15 +62,17 @@ export const renderQuestion = (
     ) => {
         rerender(
             <RenderStateRoot>
-                <Perseus.Renderer
-                    ref={(node) => (renderer = node)}
-                    content={question.content}
-                    images={question.images}
-                    widgets={question.widgets}
-                    problemNum={0}
-                    apiOptions={apiOptions}
-                    {...extraProps}
-                />
+                <DependenciesContext.Provider value={testDependenciesV2}>
+                    <Perseus.Renderer
+                        ref={(node) => (renderer = node)}
+                        content={question.content}
+                        images={question.images}
+                        widgets={question.widgets}
+                        problemNum={0}
+                        apiOptions={apiOptions}
+                        {...extraProps}
+                    />
+                </DependenciesContext.Provider>
             </RenderStateRoot>,
         );
         if (!renderer) {

--- a/packages/perseus/src/widgets/expression.tsx
+++ b/packages/perseus/src/widgets/expression.tsx
@@ -12,7 +12,7 @@ import Tooltip, {
     HorizontalDirection,
     VerticalDirection,
 } from "../components/tooltip";
-import {getDependencies} from "../dependencies";
+import {useDependencies} from "../dependencies";
 import {iconExclamationSign} from "../icon-paths";
 import {Errors as PerseusErrors, Log} from "../logging/log";
 import * as Changeable from "../mixins/changeable";
@@ -24,17 +24,6 @@ import type {
     PerseusExpressionAnswerForm,
 } from "../perseus-types";
 import type {PerseusScore, WidgetExports, WidgetProps} from "../types";
-
-const sendExpressionEvaluatedEvent = (
-    result: "correct" | "incorrect" | "invalid",
-) => {
-    getDependencies().analytics({
-        type: "perseus:expression-evaluated",
-        payload: {
-            result,
-        },
-    });
-};
 
 type InputPath = ReadonlyArray<string>;
 
@@ -64,18 +53,27 @@ const insertBraces = (value) => {
 
 type Rubric = PerseusExpressionWidgetOptions;
 
+type RenderProps = {
+    buttonSets: PerseusExpressionWidgetOptions["buttonSets"];
+    buttonsVisible?: PerseusExpressionWidgetOptions["buttonsVisible"];
+    functions: PerseusExpressionWidgetOptions["functions"];
+    times: PerseusExpressionWidgetOptions["times"];
+    keypadConfiguration: ReturnType<typeof keypadConfigurationForProps>;
+};
+
 type ExternalProps = WidgetProps<RenderProps, Rubric>;
 
-export type Props = ExternalProps & {
-    apiOptions: NonNullable<ExternalProps["apiOptions"]>;
-    buttonSets: NonNullable<ExternalProps["buttonSets"]>;
-    functions: NonNullable<ExternalProps["functions"]>;
-    linterContext: NonNullable<ExternalProps["linterContext"]>;
-    onBlur: NonNullable<ExternalProps["onBlur"]>;
-    onFocus: NonNullable<ExternalProps["onFocus"]>;
-    times: NonNullable<ExternalProps["times"]>;
-    value: string;
-};
+export type Props = ExternalProps &
+    ReturnType<typeof useDependencies> & {
+        apiOptions: NonNullable<ExternalProps["apiOptions"]>;
+        buttonSets: NonNullable<ExternalProps["buttonSets"]>;
+        functions: NonNullable<ExternalProps["functions"]>;
+        linterContext: NonNullable<ExternalProps["linterContext"]>;
+        onBlur: NonNullable<ExternalProps["onBlur"]>;
+        onFocus: NonNullable<ExternalProps["onFocus"]>;
+        times: NonNullable<ExternalProps["times"]>;
+        value: string;
+    };
 
 export type ExpressionState = {
     showErrorTooltip: boolean;
@@ -210,8 +208,6 @@ export class Expression extends React.Component<Props, ExpressionState> {
         // we did, whether it's considered correct, incorrect, or ungraded
         if (!matchingAnswerForm) {
             if (firstUngradedResult) {
-                sendExpressionEvaluatedEvent("invalid");
-
                 // While we didn't directly match with any answer form, we
                 // did at some point get an "ungraded" validation result,
                 // which might indicate e.g. a mismatch in variable casing.
@@ -226,8 +222,6 @@ export class Expression extends React.Component<Props, ExpressionState> {
                 };
             }
             if (allEmpty) {
-                sendExpressionEvaluatedEvent("invalid");
-
                 // If everything graded as empty, it's invalid.
                 return {
                     type: "invalid",
@@ -236,7 +230,6 @@ export class Expression extends React.Component<Props, ExpressionState> {
             }
             // We fell through all the possibilities and we're not empty,
             // so the answer is considered incorrect.
-            sendExpressionEvaluatedEvent("incorrect");
             return {
                 type: "points",
                 earned: 0,
@@ -251,7 +244,6 @@ export class Expression extends React.Component<Props, ExpressionState> {
                 userInput,
                 matchMessage,
             );
-            sendExpressionEvaluatedEvent("invalid");
             return {
                 type: "invalid",
                 message: apiResult === false ? null : matchMessage,
@@ -263,12 +255,6 @@ export class Expression extends React.Component<Props, ExpressionState> {
         // TODO(eater): Seems silly to translate result to this
         // invalid/points thing and immediately translate it back in
         // ItemRenderer.scoreInput()
-        sendExpressionEvaluatedEvent(
-            matchingAnswerForm.considered === "correct"
-                ? "correct"
-                : "incorrect",
-        );
-
         return {
             type: "points",
             earned: matchingAnswerForm.considered === "correct" ? 1 : 0,
@@ -368,7 +354,21 @@ export class Expression extends React.Component<Props, ExpressionState> {
         onInputError: OnInputErrorFunctionType,
     ) => PerseusScore = (rubric, onInputError) => {
         onInputError = onInputError || function () {};
-        return Expression.validate(this.getUserInput(), rubric, onInputError);
+        const result = Expression.validate(
+            this.getUserInput(),
+            rubric,
+            onInputError,
+        );
+
+        this.sendExpressionEvaluatedEvent(
+            result.type === "invalid"
+                ? "invalid"
+                : result.earned === result.total
+                ? "correct"
+                : "incorrect",
+        );
+
+        return result;
     };
 
     getUserInput: () => string = () => {
@@ -469,6 +469,15 @@ export class Expression extends React.Component<Props, ExpressionState> {
             cb,
         );
     };
+
+    sendExpressionEvaluatedEvent(result: "correct" | "incorrect" | "invalid") {
+        this.props.analytics.sendEvent({
+            type: "perseus:expression-evaluated",
+            payload: {
+                result,
+            },
+        });
+    }
 
     render():
         | React.ReactNode
@@ -639,22 +648,25 @@ const propUpgrades = {
     }),
 } as const;
 
-type RenderProps = {
-    buttonSets: any;
-    buttonsVisible?: "always" | "focused" | "never";
-    functions: ReadonlyArray<string>;
-    keypadConfiguration: {
-        extraKeys: ReadonlyArray<any | string>;
-        keypadType: any;
-    };
-    times: boolean;
-};
+const ExpressionWithDependencies = React.forwardRef<
+    Expression,
+    Omit<
+        JSX.LibraryManagedAttributes<
+            typeof Expression,
+            React.ComponentProps<typeof Expression>
+        >,
+        keyof ReturnType<typeof useDependencies>
+    >
+>((props, ref) => {
+    const deps = useDependencies();
+    return <Expression ref={ref} analytics={deps.analytics} {...props} />;
+});
 
 export default {
     name: "expression",
     displayName: "Expression / Equation",
     defaultAlignment: "inline-block",
-    widget: Expression,
+    widget: ExpressionWithDependencies,
     transform: (widgetOptions: PerseusExpressionWidgetOptions): RenderProps => {
         const {times, functions, buttonSets, buttonsVisible} = widgetOptions;
         return {
@@ -670,4 +682,4 @@ export default {
 
     // For use by the editor
     isLintable: true,
-} as WidgetExports<typeof Expression>;
+} as WidgetExports<typeof ExpressionWithDependencies>;

--- a/testing/item-renderer-with-debug-ui.tsx
+++ b/testing/item-renderer-with-debug-ui.tsx
@@ -3,6 +3,7 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import * as React from "react";
 
+import {useDependencies} from "../packages/perseus/src/dependencies";
 import {ItemRenderer} from "../packages/perseus/src/index";
 
 import KEScoreUI from "./ke-score-ui";
@@ -23,6 +24,12 @@ export const ItemRendererWithDebugUI = ({
     const ref = React.useRef<ItemRenderer | null | undefined>(null);
     const [state, setState] = React.useState<KEScore | null | undefined>(null);
 
+    // We provide the dependencies in `.storybook/preview.js` so we can just
+    // pipe it through here. If this component is used outside of Storybook,
+    // the caller will need to provide the dependencies through the
+    // DependenciesContext.Provider.
+    const deps = useDependencies();
+
     return (
         <SideBySide
             leftTitle="Renderer"
@@ -35,6 +42,7 @@ export const ItemRendererWithDebugUI = ({
                         apiOptions={apiOptions}
                         item={item}
                         savedState={null}
+                        dependencies={deps}
                     />
                     <div id="workarea" />
                     <div id="hintsarea" />

--- a/testing/multi-item-renderer-with-debug-ui.tsx
+++ b/testing/multi-item-renderer-with-debug-ui.tsx
@@ -7,6 +7,7 @@ import {simpleQuestionShape} from "../packages/perseus/src/multi-items/__testdat
 
 import KEScoreUI from "./ke-score-ui";
 import SideBySide from "./side-by-side";
+import {testDependenciesV2} from "./test-dependencies";
 
 import type {Item as MultiItem} from "../packages/perseus/src/multi-items/item-types";
 import type {APIOptions, KEScore} from "../packages/perseus/src/types";
@@ -45,6 +46,7 @@ export const MultiItemRendererWithDebugUI = ({
                         item={simpleItem}
                         shape={simpleQuestionShape}
                         ref={ref}
+                        dependencies={testDependenciesV2}
                     >
                         {(renderers) => {
                             return children(renderers);

--- a/testing/render-question-with-cypress.tsx
+++ b/testing/render-question-with-cypress.tsx
@@ -3,7 +3,10 @@ import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 import React from "react";
 
 import AssetContext from "../packages/perseus/src/asset-context";
+import {DependenciesContext} from "../packages/perseus/src/dependencies";
 import * as Perseus from "../packages/perseus/src/index";
+
+import {cypressDependenciesV2} from "./test-dependencies";
 
 import type {PerseusRenderer} from "../packages/perseus/src/perseus-types";
 import type {APIOptions} from "../packages/perseus/src/types";
@@ -42,16 +45,18 @@ const renderQuestion = (
         <div className="framework-perseus">
             <AssetContext.Provider value={{assetStatuses, setAssetStatus}}>
                 <RenderStateRoot>
-                    <Perseus.Renderer
-                        ref={(node) => (renderer = node)}
-                        content={question.content}
-                        images={question.images}
-                        widgets={question.widgets}
-                        problemNum={0}
-                        apiOptions={apiOptions}
-                        reviewMode={reviewMode}
-                        onRender={onRender}
-                    />
+                    <DependenciesContext.Provider value={cypressDependenciesV2}>
+                        <Perseus.Renderer
+                            ref={(node) => (renderer = node)}
+                            content={question.content}
+                            images={question.images}
+                            widgets={question.widgets}
+                            problemNum={0}
+                            apiOptions={apiOptions}
+                            reviewMode={reviewMode}
+                            onRender={onRender}
+                        />
+                    </DependenciesContext.Provider>
                 </RenderStateRoot>
             </AssetContext.Provider>
         </div>,

--- a/testing/server-item-renderer-with-debug-ui.tsx
+++ b/testing/server-item-renderer-with-debug-ui.tsx
@@ -7,6 +7,7 @@ import * as Perseus from "../packages/perseus/src/index";
 
 import KEScoreUI from "./ke-score-ui";
 import SideBySide from "./side-by-side";
+import {testDependenciesV2} from "./test-dependencies";
 
 import type {PerseusItem} from "../packages/perseus/src/perseus-types";
 import type {APIOptions, KEScore} from "../packages/perseus/src/types";
@@ -34,6 +35,7 @@ export const ServerItemRendererWithDebugUI = ({
                         problemNum={0}
                         apiOptions={options}
                         item={item}
+                        dependencies={testDependenciesV2}
                     />
                     <View style={{flexDirection: "row", alignItems: "center"}}>
                         <Button

--- a/testing/test-dependencies.tsx
+++ b/testing/test-dependencies.tsx
@@ -6,8 +6,11 @@ import {registerAllWidgetsForTesting} from "../packages/perseus/src/util/registe
 
 import {TestTeX} from "./test-tex";
 
-import type {PerseusDependencies} from "../packages/perseus/src/index";
 import type {ILogger} from "../packages/perseus/src/logging/log";
+import type {
+    PerseusDependencies,
+    PerseusDependenciesV2,
+} from "../packages/perseus/src/types";
 
 registerAllWidgetsForTesting();
 
@@ -98,15 +101,22 @@ export const testDependencies: PerseusDependencies = {
         protocol: "protocol-test-interface",
     },
 
-    analytics: async (event) => {
-        console.log("⚡️ Sending analytics event:", event);
-    },
-
     isDevServer: false,
     kaLocale: "en",
     isMobile: false,
 
     Log: LogForTesting,
+};
+
+// PerseusDependenciesV2 are provided through a React Context. This object
+// exists so that we can easily pass a "known" object into the renderers (see
+// renderQuestion.tsx) and then spy on any functions to do assertions.
+export const testDependenciesV2: PerseusDependenciesV2 = {
+    analytics: {
+        sendEvent: async (event) => {
+            console.log("⚡️ Sending analytics event:", event);
+        },
+    },
 };
 
 export const storybookTestDependencies: PerseusDependencies = {

--- a/testing/test-dependencies.tsx
+++ b/testing/test-dependencies.tsx
@@ -126,9 +126,19 @@ export const storybookTestDependencies: PerseusDependencies = {
     staticUrl: (str) => str,
 };
 
+export const storybookDependenciesV2: PerseusDependenciesV2 = {
+    ...testDependenciesV2,
+    // Override if necessary
+};
+
 export const cypressTestDependencies: PerseusDependencies = {
     ...testDependencies,
     TeX: TestTeX,
     // $FlowIgnore[incompatible-type]
     staticUrl: (str) => str,
+};
+
+export const cypressDependenciesV2: PerseusDependenciesV2 = {
+    ...testDependenciesV2,
+    // Override if necessary
 };


### PR DESCRIPTION
## Summary:

This PR introduces a new way of providing dependencies to Perseus. The old way (`PerseusDependencies`) presents problems when integrating into a React project. Many projects provide "infrastructure" through React Context. The `PerseusDependencies` use a global state mechanism that makes it difficult to use when the dependencies come from React Context. 

So this new approach adds a `dependencies` prop to our top-level Renderers (`ItemRenderer`, `ServerItemRenderer`, and `MultiRenderer`) which is then attached to a React Context so it's available anywhere in Perseus. 

Any React component within Perseus can now access these dependencies using the `useDependencies()` hook (part of this PR). 

The Expression widget has also been adapted to use this new mechanism to dispatch analytics events (and this provides an example for how to wrap any React component in Perseus to provide dependencies).

Issue: LC-950

## Test plan:

`yarn test`
`yarn tsc`
`yarn storybook` -> renderer stories work and don't throw