### PR TITLE
[Analytics] 1. Introduce DependenciesContext

### DIFF
--- a/.changeset/lazy-coins-dream.md
+++ b/.changeset/lazy-coins-dream.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/math-input": major
+"@khanacademy/perseus": major
+"@khanacademy/perseus-core": minor
+---
+
+Rename analytics prop from onEvent to onAnalyticsEvent

--- a/packages/math-input/src/components/keypad/__tests__/keypad-v2-mathquill.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/keypad-v2-mathquill.test.tsx
@@ -1,4 +1,4 @@
-import {PerseusAnalyticsEvent} from "@khanacademy/perseus-core";
+import {AnalyticsEventHandlerFn} from "@khanacademy/perseus-core";
 import Color from "@khanacademy/wonder-blocks-color";
 import {Popover} from "@khanacademy/wonder-blocks-popover";
 import {render, screen} from "@testing-library/react";
@@ -16,13 +16,13 @@ import Keypad from "../index";
 type Props = {
     onChangeMathInput: (mathInputTex: string) => void;
     keypadClosed?: boolean;
-    sendEvent?: (event: PerseusAnalyticsEvent) => Promise<void>;
+    onAnalyticsEvent?: AnalyticsEventHandlerFn;
 };
 
 function V2KeypadWithMathquill(props: Props) {
     const mathFieldWrapperRef = React.useRef<HTMLDivElement>(null);
     const [mathField, setMathField] = React.useState<MathFieldInterface>();
-    const {onChangeMathInput, keypadClosed, sendEvent} = props;
+    const {onChangeMathInput, keypadClosed, onAnalyticsEvent} = props;
     const [keypadOpen, setKeypadOpen] = React.useState<boolean>(!keypadClosed);
 
     React.useEffect(() => {
@@ -74,7 +74,11 @@ function V2KeypadWithMathquill(props: Props) {
                             multiplicationDot
                             preAlgebra
                             trigonometry
-                            sendEvent={sendEvent ? sendEvent : async () => {}}
+                            onAnalyticsEvent={
+                                onAnalyticsEvent
+                                    ? onAnalyticsEvent
+                                    : async () => {}
+                            }
                             showDismiss
                         />
                     </div>
@@ -251,12 +255,12 @@ describe("Keypad v2 with MathQuill", () => {
     // Keypad event tests
     it("fires the keypad open event on open", () => {
         // Arrange
-        const mockSendEvent = jest.fn();
+        const mockAnalyticsEventHandler = jest.fn();
         render(
             <V2KeypadWithMathquill
                 onChangeMathInput={() => {}}
                 keypadClosed={true}
-                sendEvent={mockSendEvent}
+                onAnalyticsEvent={mockAnalyticsEventHandler}
             />,
         );
 
@@ -264,7 +268,7 @@ describe("Keypad v2 with MathQuill", () => {
         userEvent.click(screen.getByRole("button", {name: "Keypad toggle"}));
 
         // Assert
-        expect(mockSendEvent).toHaveBeenLastCalledWith({
+        expect(mockAnalyticsEventHandler).toHaveBeenLastCalledWith({
             type: "math-input:keypad-opened",
             payload: {virtualKeypadVersion: "MATH_INPUT_KEYPAD_V2"},
         });
@@ -273,11 +277,11 @@ describe("Keypad v2 with MathQuill", () => {
     // Keypad event tests
     it("fires the keypad open event on close", () => {
         // Arrange
-        const mockSendEvent = jest.fn();
+        const mockAnalyticsEventHandler = jest.fn();
         render(
             <V2KeypadWithMathquill
                 onChangeMathInput={() => {}}
-                sendEvent={mockSendEvent}
+                onAnalyticsEvent={mockAnalyticsEventHandler}
             />,
         );
 
@@ -285,7 +289,7 @@ describe("Keypad v2 with MathQuill", () => {
         userEvent.click(screen.getByRole("button", {name: "Keypad toggle"}));
 
         // Assert
-        expect(mockSendEvent).toHaveBeenLastCalledWith({
+        expect(mockAnalyticsEventHandler).toHaveBeenLastCalledWith({
             type: "math-input:keypad-closed",
             payload: {virtualKeypadVersion: "MATH_INPUT_KEYPAD_V2"},
         });

--- a/packages/math-input/src/components/keypad/__tests__/keypad.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/keypad.test.tsx
@@ -27,7 +27,7 @@ describe("keypad", () => {
                         cursorContext={
                             context as typeof CursorContext[keyof typeof CursorContext]
                         }
-                        sendEvent={async () => {
+                        onAnalyticsEvent={async () => {
                             /* TODO: verify correct analytics event sent */
                         }}
                     />,
@@ -49,7 +49,7 @@ describe("keypad", () => {
         render(
             <Keypad
                 onClickKey={() => {}}
-                sendEvent={async () => {}}
+                onAnalyticsEvent={async () => {}}
                 showDismiss
             />,
         );
@@ -65,7 +65,9 @@ describe("keypad", () => {
     it(`hides optional dismiss button`, () => {
         // Arrange
         // Act
-        render(<Keypad onClickKey={() => {}} sendEvent={async () => {}} />);
+        render(
+            <Keypad onClickKey={() => {}} onAnalyticsEvent={async () => {}} />,
+        );
 
         // Assert
         expect(

--- a/packages/math-input/src/components/keypad/index.tsx
+++ b/packages/math-input/src/components/keypad/index.tsx
@@ -16,7 +16,7 @@ import NumbersPage from "./keypad-pages/numbers-page";
 import OperatorsPage from "./keypad-pages/operators-page";
 import SharedKeys from "./shared-keys";
 
-import type {SendEventFn} from "@khanacademy/perseus-core";
+import type {AnalyticsEventHandlerFn} from "@khanacademy/perseus-core";
 
 export type Props = {
     extraKeys: ReadonlyArray<Key>;
@@ -33,7 +33,7 @@ export type Props = {
     advancedRelations?: boolean;
 
     onClickKey: ClickKeyCallback;
-    sendEvent: SendEventFn;
+    onAnalyticsEvent: AnalyticsEventHandlerFn;
 };
 
 const defaultProps = {
@@ -84,12 +84,12 @@ export default function Keypad(props: Props) {
         basicRelations,
         advancedRelations,
         showDismiss,
-        sendEvent,
+        onAnalyticsEvent,
     } = props;
 
     useEffect(() => {
         if (!isMounted) {
-            sendEvent({
+            onAnalyticsEvent({
                 type: "math-input:keypad-opened",
                 payload: {virtualKeypadVersion: "MATH_INPUT_KEYPAD_V2"},
             });
@@ -97,14 +97,14 @@ export default function Keypad(props: Props) {
         }
         return () => {
             if (isMounted) {
-                sendEvent({
+                onAnalyticsEvent({
                     type: "math-input:keypad-closed",
                     payload: {virtualKeypadVersion: "MATH_INPUT_KEYPAD_V2"},
                 });
                 setIsMounted(false);
             }
         };
-    }, [sendEvent, isMounted]);
+    }, [onAnalyticsEvent, isMounted]);
 
     return (
         <View>

--- a/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
+++ b/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
@@ -80,7 +80,7 @@ export function V2KeypadWithMathquill() {
                             multiplicationDot
                             preAlgebra
                             trigonometry
-                            sendEvent={async (event) => {
+                            onAnalyticsEvent={async (event) => {
                                 // eslint-disable-next-line no-console
                                 console.log("Send Event:", event);
                             }}

--- a/packages/perseus-core/src/analytics.ts
+++ b/packages/perseus-core/src/analytics.ts
@@ -26,5 +26,7 @@ export type PerseusAnalyticsEvent =
 // key and a payload that varies by type.
 // | {type: "b"; payload: {name: string}};
 
-/** A function to send analytics events. */
-export type SendEventFn = (event: PerseusAnalyticsEvent) => Promise<void>;
+/** A function that is called when Perseus emits an analytics event. */
+export type AnalyticsEventHandlerFn = (
+    event: PerseusAnalyticsEvent,
+) => Promise<void>;

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -1,1 +1,1 @@
-export type {PerseusAnalyticsEvent, SendEventFn} from "./analytics";
+export type {PerseusAnalyticsEvent, AnalyticsEventHandlerFn} from "./analytics";

--- a/packages/perseus/src/dependencies.ts
+++ b/packages/perseus/src/dependencies.ts
@@ -1,4 +1,6 @@
-import type {PerseusDependencies} from "./types";
+import * as React from "react";
+
+import type {PerseusDependencies, PerseusDependenciesV2} from "./types";
 
 let _dependencies: PerseusDependencies | null | undefined = null;
 
@@ -18,4 +20,17 @@ export const getDependencies = (): PerseusDependencies => {
             "Make sure Perseus is being imported from javascript/perseus/perseus.js.",
         ].join("\n"),
     );
+};
+
+export const DependenciesContext = React.createContext<PerseusDependenciesV2>({
+    analytics: {onAnalyticsEvent: async () => {}},
+});
+
+/**
+ * useDependencies provides easy access to the current Perseus dependencies.
+ */
+export const useDependencies = (): PerseusDependenciesV2 => {
+    const deps = React.useContext(DependenciesContext);
+
+    return deps;
 };

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -5,7 +5,7 @@ import type {ILogger} from "./logging/log";
 import type {Item} from "./multi-items/item-types";
 import type {PerseusWidget} from "./perseus-types";
 import type {SizeClass} from "./util/sizing-utils";
-import type {SendEventFn} from "@khanacademy/perseus-core";
+import type {AnalyticsEventHandlerFn} from "@khanacademy/perseus-core";
 import type {Result} from "@khanacademy/wonder-blocks-data";
 
 export type FocusPath = ReadonlyArray<string> | null | undefined;
@@ -319,7 +319,7 @@ export type PerseusDependencies = {
     //misc
     staticUrl: StaticUrlFn;
     InitialRequestUrl: InitialRequestUrlInterface;
-    analytics: SendEventFn;
+    analytics: AnalyticsEventHandlerFn;
 
     // video widget
     // This is used as a hook to fetch data about a video which is used to
@@ -339,6 +339,18 @@ export type PerseusDependencies = {
     isDevServer: boolean;
     kaLocale: string;
     isMobile: boolean;
+};
+
+/**
+ * The modern iteration of Perseus Depedndencies. These dependencies are
+ * provided to Perseus through its entrypoints (for example:
+ * ServerItemRenderer) and then attached to the DependenciesContext so they are
+ * available anywhere down the React render tree.
+ *
+ * Prefer using this type over `PerseusDependencies` when possible.
+ */
+export type PerseusDependenciesV2 = {
+    analytics: {onAnalyticsEvent: AnalyticsEventHandlerFn};
 };
 
 export type APIOptionsWithDefaults = Readonly<

--- a/testing/render-keypad-with-cypress.tsx
+++ b/testing/render-keypad-with-cypress.tsx
@@ -15,7 +15,7 @@ const renderSingleKeypad = (handleClickKey) =>
             multiplicationDot
             preAlgebra
             trigonometry
-            sendEvent={async () => {
+            onAnalyticsEvent={async () => {
                 /* no-op */
             }}
         />,


### PR DESCRIPTION
## Summary:

This PR introduces a new React Context for plumbing dependencies through Perseus. The context uses a new type `PerseusDependenciesV2` (so it doesn't conflict with the original `PerseusDependencies`). 

This PR also provides a React hook (`useDependencies`) for accessing dependencies. This hook will commonly be used in wrapper component to attach dependencies to the wrapped component (next PR). 

I also renamed `sendEvent` to `onAnalyticsEvent` as that feels more natural for a callback (especially event callback... a la 'onClick`). This causes a bit more churn but hopefully that's ok as we're early in the analytics journey.

Issue: LC-950

## Test plan:

`yarn test`
`yarn tsc`