### PR TITLE
[Analytics] 2. Plumb new DependenciesContext through

### DIFF
--- a/.changeset/lazy-coins-dream.md
+++ b/.changeset/lazy-coins-dream.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/math-input": major
+"@khanacademy/perseus": major
+"@khanacademy/perseus-core": minor
+---
+
+Rename analytics prop from onEvent to onAnalyticsEvent

--- a/.changeset/small-snails-kneel.md
+++ b/.changeset/small-snails-kneel.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Introduce `dependencies` on ArticleRenderer, ItemRenderer, MultiRenderer, and ServerItemRenderer.

--- a/.changeset/thin-islands-accept.md
+++ b/.changeset/thin-islands-accept.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": minor
+---
+
+Introduce `dependencies` on Keypad.

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,7 +2,12 @@ import * as React from "react";
 import Color from "@khanacademy/wonder-blocks-color";
 import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 import {Dependencies} from "@khanacademy/perseus";
-import {storybookTestDependencies} from "../testing/test-dependencies";
+
+import {DependenciesContext} from "../packages/perseus/src/dependencies";
+import {
+    storybookTestDependencies,
+    storybookDependenciesV2,
+} from "../testing/test-dependencies";
 
 // IMPORTANT: This code runs ONCE per story file, not per story within that file.
 // If you want code to run once per story, see `StorybookWrapper`.
@@ -14,7 +19,9 @@ Dependencies.setDependencies(storybookTestDependencies);
 export const decorators = [
     (Story) => (
         <RenderStateRoot>
-            <Story />
+            <DependenciesContext.Provider value={storybookDependenciesV2}>
+                <Story />
+            </DependenciesContext.Provider>
         </RenderStateRoot>
     ),
 ];

--- a/packages/math-input/src/components/keypad/__tests__/keypad-v2-mathquill.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/keypad-v2-mathquill.test.tsx
@@ -1,4 +1,4 @@
-import {PerseusAnalyticsEvent} from "@khanacademy/perseus-core";
+import {AnalyticsEventHandlerFn} from "@khanacademy/perseus-core";
 import Color from "@khanacademy/wonder-blocks-color";
 import {Popover} from "@khanacademy/wonder-blocks-popover";
 import {render, screen} from "@testing-library/react";
@@ -16,13 +16,13 @@ import Keypad from "../index";
 type Props = {
     onChangeMathInput: (mathInputTex: string) => void;
     keypadClosed?: boolean;
-    sendEvent?: (event: PerseusAnalyticsEvent) => Promise<void>;
+    onAnalyticsEvent?: AnalyticsEventHandlerFn;
 };
 
 function V2KeypadWithMathquill(props: Props) {
     const mathFieldWrapperRef = React.useRef<HTMLDivElement>(null);
     const [mathField, setMathField] = React.useState<MathFieldInterface>();
-    const {onChangeMathInput, keypadClosed, sendEvent} = props;
+    const {onChangeMathInput, keypadClosed, onAnalyticsEvent} = props;
     const [keypadOpen, setKeypadOpen] = React.useState<boolean>(!keypadClosed);
 
     React.useEffect(() => {
@@ -74,7 +74,11 @@ function V2KeypadWithMathquill(props: Props) {
                             multiplicationDot
                             preAlgebra
                             trigonometry
-                            sendEvent={sendEvent ? sendEvent : async () => {}}
+                            onAnalyticsEvent={
+                                onAnalyticsEvent
+                                    ? onAnalyticsEvent
+                                    : async () => {}
+                            }
                             showDismiss
                         />
                     </div>
@@ -251,12 +255,12 @@ describe("Keypad v2 with MathQuill", () => {
     // Keypad event tests
     it("fires the keypad open event on open", () => {
         // Arrange
-        const mockSendEvent = jest.fn();
+        const mockAnalyticsEventHandler = jest.fn();
         render(
             <V2KeypadWithMathquill
                 onChangeMathInput={() => {}}
                 keypadClosed={true}
-                sendEvent={mockSendEvent}
+                onAnalyticsEvent={mockAnalyticsEventHandler}
             />,
         );
 
@@ -264,7 +268,7 @@ describe("Keypad v2 with MathQuill", () => {
         userEvent.click(screen.getByRole("button", {name: "Keypad toggle"}));
 
         // Assert
-        expect(mockSendEvent).toHaveBeenLastCalledWith({
+        expect(mockAnalyticsEventHandler).toHaveBeenLastCalledWith({
             type: "math-input:keypad-opened",
             payload: {virtualKeypadVersion: "MATH_INPUT_KEYPAD_V2"},
         });
@@ -273,11 +277,11 @@ describe("Keypad v2 with MathQuill", () => {
     // Keypad event tests
     it("fires the keypad open event on close", () => {
         // Arrange
-        const mockSendEvent = jest.fn();
+        const mockAnalyticsEventHandler = jest.fn();
         render(
             <V2KeypadWithMathquill
                 onChangeMathInput={() => {}}
-                sendEvent={mockSendEvent}
+                onAnalyticsEvent={mockAnalyticsEventHandler}
             />,
         );
 
@@ -285,7 +289,7 @@ describe("Keypad v2 with MathQuill", () => {
         userEvent.click(screen.getByRole("button", {name: "Keypad toggle"}));
 
         // Assert
-        expect(mockSendEvent).toHaveBeenLastCalledWith({
+        expect(mockAnalyticsEventHandler).toHaveBeenLastCalledWith({
             type: "math-input:keypad-closed",
             payload: {virtualKeypadVersion: "MATH_INPUT_KEYPAD_V2"},
         });

--- a/packages/math-input/src/components/keypad/__tests__/keypad.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/keypad.test.tsx
@@ -27,7 +27,7 @@ describe("keypad", () => {
                         cursorContext={
                             context as typeof CursorContext[keyof typeof CursorContext]
                         }
-                        sendEvent={async () => {
+                        onAnalyticsEvent={async () => {
                             /* TODO: verify correct analytics event sent */
                         }}
                     />,
@@ -49,7 +49,7 @@ describe("keypad", () => {
         render(
             <Keypad
                 onClickKey={() => {}}
-                sendEvent={async () => {}}
+                onAnalyticsEvent={async () => {}}
                 showDismiss
             />,
         );
@@ -65,7 +65,9 @@ describe("keypad", () => {
     it(`hides optional dismiss button`, () => {
         // Arrange
         // Act
-        render(<Keypad onClickKey={() => {}} sendEvent={async () => {}} />);
+        render(
+            <Keypad onClickKey={() => {}} onAnalyticsEvent={async () => {}} />,
+        );
 
         // Assert
         expect(

--- a/packages/math-input/src/components/keypad/index.tsx
+++ b/packages/math-input/src/components/keypad/index.tsx
@@ -16,7 +16,7 @@ import NumbersPage from "./keypad-pages/numbers-page";
 import OperatorsPage from "./keypad-pages/operators-page";
 import SharedKeys from "./shared-keys";
 
-import type {SendEventFn} from "@khanacademy/perseus-core";
+import type {AnalyticsEventHandlerFn} from "@khanacademy/perseus-core";
 
 export type Props = {
     extraKeys: ReadonlyArray<Key>;
@@ -33,7 +33,7 @@ export type Props = {
     advancedRelations?: boolean;
 
     onClickKey: ClickKeyCallback;
-    sendEvent: SendEventFn;
+    onAnalyticsEvent: AnalyticsEventHandlerFn;
 };
 
 const defaultProps = {
@@ -84,12 +84,12 @@ export default function Keypad(props: Props) {
         basicRelations,
         advancedRelations,
         showDismiss,
-        sendEvent,
+        onAnalyticsEvent,
     } = props;
 
     useEffect(() => {
         if (!isMounted) {
-            sendEvent({
+            onAnalyticsEvent({
                 type: "math-input:keypad-opened",
                 payload: {virtualKeypadVersion: "MATH_INPUT_KEYPAD_V2"},
             });
@@ -97,14 +97,14 @@ export default function Keypad(props: Props) {
         }
         return () => {
             if (isMounted) {
-                sendEvent({
+                onAnalyticsEvent({
                     type: "math-input:keypad-closed",
                     payload: {virtualKeypadVersion: "MATH_INPUT_KEYPAD_V2"},
                 });
                 setIsMounted(false);
             }
         };
-    }, [sendEvent, isMounted]);
+    }, [onAnalyticsEvent, isMounted]);
 
     return (
         <View>

--- a/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
+++ b/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
@@ -80,7 +80,7 @@ export function V2KeypadWithMathquill() {
                             multiplicationDot
                             preAlgebra
                             trigonometry
-                            sendEvent={async (event) => {
+                            onAnalyticsEvent={async (event) => {
                                 // eslint-disable-next-line no-console
                                 console.log("Send Event:", event);
                             }}

--- a/packages/perseus-core/src/analytics.ts
+++ b/packages/perseus-core/src/analytics.ts
@@ -26,5 +26,7 @@ export type PerseusAnalyticsEvent =
 // key and a payload that varies by type.
 // | {type: "b"; payload: {name: string}};
 
-/** A function to send analytics events. */
-export type SendEventFn = (event: PerseusAnalyticsEvent) => Promise<void>;
+/** A function that is called when Perseus emits an analytics event. */
+export type AnalyticsEventHandlerFn = (
+    event: PerseusAnalyticsEvent,
+) => Promise<void>;

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -1,1 +1,1 @@
-export type {PerseusAnalyticsEvent, SendEventFn} from "./analytics";
+export type {PerseusAnalyticsEvent, AnalyticsEventHandlerFn} from "./analytics";

--- a/packages/perseus-editor/src/multirenderer-editor.tsx
+++ b/packages/perseus-editor/src/multirenderer-editor.tsx
@@ -867,6 +867,12 @@ class MultiRendererEditor extends React.Component<MultiRendererEditorProps> {
                     item={item}
                     shape={itemShape}
                     apiOptions={apiOptions}
+                    // Today, with analytics being the only thing in
+                    // dependencies, we send in a dummy function as we don't
+                    // want to gather analytics events from within the editor.
+                    dependencies={{
+                        analytics: {onAnalyticsEvent: async () => {}},
+                    }}
                 >
                     {({renderers}) => (
                         <NodeContainer

--- a/packages/perseus/src/__tests__/item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/item-renderer.test.tsx
@@ -4,7 +4,10 @@ import userEvent from "@testing-library/user-event";
 import * as React from "react";
 import "@testing-library/jest-dom"; // Imports custom matchers
 
-import {testDependencies} from "../../../../testing/test-dependencies";
+import {
+    testDependencies,
+    testDependenciesV2,
+} from "../../../../testing/test-dependencies";
 import {
     itemWithInput,
     labelImageItem,
@@ -76,6 +79,7 @@ export const renderQuestion = (
                 reviewMode={false}
                 savedState=""
                 controlPeripherals={false}
+                dependencies={testDependenciesV2}
                 {...optionalProps}
             />
             {/* The ItemRenderer _requires_ two divs: a work area and hints

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -4,7 +4,10 @@ import userEvent from "@testing-library/user-event";
 import * as React from "react";
 import "@testing-library/jest-dom"; // Imports custom matchers
 
-import {testDependencies} from "../../../../testing/test-dependencies";
+import {
+    testDependencies,
+    testDependenciesV2,
+} from "../../../../testing/test-dependencies";
 import {
     itemWithInput,
     mockedItem,
@@ -51,6 +54,7 @@ const renderQuestion = (
                 item={question}
                 problemNum={0}
                 reviewMode={false}
+                dependencies={testDependenciesV2}
                 {...optionalProps}
             />
         </RenderStateRoot>,
@@ -228,6 +232,7 @@ describe("server item renderer", () => {
                     item={itemWithInput}
                     problemNum={0}
                     reviewMode={false}
+                    dependencies={testDependenciesV2}
                 />
             </RenderStateRoot>,
         );
@@ -243,6 +248,7 @@ describe("server item renderer", () => {
                     item={itemWithInput}
                     problemNum={1} // to force componentDidUpdate
                     reviewMode={false}
+                    dependencies={testDependenciesV2}
                 />
                 ,
             </RenderStateRoot>,
@@ -272,6 +278,7 @@ describe("server item renderer", () => {
                     problemNum={0}
                     reviewMode={false}
                     onRendered={onRendered}
+                    dependencies={testDependenciesV2}
                 />
             </RenderStateRoot>,
         );
@@ -293,6 +300,7 @@ describe("server item renderer", () => {
                     problemNum={1}
                     reviewMode={false}
                     onRendered={onRendered}
+                    dependencies={testDependenciesV2}
                 />
             </RenderStateRoot>,
         );

--- a/packages/perseus/src/dependencies.ts
+++ b/packages/perseus/src/dependencies.ts
@@ -1,4 +1,6 @@
-import type {PerseusDependencies} from "./types";
+import * as React from "react";
+
+import type {PerseusDependencies, PerseusDependenciesV2} from "./types";
 
 let _dependencies: PerseusDependencies | null | undefined = null;
 
@@ -18,4 +20,17 @@ export const getDependencies = (): PerseusDependencies => {
             "Make sure Perseus is being imported from javascript/perseus/perseus.js.",
         ].join("\n"),
     );
+};
+
+export const DependenciesContext = React.createContext<PerseusDependenciesV2>({
+    analytics: {onAnalyticsEvent: async () => {}},
+});
+
+/**
+ * useDependencies provides easy access to the current Perseus dependencies.
+ */
+export const useDependencies = (): PerseusDependenciesV2 => {
+    const deps = React.useContext(DependenciesContext);
+
+    return deps;
 };

--- a/packages/perseus/src/multi-items/__tests__/multi-renderer.test.tsx
+++ b/packages/perseus/src/multi-items/__tests__/multi-renderer.test.tsx
@@ -4,7 +4,10 @@ import userEvent from "@testing-library/user-event";
 import * as React from "react";
 import "@testing-library/jest-dom"; // Imports custom mathers
 
-import {testDependencies} from "../../../../../testing/test-dependencies";
+import {
+    testDependencies,
+    testDependenciesV2,
+} from "../../../../../testing/test-dependencies";
 import MockWidgetExport from "../../__tests__/mock-widget";
 import * as Dependencies from "../../dependencies";
 import {registerAllWidgetsForTesting} from "../../util/register-all-widgets-for-testing";
@@ -50,6 +53,7 @@ const renderSimpleQuestion = (question: Item) => {
                 item={question}
                 shape={simpleQuestionShape}
                 ref={(r) => (renderer = r)}
+                dependencies={testDependenciesV2}
             >
                 {({renderers}) => <SimpleLayout renderers={renderers} />}
             </MultiRenderer>
@@ -119,6 +123,7 @@ describe("multi-item renderer", () => {
                 <MultiRenderer
                     item={question1}
                     shape={shapes.shape({broken: shapes.content})}
+                    dependencies={testDependenciesV2}
                 >
                     {({renderers}) => {
                         return <div />;

--- a/packages/perseus/src/multi-items/multi-renderer.tsx
+++ b/packages/perseus/src/multi-items/multi-renderer.tsx
@@ -40,6 +40,7 @@ import {StyleSheet, css} from "aphrodite"; // eslint-disable-line import/no-extr
 import lens from "hubble"; // eslint-disable-line import/no-extraneous-dependencies
 import * as React from "react";
 
+import {DependenciesContext} from "../dependencies";
 import HintsRenderer from "../hints-renderer";
 import {Errors, Log} from "../logging/log";
 import Renderer from "../renderer";
@@ -49,7 +50,12 @@ import {itemToTree} from "./items";
 import {buildMapper} from "./trees";
 
 import type {Widget} from "../renderer";
-import type {APIOptions, FilterCriterion, PerseusScore} from "../types";
+import type {
+    APIOptions,
+    FilterCriterion,
+    PerseusDependenciesV2,
+    PerseusScore,
+} from "../types";
 import type {Item, ContentNode, HintNode, TagsNode} from "./item-types";
 import type {Shape, ArrayShape} from "./shape-types";
 import type {Tree} from "./tree-types";
@@ -108,6 +114,8 @@ type Props = {
     onInteractWithWidget?: (id: string) => void;
     apiOptions?: APIOptions;
     reviewMode?: boolean | null | undefined;
+
+    dependencies: PerseusDependenciesV2;
 };
 type State = {
     // We cache functions to generate renderers and refs in `rendererDataTree`,
@@ -546,9 +554,13 @@ class MultiRenderer extends React.Component<Props, State> {
 
         // Pass the renderer tree to the `children` function, which will
         // determine the actual content of this component.
-        return this.props.children({
-            renderers: this._getRenderers(),
-        });
+        return (
+            <DependenciesContext.Provider value={this.props.dependencies}>
+                {this.props.children({
+                    renderers: this._getRenderers(),
+                })}
+            </DependenciesContext.Provider>
+        );
     }
 }
 

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -11,6 +11,7 @@ import * as React from "react";
 import _ from "underscore";
 
 import AssetContext from "./asset-context";
+import {DependenciesContext} from "./dependencies";
 import HintsRenderer from "./hints-renderer";
 import Objective from "./interactive2/objective_";
 import LoadingContext from "./loading-context";
@@ -19,7 +20,13 @@ import Renderer from "./renderer";
 import Util from "./util";
 
 import type {KeypadProps} from "./mixins/provide-keypad";
-import type {APIOptions, KEScore, FocusPath, RendererInterface} from "./types";
+import type {
+    APIOptions,
+    KEScore,
+    FocusPath,
+    RendererInterface,
+    PerseusDependenciesV2,
+} from "./types";
 
 const {mapObject} = Objective;
 
@@ -35,6 +42,8 @@ type OwnProps = // These props are used by the ProvideKeypad mixin.
         reviewMode?: boolean;
         // from KeypadContext
         keypadElement?: any | null | undefined;
+
+        dependencies: PerseusDependenciesV2;
     };
 
 type HOCProps = {
@@ -423,22 +432,24 @@ export class ServerItemRenderer
         );
 
         return (
-            <div>
-                <div>{questionRenderer}</div>
-                <div
-                    className={
-                        // Avoid adding any horizontal padding when applying the
-                        // mobile hint styles, which are flush to the left.
-                        // NOTE(charlie): We may still want to apply this
-                        // padding for desktop exercises.
-                        apiOptions.isMobile
-                            ? undefined
-                            : css(styles.hintsContainer)
-                    }
-                >
-                    {hintsRenderer}
+            <DependenciesContext.Provider value={this.props.dependencies}>
+                <div>
+                    <div>{questionRenderer}</div>
+                    <div
+                        className={
+                            // Avoid adding any horizontal padding when applying the
+                            // mobile hint styles, which are flush to the left.
+                            // NOTE(charlie): We may still want to apply this
+                            // padding for desktop exercises.
+                            apiOptions.isMobile
+                                ? undefined
+                                : css(styles.hintsContainer)
+                        }
+                    >
+                        {hintsRenderer}
+                    </div>
                 </div>
-            </div>
+            </DependenciesContext.Provider>
         );
     }
 }

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -5,7 +5,7 @@ import type {ILogger} from "./logging/log";
 import type {Item} from "./multi-items/item-types";
 import type {PerseusWidget} from "./perseus-types";
 import type {SizeClass} from "./util/sizing-utils";
-import type {SendEventFn} from "@khanacademy/perseus-core";
+import type {AnalyticsEventHandlerFn} from "@khanacademy/perseus-core";
 import type {Result} from "@khanacademy/wonder-blocks-data";
 
 export type FocusPath = ReadonlyArray<string> | null | undefined;
@@ -319,7 +319,7 @@ export type PerseusDependencies = {
     //misc
     staticUrl: StaticUrlFn;
     InitialRequestUrl: InitialRequestUrlInterface;
-    analytics: SendEventFn;
+    analytics: AnalyticsEventHandlerFn;
 
     // video widget
     // This is used as a hook to fetch data about a video which is used to
@@ -339,6 +339,18 @@ export type PerseusDependencies = {
     isDevServer: boolean;
     kaLocale: string;
     isMobile: boolean;
+};
+
+/**
+ * The modern iteration of Perseus Depedndencies. These dependencies are
+ * provided to Perseus through its entrypoints (for example:
+ * ServerItemRenderer) and then attached to the DependenciesContext so they are
+ * available anywhere down the React render tree.
+ *
+ * Prefer using this type over `PerseusDependencies` when possible.
+ */
+export type PerseusDependenciesV2 = {
+    analytics: {onAnalyticsEvent: AnalyticsEventHandlerFn};
 };
 
 export type APIOptionsWithDefaults = Readonly<

--- a/packages/perseus/src/widgets/__stories__/definition.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/definition.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui";
+import {storybookDependenciesV2} from "../../../../../testing/test-dependencies";
 import ArticleRenderer from "../../article-renderer";
 
 export default {
@@ -103,5 +104,11 @@ export const MultipleDefinitions = (args: StoryArgs): React.ReactElement => {
 };
 
 export const ArticleDefintion = (args: StoryArgs): React.ReactElement => {
-    return <ArticleRenderer json={article} useNewStyles />;
+    return (
+        <ArticleRenderer
+            json={article}
+            useNewStyles
+            dependencies={storybookDependenciesV2}
+        />
+    );
 };

--- a/packages/perseus/src/widgets/__stories__/expression.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/expression.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import {ItemRendererWithDebugUI} from "../../../../../testing/item-renderer-with-debug-ui";
+import {KeypadType} from "../../../../math-input/src/enums";
 import KeypadContext from "../../keypad-context";
 import {
     expressionItem2,
@@ -62,7 +63,7 @@ export const DesktopKitchenSink = (args: StoryArgs): React.ReactElement => {
     };
 
     const keypadConfiguration = {
-        keypadType: "EXPRESSION",
+        keypadType: KeypadType.EXPRESSION,
         extraKeys: ["x", "y", "z"],
     };
 

--- a/packages/perseus/src/widgets/__tests__/expression.test.ts
+++ b/packages/perseus/src/widgets/__tests__/expression.test.ts
@@ -3,7 +3,10 @@ import {screen, fireEvent} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
-import {testDependencies} from "../../../../../testing/test-dependencies";
+import {
+    testDependencies,
+    testDependenciesV2,
+} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
 import {PerseusItem} from "../../perseus-types";
 import {
@@ -15,7 +18,11 @@ import {Expression} from "../expression";
 
 import {renderQuestion} from "./renderQuestion";
 
-const assertComplete = (itemData: PerseusItem, input, isCorrect: boolean) => {
+const assertComplete = (
+    itemData: PerseusItem,
+    input: string,
+    isCorrect: boolean,
+) => {
     const {renderer} = renderQuestion(itemData.question);
     userEvent.type(screen.getByRole("textbox"), input);
     const [_, score] = renderer.guessAndScore();
@@ -26,10 +33,10 @@ const assertComplete = (itemData: PerseusItem, input, isCorrect: boolean) => {
     });
 };
 
-const assertCorrect = (itemData: PerseusItem, input) => {
+const assertCorrect = (itemData: PerseusItem, input: string) => {
     assertComplete(itemData, input, true);
 
-    expect(testDependencies.analytics).toHaveBeenCalledWith({
+    expect(testDependenciesV2.analytics.onAnalyticsEvent).toHaveBeenCalledWith({
         type: "perseus:expression-evaluated",
         payload: {
             result: "correct",
@@ -40,7 +47,7 @@ const assertCorrect = (itemData: PerseusItem, input) => {
 const assertIncorrect = (itemData: PerseusItem, input: string) => {
     assertComplete(itemData, input, false);
 
-    expect(testDependencies.analytics).toHaveBeenCalledWith({
+    expect(testDependenciesV2.analytics.onAnalyticsEvent).toHaveBeenCalledWith({
         type: "perseus:expression-evaluated",
         payload: {
             result: "incorrect",
@@ -49,7 +56,11 @@ const assertIncorrect = (itemData: PerseusItem, input: string) => {
 };
 
 // TODO: actually Assert that message is being set on the score object.
-const assertInvalid = (itemData: PerseusItem, input, message?: string) => {
+const assertInvalid = (
+    itemData: PerseusItem,
+    input: string,
+    message?: string,
+) => {
     const {renderer} = renderQuestion(itemData.question);
     if (input.length) {
         userEvent.type(screen.getByRole("textbox"), input);
@@ -57,7 +68,7 @@ const assertInvalid = (itemData: PerseusItem, input, message?: string) => {
     const [_, score] = renderer.guessAndScore();
     expect(score).toMatchObject({type: "invalid"});
 
-    expect(testDependencies.analytics).toHaveBeenCalledWith({
+    expect(testDependenciesV2.analytics.onAnalyticsEvent).toHaveBeenCalledWith({
         type: "perseus:expression-evaluated",
         payload: {
             result: "invalid",
@@ -67,7 +78,7 @@ const assertInvalid = (itemData: PerseusItem, input, message?: string) => {
 
 describe("Expression Widget", function () {
     beforeEach(() => {
-        jest.spyOn(testDependencies, "analytics");
+        jest.spyOn(testDependenciesV2.analytics, "onAnalyticsEvent");
         jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
             testDependencies,
         );

--- a/packages/perseus/src/widgets/__tests__/renderQuestion.tsx
+++ b/packages/perseus/src/widgets/__tests__/renderQuestion.tsx
@@ -2,6 +2,9 @@ import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 import {render} from "@testing-library/react";
 import * as React from "react";
 
+// eslint-disable-next-line import/no-relative-packages
+import {testDependenciesV2} from "../../../../../testing/test-dependencies";
+import {DependenciesContext} from "../../dependencies";
 import * as Perseus from "../../index";
 import {registerAllWidgetsForTesting} from "../../util/register-all-widgets-for-testing";
 
@@ -32,18 +35,21 @@ export const renderQuestion = (
     unmount: RenderResult["unmount"];
 } => {
     registerAllWidgetsForTesting();
+
     let renderer: Perseus.Renderer | null = null;
     const {container, rerender, unmount} = render(
         <RenderStateRoot>
-            <Perseus.Renderer
-                ref={(node) => (renderer = node)}
-                content={question.content}
-                images={question.images}
-                widgets={question.widgets}
-                problemNum={0}
-                apiOptions={apiOptions}
-                {...extraProps}
-            />
+            <DependenciesContext.Provider value={testDependenciesV2}>
+                <Perseus.Renderer
+                    ref={(node) => (renderer = node)}
+                    content={question.content}
+                    images={question.images}
+                    widgets={question.widgets}
+                    problemNum={0}
+                    apiOptions={apiOptions}
+                    {...extraProps}
+                />
+            </DependenciesContext.Provider>
         </RenderStateRoot>,
     );
     if (!renderer) {
@@ -56,15 +62,17 @@ export const renderQuestion = (
     ) => {
         rerender(
             <RenderStateRoot>
-                <Perseus.Renderer
-                    ref={(node) => (renderer = node)}
-                    content={question.content}
-                    images={question.images}
-                    widgets={question.widgets}
-                    problemNum={0}
-                    apiOptions={apiOptions}
-                    {...extraProps}
-                />
+                <DependenciesContext.Provider value={testDependenciesV2}>
+                    <Perseus.Renderer
+                        ref={(node) => (renderer = node)}
+                        content={question.content}
+                        images={question.images}
+                        widgets={question.widgets}
+                        problemNum={0}
+                        apiOptions={apiOptions}
+                        {...extraProps}
+                    />
+                </DependenciesContext.Provider>
             </RenderStateRoot>,
         );
         if (!renderer) {

--- a/testing/item-renderer-with-debug-ui.tsx
+++ b/testing/item-renderer-with-debug-ui.tsx
@@ -3,6 +3,7 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import * as React from "react";
 
+import {useDependencies} from "../packages/perseus/src/dependencies";
 import {ItemRenderer} from "../packages/perseus/src/index";
 
 import KEScoreUI from "./ke-score-ui";
@@ -23,6 +24,12 @@ export const ItemRendererWithDebugUI = ({
     const ref = React.useRef<ItemRenderer | null | undefined>(null);
     const [state, setState] = React.useState<KEScore | null | undefined>(null);
 
+    // We provide the dependencies in `.storybook/preview.js` so we can just
+    // pipe it through here. If this component is used outside of Storybook,
+    // the caller will need to provide the dependencies through the
+    // DependenciesContext.Provider.
+    const deps = useDependencies();
+
     return (
         <SideBySide
             leftTitle="Renderer"
@@ -35,6 +42,7 @@ export const ItemRendererWithDebugUI = ({
                         apiOptions={apiOptions}
                         item={item}
                         savedState={null}
+                        dependencies={deps}
                     />
                     <div id="workarea" />
                     <div id="hintsarea" />

--- a/testing/multi-item-renderer-with-debug-ui.tsx
+++ b/testing/multi-item-renderer-with-debug-ui.tsx
@@ -7,6 +7,7 @@ import {simpleQuestionShape} from "../packages/perseus/src/multi-items/__testdat
 
 import KEScoreUI from "./ke-score-ui";
 import SideBySide from "./side-by-side";
+import {testDependenciesV2} from "./test-dependencies";
 
 import type {Item as MultiItem} from "../packages/perseus/src/multi-items/item-types";
 import type {APIOptions, KEScore} from "../packages/perseus/src/types";
@@ -45,6 +46,7 @@ export const MultiItemRendererWithDebugUI = ({
                         item={simpleItem}
                         shape={simpleQuestionShape}
                         ref={ref}
+                        dependencies={testDependenciesV2}
                     >
                         {(renderers) => {
                             return children(renderers);

--- a/testing/render-keypad-with-cypress.tsx
+++ b/testing/render-keypad-with-cypress.tsx
@@ -15,7 +15,7 @@ const renderSingleKeypad = (handleClickKey) =>
             multiplicationDot
             preAlgebra
             trigonometry
-            sendEvent={async () => {
+            onAnalyticsEvent={async () => {
                 /* no-op */
             }}
         />,

--- a/testing/render-question-with-cypress.tsx
+++ b/testing/render-question-with-cypress.tsx
@@ -3,7 +3,10 @@ import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 import React from "react";
 
 import AssetContext from "../packages/perseus/src/asset-context";
+import {DependenciesContext} from "../packages/perseus/src/dependencies";
 import * as Perseus from "../packages/perseus/src/index";
+
+import {cypressDependenciesV2} from "./test-dependencies";
 
 import type {PerseusRenderer} from "../packages/perseus/src/perseus-types";
 import type {APIOptions} from "../packages/perseus/src/types";
@@ -42,16 +45,18 @@ const renderQuestion = (
         <div className="framework-perseus">
             <AssetContext.Provider value={{assetStatuses, setAssetStatus}}>
                 <RenderStateRoot>
-                    <Perseus.Renderer
-                        ref={(node) => (renderer = node)}
-                        content={question.content}
-                        images={question.images}
-                        widgets={question.widgets}
-                        problemNum={0}
-                        apiOptions={apiOptions}
-                        reviewMode={reviewMode}
-                        onRender={onRender}
-                    />
+                    <DependenciesContext.Provider value={cypressDependenciesV2}>
+                        <Perseus.Renderer
+                            ref={(node) => (renderer = node)}
+                            content={question.content}
+                            images={question.images}
+                            widgets={question.widgets}
+                            problemNum={0}
+                            apiOptions={apiOptions}
+                            reviewMode={reviewMode}
+                            onRender={onRender}
+                        />
+                    </DependenciesContext.Provider>
                 </RenderStateRoot>
             </AssetContext.Provider>
         </div>,

--- a/testing/server-item-renderer-with-debug-ui.tsx
+++ b/testing/server-item-renderer-with-debug-ui.tsx
@@ -7,6 +7,7 @@ import * as Perseus from "../packages/perseus/src/index";
 
 import KEScoreUI from "./ke-score-ui";
 import SideBySide from "./side-by-side";
+import {testDependenciesV2} from "./test-dependencies";
 
 import type {PerseusItem} from "../packages/perseus/src/perseus-types";
 import type {APIOptions, KEScore} from "../packages/perseus/src/types";
@@ -34,6 +35,7 @@ export const ServerItemRendererWithDebugUI = ({
                         problemNum={0}
                         apiOptions={options}
                         item={item}
+                        dependencies={testDependenciesV2}
                     />
                     <View style={{flexDirection: "row", alignItems: "center"}}>
                         <Button

--- a/testing/test-dependencies.tsx
+++ b/testing/test-dependencies.tsx
@@ -6,8 +6,11 @@ import {registerAllWidgetsForTesting} from "../packages/perseus/src/util/registe
 
 import {TestTeX} from "./test-tex";
 
-import type {PerseusDependencies} from "../packages/perseus/src/index";
 import type {ILogger} from "../packages/perseus/src/logging/log";
+import type {
+    PerseusDependencies,
+    PerseusDependenciesV2,
+} from "../packages/perseus/src/types";
 
 registerAllWidgetsForTesting();
 
@@ -109,6 +112,17 @@ export const testDependencies: PerseusDependencies = {
     Log: LogForTesting,
 };
 
+// PerseusDependenciesV2 are provided through a React Context. This object
+// exists so that we can easily pass a "known" object into the renderers (see
+// renderQuestion.tsx) and then spy on any functions to do assertions.
+export const testDependenciesV2: PerseusDependenciesV2 = {
+    analytics: {
+        onAnalyticsEvent: async (event) => {
+            console.log("⚡️ Sending analytics event:", event);
+        },
+    },
+};
+
 export const storybookTestDependencies: PerseusDependencies = {
     ...testDependencies,
     TeX: TestTeX,
@@ -116,9 +130,19 @@ export const storybookTestDependencies: PerseusDependencies = {
     staticUrl: (str) => str,
 };
 
+export const storybookDependenciesV2: PerseusDependenciesV2 = {
+    ...testDependenciesV2,
+    // Override if necessary
+};
+
 export const cypressTestDependencies: PerseusDependencies = {
     ...testDependencies,
     TeX: TestTeX,
     // $FlowIgnore[incompatible-type]
     staticUrl: (str) => str,
+};
+
+export const cypressDependenciesV2: PerseusDependenciesV2 = {
+    ...testDependenciesV2,
+    // Override if necessary
 };


### PR DESCRIPTION
## Summary:

The next step in the new dependencies implementation. In this PR we add a new `dependencies` prop to the top-level renderers and provide that dependency object to children in the render tree via the `DependenciesContext`. 

I've also hooked the `Expression` widget to these new dependencies to prove out the concept. 

Finally, this PR includes providing the dependencies in Storybook and Cypress as the types required it now.

_💡**Note**: This PR is easier to review if you turn on the "Hide whitespace" option in the "Files changed" tab._

<img width="200" alt="image" src="https://github.com/Khan/perseus/assets/77138/feb8f9e0-0e63-49d4-9ba9-b1b1cde5d53a">


Issue: LC-950

## Test plan:

`yarn tsc`
`yarn test`