### PR TITLE
[Analytics] 3. Move RenderProps up with other props and use widget options type for prop types

### DIFF
--- a/.changeset/poor-gifts-warn.md
+++ b/.changeset/poor-gifts-warn.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": major
+---
+
+Remove 'analytics' key from PerseusDependencies

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -319,7 +319,6 @@ export type PerseusDependencies = {
     //misc
     staticUrl: StaticUrlFn;
     InitialRequestUrl: InitialRequestUrlInterface;
-    analytics: AnalyticsEventHandlerFn;
 
     // video widget
     // This is used as a hook to fetch data about a video which is used to

--- a/packages/perseus/src/widgets/expression.tsx
+++ b/packages/perseus/src/widgets/expression.tsx
@@ -53,6 +53,14 @@ const insertBraces = (value) => {
 
 type Rubric = PerseusExpressionWidgetOptions;
 
+type RenderProps = {
+    buttonSets: PerseusExpressionWidgetOptions["buttonSets"];
+    buttonsVisible?: PerseusExpressionWidgetOptions["buttonsVisible"];
+    functions: PerseusExpressionWidgetOptions["functions"];
+    times: PerseusExpressionWidgetOptions["times"];
+    keypadConfiguration: ReturnType<typeof keypadConfigurationForProps>;
+};
+
 type ExternalProps = WidgetProps<RenderProps, Rubric>;
 
 export type Props = ExternalProps &
@@ -640,16 +648,6 @@ const propUpgrades = {
     }),
 } as const;
 
-type RenderProps = {
-    buttonSets: any;
-    buttonsVisible?: "always" | "focused" | "never";
-    functions: ReadonlyArray<string>;
-    keypadConfiguration: {
-        extraKeys: ReadonlyArray<any | string>;
-        keypadType: any;
-    };
-    times: boolean;
-};
 const ExpressionWithDependencies = React.forwardRef<
     Expression,
     Omit<

--- a/testing/test-dependencies.tsx
+++ b/testing/test-dependencies.tsx
@@ -101,10 +101,6 @@ export const testDependencies: PerseusDependencies = {
         protocol: "protocol-test-interface",
     },
 
-    analytics: async (event) => {
-        console.log("⚡️ Sending analytics event:", event);
-    },
-
     isDevServer: false,
     kaLocale: "en",
     isMobile: false,


### PR DESCRIPTION
## Summary:

This PR should wrap up the analytics work for now. We remove the (now unused) `analytics` key on the legacy `PerseusDependencies` object/type. It also does a bit of tweaking of the `RenderProps` for the Expression widget by moving it to the top of the file with the other prop types. 

Issue: LC-950

## Test plan:

`yarn tsc`
`yarn test`