### PR TITLE
Changed radio instruction font from serif to sans serif

### DIFF
--- a/.changeset/ninety-rules-pretend.md
+++ b/.changeset/ninety-rules-pretend.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Changed radio widget instruction font.

--- a/packages/perseus/src/multi-items/__tests__/__snapshots__/multi-renderer.test.tsx.snap
+++ b/packages/perseus/src/multi-items/__tests__/__snapshots__/multi-renderer.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`multi-item renderer should snapshot: initial render 1`] = `
                   </legend>
                   <div
                     aria-hidden="true"
-                    class="instructions instructions_125m8j1"
+                    class="instructions instructions_f9jkqj"
                   >
                     Choose 1 answer:
                   </div>

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/group.test.tsx.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/group.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`group widget should snapshot: initial render 1`] = `
                               </legend>
                               <div
                                 aria-hidden="true"
-                                class="instructions instructions_125m8j1"
+                                class="instructions instructions_f9jkqj"
                               >
                                 Choose 1 answer:
                               </div>

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/radio.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/radio.test.ts.snap
@@ -52,7 +52,7 @@ exports[`multi-choice question should snapshot the same when invalid: invalid st
               </legend>
               <div
                 aria-hidden="true"
-                class="instructions instructions_125m8j1"
+                class="instructions instructions_f9jkqj"
               >
                 Choose all answers that apply:
               </div>
@@ -612,7 +612,7 @@ exports[`single-choice question reviewMode: false should snapshot the same with 
               </legend>
               <div
                 aria-hidden="true"
-                class="instructions instructions_125m8j1"
+                class="instructions instructions_f9jkqj"
               >
                 Choose 1 answer:
               </div>
@@ -1184,7 +1184,7 @@ exports[`single-choice question reviewMode: false should snapshot the same with 
               </legend>
               <div
                 aria-hidden="true"
-                class="instructions instructions_125m8j1"
+                class="instructions instructions_f9jkqj"
               >
                 Choose 1 answer:
               </div>
@@ -1756,7 +1756,7 @@ exports[`single-choice question reviewMode: false should snapshot the same: firs
               </legend>
               <div
                 aria-hidden="true"
-                class="instructions instructions_125m8j1"
+                class="instructions instructions_f9jkqj"
               >
                 Choose 1 answer:
               </div>
@@ -2328,7 +2328,7 @@ exports[`single-choice question reviewMode: true should snapshot the same with c
               </legend>
               <div
                 aria-hidden="true"
-                class="instructions instructions_125m8j1"
+                class="instructions instructions_f9jkqj"
               >
                 Choose 1 answer:
               </div>
@@ -2900,7 +2900,7 @@ exports[`single-choice question reviewMode: true should snapshot the same with i
               </legend>
               <div
                 aria-hidden="true"
-                class="instructions instructions_125m8j1"
+                class="instructions instructions_f9jkqj"
               >
                 Choose 1 answer:
               </div>
@@ -3472,7 +3472,7 @@ exports[`single-choice question reviewMode: true should snapshot the same: first
               </legend>
               <div
                 aria-hidden="true"
-                class="instructions instructions_125m8j1"
+                class="instructions instructions_f9jkqj"
               >
                 Choose 1 answer:
               </div>

--- a/packages/perseus/src/widgets/radio/base-radio.tsx
+++ b/packages/perseus/src/widgets/radio/base-radio.tsx
@@ -412,6 +412,7 @@ const styles: StyleDeclaration = StyleSheet.create({
         color: styleConstants.gray17,
         fontSize: 14,
         lineHeight: 1.25,
+        fontFamily: "inherit",
         fontStyle: "normal",
         fontWeight: "bold",
         marginBottom: 16,


### PR DESCRIPTION
## Summary:
Changed the style of the instructions in the base-radio component to be sans-serif
instead of serif.

Issue: LC-492

## Test plan:
- Ran `yarn storybook` and verified that the font is sans-serif
- Used npm image from PR as Perseus version in webapp and verified that the fonts work with a local frontend

<img src="https://github.com/Khan/perseus/assets/46005655/882d1de8-9571-4ecb-9f73-c1e523c99c33" alt="screenshot of a radio button exercise" width="500"/>
