### PR TITLE
Fix paragraph / line # alignment issue

### DIFF
--- a/.changeset/sharp-tables-itch.md
+++ b/.changeset/sharp-tables-itch.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Switch from `classname` to `id` for passage wrappers.

--- a/packages/perseus/src/styles/widgets/passage.less
+++ b/packages/perseus/src/styles/widgets/passage.less
@@ -1,4 +1,4 @@
-.perseus-widget-passage-container {
+#perseus-widget-passage-container {
     // NOTE(mdr): This is similar to Wonder Blocks "BodySerif" typesetting, but
     //     not quite: it's a bit smaller, for consistency with the sorta-small
     //     type styles in rest of the Perseus.
@@ -8,7 +8,7 @@
     @font-size: 16px;
     @line-height: 20px;
 
-    .perseus-widget-passage {
+    #perseus-widget-passage {
         line-height: @line-height;
         margin: 22px;
         position: relative;
@@ -31,35 +31,38 @@
         //     switch to the BodySerif component (TP-3112), and remove this
         //     special font-family rule.
         div.paragraph {
-            font-family: "minion-pro", KaTeX_Main, Times, "Times New Roman", serif;
+            font-family: "minion-pro", KaTeX_Main, Times, "Times New Roman",
+                serif;
+        }
+
+        .passage-title div.paragraph {
+            font-family: "Noto Serif", serif;
+            font-weight: 700;
+            font-size: 20px;
+            line-height: 22px;
+
+            margin: 0 0 10px;
+        }
+
+        // note(matthewc): If you need to change any of this,
+        // check that line numbers line up correctly.
+        // The margin should probably be 0 or the line height
+        .passage-text div.paragraph {
+            font-weight: 400;
+            font-size: @font-size;
+            line-height: @line-height;
+            text-indent: 20px;
+            margin: 0;
+
+            span {
+                text-indent: 0;
+            }
         }
     }
     .katex {
         line-height: @line-height - 2;
     }
-    .passage-title div.paragraph {
-        font-family: "Noto Serif", serif;
-        font-weight: 700;
-        font-size: 20px;
-        line-height: 22px;
 
-        margin: 0 0 10px;
-    }
-
-    // note(matthewc): If you need to change any of this,
-    // check that line numbers line up correctly.
-    // The margin should probably be 0 or the line height
-    .passage-text div.paragraph {
-        font-weight: 400;
-        font-size: @font-size;
-        line-height: @line-height;
-        text-indent: 20px;
-        margin: 0;
-
-        span {
-            text-indent: 0;
-        }
-    }
     .footnotes {
         margin-top: 22px;
         div.paragraph {
@@ -68,10 +71,10 @@
         }
     }
     .perseus-highlight {
-        background-color: #FFFABE;
+        background-color: #fffabe;
     }
     .perseus-review-highlight {
-        background-color: #EEE7B2;
+        background-color: #eee7b2;
     }
     .perseus-passage-square-label,
     .perseus-passage-circle-label,
@@ -138,7 +141,6 @@
 }
 
 .perseus-widget-passage-editor {
-
     .perseus-single-editor {
         font-family: Times, "Times New Roman", serif;
 

--- a/packages/perseus/src/styles/widgets/passage.less
+++ b/packages/perseus/src/styles/widgets/passage.less
@@ -1,4 +1,6 @@
-#perseus-widget-passage-container {
+// this selector increases specificity to beat out other stylesheets while still
+//   allowing for more than one passage widget on a page
+[id^="perseus-widget-passage-container"] {
     // NOTE(mdr): This is similar to Wonder Blocks "BodySerif" typesetting, but
     //     not quite: it's a bit smaller, for consistency with the sorta-small
     //     type styles in rest of the Perseus.
@@ -8,7 +10,7 @@
     @font-size: 16px;
     @line-height: 20px;
 
-    #perseus-widget-passage {
+    [id^="perseus-widget-passage"] {
         line-height: @line-height;
         margin: 22px;
         position: relative;

--- a/packages/perseus/src/styles/widgets/passage.less
+++ b/packages/perseus/src/styles/widgets/passage.less
@@ -59,6 +59,11 @@
             span {
                 text-indent: 0;
             }
+
+            em {
+                // prevents italicized text from disrupting the line height
+                line-height: 0;
+            }
         }
     }
     .katex {

--- a/packages/perseus/src/widgets/__stories__/passage-ref.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/passage-ref.stories.tsx
@@ -1,9 +1,10 @@
+import {View} from "@khanacademy/wonder-blocks-core";
 import * as React from "react";
 
 import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui";
 import {question1, question2} from "../__testdata__/passage-ref.testdata";
 
-type StoryArgs = Record<any, any>;
+import type {PerseusRenderer} from "../../perseus-types";
 
 type Story = {
     title: string;
@@ -13,10 +14,20 @@ export default {
     title: "Perseus/Widgets/PassageRef",
 } as Story;
 
-export const ShortPassage = (args: StoryArgs): React.ReactElement => {
-    return <RendererWithDebugUI question={question1} />;
-};
+const Template = (props: {question: PerseusRenderer}): React.ReactElement => (
+    <View
+        style={{
+            paddingLeft: 20,
+        }}
+    >
+        <RendererWithDebugUI question={props.question} />
+    </View>
+);
 
-export const LongPassage = (args: StoryArgs): React.ReactElement => {
-    return <RendererWithDebugUI question={question2} />;
-};
+export const ShortPassage = (): React.ReactElement => (
+    <Template question={question1} />
+);
+
+export const LongPassage = (): React.ReactElement => (
+    <Template question={question2} />
+);

--- a/packages/perseus/src/widgets/__stories__/passage.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/passage.stories.tsx
@@ -1,3 +1,4 @@
+import {View} from "@khanacademy/wonder-blocks-core";
 import * as React from "react";
 
 import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui";
@@ -7,20 +8,32 @@ import {
     question3,
 } from "../__testdata__/passage.testdata";
 
+import type {PerseusRenderer} from "../../perseus-types";
+
 export default {
     title: "Perseus/Widgets/Passage",
 };
 
 type StoryArgs = Record<any, any>;
 
+const Template = (props: {question: PerseusRenderer}): React.ReactElement => (
+    <View
+        style={{
+            paddingLeft: 20,
+        }}
+    >
+        <RendererWithDebugUI question={props.question} />
+    </View>
+);
+
 export const SimpleQuestion = (args: StoryArgs): React.ReactElement => {
-    return <RendererWithDebugUI question={question1} />;
+    return <Template question={question1} />;
 };
 
 export const MultiPassageQuestion = (args: StoryArgs): React.ReactElement => {
-    return <RendererWithDebugUI question={question2} />;
+    return <Template question={question2} />;
 };
 
 export const SingleNumberedPassage = (args: StoryArgs): React.ReactElement => {
-    return <RendererWithDebugUI question={question3} />;
+    return <Template question={question3} />;
 };

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/passage-ref.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/passage-ref.test.ts.snap
@@ -17,7 +17,7 @@ exports[`passage-ref widget should render with invalid reference 1`] = `
         >
           <div>
             <div
-              class="perseus-widget-passage-container"
+              id="perseus-widget-passage-container-"
             >
               <div
                 class="perseus-widget-passage-instructions"
@@ -26,7 +26,7 @@ exports[`passage-ref widget should render with invalid reference 1`] = `
 
               </div>
               <div
-                class="perseus-widget-passage"
+                id="perseus-widget-passage-"
               >
                 <h3
                   class="perseus-sr-only"
@@ -158,7 +158,7 @@ exports[`passage-ref widget should render with multi-line reference 1`] = `
         >
           <div>
             <div
-              class="perseus-widget-passage-container"
+              id="perseus-widget-passage-container-"
             >
               <div
                 class="perseus-widget-passage-instructions"
@@ -167,7 +167,7 @@ exports[`passage-ref widget should render with multi-line reference 1`] = `
 
               </div>
               <div
-                class="perseus-widget-passage"
+                id="perseus-widget-passage-"
               >
                 <h3
                   class="perseus-sr-only"
@@ -304,7 +304,7 @@ exports[`passage-ref widget should render with single-line reference 1`] = `
         >
           <div>
             <div
-              class="perseus-widget-passage-container"
+              id="perseus-widget-passage-container-"
             >
               <div
                 class="perseus-widget-passage-instructions"
@@ -313,7 +313,7 @@ exports[`passage-ref widget should render with single-line reference 1`] = `
 
               </div>
               <div
-                class="perseus-widget-passage"
+                id="perseus-widget-passage-"
               >
                 <h3
                   class="perseus-sr-only"

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/passage.test.tsx.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/passage.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`passage widget should snapshot multiple passages (mobile: false) 1`] = 
         >
           <div>
             <div
-              class="perseus-widget-passage-container"
+              id="perseus-widget-passage-container-passage-1"
             >
               <div
                 class="perseus-widget-passage-instructions"
@@ -136,7 +136,7 @@ exports[`passage widget should snapshot multiple passages (mobile: false) 1`] = 
                 </div>
               </div>
               <div
-                class="perseus-widget-passage"
+                id="perseus-widget-passage-passage-1"
               >
                 <h3
                   class="passage-title"
@@ -590,7 +590,7 @@ exports[`passage widget should snapshot multiple passages (mobile: false) 1`] = 
         >
           <div>
             <div
-              class="perseus-widget-passage-container"
+              id="perseus-widget-passage-container-passage-2"
             >
               <div
                 class="perseus-widget-passage-instructions"
@@ -626,7 +626,7 @@ exports[`passage widget should snapshot multiple passages (mobile: false) 1`] = 
                 </div>
               </div>
               <div
-                class="perseus-widget-passage"
+                id="perseus-widget-passage-passage-2"
               >
                 <h3
                   class="passage-title"
@@ -956,7 +956,7 @@ exports[`passage widget should snapshot multiple passages (mobile: true) 1`] = `
         >
           <div>
             <div
-              class="perseus-widget-passage-container"
+              id="perseus-widget-passage-container-passage-1"
             >
               <div
                 class="perseus-widget-passage-instructions"
@@ -995,7 +995,7 @@ exports[`passage widget should snapshot multiple passages (mobile: true) 1`] = `
                 </div>
               </div>
               <div
-                class="perseus-widget-passage"
+                id="perseus-widget-passage-passage-1"
               >
                 <h3
                   class="passage-title"
@@ -1449,7 +1449,7 @@ exports[`passage widget should snapshot multiple passages (mobile: true) 1`] = `
         >
           <div>
             <div
-              class="perseus-widget-passage-container"
+              id="perseus-widget-passage-container-passage-2"
             >
               <div
                 class="perseus-widget-passage-instructions"
@@ -1485,7 +1485,7 @@ exports[`passage widget should snapshot multiple passages (mobile: true) 1`] = `
                 </div>
               </div>
               <div
-                class="perseus-widget-passage"
+                id="perseus-widget-passage-passage-2"
               >
                 <h3
                   class="passage-title"
@@ -1778,7 +1778,7 @@ exports[`passage widget should snapshot simple passage (mobile: false) 1`] = `
         >
           <div>
             <div
-              class="perseus-widget-passage-container"
+              id="perseus-widget-passage-container-"
             >
               <div
                 class="perseus-widget-passage-instructions"
@@ -1787,7 +1787,7 @@ exports[`passage widget should snapshot simple passage (mobile: false) 1`] = `
 
               </div>
               <div
-                class="perseus-widget-passage"
+                id="perseus-widget-passage-"
               >
                 <h3
                   class="perseus-sr-only"
@@ -1875,7 +1875,7 @@ exports[`passage widget should snapshot simple passage (mobile: true) 1`] = `
         >
           <div>
             <div
-              class="perseus-widget-passage-container"
+              id="perseus-widget-passage-container-"
             >
               <div
                 class="perseus-widget-passage-instructions"
@@ -1884,7 +1884,7 @@ exports[`passage widget should snapshot simple passage (mobile: true) 1`] = `
 
               </div>
               <div
-                class="perseus-widget-passage"
+                id="perseus-widget-passage-"
               >
                 <h3
                   class="perseus-sr-only"

--- a/packages/perseus/src/widgets/passage.tsx
+++ b/packages/perseus/src/widgets/passage.tsx
@@ -512,9 +512,9 @@ export class Passage extends React.Component<PassageProps, PassageState> {
 
         return (
             <div>
-                <div className="perseus-widget-passage-container">
+                <div id="perseus-widget-passage-container">
                     {this._renderInstructions(parseState)}
-                    <div className="perseus-widget-passage">
+                    <div id="perseus-widget-passage">
                         {hasTitle && (
                             <h3 className="passage-title">
                                 <Renderer

--- a/packages/perseus/src/widgets/passage.tsx
+++ b/packages/perseus/src/widgets/passage.tsx
@@ -513,9 +513,9 @@ export class Passage extends React.Component<PassageProps, PassageState> {
 
         return (
             <div>
-                <div id={"perseus-widget-passage-container-" + joinedTitle}>
+                <div id={"perseus-widget-passage-container" + joinedTitle}>
                     {this._renderInstructions(parseState)}
-                    <div id={"perseus-widget-passage-" + joinedTitle}>
+                    <div id={"perseus-widget-passage" + joinedTitle}>
                         {hasTitle && (
                             <h3 className="passage-title">
                                 <Renderer
@@ -568,8 +568,9 @@ export class Passage extends React.Component<PassageProps, PassageState> {
     }
 }
 
+// That's All, Folks! => -thats-all-folks
 const joinString = (title: string): string =>
-    title.toLowerCase().split(" ").join("-");
+    "-"  + title.toLowerCase().replace(/[^\w\s]/gi, '').trim().split(/\s+/).join("-");
 
 export default {
     name: "passage",

--- a/packages/perseus/src/widgets/passage.tsx
+++ b/packages/perseus/src/widgets/passage.tsx
@@ -570,7 +570,13 @@ export class Passage extends React.Component<PassageProps, PassageState> {
 
 // That's All, Folks! => -thats-all-folks
 const joinString = (title: string): string =>
-    "-"  + title.toLowerCase().replace(/[^\w\s]/gi, '').trim().split(/\s+/).join("-");
+    "-"  +
+    title
+        .toLowerCase()
+        .replace(/[^\w\s]/gi, '')
+        .trim()
+        .split(/\s+/)
+        .join("-");
 
 export default {
     name: "passage",

--- a/packages/perseus/src/widgets/passage.tsx
+++ b/packages/perseus/src/widgets/passage.tsx
@@ -570,10 +570,10 @@ export class Passage extends React.Component<PassageProps, PassageState> {
 
 // That's All, Folks! => -thats-all-folks
 const joinString = (title: string): string =>
-    "-"  +
+    "-" +
     title
         .toLowerCase()
-        .replace(/[^\w\s]/gi, '')
+        .replace(/[^\w\s]/gi, "")
         .trim()
         .split(/\s+/)
         .join("-");

--- a/packages/perseus/src/widgets/passage.tsx
+++ b/packages/perseus/src/widgets/passage.tsx
@@ -509,12 +509,13 @@ export class Passage extends React.Component<PassageProps, PassageState> {
         );
         // Check if the title has any non-empty text in it.
         const hasTitle = /\S/.test(this.props.passageTitle);
+        const joinedTitle = joinString(this.props.passageTitle);
 
         return (
             <div>
-                <div id="perseus-widget-passage-container">
+                <div id={"perseus-widget-passage-container-" + joinedTitle}>
                     {this._renderInstructions(parseState)}
-                    <div id="perseus-widget-passage">
+                    <div id={"perseus-widget-passage-" + joinedTitle}>
                         {hasTitle && (
                             <h3 className="passage-title">
                                 <Renderer
@@ -566,6 +567,9 @@ export class Passage extends React.Component<PassageProps, PassageState> {
         );
     }
 }
+
+const joinString = (title: string): string =>
+    title.toLowerCase().split(" ").join("-");
 
 export default {
     name: "passage",


### PR DESCRIPTION
## Summary:
Switch from `className` to `id` in css selectors for passage wrappers in an effort to gain higher priority than article paragraph styles.

Change `line-height` on passage `em` elements to 0 since the italicized characters have a subtly different size. See second video for demo of how this resolves the problem.

https://github.com/Khan/perseus/assets/23404711/ae4902b7-128c-45ad-b2f6-56195852b50f

https://github.com/Khan/perseus/assets/23404711/7de0aaeb-891c-4a03-a97a-fa9f147d4892

Issue: LC-698

## Test plan:
- Test in webapp with npm