### PR TITLE
Better type trackInteraction function in APIOptions

### DIFF
--- a/.changeset/curly-ties-punch.md
+++ b/.changeset/curly-ties-punch.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Clarify parameter type for APIOptions.trackInteraction

--- a/packages/perseus/src/article-renderer.tsx
+++ b/packages/perseus/src/article-renderer.tsx
@@ -5,6 +5,7 @@
 
 import * as PerseusLinter from "@khanacademy/perseus-linter";
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import * as React from "react";
 
 import ProvideKeypad from "./mixins/provide-keypad";
@@ -12,30 +13,33 @@ import {ClassNames as ApiClassNames, ApiOptions} from "./perseus-api";
 import Renderer from "./renderer";
 import Util from "./util";
 
-import type {KeypadProps} from "./mixins/provide-keypad";
-import type {PerseusRenderer} from "./perseus-types";
-import type {APIOptions} from "./types";
+const rendererProps = PropTypes.shape({
+    content: PropTypes.string,
+    widgets: PropTypes.objectOf(PropTypes.any),
+    images: PropTypes.objectOf(PropTypes.any),
+});
 
-type Props = {
-    apiOptions: APIOptions;
-    json: PerseusRenderer | ReadonlyArray<PerseusRenderer>;
-
-    // Whether to use the new Bibliotron styles for articles
-    useNewStyles: boolean;
-    linterContext: PerseusLinter.LinterContextProps;
-    legacyPerseusLint?: ReadonlyArray<string>;
-} & KeypadProps;
-
-type DefaultProps = {
-    apiOptions: Props["apiOptions"];
-    useNewStyles: Props["useNewStyles"];
-    linterContext: Props["linterContext"];
-};
-
-class ArticleRenderer extends React.Component<Props, any> {
+class ArticleRenderer extends React.Component<any, any> {
     _currentFocus: any;
 
-    static defaultProps: DefaultProps = {
+    static propTypes = {
+        ...ProvideKeypad.propTypes,
+        apiOptions: PropTypes.shape({
+            onFocusChange: PropTypes.func,
+            isMobile: PropTypes.bool,
+        }),
+        json: PropTypes.oneOfType([
+            rendererProps,
+            PropTypes.arrayOf(rendererProps),
+        ]).isRequired,
+
+        // Whether to use the new Bibliotron styles for articles
+        useNewStyles: PropTypes.bool,
+        linterContext: PerseusLinter.linterContextProps,
+        legacyPerseusLint: PropTypes.arrayOf(PropTypes.string),
+    };
+
+    static defaultProps: any = {
         apiOptions: {},
         useNewStyles: false,
         linterContext: PerseusLinter.linterContextDefault,
@@ -147,7 +151,7 @@ class ArticleRenderer extends React.Component<Props, any> {
         }
     };
 
-    _sections: () => ReadonlyArray<PerseusRenderer> = () => {
+    _sections: () => any = () => {
         return Array.isArray(this.props.json)
             ? this.props.json
             : [this.props.json];
@@ -178,6 +182,7 @@ class ArticleRenderer extends React.Component<Props, any> {
                         {...section}
                         ref={refForSection}
                         key={i}
+                        key_={i}
                         keypadElement={this.keypadElement()}
                         apiOptions={{
                             ...apiOptions,

--- a/packages/perseus/src/article-renderer.tsx
+++ b/packages/perseus/src/article-renderer.tsx
@@ -5,7 +5,6 @@
 
 import * as PerseusLinter from "@khanacademy/perseus-linter";
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import * as React from "react";
 
 import ProvideKeypad from "./mixins/provide-keypad";
@@ -13,33 +12,30 @@ import {ClassNames as ApiClassNames, ApiOptions} from "./perseus-api";
 import Renderer from "./renderer";
 import Util from "./util";
 
-const rendererProps = PropTypes.shape({
-    content: PropTypes.string,
-    widgets: PropTypes.objectOf(PropTypes.any),
-    images: PropTypes.objectOf(PropTypes.any),
-});
+import type {KeypadProps} from "./mixins/provide-keypad";
+import type {PerseusRenderer} from "./perseus-types";
+import type {APIOptions} from "./types";
 
-class ArticleRenderer extends React.Component<any, any> {
+type Props = {
+    apiOptions: APIOptions;
+    json: PerseusRenderer | ReadonlyArray<PerseusRenderer>;
+
+    // Whether to use the new Bibliotron styles for articles
+    useNewStyles: boolean;
+    linterContext: PerseusLinter.LinterContextProps;
+    legacyPerseusLint?: ReadonlyArray<string>;
+} & KeypadProps;
+
+type DefaultProps = {
+    apiOptions: Props["apiOptions"];
+    useNewStyles: Props["useNewStyles"];
+    linterContext: Props["linterContext"];
+};
+
+class ArticleRenderer extends React.Component<Props, any> {
     _currentFocus: any;
 
-    static propTypes = {
-        ...ProvideKeypad.propTypes,
-        apiOptions: PropTypes.shape({
-            onFocusChange: PropTypes.func,
-            isMobile: PropTypes.bool,
-        }),
-        json: PropTypes.oneOfType([
-            rendererProps,
-            PropTypes.arrayOf(rendererProps),
-        ]).isRequired,
-
-        // Whether to use the new Bibliotron styles for articles
-        useNewStyles: PropTypes.bool,
-        linterContext: PerseusLinter.linterContextProps,
-        legacyPerseusLint: PropTypes.arrayOf(PropTypes.string),
-    };
-
-    static defaultProps: any = {
+    static defaultProps: DefaultProps = {
         apiOptions: {},
         useNewStyles: false,
         linterContext: PerseusLinter.linterContextDefault,
@@ -151,7 +147,7 @@ class ArticleRenderer extends React.Component<any, any> {
         }
     };
 
-    _sections: () => any = () => {
+    _sections: () => ReadonlyArray<PerseusRenderer> = () => {
         return Array.isArray(this.props.json)
             ? this.props.json
             : [this.props.json];
@@ -182,7 +178,6 @@ class ArticleRenderer extends React.Component<any, any> {
                         {...section}
                         ref={refForSection}
                         key={i}
-                        key_={i}
                         keypadElement={this.keypadElement()}
                         apiOptions={{
                             ...apiOptions,

--- a/packages/perseus/src/interaction-tracker.ts
+++ b/packages/perseus/src/interaction-tracker.ts
@@ -1,3 +1,5 @@
+import type {APIOptions} from "./types";
+
 /**
  * This alternate version of `.track` does nothing as an optimization.
  */
@@ -19,7 +21,7 @@ class InteractionTracker {
     widgetType: string;
 
     constructor(
-        trackApi: any, // original apiOptions.trackInteraction
+        trackApi: APIOptions["trackInteraction"],
         widgetType: string,
         widgetID: string,
         setting: "" | "all", // "" means track once
@@ -44,7 +46,7 @@ class InteractionTracker {
      * @param extraData Any extra data to track about the event.
      * @private
      */
-    _track: (extraData: unknown) => void = (extraData: unknown) => {
+    _track: (extraData: Record<string, any>) => void = (extraData) => {
         if (this._tracked && !this.setting) {
             return;
         }
@@ -52,7 +54,6 @@ class InteractionTracker {
         this.trackApi({
             type: this.widgetType,
             id: this.widgetID,
-            // @ts-expect-error [FEI-5003] - TS2698 - Spread types may only be created from object types.
             ...extraData,
         });
     };

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -183,7 +183,11 @@ export type APIOptions = Readonly<{
     // include type and id, both strings, at least and can optionally
     // include a boolean "correct" value. This is used for keeping
     // track of widget interactions.
-    trackInteraction?: () => unknown;
+    trackInteraction?: (args: {
+        type: string;
+        id: string;
+        correct?: boolean;
+    }) => void;
     // A boolean that indicates whether or not a custom keypad is
     // being used.  For mobile web this will be the ProvidedKeypad
     // component.  In this situation we use the MathInput component
@@ -462,6 +466,10 @@ export type WidgetProps<RenderProps, Rubric> = RenderProps & {
     findWidgets: (arg1: FilterCriterion) => ReadonlyArray<Widget>;
     reviewModeRubric: Rubric;
     onChange: ChangeHandler;
+    // This is slightly different from the `trackInteraction` function in
+    // APIOptions. This provides the widget an easy way to notify the renderer
+    // of an interaction. The Renderer then enriches the data provided with the
+    // widget's id and type before calling APIOptions.trackInteraction.
     trackInteraction: (extraData?: any) => void;
     isLastUsedWidget: boolean;
     // provided by widget-container.jsx#render()


### PR DESCRIPTION
## Summary:

While improving types on a previous PR, I mistakenly typed `APIOptions.trackInteraction` as not taking any parameters. That's wrong. In fact, it takes an object with at least `id`, `typed`, and optionally `correct`, in addition to any extra args provided by the originating widget. 

This PR fixes this type issue.

Issue: "none"

## Test plan:

`yarn tsc`