### PR TITLE
Defer calculating picUrl to avoid accessing dependencies too early

### DIFF
--- a/.changeset/dull-boats-decide.md
+++ b/.changeset/dull-boats-decide.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Fix bug where PlotterEditor accesses Perseus dependencies initial parsing

--- a/packages/perseus-editor/src/widgets/plotter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/plotter-editor.tsx
@@ -92,14 +92,11 @@ class PlotterEditor extends React.Component<Props, State> {
         plotDimensions: [275, 200],
         labelInterval: 1,
 
-        get picUrl() {
-            const staticUrl = Dependencies.getDependencies().staticUrl;
-            if (staticUrl) {
-                return staticUrl("/images/badges/earth-small.png");
-            }
-
-            return null;
-        },
+        // NOTE(jeremy): We _cannot_ expand this to a fully, static URL here
+        // because the Perseus dependencies may not be set yet (because these
+        // default props are derived at file parse time, not when the component
+        //is new'd. See `constructor()`.
+        picUrl: "/images/badges/earth-small.png",
     };
 
     state: State = {
@@ -110,6 +107,15 @@ class PlotterEditor extends React.Component<Props, State> {
         maxX: null,
         tickStep: null,
     };
+
+    constructor(props: Props) {
+        super(props);
+
+        // Tell the parent what the full picUrl is.
+        props.onChange({
+            picUrl: Dependencies.getDependencies().staticUrl(props.picUrl),
+        });
+    }
 
     // TODO(jangmi, CP-3288): Remove usage of `UNSAFE_componentWillMount`
     UNSAFE_componentWillMount() {
@@ -380,11 +386,7 @@ class PlotterEditor extends React.Component<Props, State> {
         );
     }
 
-    handleChangeTickStep: (arg1: number) => void = (value) => {
-        this.setState({
-            tickStep: value,
-        });
-    };
+    handleChangeTickStep: (arg1: number) => void = (value) => {};
 
     handleChangeRange: (arg1: [number, number]) => void = (newValue) => {
         this.setState({

--- a/packages/perseus-editor/src/widgets/plotter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/plotter-editor.tsx
@@ -64,7 +64,15 @@ const widgetPropTypes = {
 const formatNumber = (num) => "$" + knumber.round(num, 2) + "$";
 
 type Props = any;
-type State = any;
+
+type State = {
+    editing: "starting" | "correct";
+    pic: HTMLImageElement | null;
+    loadedUrl: string | null;
+    minX: number | null;
+    maxX: number | null;
+    tickStep: number | null;
+};
 
 class PlotterEditor extends React.Component<Props, State> {
     static propTypes = widgetPropTypes;
@@ -332,7 +340,7 @@ class PlotterEditor extends React.Component<Props, State> {
                 )}
                 <div>
                     Editing values:{" "}
-                    {["correct", "starting"].map((editing) => (
+                    {(["correct", "starting"] as const).map((editing) => (
                         <label key={editing}>
                             <input
                                 type="radio"
@@ -482,9 +490,9 @@ class PlotterEditor extends React.Component<Props, State> {
         });
     };
 
-    changeEditing: (arg1: string) => void = (editing) => {
-        this.setState({editing: editing});
-    };
+    changeEditing(editing: "starting" | "correct") {
+        this.setState({editing});
+    }
 
     setCategoriesFromScale: () => void = () => {
         const scale = this.state.tickStep || 1;

--- a/packages/perseus-editor/src/widgets/plotter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/plotter-editor.tsx
@@ -84,14 +84,11 @@ class PlotterEditor extends React.Component<Props, State> {
         plotDimensions: [275, 200],
         labelInterval: 1,
 
-        get picUrl() {
-            const staticUrl = Dependencies.getDependencies().staticUrl;
-            if (staticUrl) {
-                return staticUrl("/images/badges/earth-small.png");
-            }
-
-            return null;
-        },
+        // CAUTION(jeremy): picUrl used to be a getter here. Please do not
+        // restore this getter as it used getDependencies(). That is not
+        // reliable as sometimes that the dependencies are not provided by the
+        // host application at this point causing an error.
+        // get picUrl() {}
     };
 
     state: State = {
@@ -118,18 +115,19 @@ class PlotterEditor extends React.Component<Props, State> {
         }
     }
 
-    fetchPic: (arg1: string) => any = (url) => {
-        if (this.state.loadedUrl !== url) {
+    fetchPic(url: string) {
+        const staticUrl = Dependencies.getDependencies().staticUrl(url);
+        if (this.state.loadedUrl !== staticUrl) {
             const pic = new Image();
-            pic.src = url;
+            pic.src = staticUrl;
             pic.onload = () => {
                 this.setState({
                     pic: pic,
-                    loadedUrl: url,
+                    loadedUrl: staticUrl,
                 });
             };
         }
-    };
+    }
 
     render(): React.ReactNode {
         const setFromScale = _.contains(

--- a/packages/perseus-editor/src/widgets/plotter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/plotter-editor.tsx
@@ -84,11 +84,14 @@ class PlotterEditor extends React.Component<Props, State> {
         plotDimensions: [275, 200],
         labelInterval: 1,
 
-        // CAUTION(jeremy): picUrl used to be a getter here. Please do not
-        // restore this getter as it used getDependencies(). That is not
-        // reliable as sometimes that the dependencies are not provided by the
-        // host application at this point causing an error.
-        // get picUrl() {}
+        get picUrl() {
+            const staticUrl = Dependencies.getDependencies().staticUrl;
+            if (staticUrl) {
+                return staticUrl("/images/badges/earth-small.png");
+            }
+
+            return null;
+        },
     };
 
     state: State = {
@@ -115,19 +118,18 @@ class PlotterEditor extends React.Component<Props, State> {
         }
     }
 
-    fetchPic(url: string) {
-        const staticUrl = Dependencies.getDependencies().staticUrl(url);
-        if (this.state.loadedUrl !== staticUrl) {
+    fetchPic: (arg1: string) => any = (url) => {
+        if (this.state.loadedUrl !== url) {
             const pic = new Image();
-            pic.src = staticUrl;
+            pic.src = url;
             pic.onload = () => {
                 this.setState({
                     pic: pic,
-                    loadedUrl: staticUrl,
+                    loadedUrl: url,
                 });
             };
         }
-    }
+    };
 
     render(): React.ReactNode {
         const setFromScale = _.contains(


### PR DESCRIPTION
## Summary:

In recent changes we noticed Perseus throwing an error that dependencies hadn't been provided. This was traced back to the `plotter-editor` which uses Dependencies.staticUrl() in the default props. It appears that subtle changes have caused this file to be imported _before_ the host application has called `setDependencies`. This, in turn, caused the error. 

To fix this, I've moved the call to `staticUrl()` out of `defaultProps` and to the point where we need the fully qualified, static URL (in `fetchPic()`). This change moves it to a point where we have a much stronger guarantee that dependencies will have been provided. 

Issue: LC-1030

## Test plan:

Wait for this PR to build a snapshot npm package.
Import it into webapp
Create a PR using the Perseus snapshot package.
Wait for ZND
Test on ZND