### PR TITLE
Don't generate a snapshot release for 'Version Packages' PR

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -215,8 +215,9 @@ jobs:
 
   publish_snapshot:
     name: Publish npm snapshot
-    # We don't publish snapshots on draft PRs
-    if: '! github.event.pull_request.draft'
+    # We don't publish snapshots on draft PRs or
+    # on the main Changeset "Version Packages" PR
+    if: ${{ ! github.event.pull_request.draft && github.ref != 'refs/heads/changeset-release/main') }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
## Summary:

Today, we generate an npm snapshot for every non-draft pull request. When the changeset tooling sees a landed PR, it creates/updates a new PR that represents what will be released when that PR is landed. 

Our snapshot Github action always fails on these PRs because this PR deletes all changeset files and updates each project's README from those changeset files (again, it's representing what we'll release). 

So this PR changes our npm snapshot action  so that it doesn't try to run for these special "Version Packages" PRs.

Issue: "none"

## Test plan:

Land and then double-check we still get snapshots, but not for the "Version Packages" PR!