### PR TITLE
Add story for ExpressionEditor

### DIFF
--- a/.changeset/many-eagles-promise.md
+++ b/.changeset/many-eagles-promise.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/math-input": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Add story for ExpressionEditor

--- a/packages/math-input/src/components/keypad/keypad.stories.tsx
+++ b/packages/math-input/src/components/keypad/keypad.stories.tsx
@@ -26,6 +26,7 @@ export default {
         multiplicationDot: false,
         preAlgebra: false,
         trigonometry: false,
+        sendEvent: () => {},
     },
     argTypes: {
         advancedRelations: {

--- a/packages/perseus-editor/src/widgets/__stories__/expression-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/expression-editor.stories.tsx
@@ -4,7 +4,11 @@ import * as React from "react";
 import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui";
 import ExpressionEditor from "../expression-editor";
 
-import type {PerseusRenderer, APIOptions} from "@khanacademy/perseus";
+import type {
+    PerseusRenderer,
+    APIOptions,
+    PerseusExpressionWidgetOptions,
+} from "@khanacademy/perseus";
 
 type StoryArgs = Record<any, any>;
 
@@ -19,12 +23,7 @@ export default {
 // TODO(FEI-5054): Figure out how to get global .d.ts files working with monorepos
 type Empty = Record<string, never>;
 
-type State = {
-    answerForms: any;
-    times: boolean;
-    buttonSets: ReadonlyArray<string>;
-    functions: ReadonlyArray<string>;
-};
+type State = PerseusExpressionWidgetOptions;
 
 class WithDebug extends React.Component<Empty, State> {
     constructor(props) {

--- a/packages/perseus-editor/src/widgets/__stories__/expression-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/expression-editor.stories.tsx
@@ -1,0 +1,124 @@
+import {StyleSheet, css} from "aphrodite";
+import * as React from "react";
+
+import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui";
+import ExpressionEditor from "../expression-editor";
+
+import type {PerseusRenderer, APIOptions} from "@khanacademy/perseus";
+
+type StoryArgs = Record<any, any>;
+
+type Story = {
+    title: string;
+};
+
+export default {
+    title: "Perseus/Editor/Widgets/Expression Editor",
+} as Story;
+
+// TODO(FEI-5054): Figure out how to get global .d.ts files working with monorepos
+type Empty = Record<string, never>;
+
+type State = {
+    answerForms: any;
+    times: boolean;
+    buttonSets: ReadonlyArray<string>;
+    functions: ReadonlyArray<string>;
+};
+
+class WithDebug extends React.Component<Empty, State> {
+    constructor(props) {
+        super(props);
+
+        const baseWidget = question.widgets["expression 1"].options;
+        this.state = {
+            answerForms: baseWidget.answerForms,
+            times: baseWidget.times,
+            buttonSets: baseWidget.buttonSets,
+            functions: baseWidget.functions,
+        };
+    }
+
+    mergeQuestionWithState() {
+        return {
+            ...question,
+            widgets: {
+                ...question.widgets,
+                "expression 1": {
+                    ...question.widgets["expression 1"],
+                    options: {
+                        ...question.widgets["expression 1"].options,
+                        ...this.state,
+                    },
+                },
+            },
+        };
+    }
+
+    render(): React.ReactNode {
+        const apiOptions: APIOptions = Object.freeze({});
+
+        return (
+            <div className={css(styles.wrapper)}>
+                <div className={css(styles.editorWrapper)}>
+                    <ExpressionEditor
+                        {...this.state}
+                        apiOptions={apiOptions}
+                        onChange={(props) => {
+                            this.setState({
+                                ...props,
+                            });
+                        }}
+                    />
+                </div>
+                <RendererWithDebugUI
+                    question={this.mergeQuestionWithState()}
+                    apiOptions={apiOptions}
+                    reviewMode={true}
+                />
+            </div>
+        );
+    }
+}
+
+export const Debug = (args: StoryArgs): React.ReactElement => {
+    return <WithDebug />;
+};
+
+const question: PerseusRenderer = {
+    content:
+        "This is a cool expression question\n\n[[\u2603 expression 1]]\n\n",
+    images: {},
+    widgets: {
+        "expression 1": {
+            alignment: "default",
+            graded: true,
+            options: {
+                answerForms: [
+                    {
+                        considered: "correct",
+                        form: true,
+                        key: "0",
+                        simplify: false,
+                        value: "16+88i",
+                    },
+                ],
+                buttonSets: ["basic"],
+                functions: ["f", "g", "h"],
+                times: false,
+            },
+            static: false,
+            type: "expression",
+            version: {major: 1, minor: 0},
+        },
+    },
+};
+
+const styles = StyleSheet.create({
+    wrapper: {
+        padding: 50,
+    },
+    editorWrapper: {
+        paddingBottom: 100,
+    },
+});

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -128,6 +128,7 @@ export type {
     PerseusImageBackground,
     PerseusInteractiveGraphWidgetOptions,
     PerseusRadioWidgetOptions,
+    PerseusExpressionWidgetOptions,
     PerseusRenderer,
 } from "./perseus-types";
 export type {Coord} from "./interactive2/types";


### PR DESCRIPTION
## Summary:
<img width="998" alt="Screen Shot 2023-07-21 at 12 30 51 PM" src="https://github.com/Khan/perseus/assets/16308368/38eb2bf2-66e1-422e-8c83-64f6ca091659">

I wanted to see what options are made available to content creators, so I made a story.

Issue: LC-1069