### PR TITLE
Rework args to trackInteraction so it works when we generate Flow types for it

### DIFF
--- a/.changeset/moody-birds-search.md
+++ b/.changeset/moody-birds-search.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix APIOptions `trackInteraction` type for better Flow type generation

--- a/packages/perseus/src/interaction-tracker.ts
+++ b/packages/perseus/src/interaction-tracker.ts
@@ -8,12 +8,12 @@ function _noop() {}
 /**
  * Wrapper for the trackInteraction apiOption.
  */
-class InteractionTracker {
+class InteractionTracker<T> {
     // @ts-expect-error [FEI-5003] - TS2564 - Property '_tracked' has no initializer and is not definitely assigned in the constructor.
     _tracked: boolean;
     // @ts-expect-error [FEI-5003] - TS2564 - Property 'setting' has no initializer and is not definitely assigned in the constructor.
     setting: Tracking;
-    track: (extraData?: any) => void;
+    track: (extraData?: T) => void;
     trackApi: any;
     // @ts-expect-error [FEI-5003] - TS2564 - Property 'widgetID' has no initializer and is not definitely assigned in the constructor.
     widgetID: string;
@@ -46,7 +46,7 @@ class InteractionTracker {
      * @param extraData Any extra data to track about the event.
      * @private
      */
-    _track: (extraData: Record<string, any>) => void = (extraData) => {
+    _track: (extraData: T) => void = (extraData) => {
         if (this._tracked && !this.setting) {
             return;
         }

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -212,7 +212,7 @@ class Renderer extends React.Component<Props, State> {
     _foundTextNodes: boolean;
     // @ts-expect-error [FEI-5003] - TS2564 - Property '_interactionTrackers' has no initializer and is not definitely assigned in the constructor.
     _interactionTrackers: {
-        [id: string]: InteractionTracker;
+        [id: string]: InteractionTracker<any>;
     };
     // @ts-expect-error [FEI-5003] - TS2564 - Property '_isMounted' has no initializer and is not definitely assigned in the constructor.
     _isMounted: boolean;

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -109,6 +109,19 @@ export type Path = ReadonlyArray<string>;
 
 type StubTagEditorType = any; // from "./components/stub-tag-editor";
 
+type TrackInteractionArgs = {
+    // The widget type that this interaction originates from
+    type: string;
+    // The widget id that this interaction originates from
+    id: string;
+
+    correct?: boolean;
+
+    // Each widget can pass on additional, arbitrary, arguments.
+    // Currently, these are not defined in this type.
+    [key: string]: any;
+};
+
 // APIOptions provides different ways to customize the behaviour of Perseus.
 export type APIOptions = Readonly<{
     isArticle?: boolean;
@@ -162,15 +175,7 @@ export type APIOptions = Readonly<{
     // A function that is called when the user has interacted with a widget. It
     // also includes any extra parameters that the originating widget provided.
     // This is used for keeping track of widget interactions.
-    trackInteraction?: (
-        args: {
-            // The widget type that this interaction originates from
-            type: string;
-            // The widget id that this interaction originates from
-            id: string;
-            correct?: boolean;
-        } & Record<string, unknown>,
-    ) => void;
+    trackInteraction?: (args: TrackInteractionArgs) => void;
     // A boolean that indicates whether or not a custom keypad is
     // being used.  For mobile web this will be the ProvidedKeypad
     // component.  In this situation we use the MathInput component

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -10,6 +10,9 @@ import type {Result} from "@khanacademy/wonder-blocks-data";
 
 export type FocusPath = ReadonlyArray<string> | null | undefined;
 
+// TODO(FEI-5054): Figure out how to get global .d.ts files working with monorepos
+type Empty = Record<never, never>;
+
 export type Dimensions = {
     width?: number;
     height?: number;

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -116,11 +116,10 @@ type TrackInteractionArgs = {
     id: string;
 
     correct?: boolean;
-
-    // Each widget can pass on additional, arbitrary, arguments.
-    // Currently, these are not defined in this type.
-    [key: string]: any;
-};
+    // Tracking args are all optional here because we don't know which
+    // widgets originated the call, and thus can't know what extra
+    // araguments will be included!
+} & Partial<TrackingExtraArguments>;
 
 // APIOptions provides different ways to customize the behaviour of Perseus.
 export type APIOptions = Readonly<{
@@ -385,6 +384,24 @@ export type Tracking =
     // Track all interactions
     | "all";
 
+// See graded-group widget
+export type TrackingGradedGroupExtraArguments = {
+    status: "correct" | "incorrect" | "invalid";
+};
+
+// See sequence widget
+export type TrackingSequenceExtraArguments = {
+    visible: number;
+};
+
+// Add extra widget tracking arg types into this type as needed.
+// NOTE(jeremy): I've added `Empty` at the start to make explicity that many
+// widgets don't add extra arguments. It also has the nice side-effect of
+// formatting more nicely. :)
+export type TrackingExtraArguments = Empty &
+    TrackingGradedGroupExtraArguments &
+    TrackingSequenceExtraArguments;
+
 export type Alignment =
     | "default"
     | "block"
@@ -459,7 +476,13 @@ export type FilterCriterion =
       ) => boolean);
 
 // NOTE: Rubric should always be the corresponding widget options type for the component.
-export type WidgetProps<RenderProps, Rubric> = RenderProps & {
+export type WidgetProps<
+    RenderProps,
+    Rubric,
+    // Defines the arguments that can be passed to the `trackInteraction`
+    // function from APIOptions for this widget.
+    TrackingExtraArgs = Empty,
+> = RenderProps & {
     // provided by renderer.jsx#getWidgetProps()
     widgetId: string;
     alignment: string | null | undefined;
@@ -479,7 +502,7 @@ export type WidgetProps<RenderProps, Rubric> = RenderProps & {
     // APIOptions. This provides the widget an easy way to notify the renderer
     // of an interaction. The Renderer then enriches the data provided with the
     // widget's id and type before calling APIOptions.trackInteraction.
-    trackInteraction: (extraData?: any) => void;
+    trackInteraction: (extraData?: TrackingExtraArgs) => void;
     isLastUsedWidget: boolean;
     // provided by widget-container.jsx#render()
     linterContext: LinterContextProps;

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -119,10 +119,12 @@ type TrackInteractionArgs = {
     id: string;
 
     correct?: boolean;
+
     // Tracking args are all optional here because we don't know which
     // widgets originated the call, and thus can't know what extra
-    // araguments will be included!
-} & Partial<TrackingExtraArguments>;
+    // arguments will be included!
+} & Partial<TrackingGradedGroupExtraArguments> &
+    Partial<TrackingSequenceExtraArguments>;
 
 // APIOptions provides different ways to customize the behaviour of Perseus.
 export type APIOptions = Readonly<{
@@ -396,14 +398,6 @@ export type TrackingGradedGroupExtraArguments = {
 export type TrackingSequenceExtraArguments = {
     visible: number;
 };
-
-// Add extra widget tracking arg types into this type as needed.
-// NOTE(jeremy): I've added `Empty` at the start to make explicity that many
-// widgets don't add extra arguments. It also has the nice side-effect of
-// formatting more nicely. :)
-export type TrackingExtraArguments = Empty &
-    TrackingGradedGroupExtraArguments &
-    TrackingSequenceExtraArguments;
 
 export type Alignment =
     | "default"

--- a/packages/perseus/src/widgets/graded-group.tsx
+++ b/packages/perseus/src/widgets/graded-group.tsx
@@ -26,7 +26,12 @@ import GradedGroupAnswerBar, {
 } from "./graded-group-answer-bar";
 
 import type {PerseusGradedGroupWidgetOptions} from "../perseus-types";
-import type {PerseusScore, WidgetExports, WidgetProps} from "../types";
+import type {
+    PerseusScore,
+    TrackingGradedGroupExtraArguments,
+    WidgetExports,
+    WidgetProps,
+} from "../types";
 
 const GRADING_STATUSES = {
     ungraded: "ungraded" as const,
@@ -64,7 +69,11 @@ const DEFAULT_INVALID_MESSAGE =
 type Rubric = PerseusGradedGroupWidgetOptions;
 type RenderProps = PerseusGradedGroupWidgetOptions; // exports has no 'transform'
 
-type Props = WidgetProps<RenderProps, Rubric> & {
+type Props = WidgetProps<
+    RenderProps,
+    Rubric,
+    TrackingGradedGroupExtraArguments
+> & {
     inGradedGroupSet?: boolean; // Set by graded-group-set.jsx,
     onNextQuestion?: () => unknown; // Set by graded-group-set.jsx
 };

--- a/packages/perseus/src/widgets/sequence.tsx
+++ b/packages/perseus/src/widgets/sequence.tsx
@@ -9,11 +9,19 @@ import {PerseusSequenceWidgetOptions} from "../perseus-types";
 import Renderer from "../renderer";
 import Util from "../util";
 
-import type {WidgetExports, WidgetProps} from "../types";
+import type {
+    TrackingSequenceExtraArguments,
+    WidgetExports,
+    WidgetProps,
+} from "../types";
 
 type Rubric = PerseusSequenceWidgetOptions;
 
-type ExternalProps = WidgetProps<PerseusSequenceWidgetOptions, Rubric>;
+type ExternalProps = WidgetProps<
+    PerseusSequenceWidgetOptions,
+    Rubric,
+    TrackingSequenceExtraArguments
+>;
 
 type Props = ExternalProps;
 


### PR DESCRIPTION
## Summary:

I've been working to get a proper type for the `trackInteraction` `APIOption`. I've migrated the `InteractionTracker` to be generic so that it only accepts extra arguments defined by the `WidgetProps<T,T,T>` (this means each widget can call `trackInteraction` with args it defines). 

In the `APIOptions` the `trackInteraction` callback now defines a union of all extra args that all widgets provide.

Issue: "none"

## Test plan:

Build, build flow types, and then test it in webapp.