### PR TITLE
Add useV2Keypad API option

### DIFF
--- a/.changeset/pretty-beers-pretend.md
+++ b/.changeset/pretty-beers-pretend.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Adds useV2Keypad API option for switching between new and legacy keypads

--- a/.changeset/quick-tables-tell.md
+++ b/.changeset/quick-tables-tell.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/math-input": major
+"@khanacademy/perseus": patch
+---
+
+Replace Legacy/Mobile keypads with a component that switches between them

--- a/packages/math-input/src/components/keypad-switch.tsx
+++ b/packages/math-input/src/components/keypad-switch.tsx
@@ -1,0 +1,23 @@
+import {StyleType} from "@khanacademy/wonder-blocks-core";
+import * as React from "react";
+
+import {MobileKeypad} from "./keypad";
+import LegacyKeypad from "./keypad-legacy";
+
+type Props = {
+    onElementMounted?: (arg1: any) => void;
+    onDismiss?: () => void;
+    style?: StyleType;
+
+    useV2Keypad?: boolean;
+};
+
+function KeypadSwitch(props: Props) {
+    const {useV2Keypad = false, ...rest} = props;
+
+    const KeypadComponent = useV2Keypad ? MobileKeypad : LegacyKeypad;
+
+    return <KeypadComponent {...rest} />;
+}
+
+export default KeypadSwitch;

--- a/packages/math-input/src/full-math-input.stories.tsx
+++ b/packages/math-input/src/full-math-input.stories.tsx
@@ -1,9 +1,8 @@
 import * as React from "react";
 
-import MobileKeypad from "./components/keypad/mobile-keypad";
 import {KeypadAPI} from "./types";
 
-import {KeypadInput, KeypadType, LegacyKeypad} from "./index";
+import {KeypadInput, KeypadType, Keypad} from "./index";
 
 export default {
     title: "Full Mobile MathInput",
@@ -16,7 +15,7 @@ export const Basic = () => {
     // Whether to use Expression or Fraction keypad
     const [expression, setExpression] = React.useState<boolean>(true);
     // Whether to use v1 or v2 keypad
-    const [legacyKeypad, setLegacyKeypad] = React.useState<boolean>(false);
+    const [v2Keypad, setV2Keypad] = React.useState<boolean>(true);
 
     React.useEffect(() => {
         keypadElement?.configure(
@@ -36,8 +35,8 @@ export const Basic = () => {
                 <button onClick={() => setExpression(!expression)}>
                     {`Use ${expression ? "Fraction" : "Expression"} Keypad`}
                 </button>
-                <button onClick={() => setLegacyKeypad(!legacyKeypad)}>
-                    {`Use ${legacyKeypad ? "New" : "Legacy"} Keypad`}
+                <button onClick={() => setV2Keypad(!v2Keypad)}>
+                    {`Use ${v2Keypad ? "Legacy" : "New"} Keypad`}
                 </button>
             </div>
 
@@ -56,23 +55,14 @@ export const Basic = () => {
                 }}
             />
 
-            {legacyKeypad ? (
-                <LegacyKeypad
-                    onElementMounted={(node) => {
-                        if (node) {
-                            setKeypadElement(node);
-                        }
-                    }}
-                />
-            ) : (
-                <MobileKeypad
-                    onElementMounted={(node) => {
-                        if (node) {
-                            setKeypadElement(node);
-                        }
-                    }}
-                />
-            )}
+            <Keypad
+                onElementMounted={(node) => {
+                    if (node) {
+                        setKeypadElement(node);
+                    }
+                }}
+                useV2Keypad={v2Keypad}
+            />
         </div>
     );
 };

--- a/packages/math-input/src/index.ts
+++ b/packages/math-input/src/index.ts
@@ -24,11 +24,8 @@ export {CursorContext} from "./components/input/cursor-contexts";
 // Helper to get cursor context from MathField
 export {getCursorContext} from "./components/input/mathquill-helpers";
 
-// v1 Keypad
-export {default as LegacyKeypad} from "./components/keypad-legacy";
-
-// v2 Keypad
-export {default as Keypad, MobileKeypad} from "./components/keypad";
+// Wrapper around v1 and v2 keypads to switch between them
+export {default as Keypad} from "./components/keypad-switch";
 
 // External API of the "Provided" keypad component
 export {keypadElementPropType} from "./components/prop-types";

--- a/packages/perseus/src/mixins/provide-keypad.tsx
+++ b/packages/perseus/src/mixins/provide-keypad.tsx
@@ -10,13 +10,14 @@
  * extend a `ProvideKeypad` component instead of using this mixin.
  */
 
-import {LegacyKeypad} from "@khanacademy/math-input";
+import {Keypad} from "@khanacademy/math-input";
 import PropTypes from "prop-types";
 import * as React from "react";
 import ReactDOM from "react-dom";
 
 import reactRender from "../util/react-render";
 
+import type {APIOptions} from "../types";
 import type {CSSProperties} from "aphrodite";
 
 export type KeypadProps = {
@@ -73,13 +74,13 @@ const ProvideKeypad = {
 
     componentDidMount() {
         const _this = this;
+        // @ts-expect-error [FEI-5003] - TS2339 - Property 'props' does not exist on type '{ readonly propTypes: { readonly apiOptions: React.PropType<{ customKeypad?: boolean | undefined; nativeKeypadProxy?: ((...a: readonly any[]) => unknown) | undefined; }>; readonly keypadStyle: Requireable<any>; }; readonly getInitialState: () => { ...; }; readonly componentDidMount: () => void; readonly componentWil...'.
+        const apiOptions: APIOptions = _this.props.apiOptions;
+
         if (
-            // @ts-expect-error [FEI-5003] - TS2339 - Property 'props' does not exist on type '{ readonly propTypes: { readonly apiOptions: React.PropType<{ customKeypad?: boolean | undefined; nativeKeypadProxy?: ((...a: readonly any[]) => unknown) | undefined; }>; readonly keypadStyle: Requireable<any>; }; readonly getInitialState: () => { ...; }; readonly componentDidMount: () => void; readonly componentWil...'.
-            _this.props.apiOptions &&
-            // @ts-expect-error [FEI-5003] - TS2339 - Property 'props' does not exist on type '{ readonly propTypes: { readonly apiOptions: React.PropType<{ customKeypad?: boolean | undefined; nativeKeypadProxy?: ((...a: readonly any[]) => unknown) | undefined; }>; readonly keypadStyle: Requireable<any>; }; readonly getInitialState: () => { ...; }; readonly componentDidMount: () => void; readonly componentWil...'.
-            _this.props.apiOptions.customKeypad &&
-            // @ts-expect-error [FEI-5003] - TS2339 - Property 'props' does not exist on type '{ readonly propTypes: { readonly apiOptions: React.PropType<{ customKeypad?: boolean | undefined; nativeKeypadProxy?: ((...a: readonly any[]) => unknown) | undefined; }>; readonly keypadStyle: Requireable<any>; }; readonly getInitialState: () => { ...; }; readonly componentDidMount: () => void; readonly componentWil...'.
-            !_this.props.apiOptions.nativeKeypadProxy
+            apiOptions &&
+            apiOptions.customKeypad &&
+            !apiOptions.nativeKeypadProxy
         ) {
             // TODO(charlie): Render this and the wrapped component in the same
             // React tree. We may also want to add this keypad asynchronously
@@ -90,7 +91,7 @@ const ProvideKeypad = {
             document.body?.appendChild(_this._keypadContainer);
 
             reactRender(
-                <LegacyKeypad
+                <Keypad
                     onElementMounted={(element) => {
                         // NOTE(kevinb): The reason why this setState works is
                         // b/c we're calling it manually from item-renderer.jsx
@@ -106,6 +107,7 @@ const ProvideKeypad = {
                     }}
                     // @ts-expect-error [FEI-5003] - TS2339 - Property 'props' does not exist on type '{ readonly propTypes: { readonly apiOptions: React.PropType<{ customKeypad?: boolean | undefined; nativeKeypadProxy?: ((...a: readonly any[]) => unknown) | undefined; }>; readonly keypadStyle: Requireable<any>; }; readonly getInitialState: () => { ...; }; readonly componentDidMount: () => void; readonly componentWil...'.
                     style={_this.props.keypadStyle}
+                    useV2Keypad={apiOptions.useV2Keypad}
                 />,
                 // @ts-expect-error [FEI-5003] - TS2339 - Property '_keypadContainer' does not exist on type '{ readonly propTypes: { readonly apiOptions: React.PropType<{ customKeypad?: boolean | undefined; nativeKeypadProxy?: ((...a: readonly any[]) => unknown) | undefined; }>; readonly keypadStyle: Requireable<any>; }; readonly getInitialState: () => { ...; }; readonly componentDidMount: () => void; readonly componentWil...'.
                 _this._keypadContainer,

--- a/packages/perseus/src/perseus-api.tsx
+++ b/packages/perseus/src/perseus-api.tsx
@@ -100,6 +100,11 @@ export const ApiOptions = {
         // Indicates whether or not to use mobile styling.
         isMobile: PropTypes.bool,
 
+        // Whether to use v1 (Legacy) Keypad for MathInput mobile or
+        // use the new v2 Keypad
+        // TODO(matthewc)[LC-1088]: remove after v2 release
+        useV2Keypad: PropTypes.bool,
+
         // A function, called with a bool indicating whether use of the
         // drawing area (scratchpad) should be allowed/disallowed.
         // Previously handled by `Khan.scratchpad.enable/disable`
@@ -145,6 +150,7 @@ export const ApiOptions = {
     defaults: {
         isArticle: false,
         isMobile: false,
+        useV2Keypad: false,
         onInputError: function () {},
         onFocusChange: function () {},
         GroupMetadataEditor: StubTagEditor,

--- a/packages/perseus/src/perseus-api.tsx
+++ b/packages/perseus/src/perseus-api.tsx
@@ -102,7 +102,7 @@ export const ApiOptions = {
 
         // Whether to use v1 (Legacy) Keypad for MathInput mobile or
         // use the new v2 Keypad
-        // TODO(matthewc)[LC-1088]: remove after v2 release
+        // TODO [LC-1088]: remove after v2 release
         useV2Keypad: PropTypes.bool,
 
         // A function, called with a bool indicating whether use of the

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -197,6 +197,10 @@ export type APIOptions = Readonly<{
     // from the math-input repo instead of the existing perseus math
     // input components.
     customKeypad?: boolean;
+    // Whether to use v1 (Legacy) Keypad for MathInput mobile or
+    // use the new v2 Keypad
+    // TODO(matthewc)[LC-1088]: remove after v2 release
+    useV2Keypad?: boolean;
     // If this is provided, it is called instead of appending an instance
     // of `math-input`'s keypad to the body. This is used by the native
     // apps so they can have the keypad be defined on the native side.
@@ -359,6 +363,7 @@ export type APIOptionsWithDefaults = Readonly<
         inModal: NonNullable<APIOptions["inModal"]>;
         isArticle: NonNullable<APIOptions["isArticle"]>;
         isMobile: NonNullable<APIOptions["isMobile"]>;
+        useV2Keypad: NonNullable<APIOptions["useV2Keypad"]>;
         onFocusChange: NonNullable<APIOptions["onFocusChange"]>;
         onInputError: NonNullable<APIOptions["onInputError"]>;
         readOnly: NonNullable<APIOptions["readOnly"]>;

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -199,7 +199,7 @@ export type APIOptions = Readonly<{
     customKeypad?: boolean;
     // Whether to use v1 (Legacy) Keypad for MathInput mobile or
     // use the new v2 Keypad
-    // TODO(matthewc)[LC-1088]: remove after v2 release
+    // TODO [LC-1088]: remove after v2 release
     useV2Keypad?: boolean;
     // If this is provided, it is called instead of appending an instance
     // of `math-input`'s keypad to the body. This is used by the native

--- a/packages/perseus/src/widgets/__stories__/test-keypad-context-wrapper.tsx
+++ b/packages/perseus/src/widgets/__stories__/test-keypad-context-wrapper.tsx
@@ -1,4 +1,4 @@
-import {LegacyKeypad} from "@khanacademy/math-input";
+import {Keypad} from "@khanacademy/math-input";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
@@ -9,8 +9,8 @@ const Footer = (): React.ReactElement => {
     return (
         <View style={styles.keypadContainer}>
             <KeypadContext.Consumer>
-                {({keypadElement, setKeypadElement, renderer}) => (
-                    <LegacyKeypad
+                {({setKeypadElement, renderer}) => (
+                    <Keypad
                         onElementMounted={setKeypadElement}
                         onDismiss={() => renderer && renderer.blur()}
                         style={styles.keypad}


### PR DESCRIPTION
## Summary:
In order to switch between the v1 and v2 keypads in Perseus using a feature flag in Webapp, we're passing down a switch via API options.

The actual switching between keypads will be in the next PR.