### PR TITLE
add perseus-core to tsconfig-build for changeset

### DIFF
--- a/.changeset/breezy-crabs-sip.md
+++ b/.changeset/breezy-crabs-sip.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": minor
+---
+
+Add perseus-core to changeset

--- a/packages/perseus-core/src/types.ts
+++ b/packages/perseus-core/src/types.ts
@@ -1,7 +1,7 @@
 // Types that can be shared between Perseus packages
 // ideally without causing circular dependencies
 
-type State = any;
+type State = unknown;
 
 export interface RendererInterface {
     getSerializedState(): State;

--- a/packages/perseus-core/src/types.ts
+++ b/packages/perseus-core/src/types.ts
@@ -1,7 +1,7 @@
 // Types that can be shared between Perseus packages
 // ideally without causing circular dependencies
 
-type State = unknown;
+type State = any;
 
 export interface RendererInterface {
     getSerializedState(): State;

--- a/packages/perseus-core/src/types.ts
+++ b/packages/perseus-core/src/types.ts
@@ -1,6 +1,7 @@
 // Types that can be shared between Perseus packages
 // ideally without causing circular dependencies
 
+// TODO: this should be typed
 type State = any;
 
 export interface RendererInterface {

--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -9,6 +9,7 @@
         {"path": "./packages/kmath/tsconfig-build.json"},
         {"path": "./packages/math-input/tsconfig-build.json"},
         {"path": "./packages/perseus/tsconfig-build.json"},
+        {"path": "./packages/perseus-core/tsconfig-build.json"},
         {"path": "./packages/perseus-editor/tsconfig-build.json"},
         {"path": "./packages/perseus-error/tsconfig-build.json"},
         {"path": "./packages/perseus-linter/tsconfig-build.json"},


### PR DESCRIPTION
## Summary:
I don't know what I'm doing, please feel free to give me guidance.

I added types to `perseus-core`, but didn't notice that Changeset didn't ask me to bump the version. When I tried to cut a release in Webapp I got a bunch of errors because the new types weren't there. I then realized `perseus-core` hadn't been released and that led me to believe that Changeset didn't have an awareness of `perseus-core`.

I just copy/pasted stuff randomly, changed something in `perseus-core`, and now Changeset is prompting me for a `perseus-core` version... 🤷