### PR TITLE
add back a direct export of v2 keypad

### DIFF
--- a/.changeset/eleven-baboons-fry.md
+++ b/.changeset/eleven-baboons-fry.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/math-input": minor
+"@khanacademy/perseus": patch
+---
+
+Adds back the export of the unwrapped keypad for Khanmigo

--- a/packages/math-input/src/full-math-input.stories.tsx
+++ b/packages/math-input/src/full-math-input.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import {KeypadAPI} from "./types";
 
-import {KeypadInput, KeypadType, Keypad} from "./index";
+import {KeypadInput, KeypadType, MobileKeypad} from "./index";
 
 export default {
     title: "Full Mobile MathInput",
@@ -55,7 +55,7 @@ export const Basic = () => {
                 }}
             />
 
-            <Keypad
+            <MobileKeypad
                 onElementMounted={(node) => {
                     if (node) {
                         setKeypadElement(node);

--- a/packages/math-input/src/index.ts
+++ b/packages/math-input/src/index.ts
@@ -26,7 +26,7 @@ export {getCursorContext} from "./components/input/mathquill-helpers";
 
 // Wrapper around v1 and v2 mobile keypads to switch between them
 export {default as MobileKeypad} from "./components/keypad-switch";
-// For desktop
+// Unwrapped v2 keypad for desktop
 export {default as DesktopKeypad} from "./components/keypad";
 
 // Context used to pass data/refs around

--- a/packages/math-input/src/index.ts
+++ b/packages/math-input/src/index.ts
@@ -27,7 +27,7 @@ export {getCursorContext} from "./components/input/mathquill-helpers";
 // Wrapper around v1 and v2 mobile keypads to switch between them
 export {default as MobileKeypad} from "./components/keypad-switch";
 // For desktop
-export {default as Keypad} from "./components/keypad";
+export {default as DesktopKeypad} from "./components/keypad";
 
 // Context used to pass data/refs around
 export {default as KeypadContext} from "./components/keypad-context";

--- a/packages/math-input/src/index.ts
+++ b/packages/math-input/src/index.ts
@@ -24,8 +24,10 @@ export {CursorContext} from "./components/input/cursor-contexts";
 // Helper to get cursor context from MathField
 export {getCursorContext} from "./components/input/mathquill-helpers";
 
-// Wrapper around v1 and v2 keypads to switch between them
-export {default as Keypad} from "./components/keypad-switch";
+// Wrapper around v1 and v2 mobile keypads to switch between them
+export {default as MobileKeypad} from "./components/keypad-switch";
+// For desktop
+export {default as Keypad} from "./components/keypad";
 
 // Context used to pass data/refs around
 export {default as KeypadContext} from "./components/keypad-context";

--- a/packages/perseus/src/mixins/provide-keypad.tsx
+++ b/packages/perseus/src/mixins/provide-keypad.tsx
@@ -10,7 +10,7 @@
  * extend a `ProvideKeypad` component instead of using this mixin.
  */
 
-import {Keypad} from "@khanacademy/math-input";
+import {MobileKeypad} from "@khanacademy/math-input";
 import PropTypes from "prop-types";
 import * as React from "react";
 import ReactDOM from "react-dom";
@@ -91,7 +91,7 @@ const ProvideKeypad = {
             document.body?.appendChild(_this._keypadContainer);
 
             reactRender(
-                <Keypad
+                <MobileKeypad
                     onElementMounted={(element) => {
                         // NOTE(kevinb): The reason why this setState works is
                         // b/c we're calling it manually from item-renderer.jsx

--- a/packages/perseus/src/widgets/__stories__/test-keypad-context-wrapper.tsx
+++ b/packages/perseus/src/widgets/__stories__/test-keypad-context-wrapper.tsx
@@ -1,4 +1,4 @@
-import {KeypadContext, Keypad} from "@khanacademy/math-input";
+import {KeypadContext, MobileKeypad} from "@khanacademy/math-input";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
@@ -8,7 +8,7 @@ const Footer = (): React.ReactElement => {
         <View style={styles.keypadContainer}>
             <KeypadContext.Consumer>
                 {({setKeypadElement, renderer}) => (
-                    <Keypad
+                    <MobileKeypad
                         onElementMounted={setKeypadElement}
                         onDismiss={() => renderer && renderer.blur()}
                         style={styles.keypad}


### PR DESCRIPTION
## Summary:
I forgot that Khanmigo is using the keypad that's not wrapped in a weird API, so I needed to re-export that.