### PR TITLE
make sendEvent optional

### DIFF
--- a/.changeset/two-trains-smash.md
+++ b/.changeset/two-trains-smash.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": minor
+---
+
+Make sendEvent in the Keypad an optional param

--- a/packages/math-input/src/components/keypad/keypad.tsx
+++ b/packages/math-input/src/components/keypad/keypad.tsx
@@ -33,7 +33,7 @@ export type Props = {
     advancedRelations?: boolean;
 
     onClickKey: ClickKeyCallback;
-    sendEvent: SendEventFn;
+    sendEvent?: SendEventFn;
 };
 
 const defaultProps = {
@@ -89,7 +89,7 @@ export default function Keypad(props: Props) {
 
     useEffect(() => {
         if (!isMounted) {
-            sendEvent({
+            sendEvent?.({
                 type: "math-input:keypad-opened",
                 payload: {virtualKeypadVersion: "MATH_INPUT_KEYPAD_V2"},
             });
@@ -97,7 +97,7 @@ export default function Keypad(props: Props) {
         }
         return () => {
             if (isMounted) {
-                sendEvent({
+                sendEvent?.({
                     type: "math-input:keypad-closed",
                     payload: {virtualKeypadVersion: "MATH_INPUT_KEYPAD_V2"},
                 });


### PR DESCRIPTION
## Summary:
We don't have to merge this if it's not popular, but I keep running into `sendEvent is not a function` and right now all `sendEvent` things are just stubbed out anywhat, so I thought maybe we could just make it optional for now.