### PR TITLE
Fail PR check if there are STOPSHIPs in any code

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -36,6 +36,13 @@ jobs:
     - name: Checking out latest commit
       uses: actions/checkout@v2
 
+    # We fail the action if STOPSHIP occurs in any file in our codebase. We
+    # exclude the .github  We use STOPSHIP internally to mark code that's not
+    # safe to go live yet.
+    - name: Checks that STOP SHIP (no space) is not used in any files.
+      run: -|
+        git grep --files-with-matches -I -eSTOPSHIP -- ':(exclude).github/workflows/node-ci.yml'
+
     - name: Use Node.js ${{ matrix.node-version }} & Install & cache node_modules
       uses: Khan/actions@shared-node-cache-v0
       with:


### PR DESCRIPTION
## Summary:

I shipped a STOPSHIP this week because I assumed this repo checked for them. It doesn't... but with this PR it will.  The check is done in a Github Action, so there won't be a test that fails locally, but any PR containing the word "STOPSHIP", will fail.

Issue: "none"

## Test plan:

Add a `STOPSHIP` to the code, push the branch. Github Action should fail. 
Remove the `STOPSHIP`, push the code, Github Action should pass!