### PR TITLE
Fix font size of MathJax 3 inline math

### DIFF
--- a/.changeset/smart-turtles-rush.md
+++ b/.changeset/smart-turtles-rush.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix the font size of inline MathJax 3 math in paragraphs, making it the same as KaTeX math.

--- a/packages/perseus/src/styles/articles.less
+++ b/packages/perseus/src/styles/articles.less
@@ -58,7 +58,7 @@
         // inline, so we rely on the "actual paragraph" check above
         // (a .paragraph that contains another .paragraph instead of a
         // .perseus-block-math).
-        .katex {
+        .katex, mjx-container {
             font-size: 100%;
         }
 


### PR DESCRIPTION
## Summary:
PR https://github.com/Khan/perseus/pull/631 updated the font styling for
KaTeX to also apply to MathJax. These styles got broken by a merge, so
this commit fixes them up.

Issue: https://khanacademy.atlassian.net/browse/LC-1087

Test plan:

Follow the instructions in webapp's
`services/static/javascript/perseus/README.md` to install a dev build of
Perseus. View math in the following situations with `?devflagk=mathjax3`
appended to the URL and verify that it looks like the math on prod:

- /devadmin/tex
- /devadmin/tex/testcases
- A math article, e.g. /math/multivariable-calculus/thinking-about-multivariable-function/x786f2022:vectors-and-matrices/a/vectors-and-notation-mvc
- A math exercise
- Graphie labels
- The exercise editor (note the color contrast between math and the surrounding text in the mobile preview).
- An interactive graph
- A passage widget
- A plotter widget