### PR TITLE
Remove the build:flowtypes step from publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "extract-strings": "utils/extract-strings.ts",
     "lint": "eslint . --ext .js --ext .jsx --ext .ts --ext .tsx",
     "lint:timing": "cross-env TIMING=1 yarn lint",
-    "publish:ci": "utils/pre-publish-check-ci.ts && git diff --stat --exit-code HEAD && yarn build && yarn build:types && yarn build:flowtypes && yarn extract-strings && changeset publish",
+    "publish:ci": "utils/pre-publish-check-ci.ts && git diff --stat --exit-code HEAD && yarn build && yarn build:types && yarn extract-strings && changeset publish",
     "sloc": "sloc packages --exclude node_modules",
     "test": "yarn jest",
     "test:no-console-mock": "cross-env GLOBAL_CONSOLE_MOCK=false yarn jest",


### PR DESCRIPTION
## Summary:
Now that we've shipped typescript we no longer need to ship flowtypes.

## Test plan:
- Run *publish:ci*
- **It should be faster**