### PR TITLE
Migrated ArticleRenderer to Typescript types

### DIFF
--- a/.changeset/silent-berries-do.md
+++ b/.changeset/silent-berries-do.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Improve Typescript types for the ArticleRenderer and ProvideKeypad mixin

--- a/packages/math-input/src/components/keypad/mobile-keypad.tsx
+++ b/packages/math-input/src/components/keypad/mobile-keypad.tsx
@@ -3,9 +3,15 @@ import {StyleSheet} from "aphrodite";
 import * as React from "react";
 import ReactDOM from "react-dom";
 
-import Key from "../../data/keys";
 import {View} from "../../fake-react-native-web/index";
-import {Cursor, KeypadConfiguration, KeyHandler, KeypadAPI} from "../../types";
+
+import type Key from "../../data/keys";
+import type {
+    Cursor,
+    KeypadConfiguration,
+    KeyHandler,
+    KeypadAPI,
+} from "../../types";
 
 import Keypad from "./index";
 

--- a/packages/math-input/src/components/prop-types.ts
+++ b/packages/math-input/src/components/prop-types.ts
@@ -5,6 +5,7 @@
 import PropTypes from "prop-types";
 
 // NOTE(jared): This is no longer guaranteed to be React element
+// @deprecated Use `KeypadAPI` Typescript interface instead.
 export const keypadElementPropType = PropTypes.shape({
     activate: PropTypes.func.isRequired,
     dismiss: PropTypes.func.isRequired,

--- a/packages/math-input/src/full-math-input.stories.tsx
+++ b/packages/math-input/src/full-math-input.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import {KeypadAPI} from "./types";
+import type {KeypadAPI} from "./types";
 
 import {KeypadInput, KeypadType, MobileKeypad} from "./index";
 

--- a/packages/math-input/src/index.ts
+++ b/packages/math-input/src/index.ts
@@ -34,6 +34,7 @@ export {default as KeypadContext} from "./components/keypad-context";
 
 // External API of the "Provided" keypad component
 export {keypadElementPropType} from "./components/prop-types";
+export {KeypadAPI} from "./types";
 
 // Key list, configuration map, and types
 export type {default as Keys} from "./data/keys";

--- a/packages/math-input/src/index.ts
+++ b/packages/math-input/src/index.ts
@@ -34,7 +34,7 @@ export {default as KeypadContext} from "./components/keypad-context";
 
 // External API of the "Provided" keypad component
 export {keypadElementPropType} from "./components/prop-types";
-export {KeypadAPI} from "./types";
+export type {KeypadAPI} from "./types";
 
 // Key list, configuration map, and types
 export type {default as Keys} from "./data/keys";

--- a/packages/perseus/src/__testdata__/article-renderer.testdata.ts
+++ b/packages/perseus/src/__testdata__/article-renderer.testdata.ts
@@ -1,4 +1,6 @@
-export const passageArticle = {
+import type {PerseusRenderer} from "../perseus-types";
+
+export const passageArticle: PerseusRenderer = {
     content:
         "###Group/Pair Activity \n\nThis passage is adapted from Ed Yong, “Turtles Use the Earth’s Magnetic Field as Global GPS.” ©2011 by Kalmbach Publishing Co.\n\n[[☃ passage 1]]\n\n**Question 9**\n\nThe passage most strongly suggests that Adelita used which of the following to navigate her 9,000-mile journey?\n\nA) The current of the North Atlantic gyre\n\nB) Cues from electromagnetic coils designed by Putman and Lohmann\n\nC) The inclination and intensity of Earth’s magnetic field\n\nD) A simulated “magnetic signature” configured by Lohmann\n\n10) Which choice provides the best evidence for the answer to the previous question?\n\nA) Lines 1–2 (“In 1996...way”)\n\nB) Lines 20–21 (“Using...surface”)\n\nC) Lines 36–37 (“In the wild...stars”)\n\nD) Lines 43–45 (“Neither...it is”)\n\n**Question 12** \n\nBased on the passage, which choice best describes the relationship between Putman’s and Lohmann’s research?\n\nA) Putman’s research contradicts Lohmann’s.\n\nB) Putman’s research builds on Lohmann’s.\n\nC) Lohmann’s research confirms Putman’s.\n\nD) Lohmann’s research corrects Putman’s.",
     images: {},

--- a/packages/perseus/src/article-renderer.tsx
+++ b/packages/perseus/src/article-renderer.tsx
@@ -5,7 +5,6 @@
 
 import * as PerseusLinter from "@khanacademy/perseus-linter";
 import classNames from "classnames";
-import PropTypes from "prop-types";
 import * as React from "react";
 
 import ProvideKeypad from "./mixins/provide-keypad";
@@ -13,42 +12,44 @@ import {ClassNames as ApiClassNames, ApiOptions} from "./perseus-api";
 import Renderer from "./renderer";
 import Util from "./util";
 
-const rendererProps = PropTypes.shape({
-    content: PropTypes.string,
-    widgets: PropTypes.objectOf(PropTypes.any),
-    images: PropTypes.objectOf(PropTypes.any),
-});
+import type {KeypadProps} from "./mixins/provide-keypad";
+import type {PerseusRenderer} from "./perseus-types";
+import type {APIOptions} from "./types";
+import type {LinterContextProps} from "@khanacademy/perseus-linter";
 
-class ArticleRenderer extends React.Component<any, any> {
+type Props = {
+    apiOptions: APIOptions;
+    json: PerseusRenderer | ReadonlyArray<PerseusRenderer>;
+
+    // Whether to use the new Bibliotron styles for articles
+    /**
+     * @deprecated Does nothing
+     */
+    useNewStyles: boolean;
+    linterContext: LinterContextProps;
+    legacyPerseusLint?: ReadonlyArray<string>;
+} & KeypadProps;
+
+type DefaultProps = {
+    apiOptions: Props["apiOptions"];
+    useNewStyles: Props["useNewStyles"];
+    linterContext: Props["linterContext"];
+};
+
+type State = {
+    keypadElement: any | null;
+};
+
+class ArticleRenderer extends React.Component<Props, State> {
     _currentFocus: any;
 
-    static propTypes = {
-        ...ProvideKeypad.propTypes,
-        apiOptions: PropTypes.shape({
-            onFocusChange: PropTypes.func,
-            isMobile: PropTypes.bool,
-        }),
-        json: PropTypes.oneOfType([
-            rendererProps,
-            PropTypes.arrayOf(rendererProps),
-        ]).isRequired,
-
-        // Whether to use the new Bibliotron styles for articles
-        /**
-         * @deprecated Does nothing
-         */
-        useNewStyles: PropTypes.bool,
-        linterContext: PerseusLinter.linterContextProps,
-        legacyPerseusLint: PropTypes.arrayOf(PropTypes.string),
-    };
-
-    static defaultProps: any = {
-        apiOptions: {},
+    static defaultProps: DefaultProps = {
+        apiOptions: ApiOptions.defaults,
         useNewStyles: false,
         linterContext: PerseusLinter.linterContextDefault,
     };
 
-    constructor(props: any) {
+    constructor(props: Props) {
         super(props);
         this.state = ProvideKeypad.getInitialState.call(this);
     }
@@ -58,7 +59,7 @@ class ArticleRenderer extends React.Component<any, any> {
         this._currentFocus = null;
     }
 
-    shouldComponentUpdate(nextProps: any, nextState: any): any {
+    shouldComponentUpdate(nextProps: Props, nextState: State): boolean {
         return nextProps !== this.props || nextState !== this.state;
     }
 

--- a/packages/perseus/src/mixins/provide-keypad.tsx
+++ b/packages/perseus/src/mixins/provide-keypad.tsx
@@ -11,13 +11,14 @@
  * extend a `ProvideKeypad` component instead of using this mixin.
  */
 
-import {KeypadAPI, MobileKeypad} from "@khanacademy/math-input";
+import {MobileKeypad} from "@khanacademy/math-input";
 import * as React from "react";
 import ReactDOM from "react-dom";
 
 import reactRender from "../util/react-render";
 
 import type {APIOptions} from "../types";
+import type {KeypadAPI} from "@khanacademy/math-input";
 import type {CSSProperties} from "aphrodite";
 
 export type KeypadProps = {

--- a/packages/perseus/src/mixins/provide-keypad.tsx
+++ b/packages/perseus/src/mixins/provide-keypad.tsx
@@ -12,7 +12,6 @@
  */
 
 import {MobileKeypad} from "@khanacademy/math-input";
-import PropTypes from "prop-types";
 import * as React from "react";
 import ReactDOM from "react-dom";
 
@@ -39,18 +38,6 @@ export type KeypadApiOptions = {
 // TODO(LP-10789): replace this with a React Context object to pass information
 // between Perseus and the Keypad.
 const ProvideKeypad = {
-    propTypes: {
-        apiOptions: PropTypes.shape({
-            customKeypad: PropTypes.bool,
-            nativeKeypadProxy: PropTypes.func,
-        }),
-        // An Aphrodite style object, to be applied to the keypad container.
-        // Note that, given our awkward structure of injecting the keypad, this
-        // style won't be applied or updated dynamically. Rather, it will only
-        // be applied in `componentDidMount`.
-        keypadStyle: PropTypes.any,
-    },
-
     getInitialState(): {
         keypadElement: any | null;
     } {

--- a/packages/perseus/src/mixins/provide-keypad.tsx
+++ b/packages/perseus/src/mixins/provide-keypad.tsx
@@ -11,7 +11,7 @@
  * extend a `ProvideKeypad` component instead of using this mixin.
  */
 
-import {MobileKeypad} from "@khanacademy/math-input";
+import {KeypadAPI, MobileKeypad} from "@khanacademy/math-input";
 import * as React from "react";
 import ReactDOM from "react-dom";
 
@@ -33,25 +33,34 @@ export type KeypadApiOptions = {
     nativeKeypadProxy: any;
 };
 
+// This represents the shape of any component that uses this ProvideKeypad
+// mixin.
+type KeypadMixinHostComponent = {
+    _keypadContainer?: HTMLDivElement | null;
+    props: {
+        apiOptions: APIOptions;
+        blur?: () => void;
+    };
+    state: {
+        keypadElement: any | null;
+    };
+};
+
 // NOTE: This is not a real component.  It's a collection of methods used to
 // create and manage a Keypad instances.
 // TODO(LP-10789): replace this with a React Context object to pass information
 // between Perseus and the Keypad.
 const ProvideKeypad = {
-    getInitialState(): {
+    getInitialState(this: KeypadMixinHostComponent): {
         keypadElement: any | null;
     } {
         const _this = this;
-        let keypadElement = null;
+        let keypadElement: KeypadAPI | null = null;
         if (
-            // @ts-expect-error [FEI-5003] - TS2339 - Property 'props' does not exist on type '{ readonly propTypes: { readonly apiOptions: React.PropType<{ customKeypad?: boolean | undefined; nativeKeypadProxy?: ((...a: readonly any[]) => unknown) | undefined; }>; readonly keypadStyle: Requireable<any>; }; readonly getInitialState: () => { ...; }; readonly componentDidMount: () => void; readonly componentWil...'.
             _this.props.apiOptions &&
-            // @ts-expect-error [FEI-5003] - TS2339 - Property 'props' does not exist on type '{ readonly propTypes: { readonly apiOptions: React.PropType<{ customKeypad?: boolean | undefined; nativeKeypadProxy?: ((...a: readonly any[]) => unknown) | undefined; }>; readonly keypadStyle: Requireable<any>; }; readonly getInitialState: () => { ...; }; readonly componentDidMount: () => void; readonly componentWil...'.
             _this.props.apiOptions.customKeypad &&
-            // @ts-expect-error [FEI-5003] - TS2339 - Property 'props' does not exist on type '{ readonly propTypes: { readonly apiOptions: React.PropType<{ customKeypad?: boolean | undefined; nativeKeypadProxy?: ((...a: readonly any[]) => unknown) | undefined; }>; readonly keypadStyle: Requireable<any>; }; readonly getInitialState: () => { ...; }; readonly componentDidMount: () => void; readonly componentWil...'.
             _this.props.apiOptions.nativeKeypadProxy
         ) {
-            // @ts-expect-error [FEI-5003] - TS2339 - Property 'props' does not exist on type '{ readonly propTypes: { readonly apiOptions: React.PropType<{ customKeypad?: boolean | undefined; nativeKeypadProxy?: ((...a: readonly any[]) => unknown) | undefined; }>; readonly keypadStyle: Requireable<any>; }; readonly getInitialState: () => { ...; }; readonly componentDidMount: () => void; readonly componentWil...'.
             keypadElement = _this.props.apiOptions.nativeKeypadProxy(
                 // @ts-expect-error [FEI-5003] - TS2339 - Property 'blur' does not exist on type '{ readonly propTypes: { readonly apiOptions: React.PropType<{ customKeypad?: boolean | undefined; nativeKeypadProxy?: ((...a: readonly any[]) => unknown) | undefined; }>; readonly keypadStyle: Requireable<any>; }; readonly getInitialState: () => { ...; }; readonly componentDidMount: () => void; readonly componentWil...'. | TS2339 - Property 'blur' does not exist on type '{ readonly propTypes: { readonly apiOptions: React.PropType<{ customKeypad?: boolean | undefined; nativeKeypadProxy?: ((...a: readonly any[]) => unknown) | undefined; }>; readonly keypadStyle: Requireable<any>; }; readonly getInitialState: () => { ...; }; readonly componentDidMount: () => void; readonly componentWil...'.
                 () => _this.blur && _this.blur(),
@@ -60,9 +69,8 @@ const ProvideKeypad = {
         return {keypadElement};
     },
 
-    componentDidMount() {
+    componentDidMount(this: KeypadMixinHostComponent) {
         const _this = this;
-        // @ts-expect-error [FEI-5003] - TS2339 - Property 'props' does not exist on type '{ readonly propTypes: { readonly apiOptions: React.PropType<{ customKeypad?: boolean | undefined; nativeKeypadProxy?: ((...a: readonly any[]) => unknown) | undefined; }>; readonly keypadStyle: Requireable<any>; }; readonly getInitialState: () => { ...; }; readonly componentDidMount: () => void; readonly componentWil...'.
         const apiOptions: APIOptions = _this.props.apiOptions;
 
         if (
@@ -73,9 +81,7 @@ const ProvideKeypad = {
             // TODO(charlie): Render this and the wrapped component in the same
             // React tree. We may also want to add this keypad asynchronously
             // or on-demand in the future.
-            // @ts-expect-error [FEI-5003] - TS2339 - Property '_keypadContainer' does not exist on type '{ readonly propTypes: { readonly apiOptions: React.PropType<{ customKeypad?: boolean | undefined; nativeKeypadProxy?: ((...a: readonly any[]) => unknown) | undefined; }>; readonly keypadStyle: Requireable<any>; }; readonly getInitialState: () => { ...; }; readonly componentDidMount: () => void; readonly componentWil...'.
             _this._keypadContainer = document.createElement("div");
-            // @ts-expect-error [FEI-5003] - TS2339 - Property '_keypadContainer' does not exist on type '{ readonly propTypes: { readonly apiOptions: React.PropType<{ customKeypad?: boolean | undefined; nativeKeypadProxy?: ((...a: readonly any[]) => unknown) | undefined; }>; readonly keypadStyle: Requireable<any>; }; readonly getInitialState: () => { ...; }; readonly componentDidMount: () => void; readonly componentWil...'.
             document.body?.appendChild(_this._keypadContainer);
 
             reactRender(
@@ -97,36 +103,28 @@ const ProvideKeypad = {
                     style={_this.props.keypadStyle}
                     useV2Keypad={apiOptions.useV2Keypad}
                 />,
-                // @ts-expect-error [FEI-5003] - TS2339 - Property '_keypadContainer' does not exist on type '{ readonly propTypes: { readonly apiOptions: React.PropType<{ customKeypad?: boolean | undefined; nativeKeypadProxy?: ((...a: readonly any[]) => unknown) | undefined; }>; readonly keypadStyle: Requireable<any>; }; readonly getInitialState: () => { ...; }; readonly componentDidMount: () => void; readonly componentWil...'.
                 _this._keypadContainer,
             );
         }
     },
 
-    componentWillUnmount() {
+    componentWillUnmount(this: KeypadMixinHostComponent) {
         const _this = this;
-        // @ts-expect-error [FEI-5003] - TS2339 - Property '_keypadContainer' does not exist on type '{ readonly propTypes: { readonly apiOptions: React.PropType<{ customKeypad?: boolean | undefined; nativeKeypadProxy?: ((...a: readonly any[]) => unknown) | undefined; }>; readonly keypadStyle: Requireable<any>; }; readonly getInitialState: () => { ...; }; readonly componentDidMount: () => void; readonly componentWil...'.
         if (_this._keypadContainer) {
-            // @ts-expect-error [FEI-5003] - TS2339 - Property '_keypadContainer' does not exist on type '{ readonly propTypes: { readonly apiOptions: React.PropType<{ customKeypad?: boolean | undefined; nativeKeypadProxy?: ((...a: readonly any[]) => unknown) | undefined; }>; readonly keypadStyle: Requireable<any>; }; readonly getInitialState: () => { ...; }; readonly componentDidMount: () => void; readonly componentWil...'.
             ReactDOM.unmountComponentAtNode(_this._keypadContainer);
-            // @ts-expect-error [FEI-5003] - TS2339 - Property '_keypadContainer' does not exist on type '{ readonly propTypes: { readonly apiOptions: React.PropType<{ customKeypad?: boolean | undefined; nativeKeypadProxy?: ((...a: readonly any[]) => unknown) | undefined; }>; readonly keypadStyle: Requireable<any>; }; readonly getInitialState: () => { ...; }; readonly componentDidMount: () => void; readonly componentWil...'.
             if (_this._keypadContainer.parentNode) {
                 // Note ChildNode.remove() isn't available in older Android
                 // webviews.
-                // @ts-expect-error [FEI-5003] - TS2339 - Property '_keypadContainer' does not exist on type '{ readonly propTypes: { readonly apiOptions: React.PropType<{ customKeypad?: boolean | undefined; nativeKeypadProxy?: ((...a: readonly any[]) => unknown) | undefined; }>; readonly keypadStyle: Requireable<any>; }; readonly getInitialState: () => { ...; }; readonly componentDidMount: () => void; readonly componentWil...'.
                 _this._keypadContainer.parentNode.removeChild(
-                    // @ts-expect-error [FEI-5003] - TS2339 - Property '_keypadContainer' does not exist on type '{ readonly propTypes: { readonly apiOptions: React.PropType<{ customKeypad?: boolean | undefined; nativeKeypadProxy?: ((...a: readonly any[]) => unknown) | undefined; }>; readonly keypadStyle: Requireable<any>; }; readonly getInitialState: () => { ...; }; readonly componentDidMount: () => void; readonly componentWil...'.
                     _this._keypadContainer,
                 );
             }
-            // @ts-expect-error [FEI-5003] - TS2339 - Property '_keypadContainer' does not exist on type '{ readonly propTypes: { readonly apiOptions: React.PropType<{ customKeypad?: boolean | undefined; nativeKeypadProxy?: ((...a: readonly any[]) => unknown) | undefined; }>; readonly keypadStyle: Requireable<any>; }; readonly getInitialState: () => { ...; }; readonly componentDidMount: () => void; readonly componentWil...'.
             _this._keypadContainer = null;
         }
     },
 
-    keypadElement(): any {
+    keypadElement(this: KeypadMixinHostComponent): any {
         const _this = this;
-        // @ts-expect-error [FEI-5003] - TS2339 - Property 'state' does not exist on type '{ readonly propTypes: { readonly apiOptions: React.PropType<{ customKeypad?: boolean | undefined; nativeKeypadProxy?: ((...a: readonly any[]) => unknown) | undefined; }>; readonly keypadStyle: Requireable<any>; }; readonly getInitialState: () => { ...; }; readonly componentDidMount: () => void; readonly componentWil...'.
         return _this.state.keypadElement;
     },
 } as const;

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -5,6 +5,7 @@ import type {ILogger} from "./logging/log";
 import type {Item} from "./multi-items/item-types";
 import type {PerseusWidget} from "./perseus-types";
 import type {SizeClass} from "./util/sizing-utils";
+import type {KeypadAPI} from "@khanacademy/math-input";
 import type {SendEventFn} from "@khanacademy/perseus-core";
 import type {Result} from "@khanacademy/wonder-blocks-data";
 
@@ -187,7 +188,7 @@ export type APIOptions = Readonly<{
     // It is called with an function that, when called, blurs the input,
     // and is expected to return an object of the shape
     // keypadElementPropType from math-input/src/prop-types.js.
-    nativeKeypadProxy?: () => unknown;
+    nativeKeypadProxy?: (blur: () => void) => KeypadAPI;
     // Indicates whether or not to use mobile styling.
     isMobile?: boolean;
     // A function, called with a bool indicating whether use of the


### PR DESCRIPTION
## Summary:

I was adding some unit tests in a repo that uses the ArticleRenderer and noticed the types for ArticleRenderer were somewhat anemic. So given it was a late Friday afternoon I took a small detour and improved them. 

This PR improves our types for the article renderer a few ways:
  * Move ArticleRenderer to TS Props from PropTypes
  * Specify ProvideKeypad mixin types by defining 'this' parameter
  * Move math-input's prop-types file to TS

Issue: "none"

## Test plan:

`yarn typecheck`
`yarn test`