### PR TITLE
allow v2 keypad to have styles overwritten like v1

### DIFF
--- a/.changeset/lucky-insects-tap.md
+++ b/.changeset/lucky-insects-tap.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Allow v2 keypad to receive style prop like v1 keypad

--- a/packages/math-input/src/components/keypad/mobile-keypad.tsx
+++ b/packages/math-input/src/components/keypad/mobile-keypad.tsx
@@ -91,11 +91,15 @@ class MobileKeypad extends React.Component<Props, State> implements KeypadAPI {
     }
 
     render(): React.ReactNode {
+        const {style} = this.props;
         const {active, cursor, keypadConfig} = this.state;
 
         const containerStyle = [
+            // internal styles
             styles.keypadContainer,
             active ? styles.activeKeypadContainer : null,
+            // styles passed as props
+            ...(Array.isArray(style) ? style : [style]),
         ];
 
         const isExpression = keypadConfig?.keypadType === "EXPRESSION";


### PR DESCRIPTION
## Summary:
Pass `style` props to container so default styles can be overwritten

Issue: LC-1099

## Test plan:
- Apply styles to MobileKeypad (v2 mobile keypad)
- Note the styles are applied to the keypad container