### PR TITLE
Fix MathQuill event type

### DIFF
--- a/.changeset/brave-mugs-wonder.md
+++ b/.changeset/brave-mugs-wonder.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Fix type for parameters of `moveOutOf` event.

--- a/packages/math-input/src/components/input/mathquill-types.ts
+++ b/packages/math-input/src/components/input/mathquill-types.ts
@@ -167,7 +167,10 @@ export type MathFieldConfig = {
         edit?: (mathField: MathFieldInterface) => void;
         enter?: (mathField: MathFieldInterface) => void;
 
-        moveOutOf?: (mathField: MathFieldInterface) => void;
+        moveOutOf?: (
+            direction: MathQuillDirection,
+            mathField: MathFieldInterface,
+        ) => void;
         upOutOf?: (mathField: MathFieldInterface) => void;
         downOutOf?: (mathField: MathFieldInterface) => void;
 


### PR DESCRIPTION
`moveOutOf` was missing the `dir` parameter.
You can see in [this test](https://github.com/Khan/mathquill/blob/32d9f351aaa68537170b3120a52e99b8def3a2c3/test/unit/publicapi.test.js#L245) that it is expected to be present.