### PR TITLE
Remove moved (and duplicated) LinterContextProps

### DIFF
--- a/.changeset/purple-pianos-jog.md
+++ b/.changeset/purple-pianos-jog.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": major
+---
+
+Removed `LinterContextProps` type. Moved to `@khanacademy/perseus-linter` in a previous release, but wasn't deleted from this package.

--- a/packages/perseus/src/components/input-with-examples.tsx
+++ b/packages/perseus/src/components/input-with-examples.tsx
@@ -12,7 +12,7 @@ import MathOutput from "./math-output";
 import TextInput from "./text-input";
 import Tooltip, {HorizontalDirection, VerticalDirection} from "./tooltip";
 
-import type {LinterContextProps} from "../types";
+import type {LinterContextProps} from "@khanacademy/perseus-linter";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 const {captureScratchpadTouchStart} = Util;

--- a/packages/perseus/src/components/sortable.tsx
+++ b/packages/perseus/src/components/sortable.tsx
@@ -13,8 +13,8 @@ import {ClassNames as ApiClassNames} from "../perseus-api";
 import Renderer from "../renderer";
 import Util from "../util";
 
-import type {LinterContextProps} from "../types";
 import type {Position} from "../util";
+import type {LinterContextProps} from "@khanacademy/perseus-linter";
 
 export enum Layout {
     HORIZONTAL = "horizontal",

--- a/packages/perseus/src/hint-renderer.tsx
+++ b/packages/perseus/src/hint-renderer.tsx
@@ -8,7 +8,8 @@ import Renderer from "./renderer";
 import {baseUnitPx, hintBorderWidth, kaGreen, gray97} from "./styles/constants";
 import mediaQueries from "./styles/media-queries";
 
-import type {APIOptions, LinterContextProps} from "./types";
+import type {APIOptions} from "./types";
+import type {LinterContextProps} from "@khanacademy/perseus-linter";
 
 type Props = {
     apiOptions: APIOptions;

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -109,7 +109,6 @@ export type {
     ImageUploader,
     JiptLabelStore,
     JiptRenderer,
-    LinterContextProps,
     PerseusDependencies,
     PerseusScore,
     Version,

--- a/packages/perseus/src/item-renderer.tsx
+++ b/packages/perseus/src/item-renderer.tsx
@@ -17,13 +17,9 @@ import reactRender from "./util/react-render";
 
 import type {KeypadProps} from "./mixins/provide-keypad";
 import type {PerseusItem} from "./perseus-types";
-import type {
-    APIOptions,
-    FocusPath,
-    LinterContextProps,
-    PerseusDependenciesV2,
-} from "./types";
+import type {APIOptions, FocusPath, PerseusDependenciesV2} from "./types";
 import type {KEScore} from "@khanacademy/perseus-core";
+import type {LinterContextProps} from "@khanacademy/perseus-linter";
 
 const {mapObject} = Objective;
 

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -35,11 +35,11 @@ import type {
     APIOptionsWithDefaults,
     FilterCriterion,
     FocusPath,
-    LinterContextProps,
     PerseusScore,
     WidgetInfo,
     WidgetProps,
 } from "./types";
+import type {LinterContextProps} from "@khanacademy/perseus-linter";
 
 import "./styles/perseus-renderer.less";
 

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -5,6 +5,7 @@ import type {PerseusWidget} from "./perseus-types";
 import type {SizeClass} from "./util/sizing-utils";
 import type {KeypadAPI} from "@khanacademy/math-input";
 import type {AnalyticsEventHandlerFn} from "@khanacademy/perseus-core";
+import type {LinterContextProps} from "@khanacademy/perseus-linter";
 import type {Result} from "@khanacademy/wonder-blocks-data";
 import type * as React from "react";
 
@@ -374,14 +375,6 @@ export type APIOptionsWithDefaults = Readonly<
         useDraftEditor: NonNullable<APIOptions["useDraftEditor"]>;
     }
 >;
-
-export type LinterContextProps = {
-    contentType: string;
-    highlightLint: boolean;
-    paths: ReadonlyArray<string>;
-    stack: ReadonlyArray<string>;
-    // additional properties can be added to the context by widgets
-};
 
 export type Tracking =
     // Track interactions once

--- a/packages/perseus/src/widget-container.tsx
+++ b/packages/perseus/src/widget-container.tsx
@@ -9,7 +9,8 @@ import {containerSizeClass, getClassFromWidth} from "./util/sizing-utils";
 import * as Widgets from "./widgets";
 
 import type {PerseusWidgetOptions} from "./perseus-types";
-import type {LinterContextProps, WidgetProps} from "./types";
+import type {WidgetProps} from "./types";
+import type {LinterContextProps} from "@khanacademy/perseus-linter";
 
 type Props = {
     shouldHighlight: boolean;

--- a/packages/perseus/src/widgets/passage-ref.tsx
+++ b/packages/perseus/src/widgets/passage-ref.tsx
@@ -13,9 +13,9 @@ import type {
     PerseusScore,
     WidgetExports,
     WidgetProps,
-    LinterContextProps,
 } from "../types";
 import type {Passage, Reference} from "./passage";
+import type {LinterContextProps} from "@khanacademy/perseus-linter";
 
 const EN_DASH = "\u2013";
 


### PR DESCRIPTION
## Summary:

I noticed that we have two identical versions of `LinterContextProps`. It was moved into the `perseus-linter` package, but I suspect a merge resolution brought back the deleted copy.   

This PR deletes it again out of `@khanacademy/perseus` and updates imports to use the one that lives in `@khanacademy/perseus-linter`

Issue: "none"

## Test plan:

`yarn test`
`yarn typecheck`