### PR TITLE
Updated TabbarItemType to KeypadPageType.

### DIFF
--- a/.changeset/dull-paws-build.md
+++ b/.changeset/dull-paws-build.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Updated Keypad V2 TabbarItemType to KeypadPageType as a more accurate description.

--- a/packages/math-input/src/components/keypad-legacy/two-page-keypad.tsx
+++ b/packages/math-input/src/components/keypad-legacy/two-page-keypad.tsx
@@ -19,7 +19,7 @@ import Tabbar from "../tabbar";
 import Keypad from "./keypad";
 import Styles from "./styles";
 
-import type {TabbarItemType} from "../tabbar";
+import type {KeypadPageType} from "../../types";
 import type {State as ReduxState} from "./store/types";
 
 const {column, row, fullWidth} = Styles;
@@ -34,7 +34,7 @@ interface Props extends ReduxProps {
 }
 
 type State = {
-    selectedPage: TabbarItemType;
+    selectedPage: KeypadPageType;
 };
 
 class TwoPageKeypad extends React.Component<Props, State> {

--- a/packages/math-input/src/components/keypad/keypad.tsx
+++ b/packages/math-input/src/components/keypad/keypad.tsx
@@ -18,8 +18,8 @@ import {expandedViewThreshold} from "./utils";
 import type Key from "../../data/keys";
 import type {ClickKeyCallback} from "../../types";
 import type {CursorContext} from "../input/cursor-contexts";
-import type {TabbarItemType} from "../tabbar";
 import type {AnalyticsEventHandlerFn} from "@khanacademy/perseus-core";
+import type {KeypadPageType} from "../../types";
 
 export type Props = {
     extraKeys: ReadonlyArray<Key>;
@@ -44,13 +44,13 @@ const defaultProps = {
     extraKeys: [],
 };
 
-function getAvailableTabs(props: Props): ReadonlyArray<TabbarItemType> {
+function getAvailableTabs(props: Props): ReadonlyArray<KeypadPageType> {
     // We don't want to show any available tabs on the fractions keypad
     if (props.fractionsOnly) {
         return [];
     }
 
-    const tabs: Array<TabbarItemType> = ["Numbers"];
+    const tabs: Array<KeypadPageType> = ["Numbers"];
     if (
         // OperatorsButtonSets
         props.preAlgebra ||
@@ -79,7 +79,7 @@ export default function Keypad(props: Props) {
     // Otherwise, we want to default to the Numbers page
     const defaultSelectedPage = props.fractionsOnly ? "Fractions" : "Numbers";
     const [selectedPage, setSelectedPage] =
-        React.useState<TabbarItemType>(defaultSelectedPage);
+        React.useState<KeypadPageType>(defaultSelectedPage);
     const [isMounted, setIsMounted] = React.useState<boolean>(false);
 
     // We don't want any tabs available on mobile fractions keypad
@@ -141,8 +141,8 @@ export default function Keypad(props: Props) {
                 <Tabbar
                     items={availableTabs}
                     selectedItem={selectedPage}
-                    onSelectItem={(tabbarItem: TabbarItemType) => {
-                        setSelectedPage(tabbarItem);
+                    onSelectItem={(newSelectedPage: KeypadPageType) => {
+                        setSelectedPage(newSelectedPage);
                     }}
                     onClickClose={
                         showDismiss ? () => onClickKey("DISMISS") : undefined

--- a/packages/math-input/src/components/keypad/keypad.tsx
+++ b/packages/math-input/src/components/keypad/keypad.tsx
@@ -16,10 +16,9 @@ import SharedKeys from "./shared-keys";
 import {expandedViewThreshold} from "./utils";
 
 import type Key from "../../data/keys";
-import type {ClickKeyCallback} from "../../types";
+import type {ClickKeyCallback, KeypadPageType} from "../../types";
 import type {CursorContext} from "../input/cursor-contexts";
 import type {AnalyticsEventHandlerFn} from "@khanacademy/perseus-core";
-import type {KeypadPageType} from "../../types";
 
 export type Props = {
     extraKeys: ReadonlyArray<Key>;

--- a/packages/math-input/src/components/keypad/shared-keys.tsx
+++ b/packages/math-input/src/components/keypad/shared-keys.tsx
@@ -7,11 +7,11 @@ import {getCursorContextConfig} from "./utils";
 
 import type {ClickKeyCallback} from "../../types";
 import type {CursorContext} from "../input/cursor-contexts";
-import type {TabbarItemType} from "../tabbar";
+import type {KeypadPageType} from "../../types";
 
 type Props = {
     onClickKey: ClickKeyCallback;
-    selectedPage: TabbarItemType;
+    selectedPage: KeypadPageType;
     cursorContext?: typeof CursorContext[keyof typeof CursorContext];
     multiplicationDot?: boolean;
     divisionKey?: boolean;

--- a/packages/math-input/src/components/keypad/shared-keys.tsx
+++ b/packages/math-input/src/components/keypad/shared-keys.tsx
@@ -5,9 +5,8 @@ import Keys from "../../data/key-configs";
 import {KeypadButton} from "./keypad-button";
 import {getCursorContextConfig} from "./utils";
 
-import type {ClickKeyCallback} from "../../types";
+import type {ClickKeyCallback, KeypadPageType} from "../../types";
 import type {CursorContext} from "../input/cursor-contexts";
-import type {KeypadPageType} from "../../types";
 
 type Props = {
     onClickKey: ClickKeyCallback;

--- a/packages/math-input/src/components/tabbar/icons.tsx
+++ b/packages/math-input/src/components/tabbar/icons.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 
-import type {TabbarItemType} from "./types";
+import type {KeypadPageType} from "../../types";
 
 type Props = {
     tintColor: string;
-    type: TabbarItemType;
+    type: KeypadPageType;
 };
 
 const IconAsset = function ({tintColor, type}: Props): React.ReactElement {

--- a/packages/math-input/src/components/tabbar/index.ts
+++ b/packages/math-input/src/components/tabbar/index.ts
@@ -1,2 +1,1 @@
 export {default} from "./tabbar";
-export {TabbarItemType} from "./types";

--- a/packages/math-input/src/components/tabbar/item.tsx
+++ b/packages/math-input/src/components/tabbar/item.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 
 import IconAsset from "./icons";
 
-import type {TabbarItemType} from "./types";
+import type {KeypadPageType} from "../../types";
 
 const styles = StyleSheet.create({
     base: {
@@ -78,7 +78,7 @@ export type ItemState = "active" | "inactive" | "disabled";
 type Props = {
     onClick: () => void;
     itemState: ItemState;
-    itemType: TabbarItemType;
+    itemType: KeypadPageType;
 };
 
 class TabbarItem extends React.Component<Props> {

--- a/packages/math-input/src/components/tabbar/tabbar.stories.tsx
+++ b/packages/math-input/src/components/tabbar/tabbar.stories.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import {TabbarItemForTesting as TabbarItem} from "./item";
 import Tabbar from "./tabbar";
 
-import type {TabbarItemType} from "./types";
+import type {KeypadPageType} from "../../types";
 
 export default {title: "Tab Bar", decorators: [withKnobs]};
 
@@ -57,7 +57,7 @@ export const DisabledBarItem = () => (
 
 function StatefulTabbarWrapper() {
     const [selectedItem, setSelectedItem] =
-        React.useState<TabbarItemType>("Numbers");
+        React.useState<KeypadPageType>("Numbers");
 
     return (
         <Tabbar
@@ -66,7 +66,7 @@ function StatefulTabbarWrapper() {
                     "Numbers",
                     "Geometry",
                     "Operators",
-                ]) as ReadonlyArray<TabbarItemType>
+                ]) as ReadonlyArray<KeypadPageType>
             }
             selectedItem={selectedItem}
             onSelectItem={(selection) => {

--- a/packages/math-input/src/components/tabbar/tabbar.tsx
+++ b/packages/math-input/src/components/tabbar/tabbar.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 
 import TabbarItem from "./item";
 
-import type {TabbarItemType} from "./types";
+import type {KeypadPageType} from "../../types";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 const styles = StyleSheet.create({
@@ -22,10 +22,10 @@ const styles = StyleSheet.create({
 });
 
 type Props = {
-    items: ReadonlyArray<TabbarItemType>;
-    selectedItem: TabbarItemType;
+    items: ReadonlyArray<KeypadPageType>;
+    selectedItem: KeypadPageType;
     onClickClose?: () => void;
-    onSelectItem: (item: TabbarItemType) => void;
+    onSelectItem: (item: KeypadPageType) => void;
     style?: StyleType;
 };
 

--- a/packages/math-input/src/components/tabbar/types.ts
+++ b/packages/math-input/src/components/tabbar/types.ts
@@ -1,7 +1,0 @@
-export type TabbarItemType =
-    | "Geometry"
-    | "Operators"
-    | "Numbers"
-    | "Fractions"
-    | "Extras"
-    | "Dismiss";

--- a/packages/math-input/src/types.ts
+++ b/packages/math-input/src/types.ts
@@ -88,6 +88,14 @@ export type LayoutProps = {initialBounds: Bound};
 
 export type ClickKeyCallback = (key: Key, event?: React.SyntheticEvent) => void;
 
+export type KeypadPageType =
+    | "Geometry"
+    | "Operators"
+    | "Numbers"
+    | "Fractions"
+    | "Extras"
+    | "Dismiss";
+
 export interface KeypadAPI {
     activate: () => void;
     dismiss: () => void;


### PR DESCRIPTION
## Summary:
This is a very simple PR that updates the name of the TabbarItemType to the more accurate/descriptive KeypadPageType. 

**Reason:** After adding the Fractions page, not all of these elements are "TabbarItems" as we don't want the Fractions page to appear in the Tabbar. I decided on a name change as it seemed like the best course of action to ensure code readability. Otherwise the logic for showing the Fraction page would be much messier due to how we're currently switching between page views. This is also inline with our usage of the type on a few of variables/states called "selectedPage". 

Issue: LC-1160

## Test plan:
manual testing