### PR TITLE
Add ResizeObserver for legacy keypad

### DIFF
--- a/.changeset/nine-guests-sneeze.md
+++ b/.changeset/nine-guests-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": minor
+---
+
+Handle keypad resize better when it's positioned absolutely

--- a/packages/math-input/src/components/keypad-legacy/keypad-container.tsx
+++ b/packages/math-input/src/components/keypad-legacy/keypad-container.tsx
@@ -51,7 +51,7 @@ type State = {
 // eslint-disable-next-line react/no-unsafe
 class KeypadContainer extends React.Component<Props, State> {
     _containerRef = React.createRef<HTMLDivElement>();
-    _containerResizeObserver: ResizeObserver;
+    _containerResizeObserver: ResizeObserver | null = null;
     _resizeTimeout: number | null | undefined;
     hasMounted: boolean | undefined;
 
@@ -108,7 +108,7 @@ class KeypadContainer extends React.Component<Props, State> {
             "orientationchange",
             this._throttleResizeHandler,
         );
-        this._containerResizeObserver.disconnect();
+        this._containerResizeObserver?.disconnect();
     }
 
     _throttleResizeHandler = () => {

--- a/packages/math-input/src/components/keypad-legacy/keypad-container.tsx
+++ b/packages/math-input/src/components/keypad-legacy/keypad-container.tsx
@@ -51,6 +51,7 @@ type State = {
 // eslint-disable-next-line react/no-unsafe
 class KeypadContainer extends React.Component<Props, State> {
     _containerRef = React.createRef<HTMLDivElement>();
+    _containerResizeObserver: ResizeObserver;
     _resizeTimeout: number | null | undefined;
     hasMounted: boolean | undefined;
 
@@ -77,6 +78,14 @@ class KeypadContainer extends React.Component<Props, State> {
             "orientationchange",
             this._throttleResizeHandler,
         );
+
+        this._containerResizeObserver = new ResizeObserver(
+            this._throttleResizeHandler,
+        );
+
+        if (this._containerRef.current) {
+            this._containerResizeObserver.observe(this._containerRef.current);
+        }
     }
 
     UNSAFE_componentWillReceiveProps(nextProps) {
@@ -99,6 +108,7 @@ class KeypadContainer extends React.Component<Props, State> {
             "orientationchange",
             this._throttleResizeHandler,
         );
+        this._containerResizeObserver.disconnect();
     }
 
     _throttleResizeHandler = () => {

--- a/packages/perseus/src/__tests__/item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/item-renderer.test.tsx
@@ -132,6 +132,13 @@ describe("item renderer", () => {
     });
 
     beforeEach(() => {
+        // Mock ResizeObserver used by the mobile keypad
+        window.ResizeObserver = jest.fn().mockImplementation(() => ({
+            observe: jest.fn(),
+            unobserve: jest.fn(),
+            disconnect: jest.fn(),
+        }));
+
         jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
             testDependencies,
         );


### PR DESCRIPTION
## Summary:
Adds a ResizeObserver to trigger a keypad resize when the container size changes (like when the viewport changes).

Issue: [LC-1166](https://khanacademy.atlassian.net/browse/LC-1166)
Followup to: [LC-1126](https://khanacademy.atlassian.net/browse/LC-1126)

https://github.com/Khan/perseus/assets/16308368/76af5196-954a-4e73-92a7-e07a6f64fb81

## Test plan:
- Go to [this page](https://prod-znd-230821-16131-868a711.khanacademy.org/internal-courses/test-everything/test-everything-1/expression/e/expression-exercise)
- Emulate tablet with dev tools (might need to refresh)
- Click the input to open the keypad
- Collapse the left column
- Click the input to open the keypad again
- The keypad should scale up/down depending on the available space in the column

[LC-1166]: https://khanacademy.atlassian.net/browse/LC-1166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LC-1126]: https://khanacademy.atlassian.net/browse/LC-1126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ