### PR TITLE
Derive virtual keypad version

### DIFF
--- a/.changeset/fluffy-beans-wink.md
+++ b/.changeset/fluffy-beans-wink.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Switch `virtualKeypadVersion` on `perseus:expression-evaluated` event to be non-optional

--- a/packages/perseus-core/src/analytics.ts
+++ b/packages/perseus-core/src/analytics.ts
@@ -1,25 +1,29 @@
+export type VirtualKeypadVersion =
+    | "PERSEUS_MATH_INPUT"
+    | "MATH_INPUT_KEYPAD_V1"
+    | "MATH_INPUT_KEYPAD_V2"
+    | "REACT_NATIVE_KEYPAD";
+
 // A type union of all the events that any package in the Perseus ecosystem can
 // send.
 export type PerseusAnalyticsEvent =
     | {
           type: "perseus:expression-evaluated";
           payload: {
-              // Keypad version can be supplied by Perseus sometimes, but not always.
-              // The host application will need to fill this in if it's not present.
-              virtualKeypadVersion?: string;
+              virtualKeypadVersion: VirtualKeypadVersion;
               result: "correct" | "incorrect" | "invalid";
           };
       }
     | {
           type: "math-input:keypad-closed";
           payload: {
-              virtualKeypadVersion: string;
+              virtualKeypadVersion: VirtualKeypadVersion;
           };
       }
     | {
           type: "math-input:keypad-opened";
           payload: {
-              virtualKeypadVersion: string;
+              virtualKeypadVersion: VirtualKeypadVersion;
           };
       };
 // Add more events here as needed. Note that each event should have a `type`

--- a/packages/perseus/src/widgets/__tests__/expression.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/expression.test.tsx
@@ -18,6 +18,7 @@ import {Expression} from "../expression";
 import {renderQuestion} from "./renderQuestion";
 
 import type {PerseusItem} from "../../perseus-types";
+import type {APIOptions} from "../../types";
 
 const assertComplete = (
     itemData: PerseusItem,
@@ -41,6 +42,7 @@ const assertCorrect = (itemData: PerseusItem, input: string) => {
         type: "perseus:expression-evaluated",
         payload: {
             result: "correct",
+            virtualKeypadVersion: "PERSEUS_MATH_INPUT",
         },
     });
 };
@@ -52,6 +54,7 @@ const assertIncorrect = (itemData: PerseusItem, input: string) => {
         type: "perseus:expression-evaluated",
         payload: {
             result: "incorrect",
+            virtualKeypadVersion: "PERSEUS_MATH_INPUT",
         },
     });
 };
@@ -73,6 +76,7 @@ const assertInvalid = (
         type: "perseus:expression-evaluated",
         payload: {
             result: "invalid",
+            virtualKeypadVersion: "PERSEUS_MATH_INPUT",
         },
     });
 };
@@ -180,6 +184,56 @@ describe("Expression Widget", function () {
         it("should handle ungraded answers with no error callback", function () {
             const err = Expression.validate("x+^1", expressionItem3Options);
             expect(err).toStrictEqual({message: null, type: "invalid"});
+        });
+    });
+
+    describe("analytics", () => {
+        const assertKeypadVersion = (
+            apiOptions: APIOptions,
+            virtualKeypadVersion: string,
+        ) => {
+            const {renderer} = renderQuestion(
+                expressionItem2.question,
+                apiOptions,
+            );
+
+            renderer.guessAndScore();
+
+            expect(
+                testDependenciesV2.analytics.onAnalyticsEvent,
+            ).toHaveBeenCalledWith({
+                type: "perseus:expression-evaluated",
+                payload: {
+                    // We're not interested in validating that the expression
+                    // widget did anything useful or that the keypad worked. We
+                    // just want to make sure the code that derives which
+                    // keypad version it detected is correct.
+                    result: "invalid",
+                    virtualKeypadVersion,
+                },
+            });
+        };
+
+        it("should set the virtual keypad version to REACT_NATIVE_KEYPAD when nativeKeypadProxy is provided", () => {
+            assertKeypadVersion(
+                {nativeKeypadProxy: jest.fn()},
+                "REACT_NATIVE_KEYPAD",
+            );
+        });
+
+        it("should set the virtual keypad version to MATH_INPUT_KEYPAD_V1 when customKeypad is set and useV2Keypad is unset", () => {
+            assertKeypadVersion({customKeypad: true}, "MATH_INPUT_KEYPAD_V1");
+        });
+
+        it("should set the virtual keypad version to MATH_INPUT_KEYPAD_V2 when customKeypad is set and useV2Keypad is true", () => {
+            assertKeypadVersion(
+                {customKeypad: true, useV2Keypad: true},
+                "MATH_INPUT_KEYPAD_V2",
+            );
+        });
+
+        it("should default the virtual keypad version to PERSEUS_MATH_INPUT", () => {
+            assertKeypadVersion(Object.freeze({}), "PERSEUS_MATH_INPUT");
         });
     });
 });

--- a/packages/perseus/src/widgets/expression.tsx
+++ b/packages/perseus/src/widgets/expression.tsx
@@ -23,7 +23,12 @@ import type {
     PerseusExpressionWidgetOptions,
     PerseusExpressionAnswerForm,
 } from "../perseus-types";
-import type {PerseusScore, WidgetExports, WidgetProps} from "../types";
+import type {
+    APIOptions,
+    PerseusScore,
+    WidgetExports,
+    WidgetProps,
+} from "../types";
 import type {Keys as Key} from "@khanacademy/math-input";
 
 type InputPath = ReadonlyArray<string>;
@@ -50,6 +55,20 @@ const insertBraces = (value) => {
     //
     // TODO(alex): Properly hack MathQuill to always use explicit braces.
     return value.replace(/([_^])([^{])/g, "$1{$2}");
+};
+
+const deriveKeypadVersion = (apiOptions: APIOptions) => {
+    // We can derive which version of the keypad is in use. This is
+    // a bit tricky, but this code will be relatively short-lived
+    // as we coalesce onto the new, v2 Keypad, at which point we
+    // can remove this `virtualKeypadVersion` field entirely.
+    return apiOptions.nativeKeypadProxy != null
+        ? "REACT_NATIVE_KEYPAD"
+        : apiOptions.customKeypad === true
+        ? apiOptions.useV2Keypad === true
+            ? "MATH_INPUT_KEYPAD_V2"
+            : "MATH_INPUT_KEYPAD_V1"
+        : "PERSEUS_MATH_INPUT";
 };
 
 type Rubric = PerseusExpressionWidgetOptions;
@@ -476,6 +495,9 @@ export class Expression extends React.Component<Props, ExpressionState> {
             type: "perseus:expression-evaluated",
             payload: {
                 result,
+                virtualKeypadVersion: deriveKeypadVersion(
+                    this.props.apiOptions,
+                ),
             },
         });
     }


### PR DESCRIPTION
## Summary:

As I was integrating Perseus analytics in webapp, it became really difficult to work out how to provide the virtualKeypadVersion consistently when Perseus wasn't always providing it. After some thought, I figured out that we can pretty-reliably derive the keypad version. Given that we are actively moving to coalesce on a single keypad, I hope this is an acceptable approach for the short term. When we get to one keypad, we can delete this `virtualKeypadVersion` from the analytics anyways. 

Issue: LC-950

## Test plan:

✅ `yarn typecheck`
✅ `yarn test`