### PR TITLE
Check for ResizeContainer before using it

### DIFF
--- a/.changeset/chilly-knives-return.md
+++ b/.changeset/chilly-knives-return.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Check for existence of `ResizeObserver` before using it in KeypadContainer

--- a/packages/math-input/src/components/keypad-legacy/keypad-container.tsx
+++ b/packages/math-input/src/components/keypad-legacy/keypad-container.tsx
@@ -81,7 +81,7 @@ class KeypadContainer extends React.Component<Props, State> {
 
         // Although all browsers we support have ResizeObserver, this ensures
         // that unit tests that run in JSDOM that include this component don't
-        // fail.
+        // fail (including tests in consuming applications).
         if ("ResizeObserver" in window) {
             this._containerResizeObserver = new ResizeObserver(
                 this._throttleResizeHandler,

--- a/packages/math-input/src/components/keypad-legacy/keypad-container.tsx
+++ b/packages/math-input/src/components/keypad-legacy/keypad-container.tsx
@@ -79,12 +79,19 @@ class KeypadContainer extends React.Component<Props, State> {
             this._throttleResizeHandler,
         );
 
-        this._containerResizeObserver = new ResizeObserver(
-            this._throttleResizeHandler,
-        );
+        // Although all browsers we support have ResizeObserver, this ensures
+        // that unit tests that run in JSDOM that include this component don't
+        // fail.
+        if ("ResizeObserver" in window) {
+            this._containerResizeObserver = new ResizeObserver(
+                this._throttleResizeHandler,
+            );
 
-        if (this._containerRef.current) {
-            this._containerResizeObserver.observe(this._containerRef.current);
+            if (this._containerRef.current) {
+                this._containerResizeObserver.observe(
+                    this._containerRef.current,
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Summary:

Our KeypadContainer uses a ResizeObserver to detect size changes efficiently. This works great, until it's run within a unit test in a consuming application. At that point we're at the mercy of the test environment to have provided a stub. 

Adding a check here to avoid this complication. It will still work everywhere its available, but won't break unit tests in environments that its not (aka JSDOM, aka React Testing Library). 

Issue: "none"

## Test plan:

`yarn test` still works