### PR TITLE
Convert all JSX.LibraryManagedAttributes to use PropsFor<>

### DIFF
--- a/.changeset/beige-cobras-listen.md
+++ b/.changeset/beige-cobras-listen.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Convert all usages of JSX.LibraryManagedAttributes to WB Core's PropsFor type

--- a/packages/perseus-editor/src/components/section-control-button.tsx
+++ b/packages/perseus-editor/src/components/section-control-button.tsx
@@ -4,12 +4,11 @@ import Color from "@khanacademy/wonder-blocks-color";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
+
 const {InlineIcon} = components;
 
-type InlineIconProps = JSX.LibraryManagedAttributes<
-    typeof InlineIcon,
-    React.ComponentProps<typeof InlineIcon>
->;
+type InlineIconProps = PropsFor<typeof InlineIcon>;
 
 type SectionControlButtonProps = {
     icon: InlineIconProps;

--- a/packages/perseus-editor/src/widgets/input-number-editor.tsx
+++ b/packages/perseus-editor/src/widgets/input-number-editor.tsx
@@ -7,6 +7,7 @@ import _ from "underscore";
 import BlurInput from "../components/blur-input";
 
 import type {ParsedValue, InputNumber} from "@khanacademy/perseus";
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
 const {InfoTip} = components;
 
@@ -47,30 +48,14 @@ const answerTypes = {
 
 type Props = {
     value: number;
-    simplify: JSX.LibraryManagedAttributes<
-        typeof InputNumber.widget,
-        React.ComponentProps<typeof InputNumber.widget>
-    >["simplify"];
-    size: JSX.LibraryManagedAttributes<
-        typeof InputNumber.widget,
-        React.ComponentProps<typeof InputNumber.widget>
-    >["size"];
-    inexact: JSX.LibraryManagedAttributes<
-        typeof InputNumber.widget,
-        React.ComponentProps<typeof InputNumber.widget>
-    >["reviewModeRubric"]["inexact"];
-    maxError: JSX.LibraryManagedAttributes<
-        typeof InputNumber.widget,
-        React.ComponentProps<typeof InputNumber.widget>
+    simplify: PropsFor<typeof InputNumber.widget>["simplify"];
+    size: PropsFor<typeof InputNumber.widget>["size"];
+    inexact: PropsFor<typeof InputNumber.widget>["reviewModeRubric"]["inexact"];
+    maxError: PropsFor<
+        typeof InputNumber.widget
     >["reviewModeRubric"]["maxError"];
-    answerType: JSX.LibraryManagedAttributes<
-        typeof InputNumber.widget,
-        React.ComponentProps<typeof InputNumber.widget>
-    >["answerType"];
-    rightAlign: JSX.LibraryManagedAttributes<
-        typeof InputNumber.widget,
-        React.ComponentProps<typeof InputNumber.widget>
-    >["rightAlign"];
+    answerType: PropsFor<typeof InputNumber.widget>["answerType"];
+    rightAlign: PropsFor<typeof InputNumber.widget>["rightAlign"];
     onChange: (arg1: {
         value?: ParsedValue | 0;
         simplify?: Props["simplify"];

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
@@ -24,17 +24,14 @@ import type {
     PerseusInteractiveGraphWidgetOptions,
     APIOptionsWithDefaults,
 } from "@khanacademy/perseus";
-import type {StyleType} from "@khanacademy/wonder-blocks-core";
+import type {PropsFor, StyleType} from "@khanacademy/wonder-blocks-core";
 
 const {InfoTip} = components;
 const {containerSizeClass, getInteractiveBoxFromSizeClass} = SizingUtils;
 const DeprecationMixin = Util.DeprecationMixin;
 const InteractiveGraph = InteractiveGraphWidget.widget;
 
-type InteractiveGraphProps = JSX.LibraryManagedAttributes<
-    typeof InteractiveGraph,
-    React.ComponentProps<typeof InteractiveGraph>
->;
+type InteractiveGraphProps = PropsFor<typeof InteractiveGraph>;
 
 const defaultBackgroundImage = {
     url: null,

--- a/packages/perseus/src/__tests__/renderer.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.test.tsx
@@ -149,7 +149,6 @@ describe("renderer", () => {
             mockRunLinter.mockClear();
 
             // Act
-            // @ts-expect-error - TS2345 - Argument of type '{ problemNum: number; linterContext: { readonly contentType: "exercise"; readonly highlightLint: true; readonly paths: readonly []; readonly stack: readonly []; }; }' is not assignable to parameter of type 'Pick<{}, never> & InexactPartial<Pick<{}, never>> & InexactPartial<Pick<DefaultProps, keyof DefaultProps>>'.
             rerender(question1, {...extraProps, problemNum: 1});
 
             // Assert
@@ -1334,7 +1333,6 @@ describe("renderer", () => {
                     },
                 },
                 {},
-                // @ts-expect-error - TS2345 - Argument of type '{ problemNum: number; }' is not assignable to parameter of type 'Pick<{}, never> & InexactPartial<Pick<{}, never>> & InexactPartial<Pick<DefaultProps, keyof DefaultProps>>'.
                 {problemNum: 1},
             );
 

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -1,5 +1,3 @@
-import type {PropsFor} from "@khanacademy/wonder-blocks-core";
-
 import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 import {within, render, screen} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -30,6 +28,7 @@ import MockWidgetExport from "./mock-widget";
 import type {PerseusItem} from "../perseus-types";
 import type {APIOptions} from "../types";
 import type {MockAssetLoadingWidget} from "./mock-asset-loading-widget";
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
 // This looks alot like `widgets/__tests__/renderQuestion.jsx', except we use
 // the ServerItemRenderer instead of Renderer

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -1,3 +1,5 @@
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
+
 import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 import {within, render, screen} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -35,10 +37,7 @@ const renderQuestion = (
     question: PerseusItem,
     apiOptions: APIOptions = Object.freeze({}),
     optionalProps: Partial<
-        JSX.LibraryManagedAttributes<
-            typeof WrappedServerItemRenderer,
-            React.ComponentProps<typeof WrappedServerItemRenderer>
-        >
+        PropsFor<typeof WrappedServerItemRenderer>
     > = Object.freeze({}),
 ): {
     container: HTMLElement;

--- a/packages/perseus/src/components/info-tip.tsx
+++ b/packages/perseus/src/components/info-tip.tsx
@@ -9,10 +9,9 @@ import * as React from "react";
 
 import ReactComponentsInfoTip from "./info-tip/info-tip";
 
-type Props = JSX.LibraryManagedAttributes<
-    typeof ReactComponentsInfoTip,
-    React.ComponentProps<typeof ReactComponentsInfoTip>
->;
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
+
+type Props = PropsFor<typeof ReactComponentsInfoTip>;
 
 type State = {
     didMount: boolean;

--- a/packages/perseus/src/hints-renderer.tsx
+++ b/packages/perseus/src/hints-renderer.tsx
@@ -22,12 +22,9 @@ import Util from "./util";
 
 import type Renderer from "./renderer";
 import type {APIOptionsWithDefaults} from "./types";
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
-type Props = JSX.LibraryManagedAttributes<
-    Renderer,
-    // @ts-expect-error - TS2344 - Type 'Renderer' does not satisfy the constraint 'keyof IntrinsicElements | JSXElementConstructor<any>'.
-    React.ComponentProps<typeof Renderer>
-> & {
+type Props = PropsFor<typeof Renderer> & {
     className?: string;
     // note (mcurtis): I think this should be $ReadOnlyArray<PerseusRenderer>,
     // but things spiraled out of control when I tried to change it
@@ -36,7 +33,6 @@ type Props = JSX.LibraryManagedAttributes<
 };
 
 type DefaultProps = {
-    // @ts-expect-error - TS2339 - Property 'linterContext' does not exist on type '{ className?: string | undefined; hints: readonly any[]; hintsVisible?: number | undefined; }'.
     linterContext: Props["linterContext"];
 };
 
@@ -126,7 +122,6 @@ class HintsRenderer extends React.Component<Props, State> {
         // false in hints.
         return {
             ...ApiOptions.defaults,
-            // @ts-expect-error - TS2339 - Property 'apiOptions' does not exist on type 'Readonly<{ className?: string | undefined; hints: readonly any[]; hintsVisible?: number | undefined; }> & Readonly<{ children?: ReactNode; }>'.
             ...this.props.apiOptions,
             readOnly: false,
         };
@@ -196,10 +191,8 @@ class HintsRenderer extends React.Component<Props, State> {
                     ref={"hintRenderer" + i}
                     key={"hintRenderer" + i}
                     apiOptions={apiOptions}
-                    // @ts-expect-error - TS2339 - Property 'findExternalWidgets' does not exist on type 'Readonly<{ className?: string | undefined; hints: readonly any[]; hintsVisible?: number | undefined; }> & Readonly<{ children?: ReactNode; }>'.
                     findExternalWidgets={this.props.findExternalWidgets}
                     linterContext={PerseusLinter.pushContextStack(
-                        // @ts-expect-error - TS2339 - Property 'linterContext' does not exist on type 'Readonly<{ className?: string | undefined; hints: readonly any[]; hintsVisible?: number | undefined; }> & Readonly<{ children?: ReactNode; }>'.
                         this.props.linterContext,
                         "hints[" + i + "]",
                     )}

--- a/packages/perseus/src/item-renderer.tsx
+++ b/packages/perseus/src/item-renderer.tsx
@@ -224,7 +224,6 @@ class ItemRenderer extends React.Component<Props, State> {
                     ref={(node) => (this.hintsRenderer = node)}
                     hints={this.props.item.hints}
                     hintsVisible={this.state.hintsVisible}
-                    // @ts-expect-error - TS2769 - No overload matches this call.
                     apiOptions={apiOptions}
                     linterContext={PerseusLinter.pushContextStack(
                         this.props.linterContext,

--- a/packages/perseus/src/multi-items/multi-renderer.tsx
+++ b/packages/perseus/src/multi-items/multi-renderer.tsx
@@ -61,16 +61,13 @@ import type {Item, ContentNode, HintNode, TagsNode} from "./item-types";
 import type {Shape, ArrayShape} from "./shape-types";
 import type {Tree} from "./tree-types";
 import type {TreeMapper, ContentMapper, HintMapper, Path} from "./trees";
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
 type Hint = any; // TODO(mdr)
 type Score = any; // TODO(mdr)
 type SerializedState = any; // TODO(mdr)
 
-type RendererProps = JSX.LibraryManagedAttributes<
-    typeof Renderer,
-    // @ts-expect-error - TS2344 - Type 'typeof Renderer' does not satisfy the constraint 'keyof IntrinsicElements | JSXElementConstructor<any>'.
-    React.ComponentProps<typeof Renderer>
->;
+type RendererProps = PropsFor<typeof Renderer>;
 
 type ContentRendererElement = React.ReactElement<any>;
 type HintRendererElement = React.ReactElement<any>;
@@ -314,7 +311,6 @@ class MultiRenderer extends React.Component<Props, State> {
             makeRenderer: () => (
                 <HintsRenderer
                     {...this._getRendererProps()}
-                    // @ts-expect-error - TS2769 - No overload matches this call.
                     findExternalWidgets={findExternalWidgets}
                     hints={[hint]}
                 />
@@ -514,7 +510,6 @@ class MultiRenderer extends React.Component<Props, State> {
             (renderers as any).firstN = (n: any) => (
                 <HintsRenderer
                     {...this._getRendererProps()}
-                    // @ts-expect-error - TS2769 - No overload matches this call.
                     findExternalWidgets={
                         hintRendererDatas[0]
                             ? hintRendererDatas[0].findExternalWidgets

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -250,8 +250,8 @@ class Renderer extends React.Component<Props, State> {
         linterContext: PerseusLinter.linterContextDefault,
     };
 
-    constructor(props: Props, context: Context) {
-        super(props, context);
+    constructor(props: Props) {
+        super(props);
         this._translationLinter = new TranslationLinter();
 
         this.state = {

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -421,7 +421,6 @@ export class ServerItemRenderer
             <HintsRenderer
                 hints={this.props.item.hints}
                 hintsVisible={this.props.hintsVisible}
-                // @ts-expect-error - TS2769 - No overload matches this call.
                 apiOptions={apiOptions}
                 ref={(elem) => (this.hintsRenderer = elem)}
             />

--- a/packages/perseus/src/widgets/__tests__/renderQuestion.tsx
+++ b/packages/perseus/src/widgets/__tests__/renderQuestion.tsx
@@ -10,27 +10,20 @@ import {registerAllWidgetsForTesting} from "../../util/register-all-widgets-for-
 
 import type {PerseusRenderer} from "../../perseus-types";
 import type {APIOptions} from "../../types";
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
 type RenderResult = ReturnType<typeof render>;
 
 export const renderQuestion = (
     question: PerseusRenderer,
     apiOptions: APIOptions = Object.freeze({}),
-    extraProps?: JSX.LibraryManagedAttributes<
-        typeof Perseus.Renderer,
-        // @ts-expect-error - TS2344 - Type 'typeof Renderer' does not satisfy the constraint 'keyof IntrinsicElements | JSXElementConstructor<any>'.
-        React.ComponentProps<typeof Perseus.Renderer>
-    >,
+    extraProps?: PropsFor<typeof Perseus.Renderer>,
 ): {
     container: HTMLElement;
     renderer: Perseus.Renderer;
     rerender: (
         question: PerseusRenderer,
-        extraProps?: JSX.LibraryManagedAttributes<
-            typeof Perseus.Renderer,
-            // @ts-expect-error - TS2344 - Type 'typeof Renderer' does not satisfy the constraint 'keyof IntrinsicElements | JSXElementConstructor<any>'.
-            React.ComponentProps<typeof Perseus.Renderer>
-        >,
+        extraProps?: PropsFor<typeof Perseus.Renderer>,
     ) => void;
     unmount: RenderResult["unmount"];
 } => {
@@ -57,7 +50,6 @@ export const renderQuestion = (
     }
     const renderAgain = (
         question: PerseusRenderer,
-        // @ts-expect-error - TS2344 - Type 'typeof Renderer' does not satisfy the constraint 'keyof IntrinsicElements | JSXElementConstructor<any>'.
         extraProps: undefined | React.ComponentProps<typeof Perseus.Renderer>,
     ) => {
         rerender(

--- a/packages/perseus/src/widgets/expression.tsx
+++ b/packages/perseus/src/widgets/expression.tsx
@@ -30,6 +30,7 @@ import type {
     WidgetProps,
 } from "../types";
 import type {Keys as Key} from "@khanacademy/math-input";
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
 type InputPath = ReadonlyArray<string>;
 
@@ -673,13 +674,7 @@ const propUpgrades = {
 
 const ExpressionWithDependencies = React.forwardRef<
     Expression,
-    Omit<
-        JSX.LibraryManagedAttributes<
-            typeof Expression,
-            React.ComponentProps<typeof Expression>
-        >,
-        keyof ReturnType<typeof useDependencies>
-    >
+    Omit<PropsFor<typeof Expression>, keyof ReturnType<typeof useDependencies>>
 >((props, ref) => {
     const deps = useDependencies();
     return <Expression ref={ref} analytics={deps.analytics} {...props} />;

--- a/packages/perseus/src/widgets/grapher.tsx
+++ b/packages/perseus/src/widgets/grapher.tsx
@@ -36,6 +36,7 @@ import type {ChangeableProps} from "../mixins/changeable";
 import type {PerseusGrapherWidgetOptions} from "../perseus-types";
 import type {PerseusScore, WidgetExports, WidgetProps} from "../types";
 import type {GridDimensions} from "../util";
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
 // @ts-expect-error - TS2339 - Property 'MovablePoint' does not exist on type 'typeof Graphie'.
 const MovablePoint = Graphie.MovablePoint;
@@ -473,18 +474,9 @@ class Grapher extends React.Component<Props> {
     }
 
     _calculateMobileTickStep(
-        gridStep: JSX.LibraryManagedAttributes<
-            typeof Graphie,
-            Required<React.ComponentProps<typeof Graphie>>
-        >["gridStep"],
-        step: JSX.LibraryManagedAttributes<
-            typeof Graphie,
-            Required<React.ComponentProps<typeof Graphie>>
-        >["step"],
-        ranges: JSX.LibraryManagedAttributes<
-            typeof Graphie,
-            Required<React.ComponentProps<typeof Graphie>>
-        >["ranges"],
+        gridStep: NonNullable<PropsFor<typeof Graphie>["gridStep"]>,
+        step: NonNullable<PropsFor<typeof Graphie>["step"]>,
+        ranges: NonNullable<PropsFor<typeof Graphie>["ranges"]>,
     ): any {
         const tickStep = Util.constrainedTickStepsFromTickSteps(step, ranges);
 

--- a/testing/test-tex.tsx
+++ b/testing/test-tex.tsx
@@ -5,11 +5,9 @@ import * as React from "react";
 import "katex/dist/katex.css";
 
 import type {PerseusDependencies} from "../packages/perseus/src/types";
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
-type Props = JSX.LibraryManagedAttributes<
-    PerseusDependencies["TeX"],
-    React.ComponentProps<PerseusDependencies["TeX"]>
->;
+type Props = PropsFor<PerseusDependencies["TeX"]>;
 
 /**
  * A test version of TeX that can be used in tests and doesn't rely on


### PR DESCRIPTION
## Summary:

Previously in Flow we had a simple type for exatracting prop types of a component while reatining their optionality: `React.ElementConfig<typeof MyComponent>`. In TypeScript the equivalent is alot uglier:

```javascript 
JSX.LibraryManagedAttributes<
   typeof MyComponent,
   React.ComponentProps<typeof MyComponent>
>
```

Wonder Stuff Core recently added a helper named `PropsFor<>` that works like Flow's `ElmeentConfig<T>` and so this PR adapts to use that new type.

One related fix I made was to remove the `context` object from the `Renderer`'s constructor. That's a deprecated pattern in React and I couldn't find any usages that do that. 

Issue: "none"

## Test plan:

`yarn typecheck`
`yarn test` (just to be safe)