### PR TITLE
Propogate 'static' functions for Expression on exported forwardRef component

### DIFF
--- a/.changeset/tricky-drinks-report.md
+++ b/.changeset/tricky-drinks-report.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Restore static methods on `Expression` widget component

--- a/packages/perseus/src/__tests__/mock-asset-loading-widget.tsx
+++ b/packages/perseus/src/__tests__/mock-asset-loading-widget.tsx
@@ -2,9 +2,11 @@ import * as React from "react";
 
 import AssetContext from "../asset-context";
 
+import type {PerseusItem} from "../perseus-types";
 import type {WidgetExports} from "../types";
 
-export const mockedAssetItem = {
+// @ts-expect-error - TS2322 - Type '"mocked-asset-widget"' is not assignable to type '"categorizer" | "cs-program" | "definition" | "dropdown" | "example-graphie-widget" | "example-widget" | "explanation" | "expression" | "graded-group-set" | "graded-group" | ... 29 more ... | "video"'.
+export const mockedAssetItem: PerseusItem = {
     question: {
         content: "[[\u2603 mocked-asset-widget 1]]",
         images: Object.freeze({}),
@@ -27,7 +29,6 @@ export const mockedAssetItem = {
         zTable: false,
     },
     itemDataVersion: {major: 0, minor: 1},
-    // $FlowIgnore[signature-verification-failure]
     hints: [],
     _multi: null,
     answer: null,

--- a/packages/perseus/src/__tests__/widgets.test.ts
+++ b/packages/perseus/src/__tests__/widgets.test.ts
@@ -1,4 +1,3 @@
-import allWidgets from "../all-widgets";
 import {registerAllWidgetsForTesting} from "../util/register-all-widgets-for-testing";
 import * as Widgets from "../widgets";
 

--- a/packages/perseus/src/__tests__/widgets.test.ts
+++ b/packages/perseus/src/__tests__/widgets.test.ts
@@ -1,0 +1,35 @@
+import {registerAllWidgetsForTesting} from "../util/register-all-widgets-for-testing";
+import * as Widgets from "../widgets";
+
+describe("Widget API support", () => {
+    beforeAll(() => {
+        registerAllWidgetsForTesting();
+    });
+
+    // This list is mirrored in Khan Academy's webapp for the coach reports.
+    // If you change this, be sure to double-check that consuming applications
+    // agree on this list of supported widgets.
+    it.each([
+        "categorizer",
+        "expression",
+        "grapher",
+        "input-number",
+        "interactive-graph",
+        "numeric-input",
+        "radio",
+    ])(
+        "%s widget should provide static getUserInputFromProps",
+        (widgetType) => {
+            const Widget = Widgets.getWidget(widgetType);
+            expect(Widget).toHaveProperty("getUserInputFromProps");
+        },
+    );
+
+    it.each(["expression", "input-number", "numeric-input"])(
+        "%s widget should provide static getOneCorrectAnswerFromRubric",
+        (widgetType) => {
+            const Widget = Widgets.getWidget(widgetType);
+            expect(Widget).toHaveProperty("getOneCorrectAnswerFromRubric");
+        },
+    );
+});

--- a/packages/perseus/src/__tests__/widgets.test.ts
+++ b/packages/perseus/src/__tests__/widgets.test.ts
@@ -1,9 +1,48 @@
+import allWidgets from "../all-widgets";
 import {registerAllWidgetsForTesting} from "../util/register-all-widgets-for-testing";
 import * as Widgets from "../widgets";
 
 describe("Widget API support", () => {
     beforeAll(() => {
         registerAllWidgetsForTesting();
+    });
+
+    // This verifies a known list of widgets to ensure they provide the static
+    // validate function. Not all widgets support this function so even though
+    // this list looks exhaustive, it's not!
+    it.each([
+        "radio",
+        "input-number",
+        "numeric-input",
+        "expression",
+        "categorizer",
+        "cs-program",
+        "dropdown",
+        "explanation",
+        "definition",
+        "grapher",
+        "iframe",
+        "image",
+        "interaction",
+        "interactive-graph",
+        "label-image",
+        "matrix",
+        "matcher",
+        "measurer",
+        "number-line",
+        "orderer",
+        "passage",
+        "passage-ref",
+        "passage-ref-target",
+        "plotter",
+        "simulator",
+        "sorter",
+        "table",
+        "transformer",
+        "unit-input",
+        "video",
+    ])("%s widget should provide static validate function", (widgetType) => {
+        expect(Widgets.getWidget(widgetType)).toHaveProperty("validate");
     });
 
     // This list is mirrored in Khan Academy's webapp for the coach reports.
@@ -18,7 +57,7 @@ describe("Widget API support", () => {
         "numeric-input",
         "radio",
     ])(
-        "%s widget should provide static getUserInputFromProps",
+        "%s widget should provide static getUserInputFromProps function",
         (widgetType) => {
             const Widget = Widgets.getWidget(widgetType);
             expect(Widget).toHaveProperty("getUserInputFromProps");
@@ -26,7 +65,7 @@ describe("Widget API support", () => {
     );
 
     it.each(["expression", "input-number", "numeric-input"])(
-        "%s widget should provide static getOneCorrectAnswerFromRubric",
+        "%s widget should provide static getOneCorrectAnswerFromRubric function",
         (widgetType) => {
             const Widget = Widgets.getWidget(widgetType);
             expect(Widget).toHaveProperty("getOneCorrectAnswerFromRubric");

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -126,6 +126,7 @@ export type {
     PerseusInteractiveGraphWidgetOptions,
     PerseusRadioWidgetOptions,
     PerseusExpressionWidgetOptions,
+    PerseusItem,
     PerseusRenderer,
 } from "./perseus-types";
 export type {Coord} from "./interactive2/types";

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -21,6 +21,7 @@ import Renderer from "./renderer";
 import Util from "./util";
 
 import type {KeypadProps} from "./mixins/provide-keypad";
+import type {PerseusItem} from "./perseus-types";
 import type {APIOptions, FocusPath, PerseusDependenciesV2} from "./types";
 import type {RendererInterface, KEScore} from "@khanacademy/perseus-core";
 
@@ -30,10 +31,7 @@ type OwnProps = // These props are used by the ProvideKeypad mixin.
     KeypadProps & {
         apiOptions: APIOptions;
         hintsVisible?: number;
-        item: {
-            hints: ReadonlyArray<any>;
-            question: any;
-        };
+        item: PerseusItem;
         problemNum?: number;
         reviewMode?: boolean;
         // from KeypadContext

--- a/packages/perseus/src/widgets/expression.tsx
+++ b/packages/perseus/src/widgets/expression.tsx
@@ -680,6 +680,18 @@ const ExpressionWithDependencies = React.forwardRef<
     return <Expression ref={ref} analytics={deps.analytics} {...props} />;
 });
 
+// HACK: Propogate "static" methods onto our wrapper component.
+// In the future we should adjust client apps to not depend on these static
+// methods and instead adjust Peresus to provide these facilities through
+// instance methods on our Renderers.
+// @ts-expect-error - TS2339 - Property 'validate' does not exist on type
+ExpressionWithDependencies.validate = Expression.validate;
+// @ts-expect-error - TS2339 - Property 'validate' does not exist on type
+ExpressionWithDependencies.validate = Expression.getUserInputFromProps;
+// @ts-expect-error - TS2339 - Property 'validate' does not exist on type
+ExpressionWithDependencies.getOneCorrectAnswerFromRubric =
+    Expression.getOneCorrectAnswerFromRubric;
+
 export default {
     name: "expression",
     displayName: "Expression / Equation",

--- a/packages/perseus/src/widgets/expression.tsx
+++ b/packages/perseus/src/widgets/expression.tsx
@@ -687,7 +687,8 @@ const ExpressionWithDependencies = React.forwardRef<
 // @ts-expect-error - TS2339 - Property 'validate' does not exist on type
 ExpressionWithDependencies.validate = Expression.validate;
 // @ts-expect-error - TS2339 - Property 'validate' does not exist on type
-ExpressionWithDependencies.validate = Expression.getUserInputFromProps;
+ExpressionWithDependencies.getUserInputFromProps =
+    Expression.getUserInputFromProps;
 // @ts-expect-error - TS2339 - Property 'validate' does not exist on type
 ExpressionWithDependencies.getOneCorrectAnswerFromRubric =
     Expression.getOneCorrectAnswerFromRubric;


### PR DESCRIPTION
## Summary:

In #601 I worked out providing our new V2 PerseusDependencies to the Expression component by wrapping it in a `forwardRef<>` functional component and using a hook to get access to the dependencies. 

This worked, until we discovered that there is code in some consuming applications that calls static functions on our Widget components. 

This PR patches the exported functional component to provide the same 3 static functions. In the future, we will want a more robust solution, possibly moving this functionality into our renderers so that consuming applications don't deal with widgets directly.

Issue: LC-1180

## Test plan:

`yarn test`

Wait for this PR to push a snapshot npm package and then integrate with Webapp and test.