### PR TITLE
[🔥AUDIT🔥] Revert type changes made in #694

### DIFF
--- a/.changeset/four-plants-divide.md
+++ b/.changeset/four-plants-divide.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Revert type changes made in #694

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -126,7 +126,6 @@ export type {
     PerseusInteractiveGraphWidgetOptions,
     PerseusRadioWidgetOptions,
     PerseusExpressionWidgetOptions,
-    PerseusItem,
     PerseusRenderer,
 } from "./perseus-types";
 export type {Coord} from "./interactive2/types";

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -9,29 +9,20 @@ export type Size = [number, number];
 // TODO(FEI-5054): Figure out how to get global .d.ts files working with monorepos
 type Empty = Record<never, never>;
 
-/**
- * Multi-item is a variant of a PerseusItem where the root object has a single
- * property `_multi` which is defined by a Shape object (see
- * packages/perseus/src/multi-items/shapes.ts).
- */
-export type PerseusMultiItem = {
+export type PerseusItem = {
+    // The details of the question being asked to the user.
+    question: PerseusRenderer;
+    // A collection of hints to be offered to the user that support answering the question.
+    hints: ReadonlyArray<PerseusRenderer>;
+    // Details about the tools the user might need to answer the question
+    answerArea: PerseusAnswerArea | null | undefined;
+    // Multi-item should only show up in Test Prep content and it is a variant of a PerseusItem
     _multi: any;
+    // The version of the item.  Not used by Perseus
+    itemDataVersion: Version;
+    // Deprecated field
+    answer: any;
 };
-
-export type PerseusItem =
-    | {
-          // The details of the question being asked to the user.
-          question: PerseusRenderer;
-          // A collection of hints to be offered to the user that support answering the question.
-          hints: ReadonlyArray<PerseusRenderer>;
-          // Details about the tools the user might need to answer the question
-          answerArea: PerseusAnswerArea | null | undefined;
-          // The version of the item.  Not used by Perseus
-          itemDataVersion: Version;
-          // Deprecated field
-          answer: any;
-      }
-    | PerseusMultiItem;
 
 export type PerseusArticle = ReadonlyArray<PerseusRenderer>;
 

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -9,20 +9,29 @@ export type Size = [number, number];
 // TODO(FEI-5054): Figure out how to get global .d.ts files working with monorepos
 type Empty = Record<never, never>;
 
-export type PerseusItem = {
-    // The details of the question being asked to the user.
-    question: PerseusRenderer;
-    // A collection of hints to be offered to the user that support answering the question.
-    hints: ReadonlyArray<PerseusRenderer>;
-    // Details about the tools the user might need to answer the question
-    answerArea: PerseusAnswerArea | null | undefined;
-    // Multi-item should only show up in Test Prep content and it is a variant of a PerseusItem
+/**
+ * Multi-item is a variant of a PerseusItem where the root object has a single
+ * property `_multi` which is defined by a Shape object (see
+ * packages/perseus/src/multi-items/shapes.ts).
+ */
+export type PerseusMultiItem = {
     _multi: any;
-    // The version of the item.  Not used by Perseus
-    itemDataVersion: Version;
-    // Deprecated field
-    answer: any;
 };
+
+export type PerseusItem =
+    | {
+          // The details of the question being asked to the user.
+          question: PerseusRenderer;
+          // A collection of hints to be offered to the user that support answering the question.
+          hints: ReadonlyArray<PerseusRenderer>;
+          // Details about the tools the user might need to answer the question
+          answerArea: PerseusAnswerArea | null | undefined;
+          // The version of the item.  Not used by Perseus
+          itemDataVersion: Version;
+          // Deprecated field
+          answer: any;
+      }
+    | PerseusMultiItem;
 
 export type PerseusArticle = ReadonlyArray<PerseusRenderer>;
 

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -21,7 +21,6 @@ import Renderer from "./renderer";
 import Util from "./util";
 
 import type {KeypadProps} from "./mixins/provide-keypad";
-import type {PerseusItem} from "./perseus-types";
 import type {APIOptions, FocusPath, PerseusDependenciesV2} from "./types";
 import type {RendererInterface, KEScore} from "@khanacademy/perseus-core";
 
@@ -31,7 +30,10 @@ type OwnProps = // These props are used by the ProvideKeypad mixin.
     KeypadProps & {
         apiOptions: APIOptions;
         hintsVisible?: number;
-        item: PerseusItem;
+        item: {
+            hints: ReadonlyArray<any>;
+            question: any;
+        };
         problemNum?: number;
         reviewMode?: boolean;
         // from KeypadContext


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:

Mea culpa.

In #694 I snuck in a seemingly tiny improvement to our Perseus types: switching the `item` prop on ServerItemRenderer to be a true `PerseusItem` (which it should be). 

However, in consuming apps there are many places where we pass in data that doesn't quite conform to this type. Many of these instances are in unit test data. 

Given that we have a somewhat urgent fix waiting on `main`, I'm reverting these small type changes and we can get them implemented in the future when we aren't trying to ship a bugfix as well. 

Issue: LC-1180

## Test plan:

Once integrated into our client apps, `yarn typecheck` should pass without issues.