### PR TITLE
Ensured that the mobile keypad is not visible to screen readers until it is opened.

### DIFF
--- a/.changeset/itchy-doors-greet.md
+++ b/.changeset/itchy-doors-greet.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Ensured that the keypad is hidden from screen readers when it is closed.

--- a/packages/math-input/src/components/keypad/mobile-keypad.tsx
+++ b/packages/math-input/src/components/keypad/mobile-keypad.tsx
@@ -227,7 +227,7 @@ const styles = StyleSheet.create({
         transform: "translate3d(0, 0, 0)",
     },
     inactiveKeypadContainer: {
-        display: "none",
+        visibility: "hidden",
     },
 });
 

--- a/packages/math-input/src/components/keypad/mobile-keypad.tsx
+++ b/packages/math-input/src/components/keypad/mobile-keypad.tsx
@@ -155,7 +155,9 @@ class MobileKeypad extends React.Component<Props, State> implements KeypadAPI {
         const containerStyle = [
             // internal styles
             styles.keypadContainer,
-            active ? styles.activeKeypadContainer : null,
+            active
+                ? styles.activeKeypadContainer
+                : styles.inactiveKeypadContainer,
             // styles passed as props
             ...(Array.isArray(style) ? style : [style]),
         ];
@@ -223,9 +225,11 @@ const styles = StyleSheet.create({
         transitionProperty: "transform",
         transform: "translate3d(0, 100%, 0)",
     },
-
     activeKeypadContainer: {
         transform: "translate3d(0, 0, 0)",
+    },
+    inactiveKeypadContainer: {
+        display: "none",
     },
 });
 

--- a/packages/math-input/src/components/keypad/mobile-keypad.tsx
+++ b/packages/math-input/src/components/keypad/mobile-keypad.tsx
@@ -163,50 +163,52 @@ class MobileKeypad extends React.Component<Props, State> implements KeypadAPI {
         const isExpression = keypadConfig?.keypadType === "EXPRESSION";
 
         return (
-            <View
-                style={containerStyle}
-                forwardRef={this._containerRef}
-                ref={(element) => {
-                    if (!this.hasMounted && element) {
-                        // TODO(matthewc)[LC-1081]: clean up this weird
-                        // object and type the onElementMounted callback
-                        // Append the dispatch methods that we want to expose
-                        // externally to the returned React element.
-                        const elementWithDispatchMethods = {
-                            ...element,
-                            activate: this.activate,
-                            dismiss: this.dismiss,
-                            configure: this.configure,
-                            setCursor: this.setCursor,
-                            setKeyHandler: this.setKeyHandler,
-                            getDOMNode: this.getDOMNode,
-                        } as const;
+            <div aria-hidden={!active}>
+                <View
+                    style={containerStyle}
+                    forwardRef={this._containerRef}
+                    ref={(element) => {
+                        if (!this.hasMounted && element) {
+                            // TODO(matthewc)[LC-1081]: clean up this weird
+                            // object and type the onElementMounted callback
+                            // Append the dispatch methods that we want to expose
+                            // externally to the returned React element.
+                            const elementWithDispatchMethods = {
+                                ...element,
+                                activate: this.activate,
+                                dismiss: this.dismiss,
+                                configure: this.configure,
+                                setCursor: this.setCursor,
+                                setKeyHandler: this.setKeyHandler,
+                                getDOMNode: this.getDOMNode,
+                            } as const;
 
-                        this.hasMounted = true;
-                        this.props.onElementMounted?.(
-                            elementWithDispatchMethods,
-                        );
-                    }
-                }}
-            >
-                <Keypad
-                    // TODO(jeremy)
-                    onAnalyticsEvent={async () => {}}
-                    extraKeys={keypadConfig?.extraKeys}
-                    onClickKey={(key) => this._handleClickKey(key)}
-                    cursorContext={cursor?.context}
-                    fractionsOnly={!isExpression}
-                    multiplicationDot={isExpression}
-                    divisionKey={isExpression}
-                    trigonometry={isExpression}
-                    preAlgebra={isExpression}
-                    logarithms={isExpression}
-                    basicRelations={isExpression}
-                    advancedRelations={isExpression}
-                    expandedView={containerWidth > expandedViewThreshold}
-                    showDismiss
-                />
-            </View>
+                            this.hasMounted = true;
+                            this.props.onElementMounted?.(
+                                elementWithDispatchMethods,
+                            );
+                        }
+                    }}
+                >
+                    <Keypad
+                        // TODO(jeremy)
+                        onAnalyticsEvent={async () => {}}
+                        extraKeys={keypadConfig?.extraKeys}
+                        onClickKey={(key) => this._handleClickKey(key)}
+                        cursorContext={cursor?.context}
+                        fractionsOnly={!isExpression}
+                        multiplicationDot={isExpression}
+                        divisionKey={isExpression}
+                        trigonometry={isExpression}
+                        preAlgebra={isExpression}
+                        logarithms={isExpression}
+                        basicRelations={isExpression}
+                        advancedRelations={isExpression}
+                        expandedView={containerWidth > expandedViewThreshold}
+                        showDismiss
+                    />
+                </View>
+            </div>
         );
     }
 }

--- a/packages/math-input/src/components/keypad/mobile-keypad.tsx
+++ b/packages/math-input/src/components/keypad/mobile-keypad.tsx
@@ -155,9 +155,7 @@ class MobileKeypad extends React.Component<Props, State> implements KeypadAPI {
         const containerStyle = [
             // internal styles
             styles.keypadContainer,
-            active
-                ? styles.activeKeypadContainer
-                : styles.inactiveKeypadContainer,
+            active && styles.activeKeypadContainer,
             // styles passed as props
             ...(Array.isArray(style) ? style : [style]),
         ];
@@ -219,15 +217,14 @@ const styles = StyleSheet.create({
         left: 0,
         right: 0,
         position: "fixed",
+        transitionProperty: "all",
         transition: `200ms ease-out`,
-        transitionProperty: "transform",
+        visibility: "hidden",
         transform: "translate3d(0, 100%, 0)",
     },
     activeKeypadContainer: {
         transform: "translate3d(0, 0, 0)",
-    },
-    inactiveKeypadContainer: {
-        visibility: "hidden",
+        visibility: "visible",
     },
 });
 

--- a/packages/math-input/src/components/keypad/mobile-keypad.tsx
+++ b/packages/math-input/src/components/keypad/mobile-keypad.tsx
@@ -165,52 +165,50 @@ class MobileKeypad extends React.Component<Props, State> implements KeypadAPI {
         const isExpression = keypadConfig?.keypadType === "EXPRESSION";
 
         return (
-            <div aria-hidden={!active}>
-                <View
-                    style={containerStyle}
-                    forwardRef={this._containerRef}
-                    ref={(element) => {
-                        if (!this.hasMounted && element) {
-                            // TODO(matthewc)[LC-1081]: clean up this weird
-                            // object and type the onElementMounted callback
-                            // Append the dispatch methods that we want to expose
-                            // externally to the returned React element.
-                            const elementWithDispatchMethods = {
-                                ...element,
-                                activate: this.activate,
-                                dismiss: this.dismiss,
-                                configure: this.configure,
-                                setCursor: this.setCursor,
-                                setKeyHandler: this.setKeyHandler,
-                                getDOMNode: this.getDOMNode,
-                            } as const;
+            <View
+                style={containerStyle}
+                forwardRef={this._containerRef}
+                ref={(element) => {
+                    if (!this.hasMounted && element) {
+                        // TODO(matthewc)[LC-1081]: clean up this weird
+                        // object and type the onElementMounted callback
+                        // Append the dispatch methods that we want to expose
+                        // externally to the returned React element.
+                        const elementWithDispatchMethods = {
+                            ...element,
+                            activate: this.activate,
+                            dismiss: this.dismiss,
+                            configure: this.configure,
+                            setCursor: this.setCursor,
+                            setKeyHandler: this.setKeyHandler,
+                            getDOMNode: this.getDOMNode,
+                        } as const;
 
-                            this.hasMounted = true;
-                            this.props.onElementMounted?.(
-                                elementWithDispatchMethods,
-                            );
-                        }
-                    }}
-                >
-                    <Keypad
-                        // TODO(jeremy)
-                        onAnalyticsEvent={async () => {}}
-                        extraKeys={keypadConfig?.extraKeys}
-                        onClickKey={(key) => this._handleClickKey(key)}
-                        cursorContext={cursor?.context}
-                        fractionsOnly={!isExpression}
-                        multiplicationDot={isExpression}
-                        divisionKey={isExpression}
-                        trigonometry={isExpression}
-                        preAlgebra={isExpression}
-                        logarithms={isExpression}
-                        basicRelations={isExpression}
-                        advancedRelations={isExpression}
-                        expandedView={containerWidth > expandedViewThreshold}
-                        showDismiss
-                    />
-                </View>
-            </div>
+                        this.hasMounted = true;
+                        this.props.onElementMounted?.(
+                            elementWithDispatchMethods,
+                        );
+                    }
+                }}
+            >
+                <Keypad
+                    // TODO(jeremy)
+                    onAnalyticsEvent={async () => {}}
+                    extraKeys={keypadConfig?.extraKeys}
+                    onClickKey={(key) => this._handleClickKey(key)}
+                    cursorContext={cursor?.context}
+                    fractionsOnly={!isExpression}
+                    multiplicationDot={isExpression}
+                    divisionKey={isExpression}
+                    trigonometry={isExpression}
+                    preAlgebra={isExpression}
+                    logarithms={isExpression}
+                    basicRelations={isExpression}
+                    advancedRelations={isExpression}
+                    expandedView={containerWidth > expandedViewThreshold}
+                    showDismiss
+                />
+            </View>
         );
     }
 }


### PR DESCRIPTION
## Summary:
This is a very simple little PR that adds "display: none" to our mobile keypad container when the keypad is closed. This ensures that the screen readers don't try to tab over the keypad while it's hidden from view. 

Issue: LC-1192

## Test plan:
make tesc 