### PR TITLE
fix oversized letter buttons

### DIFF
--- a/.changeset/hip-eagles-scream.md
+++ b/.changeset/hip-eagles-scream.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Resize letter SVGs

--- a/packages/math-input/src/components/keypad/button-assets.tsx
+++ b/packages/math-input/src/components/keypad/button-assets.tsx
@@ -754,10 +754,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -769,10 +769,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -784,10 +784,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -799,10 +799,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -814,10 +814,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -829,10 +829,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -844,10 +844,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -859,10 +859,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -874,10 +874,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -889,10 +889,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -904,10 +904,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -919,10 +919,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -934,10 +934,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -949,10 +949,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -964,10 +964,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -979,10 +979,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -994,10 +994,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1009,10 +1009,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1024,10 +1024,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1039,10 +1039,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1054,10 +1054,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1069,10 +1069,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1084,10 +1084,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1099,10 +1099,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1114,10 +1114,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1129,10 +1129,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1144,10 +1144,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1159,10 +1159,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1174,10 +1174,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1189,10 +1189,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1204,10 +1204,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1219,10 +1219,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1234,10 +1234,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1249,10 +1249,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1264,10 +1264,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1279,10 +1279,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1294,10 +1294,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1309,10 +1309,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1324,10 +1324,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1339,10 +1339,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1354,10 +1354,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1369,10 +1369,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1384,10 +1384,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1399,10 +1399,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1414,10 +1414,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1429,10 +1429,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1444,10 +1444,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1459,10 +1459,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1474,10 +1474,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1489,10 +1489,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1504,10 +1504,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"
@@ -1519,10 +1519,10 @@ export default function ButtonAsset({id}: Props): React.ReactElement {
             return (
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    width="44"
-                    height="44"
+                    width="40"
+                    height="40"
                     fill="none"
-                    viewBox="0 0 44 44"
+                    viewBox="2 2 40 40"
                 >
                     <path
                         fill="#21242C"


### PR DESCRIPTION
## Summary:
The SVGs were a little too big and this was making the whole keypad too big. I don't think we want the buttons to have fixed dimensions since we stretch them in mobile, but if this keeps happening we may want to figure out how to lock the SVG size.

Just making the SVGs height/width smaller though scaled the icons down. That's why I had to zoom/recenter the viewboxes.

Issue: LC-1159

## Test plan:
- Go to this story: `?path=/story/v2-keypad-with-mathquill--v-2-keypad-with-mathquill`
- Note the size of the keypad
- Go to the "extras" tab
- Note the size doesn't change