### PR TITLE
Fix MathQuillDirection types

### DIFF
--- a/.changeset/lovely-lies-attack.md
+++ b/.changeset/lovely-lies-attack.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Fix direction types for MathQuill interface

--- a/packages/math-input/src/components/input/mathquill-types.ts
+++ b/packages/math-input/src/components/input/mathquill-types.ts
@@ -1,8 +1,8 @@
 import type Key from "../../data/keys";
 
 export interface MathQuillInterface {
-    L: "L";
-    R: "R";
+    L: -1;
+    R: 1;
 
     /**
      * Creates an editable MathQuill initialized with the contents of the HTML


### PR DESCRIPTION
"L" and "R" should stand in for `-1` and `1`, respectively.