### PR TITLE
Focus Fixes for our Mobile Expression Keypad and MathInput 

### DIFF
--- a/.changeset/tasty-forks-push.md
+++ b/.changeset/tasty-forks-push.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": minor
+---
+
+Implemented some focus management fixes and improved the full-math-input story.

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -185,7 +185,7 @@ class MathInput extends React.Component<Props, State> {
             // dismissal. This code needs to be generalized to handle
             // multi-touch.
             if (this.state.focused && this.didTouchOutside && !this.didScroll) {
-                this.blur();
+                this.blur(true);
             }
 
             this.didTouchOutside = false;
@@ -332,9 +332,11 @@ class MathInput extends React.Component<Props, State> {
         }
     };
 
-    blur: () => void = () => {
+    blur: (callPropsOnBlur: Boolean) => void = (callPropsOnBlur: Boolean) => {
         this.mathField.blur();
-        this.props.onBlur && this.props.onBlur();
+        if (callPropsOnBlur) {
+            this.props.onBlur && this.props.onBlur();
+        }
         this.setState({focused: false, handle: {visible: false}});
     };
 
@@ -917,7 +919,7 @@ class MathInput extends React.Component<Props, State> {
                     }}
                     onBlur={() => {
                         this._hideCursorHandle();
-                        this.mathField.blur();
+                        this.blur(false);
                         this.setState({
                             focused: false,
                             handle: {visible: false},

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -908,10 +908,20 @@ class MathInput extends React.Component<Props, State> {
                 overrides.css. */}
                 <div
                     className="keypad-input"
-                    // @ts-expect-error - TS2322 - Type 'string' is not assignable to type 'number | undefined'.
-                    tabIndex={"0"}
+                    tabIndex={0}
                     ref={(node) => {
                         this.inputRef = node;
+                    }}
+                    onFocus={() => {
+                        this.focus();
+                    }}
+                    onBlur={() => {
+                        this._hideCursorHandle();
+                        this.mathField.blur();
+                        this.setState({
+                            focused: false,
+                            handle: {visible: false},
+                        });
                     }}
                     onKeyUp={this.handleKeyUp}
                 >

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -920,10 +920,6 @@ class MathInput extends React.Component<Props, State> {
                     onBlur={() => {
                         this._hideCursorHandle();
                         this.blur(false);
-                        this.setState({
-                            focused: false,
-                            handle: {visible: false},
-                        });
                     }}
                     onKeyUp={this.handleKeyUp}
                 >

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -332,7 +332,7 @@ class MathInput extends React.Component<Props, State> {
         }
     };
 
-    blur: (callPropsOnBlur: Boolean) => void = (callPropsOnBlur: Boolean) => {
+    blur: (callPropsOnBlur: boolean) => void = (callPropsOnBlur: boolean) => {
         this.mathField.blur();
         if (callPropsOnBlur) {
             this.props.onBlur && this.props.onBlur();

--- a/packages/math-input/src/components/keypad/mobile-keypad.tsx
+++ b/packages/math-input/src/components/keypad/mobile-keypad.tsx
@@ -99,13 +99,17 @@ class MobileKeypad extends React.Component<Props, State> implements KeypadAPI {
     };
 
     activate: () => void = () => {
-        this.setState({active: true});
+        if (!this.state.active) {
+            this.setState({active: true});
+        }
     };
 
     dismiss: () => void = () => {
-        this.setState({active: false}, () => {
-            this.props.onDismiss?.();
-        });
+        if (this.state.active) {
+            this.setState({active: false}, () => {
+                this.props.onDismiss?.();
+            });
+        }
     };
 
     configure: (configuration: KeypadConfiguration, cb: () => void) => void = (

--- a/packages/math-input/src/full-math-input.stories.tsx
+++ b/packages/math-input/src/full-math-input.stories.tsx
@@ -29,6 +29,8 @@ export const Basic = () => {
     // Whether the keypad is open or not
     const [keypadOpen, setKeypadOpen] = React.useState<boolean>(false);
 
+    const input = React.useRef<any>(null);
+
     const toggleKeypad = () => {
         if (keypadOpen) {
             keypadElement?.dismiss();
@@ -73,10 +75,13 @@ export const Basic = () => {
 
             <KeypadInput
                 value={value}
+                ref={input}
                 keypadElement={keypadElement}
                 onChange={(newValue, callback) => {
                     setValue(newValue);
-                    callback();
+                    if (callback) {
+                        callback();
+                    }
                 }}
                 onFocus={() => {
                     keypadElement?.activate();
@@ -91,6 +96,9 @@ export const Basic = () => {
                     if (node) {
                         setKeypadElement(node);
                     }
+                }}
+                onDismiss={() => {
+                    input.current?.blur();
                 }}
                 useV2Keypad={v2Keypad}
             />

--- a/packages/math-input/src/full-math-input.stories.tsx
+++ b/packages/math-input/src/full-math-input.stories.tsx
@@ -79,9 +79,7 @@ export const Basic = () => {
                 keypadElement={keypadElement}
                 onChange={(newValue, callback) => {
                     setValue(newValue);
-                    if (callback) {
-                        callback();
-                    }
+                    callback?.();
                 }}
                 onFocus={() => {
                     keypadElement?.activate();


### PR DESCRIPTION
## Summary:
Ensured that the input span is focusable via tab navigation and that we cannot accidentally create a callback loop with our updated focus. 

I also implemented a couple of fixes to our full math input story so that it doesn't error when trying to callback, and blurs the input upon closing the keypad.

A separate fix will be implemented in WebApp that ensures that closing the keypad in an exercise moves the focus to the "Check Answer" button. It will be attached to the same ticket number (LC-1193) as it is directly related to the issue.

 ## Video:
https://github.com/Khan/perseus/assets/12463099/b5b418f6-64b6-41e5-9d6d-1a7c13410a29


Issue: LC-1193

## Test plan:
make tesc