### PR TITLE
[Perseus Analytics] Plumb through onAnalyticsEvent to mobile keypad

### DIFF
--- a/.changeset/tiny-lions-worry.md
+++ b/.changeset/tiny-lions-worry.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": major
+---
+
+Added `onAnalyticsEvent` prop to MobileKeypad to pipe out Perseus analytics

--- a/packages/math-input/src/components/keypad-switch.tsx
+++ b/packages/math-input/src/components/keypad-switch.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import {MobileKeypad} from "./keypad";
 import LegacyKeypad from "./keypad-legacy";
 
+import type {AnalyticsEventHandlerFn} from "@khanacademy/perseus-core";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 type Props = {
@@ -11,6 +12,7 @@ type Props = {
     style?: StyleType;
 
     useV2Keypad?: boolean;
+    onAnalyticsEvent: AnalyticsEventHandlerFn;
 };
 
 function KeypadSwitch(props: Props) {
@@ -18,6 +20,9 @@ function KeypadSwitch(props: Props) {
 
     const KeypadComponent = useV2Keypad ? MobileKeypad : LegacyKeypad;
 
+    // Note: Although we pass the "onAnalyticsEvent" to both keypad components,
+    // only the current one uses it. There's no point in instrumenting the
+    // legacy keypad given that it's on its way out the door.
     return <KeypadComponent {...rest} />;
 }
 

--- a/packages/math-input/src/components/keypad/mobile-keypad.tsx
+++ b/packages/math-input/src/components/keypad/mobile-keypad.tsx
@@ -13,6 +13,7 @@ import type {
     KeyHandler,
     KeypadAPI,
 } from "../../types";
+import type {AnalyticsEventHandlerFn} from "@khanacademy/perseus-core";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 import Keypad from "./index";
@@ -32,6 +33,7 @@ type Props = {
     onElementMounted?: (arg1: any) => void;
     onDismiss?: () => void;
     style?: StyleType;
+    onAnalyticsEvent: AnalyticsEventHandlerFn;
 };
 
 type State = {
@@ -190,8 +192,7 @@ class MobileKeypad extends React.Component<Props, State> implements KeypadAPI {
                 }}
             >
                 <Keypad
-                    // TODO(jeremy)
-                    onAnalyticsEvent={async () => {}}
+                    onAnalyticsEvent={this.props.onAnalyticsEvent}
                     extraKeys={keypadConfig?.extraKeys}
                     onClickKey={(key) => this._handleClickKey(key)}
                     cursorContext={cursor?.context}

--- a/packages/math-input/src/full-math-input.stories.tsx
+++ b/packages/math-input/src/full-math-input.stories.tsx
@@ -1,3 +1,4 @@
+import {action} from "@storybook/addon-actions";
 import * as React from "react";
 
 import type {KeypadAPI} from "./types";
@@ -93,6 +94,7 @@ export const Basic = () => {
                     }
                 }}
                 useV2Keypad={v2Keypad}
+                onAnalyticsEvent={async (e) => action("onAnalyticsEvent")(e)}
             />
         </div>
     );

--- a/packages/perseus/src/mixins/provide-keypad.tsx
+++ b/packages/perseus/src/mixins/provide-keypad.tsx
@@ -103,6 +103,11 @@ const ProvideKeypad = {
                     // @ts-expect-error - TS2339 - Property 'props' does not exist on type '{ readonly propTypes: { readonly apiOptions: React.PropType<{ customKeypad?: boolean | undefined; nativeKeypadProxy?: ((...a: readonly any[]) => unknown) | undefined; }>; readonly keypadStyle: Requireable<any>; }; readonly getInitialState: () => { ...; }; readonly componentDidMount: () => void; readonly componentWil...'.
                     style={_this.props.keypadStyle}
                     useV2Keypad={apiOptions.useV2Keypad}
+                    onAnalyticsEvent={async () => {
+                        // Intentionally left empty. This component is
+                        // deprecated and so we don't want/need to instrument
+                        // it.
+                    }}
                 />,
                 _this._keypadContainer,
             );

--- a/packages/perseus/src/widgets/__stories__/test-keypad-context-wrapper.tsx
+++ b/packages/perseus/src/widgets/__stories__/test-keypad-context-wrapper.tsx
@@ -15,7 +15,6 @@ const Footer = (): React.ReactElement => {
                         style={styles.keypad}
                         useV2Keypad={true}
                         onAnalyticsEvent={async (e) => {
-                            console.log(e);
                             action("onAnalyticsEvent")(e);
                         }}
                     />

--- a/packages/perseus/src/widgets/__stories__/test-keypad-context-wrapper.tsx
+++ b/packages/perseus/src/widgets/__stories__/test-keypad-context-wrapper.tsx
@@ -1,5 +1,6 @@
 import {KeypadContext, MobileKeypad} from "@khanacademy/math-input";
 import {View} from "@khanacademy/wonder-blocks-core";
+import {action} from "@storybook/addon-actions";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
@@ -12,6 +13,11 @@ const Footer = (): React.ReactElement => {
                         onElementMounted={setKeypadElement}
                         onDismiss={() => renderer && renderer.blur()}
                         style={styles.keypad}
+                        useV2Keypad={true}
+                        onAnalyticsEvent={async (e) => {
+                            console.log(e);
+                            action("onAnalyticsEvent")(e);
+                        }}
                     />
                 )}
             </KeypadContext.Consumer>


### PR DESCRIPTION
## Summary:

I had missed plumbing the analytics prop through all the mobile keypad areas. So this PR adds them. ~In the case of the LegacyKeypad, I've not bothered to do analytics as that is going away soon!~ Changed my mind: https://github.com/Khan/perseus/pull/705

Issue: LC-950

## Test plan:

`yarn test`
`yarn start` (all stories with mobile keypad still work, and should show the keypad open/close events in the Storybook "Actions" panel)