### PR TITLE
[Perseus Analytics] Add keypad open/closed analytics to provided-keypad (legacy)

### DIFF
--- a/.changeset/sour-days-attend.md
+++ b/.changeset/sour-days-attend.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": major
+---
+
+Added onAnalyticsEvent prop to the LegacyKeypad (aka ProvidedKeypad). You must now pass in this prop, which is a function, to handle analytics events originating from the legacy keypad.

--- a/.changeset/tiny-lions-worry.md
+++ b/.changeset/tiny-lions-worry.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": major
+---
+
+Added `onAnalyticsEvent` prop to MobileKeypad to pipe out Perseus analytics

--- a/packages/math-input/src/components/keypad-legacy/provided-keypad.tsx
+++ b/packages/math-input/src/components/keypad-legacy/provided-keypad.tsx
@@ -18,12 +18,15 @@ import type {
     KeyHandler,
     KeypadAPI,
 } from "../../types";
+import type {AnalyticsEventHandlerFn} from "@khanacademy/perseus-core";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 type Props = {
     onElementMounted?: (arg1: any) => void;
     onDismiss?: () => void;
     style?: StyleType;
+
+    onAnalyticsEvent: AnalyticsEventHandlerFn;
 };
 
 class ProvidedKeypad extends React.Component<Props> implements KeypadAPI {
@@ -77,6 +80,13 @@ class ProvidedKeypad extends React.Component<Props> implements KeypadAPI {
             <Provider store={this.store}>
                 <KeypadContainer
                     onElementMounted={(element) => {
+                        this.props.onAnalyticsEvent({
+                            type: "math-input:keypad-opened",
+                            payload: {
+                                virtualKeypadVersion: "MATH_INPUT_KEYPAD_V1",
+                            },
+                        });
+
                         // Append the dispatch methods that we want to expose
                         // externally to the returned React element.
                         const elementWithDispatchMethods = {
@@ -88,10 +98,18 @@ class ProvidedKeypad extends React.Component<Props> implements KeypadAPI {
                             setKeyHandler: this.setKeyHandler,
                             getDOMNode: this.getDOMNode,
                         } as const;
-                        onElementMounted &&
-                            onElementMounted(elementWithDispatchMethods);
+                        onElementMounted?.(elementWithDispatchMethods);
                     }}
-                    onDismiss={onDismiss}
+                    onDismiss={() => {
+                        this.props.onAnalyticsEvent({
+                            type: "math-input:keypad-closed",
+                            payload: {
+                                virtualKeypadVersion: "MATH_INPUT_KEYPAD_V1",
+                            },
+                        });
+
+                        onDismiss?.();
+                    }}
                     style={style}
                 />
             </Provider>

--- a/packages/math-input/src/components/keypad-switch.tsx
+++ b/packages/math-input/src/components/keypad-switch.tsx
@@ -20,9 +20,6 @@ function KeypadSwitch(props: Props) {
 
     const KeypadComponent = useV2Keypad ? MobileKeypad : LegacyKeypad;
 
-    // Note: Although we pass the "onAnalyticsEvent" to both keypad components,
-    // only the current one uses it. There's no point in instrumenting the
-    // legacy keypad given that it's on its way out the door.
     return <KeypadComponent {...rest} />;
 }
 

--- a/packages/math-input/src/components/keypad-switch.tsx
+++ b/packages/math-input/src/components/keypad-switch.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import {MobileKeypad} from "./keypad";
 import LegacyKeypad from "./keypad-legacy";
 
+import type {AnalyticsEventHandlerFn} from "@khanacademy/perseus-core";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 type Props = {
@@ -11,6 +12,7 @@ type Props = {
     style?: StyleType;
 
     useV2Keypad?: boolean;
+    onAnalyticsEvent: AnalyticsEventHandlerFn;
 };
 
 function KeypadSwitch(props: Props) {
@@ -18,6 +20,9 @@ function KeypadSwitch(props: Props) {
 
     const KeypadComponent = useV2Keypad ? MobileKeypad : LegacyKeypad;
 
+    // Note: Although we pass the "onAnalyticsEvent" to both keypad components,
+    // only the current one uses it. There's no point in instrumenting the
+    // legacy keypad given that it's on its way out the door.
     return <KeypadComponent {...rest} />;
 }
 

--- a/packages/math-input/src/components/keypad/mobile-keypad.tsx
+++ b/packages/math-input/src/components/keypad/mobile-keypad.tsx
@@ -13,6 +13,7 @@ import type {
     KeyHandler,
     KeypadAPI,
 } from "../../types";
+import type {AnalyticsEventHandlerFn} from "@khanacademy/perseus-core";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 import Keypad from "./index";
@@ -32,6 +33,7 @@ type Props = {
     onElementMounted?: (arg1: any) => void;
     onDismiss?: () => void;
     style?: StyleType;
+    onAnalyticsEvent: AnalyticsEventHandlerFn;
 };
 
 type State = {
@@ -190,8 +192,7 @@ class MobileKeypad extends React.Component<Props, State> implements KeypadAPI {
                 }}
             >
                 <Keypad
-                    // TODO(jeremy)
-                    onAnalyticsEvent={async () => {}}
+                    onAnalyticsEvent={this.props.onAnalyticsEvent}
                     extraKeys={keypadConfig?.extraKeys}
                     onClickKey={(key) => this._handleClickKey(key)}
                     cursorContext={cursor?.context}

--- a/packages/math-input/src/full-math-input.stories.tsx
+++ b/packages/math-input/src/full-math-input.stories.tsx
@@ -1,3 +1,4 @@
+import {action} from "@storybook/addon-actions";
 import * as React from "react";
 
 import type {KeypadAPI} from "./types";
@@ -93,6 +94,7 @@ export const Basic = () => {
                     }
                 }}
                 useV2Keypad={v2Keypad}
+                onAnalyticsEvent={async (e) => action("onAnalyticsEvent")(e)}
             />
         </div>
     );

--- a/packages/perseus/src/mixins/provide-keypad.tsx
+++ b/packages/perseus/src/mixins/provide-keypad.tsx
@@ -103,6 +103,11 @@ const ProvideKeypad = {
                     // @ts-expect-error - TS2339 - Property 'props' does not exist on type '{ readonly propTypes: { readonly apiOptions: React.PropType<{ customKeypad?: boolean | undefined; nativeKeypadProxy?: ((...a: readonly any[]) => unknown) | undefined; }>; readonly keypadStyle: Requireable<any>; }; readonly getInitialState: () => { ...; }; readonly componentDidMount: () => void; readonly componentWil...'.
                     style={_this.props.keypadStyle}
                     useV2Keypad={apiOptions.useV2Keypad}
+                    onAnalyticsEvent={async () => {
+                        // Intentionally left empty. This component is
+                        // deprecated and so we don't want/need to instrument
+                        // it.
+                    }}
                 />,
                 _this._keypadContainer,
             );

--- a/packages/perseus/src/widgets/__stories__/test-keypad-context-wrapper.tsx
+++ b/packages/perseus/src/widgets/__stories__/test-keypad-context-wrapper.tsx
@@ -15,7 +15,6 @@ const Footer = (): React.ReactElement => {
                         style={styles.keypad}
                         useV2Keypad={true}
                         onAnalyticsEvent={async (e) => {
-                            console.log(e);
                             action("onAnalyticsEvent")(e);
                         }}
                     />

--- a/packages/perseus/src/widgets/__stories__/test-keypad-context-wrapper.tsx
+++ b/packages/perseus/src/widgets/__stories__/test-keypad-context-wrapper.tsx
@@ -1,5 +1,6 @@
 import {KeypadContext, MobileKeypad} from "@khanacademy/math-input";
 import {View} from "@khanacademy/wonder-blocks-core";
+import {action} from "@storybook/addon-actions";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
@@ -12,6 +13,11 @@ const Footer = (): React.ReactElement => {
                         onElementMounted={setKeypadElement}
                         onDismiss={() => renderer && renderer.blur()}
                         style={styles.keypad}
+                        useV2Keypad={true}
+                        onAnalyticsEvent={async (e) => {
+                            console.log(e);
+                            action("onAnalyticsEvent")(e);
+                        }}
                     />
                 )}
             </KeypadContext.Consumer>


### PR DESCRIPTION
## Summary:

This PR adds in the analytics (keypad open/closed) events for our legacy keypad. It won't be around much longer, but while it's here we'll be able to compare usage.

I agonized a bit that there are no tests, but this entire component area doesn't have any tests. I'll look a bit further, but might just leave it as this is a legacy (soon to be deprecated) component.

Issue: LC-950

## Test plan: