### PR TITLE
[Perseus Analytics] Add and implement 'perseus:expression-focused' event

### DIFF
--- a/.changeset/lucky-maps-relax.md
+++ b/.changeset/lucky-maps-relax.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Add new Perseus analytics event: 'perseus:expression-focused'. This event is fired any time the expression widget input box receives focus.

--- a/packages/perseus-core/src/analytics.ts
+++ b/packages/perseus-core/src/analytics.ts
@@ -15,6 +15,10 @@ export type PerseusAnalyticsEvent =
           };
       }
     | {
+          type: "perseus:expression-focused";
+          payload: null;
+      }
+    | {
           type: "math-input:keypad-closed";
           payload: {
               virtualKeypadVersion: VirtualKeypadVersion;

--- a/packages/perseus/src/widgets/expression.tsx
+++ b/packages/perseus/src/widgets/expression.tsx
@@ -422,6 +422,11 @@ export class Expression extends React.Component<Props, ExpressionState> {
     };
 
     _handleFocus: () => void = () => {
+        this.props.analytics.onAnalyticsEvent({
+            type: "perseus:expression-focused",
+            payload: null,
+        });
+
         /* c8 ignore next */
         this.props.onFocus([]);
     };


### PR DESCRIPTION
## Summary:

This PR implements a new analytics event: `perseus:expression-focused`. This event is fired whenever the `expression` widget input receives focus. 

Issue: LC-861

## Test plan:

`yarn test`
`yarn typecheck`