### PR TITLE
check for ResizeObserver before using it

### DIFF
--- a/.changeset/wet-toes-live.md
+++ b/.changeset/wet-toes-live.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Check for ResizeObserver before using it

--- a/packages/math-input/src/components/keypad-legacy/keypad-container.tsx
+++ b/packages/math-input/src/components/keypad-legacy/keypad-container.tsx
@@ -79,12 +79,18 @@ class KeypadContainer extends React.Component<Props, State> {
             this._throttleResizeHandler,
         );
 
-        this._containerResizeObserver = new ResizeObserver(
-            this._throttleResizeHandler,
-        );
+        // LC-1213: some common older browsers (as of 2023-09-07)
+        // don't support ResizeObserver
+        if ("ResizeObserver" in window) {
+            this._containerResizeObserver = new window.ResizeObserver(
+                this._throttleResizeHandler,
+            );
 
-        if (this._containerRef.current) {
-            this._containerResizeObserver.observe(this._containerRef.current);
+            if (this._containerRef.current) {
+                this._containerResizeObserver.observe(
+                    this._containerRef.current,
+                );
+            }
         }
     }
 

--- a/packages/math-input/src/components/keypad/mobile-keypad.tsx
+++ b/packages/math-input/src/components/keypad/mobile-keypad.tsx
@@ -62,12 +62,18 @@ class MobileKeypad extends React.Component<Props, State> implements KeypadAPI {
             this._throttleResizeHandler,
         );
 
-        this._containerResizeObserver = new ResizeObserver(
-            this._throttleResizeHandler,
-        );
+        // LC-1213: some common older browsers (as of 2023-09-07)
+        // don't support ResizeObserver
+        if ("ResizeObserver" in window) {
+            this._containerResizeObserver = new window.ResizeObserver(
+                this._throttleResizeHandler,
+            );
 
-        if (this._containerRef.current) {
-            this._containerResizeObserver.observe(this._containerRef.current);
+            if (this._containerRef.current) {
+                this._containerResizeObserver.observe(
+                    this._containerRef.current,
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Summary:
This is basically the same thing they're doing in Webapp, I just didn't notice it before.

Issue: LC-1213

## Test plan:
Not really sure how to write tests for this...maybe I could mock the whole `window` object and just not include `ResizeObserver`? Originally I was going to do something like `window.ResizeObserver = undefined`, but interestingly:

``` JS
window.ResizeObserver = undefined
console.log("ResizeObserver" in window) // true
```

I was able to manually test with `delete`

``` JS
delete window.ResizeObserver
console.log("ResizeObserver" in window) // false
```

Just wasn't sure how to translate that to tests.

Manually testing the regression though:
- Use a mobile web browser or emulate mobile
- Use a browser that doesn't support ResizeObserver (Safari <13.1)
- Go to a page with an [Expression widget](https://www.khanacademy.org/internal-courses/test-everything/test-everything-1/expression/e/expression-exercise)
- Note that rendering the exercise doesn't result in an error