### PR TITLE
Bump perseus-core (missed in previous release)

### DIFF
--- a/.changeset/poor-bikes-complain.md
+++ b/.changeset/poor-bikes-complain.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": minor
+---
+
+Added new analytics event "perseus:expression-focused"

--- a/packages/perseus-core/src/analytics.ts
+++ b/packages/perseus-core/src/analytics.ts
@@ -4,8 +4,10 @@ export type VirtualKeypadVersion =
     | "MATH_INPUT_KEYPAD_V2"
     | "REACT_NATIVE_KEYPAD";
 
-// A type union of all the events that any package in the Perseus ecosystem can
-// send.
+/**
+ * A type union of all the events that any package in the Perseus ecosystem can
+ * send.
+ */
 export type PerseusAnalyticsEvent =
     | {
           type: "perseus:expression-evaluated";
@@ -33,6 +35,10 @@ export type PerseusAnalyticsEvent =
 // Add more events here as needed. Note that each event should have a `type`
 // key and a payload that varies by type.
 // | {type: "b"; payload: {name: string}};
+//
+// Event types should be formatted as "package-name:event-name" (where the
+// package name is the name of the package that emits the event without the
+// `@khanacademy/` prefix and then the name of the event.)
 
 /** A function that is called when Perseus emits an analytics event. */
 export type AnalyticsEventHandlerFn = (


### PR DESCRIPTION
## Summary:

In #707 I introduced a new analytics event (`perseus:expression-focused`) and implemented in Perseus. I missed marking `@khanacademy/perseus-core` as having a change in the changeset and none of our tooling warned, so the release went out without bumping that package, or the dependencies that used it. 

This PR is an attempt to just get core to version, which should version the packages that depend on it. 

Issue: LC-861

## Test plan:

`yarn test`