### PR TITLE
Change packages that are lagging on npmjs.com

### DIFF
--- a/.changeset/big-eagles-perform.md
+++ b/.changeset/big-eagles-perform.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-linter": patch
+---
+
+Convert runLinter doc comment to /\*\* \*/ format so editors pick it up better (VSCode).

--- a/.changeset/green-experts-jam.md
+++ b/.changeset/green-experts-jam.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-error": patch
+---
+
+Add comments for `Options` type.

--- a/.changeset/ten-bags-battle.md
+++ b/.changeset/ten-bags-battle.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/pure-markdown": patch
+---
+
+Move comment for mathMatcher to connect to it (so editors display it correctly).

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -184,8 +184,6 @@ jobs:
                 os: [ubuntu-latest]
                 node-version: [16.x]
         steps:
-            - name: Debugging!
-              run: echo ${{ github.head_ref }}
             - name: Checking out latest commit
               uses: actions/checkout@v2
 

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -185,7 +185,11 @@ jobs:
                 node-version: [16.x]
         steps:
             - name: Debugging!
-              run: echo ${{ github.head_ref }}
+              run: |
+                echo ${{ github.head_ref }}
+                echo ${{ github.ref_name }}
+                echo ${{ github.ref }}
+                exit 1
             - name: Checking out latest commit
               uses: actions/checkout@v2
 

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -185,11 +185,7 @@ jobs:
                 node-version: [16.x]
         steps:
             - name: Debugging!
-              run: |
-                echo ${{ github.head_ref }}
-                echo ${{ github.ref_name }}
-                echo ${{ github.ref }}
-                exit 1
+              run: echo ${{ github.head_ref }}
             - name: Checking out latest commit
               uses: actions/checkout@v2
 

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -184,6 +184,8 @@ jobs:
                 os: [ubuntu-latest]
                 node-version: [16.x]
         steps:
+            - name: Debugging!
+              run: echo ${{ github.head_ref }}
             - name: Checking out latest commit
               uses: actions/checkout@v2
 

--- a/packages/perseus-error/src/index.ts
+++ b/packages/perseus-error/src/index.ts
@@ -43,6 +43,9 @@ export const Errors = Object.freeze({
  */
 export type ErrorKind = typeof Errors[keyof typeof Errors];
 
+/**
+ * Optional extra information passed to the `PerseusError` constructor.
+ */
 type Options = {
     metadata?: Metadata | null | undefined;
 };

--- a/packages/perseus-linter/src/index.ts
+++ b/packages/perseus-linter/src/index.ts
@@ -11,30 +11,30 @@ const allLintRules: ReadonlyArray<any> = AllRules.filter(
 
 export {Rule, allLintRules as rules};
 
-//
-// Run the Perseus linter over the specified markdown parse tree,
-// with the specified context object, and
-// return a (possibly empty) array of lint warning objects.  If the
-// highlight argument is true, this function also modifies the parse
-// tree to add "lint" nodes that can be visually rendered,
-// highlighting the problems for the user. The optional rules argument
-// is an array of Rule objects specifying which lint rules should be
-// applied to this parse tree. When omitted, a default set of rules is used.
-//
-// The context object may have additional properties that some lint
-// rules require:
-//
-//   context.content is the source content string that was parsed to create
-//   the parse tree.
-//
-//   context.widgets is the widgets object associated
-//   with the content string
-//
-// TODO: to make this even more general, allow the first argument to be
-// a string and run the parser over it in that case? (but ignore highlight
-// in that case). This would allow the one function to be used for both
-// online linting and batch linting.
-//
+/**
+ * Run the Perseus linter over the specified markdown parse tree,
+ * with the specified context object, and
+ * return a (possibly empty) array of lint warning objects.  If the
+ * highlight argument is true, this function also modifies the parse
+ * tree to add "lint" nodes that can be visually rendered,
+ * highlighting the problems for the user. The optional rules argument
+ * is an array of Rule objects specifying which lint rules should be
+ * applied to this parse tree. When omitted, a default set of rules is used.
+ *
+ * The context object may have additional properties that some lint
+ * rules require:
+ *
+ *   context.content is the source content string that was parsed to create
+ *   the parse tree.
+ *
+ *   context.widgets is the widgets object associated
+ *   with the content string
+ *
+ * TODO: to make this even more general, allow the first argument to be
+ * a string and run the parser over it in that case? (but ignore highlight
+ * in that case). This would allow the one function to be used for both
+ * online linting and batch linting.
+ */
 export function runLinter(
     tree: any,
     context: any,

--- a/packages/pure-markdown/src/index.ts
+++ b/packages/pure-markdown/src/index.ts
@@ -6,6 +6,8 @@
  */
 import SimpleMarkdown from "@khanacademy/simple-markdown";
 
+const rWidgetRule = /^\[\[\u2603 (([a-z-]+) ([0-9]+))\]\]/;
+
 /**
  * This match function matches math in `$`s, such as:
  *
@@ -28,9 +30,6 @@ import SimpleMarkdown from "@khanacademy/simple-markdown";
  *
  * This can also match block-math, which is math alone in a paragraph.
  */
-
-const rWidgetRule = /^\[\[\u2603 (([a-z-]+) ([0-9]+))\]\]/;
-
 const mathMatcher = (source: any, state: any, isBlock: boolean) => {
     const length = source.length;
     let index = 0;


### PR DESCRIPTION
## Summary:

While working on integrating the latest released Perseus changes, I noticed that there are still 3 packages that have changes in the repo that aren't up to date on npmjs.com:

npmjs.com

```
@khanacademy/perseus-error     => 0.2.1
@khanacademy/perseus-linter    => 0.3.2
@khanacademy/pure-markdown     => 0.2.2
```

Locally:
```
packages/perseus-error/package.json   "0.2.2" !!
packages/perseus-linter/package.json  "0.3.3" !!
packages/pure-markdown/package.json   "0.2.5" !!
```

So this PR "bumps" each package with a comment-only change in order to force these packages to be released to npm on the next release. 

Issue: LC-1165

## Test plan:

Watch the next Version Packages PR that we land.