### PR TITLE
Add hasBeenActivated to v2 keypad

### DIFF
--- a/.changeset/tame-kangaroos-eat.md
+++ b/.changeset/tame-kangaroos-eat.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Hide v2 mobile MathInput keypad when it's never been activated

--- a/packages/math-input/src/components/keypad/mobile-keypad.tsx
+++ b/packages/math-input/src/components/keypad/mobile-keypad.tsx
@@ -39,6 +39,7 @@ type Props = {
 type State = {
     active: boolean;
     containerWidth: number;
+    hasBeenActivated: boolean;
     keypadConfig?: KeypadConfiguration;
     keyHandler?: KeyHandler;
     cursor?: Cursor;
@@ -53,6 +54,7 @@ class MobileKeypad extends React.Component<Props, State> implements KeypadAPI {
     state: State = {
         active: false,
         containerWidth: 0,
+        hasBeenActivated: false,
     };
 
     componentDidMount() {
@@ -107,7 +109,10 @@ class MobileKeypad extends React.Component<Props, State> implements KeypadAPI {
     };
 
     activate: () => void = () => {
-        this.setState({active: true});
+        this.setState({
+            active: true,
+            hasBeenActivated: true,
+        });
     };
 
     dismiss: () => void = () => {
@@ -158,12 +163,18 @@ class MobileKeypad extends React.Component<Props, State> implements KeypadAPI {
 
     render(): React.ReactNode {
         const {style} = this.props;
-        const {active, containerWidth, cursor, keypadConfig} = this.state;
+        const {active, hasBeenActivated, containerWidth, cursor, keypadConfig} =
+            this.state;
 
         const containerStyle = [
             // internal styles
             styles.keypadContainer,
             active && styles.activeKeypadContainer,
+            // If the keypad is yet to have ever been activated, we keep it invisible
+            // so as to avoid, e.g., the keypad flashing at the bottom of the page
+            // during the initial render.
+            // Done inline since stylesheets might not be loaded yet.
+            !hasBeenActivated && {visibility: "hidden"},
             // styles passed as props
             ...(Array.isArray(style) ? style : [style]),
         ];

--- a/packages/math-input/src/components/keypad/mobile-keypad.tsx
+++ b/packages/math-input/src/components/keypad/mobile-keypad.tsx
@@ -170,20 +170,25 @@ class MobileKeypad extends React.Component<Props, State> implements KeypadAPI {
             // internal styles
             styles.keypadContainer,
             active && styles.activeKeypadContainer,
-            // If the keypad is yet to have ever been activated, we keep it invisible
-            // so as to avoid, e.g., the keypad flashing at the bottom of the page
-            // during the initial render.
-            // Done inline since stylesheets might not be loaded yet.
-            !hasBeenActivated && {visibility: "hidden"},
             // styles passed as props
             ...(Array.isArray(style) ? style : [style]),
         ];
+
+        // If the keypad is yet to have ever been activated, we keep it invisible
+        // so as to avoid, e.g., the keypad flashing at the bottom of the page
+        // during the initial render.
+        // Done inline (dynamicStyle) since stylesheets might not be loaded yet.
+        let dynamicStyle = {};
+        if (!active && !hasBeenActivated) {
+            dynamicStyle = {visibility: "hidden"};
+        }
 
         const isExpression = keypadConfig?.keypadType === "EXPRESSION";
 
         return (
             <View
                 style={containerStyle}
+                dynamicStyle={dynamicStyle}
                 forwardRef={this._containerRef}
                 ref={(element) => {
                     if (!this.hasMounted && element) {


### PR DESCRIPTION
## Summary:
I did this in another PR but then removed it because I thought Third had already solved the issue.

Basically we just need to add the `visibility: hidden` to `dynamicStyle` so it's hidden from the start.

Issue: LC-1273

## Test plan:
- Emulate mobile
- Turn on v2 keypad
- Go to a page with MathInput
- The keypad should not flicker during the initial load

Before:

https://github.com/Khan/perseus/assets/16308368/e9a63104-ba88-4492-b09b-63e851888d57

After:

https://github.com/Khan/perseus/assets/16308368/d7b58289-8545-4e2f-b289-0a0bd7bdd928
