### PR TITLE
Bugfix: make FRAC buttons use the same FRAC

### DIFF
--- a/.changeset/fresh-countries-sleep.md
+++ b/.changeset/fresh-countries-sleep.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Bugfix: v1 and v2 keypad using different FRAC configs

--- a/packages/math-input/src/components/keypad/__tests__/__snapshots__/keypad.test.tsx.snap
+++ b/packages/math-input/src/components/keypad/__tests__/__snapshots__/keypad.test.tsx.snap
@@ -657,7 +657,7 @@ exports[`keypad should snapshot expanded: first render 1`] = `
           >
             <button
               aria-disabled="false"
-              aria-label="Fraction, with current expression in numerator"
+              aria-label="Fraction, excluding the current expression"
               class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-clickable_rukhmf"
               type="button"
             >
@@ -1681,7 +1681,7 @@ exports[`keypad should snapshot unexpanded: first render 1`] = `
           >
             <button
               aria-disabled="false"
-              aria-label="Fraction, with current expression in numerator"
+              aria-label="Fraction, excluding the current expression"
               class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4-o_O-clickable_rukhmf"
               type="button"
             >

--- a/packages/math-input/src/components/keypad/shared-keys.tsx
+++ b/packages/math-input/src/components/keypad/shared-keys.tsx
@@ -48,7 +48,7 @@ export default function SharedKeys(props: Props) {
                 secondary
             />
             <KeypadButton
-                keyConfig={Keys.FRAC_INCLUSIVE}
+                keyConfig={Keys.FRAC}
                 onClickKey={onClickKey}
                 coord={fractionCoord}
                 secondary


### PR DESCRIPTION
## Summary:
v1 keypad was using `FRAC` and v2 keypad was using `FRAC_INCLUSIVE`.

Issue: LC-1267

## Test plan:
- Go to v1 keypad in "Expression" mode
- Type a number
- Hit the fraction button
- Note that the number does not become the numerator
- Go to v2 keypad in "Expression" mode
- Type a number
- Hit the fraction button
- Note that the number does not become the numerator (previously it did)