### PR TITLE
Verify that there is a changeset for every changed package

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -16,14 +16,26 @@ jobs:
                 os: [ubuntu-latest]
                 node-version: [16.x]
         steps:
-            # We don't need changesets for infrastructure-type files (tests, stories,
-            # etc).
-            - uses: Khan/changeset-per-package@v0.0.0
-              if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+            - name: Checkout repository
+              uses: actions/checkout@v4
               with:
-                  exclude_extensions: .test.ts, .test.tsx, .stories.ts, .stories.tsx
-                  # Inverted match for ./packages to exclude everything but packages
-                  exclude_globs: "**/__tests__/*, **/__stories__/*, **/dist/*, !(./packages/**/*.{ts,tsx,js,html,css,md,json})"
+                  fetch-depth: 0
+
+            - name: Get changed files
+              uses: Khan/actions@get-changed-files-v1
+              id: changed
+
+            - name: Filter out files that don't need a changeset
+              uses: Khan/actions@filter-files-v0
+              id: match
+              with:
+                  changed-files: ${{ steps.changed.outputs.files }}
+                  files: packages/ # Only look for changes in packages
+
+            - name: Verify changeset entries
+              uses: Khan/changeset-per-package@v1.0.0
+              with:
+                  changed_files: ${{ steps.match.outputs.filtered }}
 
     lint:
         name: Lint, Typecheck, Format, and Test

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -32,7 +32,9 @@ jobs:
               with:
                   changed-files: ${{ steps.changed.outputs.files }}
                   files: packages/ # Only look for changes in packages
-                  globs: "!(**/__tests__/*), !(**/__stories__/*), !(**/dist/*)" # Ignore test files and dist files
+                  globs:
+                      "!(**/__tests__/*)" # Ignore test files, but not stories
+                      # so that we can release docs
 
             - name: Verify changeset entries
               uses: Khan/changeset-per-package@v1.0.0

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -16,8 +16,6 @@ jobs:
                 os: [ubuntu-latest]
                 node-version: [16.x]
         steps:
-            - name: Checking out latest commit
-              uses: actions/checkout@v4
             # We don't need changesets for infrastructure-type files (tests, stories,
             # etc).
             - uses: Khan/changeset-per-package@v0.0.0

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -32,6 +32,7 @@ jobs:
               with:
                   changed-files: ${{ steps.changed.outputs.files }}
                   files: packages/ # Only look for changes in packages
+                  globs: "!(**/__tests__/*), !(**/__stories__/*), !(**/dist/*)"
 
             - name: Verify changeset entries
               uses: Khan/changeset-per-package@v1.0.0

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -35,7 +35,7 @@ jobs:
                   globs: "!(**/__tests__/*), !(**/__stories__/*), !(**/dist/*)" # Ignore test files
 
             - name: Verify changeset entries
-              uses: Khan/changeset-per-package@v1.0.0
+              uses: Khan/changeset-per-package@v1.0.1
               with:
                   changed_files: ${{ steps.match.outputs.filtered }}
 

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -32,7 +32,7 @@ jobs:
               with:
                   changed-files: ${{ steps.changed.outputs.files }}
                   files: packages/ # Only look for changes in packages
-                  globs: "!(**/__tests__/*), !(**/__stories__/*), !(**/dist/*)"
+                  globs: "!(**/__tests__/*), !(**/__stories__/*), !(**/dist/*)" # Ignore test files and dist files
 
             - name: Verify changeset entries
               uses: Khan/changeset-per-package@v1.0.0

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
     changeset:
-        name: Check for .changeset file
+        name: Check for .changeset entries for all changed files
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
@@ -18,12 +18,12 @@ jobs:
         steps:
             # We don't need changesets for infrastructure-type files (tests, stories,
             # etc).
-            - uses: Khan/actions@check-for-changeset-v0
+            - uses: Khan/changeset-per-package@v0.0.0
               if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
               with:
                   exclude_extensions: .test.ts, .test.tsx, .stories.ts, .stories.tsx
                   # Inverted match for ./packages to exclude everything but packages
-                  exclude_globs: "**/__tests__/*, **/__stories__/*, **/dist/*, !(./packages/**/*.{ts,tsx,js,html,css,md})"
+                  exclude_globs: "**/__tests__/*, **/__stories__/*, **/dist/*, !(./packages/**/*.{ts,tsx,js,html,css,md,json})"
 
     lint:
         name: Lint, Typecheck, Format, and Test

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -16,6 +16,8 @@ jobs:
                 os: [ubuntu-latest]
                 node-version: [16.x]
         steps:
+            - name: Checking out latest commit
+              uses: actions/checkout@v4
             # We don't need changesets for infrastructure-type files (tests, stories,
             # etc).
             - uses: Khan/changeset-per-package@v0.0.0

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -32,9 +32,7 @@ jobs:
               with:
                   changed-files: ${{ steps.changed.outputs.files }}
                   files: packages/ # Only look for changes in packages
-                  globs:
-                      "!(**/__tests__/*)" # Ignore test files, but not stories
-                      # so that we can release docs
+                  globs: "!(**/__tests__/*), !(**/__stories__/*), !(**/dist/*)" # Ignore test files and dist files
 
             - name: Verify changeset entries
               uses: Khan/changeset-per-package@v1.0.0

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -10,6 +10,7 @@ on:
 jobs:
     changeset:
         name: Check for .changeset entries for all changed files
+        if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -32,7 +32,7 @@ jobs:
               with:
                   changed-files: ${{ steps.changed.outputs.files }}
                   files: packages/ # Only look for changes in packages
-                  globs: "!(**/__tests__/*), !(**/__stories__/*), !(**/dist/*)" # Ignore test files and dist files
+                  globs: "!(**/__tests__/*), !(**/__stories__/*), !(**/dist/*)" # Ignore test files
 
             - name: Verify changeset entries
               uses: Khan/changeset-per-package@v1.0.0


### PR DESCRIPTION
Switches out `check-for-changeset`, a github action that looks for the presence of a changeset file, for `changeset-per-package`, a new action that verifies that there is a changeset entry for each package with changes.

For details, see [the action repo](https://github.com/Khan/changeset-per-package).