### PR TITLE
Fixing a typo in mobile-keypad's unmount lifecycle. 

### DIFF
--- a/.changeset/wild-suns-explain.md
+++ b/.changeset/wild-suns-explain.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": minor
+---
+
+Ensured that we're properly calling componentWillUnmount

--- a/packages/math-input/src/components/keypad/mobile-keypad.tsx
+++ b/packages/math-input/src/components/keypad/mobile-keypad.tsx
@@ -81,7 +81,7 @@ class MobileKeypad extends React.Component<Props, State> implements KeypadAPI {
         }
     }
 
-    componentWillUnMount() {
+    componentWillUnmount() {
         window.removeEventListener("resize", this._throttleResizeHandler);
         window.removeEventListener(
             "orientationchange",


### PR DESCRIPTION
## Summary:
Turns out the memory leak was a simple little typo on a react lifecycle. Fixing that allows us to properly call _ComponentWillUnmount_, which removes all of our event listeners and observers related to resizing the keypad.

## Video:
https://github.com/Khan/perseus/assets/12463099/ea18a0c6-d700-4137-b8ce-cafebded9683

## Ticket: LC-1272

## Test Plan:
- make tesc
- manual testing 
