### PR TITLE
Add keypadActive state to context

### DIFF
--- a/.changeset/tall-mangos-poke.md
+++ b/.changeset/tall-mangos-poke.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/math-input": major
+"@khanacademy/perseus": patch
+---
+
+Hoist keypad active state into keypad context

--- a/packages/math-input/src/components/keypad-context.tsx
+++ b/packages/math-input/src/components/keypad-context.tsx
@@ -14,6 +14,8 @@ import type {KeypadAPI, KeypadContext as KeypadContextType} from "../types";
 // @ts-expect-error - TS2322 - Type 'Context<{ setKeypadElement: (keypadElement: HTMLElement | null | undefined) => void; keypadElement: null; setRenderer: (renderer: RendererInterface | null | undefined) => void; renderer: null; setScrollableElement: (scrollableElement: HTMLElement | ... 1 more ... | undefined) => void; scrollableElement: null; }>' is not assignable to type 'Context<KeypadContext>'.
 export const keypadContext: React.Context<KeypadContextType> =
     React.createContext({
+        setKeypadActive: (keypadActive) => {},
+        keypadActive: false,
         setKeypadElement: (keypadElement) => {},
         keypadElement: null,
         setRenderer: (renderer) => {},
@@ -25,6 +27,8 @@ export const keypadContext: React.Context<KeypadContextType> =
 type Props = React.PropsWithChildren<unknown>;
 
 export function StatefulKeypadContextProvider(props: Props) {
+    // whether or not to display the keypad
+    const [keypadActive, setKeypadActive] = useState<boolean>(false);
     // used to communicate between the keypad and the Renderer
     const [keypadElement, setKeypadElement] = useState<KeypadAPI | null>();
     // this is a KeypadContextRendererInterface from Perseus
@@ -35,6 +39,8 @@ export function StatefulKeypadContextProvider(props: Props) {
     return (
         <keypadContext.Provider
             value={{
+                setKeypadActive,
+                keypadActive,
                 setKeypadElement,
                 keypadElement,
                 setRenderer,

--- a/packages/math-input/src/components/keypad-legacy/provided-keypad.tsx
+++ b/packages/math-input/src/components/keypad-legacy/provided-keypad.tsx
@@ -22,6 +22,8 @@ import type {AnalyticsEventHandlerFn} from "@khanacademy/perseus-core";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 type Props = {
+    setKeypadActive: (keypadActive: boolean) => void;
+    keypadActive: boolean;
     onElementMounted?: (arg1: any) => void;
     onDismiss?: () => void;
     style?: StyleType;
@@ -37,12 +39,22 @@ class ProvidedKeypad extends React.Component<Props> implements KeypadAPI {
         this.store = createStore();
     }
 
+    componentDidUpdate(prevProps) {
+        if (this.props.keypadActive && !prevProps.keypadActive) {
+            this.store.dispatch(activateKeypad());
+        }
+
+        if (!this.props.keypadActive && prevProps.keypadActive) {
+            this.store.dispatch(dismissKeypad());
+        }
+    }
+
     activate: () => void = () => {
-        this.store.dispatch(activateKeypad());
+        this.props.setKeypadActive(true);
     };
 
     dismiss: () => void = () => {
-        this.store.dispatch(dismissKeypad());
+        this.props.setKeypadActive(false);
     };
 
     configure: (configuration: KeypadConfiguration, cb: () => void) => void = (

--- a/packages/math-input/src/components/keypad-switch.tsx
+++ b/packages/math-input/src/components/keypad-switch.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import {MobileKeypad} from "./keypad";
+import {keypadContext} from "./keypad-context";
 import LegacyKeypad from "./keypad-legacy";
 
 import type {AnalyticsEventHandlerFn} from "@khanacademy/perseus-core";
@@ -23,7 +24,19 @@ function KeypadSwitch(props: Props) {
     // Note: Although we pass the "onAnalyticsEvent" to both keypad components,
     // only the current one uses it. There's no point in instrumenting the
     // legacy keypad given that it's on its way out the door.
-    return <KeypadComponent {...rest} />;
+    return (
+        <keypadContext.Consumer>
+            {({setKeypadActive, keypadActive}) => {
+                return (
+                    <KeypadComponent
+                        {...rest}
+                        keypadActive={keypadActive}
+                        setKeypadActive={setKeypadActive}
+                    />
+                );
+            }}
+        </keypadContext.Consumer>
+    );
 }
 
 export default KeypadSwitch;

--- a/packages/math-input/src/components/keypad/mobile-keypad.tsx
+++ b/packages/math-input/src/components/keypad/mobile-keypad.tsx
@@ -34,10 +34,11 @@ type Props = {
     onDismiss?: () => void;
     style?: StyleType;
     onAnalyticsEvent: AnalyticsEventHandlerFn;
+    setKeypadActive: (keypadActive: boolean) => void;
+    keypadActive: boolean;
 };
 
 type State = {
-    active: boolean;
     containerWidth: number;
     hasBeenActivated: boolean;
     keypadConfig?: KeypadConfiguration;
@@ -52,7 +53,6 @@ class MobileKeypad extends React.Component<Props, State> implements KeypadAPI {
     hasMounted = false;
 
     state: State = {
-        active: false,
         containerWidth: 0,
         hasBeenActivated: false,
     };
@@ -109,16 +109,15 @@ class MobileKeypad extends React.Component<Props, State> implements KeypadAPI {
     };
 
     activate: () => void = () => {
+        this.props.setKeypadActive(true);
         this.setState({
-            active: true,
             hasBeenActivated: true,
         });
     };
 
     dismiss: () => void = () => {
-        this.setState({active: false}, () => {
-            this.props.onDismiss?.();
-        });
+        this.props.setKeypadActive(false);
+        this.props.onDismiss?.();
     };
 
     configure: (configuration: KeypadConfiguration, cb: () => void) => void = (
@@ -162,14 +161,14 @@ class MobileKeypad extends React.Component<Props, State> implements KeypadAPI {
     }
 
     render(): React.ReactNode {
-        const {style} = this.props;
-        const {active, hasBeenActivated, containerWidth, cursor, keypadConfig} =
+        const {keypadActive, style} = this.props;
+        const {hasBeenActivated, containerWidth, cursor, keypadConfig} =
             this.state;
 
         const containerStyle = [
             // internal styles
             styles.keypadContainer,
-            active && styles.activeKeypadContainer,
+            keypadActive && styles.activeKeypadContainer,
             // styles passed as props
             ...(Array.isArray(style) ? style : [style]),
         ];
@@ -179,7 +178,7 @@ class MobileKeypad extends React.Component<Props, State> implements KeypadAPI {
         // during the initial render.
         // Done inline (dynamicStyle) since stylesheets might not be loaded yet.
         let dynamicStyle = {};
-        if (!active && !hasBeenActivated) {
+        if (!keypadActive && !hasBeenActivated) {
             dynamicStyle = {visibility: "hidden"};
         }
 

--- a/packages/math-input/src/components/keypad/mobile-keypad.tsx
+++ b/packages/math-input/src/components/keypad/mobile-keypad.tsx
@@ -4,6 +4,7 @@ import ReactDOM from "react-dom";
 
 import {View} from "../../fake-react-native-web/index";
 
+import Keypad from "./keypad";
 import {expandedViewThreshold} from "./utils";
 
 import type Key from "../../data/keys";
@@ -15,8 +16,6 @@ import type {
 } from "../../types";
 import type {AnalyticsEventHandlerFn} from "@khanacademy/perseus-core";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
-
-import Keypad from "./index";
 
 /**
  * This is the v2 equivalent of v1's ProvidedKeypad. It follows the same

--- a/packages/math-input/src/full-mobile-input.stories.tsx
+++ b/packages/math-input/src/full-mobile-input.stories.tsx
@@ -1,9 +1,13 @@
 import {action} from "@storybook/addon-actions";
 import * as React from "react";
 
-import type {KeypadAPI} from "./types";
-
-import {KeypadInput, KeypadType, MobileKeypad} from "./index";
+import {
+    KeypadInput,
+    KeypadType,
+    MobileKeypad,
+    StatefulKeypadContextProvider,
+    keypadContext,
+} from "./index";
 
 export default {
     title: "math-input/Full Mobile MathInput",
@@ -19,31 +23,18 @@ export default {
     },
 };
 
-export const Basic = () => {
+const Basic = ({keypadElement, setKeypadElement}) => {
     const [value, setValue] = React.useState("");
-    // Reference to the keypad
-    const [keypadElement, setKeypadElement] = React.useState<KeypadAPI>();
     // Whether to use Expression or Fraction keypad
     const [expression, setExpression] = React.useState<boolean>(false);
     // Whether to use CDOT or TIMES
     const [times, setTimes] = React.useState<boolean>(true);
     // Whether to use v1 or v2 keypad
     const [v2Keypad, setV2Keypad] = React.useState<boolean>(true);
-    // Whether the keypad is open or not
-    const [keypadOpen, setKeypadOpen] = React.useState<boolean>(false);
 
     const input = React.useRef<KeypadInput>(null);
 
     const timesLabel = times ? "CDOT" : "TIMES";
-
-    const toggleKeypad = () => {
-        if (keypadOpen) {
-            keypadElement?.dismiss();
-        } else {
-            keypadElement?.activate();
-        }
-        setKeypadOpen(!keypadOpen);
-    };
 
     React.useEffect(() => {
         keypadElement?.configure(
@@ -72,9 +63,6 @@ export const Basic = () => {
                     </button>
                     <button onClick={() => setV2Keypad(!v2Keypad)}>
                         {`Use ${v2Keypad ? "Legacy" : "New"} Keypad`}
-                    </button>
-                    <button onClick={() => toggleKeypad()}>
-                        {`Toggle Keypad`}
                     </button>
                     <button onClick={() => setTimes(!times)}>
                         {`Toggle to ` + timesLabel}
@@ -111,3 +99,18 @@ export const Basic = () => {
         </div>
     );
 };
+
+export function Wrapped() {
+    return (
+        <StatefulKeypadContextProvider>
+            <keypadContext.Consumer>
+                {({keypadElement, setKeypadElement}) => (
+                    <Basic
+                        keypadElement={keypadElement}
+                        setKeypadElement={setKeypadElement}
+                    />
+                )}
+            </keypadContext.Consumer>
+        </StatefulKeypadContextProvider>
+    );
+}

--- a/packages/math-input/src/types.ts
+++ b/packages/math-input/src/types.ts
@@ -108,6 +108,8 @@ export interface KeypadAPI {
 }
 
 export type KeypadContext = {
+    setKeypadActive: (keypadActive: boolean) => void;
+    keypadActive: boolean;
     setKeypadElement: (keypadElement?: KeypadAPI) => void;
     keypadElement: KeypadAPI | null | undefined;
     setRenderer: (

--- a/packages/perseus/src/__tests__/item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/item-renderer.test.tsx
@@ -1,5 +1,6 @@
+import {StatefulKeypadContextProvider} from "@khanacademy/math-input";
 import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
-import {fireEvent, render, screen} from "@testing-library/react";
+import {fireEvent, render, screen, waitFor} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as React from "react";
 import "@testing-library/jest-dom"; // Imports custom matchers
@@ -71,23 +72,25 @@ export const renderQuestion = (
     let renderer: ItemRenderer | null = null;
     const {container} = render(
         <RenderStateRoot>
-            <ItemRenderer
-                ref={(node) => (renderer = node)}
-                apiOptions={apiOptions}
-                item={question}
-                problemNum={0}
-                reviewMode={false}
-                savedState=""
-                controlPeripherals={false}
-                dependencies={testDependenciesV2}
-                {...optionalProps}
-            />
-            {/* The ItemRenderer _requires_ two divs: a work area and hints
+            <StatefulKeypadContextProvider>
+                <ItemRenderer
+                    ref={(node) => (renderer = node)}
+                    apiOptions={apiOptions}
+                    item={question}
+                    problemNum={0}
+                    reviewMode={false}
+                    savedState=""
+                    controlPeripherals={false}
+                    dependencies={testDependenciesV2}
+                    {...optionalProps}
+                />
+                {/* The ItemRenderer _requires_ two divs: a work area and hints
                 area. Without both of these, it fails to render anything! */}
-            <div id="workarea" />
-            <div id="hintsarea" />
+                <div id="workarea" />
+                <div id="hintsarea" />
 
-            <Peripherals />
+                <Peripherals />
+            </StatefulKeypadContextProvider>
         </RenderStateRoot>,
     );
     if (!renderer) {
@@ -309,18 +312,21 @@ describe("item renderer", () => {
             );
         });
 
-        it("should activate the keypad when widget with input is focused", () => {
+        it("should activate the keypad when widget with input is focused", async () => {
             // Arrange
             const {renderer} = renderQuestion(itemWithInput, {
                 isMobile: true,
                 customKeypad: true,
+                useV2Keypad: true,
             });
 
             // Act
             renderer.focus();
 
             // Assert
-            expect(screen.getByLabelText("7")).toBeVisible();
+            await waitFor(() => {
+                expect(screen.getByLabelText("7")).toBeVisible();
+            });
         });
 
         it("should provide current and previous focus paths on focus change to, and away from, a single widget", () => {


### PR DESCRIPTION
## Summary:

1. [Webapp ~ Cleanup PR](https://github.com/Khan/webapp/pull/17025)
2. [Perseus ~ Bring StatefulKeypadContext into Perseus](https://github.com/Khan/perseus/pull/747)
3. **[> Perseus ~ Add "keypadActive" state](https://github.com/Khan/perseus/pull/748)**
4. [Webapp ~ Conditionally render Khanmigo button](https://github.com/Khan/webapp/pull/17063)

The main point of these PRs is to be able to tell Khanmigo when the keypad is open so it can stop putting a button over the keypad.

This PR is a good example of some of our problems in MathInput though: there wasn't really a single place for this state. v1 keypad stored this state in Redux, v2 keypad stored this in hooks, and the KeypadContext was just passing around refs to components that other components where calling methods on. I didn't scope creep and fix all of these problems, but I did try to start fixing one: we now have a StatefulKeypadContextProvider which provides `keypadActive` state.

So now the v2 MobileKeypad doesn't need to track this state, it just gets it from Context. At the same time, other things that want to know this state (like Khanmigo) can also consume the Context.

Issue: LC-1337

## Test plan:
- Nothing should really change
- Once all these PRs are landed:
  - Use or emulate a mobile device
  - Go to a page that uses a NumericInput or Expression
  - Open and close the keypad
  - Note things work the same