### PR TITLE
Ensured that we're still validating against pi when it is provided in the answerForms.

### DIFF
--- a/.changeset/eleven-jokes-wait.md
+++ b/.changeset/eleven-jokes-wait.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Ensured we're still validating against pi when strict is set to false and pi is in the answerforms.

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -762,7 +762,8 @@ export type PerseusNumericInputAnswer = {
     // The forms available for this answer.  Options: "integer, ""decimal", "proper", "improper", "mixed", or "pi"
     // NOTE: perseus_data.go says this is required even though it isn't necessary.
     answerForms?: ReadonlyArray<MathFormat>;
-    // Whether validatorForms should include the defaultAnswerForms, or strictly match to the provided answerForms
+    // Whether we should check the answer strictly against the the configured answerForms (strict = true)
+    // or include the set of default answerForms (strict = false).
     strict: boolean;
     // A range of error +/- the value
     // NOTE: perseus_data.go says this is non-nullable even though we handle null values.

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -762,7 +762,7 @@ export type PerseusNumericInputAnswer = {
     // The forms available for this answer.  Options: "integer, ""decimal", "proper", "improper", "mixed", or "pi"
     // NOTE: perseus_data.go says this is required even though it isn't necessary.
     answerForms?: ReadonlyArray<MathFormat>;
-    // Whether the answerForms should be strictly matched
+    // Whether validatorForms should include the defaultAnswerForms, or strictly match to the provided answerForms
     strict: boolean;
     // A range of error +/- the value
     // NOTE: perseus_data.go says this is non-nullable even though we handle null values.

--- a/packages/perseus/src/widgets/__tests__/numeric-input.test.ts
+++ b/packages/perseus/src/widgets/__tests__/numeric-input.test.ts
@@ -250,6 +250,41 @@ describe("static function validate", () => {
         expect(score.message?.includes("pi")).toBeFalsy();
     });
 
+    it("still validates against pi if provided in answerForms", () => {
+        const rubric: Rubric = {
+            answers: [
+                {
+                    maxError: null,
+                    message: "",
+                    simplify: "required",
+                    status: "correct",
+                    strict: false,
+                    value: 311.01767270538954,
+                    answerForms: ["pi"],
+                },
+            ],
+            labelText: "",
+            size: "normal",
+            static: false,
+            coefficient: false,
+        };
+
+        const userInput = {
+            currentValue: "99 pi",
+        } as const;
+
+        const score = NumericInput.validate(userInput, rubric);
+
+        expect(score).toMatchInlineSnapshot(`
+        {
+          "earned": 1,
+          "message": null,
+          "total": 1,
+          "type": "points",
+        }
+    `);
+    });
+
     it("with a strict answer", () => {
         const rubric: Rubric = {
             answers: [


### PR DESCRIPTION
## Summary:
This PR fixes a bug where we were no longer validating against pi when `answer.strict=false` when pi was provided in the answerForms. It looks like this is a side effect that came about with a more recent bug fix that exposed a hard-to-find historical bug. Previously we were always validating against pi by default, but we changed this after having issue with several questions being incorrectly tagged as approximations of pi. 

I updated tests to make sure that we're still validating against pi when these conditions are met.

Issue: LC-1331

## Test plan:
- new test 