### PR TITLE
Fix SHA posted when updating npm snapshots

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -292,6 +292,11 @@ jobs:
 
             - name: Calculate short SHA for this commit
               id: short-sha
+              # Why not GITHUB_SHA here? Because that is the last merge-commit
+              # for the PR (ie. the ephemeral commit that Github creates for
+              # each PR merging the base branch into the pull request HEAD) for
+              # Github Action runs). We want to reference the commit that was
+              # pushed, not this ephemeral commit.
               run: echo "short_sha=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-8)" >> $GITHUB_OUTPUT
 
             # Note: these two actions are locked to the latest version that were

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -292,7 +292,7 @@ jobs:
 
             - name: Calculate short SHA for this commit
               id: short-sha
-              run: echo "short_sha=$(echo ${GITHUB_SHA} | cut -c1-8)" >> $GITHUB_OUTPUT
+              run: echo "short_sha=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-8)" >> $GITHUB_OUTPUT
 
             # Note: these two actions are locked to the latest version that were
             # published when I created this yml file (just for security).


### PR DESCRIPTION
## Summary:

Ned [noticed](https://khanacademy.slack.com/archives/C01AZ9H8TTQ/p1696342746848549) that the git SHA posted to our "npm Snapshot: Published" comment doesn't look right. It's not! When this process was originally created, we used the `GITHUB_SHA` value. Github's [docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request) state: 

> Note that GITHUB_SHA for this event is the last merge commit of the pull request merge branch. If you want to get the commit ID for the last commit to the head branch of the pull request, use github.event.pull_request.head.sha instead.

So this PR switches to use `github.event.pull_request.head.sha` so that the commit pointed to is the latest commit on the PR, not the merge commit. 

Issue: "none"

## Test plan:

Merge and check the next PR's snapshot comment. It should be the last commit on that PR.