### PR TITLE
Updating Article Renderer to be able to return the focusedElement so that we can scroll these elements into view above the keypad.

### DIFF
--- a/.changeset/nice-days-compete.md
+++ b/.changeset/nice-days-compete.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Adding logic to ArticleRenderer so that it can return our currently focused element.

--- a/packages/perseus/src/__stories__/article-renderer.stories.tsx
+++ b/packages/perseus/src/__stories__/article-renderer.stories.tsx
@@ -67,14 +67,6 @@ export const ExpressionArticle = ({useNewStyles}): any => (
                     apiOptions={{
                         isMobile: true,
                         customKeypad: true,
-                        onFocusChange(
-                            newFocusPath,
-                            oldFocusPath,
-                            keypadElement,
-                            focusedElement,
-                        ) {
-                            // console.log(focusedElement);
-                        },
                     }}
                     keypadElement={keypadElement}
                 />
@@ -97,14 +89,6 @@ export const MultiSectionedExpressionArticle = ({useNewStyles}): any => (
                     apiOptions={{
                         isMobile: true,
                         customKeypad: true,
-                        onFocusChange(
-                            newFocusPath,
-                            oldFocusPath,
-                            keypadElement,
-                            focusedElement,
-                        ) {
-                            // console.log(focusedElement);
-                        },
                     }}
                     keypadElement={keypadElement}
                 />

--- a/packages/perseus/src/__stories__/article-renderer.stories.tsx
+++ b/packages/perseus/src/__stories__/article-renderer.stories.tsx
@@ -73,7 +73,7 @@ export const ExpressionArticle = ({useNewStyles}): any => (
                             keypadElement,
                             focusedElement,
                         ) {
-                            console.log(focusedElement);
+                            // console.log(focusedElement);
                         },
                     }}
                     keypadElement={keypadElement}
@@ -103,7 +103,7 @@ export const MultiSectionedExpressionArticle = ({useNewStyles}): any => (
                             keypadElement,
                             focusedElement,
                         ) {
-                            console.log(focusedElement);
+                            // console.log(focusedElement);
                         },
                     }}
                     keypadElement={keypadElement}

--- a/packages/perseus/src/__stories__/article-renderer.stories.tsx
+++ b/packages/perseus/src/__stories__/article-renderer.stories.tsx
@@ -56,7 +56,7 @@ export const PassageArticle = ({useNewStyles}): any => (
 export const ExpressionArticle = ({useNewStyles}): any => (
     <TestKeypadContextWrapper>
         <KeypadContext.Consumer>
-            {({keypadElement, setRenderer, scrollableElement}) => (
+            {({keypadElement, setRenderer}) => (
                 <ArticleRenderer
                     ref={(node) => {
                         setRenderer(node);
@@ -78,7 +78,7 @@ export const ExpressionArticle = ({useNewStyles}): any => (
 export const MultiSectionedExpressionArticle = ({useNewStyles}): any => (
     <TestKeypadContextWrapper>
         <KeypadContext.Consumer>
-            {({keypadElement, setRenderer, scrollableElement}) => (
+            {({keypadElement, setRenderer}) => (
                 <ArticleRenderer
                     ref={(node) => {
                         setRenderer(node);

--- a/packages/perseus/src/__stories__/article-renderer.stories.tsx
+++ b/packages/perseus/src/__stories__/article-renderer.stories.tsx
@@ -7,6 +7,7 @@ import {
     multiSectionArticle,
     passageArticle,
     articleWithExpression,
+    multiSectionArticleWithExpression,
 } from "../__testdata__/article-renderer.testdata";
 import ArticleRenderer from "../article-renderer";
 import TestKeypadContextWrapper from "../widgets/__stories__/test-keypad-context-wrapper";
@@ -63,7 +64,48 @@ export const ExpressionArticle = ({useNewStyles}): any => (
                     json={articleWithExpression}
                     dependencies={storybookDependenciesV2}
                     useNewStyles={useNewStyles}
-                    apiOptions={{isMobile: true, customKeypad: true}}
+                    apiOptions={{
+                        isMobile: true,
+                        customKeypad: true,
+                        onFocusChange(
+                            newFocusPath,
+                            oldFocusPath,
+                            keypadElement,
+                            focusedElement,
+                        ) {
+                            console.log(focusedElement);
+                        },
+                    }}
+                    keypadElement={keypadElement}
+                />
+            )}
+        </KeypadContext.Consumer>
+    </TestKeypadContextWrapper>
+);
+
+export const MultiSectionedExpressionArticle = ({useNewStyles}): any => (
+    <TestKeypadContextWrapper>
+        <KeypadContext.Consumer>
+            {({keypadElement, setRenderer, scrollableElement}) => (
+                <ArticleRenderer
+                    ref={(node) => {
+                        setRenderer(node);
+                    }}
+                    json={multiSectionArticleWithExpression}
+                    dependencies={storybookDependenciesV2}
+                    useNewStyles={useNewStyles}
+                    apiOptions={{
+                        isMobile: true,
+                        customKeypad: true,
+                        onFocusChange(
+                            newFocusPath,
+                            oldFocusPath,
+                            keypadElement,
+                            focusedElement,
+                        ) {
+                            console.log(focusedElement);
+                        },
+                    }}
                     keypadElement={keypadElement}
                 />
             )}

--- a/packages/perseus/src/__testdata__/article-renderer.testdata.ts
+++ b/packages/perseus/src/__testdata__/article-renderer.testdata.ts
@@ -125,3 +125,88 @@ export const multiSectionArticle: ReadonlyArray<PerseusRenderer> = [
         widgets: {},
     },
 ];
+
+export const multiSectionArticleWithExpression: ReadonlyArray<PerseusRenderer> =
+    [
+        {
+            content:
+                "### Practice Problem\n\n$8\\cdot(11i+2)=$ [[☃ expression 1]]  \n*Your answer should be a complex number in the form $a+bi$ where $a$ and $b$ are real numbers.*",
+            images: {},
+            widgets: {
+                "expression 1": {
+                    alignment: "default",
+                    graded: true,
+                    options: {
+                        answerForms: [
+                            {
+                                considered: "correct",
+                                form: true,
+                                simplify: false,
+                                value: "16+88i",
+                            },
+                        ],
+                        buttonSets: ["basic"],
+                        functions: ["f", "g", "h"],
+                        times: false,
+                    },
+                    static: false,
+                    type: "expression",
+                    version: {major: 1, minor: 0},
+                },
+            },
+        },
+        {
+            content:
+                "### Practice Problem\n\n$8\\cdot(11i+2)=$ [[☃ expression 2]]  \n*Your answer should be a complex number in the form $a+bi$ where $a$ and $b$ are real numbers.*",
+            images: {},
+            widgets: {
+                "expression 2": {
+                    alignment: "default",
+                    graded: true,
+                    options: {
+                        answerForms: [
+                            {
+                                considered: "correct",
+                                form: true,
+                                simplify: false,
+                                value: "16+88i",
+                            },
+                        ],
+                        buttonSets: ["basic"],
+                        functions: ["f", "g", "h"],
+                        times: false,
+                    },
+                    static: false,
+                    type: "expression",
+                    version: {major: 1, minor: 0},
+                },
+            },
+        },
+        {
+            content:
+                "### Practice Problem\n\n$8\\cdot(11i+2)=$ [[☃ expression 3]]  \n*Your answer should be a complex number in the form $a+bi$ where $a$ and $b$ are real numbers.*",
+            images: {},
+            widgets: {
+                "expression 3": {
+                    alignment: "default",
+                    graded: true,
+                    options: {
+                        answerForms: [
+                            {
+                                considered: "correct",
+                                form: true,
+                                simplify: false,
+                                value: "16+88i",
+                            },
+                        ],
+                        buttonSets: ["basic"],
+                        functions: ["f", "g", "h"],
+                        times: false,
+                    },
+                    static: false,
+                    type: "expression",
+                    version: {major: 1, minor: 0},
+                },
+            },
+        },
+    ];

--- a/packages/perseus/src/__tests__/article-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/article-renderer.test.tsx
@@ -1,0 +1,102 @@
+import {
+    StatefulKeypadContextProvider,
+    KeypadContext,
+} from "@khanacademy/math-input";
+import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
+import {render, screen} from "@testing-library/react";
+import * as React from "react";
+import "@testing-library/jest-dom"; // Imports custom matchers
+
+import {
+    testDependencies,
+    testDependenciesV2,
+} from "../../../../testing/test-dependencies";
+import {multiSectionArticleWithExpression} from "../__testdata__/article-renderer.testdata";
+import ArticleRenderer from "../article-renderer";
+import * as Dependencies from "../dependencies";
+import {ApiOptions} from "../perseus-api";
+import {registerWidget} from "../widgets";
+import ExpressionExport from "../widgets/expression";
+
+import MockWidgetExport from "./mock-widget";
+
+import type {APIOptions} from "../types";
+
+// This looks alot like `widgets/__tests__/renderQuestion.jsx', except we use
+// the ArticleRenderer instead of Renderer
+export const RenderArticle = (
+    apiOptions: APIOptions = Object.freeze({}),
+): {
+    container: HTMLElement;
+    renderer: ArticleRenderer;
+} => {
+    let renderer: ArticleRenderer | null = null;
+    const {container} = render(
+        <RenderStateRoot>
+            <StatefulKeypadContextProvider>
+                <KeypadContext.Consumer>
+                    {({keypadElement, setRenderer}) => (
+                        <ArticleRenderer
+                            ref={(node) => {
+                                renderer = node;
+                                setRenderer(node);
+                            }}
+                            json={multiSectionArticleWithExpression}
+                            dependencies={testDependenciesV2}
+                            apiOptions={{...apiOptions}}
+                            keypadElement={keypadElement}
+                        />
+                    )}
+                </KeypadContext.Consumer>
+                {/* The ItemRenderer _requires_ two divs: a work area and hints
+                area. Without both of these, it fails to render anything! */}
+                <div id="workarea" />
+                <div id="hintsarea" />
+            </StatefulKeypadContextProvider>
+        </RenderStateRoot>,
+    );
+    if (!renderer) {
+        throw new Error(`Failed to render!`);
+    }
+    return {container, renderer};
+};
+
+describe("article renderer", () => {
+    beforeAll(() => {
+        registerWidget("mock-widget", MockWidgetExport);
+        registerWidget("expression-widget", ExpressionExport);
+    });
+
+    beforeEach(() => {
+        // Mock ResizeObserver used by the mobile keypad
+        window.ResizeObserver = jest.fn().mockImplementation(() => ({
+            observe: jest.fn(),
+            unobserve: jest.fn(),
+            disconnect: jest.fn(),
+        }));
+
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    afterEach(() => {
+        // The Renderer uses a timer to wait for widgets to complete rendering.
+        // If we don't spin the timers here, then the timer fires in the test
+        // _after_ and breaks it because we do setState() in the callback,
+        // and by that point the component has been unmounted.
+        jest.runOnlyPendingTimers();
+    });
+
+    it("should render the content", () => {
+        // Arrange and Act
+        RenderArticle({
+            ...ApiOptions.defaults,
+            isMobile: false,
+            customKeypad: false,
+        });
+
+        // Assert
+        expect(screen.queryAllByRole("textbox")).toHaveLength(3);
+    });
+});

--- a/packages/perseus/src/article-renderer.tsx
+++ b/packages/perseus/src/article-renderer.tsx
@@ -171,54 +171,54 @@ class ArticleRenderer
         });
 
         // TODO(alex): Add mobile api functions and pass them down here
-        const sections = this._sections().map((section, i) => {
-            const refForSection: any = i;
+        // We're using the index as the key here because we don't have a unique
+        // identifier for each section. This should be fine as we never remove
+        // or reorder sections.
+        const sections = this._sections().map((section, sectionIndex) => {
             return (
-                <DependenciesContext.Provider
-                    key={i}
-                    value={this.props.dependencies}
-                >
-                    <div key={i} className="clearfix">
-                        <Renderer
-                            {...section}
-                            ref={(elem) => {
-                                if (elem != null) {
-                                    this.sectionRenderers[i] = elem;
-                                }
-                            }}
-                            key={i}
-                            key_={i}
-                            keypadElement={this.props.keypadElement}
-                            apiOptions={{
-                                ...apiOptions,
-                                onFocusChange: (newFocusPath, oldFocusPath) => {
-                                    // Prefix the paths with the relevant section,
-                                    // so as to allow us to distinguish between
-                                    // equivalently-named inputs across Renderers.
-                                    this._handleFocusChange(
-                                        newFocusPath &&
-                                            [refForSection].concat(
-                                                newFocusPath,
-                                            ),
-                                        oldFocusPath &&
-                                            [refForSection].concat(
-                                                oldFocusPath,
-                                            ),
-                                    );
-                                },
-                            }}
-                            linterContext={PerseusLinter.pushContextStack(
-                                this.props.linterContext,
-                                "article",
-                            )}
-                            legacyPerseusLint={this.props.legacyPerseusLint}
-                        />
-                    </div>
-                </DependenciesContext.Provider>
+                <div key={sectionIndex} className="clearfix">
+                    <Renderer
+                        {...section}
+                        ref={(elem) => {
+                            if (elem) {
+                                this.sectionRenderers[sectionIndex] = elem;
+                            }
+                        }}
+                        key={sectionIndex}
+                        key_={sectionIndex}
+                        keypadElement={this.props.keypadElement}
+                        apiOptions={{
+                            ...apiOptions,
+                            onFocusChange: (newFocusPath, oldFocusPath) => {
+                                console.log("FOCUS");
+                                // Prefix the paths with the relevant section index,
+                                // so as to allow us to distinguish between
+                                // equivalently-named inputs across Renderers.
+                                this._handleFocusChange(
+                                    newFocusPath &&
+                                        [sectionIndex].concat(newFocusPath),
+                                    oldFocusPath &&
+                                        [sectionIndex].concat(oldFocusPath),
+                                );
+                            },
+                        }}
+                        linterContext={PerseusLinter.pushContextStack(
+                            this.props.linterContext,
+                            "article",
+                        )}
+                        legacyPerseusLint={this.props.legacyPerseusLint}
+                    />
+                </div>
             );
         });
 
-        return <div className={classes}>{sections}</div>;
+        return (
+            <div className={classes}>
+                <DependenciesContext.Provider value={this.props.dependencies}>
+                    {sections}
+                </DependenciesContext.Provider>
+            </div>
+        );
     }
 }
 

--- a/packages/perseus/src/article-renderer.tsx
+++ b/packages/perseus/src/article-renderer.tsx
@@ -92,7 +92,6 @@ class ArticleRenderer
 
         if (this._currentFocus) {
             const [sectionRef, ...focusPath] = this._currentFocus;
-            // eslint-disable-next-line react/no-string-refs
 
             const inputPaths =
                 this.sectionRenderers[sectionRef].getInputPaths();
@@ -146,7 +145,6 @@ class ArticleRenderer
     blur: () => void = () => {
         if (this._currentFocus) {
             const [sectionRef, ...inputPath] = this._currentFocus;
-            // eslint-disable-next-line react/no-string-refs
             this.sectionRenderers[sectionRef].blurPath(inputPath);
         }
     };
@@ -176,7 +174,10 @@ class ArticleRenderer
         const sections = this._sections().map((section, i) => {
             const refForSection: any = i;
             return (
-                <DependenciesContext.Provider value={this.props.dependencies}>
+                <DependenciesContext.Provider
+                    key={i}
+                    value={this.props.dependencies}
+                >
                     <div key={i} className="clearfix">
                         <Renderer
                             {...section}

--- a/packages/perseus/src/article-renderer.tsx
+++ b/packages/perseus/src/article-renderer.tsx
@@ -91,16 +91,18 @@ class ArticleRenderer
         let focusedInput;
 
         if (this._currentFocus) {
-            const [sectionRef, ...focusPath] = this._currentFocus;
+            const [sectionIndex, ...focusPath] = this._currentFocus;
 
             const inputPaths =
-                this.sectionRenderers[sectionRef].getInputPaths();
+                this.sectionRenderers[sectionIndex].getInputPaths();
 
             didFocusInput = inputPaths.some((inputPath) => {
                 return Util.inputPathsEqual(inputPath, focusPath);
             });
             focusedInput =
-                this.sectionRenderers[sectionRef].getDOMNodeForPath(focusPath);
+                this.sectionRenderers[sectionIndex].getDOMNodeForPath(
+                    focusPath,
+                );
         }
 
         if (this.props.apiOptions.onFocusChange != null) {
@@ -144,8 +146,8 @@ class ArticleRenderer
 
     blur: () => void = () => {
         if (this._currentFocus) {
-            const [sectionRef, ...inputPath] = this._currentFocus;
-            this.sectionRenderers[sectionRef].blurPath(inputPath);
+            const [sectionIndex, ...inputPath] = this._currentFocus;
+            this.sectionRenderers[sectionIndex].blurPath(inputPath);
         }
     };
 

--- a/packages/perseus/src/article-renderer.tsx
+++ b/packages/perseus/src/article-renderer.tsx
@@ -190,7 +190,6 @@ class ArticleRenderer
                         apiOptions={{
                             ...apiOptions,
                             onFocusChange: (newFocusPath, oldFocusPath) => {
-                                console.log("FOCUS");
                                 // Prefix the paths with the relevant section index,
                                 // so as to allow us to distinguish between
                                 // equivalently-named inputs across Renderers.


### PR DESCRIPTION
## Summary:
It turns out we never set up our article renderer to return the focused element, which is required to be able to scroll the element above the keypad when the user focuses on it! 

This PR adds the missing logic to the article renderer, and also makes a couple of necessary modernizations as we were still using string refs. I've also created a new story for testing multiple inputs in a mobile article. Please note that the keypad does look a little strange in this view as we don't currently have the scrollable element logic in Perseus. 

(I suspect that eventually, we should probably move the scrollIntoView logic into Perseus.)