### PR TITLE
Prevent provided-keypad from re-rendering due to prop callabacks

### DIFF
--- a/.changeset/fresh-peas-hang.md
+++ b/.changeset/fresh-peas-hang.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Fix provided-keypad so that it doesn't re-render unnecessarily.

--- a/packages/math-input/src/components/keypad-legacy/provided-keypad.tsx
+++ b/packages/math-input/src/components/keypad-legacy/provided-keypad.tsx
@@ -85,43 +85,47 @@ class ProvidedKeypad extends React.Component<Props> implements KeypadAPI {
         return ReactDOM.findDOMNode(this);
     };
 
+    onElementMounted: (element: any) => void = (element) => {
+        this.props.onAnalyticsEvent({
+            type: "math-input:keypad-opened",
+            payload: {
+                virtualKeypadVersion: "MATH_INPUT_KEYPAD_V1",
+            },
+        });
+
+        // Append the dispatch methods that we want to expose
+        // externally to the returned React element.
+        const elementWithDispatchMethods = {
+            ...element,
+            activate: this.activate,
+            dismiss: this.dismiss,
+            configure: this.configure,
+            setCursor: this.setCursor,
+            setKeyHandler: this.setKeyHandler,
+            getDOMNode: this.getDOMNode,
+        } as const;
+        this.props.onElementMounted?.(elementWithDispatchMethods);
+    };
+
+    onDismiss: () => void = () => {
+        this.props.onAnalyticsEvent({
+            type: "math-input:keypad-closed",
+            payload: {
+                virtualKeypadVersion: "MATH_INPUT_KEYPAD_V1",
+            },
+        });
+
+        this.props.onDismiss?.();
+    };
+
     render(): React.ReactNode {
-        const {onElementMounted, onDismiss, style} = this.props;
+        const {style} = this.props;
 
         return (
             <Provider store={this.store}>
                 <KeypadContainer
-                    onElementMounted={(element) => {
-                        this.props.onAnalyticsEvent({
-                            type: "math-input:keypad-opened",
-                            payload: {
-                                virtualKeypadVersion: "MATH_INPUT_KEYPAD_V1",
-                            },
-                        });
-
-                        // Append the dispatch methods that we want to expose
-                        // externally to the returned React element.
-                        const elementWithDispatchMethods = {
-                            ...element,
-                            activate: this.activate,
-                            dismiss: this.dismiss,
-                            configure: this.configure,
-                            setCursor: this.setCursor,
-                            setKeyHandler: this.setKeyHandler,
-                            getDOMNode: this.getDOMNode,
-                        } as const;
-                        onElementMounted?.(elementWithDispatchMethods);
-                    }}
-                    onDismiss={() => {
-                        this.props.onAnalyticsEvent({
-                            type: "math-input:keypad-closed",
-                            payload: {
-                                virtualKeypadVersion: "MATH_INPUT_KEYPAD_V1",
-                            },
-                        });
-
-                        onDismiss?.();
-                    }}
+                    onElementMounted={this.onElementMounted}
+                    onDismiss={this.onDismiss}
                     style={style}
                 />
             </Provider>


### PR DESCRIPTION
## Summary:

While doing some performance tuning in webapp I noticed that this component is re-rendering because we are creating the callback props inline. This means that they'll always be different. Moving them to be instance functions fixes this. 

Issue: LC-1346

## Test plan:

I was able to `yarn link` all the Perseus packages into webapp and then test. All re-renders of the `ProvidedKeypad` component stopped with these changes.