### PR TITLE
Remove "grid" role from keypad

### DIFF
--- a/.changeset/lemon-bears-remain.md
+++ b/.changeset/lemon-bears-remain.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Removes "grid" role from keypad to un-muddle screen reader experience.

--- a/packages/math-input/src/components/keypad/__tests__/__snapshots__/keypad.test.tsx.snap
+++ b/packages/math-input/src/components/keypad/__tests__/__snapshots__/keypad.test.tsx.snap
@@ -170,7 +170,6 @@ exports[`keypad should snapshot expanded: first render 1`] = `
         <div
           aria-label="Keypad"
           class="default_xu2jcg-o_O-keypadGrid_ztxlrb-o_O-expressionGrid_1fuqhx9"
-          role="grid"
           tabindex="0"
         >
           <div
@@ -1223,7 +1222,6 @@ exports[`keypad should snapshot unexpanded: first render 1`] = `
         <div
           aria-label="Keypad"
           class="default_xu2jcg-o_O-keypadGrid_ztxlrb-o_O-expressionGrid_1fuqhx9"
-          role="grid"
           tabindex="0"
         >
           <div

--- a/packages/math-input/src/components/keypad/keypad.tsx
+++ b/packages/math-input/src/components/keypad/keypad.tsx
@@ -151,7 +151,6 @@ export default function Keypad(props: Props) {
                 <View style={styles.keypadInnerContainer}>
                     <View
                         style={[styles.keypadGrid, gridStyle]}
-                        role="grid"
                         tabIndex={0}
                         aria-label="Keypad"
                     >


### PR DESCRIPTION
LC-1356

Removes "grid" role from keypad. Its presence without "row" and "gridcell" roles in child elements muddles the screen reader experience.