### PR TITLE
Addition of CEDAR event for widget rending errors

### DIFF
--- a/.changeset/sour-toes-applaud.md
+++ b/.changeset/sour-toes-applaud.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-core": minor
+---
+
+Added a CEDAR event to notify us of errors in renering widgets

--- a/.changeset/sour-toes-applaud.md
+++ b/.changeset/sour-toes-applaud.md
@@ -3,4 +3,4 @@
 "@khanacademy/perseus-core": minor
 ---
 
-Added a CEDAR event to notify us of errors in renering widgets
+Added a CEDAR event to notify us of errors in rendering widgets

--- a/packages/perseus-core/src/analytics.ts
+++ b/packages/perseus-core/src/analytics.ts
@@ -31,6 +31,13 @@ export type PerseusAnalyticsEvent =
           payload: {
               virtualKeypadVersion: VirtualKeypadVersion;
           };
+      }
+    | {
+          type: "perseus:widget-rendering-error";
+          payload: {
+              widgetType: string;
+              widgetId: string;
+          };
       };
 // Add more events here as needed. Note that each event should have a `type`
 // key and a payload that varies by type.

--- a/packages/perseus/src/error-boundary.tsx
+++ b/packages/perseus/src/error-boundary.tsx
@@ -5,7 +5,9 @@ import {Errors, Log} from "./logging/log";
 type Props = {
     children: React.ReactNode;
     metadata?: Record<string, string>;
+    onError?: (error: Error, info: any) => void;
 };
+
 type State = {
     error: string;
 };
@@ -25,6 +27,7 @@ class ErrorBoundary extends React.Component<Props, State> {
                 ...this.props.metadata,
             },
         });
+        this.props.onError?.(error, info);
     }
 
     render(): React.ReactNode {


### PR DESCRIPTION
## Summary:
This CEDAR event will be integrated into our Analyzer to give us a clear signal if a widget is failing to render.

Issue: LC-1301

## Test plan: