### PR TITLE
Upgrade MathQuill to include Android keyboard fix

### DIFF
--- a/packages/math-input/package.json
+++ b/packages/math-input/package.json
@@ -21,7 +21,7 @@
     "scripts": {},
     "dependencies": {
         "@khanacademy/perseus-core": "1.1.2",
-        "mathquill": "git+https://git@github.com/Khan/mathquill.git#32d9f351aaa68537170b3120a52e99b8def3a2c3",
+        "mathquill": "git+https://git@github.com/Khan/mathquill.git#48410e80d760bbd5105544d4a4ab459a28dc2cbc",
         "performance-now": "^0.2.0"
     },
     "devDependencies": {

--- a/packages/perseus/package.json
+++ b/packages/perseus/package.json
@@ -57,7 +57,7 @@
         "jquery": "^2.1.1",
         "katex": "^0.11.1",
         "lodash.debounce": "^4.0.8",
-        "mathquill": "git+https://git@github.com/Khan/mathquill.git#32d9f351aaa68537170b3120a52e99b8def3a2c3",
+        "mathquill": "git+https://git@github.com/Khan/mathquill.git#48410e80d760bbd5105544d4a4ab459a28dc2cbc",
         "perseus-build-settings": "^0.2.1",
         "prop-types": "^15.6.1",
         "react": "16.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14020,9 +14020,9 @@ markdown-escapes@^1.0.0:
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
   integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
 
-"mathquill@git+https://git@github.com/Khan/mathquill.git#32d9f351aaa68537170b3120a52e99b8def3a2c3":
+"mathquill@git+https://git@github.com/Khan/mathquill.git#48410e80d760bbd5105544d4a4ab459a28dc2cbc":
   version "0.10.1"
-  resolved "git+https://git@github.com/Khan/mathquill.git#32d9f351aaa68537170b3120a52e99b8def3a2c3"
+  resolved "git+https://git@github.com/Khan/mathquill.git#48410e80d760bbd5105544d4a4ab459a28dc2cbc"
   dependencies:
     pjs "3.x"
 


### PR DESCRIPTION
## Summary:
Upgrades MathQuill to include a fix for Android keyboard. Previously, the Android default keyboard could not enter characters into a mathquill input until the user entered a hard return. This fixes the problem.

Issue: LC-1362

## Test Plan
With an Android device, use the ZND linked in this PR (with a yarn resolution to the updated version) verify that you can type into the math input with the default keyboard.
https://github.com/Khan/mathquill/pull/16