### PR TITLE
Fix interactive graph text overlap

### DIFF
--- a/.changeset/fast-cherries-rest.md
+++ b/.changeset/fast-cherries-rest.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Fix text overlap in interactive graph widget

--- a/packages/perseus/src/styles/perseus-renderer.less
+++ b/packages/perseus/src/styles/perseus-renderer.less
@@ -441,6 +441,7 @@
 /* Widget CSS */
 
 .perseus-graph-padding {
+    box-sizing: content-box;
     padding: 25px 25px 0 0;
 }
 


### PR DESCRIPTION
## Summary:
Fixes an issue where text was ending up under an interactive graph.

I am aiming to fix this problem in specific:

![image](https://github.com/Khan/perseus/assets/18454/a66f9530-69f5-449b-8613-16ca9e824c08)

This was happening because of the combination of setting an explicit size on the graph widget and the border-box property. By moving to content box the width and height are accounted for as part of the budget for the size and the text doesn't overlap.

Note: This might not be a perfect solution. I think there's some messiness with the way problems get laid out. For this problem The interactive graph is inside a paragaph, which is inside a paragaph. Both of those apply negative margins. The conceptually simpler solution would be to change:

```
    .perseus-renderer > .paragraph > ul:not(.perseus-widget-radio),
    .perseus-renderer > .paragraph > ol {
        margin: -11px 0px 22px 0px; // first-level lists need padding
    }
```

to 

```
    .perseus-renderer > .paragraph > ul:not(.perseus-widget-radio),
    .perseus-renderer > .paragraph > ol {
        margin: 0px 0px 22px 0px; // first-level lists need padding
    }
```

But this would likely have far-reaching consequences into all of our paragraphs. I'm trying to make the lightest but still pragmatic change I can to fix a specific bug.

Issue: https://khanacademy.atlassian.net/browse/LC-1373

## Test plan:
- After a ZND is built visit `/math/precalculus/x9e81a4f98389efdf:composite/x9e81a4f98389efdf:invertible/e/inverse-domain-range`
- The first problem should have an interactive graph widget
- The text under the widget should be readable