### PR TITLE
Ensured we have access to transform.center when working with dilation in the Transform Widget 

### DIFF
--- a/.changeset/poor-lizards-glow.md
+++ b/.changeset/poor-lizards-glow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix for broken dilation tool in the Transformer Widget

--- a/packages/perseus/src/widgets/transformer.tsx
+++ b/packages/perseus/src/widgets/transformer.tsx
@@ -2521,6 +2521,7 @@ class Transformer extends React.Component<Props> {
                     // NOTE(kevinb): It's hard to convince that this.dilationCircle
                     // will still be defined here.                    center: self.dilationCircle.centerPoint.coord,
                     scale: newRadius / oldRadius,
+                    center: self.dilationCircle.centerPoint.coord,
                 });
             },
             circleNormalStyle: {

--- a/packages/perseus/src/widgets/transformer.tsx
+++ b/packages/perseus/src/widgets/transformer.tsx
@@ -2518,8 +2518,6 @@ class Transformer extends React.Component<Props> {
                 // @ts-expect-error - TS2345 - Argument of type '{ type: "dilation"; center: any; scale: number; }' is not assignable to parameter of type 'PerseusTransformerTransformation'.
                 self.doTransform({
                     type: "dilation",
-                    // NOTE(kevinb): It's hard to convince that this.dilationCircle
-                    // will still be defined here.
                     scale: newRadius / oldRadius,
                     center: self.dilationCircle.centerPoint.coord,
                 });

--- a/packages/perseus/src/widgets/transformer.tsx
+++ b/packages/perseus/src/widgets/transformer.tsx
@@ -2518,8 +2518,8 @@ class Transformer extends React.Component<Props> {
                 // @ts-expect-error - TS2345 - Argument of type '{ type: "dilation"; center: any; scale: number; }' is not assignable to parameter of type 'PerseusTransformerTransformation'.
                 self.doTransform({
                     type: "dilation",
-                    scale: newRadius / oldRadius,
                     center: self.dilationCircle.centerPoint.coord,
+                    scale: newRadius / oldRadius,
                 });
             },
             circleNormalStyle: {

--- a/packages/perseus/src/widgets/transformer.tsx
+++ b/packages/perseus/src/widgets/transformer.tsx
@@ -2519,7 +2519,7 @@ class Transformer extends React.Component<Props> {
                 self.doTransform({
                     type: "dilation",
                     // NOTE(kevinb): It's hard to convince that this.dilationCircle
-                    // will still be defined here.                    center: self.dilationCircle.centerPoint.coord,
+                    // will still be defined here.
                     scale: newRadius / oldRadius,
                     center: self.dilationCircle.centerPoint.coord,
                 });


### PR DESCRIPTION
## Summary:
Team-LC has noticed recently that the skip rate on our transformer widget was quite a bit higher than it is normally. After further investigation, we discovered that the "homothety"/dilation tool is spitting out a large barrage of errors and is no longer functional. We suspect this is likely the main cause for the increase in reports. 

@jeanettehead and I looked into the history of the file and noticed that a key line of code was accidentally shifted to be a part of a parent comment as part of a [PR that removed all references to flow in Perseus](https://github.com/Khan/perseus/pull/457).

`center: self.dilationCircle.centerPoint.coord`

 It looks like a pesky little newline was accidentally (and likely automatically) removed, causing us to lose access to the required "center" property for our dilation tool. 

Since this widget is deprecated and only sees minimal use in our international content, the visibility of the issue was incredibly low. Thankfully the new Perseus Widget Analyzer by @pmcgill88 helped us catch this issue by providing greater insight into how our widgets are being actively used. 

Issue: LC-1384

## Test plan:
manual testing 