### PR TITLE
Add missed widgetId to 'perseus:widget-rendering-error' event

### DIFF
--- a/.changeset/itchy-toes-decide.md
+++ b/.changeset/itchy-toes-decide.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-core": minor
+---
+
+Adds 'widgetId' to the 'perseus:widget-rendering-error' analytics event.

--- a/packages/perseus-core/src/analytics.ts
+++ b/packages/perseus-core/src/analytics.ts
@@ -21,6 +21,13 @@ export type PerseusAnalyticsEvent =
           payload: null;
       }
     | {
+          type: "perseus:widget-rendering-error";
+          payload: {
+              widgetType: string;
+              widgetId: string;
+          };
+      }
+    | {
           type: "math-input:keypad-closed";
           payload: {
               virtualKeypadVersion: VirtualKeypadVersion;
@@ -30,12 +37,6 @@ export type PerseusAnalyticsEvent =
           type: "math-input:keypad-opened";
           payload: {
               virtualKeypadVersion: VirtualKeypadVersion;
-          };
-      }
-    | {
-          type: "perseus:widget-rendering-error";
-          payload: {
-              widgetType: string;
           };
       };
 // Add more events here as needed. Note that each event should have a `type`

--- a/packages/perseus/src/__tests__/widget-container.test.tsx
+++ b/packages/perseus/src/__tests__/widget-container.test.tsx
@@ -33,7 +33,7 @@ const MockWidget: WidgetExports<typeof MockWidgetComponent> = {
 describe("widget-container", () => {
     it("should render nothing when requested widget not registered", () => {
         // Arrange
-        const warnMock = jest.spyOn(console, "warn");
+        const warnMock = jest.spyOn(console, "warn").mockImplementation();
 
         // Act
         render(
@@ -88,6 +88,8 @@ describe("widget-container", () => {
         jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
             testDependencies,
         );
+        jest.spyOn(console, "error").mockImplementation(() => {});
+
         const onAnalyticsEventSpy = jest.fn();
         const depsV2 = {analytics: {onAnalyticsEvent: onAnalyticsEventSpy}};
 

--- a/packages/perseus/src/__tests__/widget-container.test.tsx
+++ b/packages/perseus/src/__tests__/widget-container.test.tsx
@@ -1,0 +1,124 @@
+import "@testing-library/jest-dom"; // Joyous side-effects
+import {render, screen} from "@testing-library/react";
+import * as React from "react";
+
+import {testDependencies} from "../../../../testing/test-dependencies";
+import * as Dependencies from "../dependencies";
+import WidgetContainer from "../widget-container";
+import {registerWidget} from "../widgets";
+import PassageWidget from "../widgets/passage";
+
+import type {WidgetExports} from "../types";
+
+const MockWidgetComponent = ({
+    text,
+    fail = false,
+}: {
+    text: string;
+    fail: boolean;
+}) => {
+    if (fail) {
+        throw new Error("MockWidget failed to render");
+    }
+
+    return <div>{text}</div>;
+};
+
+const MockWidget: WidgetExports<typeof MockWidgetComponent> = {
+    name: "mock-widget",
+    displayName: "Mock Widget",
+    widget: MockWidgetComponent,
+};
+
+describe("widget-container", () => {
+    it("should render nothing when requested widget not registered", () => {
+        // Arrange
+        const warnMock = jest.spyOn(console, "warn");
+
+        // Act
+        render(
+            <WidgetContainer
+                type="invalid-widget"
+                id="invalid-widget 1"
+                shouldHighlight={false}
+                initialProps={{apiOptions: {isMobile: false}}}
+            />,
+        );
+
+        // Assert
+        expect(warnMock).toHaveBeenCalledWith(
+            "Widget type 'invalid-widget' not found!",
+        );
+    });
+
+    it("should render the requested widget", async () => {
+        // Arrange
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+
+        registerWidget("passage", PassageWidget);
+
+        // Act
+        render(
+            <WidgetContainer
+                type="passage"
+                id="passage 1"
+                shouldHighlight={false}
+                initialProps={{
+                    passageTitle: "Greeting",
+                    passageText: "Hello world!",
+                    footnotes: null,
+                    showLineNumbers: true,
+
+                    findWidgets: () => [],
+
+                    apiOptions: {isMobile: false},
+                }}
+            />,
+        );
+
+        // Assert
+        expect(await screen.findByText("Greeting")).toBeInTheDocument();
+        expect(await screen.findByText("Hello world")).toBeInTheDocument();
+    });
+
+    it("should send analytics even when widget rendering errors", () => {
+        // Arrange
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+        const onAnalyticsEventSpy = jest.fn();
+        const depsV2 = {analytics: {onAnalyticsEvent: onAnalyticsEventSpy}};
+
+        registerWidget("mock-widget", MockWidget);
+
+        // Act
+        render(
+            <Dependencies.DependenciesContext.Provider value={depsV2}>
+                <WidgetContainer
+                    type="mock-widget"
+                    id="mock-widget 1"
+                    shouldHighlight={false}
+                    initialProps={{
+                        text: "Hello world!",
+                        fail: true,
+
+                        findWidgets: () => [],
+
+                        apiOptions: {isMobile: false},
+                    }}
+                />
+            </Dependencies.DependenciesContext.Provider>,
+        );
+
+        // Assert
+        expect(onAnalyticsEventSpy).toHaveBeenCalledWith({
+            type: "perseus:widget-rendering-error",
+            payload: {
+                widgetType: "mock-widget",
+                widgetId: "mock-widget 1",
+            },
+        });
+    });
+});

--- a/packages/perseus/src/error-boundary.tsx
+++ b/packages/perseus/src/error-boundary.tsx
@@ -21,6 +21,7 @@ class ErrorBoundary extends React.Component<Props, State> {
 
     componentDidCatch(error: Error, info: any) {
         this.setState({error: error.toString()});
+        this.props.onError?.(error, info);
         Log.error("Perseus error boundary caught error", Errors.Internal, {
             cause: error,
             loggedMetadata: {

--- a/packages/perseus/src/widget-container.tsx
+++ b/packages/perseus/src/widget-container.tsx
@@ -144,7 +144,7 @@ class WidgetContainer extends React.Component<Props, State> {
                                 widget_type: type,
                                 widget_id: this.props.id,
                             }}
-                            onError={(error) => {
+                            onError={() => {
                                 analytics.onAnalyticsEvent({
                                     type: "perseus:widget-rendering-error",
                                     payload: {

--- a/packages/perseus/src/widget-container.tsx
+++ b/packages/perseus/src/widget-container.tsx
@@ -149,6 +149,7 @@ class WidgetContainer extends React.Component<Props, State> {
                                     type: "perseus:widget-rendering-error",
                                     payload: {
                                         widgetType: type,
+                                        widgetId: this.props.id,
                                     },
                                 });
                             }}


### PR DESCRIPTION
## Summary:

Patrick and I discussed whether this event should have the `widgetId` on it. We agreed it should, but I forgot to add it back in. So here we go. 

I also realized that I missed a very important part of this implementation while adding missing tests. The part where we call the analytics. 🤦‍♂️ 🤦‍♂️ 🤦‍♂️ 🤦‍♂️ 🤦‍♂️ 🤦‍♂️   Added now!

Issue: LC-1383

## Test plan:

`yarn test`