### PR TITLE
Fix animation of mobile keypad after initial render

### DIFF
--- a/.changeset/shaggy-seals-sort.md
+++ b/.changeset/shaggy-seals-sort.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Fix a bug where the mobile keypad didn't animate in the first time it appeared.

--- a/packages/math-input/src/components/aphrodite-css-transition-group/transition-child.tsx
+++ b/packages/math-input/src/components/aphrodite-css-transition-group/transition-child.tsx
@@ -155,7 +155,8 @@ class TransitionChild extends React.Component<ChildProps, ChildState> {
 
     queueClass(removeClassName: string, addClassName: string) {
         this.classNameQueue.push([removeClassName, addClassName]);
-        this.props.schedule.animationFrame(this.flushClassNameQueue);
+        // Queue operation for after the next paint.
+        this.props.schedule.timeout(this.flushClassNameQueue, 0);
     }
 
     flushClassNameQueue = () => {


### PR DESCRIPTION
## Summary:

@third noticed that our mobile keypad wasn't animating in the first time it was opened. Subsequent closes/opens were all animating correctly. 

I tracked it down to a change I made while porting the `AphroditeCSSAnimationGroup` in. Originally, there was a call like this to queue some styling changes on the element being transitioned for after the next paint: `setTimeout(doStyleChanges, 17);`. It seemed "off" that we were trying to identify when the next paint time would be by assuming 60 fps. So I changed it to use `requestAnimationFrame()`. What I didn't understand is that `requestAnimationFrame()` queues the function to run _before_ the next paint, not after! 

This PR fixes that by switching back to `setTimeout()`. But it doesn't fully revert to use the calculated duration for 60 fps (1000ms / 60), rather just using `0` which essentially queues the operation to run after the next browser task loop, which is after the next paint. 

https://github.com/Khan/perseus/assets/77138/a49c7a30-55d3-4a6f-8884-49e53549f15e

Issue: LC-1389

## Test plan:

Run storybook (`yarn start`)
Turn on mobil emulation in the browser
Navigate to **Perseus** >> **Widgets** >> **Expression** >> **Mobile**
Tap into the Expression's input

The mobile keypad should smoothly animate in.
Tap outside the keypad and it should navigate down smoothly.