### PR TITLE
Add string for translation

### DIFF
--- a/.changeset/four-zoos-boil.md
+++ b/.changeset/four-zoos-boil.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Add string for translation for label image changes

--- a/packages/perseus/src/widgets/label-image/strings.ts
+++ b/packages/perseus/src/widgets/label-image/strings.ts
@@ -1,0 +1,3 @@
+export const strings = {
+    hideAnswersToggleLabel: "Hide answer choices",
+};


### PR DESCRIPTION
## Summary
Just adds a single string for translation so that our international team can get a jump-start on internationalization.

Issue: LC-1447