### PR TITLE
Bug Fix: Fix extra pulse when reduce motion is on

### DIFF
--- a/packages/perseus/src/widgets/label-image/marker.tsx
+++ b/packages/perseus/src/widgets/label-image/marker.tsx
@@ -111,7 +111,7 @@ export default class Marker extends React.Component<Props, State> {
             iconStyles = [
                 styles.markerPulsateBase,
                 shouldReduceMotion()
-                    ? styles.markerUnfilledPulsateOnce
+                    ? showPulsate && styles.markerUnfilledPulsateOnce
                     : showPulsate && styles.markerUnfilledPulsateInfinite,
             ];
         }


### PR DESCRIPTION
## Summary:

Prevents the dot from pulsating one extra time when reduce motion is one.

## Test plan:
- Turn on reduce motion
- Select a dot
- De-select the dot
- The dot should not pulsate