### PR TITLE
Cleanup #problemarea CSS

### DIFF
--- a/.changeset/great-kiwis-nail.md
+++ b/.changeset/great-kiwis-nail.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Removing unnecessary conflicting CSS for #problemarea.

--- a/packages/perseus-editor/src/styles/perseus-editor.less
+++ b/packages/perseus-editor/src/styles/perseus-editor.less
@@ -279,15 +279,6 @@
 
     // Question area styles
     #problemarea {
-        /* Override the min-height property used for displaying the problem.
-        While editing, the size of the editor itself is a better constraint on
-        the size of the problemarea, and having a smaller problemarea is nicer
-        if it means it aligns better with the editor. */
-        min-height: 0;
-
-        // Force the hint width to take up the width of its containing viewport.
-        width: 100%;
-
         #workarea {
             margin: 0; // override ke
 

--- a/packages/perseus/src/styles/khan-exercise.css
+++ b/packages/perseus/src/styles/khan-exercise.css
@@ -130,8 +130,6 @@ div.definition {
 
 #problemarea {
     font-size: 14px;
-    width: 70%;
-    min-height: 378px;
     position: relative;
     float: left;
     padding-bottom: 38px;


### PR DESCRIPTION
## Summary:
This PR fixes our #problemarea width and min height by removing the base setting. This CSS is not used anywhere, as the only two places the #problemarea exists (ItemEditor and in the mobile application) are both having to override these settings back to the baseline.  

Issue: LC-1475

## Test plan:
manual testing + confirming code use. 