### PR TITLE
Remove unnecessary Z-Index for #problemarea buttons/inputs

### DIFF
--- a/.changeset/green-ligers-roll.md
+++ b/.changeset/green-ligers-roll.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Removing unused CSS from #problemarea.

--- a/packages/perseus/src/styles/perseus-renderer.less
+++ b/packages/perseus/src/styles/perseus-renderer.less
@@ -96,13 +96,6 @@
 }
 
 .framework-perseus {
-    #problemarea {
-        input,
-        button {
-            .perseus-interactive;
-        }
-    }
-
     div.paragraph {
         font-family: "Lato", sans-serif;
         font-weight: 400;

--- a/packages/perseus/src/styles/perseus-renderer.less
+++ b/packages/perseus/src/styles/perseus-renderer.less
@@ -96,13 +96,6 @@
 }
 
 .framework-perseus {
-    #problemarea {
-        input,
-        button {
-            position: relative;
-        }
-    }
-
     div.paragraph {
         font-family: "Lato", sans-serif;
         font-weight: 400;

--- a/packages/perseus/src/styles/perseus-renderer.less
+++ b/packages/perseus/src/styles/perseus-renderer.less
@@ -96,6 +96,13 @@
 }
 
 .framework-perseus {
+    #problemarea {
+        input,
+        button {
+            position: relative;
+        }
+    }
+
     div.paragraph {
         font-family: "Lato", sans-serif;
         font-weight: 400;


### PR DESCRIPTION
## Summary:
On our mobile app, we're noticing that hints are rendering above our keypad due to this style that sets the z-index to 3. I don't think we need z-index here at all as the #problemarea is only used on Mobile and in the content editor - neither of which need the index. 

Rather than using .perseus-interactive, I'm now simply setting the position directly. The relative positioning is still important to ensure that the "+" symbol appears beside the "Next Hint" button. 

Issue: LC-1445

## Test plan:
manual 