### PR TITLE
[Spike] JSON Schema generation

### DIFF
--- a/.swcrc
+++ b/.swcrc
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://swc.rs/schema.json",
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "topLevelAwait": true
+        },
+        "target": "esnext",
+        "baseUrl": "."
+    },
+    "module": {
+        "type": "nodenext"
+    },
+    "isModule": true
+}

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     },
     "scripts": {
         "gen:parsers": "yarn --cwd packages/kas gen:parsers",
-    "gen:schema": "utils/generate-schema.ts",
+    "gen:schema": "SWCRC=true utils/generate-schema.ts",
         "prebuild": "yarn gen:parsers",
         "build": "rollup -c config/build/rollup.config.js",
         "build:types": "tsc --build tsconfig-build.json",

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
         "storybook": "^7.6.17",
         "style-loader": "^3.3.3",
         "tiny-invariant": "^1.3.1",
+        "ts-json-schema-generator": "^2.0.1",
         "typescript": "^5.4.2",
         "typescript-coverage-report": "^0.7.0",
         "vite-plugin-istanbul": "^5.0.0",
@@ -127,6 +128,7 @@
     },
     "scripts": {
         "gen:parsers": "yarn --cwd packages/kas gen:parsers",
+    "gen:schema": "utils/generate-schema.ts",
         "prebuild": "yarn gen:parsers",
         "build": "rollup -c config/build/rollup.config.js",
         "build:types": "tsc --build tsconfig-build.json",

--- a/utils/generate-schema.ts
+++ b/utils/generate-schema.ts
@@ -5,23 +5,121 @@ import path from "path";
 
 import {createGenerator} from "ts-json-schema-generator";
 
-import type {Config} from "ts-json-schema-generator";
+import type {Config, SchemaGenerator} from "ts-json-schema-generator";
 
-const config: Config = {
-    schemaId: "https://khanacademy.org/schema/perseus.json",
-    tsconfig: path.join(__dirname, "..", "tsconfig.json"),
-    jsDoc: "extended",
+const RefNameExtractorRegex = /#\/definitions\/(?<name>.*)/;
 
-    // type: "PerseusItem",
+const getRefDefinitionName = (ref: string) => {
+    const match = ref.match(RefNameExtractorRegex);
+    if (match) {
+        return match.groups?.["name"];
+    }
 };
 
-const outputPath = path.join(__dirname, "generated/schema.json");
-fs.mkdirSync(path.dirname(outputPath), {recursive: true});
+function derefSchema(schema: ReturnType<SchemaGenerator["createSchema"]>) {
+    const derefIfRef = (level, key, obj) => {
+        try {
+            if (
+                obj != null &&
+                typeof obj === "object" &&
+                !Array.isArray(obj) &&
+                "$ref" in obj
+            ) {
+                const defName = getRefDefinitionName(obj["$ref"]);
 
-const schema = createGenerator(config).createSchema("PerseusItem"); // config.type);
-const schemaString = JSON.stringify(schema, null, 2);
-fs.writeFile(outputPath, schemaString, (err) => {
-    if (err) {
-        throw err;
+                if (defName != null) {
+                    return schema.definitions?.[defName];
+                }
+            }
+        } catch (e) {
+            console.log(key, obj);
+            throw e;
+        }
+    };
+
+    const processProps = (path: string[], props, level: number = 0) => {
+        if (props == null) {
+            return;
+        }
+
+        if (Array.isArray(props)) {
+            for (let i = 0; i < props.length; i++) {
+                const newPath = [...path, `[${i}]`];
+                const refTarget = derefIfRef(level, i, props[i]);
+                if (refTarget) {
+                    props[i] = refTarget;
+                }
+
+                processProps(newPath, props[i], level + 1);
+            }
+        } else if (typeof props === "object") {
+            for (const [key, val] of Object.entries(props)) {
+                const newPath = [...path, key];
+                const refTarget = derefIfRef(level, key, val);
+                if (refTarget) {
+                    props[key] = refTarget;
+                }
+
+                // Stop recursion of nested Renderers
+                if (key === "widgets" && path.indexOf("widgets") !== -1) {
+                    delete props[key];
+                    continue;
+                }
+                processProps(newPath, props[key], level + 1);
+            }
+        }
+    };
+
+    processProps(["root"], schema.properties);
+    processProps(["root"], schema.additionalProperties);
+
+    return schema;
+}
+
+function generateSchema() {
+    const config: Config = {
+        schemaId: "https://khanacademy.org/schema/perseus.json",
+        tsconfig: path.join(__dirname, "..", "tsconfig.json"),
+        jsDoc: "extended",
+        expose: "all",
+        functions: "hide",
+        encodeRefs: false,
+
+        skipTypeCheck: true,
+    };
+
+    const generatedDir = path.join(__dirname, "generated");
+    const rawSchemaPath = path.join(generatedDir, "schema-raw.json");
+    const schemaPath = path.join(generatedDir, "schema.json");
+    fs.mkdirSync(path.dirname(generatedDir), {recursive: true});
+
+    console.log("Generating schema...");
+    const schema = createGenerator(config).createSchema("PerseusItem");
+    const perseusItem = schema.definitions?.["PerseusItem"];
+    if (perseusItem == null) {
+        throw new Error("Could not find PerseusItem type in defs!");
     }
-});
+    // Raise up the "PerseusItem" to the root
+    schema.type = "object";
+    for (const [name, val] of Object.entries(perseusItem)) {
+        schema[name] = val;
+    }
+
+    const schemaString = JSON.stringify(schema, undefined, "  ");
+    fs.writeFileSync(rawSchemaPath, schemaString);
+
+    console.log("Dereferencing schema...");
+    const dereferencedSchema = derefSchema(schema);
+    fs.writeFileSync(
+        schemaPath,
+        JSON.stringify(dereferencedSchema, undefined, "  "),
+    );
+}
+
+try {
+    generateSchema();
+} catch (e) {
+    console.log("Script failed!!!");
+    console.error(e);
+    process.exit(1);
+}

--- a/utils/generate-schema.ts
+++ b/utils/generate-schema.ts
@@ -1,0 +1,27 @@
+#!/usr/bin/env -S node -r @swc-node/register
+
+import fs from "fs";
+import path from "path";
+
+import {createGenerator} from "ts-json-schema-generator";
+
+import type {Config} from "ts-json-schema-generator";
+
+const config: Config = {
+    schemaId: "https://khanacademy.org/schema/perseus.json",
+    tsconfig: path.join(__dirname, "..", "tsconfig.json"),
+    jsDoc: "extended",
+
+    // type: "PerseusItem",
+};
+
+const outputPath = path.join(__dirname, "generated/schema.json");
+fs.mkdirSync(path.dirname(outputPath), {recursive: true});
+
+const schema = createGenerator(config).createSchema("PerseusItem"); // config.type);
+const schemaString = JSON.stringify(schema, null, 2);
+fs.writeFile(outputPath, schemaString, (err) => {
+    if (err) {
+        throw err;
+    }
+});

--- a/utils/generated/schema-raw.json
+++ b/utils/generated/schema-raw.json
@@ -1,0 +1,4502 @@
+{
+  "$id": "https://khanacademy.org/schema/perseus.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/PerseusItem",
+  "definitions": {
+    "PerseusItem": {
+      "type": "object",
+      "properties": {
+        "question": {
+          "$ref": "#/definitions/PerseusRenderer"
+        },
+        "hints": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusRenderer"
+          }
+        },
+        "answerArea": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusAnswerArea"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "_multi": {},
+        "itemDataVersion": {
+          "$ref": "#/definitions/Version"
+        },
+        "answer": {}
+      },
+      "required": [
+        "question",
+        "hints",
+        "_multi",
+        "itemDataVersion",
+        "answer"
+      ],
+      "additionalProperties": false,
+      "description": "The PerseusItem is the main Perseus data structure for an exercise.  It forms a question (with interactive widgets), a set of hints, and answer area configuration (such as whether to make a calculator or periodic table available to the learner)."
+    },
+    "PerseusRenderer": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "widgets": {
+          "$ref": "#/definitions/PerseusWidgetsMap"
+        },
+        "replace": {
+          "type": "boolean"
+        },
+        "metadata": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "images": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/PerseusImageDetail"
+          }
+        }
+      },
+      "required": [
+        "content",
+        "widgets",
+        "images"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusWidgetsMap": {
+      "type": "object",
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "$ref": "#/definitions/CategorizerWidget"
+          },
+          {
+            "$ref": "#/definitions/CSProgramWidget"
+          },
+          {
+            "$ref": "#/definitions/DefinitionWidget"
+          },
+          {
+            "$ref": "#/definitions/DropdownWidget"
+          },
+          {
+            "$ref": "#/definitions/ExampleWidget"
+          },
+          {
+            "$ref": "#/definitions/ExampleGraphieWidget"
+          },
+          {
+            "$ref": "#/definitions/ExplanationWidget"
+          },
+          {
+            "$ref": "#/definitions/ExpressionWidget"
+          },
+          {
+            "$ref": "#/definitions/GrapherWidget"
+          },
+          {
+            "$ref": "#/definitions/GroupWidget"
+          },
+          {
+            "$ref": "#/definitions/GradedGroupWidget"
+          },
+          {
+            "$ref": "#/definitions/GradedGroupSetWidget"
+          },
+          {
+            "$ref": "#/definitions/IFrameWidget"
+          },
+          {
+            "$ref": "#/definitions/ImageWidget"
+          },
+          {
+            "$ref": "#/definitions/InputNumberWidget"
+          },
+          {
+            "$ref": "#/definitions/InteractionWidget"
+          },
+          {
+            "$ref": "#/definitions/InteractiveGraphWidget"
+          },
+          {
+            "$ref": "#/definitions/LabelImageWidget"
+          },
+          {
+            "$ref": "#/definitions/MatcherWidget"
+          },
+          {
+            "$ref": "#/definitions/MatrixWidget"
+          },
+          {
+            "$ref": "#/definitions/MeasurerWidget"
+          },
+          {
+            "$ref": "#/definitions/MoleculeRendererWidget"
+          },
+          {
+            "$ref": "#/definitions/NumberLineWidget"
+          },
+          {
+            "$ref": "#/definitions/NumericInputWidget"
+          },
+          {
+            "$ref": "#/definitions/OrdererWidget"
+          },
+          {
+            "$ref": "#/definitions/PassageWidget"
+          },
+          {
+            "$ref": "#/definitions/PassageRefWidget"
+          },
+          {
+            "$ref": "#/definitions/PassageRefWidget"
+          },
+          {
+            "$ref": "#/definitions/PlotterWidget"
+          },
+          {
+            "$ref": "#/definitions/PythonProgramWidget"
+          },
+          {
+            "$ref": "#/definitions/RadioWidget"
+          },
+          {
+            "$ref": "#/definitions/SimpleMarkdownTesterWidget"
+          },
+          {
+            "$ref": "#/definitions/SorterWidget"
+          },
+          {
+            "$ref": "#/definitions/TableWidget"
+          },
+          {
+            "$ref": "#/definitions/UnitInputWidget"
+          },
+          {
+            "$ref": "#/definitions/VideoWidget"
+          }
+        ]
+      },
+      "properties": {}
+    },
+    "CategorizerWidget": {
+      "$ref": "#/definitions/Widget<\"categorizer\",PerseusCategorizerWidgetOptions>"
+    },
+    "Widget<\"categorizer\",PerseusCategorizerWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "categorizer"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusCategorizerWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusCategorizerWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "randomizeItems": {
+          "type": "boolean"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "highlightLint": {
+          "type": "boolean"
+        },
+        "linterContext": {
+          "$ref": "#/definitions/PerseusLinterContext"
+        }
+      },
+      "required": [
+        "items",
+        "categories",
+        "randomizeItems",
+        "static",
+        "values"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusLinterContext": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string"
+        },
+        "paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "stack": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "contentType",
+        "paths",
+        "stack"
+      ],
+      "additionalProperties": false
+    },
+    "Version": {
+      "type": "object",
+      "properties": {
+        "major": {
+          "type": "number"
+        },
+        "minor": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "major",
+        "minor"
+      ],
+      "additionalProperties": false
+    },
+    "CSProgramWidget": {
+      "$ref": "#/definitions/Widget<\"cs-program\",PerseusCSProgramWidgetOptions>"
+    },
+    "Widget<\"cs-program\",PerseusCSProgramWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "cs-program"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusCSProgramWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusCSProgramWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "programID": {
+          "type": "string"
+        },
+        "programType": {},
+        "settings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusCSProgramSetting"
+          }
+        },
+        "showEditor": {
+          "type": "boolean"
+        },
+        "showButtons": {
+          "type": "boolean"
+        },
+        "width": {
+          "type": "number"
+        },
+        "height": {
+          "type": "number"
+        },
+        "static": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "programID",
+        "settings",
+        "showEditor",
+        "showButtons",
+        "width",
+        "height",
+        "static"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusCSProgramSetting": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ],
+      "additionalProperties": false
+    },
+    "DefinitionWidget": {
+      "$ref": "#/definitions/Widget<\"definition\",PerseusDefinitionWidgetOptions>"
+    },
+    "Widget<\"definition\",PerseusDefinitionWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "definition"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusDefinitionWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusDefinitionWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "togglePrompt": {
+          "type": "string"
+        },
+        "definition": {
+          "type": "string"
+        },
+        "static": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "togglePrompt",
+        "definition",
+        "static"
+      ],
+      "additionalProperties": false
+    },
+    "DropdownWidget": {
+      "$ref": "#/definitions/Widget<\"dropdown\",PerseusDropdownWidgetOptions>"
+    },
+    "Widget<\"dropdown\",PerseusDropdownWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "dropdown"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusDropdownWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusDropdownWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "choices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusDropdownChoice"
+          }
+        },
+        "placeholder": {
+          "type": "string"
+        },
+        "static": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "choices",
+        "placeholder",
+        "static"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusDropdownChoice": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "correct": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "content",
+        "correct"
+      ],
+      "additionalProperties": false
+    },
+    "ExampleWidget": {
+      "$ref": "#/definitions/Widget<\"example-widget\",PerseusExampleWidgetOptions>"
+    },
+    "Widget<\"example-widget\",PerseusExampleWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "example-widget"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusExampleWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusExampleWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false
+    },
+    "ExampleGraphieWidget": {
+      "$ref": "#/definitions/Widget<\"example-graphie-widget\",PerseusExampleGraphieWidgetOptions>"
+    },
+    "Widget<\"example-graphie-widget\",PerseusExampleGraphieWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "example-graphie-widget"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusExampleGraphieWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusExampleGraphieWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "graph": {
+          "$ref": "#/definitions/PerseusExampleGraphieGraph"
+        },
+        "coord": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Coord"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "graph",
+        "coord"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusExampleGraphieGraph": {
+      "type": "object",
+      "properties": {
+        "box": {
+          "$ref": "#/definitions/Size"
+        },
+        "range": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Coord"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "markings": {
+          "type": "string",
+          "enum": [
+            "graph",
+            "grid",
+            "none"
+          ]
+        },
+        "gridStep": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "step": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "showProtractor": {
+          "type": "boolean"
+        },
+        "showRuler": {
+          "type": "boolean"
+        },
+        "valid": {
+          "type": "boolean"
+        },
+        "backgroundImage": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusImageBackground"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "box",
+        "range",
+        "labels",
+        "markings",
+        "gridStep",
+        "step"
+      ],
+      "additionalProperties": false
+    },
+    "Size": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "Coord": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "PerseusImageBackground": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "width": {
+          "type": "number"
+        },
+        "height": {
+          "type": "number"
+        },
+        "top": {
+          "type": "number"
+        },
+        "left": {
+          "type": "number"
+        },
+        "scale": {
+          "type": [
+            "number",
+            "string"
+          ]
+        },
+        "bottom": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExplanationWidget": {
+      "$ref": "#/definitions/Widget<\"explanation\",PerseusExplanationWidgetOptions>"
+    },
+    "Widget<\"explanation\",PerseusExplanationWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "explanation"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusExplanationWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusExplanationWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "showPrompt": {
+          "type": "string"
+        },
+        "hidePrompt": {
+          "type": "string"
+        },
+        "explanation": {
+          "type": "string"
+        },
+        "widgets": {
+          "$ref": "#/definitions/PerseusWidgetsMap"
+        },
+        "static": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "showPrompt",
+        "hidePrompt",
+        "explanation",
+        "widgets",
+        "static"
+      ],
+      "additionalProperties": false
+    },
+    "ExpressionWidget": {
+      "$ref": "#/definitions/Widget<\"expression\",PerseusExpressionWidgetOptions>"
+    },
+    "Widget<\"expression\",PerseusExpressionWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "expression"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusExpressionWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusExpressionWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "answerForms": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusExpressionAnswerForm"
+          }
+        },
+        "buttonSets": {
+          "$ref": "#/definitions/LegacyButtonSets"
+        },
+        "functions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "times": {
+          "type": "boolean"
+        },
+        "buttonsVisible": {
+          "type": "string",
+          "enum": [
+            "always",
+            "never",
+            "focused"
+          ]
+        }
+      },
+      "required": [
+        "answerForms",
+        "buttonSets",
+        "functions",
+        "times"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusExpressionAnswerForm": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "form": {
+          "type": "boolean"
+        },
+        "simplify": {
+          "type": "boolean"
+        },
+        "considered": {
+          "type": "string",
+          "enum": [
+            "correct",
+            "wrong",
+            "ungraded"
+          ]
+        },
+        "key": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "value",
+        "form",
+        "simplify",
+        "considered"
+      ],
+      "additionalProperties": false
+    },
+    "LegacyButtonSets": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "basic",
+          "basic+div",
+          "trig",
+          "prealgebra",
+          "logarithms",
+          "basic relations",
+          "advanced relations"
+        ]
+      }
+    },
+    "GrapherWidget": {
+      "$ref": "#/definitions/Widget<\"grapher\",PerseusGrapherWidgetOptions>"
+    },
+    "Widget<\"grapher\",PerseusGrapherWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "grapher"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusGrapherWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusGrapherWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "availableTypes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "absolute_value",
+              "exponential",
+              "linear",
+              "logarithm",
+              "quadratic",
+              "sinusoid",
+              "tangent"
+            ]
+          }
+        },
+        "correct": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "absolute_value"
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coord"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              },
+              "required": [
+                "type",
+                "coords"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "exponential"
+                },
+                "asymptote": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coord"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coord"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              },
+              "required": [
+                "type",
+                "asymptote",
+                "coords"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "linear"
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coord"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              },
+              "required": [
+                "type",
+                "coords"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "logarithm"
+                },
+                "asymptote": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coord"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coord"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              },
+              "required": [
+                "type",
+                "asymptote",
+                "coords"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "quadratic"
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coord"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              },
+              "required": [
+                "type",
+                "coords"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "sinusoid"
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coord"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              },
+              "required": [
+                "type",
+                "coords"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "tangent"
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coord"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              },
+              "required": [
+                "type",
+                "coords"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "graph": {
+          "type": "object",
+          "properties": {
+            "backgroundImage": {
+              "type": "object",
+              "properties": {
+                "bottom": {
+                  "type": "number"
+                },
+                "height": {
+                  "type": "number"
+                },
+                "left": {
+                  "type": "number"
+                },
+                "scale": {
+                  "type": "number"
+                },
+                "url": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "width": {
+                  "type": "number"
+                }
+              },
+              "additionalProperties": false
+            },
+            "box": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "editableSettings": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "graph",
+                  "snap",
+                  "image",
+                  "measure"
+                ]
+              }
+            },
+            "gridStep": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "labels": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "markings": {
+              "type": "string",
+              "enum": [
+                "graph",
+                "none",
+                "grid"
+              ]
+            },
+            "range": {
+              "$ref": "#/definitions/GraphRange"
+            },
+            "rulerLabel": {
+              "type": "string",
+              "const": ""
+            },
+            "rulerTicks": {
+              "type": "number"
+            },
+            "showProtractor": {
+              "type": "boolean"
+            },
+            "showRuler": {
+              "type": "boolean"
+            },
+            "showTooltips": {
+              "type": "boolean"
+            },
+            "snapStep": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "step": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "valid": {
+              "type": [
+                "boolean",
+                "string"
+              ]
+            }
+          },
+          "required": [
+            "backgroundImage",
+            "labels",
+            "markings",
+            "range",
+            "rulerLabel",
+            "rulerTicks",
+            "step"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "availableTypes",
+        "correct",
+        "graph"
+      ],
+      "additionalProperties": false
+    },
+    "GraphRange": {
+      "type": "array",
+      "minItems": 2,
+      "items": [
+        {
+          "type": "array",
+          "minItems": 2,
+          "items": [
+            {
+              "type": "number",
+              "title": "min"
+            },
+            {
+              "type": "number",
+              "title": "max"
+            }
+          ],
+          "maxItems": 2,
+          "title": "x"
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "items": [
+            {
+              "type": "number",
+              "title": "min"
+            },
+            {
+              "type": "number",
+              "title": "max"
+            }
+          ],
+          "maxItems": 2,
+          "title": "y"
+        }
+      ],
+      "maxItems": 2
+    },
+    "GroupWidget": {
+      "$ref": "#/definitions/Widget<\"group\",PerseusGroupWidgetOptions>"
+    },
+    "Widget<\"group\",PerseusGroupWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "group"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusGroupWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusGroupWidgetOptions": {
+      "$ref": "#/definitions/PerseusRenderer"
+    },
+    "GradedGroupWidget": {
+      "$ref": "#/definitions/Widget<\"graded-group\",PerseusGradedGroupWidgetOptions>"
+    },
+    "Widget<\"graded-group\",PerseusGradedGroupWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "graded-group"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusGradedGroupWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusGradedGroupWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "hasHint": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "hint": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusRenderer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "content": {
+          "type": "string"
+        },
+        "widgets": {
+          "$ref": "#/definitions/PerseusWidgetsMap"
+        },
+        "widgetEnabled": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "immutableWidgets": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "images": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/PerseusImageDetail"
+          }
+        }
+      },
+      "required": [
+        "title",
+        "content",
+        "widgets",
+        "images"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusImageDetail": {
+      "type": "object",
+      "properties": {
+        "width": {
+          "type": "number"
+        },
+        "height": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "width",
+        "height"
+      ],
+      "additionalProperties": false
+    },
+    "GradedGroupSetWidget": {
+      "$ref": "#/definitions/Widget<\"graded-group-set\",PerseusGradedGroupSetWidgetOptions>"
+    },
+    "Widget<\"graded-group-set\",PerseusGradedGroupSetWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "graded-group-set"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusGradedGroupSetWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusGradedGroupSetWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "gradedGroups": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusGradedGroupWidgetOptions"
+          }
+        }
+      },
+      "required": [
+        "gradedGroups"
+      ],
+      "additionalProperties": false
+    },
+    "IFrameWidget": {
+      "$ref": "#/definitions/Widget<\"iframe\",PerseusIFrameWidgetOptions>"
+    },
+    "Widget<\"iframe\",PerseusIFrameWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "iframe"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusIFrameWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusIFrameWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "settings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusCSProgramSetting"
+          }
+        },
+        "width": {
+          "type": [
+            "number",
+            "string"
+          ]
+        },
+        "height": {
+          "type": [
+            "number",
+            "string"
+          ]
+        },
+        "allowFullScreen": {
+          "type": "boolean"
+        },
+        "allowTopNavigation": {
+          "type": "boolean"
+        },
+        "static": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "url",
+        "settings",
+        "width",
+        "height",
+        "allowFullScreen",
+        "static"
+      ],
+      "additionalProperties": false
+    },
+    "ImageWidget": {
+      "$ref": "#/definitions/Widget<\"image\",PerseusImageWidgetOptions>"
+    },
+    "Widget<\"image\",PerseusImageWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "image"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusImageWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusImageWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "caption": {
+          "type": "string"
+        },
+        "alt": {
+          "type": "string"
+        },
+        "backgroundImage": {
+          "$ref": "#/definitions/PerseusImageBackground"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusImageLabel"
+          }
+        },
+        "range": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Interval"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "box": {
+          "$ref": "#/definitions/Size"
+        }
+      },
+      "required": [
+        "backgroundImage"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusImageLabel": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "coordinates": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        }
+      },
+      "required": [
+        "content",
+        "alignment",
+        "coordinates"
+      ],
+      "additionalProperties": false
+    },
+    "Interval": {
+      "type": "array",
+      "minItems": 2,
+      "items": [
+        {
+          "type": "number",
+          "title": "min"
+        },
+        {
+          "type": "number",
+          "title": "max"
+        }
+      ],
+      "maxItems": 2
+    },
+    "InputNumberWidget": {
+      "$ref": "#/definitions/Widget<\"input-number\",PerseusInputNumberWidgetOptions>"
+    },
+    "Widget<\"input-number\",PerseusInputNumberWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "input-number"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusInputNumberWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusInputNumberWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "answerType": {
+          "type": "string",
+          "enum": [
+            "number",
+            "decimal",
+            "integer",
+            "rational",
+            "improper",
+            "mixed",
+            "percent",
+            "pi"
+          ]
+        },
+        "inexact": {
+          "type": "boolean"
+        },
+        "maxError": {
+          "type": [
+            "number",
+            "string"
+          ]
+        },
+        "rightAlign": {
+          "type": "boolean"
+        },
+        "simplify": {
+          "type": "string",
+          "enum": [
+            "required",
+            "optional",
+            "enforced"
+          ]
+        },
+        "size": {
+          "type": "string",
+          "enum": [
+            "normal",
+            "small"
+          ]
+        },
+        "value": {
+          "type": [
+            "string",
+            "number"
+          ]
+        },
+        "customKeypad": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "simplify",
+        "size",
+        "value"
+      ],
+      "additionalProperties": false
+    },
+    "InteractionWidget": {
+      "$ref": "#/definitions/Widget<\"interaction\",PerseusInteractionWidgetOptions>"
+    },
+    "Widget<\"interaction\",PerseusInteractionWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "interaction"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusInteractionWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusInteractionWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "graph": {
+          "$ref": "#/definitions/PerseusInteractionGraph"
+        },
+        "elements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusInteractionElement"
+          }
+        },
+        "static": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "graph",
+        "elements",
+        "static"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusInteractionGraph": {
+      "type": "object",
+      "properties": {
+        "editableSettings": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "canvas",
+              "graph"
+            ]
+          }
+        },
+        "box": {
+          "$ref": "#/definitions/Size"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "range": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Interval"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "gridStep": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "markings": {
+          "type": "string",
+          "enum": [
+            "graph",
+            "grid",
+            "none"
+          ],
+          "description": "The type of markings to display on the graph.\n- graph: shows the axes and the grid lines\n- grid: shows only the grid lines\n- none: shows no markings"
+        },
+        "snapStep": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "valid": {
+          "type": [
+            "boolean",
+            "string"
+          ]
+        },
+        "backgroundImage": {
+          "$ref": "#/definitions/PerseusImageBackground"
+        },
+        "showProtractor": {
+          "type": "boolean"
+        },
+        "showRuler": {
+          "type": "boolean"
+        },
+        "rulerLabel": {
+          "type": "string"
+        },
+        "rulerTicks": {
+          "type": "number"
+        },
+        "tickStep": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        }
+      },
+      "required": [
+        "box",
+        "labels",
+        "range",
+        "gridStep",
+        "markings",
+        "tickStep"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusInteractionElement": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "function"
+            },
+            "key": {
+              "type": "string"
+            },
+            "options": {
+              "$ref": "#/definitions/PerseusInteractionFunctionElementOptions"
+            }
+          },
+          "required": [
+            "type",
+            "key",
+            "options"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "label"
+            },
+            "key": {
+              "type": "string"
+            },
+            "options": {
+              "$ref": "#/definitions/PerseusInteractionLabelElementOptions"
+            }
+          },
+          "required": [
+            "type",
+            "key",
+            "options"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "line"
+            },
+            "key": {
+              "type": "string"
+            },
+            "options": {
+              "$ref": "#/definitions/PerseusInteractionLineElementOptions"
+            }
+          },
+          "required": [
+            "type",
+            "key",
+            "options"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "movable-line"
+            },
+            "key": {
+              "type": "string"
+            },
+            "options": {
+              "$ref": "#/definitions/PerseusInteractionMovableLineElementOptions"
+            }
+          },
+          "required": [
+            "type",
+            "key",
+            "options"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "movable-point"
+            },
+            "key": {
+              "type": "string"
+            },
+            "options": {
+              "$ref": "#/definitions/PerseusInteractionMovablePointElementOptions"
+            }
+          },
+          "required": [
+            "type",
+            "key",
+            "options"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "parametric"
+            },
+            "key": {
+              "type": "string"
+            },
+            "options": {
+              "$ref": "#/definitions/PerseusInteractionParametricElementOptions"
+            }
+          },
+          "required": [
+            "type",
+            "key",
+            "options"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "point"
+            },
+            "key": {
+              "type": "string"
+            },
+            "options": {
+              "$ref": "#/definitions/PerseusInteractionPointElementOptions"
+            }
+          },
+          "required": [
+            "type",
+            "key",
+            "options"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "rectangle"
+            },
+            "key": {
+              "type": "string"
+            },
+            "options": {
+              "$ref": "#/definitions/PerseusInteractionRectangleElementOptions"
+            }
+          },
+          "required": [
+            "type",
+            "key",
+            "options"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "PerseusInteractionFunctionElementOptions": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "funcName": {
+          "type": "string"
+        },
+        "rangeMin": {
+          "type": "string"
+        },
+        "rangeMax": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        },
+        "strokeDasharray": {
+          "type": "string"
+        },
+        "strokeWidth": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "value",
+        "funcName",
+        "rangeMin",
+        "rangeMax",
+        "color",
+        "strokeDasharray",
+        "strokeWidth"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusInteractionLabelElementOptions": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        },
+        "coordX": {
+          "type": "string"
+        },
+        "coordY": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "label",
+        "color",
+        "coordX",
+        "coordY"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusInteractionLineElementOptions": {
+      "type": "object",
+      "properties": {
+        "color": {
+          "type": "string"
+        },
+        "startX": {
+          "type": "string"
+        },
+        "startY": {
+          "type": "string"
+        },
+        "endX": {
+          "type": "string"
+        },
+        "endY": {
+          "type": "string"
+        },
+        "strokeDasharray": {
+          "type": "string"
+        },
+        "strokeWidth": {
+          "type": "number"
+        },
+        "arrows": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "color",
+        "startX",
+        "startY",
+        "endX",
+        "endY",
+        "strokeDasharray",
+        "strokeWidth",
+        "arrows"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusInteractionMovableLineElementOptions": {
+      "type": "object",
+      "properties": {
+        "startX": {
+          "type": "string"
+        },
+        "startY": {
+          "type": "string"
+        },
+        "startSubscript": {
+          "type": "number"
+        },
+        "endX": {
+          "type": "string"
+        },
+        "endY": {
+          "type": "string"
+        },
+        "endSubscript": {
+          "type": "number"
+        },
+        "constraint": {
+          "type": "string"
+        },
+        "snap": {
+          "type": "number"
+        },
+        "constraintFn": {
+          "type": "string"
+        },
+        "constraintXMin": {
+          "type": "string"
+        },
+        "constraintXMax": {
+          "type": "string"
+        },
+        "constraintYMin": {
+          "type": "string"
+        },
+        "constraintYMax": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "startX",
+        "startY",
+        "startSubscript",
+        "endX",
+        "endY",
+        "endSubscript",
+        "constraint",
+        "snap",
+        "constraintFn",
+        "constraintXMin",
+        "constraintXMax",
+        "constraintYMin",
+        "constraintYMax"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusInteractionMovablePointElementOptions": {
+      "type": "object",
+      "properties": {
+        "startX": {
+          "type": "string"
+        },
+        "startY": {
+          "type": "string"
+        },
+        "varSubscript": {
+          "type": "number"
+        },
+        "constraint": {
+          "type": "string"
+        },
+        "snap": {
+          "type": "number"
+        },
+        "constraintFn": {
+          "type": "string"
+        },
+        "constraintXMin": {
+          "type": "string"
+        },
+        "constraintXMax": {
+          "type": "string"
+        },
+        "constraintYMin": {
+          "type": "string"
+        },
+        "constraintYMax": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "startX",
+        "startY",
+        "varSubscript",
+        "constraint",
+        "snap",
+        "constraintFn",
+        "constraintXMin",
+        "constraintXMax",
+        "constraintYMin",
+        "constraintYMax"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusInteractionParametricElementOptions": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "type": "string"
+        },
+        "y": {
+          "type": "string"
+        },
+        "rangeMin": {
+          "type": "string"
+        },
+        "rangeMax": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        },
+        "strokeDasharray": {
+          "type": "string"
+        },
+        "strokeWidth": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y",
+        "rangeMin",
+        "rangeMax",
+        "color",
+        "strokeDasharray",
+        "strokeWidth"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusInteractionPointElementOptions": {
+      "type": "object",
+      "properties": {
+        "color": {
+          "type": "string"
+        },
+        "coordX": {
+          "type": "string"
+        },
+        "coordY": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "color",
+        "coordX",
+        "coordY"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusInteractionRectangleElementOptions": {
+      "type": "object",
+      "properties": {
+        "color": {
+          "type": "string"
+        },
+        "coordX": {
+          "type": "string"
+        },
+        "coordY": {
+          "type": "string"
+        },
+        "width": {
+          "type": "string"
+        },
+        "height": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "color",
+        "coordX",
+        "coordY",
+        "width",
+        "height"
+      ],
+      "additionalProperties": false
+    },
+    "InteractiveGraphWidget": {
+      "$ref": "#/definitions/Widget<\"interactive-graph\",PerseusInteractiveGraphWidgetOptions>"
+    },
+    "Widget<\"interactive-graph\",PerseusInteractiveGraphWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "interactive-graph"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusInteractiveGraphWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusInteractiveGraphWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "step": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "gridStep": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "snapStep": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "backgroundImage": {
+          "$ref": "#/definitions/PerseusImageBackground"
+        },
+        "markings": {
+          "type": "string",
+          "enum": [
+            "graph",
+            "grid",
+            "none"
+          ],
+          "description": "The type of markings to display on the graph.\n- graph: shows the axes and the grid lines\n- grid: shows only the grid lines\n- none: shows no markings"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "showProtractor": {
+          "type": "boolean"
+        },
+        "showRuler": {
+          "type": "boolean"
+        },
+        "showTooltips": {
+          "type": "boolean"
+        },
+        "rulerLabel": {
+          "type": "string"
+        },
+        "rulerTicks": {
+          "type": "number"
+        },
+        "range": {
+          "$ref": "#/definitions/GraphRange"
+        },
+        "graph": {
+          "$ref": "#/definitions/PerseusGraphType"
+        },
+        "correct": {
+          "$ref": "#/definitions/PerseusGraphType"
+        },
+        "lockedFigures": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LockedFigure"
+          }
+        }
+      },
+      "required": [
+        "step",
+        "gridStep",
+        "snapStep",
+        "markings",
+        "labels",
+        "showProtractor",
+        "showRuler",
+        "rulerLabel",
+        "rulerTicks",
+        "range",
+        "graph",
+        "correct"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusGraphType": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/PerseusGraphTypeAngle"
+        },
+        {
+          "$ref": "#/definitions/PerseusGraphTypeCircle"
+        },
+        {
+          "$ref": "#/definitions/PerseusGraphTypeLinear"
+        },
+        {
+          "$ref": "#/definitions/PerseusGraphTypeLinearSystem"
+        },
+        {
+          "$ref": "#/definitions/PerseusGraphTypePoint"
+        },
+        {
+          "$ref": "#/definitions/PerseusGraphTypePolygon"
+        },
+        {
+          "$ref": "#/definitions/PerseusGraphTypeQuadratic"
+        },
+        {
+          "$ref": "#/definitions/PerseusGraphTypeRay"
+        },
+        {
+          "$ref": "#/definitions/PerseusGraphTypeSegment"
+        },
+        {
+          "$ref": "#/definitions/PerseusGraphTypeSinusoid"
+        }
+      ]
+    },
+    "PerseusGraphTypeAngle": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "angle"
+        },
+        "showAngles": {
+          "type": "boolean"
+        },
+        "allowReflexAngles": {
+          "type": "boolean"
+        },
+        "angleOffsetDeg": {
+          "type": "number"
+        },
+        "snapDegrees": {
+          "type": "number"
+        },
+        "match": {
+          "type": "string",
+          "const": "congruent"
+        },
+        "coords": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Coord"
+          }
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusGraphTypeCircle": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "coord": {
+          "$ref": "#/definitions/Coord"
+        },
+        "type": {
+          "type": "string",
+          "const": "circle"
+        },
+        "center": {
+          "$ref": "#/definitions/Coord"
+        },
+        "radius": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "PerseusGraphTypeLinear": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "coord": {
+          "$ref": "#/definitions/Coord"
+        },
+        "type": {
+          "type": "string",
+          "const": "linear"
+        },
+        "coords": {
+          "$ref": "#/definitions/CollinearTuple"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "CollinearTuple": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/vec.Vector2"
+      },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "vec.Vector2": {
+      "type": "array",
+      "minItems": 2,
+      "items": [
+        {
+          "type": "number",
+          "title": "x"
+        },
+        {
+          "type": "number",
+          "title": "y"
+        }
+      ],
+      "maxItems": 2,
+      "description": "A two-dimensional vector"
+    },
+    "PerseusGraphTypeLinearSystem": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "coord": {
+          "$ref": "#/definitions/Coord"
+        },
+        "type": {
+          "type": "string",
+          "const": "linear-system"
+        },
+        "coords": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CollinearTuple"
+          }
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "PerseusGraphTypePoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "coord": {
+          "$ref": "#/definitions/Coord"
+        },
+        "type": {
+          "type": "string",
+          "const": "point"
+        },
+        "numPoints": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string",
+              "const": "unlimited"
+            }
+          ]
+        },
+        "coords": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Coord"
+          }
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "PerseusGraphTypePolygon": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "coord": {
+          "$ref": "#/definitions/Coord"
+        },
+        "type": {
+          "type": "string",
+          "const": "polygon"
+        },
+        "numSides": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string",
+              "const": "unlimited"
+            }
+          ]
+        },
+        "showAngles": {
+          "type": "boolean"
+        },
+        "showSides": {
+          "type": "boolean"
+        },
+        "snapTo": {
+          "type": "string"
+        },
+        "match": {
+          "type": "string",
+          "enum": [
+            "similar",
+            "congruent",
+            "approx"
+          ]
+        },
+        "coords": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Coord"
+          }
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "PerseusGraphTypeQuadratic": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "coord": {
+          "$ref": "#/definitions/Coord"
+        },
+        "type": {
+          "type": "string",
+          "const": "quadratic"
+        },
+        "coords": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Coord"
+          }
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "PerseusGraphTypeRay": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "coord": {
+          "$ref": "#/definitions/Coord"
+        },
+        "type": {
+          "type": "string",
+          "const": "ray"
+        },
+        "coords": {
+          "$ref": "#/definitions/CollinearTuple"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "PerseusGraphTypeSegment": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "coord": {
+          "$ref": "#/definitions/Coord"
+        },
+        "type": {
+          "type": "string",
+          "const": "segment"
+        },
+        "numSegments": {
+          "type": "number"
+        },
+        "coords": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CollinearTuple"
+          }
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "PerseusGraphTypeSinusoid": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "coord": {
+          "$ref": "#/definitions/Coord"
+        },
+        "type": {
+          "type": "string",
+          "const": "sinusoid"
+        },
+        "coords": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Coord"
+          }
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "LockedFigure": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/LockedPointType"
+        },
+        {
+          "$ref": "#/definitions/LockedLineType"
+        }
+      ]
+    },
+    "LockedPointType": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "point"
+        },
+        "coord": {
+          "$ref": "#/definitions/Coord"
+        },
+        "color": {
+          "$ref": "#/definitions/LockedFigureColor"
+        },
+        "filled": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "type",
+        "coord",
+        "color",
+        "filled"
+      ],
+      "additionalProperties": false
+    },
+    "LockedFigureColor": {
+      "type": "string",
+      "enum": [
+        "green",
+        "grayH",
+        "purple",
+        "pink",
+        "red"
+      ]
+    },
+    "LockedLineType": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "line"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "line",
+            "ray",
+            "segment"
+          ]
+        },
+        "points": {
+          "type": "array",
+          "minItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/LockedPointType",
+              "title": "point1"
+            },
+            {
+              "$ref": "#/definitions/LockedPointType",
+              "title": "point2"
+            }
+          ],
+          "maxItems": 2
+        },
+        "color": {
+          "$ref": "#/definitions/LockedFigureColor"
+        },
+        "lineStyle": {
+          "type": "string",
+          "enum": [
+            "solid",
+            "dashed"
+          ]
+        },
+        "showPoint1": {
+          "type": "boolean"
+        },
+        "showPoint2": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "type",
+        "kind",
+        "points",
+        "color",
+        "lineStyle",
+        "showPoint1",
+        "showPoint2"
+      ],
+      "additionalProperties": false
+    },
+    "LabelImageWidget": {
+      "$ref": "#/definitions/Widget<\"label-image\",PerseusLabelImageWidgetOptions>"
+    },
+    "Widget<\"label-image\",PerseusLabelImageWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "label-image"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusLabelImageWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusLabelImageWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "choices": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "imageUrl": {
+          "type": "string"
+        },
+        "imageAlt": {
+          "type": "string"
+        },
+        "imageHeight": {
+          "type": "number"
+        },
+        "imageWidth": {
+          "type": "number"
+        },
+        "markers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusLabelImageMarker"
+          }
+        },
+        "hideChoicesFromInstructions": {
+          "type": "boolean"
+        },
+        "multipleAnswers": {
+          "type": "boolean"
+        },
+        "static": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "choices",
+        "imageUrl",
+        "imageAlt",
+        "imageHeight",
+        "imageWidth",
+        "markers",
+        "hideChoicesFromInstructions",
+        "multipleAnswers",
+        "static"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusLabelImageMarker": {
+      "type": "object",
+      "properties": {
+        "answers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "label": {
+          "type": "string"
+        },
+        "x": {
+          "type": "number"
+        },
+        "y": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "answers",
+        "label",
+        "x",
+        "y"
+      ],
+      "additionalProperties": false
+    },
+    "MatcherWidget": {
+      "$ref": "#/definitions/Widget<\"matcher\",PerseusMatcherWidgetOptions>"
+    },
+    "Widget<\"matcher\",PerseusMatcherWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "matcher"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusMatcherWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusMatcherWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "left": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "right": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "orderMatters": {
+          "type": "boolean"
+        },
+        "padding": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "labels",
+        "left",
+        "right",
+        "orderMatters",
+        "padding"
+      ],
+      "additionalProperties": false
+    },
+    "MatrixWidget": {
+      "$ref": "#/definitions/Widget<\"matrix\",PerseusMatrixWidgetOptions>"
+    },
+    "Widget<\"matrix\",PerseusMatrixWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "matrix"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusMatrixWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusMatrixWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "prefix": {
+          "type": "string"
+        },
+        "suffix": {
+          "type": "string"
+        },
+        "answers": {
+          "$ref": "#/definitions/PerseusMatrixWidgetAnswers"
+        },
+        "cursorPosition": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "matrixBoardSize": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "static": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "prefix",
+        "suffix",
+        "answers",
+        "cursorPosition",
+        "matrixBoardSize",
+        "static"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusMatrixWidgetAnswers": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        }
+      }
+    },
+    "MeasurerWidget": {
+      "$ref": "#/definitions/Widget<\"measurer\",PerseusMeasurerWidgetOptions>"
+    },
+    "Widget<\"measurer\",PerseusMeasurerWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "measurer"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusMeasurerWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusMeasurerWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "image": {
+          "$ref": "#/definitions/PerseusImageBackground"
+        },
+        "showProtractor": {
+          "type": "boolean"
+        },
+        "showRuler": {
+          "type": "boolean"
+        },
+        "rulerLabel": {
+          "type": "string"
+        },
+        "rulerTicks": {
+          "type": "number"
+        },
+        "rulerPixels": {
+          "type": "number"
+        },
+        "rulerLength": {
+          "type": "number"
+        },
+        "box": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "static": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "image",
+        "showProtractor",
+        "showRuler",
+        "rulerLabel",
+        "rulerTicks",
+        "rulerPixels",
+        "rulerLength",
+        "box",
+        "static"
+      ],
+      "additionalProperties": false
+    },
+    "MoleculeRendererWidget": {
+      "$ref": "#/definitions/Widget<\"molecule-renderer\",PerseusMoleculeRendererWidgetOptions>"
+    },
+    "Widget<\"molecule-renderer\",PerseusMoleculeRendererWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "molecule-renderer"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusMoleculeRendererWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusMoleculeRendererWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "widgetId": {
+          "type": "string"
+        },
+        "rotationAngle": {
+          "type": "number"
+        },
+        "smiles": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "widgetId"
+      ],
+      "additionalProperties": false
+    },
+    "NumberLineWidget": {
+      "$ref": "#/definitions/Widget<\"number-line\",PerseusNumberLineWidgetOptions>"
+    },
+    "Widget<\"number-line\",PerseusNumberLineWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "number-line"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusNumberLineWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusNumberLineWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "range": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "labelRange": {
+          "type": "array",
+          "items": {
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        },
+        "labelStyle": {
+          "type": "string"
+        },
+        "labelTicks": {
+          "type": "boolean"
+        },
+        "isTickCtrl": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "divisionRange": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "numDivisions": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "snapDivisions": {
+          "type": "number"
+        },
+        "tickStep": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "correctRel": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "correctX": {
+          "type": "number"
+        },
+        "initialX": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "showTooltip": {
+          "type": "boolean"
+        },
+        "static": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "range",
+        "labelRange",
+        "labelStyle",
+        "labelTicks",
+        "divisionRange",
+        "snapDivisions",
+        "correctX",
+        "static"
+      ],
+      "additionalProperties": false
+    },
+    "NumericInputWidget": {
+      "$ref": "#/definitions/Widget<\"numeric-input\",PerseusNumericInputWidgetOptions>"
+    },
+    "Widget<\"numeric-input\",PerseusNumericInputWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "numeric-input"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusNumericInputWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusNumericInputWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "answers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusNumericInputAnswer"
+          }
+        },
+        "labelText": {
+          "type": "string"
+        },
+        "size": {
+          "type": "string"
+        },
+        "coefficient": {
+          "type": "boolean"
+        },
+        "rightAlign": {
+          "type": "boolean"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "answerForms": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusNumericInputAnswerForm"
+          }
+        }
+      },
+      "required": [
+        "answers",
+        "labelText",
+        "size",
+        "coefficient",
+        "static"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusNumericInputAnswer": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "value": {
+          "type": "number"
+        },
+        "status": {
+          "type": "string"
+        },
+        "answerForms": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MathFormat"
+          }
+        },
+        "strict": {
+          "type": "boolean"
+        },
+        "maxError": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "simplify": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "message",
+        "value",
+        "status",
+        "strict"
+      ],
+      "additionalProperties": false
+    },
+    "MathFormat": {
+      "type": "string",
+      "enum": [
+        "integer",
+        "mixed",
+        "improper",
+        "proper",
+        "decimal",
+        "percent",
+        "pi"
+      ]
+    },
+    "PerseusNumericInputAnswerForm": {
+      "type": "object",
+      "properties": {
+        "simplify": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "required",
+            "correct",
+            "enforced",
+            "optional",
+            null
+          ]
+        },
+        "name": {
+          "$ref": "#/definitions/MathFormat"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "OrdererWidget": {
+      "$ref": "#/definitions/Widget<\"orderer\",PerseusOrdererWidgetOptions>"
+    },
+    "Widget<\"orderer\",PerseusOrdererWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "orderer"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusOrdererWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusOrdererWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "options": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusRenderer"
+          }
+        },
+        "correctOptions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusRenderer"
+          }
+        },
+        "otherOptions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusRenderer"
+          }
+        },
+        "height": {
+          "type": "string"
+        },
+        "layout": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "options",
+        "correctOptions",
+        "otherOptions",
+        "height",
+        "layout"
+      ],
+      "additionalProperties": false
+    },
+    "PassageWidget": {
+      "$ref": "#/definitions/Widget<\"passage\",PerseusPassageWidgetOptions>"
+    },
+    "Widget<\"passage\",PerseusPassageWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "passage"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusPassageWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusPassageWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "footnotes": {
+          "type": "string"
+        },
+        "passageText": {
+          "type": "string"
+        },
+        "passageTitle": {
+          "type": "string"
+        },
+        "showLineNumbers": {
+          "type": "boolean"
+        },
+        "static": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "footnotes",
+        "passageText",
+        "passageTitle",
+        "showLineNumbers",
+        "static"
+      ],
+      "additionalProperties": false
+    },
+    "PassageRefWidget": {
+      "$ref": "#/definitions/Widget<\"passage-ref\",PerseusPassageRefWidgetOptions>"
+    },
+    "Widget<\"passage-ref\",PerseusPassageRefWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "passage-ref"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusPassageRefWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusPassageRefWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "passageNumber": {
+          "type": "number"
+        },
+        "referenceNumber": {
+          "type": "number"
+        },
+        "summaryText": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "passageNumber",
+        "referenceNumber",
+        "summaryText"
+      ],
+      "additionalProperties": false
+    },
+    "PlotterWidget": {
+      "$ref": "#/definitions/Widget<\"plotter\",PerseusPlotterWidgetOptions>"
+    },
+    "Widget<\"plotter\",PerseusPlotterWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "plotter"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusPlotterWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusPlotterWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "type": {
+          "$ref": "#/definitions/PlotType"
+        },
+        "maxY": {
+          "type": "number"
+        },
+        "scaleY": {
+          "type": "number"
+        },
+        "labelInterval": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "snapsPerLine": {
+          "type": "number"
+        },
+        "starting": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "correct": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "picUrl": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "picSize": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "picBoxHeight": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "plotDimensions": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        }
+      },
+      "required": [
+        "labels",
+        "categories",
+        "type",
+        "maxY",
+        "scaleY",
+        "snapsPerLine",
+        "starting",
+        "correct",
+        "plotDimensions"
+      ],
+      "additionalProperties": false
+    },
+    "PlotType": {
+      "type": "string",
+      "enum": [
+        "bar",
+        "line",
+        "pic",
+        "histogram",
+        "dotplot"
+      ]
+    },
+    "PythonProgramWidget": {
+      "$ref": "#/definitions/Widget<\"python-program\",PerseusPythonProgramWidgetOptions>"
+    },
+    "Widget<\"python-program\",PerseusPythonProgramWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "python-program"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusPythonProgramWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusPythonProgramWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "programID": {
+          "type": "string"
+        },
+        "height": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "programID",
+        "height"
+      ],
+      "additionalProperties": false
+    },
+    "RadioWidget": {
+      "$ref": "#/definitions/Widget<\"radio\",PerseusRadioWidgetOptions>"
+    },
+    "Widget<\"radio\",PerseusRadioWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "radio"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusRadioWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusRadioWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "choices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusRadioChoice"
+          }
+        },
+        "hasNoneOfTheAbove": {
+          "type": "boolean"
+        },
+        "countChoices": {
+          "type": "boolean"
+        },
+        "randomize": {
+          "type": "boolean"
+        },
+        "multipleSelect": {
+          "type": "boolean"
+        },
+        "deselectEnabled": {
+          "type": "boolean"
+        },
+        "onePerLine": {
+          "type": "boolean"
+        },
+        "displayCount": {},
+        "noneOfTheAbove": {
+          "type": "boolean",
+          "const": false
+        }
+      },
+      "required": [
+        "choices"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusRadioChoice": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "clue": {
+          "type": "string"
+        },
+        "correct": {
+          "type": "boolean"
+        },
+        "isNoneOfTheAbove": {
+          "type": "boolean"
+        },
+        "widgets": {
+          "$ref": "#/definitions/PerseusWidgetsMap"
+        }
+      },
+      "required": [
+        "content"
+      ],
+      "additionalProperties": false
+    },
+    "SimpleMarkdownTesterWidget": {
+      "$ref": "#/definitions/Widget<\"simple-markdown-tester\",PerseusSimpleMarkdownTesterWidgetOptions>"
+    },
+    "Widget<\"simple-markdown-tester\",PerseusSimpleMarkdownTesterWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "simple-markdown-tester"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusSimpleMarkdownTesterWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusSimpleMarkdownTesterWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false
+    },
+    "SorterWidget": {
+      "$ref": "#/definitions/Widget<\"sorter\",PerseusSorterWidgetOptions>"
+    },
+    "Widget<\"sorter\",PerseusSorterWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "sorter"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusSorterWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusSorterWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "correct": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "padding": {
+          "type": "boolean"
+        },
+        "layout": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "correct",
+        "padding",
+        "layout"
+      ],
+      "additionalProperties": false
+    },
+    "TableWidget": {
+      "$ref": "#/definitions/Widget<\"table\",PerseusTableWidgetOptions>"
+    },
+    "Widget<\"table\",PerseusTableWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "table"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusTableWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusTableWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "headers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "rows": {
+          "type": "number"
+        },
+        "columns": {
+          "type": "number"
+        },
+        "answers": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "required": [
+        "headers",
+        "rows",
+        "columns",
+        "answers"
+      ],
+      "additionalProperties": false
+    },
+    "UnitInputWidget": {
+      "$ref": "#/definitions/Widget<\"unit-input\",PerseusUnitInputWidgetOptions>"
+    },
+    "Widget<\"unit-input\",PerseusUnitInputWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "unit-input"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusUnitInputWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusUnitInputWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false
+    },
+    "VideoWidget": {
+      "$ref": "#/definitions/Widget<\"video\",PerseusVideoWidgetOptions>"
+    },
+    "Widget<\"video\",PerseusVideoWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "video"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/PerseusVideoWidgetOptions"
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusVideoWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string"
+        },
+        "static": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "location"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusAnswerArea": {
+      "$ref": "#/definitions/Record<(\"calculator\"|\"chi2Table\"|\"financialCalculatorMonthlyPayment\"|\"financialCalculatorTotalAmount\"|\"financialCalculatorTimeToPayOff\"|\"periodicTable\"|\"periodicTableWithKey\"|\"tTable\"|\"zTable\"),boolean>"
+    },
+    "Record<(\"calculator\"|\"chi2Table\"|\"financialCalculatorMonthlyPayment\"|\"financialCalculatorTotalAmount\"|\"financialCalculatorTimeToPayOff\"|\"periodicTable\"|\"periodicTableWithKey\"|\"tTable\"|\"zTable\"),boolean>": {
+      "type": "object",
+      "properties": {
+        "calculator": {
+          "type": "boolean"
+        },
+        "chi2Table": {
+          "type": "boolean"
+        },
+        "financialCalculatorMonthlyPayment": {
+          "type": "boolean"
+        },
+        "financialCalculatorTotalAmount": {
+          "type": "boolean"
+        },
+        "financialCalculatorTimeToPayOff": {
+          "type": "boolean"
+        },
+        "periodicTable": {
+          "type": "boolean"
+        },
+        "periodicTableWithKey": {
+          "type": "boolean"
+        },
+        "tTable": {
+          "type": "boolean"
+        },
+        "zTable": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "calculator",
+        "chi2Table",
+        "financialCalculatorMonthlyPayment",
+        "financialCalculatorTotalAmount",
+        "financialCalculatorTimeToPayOff",
+        "periodicTable",
+        "periodicTableWithKey",
+        "tTable",
+        "zTable"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "properties": {
+    "question": {
+      "$ref": "#/definitions/PerseusRenderer"
+    },
+    "hints": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PerseusRenderer"
+      }
+    },
+    "answerArea": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/PerseusAnswerArea"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "_multi": {},
+    "itemDataVersion": {
+      "$ref": "#/definitions/Version"
+    },
+    "answer": {}
+  },
+  "required": [
+    "question",
+    "hints",
+    "_multi",
+    "itemDataVersion",
+    "answer"
+  ],
+  "additionalProperties": false,
+  "description": "The PerseusItem is the main Perseus data structure for an exercise.  It forms a question (with interactive widgets), a set of hints, and answer area configuration (such as whether to make a calculator or periodic table available to the learner)."
+}

--- a/utils/generated/schema.json
+++ b/utils/generated/schema.json
@@ -1,0 +1,5235 @@
+{
+  "$id": "https://khanacademy.org/schema/perseus.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/PerseusItem",
+  "definitions": {
+    "PerseusItem": {
+      "type": "object",
+      "properties": {
+        "question": {
+          "$ref": "#/definitions/PerseusRenderer"
+        },
+        "hints": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusRenderer"
+          }
+        },
+        "answerArea": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusAnswerArea"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "_multi": {},
+        "itemDataVersion": {
+          "$ref": "#/definitions/Version"
+        },
+        "answer": {}
+      },
+      "required": [
+        "question",
+        "hints",
+        "_multi",
+        "itemDataVersion",
+        "answer"
+      ],
+      "additionalProperties": false,
+      "description": "The PerseusItem is the main data structure for a Perseus Item.  It is a collection of widgets that are rendered to the user.  The user can interact with the widgets and the widgets can be graded."
+    },
+    "PerseusRenderer": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "widgets": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/PerseusWidget"
+          }
+        },
+        "replace": {
+          "type": "boolean"
+        },
+        "metadata": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "images": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/PerseusImageDetail"
+          }
+        }
+      },
+      "required": [
+        "content",
+        "widgets",
+        "images"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusWidget": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/CategorizerWidget"
+        },
+        {
+          "$ref": "#/definitions/CSProgramWidget"
+        },
+        {
+          "$ref": "#/definitions/DefinitionWidget"
+        },
+        {
+          "$ref": "#/definitions/DropdownWidget"
+        },
+        {
+          "$ref": "#/definitions/ExampleGraphieWidget"
+        },
+        {
+          "$ref": "#/definitions/ExampleWidget"
+        },
+        {
+          "$ref": "#/definitions/ExplanationWidget"
+        },
+        {
+          "$ref": "#/definitions/ExpressionWidget"
+        },
+        {
+          "$ref": "#/definitions/GradedGroupSetWidget"
+        },
+        {
+          "$ref": "#/definitions/GradedGroupWidget"
+        },
+        {
+          "$ref": "#/definitions/GrapherWidget"
+        },
+        {
+          "$ref": "#/definitions/GroupWidget"
+        },
+        {
+          "$ref": "#/definitions/IFrameWidget"
+        },
+        {
+          "$ref": "#/definitions/ImageWidget"
+        },
+        {
+          "$ref": "#/definitions/InputNumberWidget"
+        },
+        {
+          "$ref": "#/definitions/InteractionWidget"
+        },
+        {
+          "$ref": "#/definitions/InteractiveGraphWidget"
+        },
+        {
+          "$ref": "#/definitions/LabelImageWidget"
+        },
+        {
+          "$ref": "#/definitions/LightsPuzzleWidget"
+        },
+        {
+          "$ref": "#/definitions/MatcherWidget"
+        },
+        {
+          "$ref": "#/definitions/MatrixWidget"
+        },
+        {
+          "$ref": "#/definitions/MeasurerWidget"
+        },
+        {
+          "$ref": "#/definitions/MoleculeRendererWidget"
+        },
+        {
+          "$ref": "#/definitions/NumberLineWidget"
+        },
+        {
+          "$ref": "#/definitions/NumericInputWidget"
+        },
+        {
+          "$ref": "#/definitions/OrdererWidget"
+        },
+        {
+          "$ref": "#/definitions/PassageRefWidget"
+        },
+        {
+          "$ref": "#/definitions/PassageWidget"
+        },
+        {
+          "$ref": "#/definitions/PlotterWidget"
+        },
+        {
+          "$ref": "#/definitions/RadioWidget"
+        },
+        {
+          "$ref": "#/definitions/ReactionDiagramWidget"
+        },
+        {
+          "$ref": "#/definitions/RefTargetWidget"
+        },
+        {
+          "$ref": "#/definitions/SequenceWidget"
+        },
+        {
+          "$ref": "#/definitions/SimpleMarkdownTesterWidget"
+        },
+        {
+          "$ref": "#/definitions/SimulatorWidget"
+        },
+        {
+          "$ref": "#/definitions/SorterWidget"
+        },
+        {
+          "$ref": "#/definitions/TableWidget"
+        },
+        {
+          "$ref": "#/definitions/TransformerWidget"
+        },
+        {
+          "$ref": "#/definitions/UnitInputWidget"
+        },
+        {
+          "$ref": "#/definitions/VideoWidget"
+        }
+      ]
+    },
+    "CategorizerWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "categorizer"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusCategorizerWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusCategorizerWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "randomizeItems": {
+          "type": "boolean"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "highlightLint": {
+          "type": "boolean"
+        },
+        "linterContext": {
+          "$ref": "#/definitions/PerseusLinterContext"
+        }
+      },
+      "required": [
+        "items",
+        "categories",
+        "randomizeItems",
+        "static",
+        "values"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusLinterContext": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string"
+        },
+        "paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "stack": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "contentType",
+        "paths",
+        "stack"
+      ],
+      "additionalProperties": false
+    },
+    "Version": {
+      "type": "object",
+      "properties": {
+        "major": {
+          "type": "number"
+        },
+        "minor": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "major",
+        "minor"
+      ],
+      "additionalProperties": false
+    },
+    "CSProgramWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "cs-program"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusCSProgramWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusCSProgramWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "programID": {
+          "type": "string"
+        },
+        "programType": {},
+        "settings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusCSProgramSetting"
+          }
+        },
+        "showEditor": {
+          "type": "boolean"
+        },
+        "showButtons": {
+          "type": "boolean"
+        },
+        "width": {
+          "type": "number"
+        },
+        "height": {
+          "type": "number"
+        },
+        "static": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "programID",
+        "settings",
+        "showEditor",
+        "showButtons",
+        "width",
+        "height",
+        "static"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusCSProgramSetting": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ],
+      "additionalProperties": false
+    },
+    "DefinitionWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "definition"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusDefinitionWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusDefinitionWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "togglePrompt": {
+          "type": "string"
+        },
+        "definition": {
+          "type": "string"
+        },
+        "static": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "togglePrompt",
+        "definition",
+        "static"
+      ],
+      "additionalProperties": false
+    },
+    "DropdownWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "dropdown"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusDropdownWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusDropdownWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "choices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusDropdownChoice"
+          }
+        },
+        "placeholder": {
+          "type": "string"
+        },
+        "static": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "choices",
+        "placeholder",
+        "static"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusDropdownChoice": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "correct": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "content",
+        "correct"
+      ],
+      "additionalProperties": false
+    },
+    "ExampleGraphieWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "example-graphie-widget"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusExampleGraphieWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusExampleGraphieWidgetOptions": {},
+    "ExampleWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "example-widget"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusExampleWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusExampleWidgetOptions": {},
+    "ExplanationWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "explanation"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusExplanationWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusExplanationWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "showPrompt": {
+          "type": "string"
+        },
+        "hidePrompt": {
+          "type": "string"
+        },
+        "explanation": {
+          "type": "string"
+        },
+        "widgets": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/PerseusWidget"
+          }
+        },
+        "static": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "showPrompt",
+        "hidePrompt",
+        "explanation",
+        "widgets",
+        "static"
+      ],
+      "additionalProperties": false
+    },
+    "ExpressionWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "expression"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusExpressionWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusExpressionWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "answerForms": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusExpressionAnswerForm"
+          }
+        },
+        "buttonSets": {
+          "$ref": "#/definitions/LegacyButtonSets"
+        },
+        "functions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "times": {
+          "type": "boolean"
+        },
+        "buttonsVisible": {
+          "type": "string",
+          "enum": [
+            "always",
+            "never",
+            "focused"
+          ]
+        }
+      },
+      "required": [
+        "answerForms",
+        "buttonSets",
+        "functions",
+        "times"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusExpressionAnswerForm": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "form": {
+          "type": "boolean"
+        },
+        "simplify": {
+          "type": "boolean"
+        },
+        "considered": {
+          "type": "string",
+          "enum": [
+            "correct",
+            "wrong",
+            "ungraded"
+          ]
+        },
+        "key": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "value",
+        "form",
+        "simplify",
+        "considered"
+      ],
+      "additionalProperties": false
+    },
+    "LegacyButtonSets": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "basic",
+          "basic+div",
+          "trig",
+          "prealgebra",
+          "logarithms",
+          "basic relations",
+          "advanced relations"
+        ]
+      }
+    },
+    "GradedGroupSetWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "graded-group-set"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusGradedGroupSetWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusGradedGroupSetWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "gradedGroups": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusGradedGroupWidgetOptions"
+          }
+        }
+      },
+      "required": [
+        "gradedGroups"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusGradedGroupWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "hasHint": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "hint": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusRenderer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "content": {
+          "type": "string"
+        },
+        "widgets": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/PerseusWidget"
+          }
+        },
+        "widgetEnabled": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "immutableWidgets": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "images": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/PerseusImageDetail"
+          }
+        }
+      },
+      "required": [
+        "title",
+        "content",
+        "widgets",
+        "images"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusImageDetail": {
+      "type": "object",
+      "properties": {
+        "width": {
+          "type": "number"
+        },
+        "height": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "width",
+        "height"
+      ],
+      "additionalProperties": false
+    },
+    "GradedGroupWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "graded-group"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusGradedGroupWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "GrapherWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "grapher"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusGrapherWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusGrapherWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "availableTypes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "absolute_value",
+              "exponential",
+              "linear",
+              "logarithm",
+              "quadratic",
+              "sinusoid",
+              "tangent"
+            ]
+          }
+        },
+        "correct": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "absolute_value"
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coord"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              },
+              "required": [
+                "type",
+                "coords"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "exponential"
+                },
+                "asymptote": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coord"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coord"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              },
+              "required": [
+                "type",
+                "asymptote",
+                "coords"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "linear"
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coord"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              },
+              "required": [
+                "type",
+                "coords"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "logarithm"
+                },
+                "asymptote": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coord"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coord"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              },
+              "required": [
+                "type",
+                "asymptote",
+                "coords"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "quadratic"
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coord"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              },
+              "required": [
+                "type",
+                "coords"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "sinusoid"
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coord"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              },
+              "required": [
+                "type",
+                "coords"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "tangent"
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coord"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              },
+              "required": [
+                "type",
+                "coords"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "graph": {
+          "type": "object",
+          "properties": {
+            "backgroundImage": {
+              "type": "object",
+              "properties": {
+                "bottom": {
+                  "type": "number"
+                },
+                "height": {
+                  "type": "number"
+                },
+                "left": {
+                  "type": "number"
+                },
+                "scale": {
+                  "type": "number"
+                },
+                "url": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "width": {
+                  "type": "number"
+                }
+              },
+              "additionalProperties": false
+            },
+            "box": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "editableSettings": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "graph",
+                  "snap",
+                  "image",
+                  "measure"
+                ]
+              }
+            },
+            "gridStep": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "labels": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "markings": {
+              "type": "string",
+              "enum": [
+                "graph",
+                "none",
+                "grid"
+              ]
+            },
+            "range": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 2,
+                "maxItems": 2
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "rulerLabel": {
+              "type": "string",
+              "const": ""
+            },
+            "rulerTicks": {
+              "type": "number"
+            },
+            "showProtractor": {
+              "type": "boolean"
+            },
+            "showRuler": {
+              "type": "boolean"
+            },
+            "showTooltips": {
+              "type": "boolean"
+            },
+            "snapStep": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "step": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "valid": {
+              "type": [
+                "boolean",
+                "string"
+              ]
+            }
+          },
+          "required": [
+            "backgroundImage",
+            "labels",
+            "markings",
+            "range",
+            "rulerLabel",
+            "rulerTicks",
+            "step"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "availableTypes",
+        "correct",
+        "graph"
+      ],
+      "additionalProperties": false
+    },
+    "Coord": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "GroupWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "group"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusGroupWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusGroupWidgetOptions": {
+      "$ref": "#/definitions/PerseusRenderer"
+    },
+    "IFrameWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "iframe"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusIFrameWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusIFrameWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "settings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusCSProgramSetting"
+          }
+        },
+        "width": {
+          "type": [
+            "number",
+            "string"
+          ]
+        },
+        "height": {
+          "type": [
+            "number",
+            "string"
+          ]
+        },
+        "allowFullScreen": {
+          "type": "boolean"
+        },
+        "allowTopNavigation": {
+          "type": "boolean"
+        },
+        "static": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "url",
+        "settings",
+        "width",
+        "height",
+        "allowFullScreen",
+        "static"
+      ],
+      "additionalProperties": false
+    },
+    "ImageWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "image"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusImageWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusImageWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "caption": {
+          "type": "string"
+        },
+        "alt": {
+          "type": "string"
+        },
+        "backgroundImage": {
+          "$ref": "#/definitions/PerseusImageBackground"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusImageLabel"
+          }
+        },
+        "range": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Range"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "box": {
+          "$ref": "#/definitions/Size"
+        }
+      },
+      "required": [
+        "backgroundImage"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusImageBackground": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "width": {
+          "type": "number"
+        },
+        "height": {
+          "type": "number"
+        },
+        "top": {
+          "type": "number"
+        },
+        "left": {
+          "type": "number"
+        },
+        "scale": {
+          "type": [
+            "number",
+            "string"
+          ]
+        },
+        "bottom": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false
+    },
+    "PerseusImageLabel": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "coordinates": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        }
+      },
+      "required": [
+        "content",
+        "alignment",
+        "coordinates"
+      ],
+      "additionalProperties": false
+    },
+    "Range": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "Size": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "InputNumberWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "input-number"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusInputNumberWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusInputNumberWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "answerType": {
+          "type": "string",
+          "enum": [
+            "number",
+            "decimal",
+            "integer",
+            "rational",
+            "improper",
+            "mixed",
+            "percent",
+            "pi"
+          ]
+        },
+        "inexact": {
+          "type": "boolean"
+        },
+        "maxError": {
+          "type": [
+            "number",
+            "string"
+          ]
+        },
+        "rightAlign": {
+          "type": "boolean"
+        },
+        "simplify": {
+          "type": "string",
+          "enum": [
+            "required",
+            "optional",
+            "enforced"
+          ]
+        },
+        "size": {
+          "type": "string",
+          "enum": [
+            "normal",
+            "small"
+          ]
+        },
+        "value": {
+          "type": [
+            "string",
+            "number"
+          ]
+        },
+        "customKeypad": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "simplify",
+        "size",
+        "value"
+      ],
+      "additionalProperties": false
+    },
+    "InteractionWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "interaction"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusInteractionWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusInteractionWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "graph": {
+          "$ref": "#/definitions/PerseusInteractionGraph"
+        },
+        "elements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusInteractionElement"
+          }
+        },
+        "static": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "graph",
+        "elements",
+        "static"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusInteractionGraph": {
+      "type": "object",
+      "properties": {
+        "editableSettings": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "canvas",
+              "graph"
+            ]
+          }
+        },
+        "box": {
+          "$ref": "#/definitions/Size"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "range": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Range"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "gridStep": {
+          "type": "object",
+          "properties": {
+            "0": {
+              "type": "number"
+            },
+            "1": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "0",
+            "1"
+          ],
+          "additionalProperties": false
+        },
+        "markings": {
+          "type": "string"
+        },
+        "snapStep": {
+          "type": "object",
+          "properties": {
+            "0": {
+              "type": "number"
+            },
+            "1": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "0",
+            "1"
+          ],
+          "additionalProperties": false
+        },
+        "valid": {
+          "type": [
+            "boolean",
+            "string"
+          ]
+        },
+        "backgroundImage": {
+          "$ref": "#/definitions/PerseusImageBackground"
+        },
+        "showProtractor": {
+          "type": "boolean"
+        },
+        "showRuler": {
+          "type": "boolean"
+        },
+        "rulerLabel": {
+          "type": "string"
+        },
+        "rulerTicks": {
+          "type": "number"
+        },
+        "tickStep": {
+          "type": "object",
+          "properties": {
+            "0": {
+              "type": "number"
+            },
+            "1": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "0",
+            "1"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "box",
+        "labels",
+        "range",
+        "gridStep",
+        "markings",
+        "tickStep"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusInteractionElement": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "function"
+            },
+            "key": {
+              "type": "string"
+            },
+            "options": {
+              "$ref": "#/definitions/PerseusInteractionFunctionElementOptions"
+            }
+          },
+          "required": [
+            "type",
+            "key",
+            "options"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "label"
+            },
+            "key": {
+              "type": "string"
+            },
+            "options": {
+              "$ref": "#/definitions/PerseusInteractionLabelElementOptions"
+            }
+          },
+          "required": [
+            "type",
+            "key",
+            "options"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "line"
+            },
+            "key": {
+              "type": "string"
+            },
+            "options": {
+              "$ref": "#/definitions/PerseusInteractionLineElementOptions"
+            }
+          },
+          "required": [
+            "type",
+            "key",
+            "options"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "movable-line"
+            },
+            "key": {
+              "type": "string"
+            },
+            "options": {
+              "$ref": "#/definitions/PerseusInteractionMovableLineElementOptions"
+            }
+          },
+          "required": [
+            "type",
+            "key",
+            "options"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "movable-point"
+            },
+            "key": {
+              "type": "string"
+            },
+            "options": {
+              "$ref": "#/definitions/PerseusInteractionMovablePointElementOptions"
+            }
+          },
+          "required": [
+            "type",
+            "key",
+            "options"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "parametric"
+            },
+            "key": {
+              "type": "string"
+            },
+            "options": {
+              "$ref": "#/definitions/PerseusInteractionParametricElementOptions"
+            }
+          },
+          "required": [
+            "type",
+            "key",
+            "options"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "point"
+            },
+            "key": {
+              "type": "string"
+            },
+            "options": {
+              "$ref": "#/definitions/PerseusInteractionPointElementOptions"
+            }
+          },
+          "required": [
+            "type",
+            "key",
+            "options"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "rectangle"
+            },
+            "key": {
+              "type": "string"
+            },
+            "options": {
+              "$ref": "#/definitions/PerseusInteractionRectangleElementOptions"
+            }
+          },
+          "required": [
+            "type",
+            "key",
+            "options"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "PerseusInteractionFunctionElementOptions": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "funcName": {
+          "type": "string"
+        },
+        "rangeMin": {
+          "type": "string"
+        },
+        "rangeMax": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        },
+        "strokeDasharray": {
+          "type": "string"
+        },
+        "strokeWidth": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "value",
+        "funcName",
+        "rangeMin",
+        "rangeMax",
+        "color",
+        "strokeDasharray",
+        "strokeWidth"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusInteractionLabelElementOptions": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        },
+        "coordX": {
+          "type": "string"
+        },
+        "coordY": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "label",
+        "color",
+        "coordX",
+        "coordY"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusInteractionLineElementOptions": {
+      "type": "object",
+      "properties": {
+        "color": {
+          "type": "string"
+        },
+        "startX": {
+          "type": "string"
+        },
+        "startY": {
+          "type": "string"
+        },
+        "endX": {
+          "type": "string"
+        },
+        "endY": {
+          "type": "string"
+        },
+        "strokeDasharray": {
+          "type": "string"
+        },
+        "strokeWidth": {
+          "type": "number"
+        },
+        "arrows": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "color",
+        "startX",
+        "startY",
+        "endX",
+        "endY",
+        "strokeDasharray",
+        "strokeWidth",
+        "arrows"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusInteractionMovableLineElementOptions": {
+      "type": "object",
+      "properties": {
+        "startX": {
+          "type": "string"
+        },
+        "startY": {
+          "type": "string"
+        },
+        "startSubscript": {
+          "type": "number"
+        },
+        "endX": {
+          "type": "string"
+        },
+        "endY": {
+          "type": "string"
+        },
+        "endSubscript": {
+          "type": "number"
+        },
+        "constraint": {
+          "type": "string"
+        },
+        "snap": {
+          "type": "number"
+        },
+        "constraintFn": {
+          "type": "string"
+        },
+        "constraintXMin": {
+          "type": "string"
+        },
+        "constraintXMax": {
+          "type": "string"
+        },
+        "constraintYMin": {
+          "type": "string"
+        },
+        "constraintYMax": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "startX",
+        "startY",
+        "startSubscript",
+        "endX",
+        "endY",
+        "endSubscript",
+        "constraint",
+        "snap",
+        "constraintFn",
+        "constraintXMin",
+        "constraintXMax",
+        "constraintYMin",
+        "constraintYMax"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusInteractionMovablePointElementOptions": {
+      "type": "object",
+      "properties": {
+        "startX": {
+          "type": "string"
+        },
+        "startY": {
+          "type": "string"
+        },
+        "varSubscript": {
+          "type": "number"
+        },
+        "constraint": {
+          "type": "string"
+        },
+        "snap": {
+          "type": "number"
+        },
+        "constraintFn": {
+          "type": "string"
+        },
+        "constraintXMin": {
+          "type": "string"
+        },
+        "constraintXMax": {
+          "type": "string"
+        },
+        "constraintYMin": {
+          "type": "string"
+        },
+        "constraintYMax": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "startX",
+        "startY",
+        "varSubscript",
+        "constraint",
+        "snap",
+        "constraintFn",
+        "constraintXMin",
+        "constraintXMax",
+        "constraintYMin",
+        "constraintYMax"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusInteractionParametricElementOptions": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "type": "string"
+        },
+        "y": {
+          "type": "string"
+        },
+        "rangeMin": {
+          "type": "string"
+        },
+        "rangeMax": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        },
+        "strokeDasharray": {
+          "type": "string"
+        },
+        "strokeWidth": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y",
+        "rangeMin",
+        "rangeMax",
+        "color",
+        "strokeDasharray",
+        "strokeWidth"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusInteractionPointElementOptions": {
+      "type": "object",
+      "properties": {
+        "color": {
+          "type": "string"
+        },
+        "coordX": {
+          "type": "string"
+        },
+        "coordY": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "color",
+        "coordX",
+        "coordY"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusInteractionRectangleElementOptions": {
+      "type": "object",
+      "properties": {
+        "color": {
+          "type": "string"
+        },
+        "coordX": {
+          "type": "string"
+        },
+        "coordY": {
+          "type": "string"
+        },
+        "width": {
+          "type": "string"
+        },
+        "height": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "color",
+        "coordX",
+        "coordY",
+        "width",
+        "height"
+      ],
+      "additionalProperties": false
+    },
+    "InteractiveGraphWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "interactive-graph"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusInteractiveGraphWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusInteractiveGraphWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "step": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "gridStep": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "snapStep": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "backgroundImage": {
+          "$ref": "#/definitions/PerseusImageBackground"
+        },
+        "markings": {
+          "type": "string"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "showProtractor": {
+          "type": "boolean"
+        },
+        "showRuler": {
+          "type": "boolean"
+        },
+        "showTooltips": {
+          "type": "boolean"
+        },
+        "rulerLabel": {
+          "type": "string"
+        },
+        "rulerTicks": {
+          "type": "number"
+        },
+        "range": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "minItems": 2,
+            "maxItems": 2
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "graph": {
+          "$ref": "#/definitions/PerseusGraphType"
+        },
+        "correct": {
+          "$ref": "#/definitions/PerseusGraphType"
+        }
+      },
+      "required": [
+        "step",
+        "gridStep",
+        "snapStep",
+        "markings",
+        "labels",
+        "showProtractor",
+        "showRuler",
+        "rulerLabel",
+        "rulerTicks",
+        "range",
+        "graph",
+        "correct"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusGraphType": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/PerseusGraphTypeAngle"
+        },
+        {
+          "$ref": "#/definitions/PerseusGraphTypeCircle"
+        },
+        {
+          "$ref": "#/definitions/PerseusGraphTypeLinear"
+        },
+        {
+          "$ref": "#/definitions/PerseusGraphTypeLinearSystem"
+        },
+        {
+          "$ref": "#/definitions/PerseusGraphTypePoint"
+        },
+        {
+          "$ref": "#/definitions/PerseusGraphTypePolygon"
+        },
+        {
+          "$ref": "#/definitions/PerseusGraphTypeQuadratic"
+        },
+        {
+          "$ref": "#/definitions/PerseusGraphTypeRay"
+        },
+        {
+          "$ref": "#/definitions/PerseusGraphTypeSegment"
+        },
+        {
+          "$ref": "#/definitions/PerseusGraphTypeSinusoid"
+        }
+      ]
+    },
+    "PerseusGraphTypeAngle": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "angle"
+        },
+        "showAngles": {
+          "type": "boolean"
+        },
+        "allowReflexAngles": {
+          "type": "boolean"
+        },
+        "angleOffsetDeg": {
+          "type": "number"
+        },
+        "snapDegrees": {
+          "type": "number"
+        },
+        "match": {
+          "type": "string",
+          "const": "congruent"
+        },
+        "coords": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Coord"
+          }
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusGraphTypeCircle": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "coord": {
+          "$ref": "#/definitions/Coord"
+        },
+        "type": {
+          "type": "string",
+          "const": "circle"
+        },
+        "center": {
+          "$ref": "#/definitions/Coord"
+        },
+        "radius": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "PerseusGraphTypeLinear": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "coord": {
+          "$ref": "#/definitions/Coord"
+        },
+        "type": {
+          "type": "string",
+          "const": "linear"
+        },
+        "coords": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Coord"
+          }
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "PerseusGraphTypeLinearSystem": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "coord": {
+          "$ref": "#/definitions/Coord"
+        },
+        "type": {
+          "type": "string",
+          "const": "linear-system"
+        },
+        "coords": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Coord"
+            }
+          }
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "PerseusGraphTypePoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "coord": {
+          "$ref": "#/definitions/Coord"
+        },
+        "type": {
+          "type": "string",
+          "const": "point"
+        },
+        "numPoints": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string",
+              "const": "unlimited"
+            }
+          ]
+        },
+        "coords": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Coord"
+          }
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "PerseusGraphTypePolygon": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "coord": {
+          "$ref": "#/definitions/Coord"
+        },
+        "type": {
+          "type": "string",
+          "const": "polygon"
+        },
+        "numSides": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string",
+              "const": "unlimited"
+            }
+          ]
+        },
+        "showAngles": {
+          "type": "boolean"
+        },
+        "showSides": {
+          "type": "boolean"
+        },
+        "snapTo": {
+          "type": "string"
+        },
+        "match": {
+          "type": "string",
+          "enum": [
+            "similar",
+            "congruent",
+            "approx"
+          ]
+        },
+        "coords": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Coord"
+          }
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "PerseusGraphTypeQuadratic": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "coord": {
+          "$ref": "#/definitions/Coord"
+        },
+        "type": {
+          "type": "string",
+          "const": "quadratic"
+        },
+        "coords": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Coord"
+          }
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "PerseusGraphTypeRay": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "coord": {
+          "$ref": "#/definitions/Coord"
+        },
+        "type": {
+          "type": "string",
+          "const": "ray"
+        },
+        "coords": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Coord"
+          }
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "PerseusGraphTypeSegment": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "coord": {
+          "$ref": "#/definitions/Coord"
+        },
+        "type": {
+          "type": "string",
+          "const": "segment"
+        },
+        "numSegments": {
+          "type": "number"
+        },
+        "coords": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Coord"
+            }
+          }
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "PerseusGraphTypeSinusoid": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "coord": {
+          "$ref": "#/definitions/Coord"
+        },
+        "type": {
+          "type": "string",
+          "const": "sinusoid"
+        },
+        "coords": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Coord"
+          }
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "LabelImageWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "label-image"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusLabelImageWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusLabelImageWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "choices": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "imageUrl": {
+          "type": "string"
+        },
+        "imageAlt": {
+          "type": "string"
+        },
+        "imageHeight": {
+          "type": "number"
+        },
+        "imageWidth": {
+          "type": "number"
+        },
+        "markers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusLabelImageMarker"
+          }
+        },
+        "hideChoicesFromInstructions": {
+          "type": "boolean"
+        },
+        "multipleAnswers": {
+          "type": "boolean"
+        },
+        "static": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "choices",
+        "imageUrl",
+        "imageAlt",
+        "imageHeight",
+        "imageWidth",
+        "markers",
+        "hideChoicesFromInstructions",
+        "multipleAnswers",
+        "static"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusLabelImageMarker": {
+      "type": "object",
+      "properties": {
+        "answers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "label": {
+          "type": "string"
+        },
+        "x": {
+          "type": "number"
+        },
+        "y": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "answers",
+        "label",
+        "x",
+        "y"
+      ],
+      "additionalProperties": false
+    },
+    "LightsPuzzleWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "lights-puzzle"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusLightsPuzzleWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusLightsPuzzleWidgetOptions": {},
+    "MatcherWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "matcher"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusMatcherWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusMatcherWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "left": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "right": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "orderMatters": {
+          "type": "boolean"
+        },
+        "padding": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "labels",
+        "left",
+        "right",
+        "orderMatters",
+        "padding"
+      ],
+      "additionalProperties": false
+    },
+    "MatrixWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "matrix"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusMatrixWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusMatrixWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "prefix": {
+          "type": "string"
+        },
+        "suffix": {
+          "type": "string"
+        },
+        "answers": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        },
+        "cursorPosition": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "matrixBoardSize": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "static": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "prefix",
+        "suffix",
+        "answers",
+        "cursorPosition",
+        "matrixBoardSize",
+        "static"
+      ],
+      "additionalProperties": false
+    },
+    "MeasurerWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "measurer"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusMeasurerWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusMeasurerWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "image": {
+          "$ref": "#/definitions/PerseusImageBackground"
+        },
+        "showProtractor": {
+          "type": "boolean"
+        },
+        "showRuler": {
+          "type": "boolean"
+        },
+        "rulerLabel": {
+          "type": "string"
+        },
+        "rulerTicks": {
+          "type": "number"
+        },
+        "rulerPixels": {
+          "type": "number"
+        },
+        "rulerLength": {
+          "type": "number"
+        },
+        "box": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "static": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "image",
+        "showProtractor",
+        "showRuler",
+        "rulerLabel",
+        "rulerTicks",
+        "rulerPixels",
+        "rulerLength",
+        "box",
+        "static"
+      ],
+      "additionalProperties": false
+    },
+    "MoleculeRendererWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "molecule-renderer"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusMoleculeRendererWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusMoleculeRendererWidgetOptions": {},
+    "NumberLineWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "number-line"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusNumberLineWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusNumberLineWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "range": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "labelRange": {
+          "type": "array",
+          "items": {
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        },
+        "labelStyle": {
+          "type": "string"
+        },
+        "labelTicks": {
+          "type": "boolean"
+        },
+        "isTickCtrl": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "divisionRange": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "numDivisions": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "snapDivisions": {
+          "type": "number"
+        },
+        "tickStep": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "correctRel": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "correctX": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "initialX": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "showTooltip": {
+          "type": "boolean"
+        },
+        "static": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "range",
+        "labelRange",
+        "labelStyle",
+        "labelTicks",
+        "divisionRange",
+        "snapDivisions",
+        "static"
+      ],
+      "additionalProperties": false
+    },
+    "NumericInputWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "numeric-input"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusNumericInputWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusNumericInputWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "answers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusNumericInputAnswer"
+          }
+        },
+        "labelText": {
+          "type": "string"
+        },
+        "size": {
+          "type": "string"
+        },
+        "coefficient": {
+          "type": "boolean"
+        },
+        "rightAlign": {
+          "type": "boolean"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "answerForms": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusNumericInputAnswerForm"
+          }
+        }
+      },
+      "required": [
+        "answers",
+        "labelText",
+        "size",
+        "coefficient",
+        "static"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusNumericInputAnswer": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "value": {
+          "type": "number"
+        },
+        "status": {
+          "type": "string"
+        },
+        "answerForms": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MathFormat"
+          }
+        },
+        "strict": {
+          "type": "boolean"
+        },
+        "maxError": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "simplify": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "message",
+        "value",
+        "status",
+        "strict"
+      ],
+      "additionalProperties": false
+    },
+    "MathFormat": {
+      "type": "string",
+      "enum": [
+        "integer",
+        "mixed",
+        "improper",
+        "proper",
+        "decimal",
+        "percent",
+        "pi"
+      ]
+    },
+    "PerseusNumericInputAnswerForm": {
+      "type": "object",
+      "properties": {
+        "simplify": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "required",
+            "correct",
+            "enforced",
+            "optional",
+            null
+          ]
+        },
+        "name": {
+          "$ref": "#/definitions/MathFormat"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "OrdererWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "orderer"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusOrdererWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusOrdererWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "options": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusRenderer"
+          }
+        },
+        "correctOptions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusRenderer"
+          }
+        },
+        "otherOptions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusRenderer"
+          }
+        },
+        "height": {
+          "type": "string"
+        },
+        "layout": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "options",
+        "correctOptions",
+        "otherOptions",
+        "height",
+        "layout"
+      ],
+      "additionalProperties": false
+    },
+    "PassageRefWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "passage-ref"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusPassageRefWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusPassageRefWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "passageNumber": {
+          "type": "number"
+        },
+        "referenceNumber": {
+          "type": "number"
+        },
+        "summaryText": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "passageNumber",
+        "referenceNumber",
+        "summaryText"
+      ],
+      "additionalProperties": false
+    },
+    "PassageWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "passage"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusPassageWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusPassageWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "footnotes": {
+          "type": "string"
+        },
+        "passageText": {
+          "type": "string"
+        },
+        "passageTitle": {
+          "type": "string"
+        },
+        "showLineNumbers": {
+          "type": "boolean"
+        },
+        "static": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "footnotes",
+        "passageText",
+        "passageTitle",
+        "showLineNumbers",
+        "static"
+      ],
+      "additionalProperties": false
+    },
+    "PlotterWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "plotter"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusPlotterWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusPlotterWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "type": {
+          "$ref": "#/definitions/PlotType"
+        },
+        "maxY": {
+          "type": "number"
+        },
+        "scaleY": {
+          "type": "number"
+        },
+        "labelInterval": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "snapsPerLine": {
+          "type": "number"
+        },
+        "starting": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "correct": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "picUrl": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "picSize": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "picBoxHeight": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "plotDimensions": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        }
+      },
+      "required": [
+        "labels",
+        "categories",
+        "type",
+        "maxY",
+        "scaleY",
+        "snapsPerLine",
+        "starting",
+        "correct",
+        "plotDimensions"
+      ],
+      "additionalProperties": false
+    },
+    "PlotType": {
+      "type": "string",
+      "enum": [
+        "bar",
+        "line",
+        "pic",
+        "histogram",
+        "dotplot"
+      ]
+    },
+    "RadioWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "radio"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusRadioWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusRadioWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "choices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusRadioChoice"
+          }
+        },
+        "hasNoneOfTheAbove": {
+          "type": "boolean"
+        },
+        "countChoices": {
+          "type": "boolean"
+        },
+        "randomize": {
+          "type": "boolean"
+        },
+        "multipleSelect": {
+          "type": "boolean"
+        },
+        "deselectEnabled": {
+          "type": "boolean"
+        },
+        "onePerLine": {
+          "type": "boolean"
+        },
+        "displayCount": {},
+        "noneOfTheAbove": {
+          "type": "boolean",
+          "const": false
+        }
+      },
+      "required": [
+        "choices"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusRadioChoice": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "clue": {
+          "type": "string"
+        },
+        "correct": {
+          "type": "boolean"
+        },
+        "isNoneOfTheAbove": {
+          "type": "boolean"
+        },
+        "widgets": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/PerseusWidget"
+          }
+        }
+      },
+      "required": [
+        "content"
+      ],
+      "additionalProperties": false
+    },
+    "ReactionDiagramWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "reaction-diagtram"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusReactionDiagramWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusReactionDiagramWidgetOptions": {},
+    "RefTargetWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "passage-ref-target"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusPassageRefTargetWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusPassageRefTargetWidgetOptions": {},
+    "SequenceWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "sequence"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusSequenceWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusSequenceWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "json": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PerseusRenderer"
+          }
+        }
+      },
+      "required": [
+        "json"
+      ],
+      "additionalProperties": false
+    },
+    "SimpleMarkdownTesterWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "simple-markdown-tester"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusSimpleMarkdownTesterWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusSimpleMarkdownTesterWidgetOptions": {},
+    "SimulatorWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "simulator"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusSimulatorWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusSimulatorWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "xAxisLabel": {
+          "type": "string"
+        },
+        "yAxisLabel": {
+          "type": "string"
+        },
+        "proportionLabel": {
+          "type": "string"
+        },
+        "proportionOrPercentage": {
+          "type": "string"
+        },
+        "numTrials": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "xAxisLabel",
+        "yAxisLabel",
+        "proportionLabel",
+        "proportionOrPercentage",
+        "numTrials"
+      ],
+      "additionalProperties": false
+    },
+    "SorterWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "sorter"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusSorterWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusSorterWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "correct": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "padding": {
+          "type": "boolean"
+        },
+        "layout": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "correct",
+        "padding",
+        "layout"
+      ],
+      "additionalProperties": false
+    },
+    "TableWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "table"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusTableWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusTableWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "headers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "rows": {
+          "type": "number"
+        },
+        "columns": {
+          "type": "number"
+        },
+        "answers": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "required": [
+        "headers",
+        "rows",
+        "columns",
+        "answers"
+      ],
+      "additionalProperties": false
+    },
+    "TransformerWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "transformer"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusTransformerWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusTransformerWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "correct": {
+          "type": "object",
+          "properties": {
+            "shape": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "polygon-5",
+                      "polygon-3",
+                      "polygon-4",
+                      "lineSegment",
+                      "polygon-6",
+                      "angle",
+                      "line",
+                      "circle"
+                    ]
+                  }
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coord"
+                  }
+                },
+                "options": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "reflex": {
+                        "type": "boolean"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "required": [
+                "type",
+                "coords"
+              ],
+              "additionalProperties": false
+            },
+            "transformations": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PerseusTransformerTransformation"
+              }
+            }
+          },
+          "required": [
+            "shape",
+            "transformations"
+          ],
+          "additionalProperties": false
+        },
+        "drawSolutionShape": {
+          "type": "boolean"
+        },
+        "gradeEmpty": {
+          "type": "boolean"
+        },
+        "graph": {
+          "type": "object",
+          "properties": {
+            "backgroundImage": {
+              "type": "object",
+              "properties": {
+                "bottom": {
+                  "type": "number"
+                },
+                "height": {
+                  "type": "number"
+                },
+                "left": {
+                  "type": "number"
+                },
+                "scale": {
+                  "type": "number"
+                },
+                "url": {
+                  "type": "string"
+                },
+                "width": {
+                  "type": "number"
+                }
+              },
+              "additionalProperties": false
+            },
+            "gridStep": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "labels": {
+              "type": "array",
+              "minItems": 2,
+              "items": [
+                {
+                  "type": "string",
+                  "const": "x"
+                },
+                {
+                  "type": "string",
+                  "const": "y"
+                }
+              ],
+              "maxItems": 2
+            },
+            "markings": {
+              "type": "string",
+              "enum": [
+                "none",
+                "graph",
+                "grid"
+              ]
+            },
+            "range": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 2,
+                "maxItems": 2
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "rulerLabel": {
+              "type": "string"
+            },
+            "rulerTicks": {
+              "type": "number"
+            },
+            "showProtractor": {
+              "type": "boolean"
+            },
+            "showRuler": {
+              "type": "boolean"
+            },
+            "snapStep": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "step": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": [
+            "backgroundImage",
+            "markings",
+            "range",
+            "showProtractor",
+            "step"
+          ],
+          "additionalProperties": false
+        },
+        "graphMode": {
+          "type": "string",
+          "enum": [
+            "dynamic",
+            "interactive",
+            "static"
+          ]
+        },
+        "listMode": {
+          "type": "string",
+          "enum": [
+            "interactive",
+            "dynamic",
+            "static"
+          ]
+        },
+        "starting": {
+          "type": "object",
+          "properties": {
+            "shape": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "polygon-5",
+                          "polygon-3",
+                          "polygon-4",
+                          "lineSegment",
+                          "polygon-6"
+                        ]
+                      }
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coord"
+                      }
+                    },
+                    "options": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "coords"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "polygon-3"
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coord"
+                      },
+                      "minItems": 3,
+                      "maxItems": 3
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "coords"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "polygon-3",
+                          "lineSegment",
+                          "polygon-4",
+                          "polygon-5",
+                          "polygon-6",
+                          "line",
+                          "circle"
+                        ]
+                      },
+                      "minItems": 1,
+                      "maxItems": 1
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coord"
+                      }
+                    },
+                    "options": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "minItems": 1,
+                      "maxItems": 1
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "coords",
+                    "options"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "const": "polygon-3"
+                      },
+                      "minItems": 1,
+                      "maxItems": 1
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coord"
+                      },
+                      "minItems": 3,
+                      "maxItems": 3
+                    },
+                    "options": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "minItems": 1,
+                      "maxItems": 1
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "coords"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "const": "angle"
+                      },
+                      "minItems": 1,
+                      "maxItems": 1
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coord"
+                      },
+                      "minItems": 3,
+                      "maxItems": 3
+                    },
+                    "options": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "reflex": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "reflex"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "minItems": 1,
+                      "maxItems": 1
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "coords",
+                    "options"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "line",
+                          "lineSegment"
+                        ]
+                      },
+                      "minItems": 1,
+                      "maxItems": 1
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coord"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "options": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "minItems": 1,
+                      "maxItems": 1
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "coords"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "polygon"
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coord"
+                      }
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "coords"
+                  ],
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "transformations": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PerseusTransformerTransformation"
+              }
+            }
+          },
+          "required": [
+            "shape",
+            "transformations"
+          ],
+          "additionalProperties": false
+        },
+        "tools": {
+          "type": "object",
+          "properties": {
+            "dilation": {
+              "type": "object",
+              "properties": {
+                "constraints": {
+                  "$ref": "#/definitions/PerseusTransformerToolConstraints"
+                },
+                "coord": {
+                  "$ref": "#/definitions/Coord"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "required": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "constraints",
+                "coord",
+                "enabled"
+              ],
+              "additionalProperties": false
+            },
+            "reflection": {
+              "type": "object",
+              "properties": {
+                "constraints": {
+                  "$ref": "#/definitions/PerseusTransformerToolConstraints"
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coord"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "required": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "constraints",
+                "coords",
+                "enabled"
+              ],
+              "additionalProperties": false
+            },
+            "rotation": {
+              "type": "object",
+              "properties": {
+                "constraints": {
+                  "$ref": "#/definitions/PerseusTransformerToolConstraints"
+                },
+                "coord": {
+                  "$ref": "#/definitions/Coord"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "required": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "constraints",
+                "coord",
+                "enabled"
+              ],
+              "additionalProperties": false
+            },
+            "translation": {
+              "type": "object",
+              "properties": {
+                "constraints": {
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "required": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "constraints",
+                "enabled"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "dilation",
+            "reflection",
+            "rotation",
+            "translation"
+          ],
+          "additionalProperties": false
+        },
+        "version": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "correct",
+        "drawSolutionShape",
+        "gradeEmpty",
+        "graph",
+        "graphMode",
+        "listMode",
+        "starting",
+        "tools",
+        "version"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusTransformerTransformation": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DilationTransformation"
+        },
+        {
+          "$ref": "#/definitions/ReflectionTransformation"
+        },
+        {
+          "$ref": "#/definitions/RotationTransformation"
+        },
+        {
+          "$ref": "#/definitions/TranslationTransformation"
+        }
+      ]
+    },
+    "DilationTransformation": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "dilation"
+        },
+        "center": {
+          "$ref": "#/definitions/Coord"
+        },
+        "scale": {
+          "type": "number"
+        },
+        "constraints": {
+          "type": "object",
+          "properties": {
+            "fixed": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "fixed"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "type",
+        "center",
+        "scale",
+        "constraints"
+      ],
+      "additionalProperties": false
+    },
+    "ReflectionTransformation": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "reflection"
+        },
+        "line": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Coord"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "constraints": {
+          "type": "object",
+          "properties": {
+            "fixed": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "fixed"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "type",
+        "line"
+      ],
+      "additionalProperties": false
+    },
+    "RotationTransformation": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "rotation"
+        },
+        "angleDeg": {
+          "type": "number"
+        },
+        "center": {
+          "$ref": "#/definitions/Coord"
+        },
+        "constraints": {
+          "type": "object",
+          "properties": {
+            "fixed": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "fixed"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "type",
+        "angleDeg",
+        "center",
+        "constraints"
+      ],
+      "additionalProperties": false
+    },
+    "TranslationTransformation": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "translation"
+        },
+        "vector": {
+          "$ref": "#/definitions/Coord"
+        },
+        "contraints": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "type",
+        "vector",
+        "contraints"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusTransformerToolConstraints": {
+      "type": "object",
+      "properties": {
+        "fixed": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "fixed"
+      ],
+      "additionalProperties": false
+    },
+    "UnitInputWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "unit-input"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusUnitInputWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusUnitInputWidgetOptions": {},
+    "VideoWidget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "video"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PerseusVideoWidgetOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "$ref": "#/definitions/Version"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusVideoWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string"
+        },
+        "static": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "location"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusAnswerArea": {
+      "type": "object",
+      "properties": {
+        "zTable": {
+          "type": "boolean"
+        },
+        "chi2Table": {
+          "type": "boolean"
+        },
+        "tTable": {
+          "type": "boolean"
+        },
+        "calculator": {
+          "type": "boolean"
+        },
+        "periodicTable": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "zTable",
+        "chi2Table",
+        "tTable",
+        "calculator",
+        "periodicTable"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/utils/generated/schema.json
+++ b/utils/generated/schema.json
@@ -7,18 +7,96 @@
       "type": "object",
       "properties": {
         "question": {
-          "$ref": "#/definitions/PerseusRenderer"
+          "type": "object",
+          "properties": {
+            "content": {
+              "type": "string"
+            },
+            "replace": {
+              "type": "boolean"
+            },
+            "metadata": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "images": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "width": {
+                    "type": "number"
+                  },
+                  "height": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "width",
+                  "height"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": [
+            "content",
+            "widgets",
+            "images"
+          ],
+          "additionalProperties": false
         },
         "hints": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/PerseusRenderer"
+            "type": "object",
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "replace": {
+                "type": "boolean"
+              },
+              "metadata": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "images": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "width": {
+                      "type": "number"
+                    },
+                    "height": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "width",
+                    "height"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "content",
+              "widgets",
+              "images"
+            ],
+            "additionalProperties": false
           }
         },
         "answerArea": {
           "anyOf": [
             {
-              "$ref": "#/definitions/PerseusAnswerArea"
+              "$ref": "#/definitions/Record<(\"calculator\"|\"chi2Table\"|\"financialCalculatorMonthlyPayment\"|\"financialCalculatorTotalAmount\"|\"financialCalculatorTimeToPayOff\"|\"periodicTable\"|\"periodicTableWithKey\"|\"tTable\"|\"zTable\"),boolean>"
             },
             {
               "type": "null"
@@ -27,7 +105,20 @@
         },
         "_multi": {},
         "itemDataVersion": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         },
         "answer": {}
       },
@@ -39,19 +130,13 @@
         "answer"
       ],
       "additionalProperties": false,
-      "description": "The PerseusItem is the main data structure for a Perseus Item.  It is a collection of widgets that are rendered to the user.  The user can interact with the widgets and the widgets can be graded."
+      "description": "The PerseusItem is the main Perseus data structure for an exercise.  It forms a question (with interactive widgets), a set of hints, and answer area configuration (such as whether to make a calculator or periodic table available to the learner)."
     },
     "PerseusRenderer": {
       "type": "object",
       "properties": {
         "content": {
           "type": "string"
-        },
-        "widgets": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/PerseusWidget"
-          }
         },
         "replace": {
           "type": "boolean"
@@ -65,7 +150,20 @@
         "images": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/PerseusImageDetail"
+            "type": "object",
+            "properties": {
+              "width": {
+                "type": "number"
+              },
+              "height": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "width",
+              "height"
+            ],
+            "additionalProperties": false
           }
         }
       },
@@ -76,131 +174,5516 @@
       ],
       "additionalProperties": false
     },
-    "PerseusWidget": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/CategorizerWidget"
-        },
-        {
-          "$ref": "#/definitions/CSProgramWidget"
-        },
-        {
-          "$ref": "#/definitions/DefinitionWidget"
-        },
-        {
-          "$ref": "#/definitions/DropdownWidget"
-        },
-        {
-          "$ref": "#/definitions/ExampleGraphieWidget"
-        },
-        {
-          "$ref": "#/definitions/ExampleWidget"
-        },
-        {
-          "$ref": "#/definitions/ExplanationWidget"
-        },
-        {
-          "$ref": "#/definitions/ExpressionWidget"
-        },
-        {
-          "$ref": "#/definitions/GradedGroupSetWidget"
-        },
-        {
-          "$ref": "#/definitions/GradedGroupWidget"
-        },
-        {
-          "$ref": "#/definitions/GrapherWidget"
-        },
-        {
-          "$ref": "#/definitions/GroupWidget"
-        },
-        {
-          "$ref": "#/definitions/IFrameWidget"
-        },
-        {
-          "$ref": "#/definitions/ImageWidget"
-        },
-        {
-          "$ref": "#/definitions/InputNumberWidget"
-        },
-        {
-          "$ref": "#/definitions/InteractionWidget"
-        },
-        {
-          "$ref": "#/definitions/InteractiveGraphWidget"
-        },
-        {
-          "$ref": "#/definitions/LabelImageWidget"
-        },
-        {
-          "$ref": "#/definitions/LightsPuzzleWidget"
-        },
-        {
-          "$ref": "#/definitions/MatcherWidget"
-        },
-        {
-          "$ref": "#/definitions/MatrixWidget"
-        },
-        {
-          "$ref": "#/definitions/MeasurerWidget"
-        },
-        {
-          "$ref": "#/definitions/MoleculeRendererWidget"
-        },
-        {
-          "$ref": "#/definitions/NumberLineWidget"
-        },
-        {
-          "$ref": "#/definitions/NumericInputWidget"
-        },
-        {
-          "$ref": "#/definitions/OrdererWidget"
-        },
-        {
-          "$ref": "#/definitions/PassageRefWidget"
-        },
-        {
-          "$ref": "#/definitions/PassageWidget"
-        },
-        {
-          "$ref": "#/definitions/PlotterWidget"
-        },
-        {
-          "$ref": "#/definitions/RadioWidget"
-        },
-        {
-          "$ref": "#/definitions/ReactionDiagramWidget"
-        },
-        {
-          "$ref": "#/definitions/RefTargetWidget"
-        },
-        {
-          "$ref": "#/definitions/SequenceWidget"
-        },
-        {
-          "$ref": "#/definitions/SimpleMarkdownTesterWidget"
-        },
-        {
-          "$ref": "#/definitions/SimulatorWidget"
-        },
-        {
-          "$ref": "#/definitions/SorterWidget"
-        },
-        {
-          "$ref": "#/definitions/TableWidget"
-        },
-        {
-          "$ref": "#/definitions/TransformerWidget"
-        },
-        {
-          "$ref": "#/definitions/UnitInputWidget"
-        },
-        {
-          "$ref": "#/definitions/VideoWidget"
-        }
-      ]
+    "PerseusWidgetsMap": {
+      "type": "object",
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "categorizer"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "categories": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "randomizeItems": {
+                    "type": "boolean"
+                  },
+                  "static": {
+                    "type": "boolean"
+                  },
+                  "values": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  },
+                  "highlightLint": {
+                    "type": "boolean"
+                  },
+                  "linterContext": {
+                    "type": "object",
+                    "properties": {
+                      "contentType": {
+                        "type": "string"
+                      },
+                      "paths": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "stack": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": [
+                      "contentType",
+                      "paths",
+                      "stack"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "items",
+                  "categories",
+                  "randomizeItems",
+                  "static",
+                  "values"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "cs-program"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "programID": {
+                    "type": "string"
+                  },
+                  "programType": {},
+                  "settings": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "showEditor": {
+                    "type": "boolean"
+                  },
+                  "showButtons": {
+                    "type": "boolean"
+                  },
+                  "width": {
+                    "type": "number"
+                  },
+                  "height": {
+                    "type": "number"
+                  },
+                  "static": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "programID",
+                  "settings",
+                  "showEditor",
+                  "showButtons",
+                  "width",
+                  "height",
+                  "static"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "definition"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "togglePrompt": {
+                    "type": "string"
+                  },
+                  "definition": {
+                    "type": "string"
+                  },
+                  "static": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "togglePrompt",
+                  "definition",
+                  "static"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "dropdown"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "choices": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "content": {
+                          "type": "string"
+                        },
+                        "correct": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "content",
+                        "correct"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "placeholder": {
+                    "type": "string"
+                  },
+                  "static": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "choices",
+                  "placeholder",
+                  "static"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "example-widget"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "value"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "example-graphie-widget"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "graph": {
+                    "type": "object",
+                    "properties": {
+                      "box": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      },
+                      "range": {
+                        "type": "array",
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "number"
+                          },
+                          "minItems": 2,
+                          "maxItems": 2
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      },
+                      "labels": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "markings": {
+                        "type": "string",
+                        "enum": [
+                          "graph",
+                          "grid",
+                          "none"
+                        ]
+                      },
+                      "gridStep": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      },
+                      "step": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      },
+                      "showProtractor": {
+                        "type": "boolean"
+                      },
+                      "showRuler": {
+                        "type": "boolean"
+                      },
+                      "valid": {
+                        "type": "boolean"
+                      },
+                      "backgroundImage": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "url": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "width": {
+                                "type": "number"
+                              },
+                              "height": {
+                                "type": "number"
+                              },
+                              "top": {
+                                "type": "number"
+                              },
+                              "left": {
+                                "type": "number"
+                              },
+                              "scale": {
+                                "type": [
+                                  "number",
+                                  "string"
+                                ]
+                              },
+                              "bottom": {
+                                "type": "number"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "box",
+                      "range",
+                      "labels",
+                      "markings",
+                      "gridStep",
+                      "step"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "coord": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "number"
+                          },
+                          "minItems": 2,
+                          "maxItems": 2
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "graph",
+                  "coord"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "explanation"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "showPrompt": {
+                    "type": "string"
+                  },
+                  "hidePrompt": {
+                    "type": "string"
+                  },
+                  "explanation": {
+                    "type": "string"
+                  },
+                  "static": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "showPrompt",
+                  "hidePrompt",
+                  "explanation",
+                  "widgets",
+                  "static"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "expression"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "answerForms": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "value": {
+                          "type": "string"
+                        },
+                        "form": {
+                          "type": "boolean"
+                        },
+                        "simplify": {
+                          "type": "boolean"
+                        },
+                        "considered": {
+                          "type": "string",
+                          "enum": [
+                            "correct",
+                            "wrong",
+                            "ungraded"
+                          ]
+                        },
+                        "key": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "value",
+                        "form",
+                        "simplify",
+                        "considered"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "buttonSets": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "basic",
+                        "basic+div",
+                        "trig",
+                        "prealgebra",
+                        "logarithms",
+                        "basic relations",
+                        "advanced relations"
+                      ]
+                    }
+                  },
+                  "functions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "times": {
+                    "type": "boolean"
+                  },
+                  "buttonsVisible": {
+                    "type": "string",
+                    "enum": [
+                      "always",
+                      "never",
+                      "focused"
+                    ]
+                  }
+                },
+                "required": [
+                  "answerForms",
+                  "buttonSets",
+                  "functions",
+                  "times"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "grapher"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "availableTypes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "absolute_value",
+                        "exponential",
+                        "linear",
+                        "logarithm",
+                        "quadratic",
+                        "sinusoid",
+                        "tangent"
+                      ]
+                    }
+                  },
+                  "correct": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "absolute_value"
+                          },
+                          "coords": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "coords"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "exponential"
+                          },
+                          "asymptote": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          },
+                          "coords": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "asymptote",
+                          "coords"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "linear"
+                          },
+                          "coords": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "coords"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "logarithm"
+                          },
+                          "asymptote": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          },
+                          "coords": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "asymptote",
+                          "coords"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "quadratic"
+                          },
+                          "coords": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "coords"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "sinusoid"
+                          },
+                          "coords": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "coords"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "tangent"
+                          },
+                          "coords": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "coords"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  },
+                  "graph": {
+                    "type": "object",
+                    "properties": {
+                      "backgroundImage": {
+                        "type": "object",
+                        "properties": {
+                          "bottom": {
+                            "type": "number"
+                          },
+                          "height": {
+                            "type": "number"
+                          },
+                          "left": {
+                            "type": "number"
+                          },
+                          "scale": {
+                            "type": "number"
+                          },
+                          "url": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "width": {
+                            "type": "number"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "box": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      },
+                      "editableSettings": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "enum": [
+                            "graph",
+                            "snap",
+                            "image",
+                            "measure"
+                          ]
+                        }
+                      },
+                      "gridStep": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      },
+                      "labels": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      },
+                      "markings": {
+                        "type": "string",
+                        "enum": [
+                          "graph",
+                          "none",
+                          "grid"
+                        ]
+                      },
+                      "range": {
+                        "type": "array",
+                        "minItems": 2,
+                        "items": [
+                          {
+                            "type": "array",
+                            "minItems": 2,
+                            "items": [
+                              {
+                                "type": "number",
+                                "title": "min"
+                              },
+                              {
+                                "type": "number",
+                                "title": "max"
+                              }
+                            ],
+                            "maxItems": 2,
+                            "title": "x"
+                          },
+                          {
+                            "type": "array",
+                            "minItems": 2,
+                            "items": [
+                              {
+                                "type": "number",
+                                "title": "min"
+                              },
+                              {
+                                "type": "number",
+                                "title": "max"
+                              }
+                            ],
+                            "maxItems": 2,
+                            "title": "y"
+                          }
+                        ],
+                        "maxItems": 2
+                      },
+                      "rulerLabel": {
+                        "type": "string",
+                        "const": ""
+                      },
+                      "rulerTicks": {
+                        "type": "number"
+                      },
+                      "showProtractor": {
+                        "type": "boolean"
+                      },
+                      "showRuler": {
+                        "type": "boolean"
+                      },
+                      "showTooltips": {
+                        "type": "boolean"
+                      },
+                      "snapStep": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      },
+                      "step": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      },
+                      "valid": {
+                        "type": [
+                          "boolean",
+                          "string"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "backgroundImage",
+                      "labels",
+                      "markings",
+                      "range",
+                      "rulerLabel",
+                      "rulerTicks",
+                      "step"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "availableTypes",
+                  "correct",
+                  "graph"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "group"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "$ref": "#/definitions/PerseusRenderer"
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "graded-group"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  },
+                  "hasHint": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "hint": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "content": {
+                            "type": "string"
+                          },
+                          "replace": {
+                            "type": "boolean"
+                          },
+                          "metadata": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "images": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "object",
+                              "properties": {
+                                "width": {
+                                  "type": "number"
+                                },
+                                "height": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "width",
+                                "height"
+                              ],
+                              "additionalProperties": false
+                            }
+                          }
+                        },
+                        "required": [
+                          "content",
+                          "widgets",
+                          "images"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "content": {
+                    "type": "string"
+                  },
+                  "widgetEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "immutableWidgets": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "images": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "object",
+                      "properties": {
+                        "width": {
+                          "type": "number"
+                        },
+                        "height": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "width",
+                        "height"
+                      ],
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "required": [
+                  "title",
+                  "content",
+                  "widgets",
+                  "images"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "graded-group-set"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "gradedGroups": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "title": {
+                          "type": "string"
+                        },
+                        "hasHint": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "hint": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "content": {
+                                  "type": "string"
+                                },
+                                "replace": {
+                                  "type": "boolean"
+                                },
+                                "metadata": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "images": {
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "type": "object",
+                                    "properties": {
+                                      "width": {
+                                        "type": "number"
+                                      },
+                                      "height": {
+                                        "type": "number"
+                                      }
+                                    },
+                                    "required": [
+                                      "width",
+                                      "height"
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                }
+                              },
+                              "required": [
+                                "content",
+                                "widgets",
+                                "images"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "content": {
+                          "type": "string"
+                        },
+                        "widgetEnabled": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "immutableWidgets": {
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        "images": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                              "width": {
+                                "type": "number"
+                              },
+                              "height": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "width",
+                              "height"
+                            ],
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "required": [
+                        "title",
+                        "content",
+                        "widgets",
+                        "images"
+                      ],
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "required": [
+                  "gradedGroups"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "iframe"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "string"
+                  },
+                  "settings": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "width": {
+                    "type": [
+                      "number",
+                      "string"
+                    ]
+                  },
+                  "height": {
+                    "type": [
+                      "number",
+                      "string"
+                    ]
+                  },
+                  "allowFullScreen": {
+                    "type": "boolean"
+                  },
+                  "allowTopNavigation": {
+                    "type": "boolean"
+                  },
+                  "static": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "url",
+                  "settings",
+                  "width",
+                  "height",
+                  "allowFullScreen",
+                  "static"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "image"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  },
+                  "caption": {
+                    "type": "string"
+                  },
+                  "alt": {
+                    "type": "string"
+                  },
+                  "backgroundImage": {
+                    "type": "object",
+                    "properties": {
+                      "url": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "width": {
+                        "type": "number"
+                      },
+                      "height": {
+                        "type": "number"
+                      },
+                      "top": {
+                        "type": "number"
+                      },
+                      "left": {
+                        "type": "number"
+                      },
+                      "scale": {
+                        "type": [
+                          "number",
+                          "string"
+                        ]
+                      },
+                      "bottom": {
+                        "type": "number"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "static": {
+                    "type": "boolean"
+                  },
+                  "labels": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "content": {
+                          "type": "string"
+                        },
+                        "alignment": {
+                          "type": "string"
+                        },
+                        "coordinates": {
+                          "type": "array",
+                          "items": {
+                            "type": "number"
+                          }
+                        }
+                      },
+                      "required": [
+                        "content",
+                        "alignment",
+                        "coordinates"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "range": {
+                    "type": "array",
+                    "items": {
+                      "type": "array",
+                      "minItems": 2,
+                      "items": [
+                        {
+                          "type": "number",
+                          "title": "min"
+                        },
+                        {
+                          "type": "number",
+                          "title": "max"
+                        }
+                      ],
+                      "maxItems": 2
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  },
+                  "box": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  }
+                },
+                "required": [
+                  "backgroundImage"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "input-number"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "answerType": {
+                    "type": "string",
+                    "enum": [
+                      "number",
+                      "decimal",
+                      "integer",
+                      "rational",
+                      "improper",
+                      "mixed",
+                      "percent",
+                      "pi"
+                    ]
+                  },
+                  "inexact": {
+                    "type": "boolean"
+                  },
+                  "maxError": {
+                    "type": [
+                      "number",
+                      "string"
+                    ]
+                  },
+                  "rightAlign": {
+                    "type": "boolean"
+                  },
+                  "simplify": {
+                    "type": "string",
+                    "enum": [
+                      "required",
+                      "optional",
+                      "enforced"
+                    ]
+                  },
+                  "size": {
+                    "type": "string",
+                    "enum": [
+                      "normal",
+                      "small"
+                    ]
+                  },
+                  "value": {
+                    "type": [
+                      "string",
+                      "number"
+                    ]
+                  },
+                  "customKeypad": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "simplify",
+                  "size",
+                  "value"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "interaction"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "graph": {
+                    "type": "object",
+                    "properties": {
+                      "editableSettings": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "enum": [
+                            "canvas",
+                            "graph"
+                          ]
+                        }
+                      },
+                      "box": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      },
+                      "labels": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "range": {
+                        "type": "array",
+                        "items": {
+                          "type": "array",
+                          "minItems": 2,
+                          "items": [
+                            {
+                              "type": "number",
+                              "title": "min"
+                            },
+                            {
+                              "type": "number",
+                              "title": "max"
+                            }
+                          ],
+                          "maxItems": 2
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      },
+                      "gridStep": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      },
+                      "markings": {
+                        "type": "string",
+                        "enum": [
+                          "graph",
+                          "grid",
+                          "none"
+                        ],
+                        "description": "The type of markings to display on the graph.\n- graph: shows the axes and the grid lines\n- grid: shows only the grid lines\n- none: shows no markings"
+                      },
+                      "snapStep": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      },
+                      "valid": {
+                        "type": [
+                          "boolean",
+                          "string"
+                        ]
+                      },
+                      "backgroundImage": {
+                        "type": "object",
+                        "properties": {
+                          "url": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "width": {
+                            "type": "number"
+                          },
+                          "height": {
+                            "type": "number"
+                          },
+                          "top": {
+                            "type": "number"
+                          },
+                          "left": {
+                            "type": "number"
+                          },
+                          "scale": {
+                            "type": [
+                              "number",
+                              "string"
+                            ]
+                          },
+                          "bottom": {
+                            "type": "number"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "showProtractor": {
+                        "type": "boolean"
+                      },
+                      "showRuler": {
+                        "type": "boolean"
+                      },
+                      "rulerLabel": {
+                        "type": "string"
+                      },
+                      "rulerTicks": {
+                        "type": "number"
+                      },
+                      "tickStep": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      }
+                    },
+                    "required": [
+                      "box",
+                      "labels",
+                      "range",
+                      "gridStep",
+                      "markings",
+                      "tickStep"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "elements": {
+                    "type": "array",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "const": "function"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "options": {
+                              "type": "object",
+                              "properties": {
+                                "value": {
+                                  "type": "string"
+                                },
+                                "funcName": {
+                                  "type": "string"
+                                },
+                                "rangeMin": {
+                                  "type": "string"
+                                },
+                                "rangeMax": {
+                                  "type": "string"
+                                },
+                                "color": {
+                                  "type": "string"
+                                },
+                                "strokeDasharray": {
+                                  "type": "string"
+                                },
+                                "strokeWidth": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "value",
+                                "funcName",
+                                "rangeMin",
+                                "rangeMax",
+                                "color",
+                                "strokeDasharray",
+                                "strokeWidth"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "key",
+                            "options"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "const": "label"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "options": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string"
+                                },
+                                "color": {
+                                  "type": "string"
+                                },
+                                "coordX": {
+                                  "type": "string"
+                                },
+                                "coordY": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "label",
+                                "color",
+                                "coordX",
+                                "coordY"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "key",
+                            "options"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "const": "line"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "options": {
+                              "type": "object",
+                              "properties": {
+                                "color": {
+                                  "type": "string"
+                                },
+                                "startX": {
+                                  "type": "string"
+                                },
+                                "startY": {
+                                  "type": "string"
+                                },
+                                "endX": {
+                                  "type": "string"
+                                },
+                                "endY": {
+                                  "type": "string"
+                                },
+                                "strokeDasharray": {
+                                  "type": "string"
+                                },
+                                "strokeWidth": {
+                                  "type": "number"
+                                },
+                                "arrows": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "color",
+                                "startX",
+                                "startY",
+                                "endX",
+                                "endY",
+                                "strokeDasharray",
+                                "strokeWidth",
+                                "arrows"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "key",
+                            "options"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "const": "movable-line"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "options": {
+                              "type": "object",
+                              "properties": {
+                                "startX": {
+                                  "type": "string"
+                                },
+                                "startY": {
+                                  "type": "string"
+                                },
+                                "startSubscript": {
+                                  "type": "number"
+                                },
+                                "endX": {
+                                  "type": "string"
+                                },
+                                "endY": {
+                                  "type": "string"
+                                },
+                                "endSubscript": {
+                                  "type": "number"
+                                },
+                                "constraint": {
+                                  "type": "string"
+                                },
+                                "snap": {
+                                  "type": "number"
+                                },
+                                "constraintFn": {
+                                  "type": "string"
+                                },
+                                "constraintXMin": {
+                                  "type": "string"
+                                },
+                                "constraintXMax": {
+                                  "type": "string"
+                                },
+                                "constraintYMin": {
+                                  "type": "string"
+                                },
+                                "constraintYMax": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "startX",
+                                "startY",
+                                "startSubscript",
+                                "endX",
+                                "endY",
+                                "endSubscript",
+                                "constraint",
+                                "snap",
+                                "constraintFn",
+                                "constraintXMin",
+                                "constraintXMax",
+                                "constraintYMin",
+                                "constraintYMax"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "key",
+                            "options"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "const": "movable-point"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "options": {
+                              "type": "object",
+                              "properties": {
+                                "startX": {
+                                  "type": "string"
+                                },
+                                "startY": {
+                                  "type": "string"
+                                },
+                                "varSubscript": {
+                                  "type": "number"
+                                },
+                                "constraint": {
+                                  "type": "string"
+                                },
+                                "snap": {
+                                  "type": "number"
+                                },
+                                "constraintFn": {
+                                  "type": "string"
+                                },
+                                "constraintXMin": {
+                                  "type": "string"
+                                },
+                                "constraintXMax": {
+                                  "type": "string"
+                                },
+                                "constraintYMin": {
+                                  "type": "string"
+                                },
+                                "constraintYMax": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "startX",
+                                "startY",
+                                "varSubscript",
+                                "constraint",
+                                "snap",
+                                "constraintFn",
+                                "constraintXMin",
+                                "constraintXMax",
+                                "constraintYMin",
+                                "constraintYMax"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "key",
+                            "options"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "const": "parametric"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "options": {
+                              "type": "object",
+                              "properties": {
+                                "x": {
+                                  "type": "string"
+                                },
+                                "y": {
+                                  "type": "string"
+                                },
+                                "rangeMin": {
+                                  "type": "string"
+                                },
+                                "rangeMax": {
+                                  "type": "string"
+                                },
+                                "color": {
+                                  "type": "string"
+                                },
+                                "strokeDasharray": {
+                                  "type": "string"
+                                },
+                                "strokeWidth": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "x",
+                                "y",
+                                "rangeMin",
+                                "rangeMax",
+                                "color",
+                                "strokeDasharray",
+                                "strokeWidth"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "key",
+                            "options"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "const": "point"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "options": {
+                              "type": "object",
+                              "properties": {
+                                "color": {
+                                  "type": "string"
+                                },
+                                "coordX": {
+                                  "type": "string"
+                                },
+                                "coordY": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "color",
+                                "coordX",
+                                "coordY"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "key",
+                            "options"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "const": "rectangle"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "options": {
+                              "type": "object",
+                              "properties": {
+                                "color": {
+                                  "type": "string"
+                                },
+                                "coordX": {
+                                  "type": "string"
+                                },
+                                "coordY": {
+                                  "type": "string"
+                                },
+                                "width": {
+                                  "type": "string"
+                                },
+                                "height": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "color",
+                                "coordX",
+                                "coordY",
+                                "width",
+                                "height"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "key",
+                            "options"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  },
+                  "static": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "graph",
+                  "elements",
+                  "static"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "interactive-graph"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "step": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  },
+                  "gridStep": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  },
+                  "snapStep": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  },
+                  "backgroundImage": {
+                    "type": "object",
+                    "properties": {
+                      "url": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "width": {
+                        "type": "number"
+                      },
+                      "height": {
+                        "type": "number"
+                      },
+                      "top": {
+                        "type": "number"
+                      },
+                      "left": {
+                        "type": "number"
+                      },
+                      "scale": {
+                        "type": [
+                          "number",
+                          "string"
+                        ]
+                      },
+                      "bottom": {
+                        "type": "number"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "markings": {
+                    "type": "string",
+                    "enum": [
+                      "graph",
+                      "grid",
+                      "none"
+                    ],
+                    "description": "The type of markings to display on the graph.\n- graph: shows the axes and the grid lines\n- grid: shows only the grid lines\n- none: shows no markings"
+                  },
+                  "labels": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "showProtractor": {
+                    "type": "boolean"
+                  },
+                  "showRuler": {
+                    "type": "boolean"
+                  },
+                  "showTooltips": {
+                    "type": "boolean"
+                  },
+                  "rulerLabel": {
+                    "type": "string"
+                  },
+                  "rulerTicks": {
+                    "type": "number"
+                  },
+                  "range": {
+                    "type": "array",
+                    "minItems": 2,
+                    "items": [
+                      {
+                        "type": "array",
+                        "minItems": 2,
+                        "items": [
+                          {
+                            "type": "number",
+                            "title": "min"
+                          },
+                          {
+                            "type": "number",
+                            "title": "max"
+                          }
+                        ],
+                        "maxItems": 2,
+                        "title": "x"
+                      },
+                      {
+                        "type": "array",
+                        "minItems": 2,
+                        "items": [
+                          {
+                            "type": "number",
+                            "title": "min"
+                          },
+                          {
+                            "type": "number",
+                            "title": "max"
+                          }
+                        ],
+                        "maxItems": 2,
+                        "title": "y"
+                      }
+                    ],
+                    "maxItems": 2
+                  },
+                  "graph": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "angle"
+                          },
+                          "showAngles": {
+                            "type": "boolean"
+                          },
+                          "allowReflexAngles": {
+                            "type": "boolean"
+                          },
+                          "angleOffsetDeg": {
+                            "type": "number"
+                          },
+                          "snapDegrees": {
+                            "type": "number"
+                          },
+                          "match": {
+                            "type": "string",
+                            "const": "congruent"
+                          },
+                          "coords": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            }
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "coord": {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          },
+                          "type": {
+                            "type": "string",
+                            "const": "circle"
+                          },
+                          "center": {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          },
+                          "radius": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "coord": {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          },
+                          "type": {
+                            "type": "string",
+                            "const": "linear"
+                          },
+                          "coords": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "minItems": 2,
+                              "items": [
+                                {
+                                  "type": "number",
+                                  "title": "x"
+                                },
+                                {
+                                  "type": "number",
+                                  "title": "y"
+                                }
+                              ],
+                              "maxItems": 2,
+                              "description": "A two-dimensional vector"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "coord": {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          },
+                          "type": {
+                            "type": "string",
+                            "const": "linear-system"
+                          },
+                          "coords": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "array",
+                                "minItems": 2,
+                                "items": [
+                                  {
+                                    "type": "number",
+                                    "title": "x"
+                                  },
+                                  {
+                                    "type": "number",
+                                    "title": "y"
+                                  }
+                                ],
+                                "maxItems": 2,
+                                "description": "A two-dimensional vector"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            }
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "coord": {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          },
+                          "type": {
+                            "type": "string",
+                            "const": "point"
+                          },
+                          "numPoints": {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string",
+                                "const": "unlimited"
+                              }
+                            ]
+                          },
+                          "coords": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            }
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "coord": {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          },
+                          "type": {
+                            "type": "string",
+                            "const": "polygon"
+                          },
+                          "numSides": {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string",
+                                "const": "unlimited"
+                              }
+                            ]
+                          },
+                          "showAngles": {
+                            "type": "boolean"
+                          },
+                          "showSides": {
+                            "type": "boolean"
+                          },
+                          "snapTo": {
+                            "type": "string"
+                          },
+                          "match": {
+                            "type": "string",
+                            "enum": [
+                              "similar",
+                              "congruent",
+                              "approx"
+                            ]
+                          },
+                          "coords": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            }
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "coord": {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          },
+                          "type": {
+                            "type": "string",
+                            "const": "quadratic"
+                          },
+                          "coords": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            }
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "coord": {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          },
+                          "type": {
+                            "type": "string",
+                            "const": "ray"
+                          },
+                          "coords": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "minItems": 2,
+                              "items": [
+                                {
+                                  "type": "number",
+                                  "title": "x"
+                                },
+                                {
+                                  "type": "number",
+                                  "title": "y"
+                                }
+                              ],
+                              "maxItems": 2,
+                              "description": "A two-dimensional vector"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "coord": {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          },
+                          "type": {
+                            "type": "string",
+                            "const": "segment"
+                          },
+                          "numSegments": {
+                            "type": "number"
+                          },
+                          "coords": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "array",
+                                "minItems": 2,
+                                "items": [
+                                  {
+                                    "type": "number",
+                                    "title": "x"
+                                  },
+                                  {
+                                    "type": "number",
+                                    "title": "y"
+                                  }
+                                ],
+                                "maxItems": 2,
+                                "description": "A two-dimensional vector"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            }
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "coord": {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          },
+                          "type": {
+                            "type": "string",
+                            "const": "sinusoid"
+                          },
+                          "coords": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            }
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ]
+                      }
+                    ]
+                  },
+                  "correct": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "angle"
+                          },
+                          "showAngles": {
+                            "type": "boolean"
+                          },
+                          "allowReflexAngles": {
+                            "type": "boolean"
+                          },
+                          "angleOffsetDeg": {
+                            "type": "number"
+                          },
+                          "snapDegrees": {
+                            "type": "number"
+                          },
+                          "match": {
+                            "type": "string",
+                            "const": "congruent"
+                          },
+                          "coords": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            }
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "coord": {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          },
+                          "type": {
+                            "type": "string",
+                            "const": "circle"
+                          },
+                          "center": {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          },
+                          "radius": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "coord": {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          },
+                          "type": {
+                            "type": "string",
+                            "const": "linear"
+                          },
+                          "coords": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "minItems": 2,
+                              "items": [
+                                {
+                                  "type": "number",
+                                  "title": "x"
+                                },
+                                {
+                                  "type": "number",
+                                  "title": "y"
+                                }
+                              ],
+                              "maxItems": 2,
+                              "description": "A two-dimensional vector"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "coord": {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          },
+                          "type": {
+                            "type": "string",
+                            "const": "linear-system"
+                          },
+                          "coords": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "array",
+                                "minItems": 2,
+                                "items": [
+                                  {
+                                    "type": "number",
+                                    "title": "x"
+                                  },
+                                  {
+                                    "type": "number",
+                                    "title": "y"
+                                  }
+                                ],
+                                "maxItems": 2,
+                                "description": "A two-dimensional vector"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            }
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "coord": {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          },
+                          "type": {
+                            "type": "string",
+                            "const": "point"
+                          },
+                          "numPoints": {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string",
+                                "const": "unlimited"
+                              }
+                            ]
+                          },
+                          "coords": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            }
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "coord": {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          },
+                          "type": {
+                            "type": "string",
+                            "const": "polygon"
+                          },
+                          "numSides": {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string",
+                                "const": "unlimited"
+                              }
+                            ]
+                          },
+                          "showAngles": {
+                            "type": "boolean"
+                          },
+                          "showSides": {
+                            "type": "boolean"
+                          },
+                          "snapTo": {
+                            "type": "string"
+                          },
+                          "match": {
+                            "type": "string",
+                            "enum": [
+                              "similar",
+                              "congruent",
+                              "approx"
+                            ]
+                          },
+                          "coords": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            }
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "coord": {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          },
+                          "type": {
+                            "type": "string",
+                            "const": "quadratic"
+                          },
+                          "coords": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            }
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "coord": {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          },
+                          "type": {
+                            "type": "string",
+                            "const": "ray"
+                          },
+                          "coords": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "minItems": 2,
+                              "items": [
+                                {
+                                  "type": "number",
+                                  "title": "x"
+                                },
+                                {
+                                  "type": "number",
+                                  "title": "y"
+                                }
+                              ],
+                              "maxItems": 2,
+                              "description": "A two-dimensional vector"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "coord": {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          },
+                          "type": {
+                            "type": "string",
+                            "const": "segment"
+                          },
+                          "numSegments": {
+                            "type": "number"
+                          },
+                          "coords": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "array",
+                                "minItems": 2,
+                                "items": [
+                                  {
+                                    "type": "number",
+                                    "title": "x"
+                                  },
+                                  {
+                                    "type": "number",
+                                    "title": "y"
+                                  }
+                                ],
+                                "maxItems": 2,
+                                "description": "A two-dimensional vector"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            }
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "coord": {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          },
+                          "type": {
+                            "type": "string",
+                            "const": "sinusoid"
+                          },
+                          "coords": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            }
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ]
+                      }
+                    ]
+                  },
+                  "lockedFigures": {
+                    "type": "array",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "const": "point"
+                            },
+                            "coord": {
+                              "type": "array",
+                              "items": {
+                                "type": "number"
+                              },
+                              "minItems": 2,
+                              "maxItems": 2
+                            },
+                            "color": {
+                              "type": "string",
+                              "enum": [
+                                "green",
+                                "grayH",
+                                "purple",
+                                "pink",
+                                "red"
+                              ]
+                            },
+                            "filled": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "coord",
+                            "color",
+                            "filled"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "const": "line"
+                            },
+                            "kind": {
+                              "type": "string",
+                              "enum": [
+                                "line",
+                                "ray",
+                                "segment"
+                              ]
+                            },
+                            "points": {
+                              "type": "array",
+                              "minItems": 2,
+                              "items": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "point"
+                                    },
+                                    "coord": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "number"
+                                      },
+                                      "minItems": 2,
+                                      "maxItems": 2
+                                    },
+                                    "color": {
+                                      "type": "string",
+                                      "enum": [
+                                        "green",
+                                        "grayH",
+                                        "purple",
+                                        "pink",
+                                        "red"
+                                      ]
+                                    },
+                                    "filled": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "coord",
+                                    "color",
+                                    "filled"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "point"
+                                    },
+                                    "coord": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "number"
+                                      },
+                                      "minItems": 2,
+                                      "maxItems": 2
+                                    },
+                                    "color": {
+                                      "type": "string",
+                                      "enum": [
+                                        "green",
+                                        "grayH",
+                                        "purple",
+                                        "pink",
+                                        "red"
+                                      ]
+                                    },
+                                    "filled": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "coord",
+                                    "color",
+                                    "filled"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              ],
+                              "maxItems": 2
+                            },
+                            "color": {
+                              "type": "string",
+                              "enum": [
+                                "green",
+                                "grayH",
+                                "purple",
+                                "pink",
+                                "red"
+                              ]
+                            },
+                            "lineStyle": {
+                              "type": "string",
+                              "enum": [
+                                "solid",
+                                "dashed"
+                              ]
+                            },
+                            "showPoint1": {
+                              "type": "boolean"
+                            },
+                            "showPoint2": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "kind",
+                            "points",
+                            "color",
+                            "lineStyle",
+                            "showPoint1",
+                            "showPoint2"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  }
+                },
+                "required": [
+                  "step",
+                  "gridStep",
+                  "snapStep",
+                  "markings",
+                  "labels",
+                  "showProtractor",
+                  "showRuler",
+                  "rulerLabel",
+                  "rulerTicks",
+                  "range",
+                  "graph",
+                  "correct"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "label-image"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "choices": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "imageUrl": {
+                    "type": "string"
+                  },
+                  "imageAlt": {
+                    "type": "string"
+                  },
+                  "imageHeight": {
+                    "type": "number"
+                  },
+                  "imageWidth": {
+                    "type": "number"
+                  },
+                  "markers": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "answers": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "x": {
+                          "type": "number"
+                        },
+                        "y": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "answers",
+                        "label",
+                        "x",
+                        "y"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "hideChoicesFromInstructions": {
+                    "type": "boolean"
+                  },
+                  "multipleAnswers": {
+                    "type": "boolean"
+                  },
+                  "static": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "choices",
+                  "imageUrl",
+                  "imageAlt",
+                  "imageHeight",
+                  "imageWidth",
+                  "markers",
+                  "hideChoicesFromInstructions",
+                  "multipleAnswers",
+                  "static"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "matcher"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "labels": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "left": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "right": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "orderMatters": {
+                    "type": "boolean"
+                  },
+                  "padding": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "labels",
+                  "left",
+                  "right",
+                  "orderMatters",
+                  "padding"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "matrix"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "prefix": {
+                    "type": "string"
+                  },
+                  "suffix": {
+                    "type": "string"
+                  },
+                  "answers": {
+                    "type": "array",
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      }
+                    }
+                  },
+                  "cursorPosition": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  },
+                  "matrixBoardSize": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  },
+                  "static": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "prefix",
+                  "suffix",
+                  "answers",
+                  "cursorPosition",
+                  "matrixBoardSize",
+                  "static"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "measurer"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "image": {
+                    "type": "object",
+                    "properties": {
+                      "url": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "width": {
+                        "type": "number"
+                      },
+                      "height": {
+                        "type": "number"
+                      },
+                      "top": {
+                        "type": "number"
+                      },
+                      "left": {
+                        "type": "number"
+                      },
+                      "scale": {
+                        "type": [
+                          "number",
+                          "string"
+                        ]
+                      },
+                      "bottom": {
+                        "type": "number"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "showProtractor": {
+                    "type": "boolean"
+                  },
+                  "showRuler": {
+                    "type": "boolean"
+                  },
+                  "rulerLabel": {
+                    "type": "string"
+                  },
+                  "rulerTicks": {
+                    "type": "number"
+                  },
+                  "rulerPixels": {
+                    "type": "number"
+                  },
+                  "rulerLength": {
+                    "type": "number"
+                  },
+                  "box": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  },
+                  "static": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "image",
+                  "showProtractor",
+                  "showRuler",
+                  "rulerLabel",
+                  "rulerTicks",
+                  "rulerPixels",
+                  "rulerLength",
+                  "box",
+                  "static"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "molecule-renderer"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "widgetId": {
+                    "type": "string"
+                  },
+                  "rotationAngle": {
+                    "type": "number"
+                  },
+                  "smiles": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "widgetId"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "number-line"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "range": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  },
+                  "labelRange": {
+                    "type": "array",
+                    "items": {
+                      "type": [
+                        "number",
+                        "null"
+                      ]
+                    }
+                  },
+                  "labelStyle": {
+                    "type": "string"
+                  },
+                  "labelTicks": {
+                    "type": "boolean"
+                  },
+                  "isTickCtrl": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "divisionRange": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  },
+                  "numDivisions": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "snapDivisions": {
+                    "type": "number"
+                  },
+                  "tickStep": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "correctRel": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "correctX": {
+                    "type": "number"
+                  },
+                  "initialX": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "showTooltip": {
+                    "type": "boolean"
+                  },
+                  "static": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "range",
+                  "labelRange",
+                  "labelStyle",
+                  "labelTicks",
+                  "divisionRange",
+                  "snapDivisions",
+                  "correctX",
+                  "static"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "numeric-input"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "answers": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "number"
+                        },
+                        "status": {
+                          "type": "string"
+                        },
+                        "answerForms": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "enum": [
+                              "integer",
+                              "mixed",
+                              "improper",
+                              "proper",
+                              "decimal",
+                              "percent",
+                              "pi"
+                            ]
+                          }
+                        },
+                        "strict": {
+                          "type": "boolean"
+                        },
+                        "maxError": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "simplify": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "message",
+                        "value",
+                        "status",
+                        "strict"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "labelText": {
+                    "type": "string"
+                  },
+                  "size": {
+                    "type": "string"
+                  },
+                  "coefficient": {
+                    "type": "boolean"
+                  },
+                  "rightAlign": {
+                    "type": "boolean"
+                  },
+                  "static": {
+                    "type": "boolean"
+                  },
+                  "answerForms": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "simplify": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "enum": [
+                            "required",
+                            "correct",
+                            "enforced",
+                            "optional",
+                            null
+                          ]
+                        },
+                        "name": {
+                          "type": "string",
+                          "enum": [
+                            "integer",
+                            "mixed",
+                            "improper",
+                            "proper",
+                            "decimal",
+                            "percent",
+                            "pi"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "required": [
+                  "answers",
+                  "labelText",
+                  "size",
+                  "coefficient",
+                  "static"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "orderer"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "options": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "content": {
+                          "type": "string"
+                        },
+                        "replace": {
+                          "type": "boolean"
+                        },
+                        "metadata": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "images": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                              "width": {
+                                "type": "number"
+                              },
+                              "height": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "width",
+                              "height"
+                            ],
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "required": [
+                        "content",
+                        "widgets",
+                        "images"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "correctOptions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "content": {
+                          "type": "string"
+                        },
+                        "replace": {
+                          "type": "boolean"
+                        },
+                        "metadata": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "images": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                              "width": {
+                                "type": "number"
+                              },
+                              "height": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "width",
+                              "height"
+                            ],
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "required": [
+                        "content",
+                        "widgets",
+                        "images"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "otherOptions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "content": {
+                          "type": "string"
+                        },
+                        "replace": {
+                          "type": "boolean"
+                        },
+                        "metadata": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "images": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                              "width": {
+                                "type": "number"
+                              },
+                              "height": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "width",
+                              "height"
+                            ],
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "required": [
+                        "content",
+                        "widgets",
+                        "images"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "height": {
+                    "type": "string"
+                  },
+                  "layout": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "options",
+                  "correctOptions",
+                  "otherOptions",
+                  "height",
+                  "layout"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "passage"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "footnotes": {
+                    "type": "string"
+                  },
+                  "passageText": {
+                    "type": "string"
+                  },
+                  "passageTitle": {
+                    "type": "string"
+                  },
+                  "showLineNumbers": {
+                    "type": "boolean"
+                  },
+                  "static": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "footnotes",
+                  "passageText",
+                  "passageTitle",
+                  "showLineNumbers",
+                  "static"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "passage-ref"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "passageNumber": {
+                    "type": "number"
+                  },
+                  "referenceNumber": {
+                    "type": "number"
+                  },
+                  "summaryText": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "passageNumber",
+                  "referenceNumber",
+                  "summaryText"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "passage-ref"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "passageNumber": {
+                    "type": "number"
+                  },
+                  "referenceNumber": {
+                    "type": "number"
+                  },
+                  "summaryText": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "passageNumber",
+                  "referenceNumber",
+                  "summaryText"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "plotter"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "labels": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "categories": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "bar",
+                      "line",
+                      "pic",
+                      "histogram",
+                      "dotplot"
+                    ]
+                  },
+                  "maxY": {
+                    "type": "number"
+                  },
+                  "scaleY": {
+                    "type": "number"
+                  },
+                  "labelInterval": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "snapsPerLine": {
+                    "type": "number"
+                  },
+                  "starting": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  },
+                  "correct": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  },
+                  "picUrl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "picSize": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "picBoxHeight": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "plotDimensions": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  }
+                },
+                "required": [
+                  "labels",
+                  "categories",
+                  "type",
+                  "maxY",
+                  "scaleY",
+                  "snapsPerLine",
+                  "starting",
+                  "correct",
+                  "plotDimensions"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "python-program"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "programID": {
+                    "type": "string"
+                  },
+                  "height": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "programID",
+                  "height"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "radio"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "choices": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "content": {
+                          "type": "string"
+                        },
+                        "clue": {
+                          "type": "string"
+                        },
+                        "correct": {
+                          "type": "boolean"
+                        },
+                        "isNoneOfTheAbove": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "hasNoneOfTheAbove": {
+                    "type": "boolean"
+                  },
+                  "countChoices": {
+                    "type": "boolean"
+                  },
+                  "randomize": {
+                    "type": "boolean"
+                  },
+                  "multipleSelect": {
+                    "type": "boolean"
+                  },
+                  "deselectEnabled": {
+                    "type": "boolean"
+                  },
+                  "onePerLine": {
+                    "type": "boolean"
+                  },
+                  "displayCount": {},
+                  "noneOfTheAbove": {
+                    "type": "boolean",
+                    "const": false
+                  }
+                },
+                "required": [
+                  "choices"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "simple-markdown-tester"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "value"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "sorter"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "correct": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "padding": {
+                    "type": "boolean"
+                  },
+                  "layout": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "correct",
+                  "padding",
+                  "layout"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "table"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "headers": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "rows": {
+                    "type": "number"
+                  },
+                  "columns": {
+                    "type": "number"
+                  },
+                  "answers": {
+                    "type": "array",
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "headers",
+                  "rows",
+                  "columns",
+                  "answers"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "unit-input"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "value"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "video"
+              },
+              "static": {
+                "type": "boolean"
+              },
+              "graded": {
+                "type": "boolean"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "options": {
+                "type": "object",
+                "properties": {
+                  "location": {
+                    "type": "string"
+                  },
+                  "static": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "location"
+                ],
+                "additionalProperties": false
+              },
+              "key": {
+                "type": "number"
+              },
+              "version": {
+                "type": "object",
+                "properties": {
+                  "major": {
+                    "type": "number"
+                  },
+                  "minor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "major",
+                  "minor"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "options"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "properties": {}
     },
     "CategorizerWidget": {
+      "$ref": "#/definitions/Widget<\"categorizer\",PerseusCategorizerWidgetOptions>"
+    },
+    "Widget<\"categorizer\",PerseusCategorizerWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -217,24 +5700,94 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusCategorizerWidgetOptions"
+          "type": "object",
+          "properties": {
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
-            {
-              "type": "null"
+            "categories": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "randomizeItems": {
+              "type": "boolean"
+            },
+            "static": {
+              "type": "boolean"
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "highlightLint": {
+              "type": "boolean"
+            },
+            "linterContext": {
+              "type": "object",
+              "properties": {
+                "contentType": {
+                  "type": "string"
+                },
+                "paths": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "stack": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "contentType",
+                "paths",
+                "stack"
+              ],
+              "additionalProperties": false
             }
-          ]
+          },
+          "required": [
+            "items",
+            "categories",
+            "randomizeItems",
+            "static",
+            "values"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -269,7 +5822,30 @@
           "type": "boolean"
         },
         "linterContext": {
-          "$ref": "#/definitions/PerseusLinterContext"
+          "type": "object",
+          "properties": {
+            "contentType": {
+              "type": "string"
+            },
+            "paths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "stack": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [
+            "contentType",
+            "paths",
+            "stack"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
@@ -324,6 +5900,9 @@
       "additionalProperties": false
     },
     "CSProgramWidget": {
+      "$ref": "#/definitions/Widget<\"cs-program\",PerseusCSProgramWidgetOptions>"
+    },
+    "Widget<\"cs-program\",PerseusCSProgramWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -340,24 +5919,81 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusCSProgramWidgetOptions"
+          "type": "object",
+          "properties": {
+            "programID": {
+              "type": "string"
             },
-            {
-              "type": "null"
+            "programType": {},
+            "settings": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "showEditor": {
+              "type": "boolean"
+            },
+            "showButtons": {
+              "type": "boolean"
+            },
+            "width": {
+              "type": "number"
+            },
+            "height": {
+              "type": "number"
+            },
+            "static": {
+              "type": "boolean"
             }
-          ]
+          },
+          "required": [
+            "programID",
+            "settings",
+            "showEditor",
+            "showButtons",
+            "width",
+            "height",
+            "static"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -371,7 +6007,20 @@
         "settings": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/PerseusCSProgramSetting"
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "additionalProperties": false
           }
         },
         "showEditor": {
@@ -418,6 +6067,9 @@
       "additionalProperties": false
     },
     "DefinitionWidget": {
+      "$ref": "#/definitions/Widget<\"definition\",PerseusDefinitionWidgetOptions>"
+    },
+    "Widget<\"definition\",PerseusDefinitionWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -434,24 +6086,48 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusDefinitionWidgetOptions"
+          "type": "object",
+          "properties": {
+            "togglePrompt": {
+              "type": "string"
             },
-            {
-              "type": "null"
+            "definition": {
+              "type": "string"
+            },
+            "static": {
+              "type": "boolean"
             }
-          ]
+          },
+          "required": [
+            "togglePrompt",
+            "definition",
+            "static"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -476,6 +6152,9 @@
       "additionalProperties": false
     },
     "DropdownWidget": {
+      "$ref": "#/definitions/Widget<\"dropdown\",PerseusDropdownWidgetOptions>"
+    },
+    "Widget<\"dropdown\",PerseusDropdownWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -492,24 +6171,64 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusDropdownWidgetOptions"
+          "type": "object",
+          "properties": {
+            "choices": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "content": {
+                    "type": "string"
+                  },
+                  "correct": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "content",
+                  "correct"
+                ],
+                "additionalProperties": false
+              }
             },
-            {
-              "type": "null"
+            "placeholder": {
+              "type": "string"
+            },
+            "static": {
+              "type": "boolean"
             }
-          ]
+          },
+          "required": [
+            "choices",
+            "placeholder",
+            "static"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -519,7 +6238,20 @@
         "choices": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/PerseusDropdownChoice"
+            "type": "object",
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "correct": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "content",
+              "correct"
+            ],
+            "additionalProperties": false
           }
         },
         "placeholder": {
@@ -552,46 +6284,10 @@
       ],
       "additionalProperties": false
     },
-    "ExampleGraphieWidget": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "const": "example-graphie-widget"
-        },
-        "static": {
-          "type": "boolean"
-        },
-        "graded": {
-          "type": "boolean"
-        },
-        "alignment": {
-          "type": "string"
-        },
-        "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusExampleGraphieWidgetOptions"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "key": {
-          "type": "number"
-        },
-        "version": {
-          "$ref": "#/definitions/Version"
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "PerseusExampleGraphieWidgetOptions": {},
     "ExampleWidget": {
+      "$ref": "#/definitions/Widget<\"example-widget\",PerseusExampleWidgetOptions>"
+    },
+    "Widget<\"example-widget\",PerseusExampleWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -608,29 +6304,555 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusExampleWidgetOptions"
-            },
-            {
-              "type": "null"
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "string"
             }
-          ]
+          },
+          "required": [
+            "value"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
-    "PerseusExampleWidgetOptions": {},
+    "PerseusExampleWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false
+    },
+    "ExampleGraphieWidget": {
+      "$ref": "#/definitions/Widget<\"example-graphie-widget\",PerseusExampleGraphieWidgetOptions>"
+    },
+    "Widget<\"example-graphie-widget\",PerseusExampleGraphieWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "example-graphie-widget"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "type": "object",
+          "properties": {
+            "graph": {
+              "type": "object",
+              "properties": {
+                "box": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "range": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "labels": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "markings": {
+                  "type": "string",
+                  "enum": [
+                    "graph",
+                    "grid",
+                    "none"
+                  ]
+                },
+                "gridStep": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "step": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "showProtractor": {
+                  "type": "boolean"
+                },
+                "showRuler": {
+                  "type": "boolean"
+                },
+                "valid": {
+                  "type": "boolean"
+                },
+                "backgroundImage": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "width": {
+                          "type": "number"
+                        },
+                        "height": {
+                          "type": "number"
+                        },
+                        "top": {
+                          "type": "number"
+                        },
+                        "left": {
+                          "type": "number"
+                        },
+                        "scale": {
+                          "type": [
+                            "number",
+                            "string"
+                          ]
+                        },
+                        "bottom": {
+                          "type": "number"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "box",
+                "range",
+                "labels",
+                "markings",
+                "gridStep",
+                "step"
+              ],
+              "additionalProperties": false
+            },
+            "coord": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "graph",
+            "coord"
+          ],
+          "additionalProperties": false
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusExampleGraphieWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "graph": {
+          "type": "object",
+          "properties": {
+            "box": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "range": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 2,
+                "maxItems": 2
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "labels": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "markings": {
+              "type": "string",
+              "enum": [
+                "graph",
+                "grid",
+                "none"
+              ]
+            },
+            "gridStep": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "step": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "showProtractor": {
+              "type": "boolean"
+            },
+            "showRuler": {
+              "type": "boolean"
+            },
+            "valid": {
+              "type": "boolean"
+            },
+            "backgroundImage": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "url": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "width": {
+                      "type": "number"
+                    },
+                    "height": {
+                      "type": "number"
+                    },
+                    "top": {
+                      "type": "number"
+                    },
+                    "left": {
+                      "type": "number"
+                    },
+                    "scale": {
+                      "type": [
+                        "number",
+                        "string"
+                      ]
+                    },
+                    "bottom": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "box",
+            "range",
+            "labels",
+            "markings",
+            "gridStep",
+            "step"
+          ],
+          "additionalProperties": false
+        },
+        "coord": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 2,
+                "maxItems": 2
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "graph",
+        "coord"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusExampleGraphieGraph": {
+      "type": "object",
+      "properties": {
+        "box": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "range": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "minItems": 2,
+            "maxItems": 2
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "markings": {
+          "type": "string",
+          "enum": [
+            "graph",
+            "grid",
+            "none"
+          ]
+        },
+        "gridStep": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "step": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "showProtractor": {
+          "type": "boolean"
+        },
+        "showRuler": {
+          "type": "boolean"
+        },
+        "valid": {
+          "type": "boolean"
+        },
+        "backgroundImage": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "width": {
+                  "type": "number"
+                },
+                "height": {
+                  "type": "number"
+                },
+                "top": {
+                  "type": "number"
+                },
+                "left": {
+                  "type": "number"
+                },
+                "scale": {
+                  "type": [
+                    "number",
+                    "string"
+                  ]
+                },
+                "bottom": {
+                  "type": "number"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "box",
+        "range",
+        "labels",
+        "markings",
+        "gridStep",
+        "step"
+      ],
+      "additionalProperties": false
+    },
+    "Size": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "Coord": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "PerseusImageBackground": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "width": {
+          "type": "number"
+        },
+        "height": {
+          "type": "number"
+        },
+        "top": {
+          "type": "number"
+        },
+        "left": {
+          "type": "number"
+        },
+        "scale": {
+          "type": [
+            "number",
+            "string"
+          ]
+        },
+        "bottom": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false
+    },
     "ExplanationWidget": {
+      "$ref": "#/definitions/Widget<\"explanation\",PerseusExplanationWidgetOptions>"
+    },
+    "Widget<\"explanation\",PerseusExplanationWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -647,24 +6869,53 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusExplanationWidgetOptions"
+          "type": "object",
+          "properties": {
+            "showPrompt": {
+              "type": "string"
             },
-            {
-              "type": "null"
+            "hidePrompt": {
+              "type": "string"
+            },
+            "explanation": {
+              "type": "string"
+            },
+            "static": {
+              "type": "boolean"
             }
-          ]
+          },
+          "required": [
+            "showPrompt",
+            "hidePrompt",
+            "explanation",
+            "widgets",
+            "static"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -680,12 +6931,6 @@
         "explanation": {
           "type": "string"
         },
-        "widgets": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/PerseusWidget"
-          }
-        },
         "static": {
           "type": "boolean"
         }
@@ -700,6 +6945,9 @@
       "additionalProperties": false
     },
     "ExpressionWidget": {
+      "$ref": "#/definitions/Widget<\"expression\",PerseusExpressionWidgetOptions>"
+    },
+    "Widget<\"expression\",PerseusExpressionWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -716,24 +6964,107 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusExpressionWidgetOptions"
+          "type": "object",
+          "properties": {
+            "answerForms": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": "string"
+                  },
+                  "form": {
+                    "type": "boolean"
+                  },
+                  "simplify": {
+                    "type": "boolean"
+                  },
+                  "considered": {
+                    "type": "string",
+                    "enum": [
+                      "correct",
+                      "wrong",
+                      "ungraded"
+                    ]
+                  },
+                  "key": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "value",
+                  "form",
+                  "simplify",
+                  "considered"
+                ],
+                "additionalProperties": false
+              }
             },
-            {
-              "type": "null"
+            "buttonSets": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "basic",
+                  "basic+div",
+                  "trig",
+                  "prealgebra",
+                  "logarithms",
+                  "basic relations",
+                  "advanced relations"
+                ]
+              }
+            },
+            "functions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "times": {
+              "type": "boolean"
+            },
+            "buttonsVisible": {
+              "type": "string",
+              "enum": [
+                "always",
+                "never",
+                "focused"
+              ]
             }
-          ]
+          },
+          "required": [
+            "answerForms",
+            "buttonSets",
+            "functions",
+            "times"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -743,11 +7074,52 @@
         "answerForms": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/PerseusExpressionAnswerForm"
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "form": {
+                "type": "boolean"
+              },
+              "simplify": {
+                "type": "boolean"
+              },
+              "considered": {
+                "type": "string",
+                "enum": [
+                  "correct",
+                  "wrong",
+                  "ungraded"
+                ]
+              },
+              "key": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "form",
+              "simplify",
+              "considered"
+            ],
+            "additionalProperties": false
           }
         },
         "buttonSets": {
-          "$ref": "#/definitions/LegacyButtonSets"
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "basic",
+              "basic+div",
+              "trig",
+              "prealgebra",
+              "logarithms",
+              "basic relations",
+              "advanced relations"
+            ]
+          }
         },
         "functions": {
           "type": "array",
@@ -822,172 +7194,10 @@
         ]
       }
     },
-    "GradedGroupSetWidget": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "const": "graded-group-set"
-        },
-        "static": {
-          "type": "boolean"
-        },
-        "graded": {
-          "type": "boolean"
-        },
-        "alignment": {
-          "type": "string"
-        },
-        "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusGradedGroupSetWidgetOptions"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "key": {
-          "type": "number"
-        },
-        "version": {
-          "$ref": "#/definitions/Version"
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "PerseusGradedGroupSetWidgetOptions": {
-      "type": "object",
-      "properties": {
-        "gradedGroups": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/PerseusGradedGroupWidgetOptions"
-          }
-        }
-      },
-      "required": [
-        "gradedGroups"
-      ],
-      "additionalProperties": false
-    },
-    "PerseusGradedGroupWidgetOptions": {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "hasHint": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "hint": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusRenderer"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "content": {
-          "type": "string"
-        },
-        "widgets": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/PerseusWidget"
-          }
-        },
-        "widgetEnabled": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "immutableWidgets": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "images": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/PerseusImageDetail"
-          }
-        }
-      },
-      "required": [
-        "title",
-        "content",
-        "widgets",
-        "images"
-      ],
-      "additionalProperties": false
-    },
-    "PerseusImageDetail": {
-      "type": "object",
-      "properties": {
-        "width": {
-          "type": "number"
-        },
-        "height": {
-          "type": "number"
-        }
-      },
-      "required": [
-        "width",
-        "height"
-      ],
-      "additionalProperties": false
-    },
-    "GradedGroupWidget": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "const": "graded-group"
-        },
-        "static": {
-          "type": "boolean"
-        },
-        "graded": {
-          "type": "boolean"
-        },
-        "alignment": {
-          "type": "string"
-        },
-        "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusGradedGroupWidgetOptions"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "key": {
-          "type": "number"
-        },
-        "version": {
-          "$ref": "#/definitions/Version"
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
     "GrapherWidget": {
+      "$ref": "#/definitions/Widget<\"grapher\",PerseusGrapherWidgetOptions>"
+    },
+    "Widget<\"grapher\",PerseusGrapherWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -1004,24 +7214,438 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusGrapherWidgetOptions"
+          "type": "object",
+          "properties": {
+            "availableTypes": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "absolute_value",
+                  "exponential",
+                  "linear",
+                  "logarithm",
+                  "quadratic",
+                  "sinusoid",
+                  "tangent"
+                ]
+              }
             },
-            {
-              "type": "null"
+            "correct": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "absolute_value"
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "coords"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "exponential"
+                    },
+                    "asymptote": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "asymptote",
+                    "coords"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "linear"
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "coords"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "logarithm"
+                    },
+                    "asymptote": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "asymptote",
+                    "coords"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "quadratic"
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "coords"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "sinusoid"
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "coords"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "tangent"
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "coords"
+                  ],
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "graph": {
+              "type": "object",
+              "properties": {
+                "backgroundImage": {
+                  "type": "object",
+                  "properties": {
+                    "bottom": {
+                      "type": "number"
+                    },
+                    "height": {
+                      "type": "number"
+                    },
+                    "left": {
+                      "type": "number"
+                    },
+                    "scale": {
+                      "type": "number"
+                    },
+                    "url": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "width": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "box": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "editableSettings": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "graph",
+                      "snap",
+                      "image",
+                      "measure"
+                    ]
+                  }
+                },
+                "gridStep": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "labels": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "markings": {
+                  "type": "string",
+                  "enum": [
+                    "graph",
+                    "none",
+                    "grid"
+                  ]
+                },
+                "range": {
+                  "type": "array",
+                  "minItems": 2,
+                  "items": [
+                    {
+                      "type": "array",
+                      "minItems": 2,
+                      "items": [
+                        {
+                          "type": "number",
+                          "title": "min"
+                        },
+                        {
+                          "type": "number",
+                          "title": "max"
+                        }
+                      ],
+                      "maxItems": 2,
+                      "title": "x"
+                    },
+                    {
+                      "type": "array",
+                      "minItems": 2,
+                      "items": [
+                        {
+                          "type": "number",
+                          "title": "min"
+                        },
+                        {
+                          "type": "number",
+                          "title": "max"
+                        }
+                      ],
+                      "maxItems": 2,
+                      "title": "y"
+                    }
+                  ],
+                  "maxItems": 2
+                },
+                "rulerLabel": {
+                  "type": "string",
+                  "const": ""
+                },
+                "rulerTicks": {
+                  "type": "number"
+                },
+                "showProtractor": {
+                  "type": "boolean"
+                },
+                "showRuler": {
+                  "type": "boolean"
+                },
+                "showTooltips": {
+                  "type": "boolean"
+                },
+                "snapStep": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "step": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "valid": {
+                  "type": [
+                    "boolean",
+                    "string"
+                  ]
+                }
+              },
+              "required": [
+                "backgroundImage",
+                "labels",
+                "markings",
+                "range",
+                "rulerLabel",
+                "rulerTicks",
+                "step"
+              ],
+              "additionalProperties": false
             }
-          ]
+          },
+          "required": [
+            "availableTypes",
+            "correct",
+            "graph"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -1055,7 +7679,12 @@
                 "coords": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/definitions/Coord"
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
                   },
                   "minItems": 2,
                   "maxItems": 2
@@ -1077,7 +7706,12 @@
                 "asymptote": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/definitions/Coord"
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
                   },
                   "minItems": 2,
                   "maxItems": 2
@@ -1085,7 +7719,12 @@
                 "coords": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/definitions/Coord"
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
                   },
                   "minItems": 2,
                   "maxItems": 2
@@ -1108,7 +7747,12 @@
                 "coords": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/definitions/Coord"
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
                   },
                   "minItems": 2,
                   "maxItems": 2
@@ -1130,7 +7774,12 @@
                 "asymptote": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/definitions/Coord"
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
                   },
                   "minItems": 2,
                   "maxItems": 2
@@ -1138,7 +7787,12 @@
                 "coords": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/definitions/Coord"
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
                   },
                   "minItems": 2,
                   "maxItems": 2
@@ -1161,7 +7815,12 @@
                 "coords": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/definitions/Coord"
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
                   },
                   "minItems": 2,
                   "maxItems": 2
@@ -1183,7 +7842,12 @@
                 "coords": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/definitions/Coord"
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
                   },
                   "minItems": 2,
                   "maxItems": 2
@@ -1205,7 +7869,12 @@
                 "coords": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/definitions/Coord"
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
                   },
                   "minItems": 2,
                   "maxItems": 2
@@ -1295,15 +7964,41 @@
             },
             "range": {
               "type": "array",
-              "items": {
-                "type": "array",
-                "items": {
-                  "type": "number"
-                },
-                "minItems": 2,
-                "maxItems": 2
-              },
               "minItems": 2,
+              "items": [
+                {
+                  "type": "array",
+                  "minItems": 2,
+                  "items": [
+                    {
+                      "type": "number",
+                      "title": "min"
+                    },
+                    {
+                      "type": "number",
+                      "title": "max"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "title": "x"
+                },
+                {
+                  "type": "array",
+                  "minItems": 2,
+                  "items": [
+                    {
+                      "type": "number",
+                      "title": "min"
+                    },
+                    {
+                      "type": "number",
+                      "title": "max"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "title": "y"
+                }
+              ],
               "maxItems": 2
             },
             "rulerLabel": {
@@ -1364,15 +8059,49 @@
       ],
       "additionalProperties": false
     },
-    "Coord": {
+    "GraphRange": {
       "type": "array",
-      "items": {
-        "type": "number"
-      },
       "minItems": 2,
+      "items": [
+        {
+          "type": "array",
+          "minItems": 2,
+          "items": [
+            {
+              "type": "number",
+              "title": "min"
+            },
+            {
+              "type": "number",
+              "title": "max"
+            }
+          ],
+          "maxItems": 2,
+          "title": "x"
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "items": [
+            {
+              "type": "number",
+              "title": "min"
+            },
+            {
+              "type": "number",
+              "title": "max"
+            }
+          ],
+          "maxItems": 2,
+          "title": "y"
+        }
+      ],
       "maxItems": 2
     },
     "GroupWidget": {
+      "$ref": "#/definitions/Widget<\"group\",PerseusGroupWidgetOptions>"
+    },
+    "Widget<\"group\",PerseusGroupWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -1389,31 +8118,587 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusGroupWidgetOptions"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "$ref": "#/definitions/PerseusRenderer"
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
     "PerseusGroupWidgetOptions": {
       "$ref": "#/definitions/PerseusRenderer"
     },
+    "GradedGroupWidget": {
+      "$ref": "#/definitions/Widget<\"graded-group\",PerseusGradedGroupWidgetOptions>"
+    },
+    "Widget<\"graded-group\",PerseusGradedGroupWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "graded-group"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string"
+            },
+            "hasHint": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "hint": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "content": {
+                      "type": "string"
+                    },
+                    "replace": {
+                      "type": "boolean"
+                    },
+                    "metadata": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "images": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                          "width": {
+                            "type": "number"
+                          },
+                          "height": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "width",
+                          "height"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "content",
+                    "widgets",
+                    "images"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "content": {
+              "type": "string"
+            },
+            "widgetEnabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "immutableWidgets": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "images": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "width": {
+                    "type": "number"
+                  },
+                  "height": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "width",
+                  "height"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": [
+            "title",
+            "content",
+            "widgets",
+            "images"
+          ],
+          "additionalProperties": false
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusGradedGroupWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "hasHint": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "hint": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "content": {
+                  "type": "string"
+                },
+                "replace": {
+                  "type": "boolean"
+                },
+                "metadata": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "images": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "width": {
+                        "type": "number"
+                      },
+                      "height": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "width",
+                      "height"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "required": [
+                "content",
+                "widgets",
+                "images"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "content": {
+          "type": "string"
+        },
+        "widgetEnabled": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "immutableWidgets": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "images": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "width": {
+                "type": "number"
+              },
+              "height": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "width",
+              "height"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "title",
+        "content",
+        "widgets",
+        "images"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusImageDetail": {
+      "type": "object",
+      "properties": {
+        "width": {
+          "type": "number"
+        },
+        "height": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "width",
+        "height"
+      ],
+      "additionalProperties": false
+    },
+    "GradedGroupSetWidget": {
+      "$ref": "#/definitions/Widget<\"graded-group-set\",PerseusGradedGroupSetWidgetOptions>"
+    },
+    "Widget<\"graded-group-set\",PerseusGradedGroupSetWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "graded-group-set"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "type": "object",
+          "properties": {
+            "gradedGroups": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  },
+                  "hasHint": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "hint": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "content": {
+                            "type": "string"
+                          },
+                          "replace": {
+                            "type": "boolean"
+                          },
+                          "metadata": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "images": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "object",
+                              "properties": {
+                                "width": {
+                                  "type": "number"
+                                },
+                                "height": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "width",
+                                "height"
+                              ],
+                              "additionalProperties": false
+                            }
+                          }
+                        },
+                        "required": [
+                          "content",
+                          "widgets",
+                          "images"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "content": {
+                    "type": "string"
+                  },
+                  "widgetEnabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "immutableWidgets": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "images": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "object",
+                      "properties": {
+                        "width": {
+                          "type": "number"
+                        },
+                        "height": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "width",
+                        "height"
+                      ],
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "required": [
+                  "title",
+                  "content",
+                  "widgets",
+                  "images"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": [
+            "gradedGroups"
+          ],
+          "additionalProperties": false
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusGradedGroupSetWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "gradedGroups": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "hasHint": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "hint": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "content": {
+                        "type": "string"
+                      },
+                      "replace": {
+                        "type": "boolean"
+                      },
+                      "metadata": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "images": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "object",
+                          "properties": {
+                            "width": {
+                              "type": "number"
+                            },
+                            "height": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "width",
+                            "height"
+                          ],
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "required": [
+                      "content",
+                      "widgets",
+                      "images"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "content": {
+                "type": "string"
+              },
+              "widgetEnabled": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "immutableWidgets": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "images": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "width": {
+                      "type": "number"
+                    },
+                    "height": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "width",
+                    "height"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "title",
+              "content",
+              "widgets",
+              "images"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "gradedGroups"
+      ],
+      "additionalProperties": false
+    },
     "IFrameWidget": {
+      "$ref": "#/definitions/Widget<\"iframe\",PerseusIFrameWidgetOptions>"
+    },
+    "Widget<\"iframe\",PerseusIFrameWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -1430,24 +8715,85 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusIFrameWidgetOptions"
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string"
             },
-            {
-              "type": "null"
+            "settings": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "width": {
+              "type": [
+                "number",
+                "string"
+              ]
+            },
+            "height": {
+              "type": [
+                "number",
+                "string"
+              ]
+            },
+            "allowFullScreen": {
+              "type": "boolean"
+            },
+            "allowTopNavigation": {
+              "type": "boolean"
+            },
+            "static": {
+              "type": "boolean"
             }
-          ]
+          },
+          "required": [
+            "url",
+            "settings",
+            "width",
+            "height",
+            "allowFullScreen",
+            "static"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -1460,7 +8806,20 @@
         "settings": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/PerseusCSProgramSetting"
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "additionalProperties": false
           }
         },
         "width": {
@@ -1496,6 +8855,9 @@
       "additionalProperties": false
     },
     "ImageWidget": {
+      "$ref": "#/definitions/Widget<\"image\",PerseusImageWidgetOptions>"
+    },
+    "Widget<\"image\",PerseusImageWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -1512,24 +8874,136 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusImageWidgetOptions"
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string"
             },
-            {
-              "type": "null"
+            "caption": {
+              "type": "string"
+            },
+            "alt": {
+              "type": "string"
+            },
+            "backgroundImage": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "width": {
+                  "type": "number"
+                },
+                "height": {
+                  "type": "number"
+                },
+                "top": {
+                  "type": "number"
+                },
+                "left": {
+                  "type": "number"
+                },
+                "scale": {
+                  "type": [
+                    "number",
+                    "string"
+                  ]
+                },
+                "bottom": {
+                  "type": "number"
+                }
+              },
+              "additionalProperties": false
+            },
+            "static": {
+              "type": "boolean"
+            },
+            "labels": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "content": {
+                    "type": "string"
+                  },
+                  "alignment": {
+                    "type": "string"
+                  },
+                  "coordinates": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  }
+                },
+                "required": [
+                  "content",
+                  "alignment",
+                  "coordinates"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "range": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "minItems": 2,
+                "items": [
+                  {
+                    "type": "number",
+                    "title": "min"
+                  },
+                  {
+                    "type": "number",
+                    "title": "max"
+                  }
+                ],
+                "maxItems": 2
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "box": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
             }
-          ]
+          },
+          "required": [
+            "backgroundImage"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -1546,7 +9020,37 @@
           "type": "string"
         },
         "backgroundImage": {
-          "$ref": "#/definitions/PerseusImageBackground"
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "width": {
+              "type": "number"
+            },
+            "height": {
+              "type": "number"
+            },
+            "top": {
+              "type": "number"
+            },
+            "left": {
+              "type": "number"
+            },
+            "scale": {
+              "type": [
+                "number",
+                "string"
+              ]
+            },
+            "bottom": {
+              "type": "number"
+            }
+          },
+          "additionalProperties": false
         },
         "static": {
           "type": "boolean"
@@ -1554,57 +9058,61 @@
         "labels": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/PerseusImageLabel"
+            "type": "object",
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "alignment": {
+                "type": "string"
+              },
+              "coordinates": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              }
+            },
+            "required": [
+              "content",
+              "alignment",
+              "coordinates"
+            ],
+            "additionalProperties": false
           }
         },
         "range": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Range"
+            "type": "array",
+            "minItems": 2,
+            "items": [
+              {
+                "type": "number",
+                "title": "min"
+              },
+              {
+                "type": "number",
+                "title": "max"
+              }
+            ],
+            "maxItems": 2
           },
           "minItems": 2,
           "maxItems": 2
         },
         "box": {
-          "$ref": "#/definitions/Size"
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
         }
       },
       "required": [
         "backgroundImage"
       ],
-      "additionalProperties": false
-    },
-    "PerseusImageBackground": {
-      "type": "object",
-      "properties": {
-        "url": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "width": {
-          "type": "number"
-        },
-        "height": {
-          "type": "number"
-        },
-        "top": {
-          "type": "number"
-        },
-        "left": {
-          "type": "number"
-        },
-        "scale": {
-          "type": [
-            "number",
-            "string"
-          ]
-        },
-        "bottom": {
-          "type": "number"
-        }
-      },
       "additionalProperties": false
     },
     "PerseusImageLabel": {
@@ -1630,23 +9138,25 @@
       ],
       "additionalProperties": false
     },
-    "Range": {
+    "Interval": {
       "type": "array",
-      "items": {
-        "type": "number"
-      },
       "minItems": 2,
-      "maxItems": 2
-    },
-    "Size": {
-      "type": "array",
-      "items": {
-        "type": "number"
-      },
-      "minItems": 2,
+      "items": [
+        {
+          "type": "number",
+          "title": "min"
+        },
+        {
+          "type": "number",
+          "title": "max"
+        }
+      ],
       "maxItems": 2
     },
     "InputNumberWidget": {
+      "$ref": "#/definitions/Widget<\"input-number\",PerseusInputNumberWidgetOptions>"
+    },
+    "Widget<\"input-number\",PerseusInputNumberWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -1663,24 +9173,88 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusInputNumberWidgetOptions"
+          "type": "object",
+          "properties": {
+            "answerType": {
+              "type": "string",
+              "enum": [
+                "number",
+                "decimal",
+                "integer",
+                "rational",
+                "improper",
+                "mixed",
+                "percent",
+                "pi"
+              ]
             },
-            {
-              "type": "null"
+            "inexact": {
+              "type": "boolean"
+            },
+            "maxError": {
+              "type": [
+                "number",
+                "string"
+              ]
+            },
+            "rightAlign": {
+              "type": "boolean"
+            },
+            "simplify": {
+              "type": "string",
+              "enum": [
+                "required",
+                "optional",
+                "enforced"
+              ]
+            },
+            "size": {
+              "type": "string",
+              "enum": [
+                "normal",
+                "small"
+              ]
+            },
+            "value": {
+              "type": [
+                "string",
+                "number"
+              ]
+            },
+            "customKeypad": {
+              "type": "boolean"
             }
-          ]
+          },
+          "required": [
+            "simplify",
+            "size",
+            "value"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -1745,6 +9319,9 @@
       "additionalProperties": false
     },
     "InteractionWidget": {
+      "$ref": "#/definitions/Widget<\"interaction\",PerseusInteractionWidgetOptions>"
+    },
+    "Widget<\"interaction\",PerseusInteractionWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -1761,24 +9338,627 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusInteractionWidgetOptions"
+          "type": "object",
+          "properties": {
+            "graph": {
+              "type": "object",
+              "properties": {
+                "editableSettings": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "canvas",
+                      "graph"
+                    ]
+                  }
+                },
+                "box": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "labels": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "range": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "minItems": 2,
+                    "items": [
+                      {
+                        "type": "number",
+                        "title": "min"
+                      },
+                      {
+                        "type": "number",
+                        "title": "max"
+                      }
+                    ],
+                    "maxItems": 2
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "gridStep": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "markings": {
+                  "type": "string",
+                  "enum": [
+                    "graph",
+                    "grid",
+                    "none"
+                  ],
+                  "description": "The type of markings to display on the graph.\n- graph: shows the axes and the grid lines\n- grid: shows only the grid lines\n- none: shows no markings"
+                },
+                "snapStep": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "valid": {
+                  "type": [
+                    "boolean",
+                    "string"
+                  ]
+                },
+                "backgroundImage": {
+                  "type": "object",
+                  "properties": {
+                    "url": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "width": {
+                      "type": "number"
+                    },
+                    "height": {
+                      "type": "number"
+                    },
+                    "top": {
+                      "type": "number"
+                    },
+                    "left": {
+                      "type": "number"
+                    },
+                    "scale": {
+                      "type": [
+                        "number",
+                        "string"
+                      ]
+                    },
+                    "bottom": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "showProtractor": {
+                  "type": "boolean"
+                },
+                "showRuler": {
+                  "type": "boolean"
+                },
+                "rulerLabel": {
+                  "type": "string"
+                },
+                "rulerTicks": {
+                  "type": "number"
+                },
+                "tickStep": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              },
+              "required": [
+                "box",
+                "labels",
+                "range",
+                "gridStep",
+                "markings",
+                "tickStep"
+              ],
+              "additionalProperties": false
             },
-            {
-              "type": "null"
+            "elements": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "const": "function"
+                      },
+                      "key": {
+                        "type": "string"
+                      },
+                      "options": {
+                        "type": "object",
+                        "properties": {
+                          "value": {
+                            "type": "string"
+                          },
+                          "funcName": {
+                            "type": "string"
+                          },
+                          "rangeMin": {
+                            "type": "string"
+                          },
+                          "rangeMax": {
+                            "type": "string"
+                          },
+                          "color": {
+                            "type": "string"
+                          },
+                          "strokeDasharray": {
+                            "type": "string"
+                          },
+                          "strokeWidth": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "value",
+                          "funcName",
+                          "rangeMin",
+                          "rangeMax",
+                          "color",
+                          "strokeDasharray",
+                          "strokeWidth"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "key",
+                      "options"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "const": "label"
+                      },
+                      "key": {
+                        "type": "string"
+                      },
+                      "options": {
+                        "type": "object",
+                        "properties": {
+                          "label": {
+                            "type": "string"
+                          },
+                          "color": {
+                            "type": "string"
+                          },
+                          "coordX": {
+                            "type": "string"
+                          },
+                          "coordY": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "label",
+                          "color",
+                          "coordX",
+                          "coordY"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "key",
+                      "options"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "const": "line"
+                      },
+                      "key": {
+                        "type": "string"
+                      },
+                      "options": {
+                        "type": "object",
+                        "properties": {
+                          "color": {
+                            "type": "string"
+                          },
+                          "startX": {
+                            "type": "string"
+                          },
+                          "startY": {
+                            "type": "string"
+                          },
+                          "endX": {
+                            "type": "string"
+                          },
+                          "endY": {
+                            "type": "string"
+                          },
+                          "strokeDasharray": {
+                            "type": "string"
+                          },
+                          "strokeWidth": {
+                            "type": "number"
+                          },
+                          "arrows": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "color",
+                          "startX",
+                          "startY",
+                          "endX",
+                          "endY",
+                          "strokeDasharray",
+                          "strokeWidth",
+                          "arrows"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "key",
+                      "options"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "const": "movable-line"
+                      },
+                      "key": {
+                        "type": "string"
+                      },
+                      "options": {
+                        "type": "object",
+                        "properties": {
+                          "startX": {
+                            "type": "string"
+                          },
+                          "startY": {
+                            "type": "string"
+                          },
+                          "startSubscript": {
+                            "type": "number"
+                          },
+                          "endX": {
+                            "type": "string"
+                          },
+                          "endY": {
+                            "type": "string"
+                          },
+                          "endSubscript": {
+                            "type": "number"
+                          },
+                          "constraint": {
+                            "type": "string"
+                          },
+                          "snap": {
+                            "type": "number"
+                          },
+                          "constraintFn": {
+                            "type": "string"
+                          },
+                          "constraintXMin": {
+                            "type": "string"
+                          },
+                          "constraintXMax": {
+                            "type": "string"
+                          },
+                          "constraintYMin": {
+                            "type": "string"
+                          },
+                          "constraintYMax": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "startX",
+                          "startY",
+                          "startSubscript",
+                          "endX",
+                          "endY",
+                          "endSubscript",
+                          "constraint",
+                          "snap",
+                          "constraintFn",
+                          "constraintXMin",
+                          "constraintXMax",
+                          "constraintYMin",
+                          "constraintYMax"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "key",
+                      "options"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "const": "movable-point"
+                      },
+                      "key": {
+                        "type": "string"
+                      },
+                      "options": {
+                        "type": "object",
+                        "properties": {
+                          "startX": {
+                            "type": "string"
+                          },
+                          "startY": {
+                            "type": "string"
+                          },
+                          "varSubscript": {
+                            "type": "number"
+                          },
+                          "constraint": {
+                            "type": "string"
+                          },
+                          "snap": {
+                            "type": "number"
+                          },
+                          "constraintFn": {
+                            "type": "string"
+                          },
+                          "constraintXMin": {
+                            "type": "string"
+                          },
+                          "constraintXMax": {
+                            "type": "string"
+                          },
+                          "constraintYMin": {
+                            "type": "string"
+                          },
+                          "constraintYMax": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "startX",
+                          "startY",
+                          "varSubscript",
+                          "constraint",
+                          "snap",
+                          "constraintFn",
+                          "constraintXMin",
+                          "constraintXMax",
+                          "constraintYMin",
+                          "constraintYMax"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "key",
+                      "options"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "const": "parametric"
+                      },
+                      "key": {
+                        "type": "string"
+                      },
+                      "options": {
+                        "type": "object",
+                        "properties": {
+                          "x": {
+                            "type": "string"
+                          },
+                          "y": {
+                            "type": "string"
+                          },
+                          "rangeMin": {
+                            "type": "string"
+                          },
+                          "rangeMax": {
+                            "type": "string"
+                          },
+                          "color": {
+                            "type": "string"
+                          },
+                          "strokeDasharray": {
+                            "type": "string"
+                          },
+                          "strokeWidth": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "x",
+                          "y",
+                          "rangeMin",
+                          "rangeMax",
+                          "color",
+                          "strokeDasharray",
+                          "strokeWidth"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "key",
+                      "options"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "const": "point"
+                      },
+                      "key": {
+                        "type": "string"
+                      },
+                      "options": {
+                        "type": "object",
+                        "properties": {
+                          "color": {
+                            "type": "string"
+                          },
+                          "coordX": {
+                            "type": "string"
+                          },
+                          "coordY": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "color",
+                          "coordX",
+                          "coordY"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "key",
+                      "options"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "const": "rectangle"
+                      },
+                      "key": {
+                        "type": "string"
+                      },
+                      "options": {
+                        "type": "object",
+                        "properties": {
+                          "color": {
+                            "type": "string"
+                          },
+                          "coordX": {
+                            "type": "string"
+                          },
+                          "coordY": {
+                            "type": "string"
+                          },
+                          "width": {
+                            "type": "string"
+                          },
+                          "height": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "color",
+                          "coordX",
+                          "coordY",
+                          "width",
+                          "height"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "key",
+                      "options"
+                    ],
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            },
+            "static": {
+              "type": "boolean"
             }
-          ]
+          },
+          "required": [
+            "graph",
+            "elements",
+            "static"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -1786,12 +9966,588 @@
       "type": "object",
       "properties": {
         "graph": {
-          "$ref": "#/definitions/PerseusInteractionGraph"
+          "type": "object",
+          "properties": {
+            "editableSettings": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "canvas",
+                  "graph"
+                ]
+              }
+            },
+            "box": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "labels": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "range": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "minItems": 2,
+                "items": [
+                  {
+                    "type": "number",
+                    "title": "min"
+                  },
+                  {
+                    "type": "number",
+                    "title": "max"
+                  }
+                ],
+                "maxItems": 2
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "gridStep": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "markings": {
+              "type": "string",
+              "enum": [
+                "graph",
+                "grid",
+                "none"
+              ],
+              "description": "The type of markings to display on the graph.\n- graph: shows the axes and the grid lines\n- grid: shows only the grid lines\n- none: shows no markings"
+            },
+            "snapStep": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "valid": {
+              "type": [
+                "boolean",
+                "string"
+              ]
+            },
+            "backgroundImage": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "width": {
+                  "type": "number"
+                },
+                "height": {
+                  "type": "number"
+                },
+                "top": {
+                  "type": "number"
+                },
+                "left": {
+                  "type": "number"
+                },
+                "scale": {
+                  "type": [
+                    "number",
+                    "string"
+                  ]
+                },
+                "bottom": {
+                  "type": "number"
+                }
+              },
+              "additionalProperties": false
+            },
+            "showProtractor": {
+              "type": "boolean"
+            },
+            "showRuler": {
+              "type": "boolean"
+            },
+            "rulerLabel": {
+              "type": "string"
+            },
+            "rulerTicks": {
+              "type": "number"
+            },
+            "tickStep": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": [
+            "box",
+            "labels",
+            "range",
+            "gridStep",
+            "markings",
+            "tickStep"
+          ],
+          "additionalProperties": false
         },
         "elements": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/PerseusInteractionElement"
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "function"
+                  },
+                  "key": {
+                    "type": "string"
+                  },
+                  "options": {
+                    "type": "object",
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      },
+                      "funcName": {
+                        "type": "string"
+                      },
+                      "rangeMin": {
+                        "type": "string"
+                      },
+                      "rangeMax": {
+                        "type": "string"
+                      },
+                      "color": {
+                        "type": "string"
+                      },
+                      "strokeDasharray": {
+                        "type": "string"
+                      },
+                      "strokeWidth": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "value",
+                      "funcName",
+                      "rangeMin",
+                      "rangeMax",
+                      "color",
+                      "strokeDasharray",
+                      "strokeWidth"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "type",
+                  "key",
+                  "options"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "label"
+                  },
+                  "key": {
+                    "type": "string"
+                  },
+                  "options": {
+                    "type": "object",
+                    "properties": {
+                      "label": {
+                        "type": "string"
+                      },
+                      "color": {
+                        "type": "string"
+                      },
+                      "coordX": {
+                        "type": "string"
+                      },
+                      "coordY": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "label",
+                      "color",
+                      "coordX",
+                      "coordY"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "type",
+                  "key",
+                  "options"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "line"
+                  },
+                  "key": {
+                    "type": "string"
+                  },
+                  "options": {
+                    "type": "object",
+                    "properties": {
+                      "color": {
+                        "type": "string"
+                      },
+                      "startX": {
+                        "type": "string"
+                      },
+                      "startY": {
+                        "type": "string"
+                      },
+                      "endX": {
+                        "type": "string"
+                      },
+                      "endY": {
+                        "type": "string"
+                      },
+                      "strokeDasharray": {
+                        "type": "string"
+                      },
+                      "strokeWidth": {
+                        "type": "number"
+                      },
+                      "arrows": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "color",
+                      "startX",
+                      "startY",
+                      "endX",
+                      "endY",
+                      "strokeDasharray",
+                      "strokeWidth",
+                      "arrows"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "type",
+                  "key",
+                  "options"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "movable-line"
+                  },
+                  "key": {
+                    "type": "string"
+                  },
+                  "options": {
+                    "type": "object",
+                    "properties": {
+                      "startX": {
+                        "type": "string"
+                      },
+                      "startY": {
+                        "type": "string"
+                      },
+                      "startSubscript": {
+                        "type": "number"
+                      },
+                      "endX": {
+                        "type": "string"
+                      },
+                      "endY": {
+                        "type": "string"
+                      },
+                      "endSubscript": {
+                        "type": "number"
+                      },
+                      "constraint": {
+                        "type": "string"
+                      },
+                      "snap": {
+                        "type": "number"
+                      },
+                      "constraintFn": {
+                        "type": "string"
+                      },
+                      "constraintXMin": {
+                        "type": "string"
+                      },
+                      "constraintXMax": {
+                        "type": "string"
+                      },
+                      "constraintYMin": {
+                        "type": "string"
+                      },
+                      "constraintYMax": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "startX",
+                      "startY",
+                      "startSubscript",
+                      "endX",
+                      "endY",
+                      "endSubscript",
+                      "constraint",
+                      "snap",
+                      "constraintFn",
+                      "constraintXMin",
+                      "constraintXMax",
+                      "constraintYMin",
+                      "constraintYMax"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "type",
+                  "key",
+                  "options"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "movable-point"
+                  },
+                  "key": {
+                    "type": "string"
+                  },
+                  "options": {
+                    "type": "object",
+                    "properties": {
+                      "startX": {
+                        "type": "string"
+                      },
+                      "startY": {
+                        "type": "string"
+                      },
+                      "varSubscript": {
+                        "type": "number"
+                      },
+                      "constraint": {
+                        "type": "string"
+                      },
+                      "snap": {
+                        "type": "number"
+                      },
+                      "constraintFn": {
+                        "type": "string"
+                      },
+                      "constraintXMin": {
+                        "type": "string"
+                      },
+                      "constraintXMax": {
+                        "type": "string"
+                      },
+                      "constraintYMin": {
+                        "type": "string"
+                      },
+                      "constraintYMax": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "startX",
+                      "startY",
+                      "varSubscript",
+                      "constraint",
+                      "snap",
+                      "constraintFn",
+                      "constraintXMin",
+                      "constraintXMax",
+                      "constraintYMin",
+                      "constraintYMax"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "type",
+                  "key",
+                  "options"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "parametric"
+                  },
+                  "key": {
+                    "type": "string"
+                  },
+                  "options": {
+                    "type": "object",
+                    "properties": {
+                      "x": {
+                        "type": "string"
+                      },
+                      "y": {
+                        "type": "string"
+                      },
+                      "rangeMin": {
+                        "type": "string"
+                      },
+                      "rangeMax": {
+                        "type": "string"
+                      },
+                      "color": {
+                        "type": "string"
+                      },
+                      "strokeDasharray": {
+                        "type": "string"
+                      },
+                      "strokeWidth": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "x",
+                      "y",
+                      "rangeMin",
+                      "rangeMax",
+                      "color",
+                      "strokeDasharray",
+                      "strokeWidth"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "type",
+                  "key",
+                  "options"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "point"
+                  },
+                  "key": {
+                    "type": "string"
+                  },
+                  "options": {
+                    "type": "object",
+                    "properties": {
+                      "color": {
+                        "type": "string"
+                      },
+                      "coordX": {
+                        "type": "string"
+                      },
+                      "coordY": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "color",
+                      "coordX",
+                      "coordY"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "type",
+                  "key",
+                  "options"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "rectangle"
+                  },
+                  "key": {
+                    "type": "string"
+                  },
+                  "options": {
+                    "type": "object",
+                    "properties": {
+                      "color": {
+                        "type": "string"
+                      },
+                      "coordX": {
+                        "type": "string"
+                      },
+                      "coordY": {
+                        "type": "string"
+                      },
+                      "width": {
+                        "type": "string"
+                      },
+                      "height": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "color",
+                      "coordX",
+                      "coordY",
+                      "width",
+                      "height"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "type",
+                  "key",
+                  "options"
+                ],
+                "additionalProperties": false
+              }
+            ]
           }
         },
         "static": {
@@ -1819,7 +10575,12 @@
           }
         },
         "box": {
-          "$ref": "#/definitions/Size"
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
         },
         "labels": {
           "type": "array",
@@ -1830,45 +10591,47 @@
         "range": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Range"
+            "type": "array",
+            "minItems": 2,
+            "items": [
+              {
+                "type": "number",
+                "title": "min"
+              },
+              {
+                "type": "number",
+                "title": "max"
+              }
+            ],
+            "maxItems": 2
           },
           "minItems": 2,
           "maxItems": 2
         },
         "gridStep": {
-          "type": "object",
-          "properties": {
-            "0": {
-              "type": "number"
-            },
-            "1": {
-              "type": "number"
-            }
+          "type": "array",
+          "items": {
+            "type": "number"
           },
-          "required": [
-            "0",
-            "1"
-          ],
-          "additionalProperties": false
+          "minItems": 2,
+          "maxItems": 2
         },
         "markings": {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "graph",
+            "grid",
+            "none"
+          ],
+          "description": "The type of markings to display on the graph.\n- graph: shows the axes and the grid lines\n- grid: shows only the grid lines\n- none: shows no markings"
         },
         "snapStep": {
-          "type": "object",
-          "properties": {
-            "0": {
-              "type": "number"
-            },
-            "1": {
-              "type": "number"
-            }
+          "type": "array",
+          "items": {
+            "type": "number"
           },
-          "required": [
-            "0",
-            "1"
-          ],
-          "additionalProperties": false
+          "minItems": 2,
+          "maxItems": 2
         },
         "valid": {
           "type": [
@@ -1877,7 +10640,37 @@
           ]
         },
         "backgroundImage": {
-          "$ref": "#/definitions/PerseusImageBackground"
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "width": {
+              "type": "number"
+            },
+            "height": {
+              "type": "number"
+            },
+            "top": {
+              "type": "number"
+            },
+            "left": {
+              "type": "number"
+            },
+            "scale": {
+              "type": [
+                "number",
+                "string"
+              ]
+            },
+            "bottom": {
+              "type": "number"
+            }
+          },
+          "additionalProperties": false
         },
         "showProtractor": {
           "type": "boolean"
@@ -1892,20 +10685,12 @@
           "type": "number"
         },
         "tickStep": {
-          "type": "object",
-          "properties": {
-            "0": {
-              "type": "number"
-            },
-            "1": {
-              "type": "number"
-            }
+          "type": "array",
+          "items": {
+            "type": "number"
           },
-          "required": [
-            "0",
-            "1"
-          ],
-          "additionalProperties": false
+          "minItems": 2,
+          "maxItems": 2
         }
       },
       "required": [
@@ -1931,7 +10716,40 @@
               "type": "string"
             },
             "options": {
-              "$ref": "#/definitions/PerseusInteractionFunctionElementOptions"
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "string"
+                },
+                "funcName": {
+                  "type": "string"
+                },
+                "rangeMin": {
+                  "type": "string"
+                },
+                "rangeMax": {
+                  "type": "string"
+                },
+                "color": {
+                  "type": "string"
+                },
+                "strokeDasharray": {
+                  "type": "string"
+                },
+                "strokeWidth": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "value",
+                "funcName",
+                "rangeMin",
+                "rangeMax",
+                "color",
+                "strokeDasharray",
+                "strokeWidth"
+              ],
+              "additionalProperties": false
             }
           },
           "required": [
@@ -1952,7 +10770,28 @@
               "type": "string"
             },
             "options": {
-              "$ref": "#/definitions/PerseusInteractionLabelElementOptions"
+              "type": "object",
+              "properties": {
+                "label": {
+                  "type": "string"
+                },
+                "color": {
+                  "type": "string"
+                },
+                "coordX": {
+                  "type": "string"
+                },
+                "coordY": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "label",
+                "color",
+                "coordX",
+                "coordY"
+              ],
+              "additionalProperties": false
             }
           },
           "required": [
@@ -1973,7 +10812,44 @@
               "type": "string"
             },
             "options": {
-              "$ref": "#/definitions/PerseusInteractionLineElementOptions"
+              "type": "object",
+              "properties": {
+                "color": {
+                  "type": "string"
+                },
+                "startX": {
+                  "type": "string"
+                },
+                "startY": {
+                  "type": "string"
+                },
+                "endX": {
+                  "type": "string"
+                },
+                "endY": {
+                  "type": "string"
+                },
+                "strokeDasharray": {
+                  "type": "string"
+                },
+                "strokeWidth": {
+                  "type": "number"
+                },
+                "arrows": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "color",
+                "startX",
+                "startY",
+                "endX",
+                "endY",
+                "strokeDasharray",
+                "strokeWidth",
+                "arrows"
+              ],
+              "additionalProperties": false
             }
           },
           "required": [
@@ -1994,7 +10870,64 @@
               "type": "string"
             },
             "options": {
-              "$ref": "#/definitions/PerseusInteractionMovableLineElementOptions"
+              "type": "object",
+              "properties": {
+                "startX": {
+                  "type": "string"
+                },
+                "startY": {
+                  "type": "string"
+                },
+                "startSubscript": {
+                  "type": "number"
+                },
+                "endX": {
+                  "type": "string"
+                },
+                "endY": {
+                  "type": "string"
+                },
+                "endSubscript": {
+                  "type": "number"
+                },
+                "constraint": {
+                  "type": "string"
+                },
+                "snap": {
+                  "type": "number"
+                },
+                "constraintFn": {
+                  "type": "string"
+                },
+                "constraintXMin": {
+                  "type": "string"
+                },
+                "constraintXMax": {
+                  "type": "string"
+                },
+                "constraintYMin": {
+                  "type": "string"
+                },
+                "constraintYMax": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "startX",
+                "startY",
+                "startSubscript",
+                "endX",
+                "endY",
+                "endSubscript",
+                "constraint",
+                "snap",
+                "constraintFn",
+                "constraintXMin",
+                "constraintXMax",
+                "constraintYMin",
+                "constraintYMax"
+              ],
+              "additionalProperties": false
             }
           },
           "required": [
@@ -2015,7 +10948,52 @@
               "type": "string"
             },
             "options": {
-              "$ref": "#/definitions/PerseusInteractionMovablePointElementOptions"
+              "type": "object",
+              "properties": {
+                "startX": {
+                  "type": "string"
+                },
+                "startY": {
+                  "type": "string"
+                },
+                "varSubscript": {
+                  "type": "number"
+                },
+                "constraint": {
+                  "type": "string"
+                },
+                "snap": {
+                  "type": "number"
+                },
+                "constraintFn": {
+                  "type": "string"
+                },
+                "constraintXMin": {
+                  "type": "string"
+                },
+                "constraintXMax": {
+                  "type": "string"
+                },
+                "constraintYMin": {
+                  "type": "string"
+                },
+                "constraintYMax": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "startX",
+                "startY",
+                "varSubscript",
+                "constraint",
+                "snap",
+                "constraintFn",
+                "constraintXMin",
+                "constraintXMax",
+                "constraintYMin",
+                "constraintYMax"
+              ],
+              "additionalProperties": false
             }
           },
           "required": [
@@ -2036,7 +11014,40 @@
               "type": "string"
             },
             "options": {
-              "$ref": "#/definitions/PerseusInteractionParametricElementOptions"
+              "type": "object",
+              "properties": {
+                "x": {
+                  "type": "string"
+                },
+                "y": {
+                  "type": "string"
+                },
+                "rangeMin": {
+                  "type": "string"
+                },
+                "rangeMax": {
+                  "type": "string"
+                },
+                "color": {
+                  "type": "string"
+                },
+                "strokeDasharray": {
+                  "type": "string"
+                },
+                "strokeWidth": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "x",
+                "y",
+                "rangeMin",
+                "rangeMax",
+                "color",
+                "strokeDasharray",
+                "strokeWidth"
+              ],
+              "additionalProperties": false
             }
           },
           "required": [
@@ -2057,7 +11068,24 @@
               "type": "string"
             },
             "options": {
-              "$ref": "#/definitions/PerseusInteractionPointElementOptions"
+              "type": "object",
+              "properties": {
+                "color": {
+                  "type": "string"
+                },
+                "coordX": {
+                  "type": "string"
+                },
+                "coordY": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "color",
+                "coordX",
+                "coordY"
+              ],
+              "additionalProperties": false
             }
           },
           "required": [
@@ -2078,7 +11106,32 @@
               "type": "string"
             },
             "options": {
-              "$ref": "#/definitions/PerseusInteractionRectangleElementOptions"
+              "type": "object",
+              "properties": {
+                "color": {
+                  "type": "string"
+                },
+                "coordX": {
+                  "type": "string"
+                },
+                "coordY": {
+                  "type": "string"
+                },
+                "width": {
+                  "type": "string"
+                },
+                "height": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "color",
+                "coordX",
+                "coordY",
+                "width",
+                "height"
+              ],
+              "additionalProperties": false
             }
           },
           "required": [
@@ -2383,6 +11436,9 @@
       "additionalProperties": false
     },
     "InteractiveGraphWidget": {
+      "$ref": "#/definitions/Widget<\"interactive-graph\",PerseusInteractiveGraphWidgetOptions>"
+    },
+    "Widget<\"interactive-graph\",PerseusInteractiveGraphWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -2399,24 +11455,1189 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusInteractiveGraphWidgetOptions"
+          "type": "object",
+          "properties": {
+            "step": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
             },
-            {
-              "type": "null"
+            "gridStep": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "snapStep": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "backgroundImage": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "width": {
+                  "type": "number"
+                },
+                "height": {
+                  "type": "number"
+                },
+                "top": {
+                  "type": "number"
+                },
+                "left": {
+                  "type": "number"
+                },
+                "scale": {
+                  "type": [
+                    "number",
+                    "string"
+                  ]
+                },
+                "bottom": {
+                  "type": "number"
+                }
+              },
+              "additionalProperties": false
+            },
+            "markings": {
+              "type": "string",
+              "enum": [
+                "graph",
+                "grid",
+                "none"
+              ],
+              "description": "The type of markings to display on the graph.\n- graph: shows the axes and the grid lines\n- grid: shows only the grid lines\n- none: shows no markings"
+            },
+            "labels": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "showProtractor": {
+              "type": "boolean"
+            },
+            "showRuler": {
+              "type": "boolean"
+            },
+            "showTooltips": {
+              "type": "boolean"
+            },
+            "rulerLabel": {
+              "type": "string"
+            },
+            "rulerTicks": {
+              "type": "number"
+            },
+            "range": {
+              "type": "array",
+              "minItems": 2,
+              "items": [
+                {
+                  "type": "array",
+                  "minItems": 2,
+                  "items": [
+                    {
+                      "type": "number",
+                      "title": "min"
+                    },
+                    {
+                      "type": "number",
+                      "title": "max"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "title": "x"
+                },
+                {
+                  "type": "array",
+                  "minItems": 2,
+                  "items": [
+                    {
+                      "type": "number",
+                      "title": "min"
+                    },
+                    {
+                      "type": "number",
+                      "title": "max"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "title": "y"
+                }
+              ],
+              "maxItems": 2
+            },
+            "graph": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "angle"
+                    },
+                    "showAngles": {
+                      "type": "boolean"
+                    },
+                    "allowReflexAngles": {
+                      "type": "boolean"
+                    },
+                    "angleOffsetDeg": {
+                      "type": "number"
+                    },
+                    "snapDegrees": {
+                      "type": "number"
+                    },
+                    "match": {
+                      "type": "string",
+                      "const": "congruent"
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      }
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "coord": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "circle"
+                    },
+                    "center": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "radius": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "coord": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "linear"
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "minItems": 2,
+                        "items": [
+                          {
+                            "type": "number",
+                            "title": "x"
+                          },
+                          {
+                            "type": "number",
+                            "title": "y"
+                          }
+                        ],
+                        "maxItems": 2,
+                        "description": "A two-dimensional vector"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "coord": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "linear-system"
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "array",
+                          "minItems": 2,
+                          "items": [
+                            {
+                              "type": "number",
+                              "title": "x"
+                            },
+                            {
+                              "type": "number",
+                              "title": "y"
+                            }
+                          ],
+                          "maxItems": 2,
+                          "description": "A two-dimensional vector"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      }
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "coord": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "point"
+                    },
+                    "numPoints": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string",
+                          "const": "unlimited"
+                        }
+                      ]
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      }
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "coord": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "polygon"
+                    },
+                    "numSides": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string",
+                          "const": "unlimited"
+                        }
+                      ]
+                    },
+                    "showAngles": {
+                      "type": "boolean"
+                    },
+                    "showSides": {
+                      "type": "boolean"
+                    },
+                    "snapTo": {
+                      "type": "string"
+                    },
+                    "match": {
+                      "type": "string",
+                      "enum": [
+                        "similar",
+                        "congruent",
+                        "approx"
+                      ]
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      }
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "coord": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "quadratic"
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      }
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "coord": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "ray"
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "minItems": 2,
+                        "items": [
+                          {
+                            "type": "number",
+                            "title": "x"
+                          },
+                          {
+                            "type": "number",
+                            "title": "y"
+                          }
+                        ],
+                        "maxItems": 2,
+                        "description": "A two-dimensional vector"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "coord": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "segment"
+                    },
+                    "numSegments": {
+                      "type": "number"
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "array",
+                          "minItems": 2,
+                          "items": [
+                            {
+                              "type": "number",
+                              "title": "x"
+                            },
+                            {
+                              "type": "number",
+                              "title": "y"
+                            }
+                          ],
+                          "maxItems": 2,
+                          "description": "A two-dimensional vector"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      }
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "coord": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "sinusoid"
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      }
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                }
+              ]
+            },
+            "correct": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "angle"
+                    },
+                    "showAngles": {
+                      "type": "boolean"
+                    },
+                    "allowReflexAngles": {
+                      "type": "boolean"
+                    },
+                    "angleOffsetDeg": {
+                      "type": "number"
+                    },
+                    "snapDegrees": {
+                      "type": "number"
+                    },
+                    "match": {
+                      "type": "string",
+                      "const": "congruent"
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      }
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "coord": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "circle"
+                    },
+                    "center": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "radius": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "coord": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "linear"
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "minItems": 2,
+                        "items": [
+                          {
+                            "type": "number",
+                            "title": "x"
+                          },
+                          {
+                            "type": "number",
+                            "title": "y"
+                          }
+                        ],
+                        "maxItems": 2,
+                        "description": "A two-dimensional vector"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "coord": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "linear-system"
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "array",
+                          "minItems": 2,
+                          "items": [
+                            {
+                              "type": "number",
+                              "title": "x"
+                            },
+                            {
+                              "type": "number",
+                              "title": "y"
+                            }
+                          ],
+                          "maxItems": 2,
+                          "description": "A two-dimensional vector"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      }
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "coord": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "point"
+                    },
+                    "numPoints": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string",
+                          "const": "unlimited"
+                        }
+                      ]
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      }
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "coord": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "polygon"
+                    },
+                    "numSides": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string",
+                          "const": "unlimited"
+                        }
+                      ]
+                    },
+                    "showAngles": {
+                      "type": "boolean"
+                    },
+                    "showSides": {
+                      "type": "boolean"
+                    },
+                    "snapTo": {
+                      "type": "string"
+                    },
+                    "match": {
+                      "type": "string",
+                      "enum": [
+                        "similar",
+                        "congruent",
+                        "approx"
+                      ]
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      }
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "coord": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "quadratic"
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      }
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "coord": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "ray"
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "minItems": 2,
+                        "items": [
+                          {
+                            "type": "number",
+                            "title": "x"
+                          },
+                          {
+                            "type": "number",
+                            "title": "y"
+                          }
+                        ],
+                        "maxItems": 2,
+                        "description": "A two-dimensional vector"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "coord": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "segment"
+                    },
+                    "numSegments": {
+                      "type": "number"
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "array",
+                          "minItems": 2,
+                          "items": [
+                            {
+                              "type": "number",
+                              "title": "x"
+                            },
+                            {
+                              "type": "number",
+                              "title": "y"
+                            }
+                          ],
+                          "maxItems": 2,
+                          "description": "A two-dimensional vector"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      }
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "coord": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "sinusoid"
+                    },
+                    "coords": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      }
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                }
+              ]
+            },
+            "lockedFigures": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "const": "point"
+                      },
+                      "coord": {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                      },
+                      "color": {
+                        "type": "string",
+                        "enum": [
+                          "green",
+                          "grayH",
+                          "purple",
+                          "pink",
+                          "red"
+                        ]
+                      },
+                      "filled": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "coord",
+                      "color",
+                      "filled"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "const": "line"
+                      },
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "line",
+                          "ray",
+                          "segment"
+                        ]
+                      },
+                      "points": {
+                        "type": "array",
+                        "minItems": 2,
+                        "items": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "const": "point"
+                              },
+                              "coord": {
+                                "type": "array",
+                                "items": {
+                                  "type": "number"
+                                },
+                                "minItems": 2,
+                                "maxItems": 2
+                              },
+                              "color": {
+                                "type": "string",
+                                "enum": [
+                                  "green",
+                                  "grayH",
+                                  "purple",
+                                  "pink",
+                                  "red"
+                                ]
+                              },
+                              "filled": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "coord",
+                              "color",
+                              "filled"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "const": "point"
+                              },
+                              "coord": {
+                                "type": "array",
+                                "items": {
+                                  "type": "number"
+                                },
+                                "minItems": 2,
+                                "maxItems": 2
+                              },
+                              "color": {
+                                "type": "string",
+                                "enum": [
+                                  "green",
+                                  "grayH",
+                                  "purple",
+                                  "pink",
+                                  "red"
+                                ]
+                              },
+                              "filled": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "coord",
+                              "color",
+                              "filled"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ],
+                        "maxItems": 2
+                      },
+                      "color": {
+                        "type": "string",
+                        "enum": [
+                          "green",
+                          "grayH",
+                          "purple",
+                          "pink",
+                          "red"
+                        ]
+                      },
+                      "lineStyle": {
+                        "type": "string",
+                        "enum": [
+                          "solid",
+                          "dashed"
+                        ]
+                      },
+                      "showPoint1": {
+                        "type": "boolean"
+                      },
+                      "showPoint2": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "kind",
+                      "points",
+                      "color",
+                      "lineStyle",
+                      "showPoint1",
+                      "showPoint2"
+                    ],
+                    "additionalProperties": false
+                  }
+                ]
+              }
             }
-          ]
+          },
+          "required": [
+            "step",
+            "gridStep",
+            "snapStep",
+            "markings",
+            "labels",
+            "showProtractor",
+            "showRuler",
+            "rulerLabel",
+            "rulerTicks",
+            "range",
+            "graph",
+            "correct"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -2448,10 +12669,46 @@
           "maxItems": 2
         },
         "backgroundImage": {
-          "$ref": "#/definitions/PerseusImageBackground"
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "width": {
+              "type": "number"
+            },
+            "height": {
+              "type": "number"
+            },
+            "top": {
+              "type": "number"
+            },
+            "left": {
+              "type": "number"
+            },
+            "scale": {
+              "type": [
+                "number",
+                "string"
+              ]
+            },
+            "bottom": {
+              "type": "number"
+            }
+          },
+          "additionalProperties": false
         },
         "markings": {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "graph",
+            "grid",
+            "none"
+          ],
+          "description": "The type of markings to display on the graph.\n- graph: shows the axes and the grid lines\n- grid: shows only the grid lines\n- none: shows no markings"
         },
         "labels": {
           "type": "array",
@@ -2476,22 +12733,1057 @@
         },
         "range": {
           "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "number"
-            },
-            "minItems": 2,
-            "maxItems": 2
-          },
           "minItems": 2,
+          "items": [
+            {
+              "type": "array",
+              "minItems": 2,
+              "items": [
+                {
+                  "type": "number",
+                  "title": "min"
+                },
+                {
+                  "type": "number",
+                  "title": "max"
+                }
+              ],
+              "maxItems": 2,
+              "title": "x"
+            },
+            {
+              "type": "array",
+              "minItems": 2,
+              "items": [
+                {
+                  "type": "number",
+                  "title": "min"
+                },
+                {
+                  "type": "number",
+                  "title": "max"
+                }
+              ],
+              "maxItems": 2,
+              "title": "y"
+            }
+          ],
           "maxItems": 2
         },
         "graph": {
-          "$ref": "#/definitions/PerseusGraphType"
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "angle"
+                },
+                "showAngles": {
+                  "type": "boolean"
+                },
+                "allowReflexAngles": {
+                  "type": "boolean"
+                },
+                "angleOffsetDeg": {
+                  "type": "number"
+                },
+                "snapDegrees": {
+                  "type": "number"
+                },
+                "match": {
+                  "type": "string",
+                  "const": "congruent"
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  }
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "coord": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "type": {
+                  "type": "string",
+                  "const": "circle"
+                },
+                "center": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "radius": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "coord": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "type": {
+                  "type": "string",
+                  "const": "linear"
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "minItems": 2,
+                    "items": [
+                      {
+                        "type": "number",
+                        "title": "x"
+                      },
+                      {
+                        "type": "number",
+                        "title": "y"
+                      }
+                    ],
+                    "maxItems": 2,
+                    "description": "A two-dimensional vector"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "coord": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "type": {
+                  "type": "string",
+                  "const": "linear-system"
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "array",
+                      "minItems": 2,
+                      "items": [
+                        {
+                          "type": "number",
+                          "title": "x"
+                        },
+                        {
+                          "type": "number",
+                          "title": "y"
+                        }
+                      ],
+                      "maxItems": 2,
+                      "description": "A two-dimensional vector"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  }
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "coord": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "type": {
+                  "type": "string",
+                  "const": "point"
+                },
+                "numPoints": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string",
+                      "const": "unlimited"
+                    }
+                  ]
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  }
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "coord": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "type": {
+                  "type": "string",
+                  "const": "polygon"
+                },
+                "numSides": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string",
+                      "const": "unlimited"
+                    }
+                  ]
+                },
+                "showAngles": {
+                  "type": "boolean"
+                },
+                "showSides": {
+                  "type": "boolean"
+                },
+                "snapTo": {
+                  "type": "string"
+                },
+                "match": {
+                  "type": "string",
+                  "enum": [
+                    "similar",
+                    "congruent",
+                    "approx"
+                  ]
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  }
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "coord": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "type": {
+                  "type": "string",
+                  "const": "quadratic"
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  }
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "coord": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "type": {
+                  "type": "string",
+                  "const": "ray"
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "minItems": 2,
+                    "items": [
+                      {
+                        "type": "number",
+                        "title": "x"
+                      },
+                      {
+                        "type": "number",
+                        "title": "y"
+                      }
+                    ],
+                    "maxItems": 2,
+                    "description": "A two-dimensional vector"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "coord": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "type": {
+                  "type": "string",
+                  "const": "segment"
+                },
+                "numSegments": {
+                  "type": "number"
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "array",
+                      "minItems": 2,
+                      "items": [
+                        {
+                          "type": "number",
+                          "title": "x"
+                        },
+                        {
+                          "type": "number",
+                          "title": "y"
+                        }
+                      ],
+                      "maxItems": 2,
+                      "description": "A two-dimensional vector"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  }
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "coord": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "type": {
+                  "type": "string",
+                  "const": "sinusoid"
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  }
+                }
+              },
+              "required": [
+                "type"
+              ]
+            }
+          ]
         },
         "correct": {
-          "$ref": "#/definitions/PerseusGraphType"
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "angle"
+                },
+                "showAngles": {
+                  "type": "boolean"
+                },
+                "allowReflexAngles": {
+                  "type": "boolean"
+                },
+                "angleOffsetDeg": {
+                  "type": "number"
+                },
+                "snapDegrees": {
+                  "type": "number"
+                },
+                "match": {
+                  "type": "string",
+                  "const": "congruent"
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  }
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "coord": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "type": {
+                  "type": "string",
+                  "const": "circle"
+                },
+                "center": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "radius": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "coord": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "type": {
+                  "type": "string",
+                  "const": "linear"
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "minItems": 2,
+                    "items": [
+                      {
+                        "type": "number",
+                        "title": "x"
+                      },
+                      {
+                        "type": "number",
+                        "title": "y"
+                      }
+                    ],
+                    "maxItems": 2,
+                    "description": "A two-dimensional vector"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "coord": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "type": {
+                  "type": "string",
+                  "const": "linear-system"
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "array",
+                      "minItems": 2,
+                      "items": [
+                        {
+                          "type": "number",
+                          "title": "x"
+                        },
+                        {
+                          "type": "number",
+                          "title": "y"
+                        }
+                      ],
+                      "maxItems": 2,
+                      "description": "A two-dimensional vector"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  }
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "coord": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "type": {
+                  "type": "string",
+                  "const": "point"
+                },
+                "numPoints": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string",
+                      "const": "unlimited"
+                    }
+                  ]
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  }
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "coord": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "type": {
+                  "type": "string",
+                  "const": "polygon"
+                },
+                "numSides": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string",
+                      "const": "unlimited"
+                    }
+                  ]
+                },
+                "showAngles": {
+                  "type": "boolean"
+                },
+                "showSides": {
+                  "type": "boolean"
+                },
+                "snapTo": {
+                  "type": "string"
+                },
+                "match": {
+                  "type": "string",
+                  "enum": [
+                    "similar",
+                    "congruent",
+                    "approx"
+                  ]
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  }
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "coord": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "type": {
+                  "type": "string",
+                  "const": "quadratic"
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  }
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "coord": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "type": {
+                  "type": "string",
+                  "const": "ray"
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "minItems": 2,
+                    "items": [
+                      {
+                        "type": "number",
+                        "title": "x"
+                      },
+                      {
+                        "type": "number",
+                        "title": "y"
+                      }
+                    ],
+                    "maxItems": 2,
+                    "description": "A two-dimensional vector"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "coord": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "type": {
+                  "type": "string",
+                  "const": "segment"
+                },
+                "numSegments": {
+                  "type": "number"
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "array",
+                      "minItems": 2,
+                      "items": [
+                        {
+                          "type": "number",
+                          "title": "x"
+                        },
+                        {
+                          "type": "number",
+                          "title": "y"
+                        }
+                      ],
+                      "maxItems": 2,
+                      "description": "A two-dimensional vector"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  }
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "coord": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "type": {
+                  "type": "string",
+                  "const": "sinusoid"
+                },
+                "coords": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  }
+                }
+              },
+              "required": [
+                "type"
+              ]
+            }
+          ]
+        },
+        "lockedFigures": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "point"
+                  },
+                  "coord": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  },
+                  "color": {
+                    "type": "string",
+                    "enum": [
+                      "green",
+                      "grayH",
+                      "purple",
+                      "pink",
+                      "red"
+                    ]
+                  },
+                  "filled": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "type",
+                  "coord",
+                  "color",
+                  "filled"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "line"
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "line",
+                      "ray",
+                      "segment"
+                    ]
+                  },
+                  "points": {
+                    "type": "array",
+                    "minItems": 2,
+                    "items": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "point"
+                          },
+                          "coord": {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          },
+                          "color": {
+                            "type": "string",
+                            "enum": [
+                              "green",
+                              "grayH",
+                              "purple",
+                              "pink",
+                              "red"
+                            ]
+                          },
+                          "filled": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "coord",
+                          "color",
+                          "filled"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "point"
+                          },
+                          "coord": {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                          },
+                          "color": {
+                            "type": "string",
+                            "enum": [
+                              "green",
+                              "grayH",
+                              "purple",
+                              "pink",
+                              "red"
+                            ]
+                          },
+                          "filled": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "coord",
+                          "color",
+                          "filled"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ],
+                    "maxItems": 2
+                  },
+                  "color": {
+                    "type": "string",
+                    "enum": [
+                      "green",
+                      "grayH",
+                      "purple",
+                      "pink",
+                      "red"
+                    ]
+                  },
+                  "lineStyle": {
+                    "type": "string",
+                    "enum": [
+                      "solid",
+                      "dashed"
+                    ]
+                  },
+                  "showPoint1": {
+                    "type": "boolean"
+                  },
+                  "showPoint2": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "type",
+                  "kind",
+                  "points",
+                  "color",
+                  "lineStyle",
+                  "showPoint1",
+                  "showPoint2"
+                ],
+                "additionalProperties": false
+              }
+            ]
+          }
         }
       },
       "required": [
@@ -2513,34 +13805,420 @@
     "PerseusGraphType": {
       "anyOf": [
         {
-          "$ref": "#/definitions/PerseusGraphTypeAngle"
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "angle"
+            },
+            "showAngles": {
+              "type": "boolean"
+            },
+            "allowReflexAngles": {
+              "type": "boolean"
+            },
+            "angleOffsetDeg": {
+              "type": "number"
+            },
+            "snapDegrees": {
+              "type": "number"
+            },
+            "match": {
+              "type": "string",
+              "const": "congruent"
+            },
+            "coords": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 2,
+                "maxItems": 2
+              }
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
         },
         {
-          "$ref": "#/definitions/PerseusGraphTypeCircle"
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "coord": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "type": {
+              "type": "string",
+              "const": "circle"
+            },
+            "center": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "radius": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "type"
+          ]
         },
         {
-          "$ref": "#/definitions/PerseusGraphTypeLinear"
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "coord": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "type": {
+              "type": "string",
+              "const": "linear"
+            },
+            "coords": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "minItems": 2,
+                "items": [
+                  {
+                    "type": "number",
+                    "title": "x"
+                  },
+                  {
+                    "type": "number",
+                    "title": "y"
+                  }
+                ],
+                "maxItems": 2,
+                "description": "A two-dimensional vector"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": [
+            "type"
+          ]
         },
         {
-          "$ref": "#/definitions/PerseusGraphTypeLinearSystem"
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "coord": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "type": {
+              "type": "string",
+              "const": "linear-system"
+            },
+            "coords": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "minItems": 2,
+                  "items": [
+                    {
+                      "type": "number",
+                      "title": "x"
+                    },
+                    {
+                      "type": "number",
+                      "title": "y"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "description": "A two-dimensional vector"
+                },
+                "minItems": 2,
+                "maxItems": 2
+              }
+            }
+          },
+          "required": [
+            "type"
+          ]
         },
         {
-          "$ref": "#/definitions/PerseusGraphTypePoint"
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "coord": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "type": {
+              "type": "string",
+              "const": "point"
+            },
+            "numPoints": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string",
+                  "const": "unlimited"
+                }
+              ]
+            },
+            "coords": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 2,
+                "maxItems": 2
+              }
+            }
+          },
+          "required": [
+            "type"
+          ]
         },
         {
-          "$ref": "#/definitions/PerseusGraphTypePolygon"
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "coord": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "type": {
+              "type": "string",
+              "const": "polygon"
+            },
+            "numSides": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string",
+                  "const": "unlimited"
+                }
+              ]
+            },
+            "showAngles": {
+              "type": "boolean"
+            },
+            "showSides": {
+              "type": "boolean"
+            },
+            "snapTo": {
+              "type": "string"
+            },
+            "match": {
+              "type": "string",
+              "enum": [
+                "similar",
+                "congruent",
+                "approx"
+              ]
+            },
+            "coords": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 2,
+                "maxItems": 2
+              }
+            }
+          },
+          "required": [
+            "type"
+          ]
         },
         {
-          "$ref": "#/definitions/PerseusGraphTypeQuadratic"
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "coord": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "type": {
+              "type": "string",
+              "const": "quadratic"
+            },
+            "coords": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 2,
+                "maxItems": 2
+              }
+            }
+          },
+          "required": [
+            "type"
+          ]
         },
         {
-          "$ref": "#/definitions/PerseusGraphTypeRay"
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "coord": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "type": {
+              "type": "string",
+              "const": "ray"
+            },
+            "coords": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "minItems": 2,
+                "items": [
+                  {
+                    "type": "number",
+                    "title": "x"
+                  },
+                  {
+                    "type": "number",
+                    "title": "y"
+                  }
+                ],
+                "maxItems": 2,
+                "description": "A two-dimensional vector"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": [
+            "type"
+          ]
         },
         {
-          "$ref": "#/definitions/PerseusGraphTypeSegment"
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "coord": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "type": {
+              "type": "string",
+              "const": "segment"
+            },
+            "numSegments": {
+              "type": "number"
+            },
+            "coords": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "minItems": 2,
+                  "items": [
+                    {
+                      "type": "number",
+                      "title": "x"
+                    },
+                    {
+                      "type": "number",
+                      "title": "y"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "description": "A two-dimensional vector"
+                },
+                "minItems": 2,
+                "maxItems": 2
+              }
+            }
+          },
+          "required": [
+            "type"
+          ]
         },
         {
-          "$ref": "#/definitions/PerseusGraphTypeSinusoid"
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "coord": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "type": {
+              "type": "string",
+              "const": "sinusoid"
+            },
+            "coords": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 2,
+                "maxItems": 2
+              }
+            }
+          },
+          "required": [
+            "type"
+          ]
         }
       ]
     },
@@ -2570,7 +14248,12 @@
         "coords": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Coord"
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "minItems": 2,
+            "maxItems": 2
           }
         }
       },
@@ -2584,14 +14267,24 @@
       "additionalProperties": false,
       "properties": {
         "coord": {
-          "$ref": "#/definitions/Coord"
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
         },
         "type": {
           "type": "string",
           "const": "circle"
         },
         "center": {
-          "$ref": "#/definitions/Coord"
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
         },
         "radius": {
           "type": "number"
@@ -2606,7 +14299,12 @@
       "additionalProperties": false,
       "properties": {
         "coord": {
-          "$ref": "#/definitions/Coord"
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
         },
         "type": {
           "type": "string",
@@ -2615,20 +14313,77 @@
         "coords": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Coord"
-          }
+            "type": "array",
+            "minItems": 2,
+            "items": [
+              {
+                "type": "number",
+                "title": "x"
+              },
+              {
+                "type": "number",
+                "title": "y"
+              }
+            ],
+            "maxItems": 2,
+            "description": "A two-dimensional vector"
+          },
+          "minItems": 2,
+          "maxItems": 2
         }
       },
       "required": [
         "type"
       ]
     },
+    "CollinearTuple": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "minItems": 2,
+        "items": [
+          {
+            "type": "number",
+            "title": "x"
+          },
+          {
+            "type": "number",
+            "title": "y"
+          }
+        ],
+        "maxItems": 2,
+        "description": "A two-dimensional vector"
+      },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "vec.Vector2": {
+      "type": "array",
+      "minItems": 2,
+      "items": [
+        {
+          "type": "number",
+          "title": "x"
+        },
+        {
+          "type": "number",
+          "title": "y"
+        }
+      ],
+      "maxItems": 2,
+      "description": "A two-dimensional vector"
+    },
     "PerseusGraphTypeLinearSystem": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "coord": {
-          "$ref": "#/definitions/Coord"
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
         },
         "type": {
           "type": "string",
@@ -2639,8 +14394,23 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Coord"
-            }
+              "type": "array",
+              "minItems": 2,
+              "items": [
+                {
+                  "type": "number",
+                  "title": "x"
+                },
+                {
+                  "type": "number",
+                  "title": "y"
+                }
+              ],
+              "maxItems": 2,
+              "description": "A two-dimensional vector"
+            },
+            "minItems": 2,
+            "maxItems": 2
           }
         }
       },
@@ -2653,7 +14423,12 @@
       "additionalProperties": false,
       "properties": {
         "coord": {
-          "$ref": "#/definitions/Coord"
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
         },
         "type": {
           "type": "string",
@@ -2673,7 +14448,12 @@
         "coords": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Coord"
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "minItems": 2,
+            "maxItems": 2
           }
         }
       },
@@ -2686,7 +14466,12 @@
       "additionalProperties": false,
       "properties": {
         "coord": {
-          "$ref": "#/definitions/Coord"
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
         },
         "type": {
           "type": "string",
@@ -2723,7 +14508,12 @@
         "coords": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Coord"
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "minItems": 2,
+            "maxItems": 2
           }
         }
       },
@@ -2736,7 +14526,12 @@
       "additionalProperties": false,
       "properties": {
         "coord": {
-          "$ref": "#/definitions/Coord"
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
         },
         "type": {
           "type": "string",
@@ -2745,7 +14540,12 @@
         "coords": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Coord"
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "minItems": 2,
+            "maxItems": 2
           }
         }
       },
@@ -2758,7 +14558,12 @@
       "additionalProperties": false,
       "properties": {
         "coord": {
-          "$ref": "#/definitions/Coord"
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
         },
         "type": {
           "type": "string",
@@ -2767,8 +14572,23 @@
         "coords": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Coord"
-          }
+            "type": "array",
+            "minItems": 2,
+            "items": [
+              {
+                "type": "number",
+                "title": "x"
+              },
+              {
+                "type": "number",
+                "title": "y"
+              }
+            ],
+            "maxItems": 2,
+            "description": "A two-dimensional vector"
+          },
+          "minItems": 2,
+          "maxItems": 2
         }
       },
       "required": [
@@ -2780,7 +14600,12 @@
       "additionalProperties": false,
       "properties": {
         "coord": {
-          "$ref": "#/definitions/Coord"
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
         },
         "type": {
           "type": "string",
@@ -2794,8 +14619,23 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Coord"
-            }
+              "type": "array",
+              "minItems": 2,
+              "items": [
+                {
+                  "type": "number",
+                  "title": "x"
+                },
+                {
+                  "type": "number",
+                  "title": "y"
+                }
+              ],
+              "maxItems": 2,
+              "description": "A two-dimensional vector"
+            },
+            "minItems": 2,
+            "maxItems": 2
           }
         }
       },
@@ -2808,7 +14648,12 @@
       "additionalProperties": false,
       "properties": {
         "coord": {
-          "$ref": "#/definitions/Coord"
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
         },
         "type": {
           "type": "string",
@@ -2817,7 +14662,12 @@
         "coords": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Coord"
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "minItems": 2,
+            "maxItems": 2
           }
         }
       },
@@ -2825,7 +14675,360 @@
         "type"
       ]
     },
+    "LockedFigure": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "point"
+            },
+            "coord": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "color": {
+              "type": "string",
+              "enum": [
+                "green",
+                "grayH",
+                "purple",
+                "pink",
+                "red"
+              ]
+            },
+            "filled": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "type",
+            "coord",
+            "color",
+            "filled"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "line"
+            },
+            "kind": {
+              "type": "string",
+              "enum": [
+                "line",
+                "ray",
+                "segment"
+              ]
+            },
+            "points": {
+              "type": "array",
+              "minItems": 2,
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "point"
+                    },
+                    "coord": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "color": {
+                      "type": "string",
+                      "enum": [
+                        "green",
+                        "grayH",
+                        "purple",
+                        "pink",
+                        "red"
+                      ]
+                    },
+                    "filled": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "coord",
+                    "color",
+                    "filled"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "point"
+                    },
+                    "coord": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "color": {
+                      "type": "string",
+                      "enum": [
+                        "green",
+                        "grayH",
+                        "purple",
+                        "pink",
+                        "red"
+                      ]
+                    },
+                    "filled": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "coord",
+                    "color",
+                    "filled"
+                  ],
+                  "additionalProperties": false
+                }
+              ],
+              "maxItems": 2
+            },
+            "color": {
+              "type": "string",
+              "enum": [
+                "green",
+                "grayH",
+                "purple",
+                "pink",
+                "red"
+              ]
+            },
+            "lineStyle": {
+              "type": "string",
+              "enum": [
+                "solid",
+                "dashed"
+              ]
+            },
+            "showPoint1": {
+              "type": "boolean"
+            },
+            "showPoint2": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "type",
+            "kind",
+            "points",
+            "color",
+            "lineStyle",
+            "showPoint1",
+            "showPoint2"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "LockedPointType": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "point"
+        },
+        "coord": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "color": {
+          "type": "string",
+          "enum": [
+            "green",
+            "grayH",
+            "purple",
+            "pink",
+            "red"
+          ]
+        },
+        "filled": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "type",
+        "coord",
+        "color",
+        "filled"
+      ],
+      "additionalProperties": false
+    },
+    "LockedFigureColor": {
+      "type": "string",
+      "enum": [
+        "green",
+        "grayH",
+        "purple",
+        "pink",
+        "red"
+      ]
+    },
+    "LockedLineType": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "line"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "line",
+            "ray",
+            "segment"
+          ]
+        },
+        "points": {
+          "type": "array",
+          "minItems": 2,
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "point"
+                },
+                "coord": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "color": {
+                  "type": "string",
+                  "enum": [
+                    "green",
+                    "grayH",
+                    "purple",
+                    "pink",
+                    "red"
+                  ]
+                },
+                "filled": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "type",
+                "coord",
+                "color",
+                "filled"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "point"
+                },
+                "coord": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "color": {
+                  "type": "string",
+                  "enum": [
+                    "green",
+                    "grayH",
+                    "purple",
+                    "pink",
+                    "red"
+                  ]
+                },
+                "filled": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "type",
+                "coord",
+                "color",
+                "filled"
+              ],
+              "additionalProperties": false
+            }
+          ],
+          "maxItems": 2
+        },
+        "color": {
+          "type": "string",
+          "enum": [
+            "green",
+            "grayH",
+            "purple",
+            "pink",
+            "red"
+          ]
+        },
+        "lineStyle": {
+          "type": "string",
+          "enum": [
+            "solid",
+            "dashed"
+          ]
+        },
+        "showPoint1": {
+          "type": "boolean"
+        },
+        "showPoint2": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "type",
+        "kind",
+        "points",
+        "color",
+        "lineStyle",
+        "showPoint1",
+        "showPoint2"
+      ],
+      "additionalProperties": false
+    },
     "LabelImageWidget": {
+      "$ref": "#/definitions/Widget<\"label-image\",PerseusLabelImageWidgetOptions>"
+    },
+    "Widget<\"label-image\",PerseusLabelImageWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -2842,24 +15045,102 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusLabelImageWidgetOptions"
+          "type": "object",
+          "properties": {
+            "choices": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
-            {
-              "type": "null"
+            "imageUrl": {
+              "type": "string"
+            },
+            "imageAlt": {
+              "type": "string"
+            },
+            "imageHeight": {
+              "type": "number"
+            },
+            "imageWidth": {
+              "type": "number"
+            },
+            "markers": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "answers": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "x": {
+                    "type": "number"
+                  },
+                  "y": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "answers",
+                  "label",
+                  "x",
+                  "y"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "hideChoicesFromInstructions": {
+              "type": "boolean"
+            },
+            "multipleAnswers": {
+              "type": "boolean"
+            },
+            "static": {
+              "type": "boolean"
             }
-          ]
+          },
+          "required": [
+            "choices",
+            "imageUrl",
+            "imageAlt",
+            "imageHeight",
+            "imageWidth",
+            "markers",
+            "hideChoicesFromInstructions",
+            "multipleAnswers",
+            "static"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -2887,7 +15168,31 @@
         "markers": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/PerseusLabelImageMarker"
+            "type": "object",
+            "properties": {
+              "answers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "label": {
+                "type": "string"
+              },
+              "x": {
+                "type": "number"
+              },
+              "y": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "answers",
+              "label",
+              "x",
+              "y"
+            ],
+            "additionalProperties": false
           }
         },
         "hideChoicesFromInstructions": {
@@ -2940,46 +15245,10 @@
       ],
       "additionalProperties": false
     },
-    "LightsPuzzleWidget": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "const": "lights-puzzle"
-        },
-        "static": {
-          "type": "boolean"
-        },
-        "graded": {
-          "type": "boolean"
-        },
-        "alignment": {
-          "type": "string"
-        },
-        "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusLightsPuzzleWidgetOptions"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "key": {
-          "type": "number"
-        },
-        "version": {
-          "$ref": "#/definitions/Version"
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "PerseusLightsPuzzleWidgetOptions": {},
     "MatcherWidget": {
+      "$ref": "#/definitions/Widget<\"matcher\",PerseusMatcherWidgetOptions>"
+    },
+    "Widget<\"matcher\",PerseusMatcherWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -2996,24 +15265,65 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusMatcherWidgetOptions"
+          "type": "object",
+          "properties": {
+            "labels": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
-            {
-              "type": "null"
+            "left": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "right": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "orderMatters": {
+              "type": "boolean"
+            },
+            "padding": {
+              "type": "boolean"
             }
-          ]
+          },
+          "required": [
+            "labels",
+            "left",
+            "right",
+            "orderMatters",
+            "padding"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -3055,6 +15365,9 @@
       "additionalProperties": false
     },
     "MatrixWidget": {
+      "$ref": "#/definitions/Widget<\"matrix\",PerseusMatrixWidgetOptions>"
+    },
+    "Widget<\"matrix\",PerseusMatrixWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -3071,24 +15384,72 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusMatrixWidgetOptions"
+          "type": "object",
+          "properties": {
+            "prefix": {
+              "type": "string"
             },
-            {
-              "type": "null"
+            "suffix": {
+              "type": "string"
+            },
+            "answers": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              }
+            },
+            "cursorPosition": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "matrixBoardSize": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "static": {
+              "type": "boolean"
             }
-          ]
+          },
+          "required": [
+            "prefix",
+            "suffix",
+            "answers",
+            "cursorPosition",
+            "matrixBoardSize",
+            "static"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -3136,7 +15497,19 @@
       ],
       "additionalProperties": false
     },
+    "PerseusMatrixWidgetAnswers": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        }
+      }
+    },
     "MeasurerWidget": {
+      "$ref": "#/definitions/Widget<\"measurer\",PerseusMeasurerWidgetOptions>"
+    },
+    "Widget<\"measurer\",PerseusMeasurerWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -3153,24 +15526,105 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusMeasurerWidgetOptions"
+          "type": "object",
+          "properties": {
+            "image": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "width": {
+                  "type": "number"
+                },
+                "height": {
+                  "type": "number"
+                },
+                "top": {
+                  "type": "number"
+                },
+                "left": {
+                  "type": "number"
+                },
+                "scale": {
+                  "type": [
+                    "number",
+                    "string"
+                  ]
+                },
+                "bottom": {
+                  "type": "number"
+                }
+              },
+              "additionalProperties": false
             },
-            {
-              "type": "null"
+            "showProtractor": {
+              "type": "boolean"
+            },
+            "showRuler": {
+              "type": "boolean"
+            },
+            "rulerLabel": {
+              "type": "string"
+            },
+            "rulerTicks": {
+              "type": "number"
+            },
+            "rulerPixels": {
+              "type": "number"
+            },
+            "rulerLength": {
+              "type": "number"
+            },
+            "box": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "static": {
+              "type": "boolean"
             }
-          ]
+          },
+          "required": [
+            "image",
+            "showProtractor",
+            "showRuler",
+            "rulerLabel",
+            "rulerTicks",
+            "rulerPixels",
+            "rulerLength",
+            "box",
+            "static"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -3178,7 +15632,37 @@
       "type": "object",
       "properties": {
         "image": {
-          "$ref": "#/definitions/PerseusImageBackground"
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "width": {
+              "type": "number"
+            },
+            "height": {
+              "type": "number"
+            },
+            "top": {
+              "type": "number"
+            },
+            "left": {
+              "type": "number"
+            },
+            "scale": {
+              "type": [
+                "number",
+                "string"
+              ]
+            },
+            "bottom": {
+              "type": "number"
+            }
+          },
+          "additionalProperties": false
         },
         "showProtractor": {
           "type": "boolean"
@@ -3222,6 +15706,9 @@
       "additionalProperties": false
     },
     "MoleculeRendererWidget": {
+      "$ref": "#/definitions/Widget<\"molecule-renderer\",PerseusMoleculeRendererWidgetOptions>"
+    },
+    "Widget<\"molecule-renderer\",PerseusMoleculeRendererWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -3238,29 +15725,71 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusMoleculeRendererWidgetOptions"
+          "type": "object",
+          "properties": {
+            "widgetId": {
+              "type": "string"
             },
-            {
-              "type": "null"
+            "rotationAngle": {
+              "type": "number"
+            },
+            "smiles": {
+              "type": "string"
             }
-          ]
+          },
+          "required": [
+            "widgetId"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
-    "PerseusMoleculeRendererWidgetOptions": {},
+    "PerseusMoleculeRendererWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "widgetId": {
+          "type": "string"
+        },
+        "rotationAngle": {
+          "type": "number"
+        },
+        "smiles": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "widgetId"
+      ],
+      "additionalProperties": false
+    },
     "NumberLineWidget": {
+      "$ref": "#/definitions/Widget<\"number-line\",PerseusNumberLineWidgetOptions>"
+    },
+    "Widget<\"number-line\",PerseusNumberLineWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -3277,24 +15806,113 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusNumberLineWidgetOptions"
+          "type": "object",
+          "properties": {
+            "range": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
             },
-            {
-              "type": "null"
+            "labelRange": {
+              "type": "array",
+              "items": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              }
+            },
+            "labelStyle": {
+              "type": "string"
+            },
+            "labelTicks": {
+              "type": "boolean"
+            },
+            "isTickCtrl": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "divisionRange": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "numDivisions": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "snapDivisions": {
+              "type": "number"
+            },
+            "tickStep": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "correctRel": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "correctX": {
+              "type": "number"
+            },
+            "initialX": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "showTooltip": {
+              "type": "boolean"
+            },
+            "static": {
+              "type": "boolean"
             }
-          ]
+          },
+          "required": [
+            "range",
+            "labelRange",
+            "labelStyle",
+            "labelTicks",
+            "divisionRange",
+            "snapDivisions",
+            "correctX",
+            "static"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -3356,10 +15974,7 @@
           ]
         },
         "correctX": {
-          "type": [
-            "number",
-            "null"
-          ]
+          "type": "number"
         },
         "initialX": {
           "type": [
@@ -3381,11 +15996,15 @@
         "labelTicks",
         "divisionRange",
         "snapDivisions",
+        "correctX",
         "static"
       ],
       "additionalProperties": false
     },
     "NumericInputWidget": {
+      "$ref": "#/definitions/Widget<\"numeric-input\",PerseusNumericInputWidgetOptions>"
+    },
+    "Widget<\"numeric-input\",PerseusNumericInputWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -3402,24 +16021,147 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusNumericInputWidgetOptions"
+          "type": "object",
+          "properties": {
+            "answers": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "number"
+                  },
+                  "status": {
+                    "type": "string"
+                  },
+                  "answerForms": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "integer",
+                        "mixed",
+                        "improper",
+                        "proper",
+                        "decimal",
+                        "percent",
+                        "pi"
+                      ]
+                    }
+                  },
+                  "strict": {
+                    "type": "boolean"
+                  },
+                  "maxError": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "simplify": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "message",
+                  "value",
+                  "status",
+                  "strict"
+                ],
+                "additionalProperties": false
+              }
             },
-            {
-              "type": "null"
+            "labelText": {
+              "type": "string"
+            },
+            "size": {
+              "type": "string"
+            },
+            "coefficient": {
+              "type": "boolean"
+            },
+            "rightAlign": {
+              "type": "boolean"
+            },
+            "static": {
+              "type": "boolean"
+            },
+            "answerForms": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "simplify": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "required",
+                      "correct",
+                      "enforced",
+                      "optional",
+                      null
+                    ]
+                  },
+                  "name": {
+                    "type": "string",
+                    "enum": [
+                      "integer",
+                      "mixed",
+                      "improper",
+                      "proper",
+                      "decimal",
+                      "percent",
+                      "pi"
+                    ]
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "additionalProperties": false
+              }
             }
-          ]
+          },
+          "required": [
+            "answers",
+            "labelText",
+            "size",
+            "coefficient",
+            "static"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -3429,7 +16171,55 @@
         "answers": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/PerseusNumericInputAnswer"
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              },
+              "value": {
+                "type": "number"
+              },
+              "status": {
+                "type": "string"
+              },
+              "answerForms": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "integer",
+                    "mixed",
+                    "improper",
+                    "proper",
+                    "decimal",
+                    "percent",
+                    "pi"
+                  ]
+                }
+              },
+              "strict": {
+                "type": "boolean"
+              },
+              "maxError": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "simplify": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "message",
+              "value",
+              "status",
+              "strict"
+            ],
+            "additionalProperties": false
           }
         },
         "labelText": {
@@ -3450,7 +16240,38 @@
         "answerForms": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/PerseusNumericInputAnswerForm"
+            "type": "object",
+            "properties": {
+              "simplify": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  "required",
+                  "correct",
+                  "enforced",
+                  "optional",
+                  null
+                ]
+              },
+              "name": {
+                "type": "string",
+                "enum": [
+                  "integer",
+                  "mixed",
+                  "improper",
+                  "proper",
+                  "decimal",
+                  "percent",
+                  "pi"
+                ]
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "additionalProperties": false
           }
         }
       },
@@ -3478,7 +16299,16 @@
         "answerForms": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/MathFormat"
+            "type": "string",
+            "enum": [
+              "integer",
+              "mixed",
+              "improper",
+              "proper",
+              "decimal",
+              "percent",
+              "pi"
+            ]
           }
         },
         "strict": {
@@ -3534,7 +16364,16 @@
           ]
         },
         "name": {
-          "$ref": "#/definitions/MathFormat"
+          "type": "string",
+          "enum": [
+            "integer",
+            "mixed",
+            "improper",
+            "proper",
+            "decimal",
+            "percent",
+            "pi"
+          ]
         }
       },
       "required": [
@@ -3543,6 +16382,9 @@
       "additionalProperties": false
     },
     "OrdererWidget": {
+      "$ref": "#/definitions/Widget<\"orderer\",PerseusOrdererWidgetOptions>"
+    },
+    "Widget<\"orderer\",PerseusOrdererWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -3559,24 +16401,182 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusOrdererWidgetOptions"
+          "type": "object",
+          "properties": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "content": {
+                    "type": "string"
+                  },
+                  "replace": {
+                    "type": "boolean"
+                  },
+                  "metadata": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "images": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "object",
+                      "properties": {
+                        "width": {
+                          "type": "number"
+                        },
+                        "height": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "width",
+                        "height"
+                      ],
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "required": [
+                  "content",
+                  "widgets",
+                  "images"
+                ],
+                "additionalProperties": false
+              }
             },
-            {
-              "type": "null"
+            "correctOptions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "content": {
+                    "type": "string"
+                  },
+                  "replace": {
+                    "type": "boolean"
+                  },
+                  "metadata": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "images": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "object",
+                      "properties": {
+                        "width": {
+                          "type": "number"
+                        },
+                        "height": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "width",
+                        "height"
+                      ],
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "required": [
+                  "content",
+                  "widgets",
+                  "images"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "otherOptions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "content": {
+                    "type": "string"
+                  },
+                  "replace": {
+                    "type": "boolean"
+                  },
+                  "metadata": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "images": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "object",
+                      "properties": {
+                        "width": {
+                          "type": "number"
+                        },
+                        "height": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "width",
+                        "height"
+                      ],
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "required": [
+                  "content",
+                  "widgets",
+                  "images"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "height": {
+              "type": "string"
+            },
+            "layout": {
+              "type": "string"
             }
-          ]
+          },
+          "required": [
+            "options",
+            "correctOptions",
+            "otherOptions",
+            "height",
+            "layout"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -3586,19 +16586,136 @@
         "options": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/PerseusRenderer"
+            "type": "object",
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "replace": {
+                "type": "boolean"
+              },
+              "metadata": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "images": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "width": {
+                      "type": "number"
+                    },
+                    "height": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "width",
+                    "height"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "content",
+              "widgets",
+              "images"
+            ],
+            "additionalProperties": false
           }
         },
         "correctOptions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/PerseusRenderer"
+            "type": "object",
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "replace": {
+                "type": "boolean"
+              },
+              "metadata": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "images": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "width": {
+                      "type": "number"
+                    },
+                    "height": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "width",
+                    "height"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "content",
+              "widgets",
+              "images"
+            ],
+            "additionalProperties": false
           }
         },
         "otherOptions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/PerseusRenderer"
+            "type": "object",
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "replace": {
+                "type": "boolean"
+              },
+              "metadata": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "images": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "width": {
+                      "type": "number"
+                    },
+                    "height": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "width",
+                    "height"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "content",
+              "widgets",
+              "images"
+            ],
+            "additionalProperties": false
           }
         },
         "height": {
@@ -3617,65 +16734,10 @@
       ],
       "additionalProperties": false
     },
-    "PassageRefWidget": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "const": "passage-ref"
-        },
-        "static": {
-          "type": "boolean"
-        },
-        "graded": {
-          "type": "boolean"
-        },
-        "alignment": {
-          "type": "string"
-        },
-        "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusPassageRefWidgetOptions"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "key": {
-          "type": "number"
-        },
-        "version": {
-          "$ref": "#/definitions/Version"
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "PerseusPassageRefWidgetOptions": {
-      "type": "object",
-      "properties": {
-        "passageNumber": {
-          "type": "number"
-        },
-        "referenceNumber": {
-          "type": "number"
-        },
-        "summaryText": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "passageNumber",
-        "referenceNumber",
-        "summaryText"
-      ],
-      "additionalProperties": false
-    },
     "PassageWidget": {
+      "$ref": "#/definitions/Widget<\"passage\",PerseusPassageWidgetOptions>"
+    },
+    "Widget<\"passage\",PerseusPassageWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -3692,24 +16754,56 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusPassageWidgetOptions"
+          "type": "object",
+          "properties": {
+            "footnotes": {
+              "type": "string"
             },
-            {
-              "type": "null"
+            "passageText": {
+              "type": "string"
+            },
+            "passageTitle": {
+              "type": "string"
+            },
+            "showLineNumbers": {
+              "type": "boolean"
+            },
+            "static": {
+              "type": "boolean"
             }
-          ]
+          },
+          "required": [
+            "footnotes",
+            "passageText",
+            "passageTitle",
+            "showLineNumbers",
+            "static"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -3741,7 +16835,95 @@
       ],
       "additionalProperties": false
     },
+    "PassageRefWidget": {
+      "$ref": "#/definitions/Widget<\"passage-ref\",PerseusPassageRefWidgetOptions>"
+    },
+    "Widget<\"passage-ref\",PerseusPassageRefWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "passage-ref"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "type": "object",
+          "properties": {
+            "passageNumber": {
+              "type": "number"
+            },
+            "referenceNumber": {
+              "type": "number"
+            },
+            "summaryText": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "passageNumber",
+            "referenceNumber",
+            "summaryText"
+          ],
+          "additionalProperties": false
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusPassageRefWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "passageNumber": {
+          "type": "number"
+        },
+        "referenceNumber": {
+          "type": "number"
+        },
+        "summaryText": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "passageNumber",
+        "referenceNumber",
+        "summaryText"
+      ],
+      "additionalProperties": false
+    },
     "PlotterWidget": {
+      "$ref": "#/definitions/Widget<\"plotter\",PerseusPlotterWidgetOptions>"
+    },
+    "Widget<\"plotter\",PerseusPlotterWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -3758,24 +16940,118 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusPlotterWidgetOptions"
+          "type": "object",
+          "properties": {
+            "labels": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
-            {
-              "type": "null"
+            "categories": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "bar",
+                "line",
+                "pic",
+                "histogram",
+                "dotplot"
+              ]
+            },
+            "maxY": {
+              "type": "number"
+            },
+            "scaleY": {
+              "type": "number"
+            },
+            "labelInterval": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "snapsPerLine": {
+              "type": "number"
+            },
+            "starting": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "correct": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "picUrl": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "picSize": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "picBoxHeight": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "plotDimensions": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
             }
-          ]
+          },
+          "required": [
+            "labels",
+            "categories",
+            "type",
+            "maxY",
+            "scaleY",
+            "snapsPerLine",
+            "starting",
+            "correct",
+            "plotDimensions"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -3795,7 +17071,14 @@
           }
         },
         "type": {
-          "$ref": "#/definitions/PlotType"
+          "type": "string",
+          "enum": [
+            "bar",
+            "line",
+            "pic",
+            "histogram",
+            "dotplot"
+          ]
         },
         "maxY": {
           "type": "number"
@@ -3872,7 +17155,87 @@
         "dotplot"
       ]
     },
+    "PythonProgramWidget": {
+      "$ref": "#/definitions/Widget<\"python-program\",PerseusPythonProgramWidgetOptions>"
+    },
+    "Widget<\"python-program\",PerseusPythonProgramWidgetOptions>": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "python-program"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "graded": {
+          "type": "boolean"
+        },
+        "alignment": {
+          "type": "string"
+        },
+        "options": {
+          "type": "object",
+          "properties": {
+            "programID": {
+              "type": "string"
+            },
+            "height": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "programID",
+            "height"
+          ],
+          "additionalProperties": false
+        },
+        "key": {
+          "type": "number"
+        },
+        "version": {
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "PerseusPythonProgramWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "programID": {
+          "type": "string"
+        },
+        "height": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "programID",
+        "height"
+      ],
+      "additionalProperties": false
+    },
     "RadioWidget": {
+      "$ref": "#/definitions/Widget<\"radio\",PerseusRadioWidgetOptions>"
+    },
+    "Widget<\"radio\",PerseusRadioWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -3889,24 +17252,84 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusRadioWidgetOptions"
+          "type": "object",
+          "properties": {
+            "choices": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "content": {
+                    "type": "string"
+                  },
+                  "clue": {
+                    "type": "string"
+                  },
+                  "correct": {
+                    "type": "boolean"
+                  },
+                  "isNoneOfTheAbove": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "content"
+                ],
+                "additionalProperties": false
+              }
             },
-            {
-              "type": "null"
+            "hasNoneOfTheAbove": {
+              "type": "boolean"
+            },
+            "countChoices": {
+              "type": "boolean"
+            },
+            "randomize": {
+              "type": "boolean"
+            },
+            "multipleSelect": {
+              "type": "boolean"
+            },
+            "deselectEnabled": {
+              "type": "boolean"
+            },
+            "onePerLine": {
+              "type": "boolean"
+            },
+            "displayCount": {},
+            "noneOfTheAbove": {
+              "type": "boolean",
+              "const": false
             }
-          ]
+          },
+          "required": [
+            "choices"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -3916,7 +17339,25 @@
         "choices": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/PerseusRadioChoice"
+            "type": "object",
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "clue": {
+                "type": "string"
+              },
+              "correct": {
+                "type": "boolean"
+              },
+              "isNoneOfTheAbove": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "content"
+            ],
+            "additionalProperties": false
           }
         },
         "hasNoneOfTheAbove": {
@@ -3962,12 +17403,6 @@
         },
         "isNoneOfTheAbove": {
           "type": "boolean"
-        },
-        "widgets": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/PerseusWidget"
-          }
         }
       },
       "required": [
@@ -3975,138 +17410,10 @@
       ],
       "additionalProperties": false
     },
-    "ReactionDiagramWidget": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "const": "reaction-diagtram"
-        },
-        "static": {
-          "type": "boolean"
-        },
-        "graded": {
-          "type": "boolean"
-        },
-        "alignment": {
-          "type": "string"
-        },
-        "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusReactionDiagramWidgetOptions"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "key": {
-          "type": "number"
-        },
-        "version": {
-          "$ref": "#/definitions/Version"
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "PerseusReactionDiagramWidgetOptions": {},
-    "RefTargetWidget": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "const": "passage-ref-target"
-        },
-        "static": {
-          "type": "boolean"
-        },
-        "graded": {
-          "type": "boolean"
-        },
-        "alignment": {
-          "type": "string"
-        },
-        "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusPassageRefTargetWidgetOptions"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "key": {
-          "type": "number"
-        },
-        "version": {
-          "$ref": "#/definitions/Version"
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "PerseusPassageRefTargetWidgetOptions": {},
-    "SequenceWidget": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "const": "sequence"
-        },
-        "static": {
-          "type": "boolean"
-        },
-        "graded": {
-          "type": "boolean"
-        },
-        "alignment": {
-          "type": "string"
-        },
-        "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusSequenceWidgetOptions"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "key": {
-          "type": "number"
-        },
-        "version": {
-          "$ref": "#/definitions/Version"
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "PerseusSequenceWidgetOptions": {
-      "type": "object",
-      "properties": {
-        "json": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/PerseusRenderer"
-          }
-        }
-      },
-      "required": [
-        "json"
-      ],
-      "additionalProperties": false
-    },
     "SimpleMarkdownTesterWidget": {
+      "$ref": "#/definitions/Widget<\"simple-markdown-tester\",PerseusSimpleMarkdownTesterWidgetOptions>"
+    },
+    "Widget<\"simple-markdown-tester\",PerseusSimpleMarkdownTesterWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -4123,95 +17430,59 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusSimpleMarkdownTesterWidgetOptions"
-            },
-            {
-              "type": "null"
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "string"
             }
-          ]
+          },
+          "required": [
+            "value"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "PerseusSimpleMarkdownTesterWidgetOptions": {},
-    "SimulatorWidget": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "const": "simulator"
-        },
-        "static": {
-          "type": "boolean"
-        },
-        "graded": {
-          "type": "boolean"
-        },
-        "alignment": {
-          "type": "string"
-        },
-        "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusSimulatorWidgetOptions"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
             },
-            {
-              "type": "null"
+            "minor": {
+              "type": "number"
             }
-          ]
-        },
-        "key": {
-          "type": "number"
-        },
-        "version": {
-          "$ref": "#/definitions/Version"
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
-    "PerseusSimulatorWidgetOptions": {
+    "PerseusSimpleMarkdownTesterWidgetOptions": {
       "type": "object",
       "properties": {
-        "xAxisLabel": {
+        "value": {
           "type": "string"
-        },
-        "yAxisLabel": {
-          "type": "string"
-        },
-        "proportionLabel": {
-          "type": "string"
-        },
-        "proportionOrPercentage": {
-          "type": "string"
-        },
-        "numTrials": {
-          "type": "number"
         }
       },
       "required": [
-        "xAxisLabel",
-        "yAxisLabel",
-        "proportionLabel",
-        "proportionOrPercentage",
-        "numTrials"
+        "value"
       ],
       "additionalProperties": false
     },
     "SorterWidget": {
+      "$ref": "#/definitions/Widget<\"sorter\",PerseusSorterWidgetOptions>"
+    },
+    "Widget<\"sorter\",PerseusSorterWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -4228,24 +17499,51 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusSorterWidgetOptions"
+          "type": "object",
+          "properties": {
+            "correct": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
-            {
-              "type": "null"
+            "padding": {
+              "type": "boolean"
+            },
+            "layout": {
+              "type": "string"
             }
-          ]
+          },
+          "required": [
+            "correct",
+            "padding",
+            "layout"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -4273,6 +17571,9 @@
       "additionalProperties": false
     },
     "TableWidget": {
+      "$ref": "#/definitions/Widget<\"table\",PerseusTableWidgetOptions>"
+    },
+    "Widget<\"table\",PerseusTableWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -4289,24 +17590,61 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusTableWidgetOptions"
+          "type": "object",
+          "properties": {
+            "headers": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
-            {
-              "type": "null"
+            "rows": {
+              "type": "number"
+            },
+            "columns": {
+              "type": "number"
+            },
+            "answers": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
             }
-          ]
+          },
+          "required": [
+            "headers",
+            "rows",
+            "columns",
+            "answers"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -4343,775 +17681,10 @@
       ],
       "additionalProperties": false
     },
-    "TransformerWidget": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "const": "transformer"
-        },
-        "static": {
-          "type": "boolean"
-        },
-        "graded": {
-          "type": "boolean"
-        },
-        "alignment": {
-          "type": "string"
-        },
-        "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusTransformerWidgetOptions"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "key": {
-          "type": "number"
-        },
-        "version": {
-          "$ref": "#/definitions/Version"
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "PerseusTransformerWidgetOptions": {
-      "type": "object",
-      "properties": {
-        "correct": {
-          "type": "object",
-          "properties": {
-            "shape": {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "enum": [
-                      "polygon-5",
-                      "polygon-3",
-                      "polygon-4",
-                      "lineSegment",
-                      "polygon-6",
-                      "angle",
-                      "line",
-                      "circle"
-                    ]
-                  }
-                },
-                "coords": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/Coord"
-                  }
-                },
-                "options": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "reflex": {
-                        "type": "boolean"
-                      }
-                    },
-                    "additionalProperties": false
-                  }
-                }
-              },
-              "required": [
-                "type",
-                "coords"
-              ],
-              "additionalProperties": false
-            },
-            "transformations": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/PerseusTransformerTransformation"
-              }
-            }
-          },
-          "required": [
-            "shape",
-            "transformations"
-          ],
-          "additionalProperties": false
-        },
-        "drawSolutionShape": {
-          "type": "boolean"
-        },
-        "gradeEmpty": {
-          "type": "boolean"
-        },
-        "graph": {
-          "type": "object",
-          "properties": {
-            "backgroundImage": {
-              "type": "object",
-              "properties": {
-                "bottom": {
-                  "type": "number"
-                },
-                "height": {
-                  "type": "number"
-                },
-                "left": {
-                  "type": "number"
-                },
-                "scale": {
-                  "type": "number"
-                },
-                "url": {
-                  "type": "string"
-                },
-                "width": {
-                  "type": "number"
-                }
-              },
-              "additionalProperties": false
-            },
-            "gridStep": {
-              "type": "array",
-              "items": {
-                "type": "number"
-              },
-              "minItems": 2,
-              "maxItems": 2
-            },
-            "labels": {
-              "type": "array",
-              "minItems": 2,
-              "items": [
-                {
-                  "type": "string",
-                  "const": "x"
-                },
-                {
-                  "type": "string",
-                  "const": "y"
-                }
-              ],
-              "maxItems": 2
-            },
-            "markings": {
-              "type": "string",
-              "enum": [
-                "none",
-                "graph",
-                "grid"
-              ]
-            },
-            "range": {
-              "type": "array",
-              "items": {
-                "type": "array",
-                "items": {
-                  "type": "number"
-                },
-                "minItems": 2,
-                "maxItems": 2
-              },
-              "minItems": 2,
-              "maxItems": 2
-            },
-            "rulerLabel": {
-              "type": "string"
-            },
-            "rulerTicks": {
-              "type": "number"
-            },
-            "showProtractor": {
-              "type": "boolean"
-            },
-            "showRuler": {
-              "type": "boolean"
-            },
-            "snapStep": {
-              "type": "array",
-              "items": {
-                "type": "number"
-              },
-              "minItems": 2,
-              "maxItems": 2
-            },
-            "step": {
-              "type": "array",
-              "items": {
-                "type": "number"
-              },
-              "minItems": 2,
-              "maxItems": 2
-            }
-          },
-          "required": [
-            "backgroundImage",
-            "markings",
-            "range",
-            "showProtractor",
-            "step"
-          ],
-          "additionalProperties": false
-        },
-        "graphMode": {
-          "type": "string",
-          "enum": [
-            "dynamic",
-            "interactive",
-            "static"
-          ]
-        },
-        "listMode": {
-          "type": "string",
-          "enum": [
-            "interactive",
-            "dynamic",
-            "static"
-          ]
-        },
-        "starting": {
-          "type": "object",
-          "properties": {
-            "shape": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "array",
-                      "items": {
-                        "type": "string",
-                        "enum": [
-                          "polygon-5",
-                          "polygon-3",
-                          "polygon-4",
-                          "lineSegment",
-                          "polygon-6"
-                        ]
-                      }
-                    },
-                    "coords": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/definitions/Coord"
-                      }
-                    },
-                    "options": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "additionalProperties": false
-                      }
-                    }
-                  },
-                  "required": [
-                    "type",
-                    "coords"
-                  ],
-                  "additionalProperties": false
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "const": "polygon-3"
-                    },
-                    "coords": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/definitions/Coord"
-                      },
-                      "minItems": 3,
-                      "maxItems": 3
-                    }
-                  },
-                  "required": [
-                    "type",
-                    "coords"
-                  ],
-                  "additionalProperties": false
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "array",
-                      "items": {
-                        "type": "string",
-                        "enum": [
-                          "polygon-3",
-                          "lineSegment",
-                          "polygon-4",
-                          "polygon-5",
-                          "polygon-6",
-                          "line",
-                          "circle"
-                        ]
-                      },
-                      "minItems": 1,
-                      "maxItems": 1
-                    },
-                    "coords": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/definitions/Coord"
-                      }
-                    },
-                    "options": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "minItems": 1,
-                      "maxItems": 1
-                    }
-                  },
-                  "required": [
-                    "type",
-                    "coords",
-                    "options"
-                  ],
-                  "additionalProperties": false
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "array",
-                      "items": {
-                        "type": "string",
-                        "const": "polygon-3"
-                      },
-                      "minItems": 1,
-                      "maxItems": 1
-                    },
-                    "coords": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/definitions/Coord"
-                      },
-                      "minItems": 3,
-                      "maxItems": 3
-                    },
-                    "options": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "minItems": 1,
-                      "maxItems": 1
-                    }
-                  },
-                  "required": [
-                    "type",
-                    "coords"
-                  ],
-                  "additionalProperties": false
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "array",
-                      "items": {
-                        "type": "string",
-                        "const": "angle"
-                      },
-                      "minItems": 1,
-                      "maxItems": 1
-                    },
-                    "coords": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/definitions/Coord"
-                      },
-                      "minItems": 3,
-                      "maxItems": 3
-                    },
-                    "options": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "reflex": {
-                            "type": "boolean"
-                          }
-                        },
-                        "required": [
-                          "reflex"
-                        ],
-                        "additionalProperties": false
-                      },
-                      "minItems": 1,
-                      "maxItems": 1
-                    }
-                  },
-                  "required": [
-                    "type",
-                    "coords",
-                    "options"
-                  ],
-                  "additionalProperties": false
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "array",
-                      "items": {
-                        "type": "string",
-                        "enum": [
-                          "line",
-                          "lineSegment"
-                        ]
-                      },
-                      "minItems": 1,
-                      "maxItems": 1
-                    },
-                    "coords": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/definitions/Coord"
-                      },
-                      "minItems": 2,
-                      "maxItems": 2
-                    },
-                    "options": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "minItems": 1,
-                      "maxItems": 1
-                    }
-                  },
-                  "required": [
-                    "type",
-                    "coords"
-                  ],
-                  "additionalProperties": false
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "const": "polygon"
-                    },
-                    "coords": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/definitions/Coord"
-                      }
-                    }
-                  },
-                  "required": [
-                    "type",
-                    "coords"
-                  ],
-                  "additionalProperties": false
-                }
-              ]
-            },
-            "transformations": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/PerseusTransformerTransformation"
-              }
-            }
-          },
-          "required": [
-            "shape",
-            "transformations"
-          ],
-          "additionalProperties": false
-        },
-        "tools": {
-          "type": "object",
-          "properties": {
-            "dilation": {
-              "type": "object",
-              "properties": {
-                "constraints": {
-                  "$ref": "#/definitions/PerseusTransformerToolConstraints"
-                },
-                "coord": {
-                  "$ref": "#/definitions/Coord"
-                },
-                "enabled": {
-                  "type": "boolean"
-                },
-                "required": {
-                  "type": "boolean"
-                }
-              },
-              "required": [
-                "constraints",
-                "coord",
-                "enabled"
-              ],
-              "additionalProperties": false
-            },
-            "reflection": {
-              "type": "object",
-              "properties": {
-                "constraints": {
-                  "$ref": "#/definitions/PerseusTransformerToolConstraints"
-                },
-                "coords": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/Coord"
-                  },
-                  "minItems": 2,
-                  "maxItems": 2
-                },
-                "enabled": {
-                  "type": "boolean"
-                },
-                "required": {
-                  "type": "boolean"
-                }
-              },
-              "required": [
-                "constraints",
-                "coords",
-                "enabled"
-              ],
-              "additionalProperties": false
-            },
-            "rotation": {
-              "type": "object",
-              "properties": {
-                "constraints": {
-                  "$ref": "#/definitions/PerseusTransformerToolConstraints"
-                },
-                "coord": {
-                  "$ref": "#/definitions/Coord"
-                },
-                "enabled": {
-                  "type": "boolean"
-                },
-                "required": {
-                  "type": "boolean"
-                }
-              },
-              "required": [
-                "constraints",
-                "coord",
-                "enabled"
-              ],
-              "additionalProperties": false
-            },
-            "translation": {
-              "type": "object",
-              "properties": {
-                "constraints": {
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "enabled": {
-                  "type": "boolean"
-                },
-                "required": {
-                  "type": "boolean"
-                }
-              },
-              "required": [
-                "constraints",
-                "enabled"
-              ],
-              "additionalProperties": false
-            }
-          },
-          "required": [
-            "dilation",
-            "reflection",
-            "rotation",
-            "translation"
-          ],
-          "additionalProperties": false
-        },
-        "version": {
-          "type": "number"
-        }
-      },
-      "required": [
-        "correct",
-        "drawSolutionShape",
-        "gradeEmpty",
-        "graph",
-        "graphMode",
-        "listMode",
-        "starting",
-        "tools",
-        "version"
-      ],
-      "additionalProperties": false
-    },
-    "PerseusTransformerTransformation": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/DilationTransformation"
-        },
-        {
-          "$ref": "#/definitions/ReflectionTransformation"
-        },
-        {
-          "$ref": "#/definitions/RotationTransformation"
-        },
-        {
-          "$ref": "#/definitions/TranslationTransformation"
-        }
-      ]
-    },
-    "DilationTransformation": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "const": "dilation"
-        },
-        "center": {
-          "$ref": "#/definitions/Coord"
-        },
-        "scale": {
-          "type": "number"
-        },
-        "constraints": {
-          "type": "object",
-          "properties": {
-            "fixed": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "fixed"
-          ],
-          "additionalProperties": false
-        }
-      },
-      "required": [
-        "type",
-        "center",
-        "scale",
-        "constraints"
-      ],
-      "additionalProperties": false
-    },
-    "ReflectionTransformation": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "const": "reflection"
-        },
-        "line": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Coord"
-          },
-          "minItems": 2,
-          "maxItems": 2
-        },
-        "constraints": {
-          "type": "object",
-          "properties": {
-            "fixed": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "fixed"
-          ],
-          "additionalProperties": false
-        }
-      },
-      "required": [
-        "type",
-        "line"
-      ],
-      "additionalProperties": false
-    },
-    "RotationTransformation": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "const": "rotation"
-        },
-        "angleDeg": {
-          "type": "number"
-        },
-        "center": {
-          "$ref": "#/definitions/Coord"
-        },
-        "constraints": {
-          "type": "object",
-          "properties": {
-            "fixed": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "fixed"
-          ],
-          "additionalProperties": false
-        }
-      },
-      "required": [
-        "type",
-        "angleDeg",
-        "center",
-        "constraints"
-      ],
-      "additionalProperties": false
-    },
-    "TranslationTransformation": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "const": "translation"
-        },
-        "vector": {
-          "$ref": "#/definitions/Coord"
-        },
-        "contraints": {
-          "type": "object",
-          "additionalProperties": false
-        }
-      },
-      "required": [
-        "type",
-        "vector",
-        "contraints"
-      ],
-      "additionalProperties": false
-    },
-    "PerseusTransformerToolConstraints": {
-      "type": "object",
-      "properties": {
-        "fixed": {
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "fixed"
-      ],
-      "additionalProperties": false
-    },
     "UnitInputWidget": {
+      "$ref": "#/definitions/Widget<\"unit-input\",PerseusUnitInputWidgetOptions>"
+    },
+    "Widget<\"unit-input\",PerseusUnitInputWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -5128,29 +17701,59 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusUnitInputWidgetOptions"
-            },
-            {
-              "type": "null"
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "string"
             }
-          ]
+          },
+          "required": [
+            "value"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
-    "PerseusUnitInputWidgetOptions": {},
+    "PerseusUnitInputWidgetOptions": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false
+    },
     "VideoWidget": {
+      "$ref": "#/definitions/Widget<\"video\",PerseusVideoWidgetOptions>"
+    },
+    "Widget<\"video\",PerseusVideoWidgetOptions>": {
       "type": "object",
       "properties": {
         "type": {
@@ -5167,24 +17770,43 @@
           "type": "string"
         },
         "options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PerseusVideoWidgetOptions"
+          "type": "object",
+          "properties": {
+            "location": {
+              "type": "string"
             },
-            {
-              "type": "null"
+            "static": {
+              "type": "boolean"
             }
-          ]
+          },
+          "required": [
+            "location"
+          ],
+          "additionalProperties": false
         },
         "key": {
           "type": "number"
         },
         "version": {
-          "$ref": "#/definitions/Version"
+          "type": "object",
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "major",
+            "minor"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "type"
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -5204,32 +17826,178 @@
       "additionalProperties": false
     },
     "PerseusAnswerArea": {
+      "$ref": "#/definitions/Record<(\"calculator\"|\"chi2Table\"|\"financialCalculatorMonthlyPayment\"|\"financialCalculatorTotalAmount\"|\"financialCalculatorTimeToPayOff\"|\"periodicTable\"|\"periodicTableWithKey\"|\"tTable\"|\"zTable\"),boolean>"
+    },
+    "Record<(\"calculator\"|\"chi2Table\"|\"financialCalculatorMonthlyPayment\"|\"financialCalculatorTotalAmount\"|\"financialCalculatorTimeToPayOff\"|\"periodicTable\"|\"periodicTableWithKey\"|\"tTable\"|\"zTable\"),boolean>": {
       "type": "object",
       "properties": {
-        "zTable": {
+        "calculator": {
           "type": "boolean"
         },
         "chi2Table": {
           "type": "boolean"
         },
-        "tTable": {
+        "financialCalculatorMonthlyPayment": {
           "type": "boolean"
         },
-        "calculator": {
+        "financialCalculatorTotalAmount": {
+          "type": "boolean"
+        },
+        "financialCalculatorTimeToPayOff": {
           "type": "boolean"
         },
         "periodicTable": {
           "type": "boolean"
+        },
+        "periodicTableWithKey": {
+          "type": "boolean"
+        },
+        "tTable": {
+          "type": "boolean"
+        },
+        "zTable": {
+          "type": "boolean"
         }
       },
       "required": [
-        "zTable",
-        "chi2Table",
-        "tTable",
         "calculator",
-        "periodicTable"
+        "chi2Table",
+        "financialCalculatorMonthlyPayment",
+        "financialCalculatorTotalAmount",
+        "financialCalculatorTimeToPayOff",
+        "periodicTable",
+        "periodicTableWithKey",
+        "tTable",
+        "zTable"
       ],
       "additionalProperties": false
     }
-  }
+  },
+  "type": "object",
+  "properties": {
+    "question": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "replace": {
+          "type": "boolean"
+        },
+        "metadata": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "images": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "width": {
+                "type": "number"
+              },
+              "height": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "width",
+              "height"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "content",
+        "widgets",
+        "images"
+      ],
+      "additionalProperties": false
+    },
+    "hints": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "replace": {
+            "type": "boolean"
+          },
+          "metadata": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "images": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "width": {
+                  "type": "number"
+                },
+                "height": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "width",
+                "height"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "content",
+          "widgets",
+          "images"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "answerArea": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Record<(\"calculator\"|\"chi2Table\"|\"financialCalculatorMonthlyPayment\"|\"financialCalculatorTotalAmount\"|\"financialCalculatorTimeToPayOff\"|\"periodicTable\"|\"periodicTableWithKey\"|\"tTable\"|\"zTable\"),boolean>"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "_multi": {},
+    "itemDataVersion": {
+      "type": "object",
+      "properties": {
+        "major": {
+          "type": "number"
+        },
+        "minor": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "major",
+        "minor"
+      ],
+      "additionalProperties": false
+    },
+    "answer": {}
+  },
+  "required": [
+    "question",
+    "hints",
+    "_multi",
+    "itemDataVersion",
+    "answer"
+  ],
+  "additionalProperties": false,
+  "description": "The PerseusItem is the main Perseus data structure for an exercise.  It forms a question (with interactive widgets), a set of hints, and answer area configuration (such as whether to make a calculator or periodic table available to the learner)."
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4521,7 +4521,7 @@
     "@types/tough-cookie" "*"
     parse5 "^7.0.0"
 
-"@types/json-schema@^7.0.12":
+"@types/json-schema@^7.0.12", "@types/json-schema@^7.0.15":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
@@ -6475,6 +6475,11 @@ commander@9.2.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.2.0.tgz#6e21014b2ed90d8b7c9647230d8b7a94a4a419a9"
   integrity sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==
+
+commander@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-12.0.0.tgz#b929db6df8546080adfd004ab215ed48cf6f2592"
+  integrity sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==
 
 commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
@@ -9255,6 +9260,17 @@ glob@^7.1.3, glob@^7.1.4, glob@^7.2.0:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@^8.0.3:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
 
 global-dirs@^3.0.0:
   version "3.0.0"
@@ -14475,6 +14491,11 @@ safe-stable-stringify@^2.3.1:
   resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz#ab67cbe1fe7d40603ca641c5e765cb942d04fc73"
   integrity sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg==
 
+safe-stable-stringify@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz#138c84b6f6edb3db5f8ef3ef7115b8f55ccbf886"
+  integrity sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==
+
 "safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
@@ -15589,6 +15610,19 @@ ts-dedent@^2.0.0, ts-dedent@^2.2.0:
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.2.0.tgz#39e4bd297cd036292ae2394eb3412be63f563bb5"
   integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
 
+ts-json-schema-generator@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ts-json-schema-generator/-/ts-json-schema-generator-2.0.1.tgz#f6c29c9e33b9ce568ded931e06b356d5ec37f006"
+  integrity sha512-0sWa9uXFzkcZS/0LV4BLB91elC+2brg6JyIYXZEUCs6P7Z/BXuhUutxO4ssg7Kb9Xe4dzQXsc5IAmOHt7IETmA==
+  dependencies:
+    "@types/json-schema" "^7.0.15"
+    commander "^12.0.0"
+    glob "^8.0.3"
+    json5 "^2.2.3"
+    normalize-path "^3.0.0"
+    safe-stable-stringify "^2.4.3"
+    typescript "~5.4.5"
+
 tsconfig-paths@^3.15.0:
   version "3.15.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz#5299ec605e55b1abb23ec939ef15edaf483070d4"
@@ -15842,6 +15876,11 @@ typescript@^5.4.2:
   version "5.4.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.2.tgz#0ae9cebcfae970718474fe0da2c090cad6577372"
   integrity sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==
+
+typescript@~5.4.5:
+  version "5.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
+  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
 
 ua-parser-js@^0.7.30:
   version "0.7.31"


### PR DESCRIPTION
## Summary:

**SPIKE: DO NOT MERGE** 

While watching the Perseus Data Format meeting recording, I remembered an idea that we've batted around to generate a JSON Schema for our Perseus data format using the existing Typescript types. 

This PR introduces a package.json script `gen:schema` which generates a JSON schema for the `PerseusItem` type as a proof of concept. 

This wouldn't address all of our API needs, but it might help with external partners who consume the Perseus data format. 

Issue: 'none'

## Test plan: