### PR TITLE
Remove console mocking in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,6 @@
     "publish:ci": "utils/pre-publish-check-ci.ts && git diff --stat --exit-code HEAD && yarn build && yarn build:types && yarn extract-strings && changeset publish",
     "sloc": "sloc packages --exclude node_modules",
     "test": "yarn jest",
-    "test:no-console-mock": "cross-env GLOBAL_CONSOLE_MOCK=false yarn jest",
     "storybook": "storybook dev -p 6006",
     "start": "storybook dev -p 6006",
     "build-storybook": "storybook build",

--- a/wallaby.js
+++ b/wallaby.js
@@ -18,10 +18,5 @@ module.exports = (wallaby) => {
         autoDetect: true,
         runMode: "onsave",
         trace: true,
-        env: {
-            params: {
-                env: "GLOBAL_CONSOLE_MOCK=false",
-            },
-        },
     };
 };


### PR DESCRIPTION
## Summary:

When we moved Perseus out of webapp we brought along a mechanism to mock `console.*()` calls. I think the original intent was to make it an explicit choice to have console logging in our production code. 

In reality, this has caused more headaches than it has saved us. Also, our build system can strip out console logging if we need that in the future. 

Issue: "none"

## Test plan: