### PR TITLE
For wide images, label image popovers go above or below markers to lessen chances of covering markers

### DIFF
--- a/.changeset/calm-buses-sparkle.md
+++ b/.changeset/calm-buses-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+For wide image, label image popovers only go above or below marker

--- a/packages/perseus/src/widgets/__stories__/label-image.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/label-image.stories.tsx
@@ -1,7 +1,11 @@
 import * as React from "react";
 
 import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui";
-import {textQuestion, mathQuestion} from "../__testdata__/label-image.testdata";
+import {
+    textQuestion,
+    mathQuestion,
+    numberline,
+} from "../__testdata__/label-image.testdata";
 
 import type {APIOptions} from "../../types";
 
@@ -31,6 +35,16 @@ export const LabelWidgetWithMath = (args: StoryArgs): React.ReactElement => {
 
     return (
         <RendererWithDebugUI question={mathQuestion} apiOptions={apiOptions} />
+    );
+};
+
+export const LabelImageNumberline = (args: StoryArgs): React.ReactElement => {
+    const apiOptions: APIOptions = {
+        isMobile: args.isMobile,
+    };
+
+    return (
+        <RendererWithDebugUI question={numberline} apiOptions={apiOptions} />
     );
 };
 

--- a/packages/perseus/src/widgets/__testdata__/label-image.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/label-image.testdata.ts
@@ -128,3 +128,53 @@ export const mathQuestion: PerseusRenderer = {
         },
     },
 };
+
+export const numberline: PerseusRenderer = {
+    content:
+        "**Label each point on the number line with the correct value.**\n\n[[☃ label-image 1]]",
+    images: {},
+    widgets: {
+        "label-image 1": {
+            type: "label-image",
+            alignment: "default",
+            static: false,
+            graded: true,
+            options: {
+                static: false,
+                choices: ["$-\\dfrac{7}{3}$", "$-2\\dfrac{5}{8}$", "$-2.9$"],
+                imageAlt:
+                    "A number line from negative 6 halves to negative 3 halves, labeled in increments of 1 half. There are three points on the line, labeled from left to right with a, b, and c.",
+                imageUrl:
+                    "web+graphie://ka-perseus-graphie.s3.amazonaws.com/05faa925d02e5effd3069bf24da4777e3ae1a28b",
+                imageWidth: 360,
+                imageHeight: 160,
+                markers: [
+                    {
+                        answers: ["$-2.9$"],
+                        label: "Point a is the leftmost of two points between negative 6 halves and negative 5 halves.",
+                        x: 14.25,
+                        y: 50,
+                    },
+                    {
+                        answers: ["$-2\\dfrac{5}{8}$"],
+                        label: "Point b is the rightmost of two points between negative 6 halves and negative 5 halves.",
+                        x: 29.5,
+                        y: 50,
+                    },
+                    {
+                        answers: ["$-\\dfrac{7}{3}$"],
+                        label: "Point c is between negative 5 halves and negative 4 halves.",
+                        x: 45.5,
+                        y: 50,
+                    },
+                ],
+                multipleAnswers: false,
+                hideChoicesFromInstructions: false,
+            },
+            version: {
+                major: 0,
+                minor: 0,
+            },
+        },
+    },
+};

--- a/packages/perseus/src/widgets/label-image.tsx
+++ b/packages/perseus/src/widgets/label-image.tsx
@@ -645,11 +645,15 @@ class LabelImage extends React.Component<LabelImageProps, LabelImageState> {
                 mediaQueries.xsOrSmaller.replace("@media ", ""),
             ).matches;
 
+            // Determine whether the image is wider than it is tall.
+            const isWideImage =
+                this.props.imageWidth / 2 > this.props.imageHeight;
+
             let side: "bottom" | "left" | "right" | "top";
             let markerPosition;
             // Position popup closest to the center, preferring it renders
             // entirely within the image area.
-            if (isNarrowPage) {
+            if (isNarrowPage || isWideImage) {
                 side = marker.y > 50 ? "top" : "bottom";
                 markerPosition = marker.y > 50 ? "bottom" : "top";
             } else {


### PR DESCRIPTION
## Summary
If an image is wider than it is tall, popovers and pills can only appear above or below markers.
Lessens changes of pills overlapping markers or each other.
Adds the number line story from Test Everything to verify.

Issue: LC-1504

![Screenshot 2023-11-28 at 5 28 54 PM](https://github.com/Khan/perseus/assets/23404711/ccc334ea-cb98-416a-a4e8-1c8747d94fb4)


https://github.com/Khan/perseus/assets/23404711/84093a82-d2eb-498c-8daf-553d1f164660

## Test strategy
Check out the story.