### PR TITLE
Revert expression-editor changes to answer form key handling

### DIFF
--- a/packages/perseus-editor/src/widgets/__tests__/expression-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/expression-editor.test.tsx
@@ -1,0 +1,56 @@
+import {Dependencies} from "@khanacademy/perseus";
+import {render, screen} from "@testing-library/react";
+import * as React from "react";
+
+import "@testing-library/jest-dom";
+
+import {testDependencies} from "../../../../../testing/test-dependencies";
+import ExpressionEditor from "../expression-editor";
+
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
+
+describe("expression-editor", () => {
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("should render", async () => {
+        render(<ExpressionEditor onChange={() => undefined} />);
+
+        expect(await screen.findByText(/Add new answer/)).toBeInTheDocument();
+    });
+
+    it("should render answerForms missing a key", async () => {
+        const answerForms: PropsFor<typeof ExpressionEditor>["answerForms"] = [
+            {
+                value: "x\\cdot3=y",
+                form: true,
+                simplify: true,
+                considered: "correct",
+            },
+            {
+                value: "x^2=y",
+                form: true,
+                simplify: true,
+                considered: "wrong",
+            },
+            {
+                value: "x=y\\cdotπ",
+                form: true,
+                simplify: true,
+                considered: "wrong",
+            },
+        ];
+
+        render(
+            <ExpressionEditor
+                onChange={() => undefined}
+                answerForms={answerForms}
+            />,
+        );
+
+        expect(await screen.findByText(/π/)).toBeInTheDocument();
+    });
+});

--- a/packages/perseus-editor/src/widgets/expression-editor.tsx
+++ b/packages/perseus-editor/src/widgets/expression-editor.tsx
@@ -37,11 +37,12 @@ type DefaultProps = {
 };
 
 const parseAnswerKey = ({key}: AnswerForm): number => {
-    const parsedKey = Number.parseInt(key ?? "");
-    if (Number.isNaN(parsedKey)) {
-        throw new Error(`Invalid answer key: ${key}`);
-    }
-    return parsedKey;
+    // We don't throw here because there is data stored in some
+    // exercises/articles where the answer forms don't have a key. If we throw,
+    // it blocks content editors from loading the page at all.
+    // TODO(Jeremy): find a way to handle these answer forms that are missing
+    // keys more gracefully.
+    return Number.parseInt(key ?? "");
 };
 
 // Pick a key that isn't currently used by an answer in answerForms

--- a/packages/perseus-editor/src/widgets/expression-editor.tsx
+++ b/packages/perseus-editor/src/widgets/expression-editor.tsx
@@ -18,7 +18,6 @@ import SortableArea from "../components/sortable";
 import type {PerseusExpressionWidgetOptions} from "@khanacademy/perseus";
 
 const {InfoTip, PropCheckBox, TexButtons} = components;
-const {getDependencies} = Dependencies;
 
 type Props = {
     widgetId?: any;
@@ -182,7 +181,7 @@ class ExpressionEditor extends React.Component<Props, State> {
             },
         );
 
-        const {TeX} = getDependencies(); // OldExpression only
+        const {TeX} = Dependencies.getDependencies(); // OldExpression only
 
         buttonSetChoices.splice(
             1,


### PR DESCRIPTION
## Summary:

In #711 we added some protective parsing code for AnswerForm `key`s. However, we discovered ([Slack](https://khanacademy.slack.com/archives/C3SLM30AW/p1701199431143119)) that there are instances of data where the key is entirely missing. 

Reverting the `throw` for now to unblock our content authors. I'll continue working on this in a separate PR/deploy to fix this more correctly as Ned was onto something!

Issue: LC-1502

## Test plan:

Run the tests. They should pass.