### PR TITLE
Fix dark typography on mobile view

### DIFF
--- a/.changeset/grumpy-sheep-own.md
+++ b/.changeset/grumpy-sheep-own.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Reverts Perseus global mobile styles for answer pill in label image widget

--- a/packages/perseus/src/styles/widgets/label-image.less
+++ b/packages/perseus/src/styles/widgets/label-image.less
@@ -5,7 +5,7 @@
             margin: 0;
         }
     }
-    [id^="answer-choice-"] {
+    button[id^="perseus-label-image-widget-answer-pill-"] {
         // Reset text content.
         div.paragraph {
             all: revert;
@@ -14,6 +14,23 @@
         // https://github.com/Khan/perseus/blob/bafd35daee723456bf259a39b88e7638d91c8c3b/packages/perseus/src/renderer.tsx#L1176
         div.perseus-block-math-inner {
             margin: -5px 0 !important;
+        }
+    }
+}
+
+// Reset mobile text content for answer pills.
+@media (max-width: 767px) {
+    [id^="perseus-label-image-widget-answer-pill-"] {
+        div.paragraph,
+        .framework-perseus.perseus-mobile
+            .perseus-renderer
+            > .paragraph
+            .paragraph,
+        .framework-perseus.perseus-mobile .perseus-renderer > .paragraph {
+            all: revert;
+        }
+        > div.perseus-renderer-responsive {
+            all: revert;
         }
     }
 }

--- a/packages/perseus/src/styles/widgets/label-image.less
+++ b/packages/perseus/src/styles/widgets/label-image.less
@@ -21,15 +21,18 @@
 // Reset mobile text content for answer pills.
 @media (max-width: 767px) {
     [id^="perseus-label-image-widget-answer-pill-"] {
-        div.paragraph,
-        .framework-perseus.perseus-mobile
-            .perseus-renderer
-            > .paragraph
-            .paragraph,
-        .framework-perseus.perseus-mobile .perseus-renderer > .paragraph {
+        div.paragraph {
             all: revert;
         }
         > div.perseus-renderer-responsive {
+            all: revert;
+        }
+    }
+
+    .framework-perseus.perseus-mobile
+        [id^="perseus-label-image-widget-answer-pill-"] {
+        .perseus-renderer > .paragraph,
+        .perseus-renderer > .paragraph .paragraph {
             all: revert;
         }
     }

--- a/packages/perseus/src/widgets/label-image.tsx
+++ b/packages/perseus/src/widgets/label-image.tsx
@@ -715,7 +715,11 @@ class LabelImage extends React.Component<LabelImageProps, LabelImageState> {
                     </Popover>
                     {!!marker.selected && showAnswerChoice && (
                         <AnswerPill
-                            id={`answer-choice-${marker.x}.${marker.y}`}
+                            id={
+                                // will be prepended with
+                                // "perseus-label-image-widget-answer-pill-"
+                                `${marker.x}.${marker.y}`
+                            }
                             selectedAnswers={marker.selected}
                             showCorrectness={showCorrectness}
                             markerRef={

--- a/packages/perseus/src/widgets/label-image/answer-pill.tsx
+++ b/packages/perseus/src/widgets/label-image/answer-pill.tsx
@@ -58,7 +58,7 @@ export const AnswerPill = (props: {
                 <Pill
                     size="large"
                     kind="accent"
-                    id={id}
+                    id={"perseus-label-image-widget-answer-pill-" + id}
                     onClick={correct ? undefined : onClick}
                     ref={ref}
                     style={[


### PR DESCRIPTION
## Summary
Reverts all Perseus global mobile styles for WB answer pill

BEFORE:
![Screen Shot 2023-11-30 at 10 47 12 AM](https://github.com/Khan/perseus/assets/23404711/49097acd-9b84-4795-b963-5d0b3400acdf)

AFTER:
![Screenshot 2023-11-30 at 12 25 40 PM](https://github.com/Khan/perseus/assets/23404711/83b99afa-649f-48f0-8c73-9a589b0a5fb5)

Issue: LC-1515

## Testing strategy:
Check pill in webapp in mobile web and editor view. Should have white lettering.