### PR TITLE
Add accessible label to hide answers switch (also increase padding and prevent ID collisions)

### DIFF
--- a/.changeset/perfect-experts-doubt.md
+++ b/.changeset/perfect-experts-doubt.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Give label image widget switch an accessible label.

--- a/packages/perseus/src/styles/widgets/label-image.less
+++ b/packages/perseus/src/styles/widgets/label-image.less
@@ -5,7 +5,7 @@
             margin: 0;
         }
     }
-    button[id^="perseus-label-image-widget-answer-pill-"] {
+    button[id*="perseus-label-image-widget-answer-pill"] {
         // Reset text content.
         div.paragraph {
             all: revert;
@@ -20,7 +20,7 @@
 
 // Reset mobile text content for answer pills.
 @media (max-width: 767px) {
-    [id^="perseus-label-image-widget-answer-pill-"] {
+    [id*="perseus-label-image-widget-answer-pill"] {
         div.paragraph {
             all: revert;
         }
@@ -30,7 +30,7 @@
     }
 
     .framework-perseus.perseus-mobile
-        [id^="perseus-label-image-widget-answer-pill-"] {
+        [id*="perseus-label-image-widget-answer-pill"] {
         .perseus-renderer > .paragraph,
         .perseus-renderer > .paragraph .paragraph {
             all: revert;

--- a/packages/perseus/src/widgets/label-image.tsx
+++ b/packages/perseus/src/widgets/label-image.tsx
@@ -6,11 +6,8 @@
  * knowledge by directly interacting with the image.
  */
 
-import {View} from "@khanacademy/wonder-blocks-core";
 import * as i18n from "@khanacademy/wonder-blocks-i18n";
 import {Popover, PopoverContentCore} from "@khanacademy/wonder-blocks-popover";
-import Switch from "@khanacademy/wonder-blocks-switch";
-import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import {StyleSheet, css} from "aphrodite";
 import classNames from "classnames";
 import * as React from "react";
@@ -24,8 +21,8 @@ import mediaQueries from "../styles/media-queries";
 
 import AnswerChoices from "./label-image/answer-choices";
 import {AnswerPill} from "./label-image/answer-pill";
+import {HideAnswersToggle} from "./label-image/hide-answers-toggle";
 import Marker from "./label-image/marker";
-import {strings} from "./label-image/strings";
 
 import type {ChangeableProps} from "../mixins/changeable";
 import type {APIOptions, PerseusScore, WidgetExports} from "../types";
@@ -715,11 +712,6 @@ class LabelImage extends React.Component<LabelImageProps, LabelImageState> {
                     </Popover>
                     {!!marker.selected && showAnswerChoice && (
                         <AnswerPill
-                            id={
-                                // will be prepended with
-                                // "perseus-label-image-widget-answer-pill-"
-                                `${marker.x}.${marker.y}`
-                            }
                             selectedAnswers={marker.selected}
                             showCorrectness={showCorrectness}
                             markerRef={
@@ -832,15 +824,10 @@ class LabelImage extends React.Component<LabelImageProps, LabelImageState> {
                     </div>
                     {this.renderMarkers()}
                 </div>
-                <View style={styles.switchWrapper}>
-                    <LabelMedium id="hide-answers-label">
-                        {strings.hideAnswersToggleLabel}
-                    </LabelMedium>
-                    <Switch
-                        checked={this.state.hideAnswers}
-                        onChange={(hideAnswers) => this.setState({hideAnswers})}
-                    />
-                </View>
+                <HideAnswersToggle
+                    areAnswersHidden={this.state.hideAnswers}
+                    onChange={(hideAnswers) => this.setState({hideAnswers})}
+                />
             </div>
         );
     }
@@ -916,14 +903,6 @@ const styles = StyleSheet.create({
 
     choicesPopover: {
         padding: 0,
-    },
-
-    switchWrapper: {
-        display: "flex",
-        flexDirection: "row",
-        flexWrap: "wrap",
-        alignItems: "center",
-        gap: "1em",
     },
 });
 

--- a/packages/perseus/src/widgets/label-image/__tests__/answer-pill.test.tsx
+++ b/packages/perseus/src/widgets/label-image/__tests__/answer-pill.test.tsx
@@ -18,7 +18,6 @@ describe("AnswerPill", () => {
         const screen = render(
             <AnswerPill
                 selectedAnswers={selectedAnswers}
-                id={""}
                 side={"top"}
                 onClick={() => {}}
             />,
@@ -31,7 +30,6 @@ describe("AnswerPill", () => {
         const screen = render(
             <AnswerPill
                 selectedAnswers={selectedAnswers}
-                id={""}
                 side={"top"}
                 onClick={() => {}}
             />,
@@ -46,7 +44,6 @@ describe("AnswerPill", () => {
         const screen = render(
             <AnswerPill
                 selectedAnswers={selectedAnswers}
-                id={""}
                 side={"top"}
                 onClick={clickSpy}
             />,
@@ -66,7 +63,6 @@ describe("AnswerPill", () => {
         const screen = render(
             <AnswerPill
                 selectedAnswers={selectedAnswers}
-                id={""}
                 side={"top"}
                 onClick={clickSpy}
                 showCorrectness="correct"

--- a/packages/perseus/src/widgets/label-image/__tests__/answer-pill.test.tsx
+++ b/packages/perseus/src/widgets/label-image/__tests__/answer-pill.test.tsx
@@ -1,3 +1,4 @@
+import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 import {render} from "@testing-library/react";
 import "@testing-library/jest-dom";
 import * as React from "react";
@@ -21,6 +22,7 @@ describe("AnswerPill", () => {
                 side={"top"}
                 onClick={() => {}}
             />,
+            {wrapper: RenderStateRoot},
         );
         expect(screen.getByText("Answer 1")).toBeInTheDocument();
     });
@@ -33,6 +35,7 @@ describe("AnswerPill", () => {
                 side={"top"}
                 onClick={() => {}}
             />,
+            {wrapper: RenderStateRoot},
         );
         expect(screen.getByText("3 answers")).toBeInTheDocument();
     });
@@ -47,6 +50,7 @@ describe("AnswerPill", () => {
                 side={"top"}
                 onClick={clickSpy}
             />,
+            {wrapper: RenderStateRoot},
         );
 
         // act
@@ -67,6 +71,7 @@ describe("AnswerPill", () => {
                 onClick={clickSpy}
                 showCorrectness="correct"
             />,
+            {wrapper: RenderStateRoot},
         );
 
         // act

--- a/packages/perseus/src/widgets/label-image/__tests__/hide-answers-toggle.test.tsx
+++ b/packages/perseus/src/widgets/label-image/__tests__/hide-answers-toggle.test.tsx
@@ -1,0 +1,39 @@
+import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
+import {render} from "@testing-library/react";
+import "@testing-library/jest-dom";
+import userEvent from "@testing-library/user-event";
+import * as React from "react";
+
+import {HideAnswersToggle} from "../hide-answers-toggle";
+import {strings} from "../strings";
+
+const labelText = strings.hideAnswersToggleLabel;
+
+describe("HideAnswersToggle", () => {
+    it("should render the toggle switch", () => {
+        const screen = render(
+            <HideAnswersToggle areAnswersHidden={false} onChange={undefined} />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
+        const toggleSwitch = screen.getByLabelText(
+            labelText,
+        ) as HTMLInputElement;
+        expect(toggleSwitch).toBeInTheDocument();
+        expect(toggleSwitch.checked).toBe(false);
+    });
+
+    it("should call the onChange callback when the toggle switch is clicked", async () => {
+        const onChange = jest.fn((checked) => expect(checked).toBe(true));
+        const screen = render(
+            <HideAnswersToggle areAnswersHidden={false} onChange={onChange} />,
+            {wrapper: RenderStateRoot},
+        );
+        const toggleSwitchBefore = screen.getByLabelText(
+            labelText,
+        ) as HTMLInputElement;
+        userEvent.click(toggleSwitchBefore);
+        expect(onChange).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/perseus/src/widgets/label-image/answer-pill.tsx
+++ b/packages/perseus/src/widgets/label-image/answer-pill.tsx
@@ -1,4 +1,5 @@
 import Color from "@khanacademy/wonder-blocks-color";
+import {useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
 import * as i18n from "@khanacademy/wonder-blocks-i18n";
 import Pill from "@khanacademy/wonder-blocks-pill";
 import {StyleSheet, type CSSProperties} from "aphrodite";
@@ -8,7 +9,6 @@ import {Popper} from "react-popper";
 import Renderer from "../../renderer";
 
 export const AnswerPill = (props: {
-    id: string;
     selectedAnswers: readonly string[];
     showCorrectness?: "correct" | "incorrect";
     markerRef?: HTMLElement;
@@ -16,15 +16,10 @@ export const AnswerPill = (props: {
     onClick: () => void;
     style?: CSSProperties;
 }) => {
-    const {
-        id,
-        selectedAnswers,
-        showCorrectness,
-        markerRef,
-        side,
-        onClick,
-        style,
-    } = props;
+    const {selectedAnswers, showCorrectness, markerRef, side, onClick, style} =
+        props;
+
+    const id = useUniqueIdWithMock();
 
     const answerString =
         selectedAnswers.length > 1
@@ -58,7 +53,7 @@ export const AnswerPill = (props: {
                 <Pill
                     size="large"
                     kind="accent"
-                    id={"perseus-label-image-widget-answer-pill-" + id}
+                    id={id.get("perseus-label-image-widget-answer-pill")}
                     onClick={correct ? undefined : onClick}
                     ref={ref}
                     style={[

--- a/packages/perseus/src/widgets/label-image/answer-pill.tsx
+++ b/packages/perseus/src/widgets/label-image/answer-pill.tsx
@@ -19,7 +19,7 @@ export const AnswerPill = (props: {
     const {selectedAnswers, showCorrectness, markerRef, side, onClick, style} =
         props;
 
-    const id = useUniqueIdWithMock();
+    const idFactory = useUniqueIdWithMock();
 
     const answerString =
         selectedAnswers.length > 1
@@ -53,7 +53,7 @@ export const AnswerPill = (props: {
                 <Pill
                     size="large"
                     kind="accent"
-                    id={id.get("perseus-label-image-widget-answer-pill")}
+                    id={idFactory.get("perseus-label-image-widget-answer-pill")}
                     onClick={correct ? undefined : onClick}
                     ref={ref}
                     style={[

--- a/packages/perseus/src/widgets/label-image/hide-answers-toggle.tsx
+++ b/packages/perseus/src/widgets/label-image/hide-answers-toggle.tsx
@@ -1,0 +1,40 @@
+import {View, useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
+import Switch from "@khanacademy/wonder-blocks-switch";
+import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
+import {StyleSheet} from "aphrodite";
+import * as React from "react";
+
+import {strings} from "./strings";
+
+export const HideAnswersToggle = (props: {
+    areAnswersHidden: boolean;
+    onChange: React.ComponentPropsWithoutRef<typeof Switch>["onChange"];
+}) => {
+    const idFactory = useUniqueIdWithMock();
+    const switchId = idFactory.get("hide-answers-toggle");
+    const labelId = idFactory.get("hide-answers-label");
+    return (
+        <View style={styles.switchWrapper}>
+            <Switch
+                id={switchId}
+                checked={props.areAnswersHidden}
+                onChange={props.onChange}
+                aria-labelledby={labelId}
+            />
+            <LabelMedium id={labelId} htmlFor={switchId}>
+                {strings.hideAnswersToggleLabel}
+            </LabelMedium>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    switchWrapper: {
+        display: "flex",
+        flexDirection: "row",
+        flexWrap: "wrap-reverse",
+        alignItems: "center",
+        gap: "0.5em",
+        marginTop: "1em",
+    },
+});


### PR DESCRIPTION
## Summary
Moves switch to its own functional component in order to take advantage of WB id hook.
Also applies id hook to answer pill to prevent unlikely ID collisions that @jeremywiebe brought up.
Finally, switches the position of the switch and label and adds a bit of margin to make it less likely that the switch would be covered up by an answer pill.

Issue: LC-1517

## Testing strategy
Toggle now has accessible label when focused by screen reader.