### PR TITLE
Minor editor bugfix for periodic table: uncheck key with table

### DIFF
--- a/packages/perseus-editor/src/__tests__/items-extras-editors.test.tsx
+++ b/packages/perseus-editor/src/__tests__/items-extras-editors.test.tsx
@@ -1,0 +1,59 @@
+import "@testing-library/jest-dom";
+import {render, screen} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import ItemExtrasEditor from "../item-extras-editor";
+
+describe("ItemExtrasEditor", () => {
+    it("should render correctly with default props", () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+
+        // Act
+        render(<ItemExtrasEditor onChange={onChangeMock} />);
+
+        // Assert
+        expect(
+            screen.getByLabelText("Show periodic table:"),
+        ).toBeInTheDocument();
+        expect(screen.getByLabelText("Show periodic table:")).not.toBeChecked();
+    });
+
+    it("should call onChange with updated calculator value", () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+        render(<ItemExtrasEditor calculator={false} onChange={onChangeMock} />);
+        const checkbox = screen.getByLabelText("Show calculator:");
+
+        // Act
+        userEvent.click(checkbox);
+
+        // Assert
+        expect(onChangeMock).toHaveBeenCalledWith({calculator: true});
+    });
+
+    it("should call onChange with updated periodicTableWithKey value when periodicTable is unchecked", () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+        render(
+            <ItemExtrasEditor
+                periodicTable={true}
+                periodicTableWithKey={true}
+                onChange={onChangeMock}
+            />,
+        );
+        const checkbox = screen.getByLabelText("Show periodic table:");
+
+        // Act
+        userEvent.click(checkbox);
+
+        // Assert
+        expect(onChangeMock).toHaveBeenNthCalledWith(1, {
+            periodicTable: false,
+        });
+        expect(onChangeMock).toHaveBeenNthCalledWith(2, {
+            periodicTableWithKey: false,
+        });
+    });
+});

--- a/packages/perseus-editor/src/item-extras-editor.tsx
+++ b/packages/perseus-editor/src/item-extras-editor.tsx
@@ -79,6 +79,13 @@ class ItemExtrasEditor extends React.Component<Props> {
                                     this.props.onChange({
                                         periodicTable: e.target.checked,
                                     });
+                                    if (!e.target.checked) {
+                                        // When we remove the periodic table,
+                                        // we should also remove sub-options.
+                                        this.props.onChange({
+                                            periodicTableWithKey: false,
+                                        });
+                                    }
                                 }}
                             />
                         </label>

--- a/packages/perseus-editor/src/item-extras-editor.tsx
+++ b/packages/perseus-editor/src/item-extras-editor.tsx
@@ -51,6 +51,13 @@ class ItemExtrasEditor extends React.Component<Props> {
                                     this.props.onChange({
                                         calculator: e.target.checked,
                                     });
+                                    if (!e.target.checked) {
+                                        // When we remove the periodic table,
+                                        // we should also remove sub-options.
+                                        this.props.onChange({
+                                            periodicTableWithKey: false,
+                                        });
+                                    }
                                 }}
                             />
                         </label>


### PR DESCRIPTION
When table option unchecked, ensure key is unchecked.
This would only have made the setting "sticky" for the exercise and would have had no effect on the published, rendered result.

Issue: LC-1534

Testing strategy:
Unit tests added. In ZND or after deploy, try:
- Check table option
- Check key option
- Uncheck table option
- Verify that no "unsaved change" is registered
- Verify that checking table option again shows unchecked key