### PR TITLE
Make Perseus error reports easier to triage

### DIFF
--- a/.changeset/proud-rockets-roll.md
+++ b/.changeset/proud-rockets-roll.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Widget rendering errors are now reported as distinct errors to the Perseus logging infrastructure.

--- a/packages/perseus/src/__tests__/error-boundary.test.tsx
+++ b/packages/perseus/src/__tests__/error-boundary.test.tsx
@@ -1,0 +1,76 @@
+import * as React from "react";
+import {screen, render, logRoles} from "@testing-library/react";
+import ErrorBoundary from "../error-boundary";
+
+import {testDependencies} from "../../../../testing/test-dependencies";
+import * as Dependencies from "../dependencies";
+
+import "@testing-library/jest-dom";
+
+const ProblematicComponent = () => {
+    throw new Error("I can haz error");
+};
+
+describe("error boundary", () => {
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("should render children", () => {
+        render(
+            <ErrorBoundary>
+                <span>Hello world</span>
+            </ErrorBoundary>,
+        );
+
+        expect(screen.getByText("Hello world")).toBeInTheDocument();
+    });
+
+    it("should render error icon when children error", () => {
+        render(
+            <ErrorBoundary>
+                <ProblematicComponent />
+            </ErrorBoundary>,
+        );
+
+        expect(screen.getByRole("img")).toBeInTheDocument();
+        expect(screen.getByTitle("Rendering Error!")).toBeInTheDocument();
+    });
+
+    it("should call the onError callback when children error", () => {
+        const onErrorCallback = jest.fn();
+
+        render(
+            <ErrorBoundary onError={onErrorCallback}>
+                <ProblematicComponent />
+            </ErrorBoundary>,
+        );
+
+        expect(onErrorCallback).toHaveBeenCalled();
+    });
+
+    it("should log the error when children error", () => {
+        const errorSpy = jest.spyOn(testDependencies.Log, "error");
+
+        render(
+            <ErrorBoundary>
+                <ProblematicComponent />
+            </ErrorBoundary>,
+        );
+
+        expect(errorSpy).toHaveBeenCalledWith(
+            "Unhandled Perseus error: I can haz error",
+            "Internal",
+            {
+                cause: expect.anything(),
+                loggedMetadata: {
+                    componentStack: `
+    in ProblematicComponent
+    in ErrorBoundary`,
+                },
+            },
+        );
+    });
+});

--- a/packages/perseus/src/__tests__/error-boundary.test.tsx
+++ b/packages/perseus/src/__tests__/error-boundary.test.tsx
@@ -1,9 +1,9 @@
+import {screen, render} from "@testing-library/react";
 import * as React from "react";
-import {screen, render, logRoles} from "@testing-library/react";
-import ErrorBoundary from "../error-boundary";
 
 import {testDependencies} from "../../../../testing/test-dependencies";
 import * as Dependencies from "../dependencies";
+import ErrorBoundary from "../error-boundary";
 
 import "@testing-library/jest-dom";
 

--- a/packages/perseus/src/error-boundary.tsx
+++ b/packages/perseus/src/error-boundary.tsx
@@ -35,7 +35,10 @@ class ErrorBoundary extends React.Component<Props, State> {
             {
                 cause: error,
                 loggedMetadata: {
-                    componentStack: info.componentStack,
+                    componentStack:
+                        "componentStack" in info
+                            ? info.componentStack
+                            : "componentStack not provided",
                     ...this.props.metadata,
                 },
             },
@@ -50,7 +53,8 @@ class ErrorBoundary extends React.Component<Props, State> {
             // errors into inline elements.
             // TODO(michaelpolyak): Link error icon to "Report a problem".
             return (
-                <svg height="16" width="16" viewBox="0 0 16 16">
+                <svg height="16" width="16" viewBox="0 0 16 16" role={"img"}>
+                    <title>Rendering Error!</title>
                     <path
                         d="m8 16c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm0-3c0.55 0 1-0.45 1-1s-0.45-1-1-1-1 0.45-1 1 0.45 1 1 1zm0-9c-0.55 0-1 0.45-1 1v4c0 0.55.45 1 1 1s1-0.45 1-1v-4c0-0.55-0.45-1-1-1z"
                         fill="#d92916"

--- a/packages/perseus/src/error-boundary.tsx
+++ b/packages/perseus/src/error-boundary.tsx
@@ -22,13 +22,24 @@ class ErrorBoundary extends React.Component<Props, State> {
     componentDidCatch(error: Error, info: any) {
         this.setState({error: error.toString()});
         this.props.onError?.(error, info);
-        Log.error("Perseus error boundary caught error", Errors.Internal, {
-            cause: error,
-            loggedMetadata: {
-                componentStack: info.componentStack,
-                ...this.props.metadata,
+        Log.error(
+            // NOTE(jeremy): We concatenate the error messsage here. Typical
+            // Khan Academy error handling guidance says that you should never
+            // "build" the error message that might be sent to our error
+            // reporting tool (currently Sentry). However, if we don't
+            // differentiate between the different errors that are thrown, they
+            // all end up being grouped as a single Sentry event, which is very
+            // unhelpful.
+            "Unhandled Perseus error: " + error.message,
+            Errors.Internal,
+            {
+                cause: error,
+                loggedMetadata: {
+                    componentStack: info.componentStack,
+                    ...this.props.metadata,
+                },
             },
-        });
+        );
     }
 
     render(): React.ReactNode {

--- a/packages/perseus/src/error-boundary.tsx
+++ b/packages/perseus/src/error-boundary.tsx
@@ -36,7 +36,7 @@ class ErrorBoundary extends React.Component<Props, State> {
                 cause: error,
                 loggedMetadata: {
                     componentStack:
-                        "componentStack" in info
+                        !!info && "componentStack" in info
                             ? info.componentStack
                             : "componentStack not provided",
                     ...this.props.metadata,


### PR DESCRIPTION
## Summary:

I was looking at our Sentry dashboard and noticed that _all_ Perseus rendering errors are grouped together under one event. This is largely due to the fact that the error boundary uses the same string for all errors it catches.

So this PR changes that error logging so that each different type of error caught by the boundary are logged as a different error (Sentry event). This will help us to triage/review errors in Sentry and not group all Perseus errors together in host applications.

Issue: "none"

## Test plan: