### PR TITLE
Fix padding on correct pill

### DIFF
--- a/.changeset/tame-maps-do.md
+++ b/.changeset/tame-maps-do.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix label image answer pill padding when correct answer registered

--- a/packages/perseus/src/styles/widgets/label-image.less
+++ b/packages/perseus/src/styles/widgets/label-image.less
@@ -5,7 +5,8 @@
             margin: 0;
         }
     }
-    button[id*="perseus-label-image-widget-answer-pill"] {
+    button[id*="perseus-label-image-widget-answer-pill"],
+    div[id*="perseus-label-image-widget-answer-pill"] {
         // Reset text content.
         div.paragraph {
             all: revert;


### PR DESCRIPTION
## Summary:
Fixes padding on correct pills.
The CSS was only targeting `button` tags with the given ID, but when the pill becomes non-interactive, it turns into a `div`.
Corrected the styles to account for this change.
<img width="439" alt="Screenshot 2023-12-05 at 4 38 29 PM" src="https://github.com/Khan/perseus/assets/23404711/882f84fb-95ce-4bc0-a1bf-f1fa77fe245d">

Issue: LC-1525

Testing strategy:
Ensure pill padding is consistent in all states.