### PR TITLE
Ensure that we're always getting the correct keypad bounds

### DIFF
--- a/.changeset/loud-chefs-taste.md
+++ b/.changeset/loud-chefs-taste.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": minor
+---
+
+Ensure that we're always getting the current keypadBounds

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -361,26 +361,7 @@ class MathInput extends React.Component<Props, State> {
 
         this.mathField.focus();
         this.props?.onFocus();
-        this.setState({focused: true}, () => {
-            // NOTE(charlie): We use `setTimeout` to allow for a layout pass to
-            // occur. Otherwise, the keypad is measured incorrectly. Ideally,
-            // we'd use requestAnimationFrame here, but it's unsupported on
-            // Android Browser 4.3.
-            setTimeout(() => {
-                console.log("scroll");
-                if (this._isMounted) {
-                    // TODO(benkomalo): the keypad is animating at this point,
-                    // so we can't call _cacheKeypadBounds(), even though
-                    // it'd be nice to do so. It should probably be the case
-                    // that the higher level controller tells us when the
-                    // keypad is settled (then scrollIntoView wouldn't have
-                    // to make assumptions about that either).
-                    const maybeKeypadNode =
-                        this.props.keypadElement?.getDOMNode();
-                    scrollIntoView(this._container, maybeKeypadNode);
-                }
-            });
-        });
+        this.setState({focused: true});
     };
 
     /**

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -361,7 +361,25 @@ class MathInput extends React.Component<Props, State> {
 
         this.mathField.focus();
         this.props?.onFocus();
-        this.setState({focused: true});
+        this.setState({focused: true}, () => {
+            // NOTE(charlie): We use `setTimeout` to allow for a layout pass to
+            // occur. Otherwise, the keypad is measured incorrectly. Ideally,
+            // we'd use requestAnimationFrame here, but it's unsupported on
+            // Android Browser 4.3.
+            setTimeout(() => {
+                if (this._isMounted) {
+                    // TODO(benkomalo): the keypad is animating at this point,
+                    // so we can't call _cacheKeypadBounds(), even though
+                    // it'd be nice to do so. It should probably be the case
+                    // that the higher level controller tells us when the
+                    // keypad is settled (then scrollIntoView wouldn't have
+                    // to make assumptions about that either).
+                    const maybeKeypadNode =
+                        this.props.keypadElement?.getDOMNode();
+                    scrollIntoView(this._container, maybeKeypadNode);
+                }
+            });
+        });
     };
 
     /**

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -125,7 +125,7 @@ class MathInput extends React.Component<Props, State> {
             const bounds = this._getKeypadBounds();
 
             // If there are no bounds, then the keypad is not mounted, so we
-            // assume that the touch is not within the keypad bounds.
+            // assume that the event is not within the keypad bounds.
             if (!bounds) {
                 return false;
             }

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -123,9 +123,15 @@ class MathInput extends React.Component<Props, State> {
 
         const isWithinKeypadBounds = (x: number, y: number): boolean => {
             const bounds = this._getKeypadBounds();
+
+            // If there are no bounds, then the keypad is not mounted, so we
+            // assume that the touch is not within the keypad bounds.
+            if (!bounds) {
+                return false;
+            }
+
             return (
-                (bounds &&
-                    bounds.left <= x &&
+                (bounds.left <= x &&
                     bounds.right >= x &&
                     bounds.top <= y &&
                     bounds.bottom >= y) ||
@@ -262,10 +268,16 @@ class MathInput extends React.Component<Props, State> {
     };
 
     /** Returns the current bounds of the keypadElement */
-    _getKeypadBounds: () => any = () => {
-        const keypadNode = this.props.keypadElement?.getDOMNode() as Element;
-        return keypadNode.getBoundingClientRect();
-    };
+    _getKeypadBounds(): DOMRect | null {
+        const keypadNode = this.props.keypadElement?.getDOMNode();
+
+        // If the keypad is mounted, return its bounds. Otherwise, return null.
+        if (keypadNode instanceof Element) {
+            return keypadNode.getBoundingClientRect();
+        }
+
+        return null;
+    }
 
     _updateCursorHandle: (arg1?: boolean) => void = (animateIntoPosition) => {
         const containerBounds = this._container.getBoundingClientRect();

--- a/packages/math-input/src/components/input/scroll-into-view.ts
+++ b/packages/math-input/src/components/input/scroll-into-view.ts
@@ -18,6 +18,7 @@ export const scrollIntoView = (containerNode, keypadNode) => {
     // TODO(charlie): There's no need for us to be reading the keypad bounds
     // here, since they're pre-determined by logic in the store. We should
     // instead pass around an object that knows the bounds.
+    console.log("scrolling into view", containerNode, keypadNode);
     const containerBounds = containerNode.getBoundingClientRect();
     const containerBottomPx = containerBounds.bottom;
     const containerTopPx = containerBounds.top;

--- a/packages/math-input/src/components/input/scroll-into-view.ts
+++ b/packages/math-input/src/components/input/scroll-into-view.ts
@@ -18,7 +18,6 @@ export const scrollIntoView = (containerNode, keypadNode) => {
     // TODO(charlie): There's no need for us to be reading the keypad bounds
     // here, since they're pre-determined by logic in the store. We should
     // instead pass around an object that knows the bounds.
-    console.log("scrolling into view", containerNode, keypadNode);
     const containerBounds = containerNode.getBoundingClientRect();
     const containerBottomPx = containerBounds.bottom;
     const containerTopPx = containerBounds.top;


### PR DESCRIPTION
## Summary:
While investigating the blur issue from LC-1523, I discovered that we have some historical logic for caching our keypad bounds. None of that is necessary any longer. 

Fixing/removing this logic solves LC-1523 by ensuring that we are always getting the _current_ keypadBounds, which allows us to be able to click under the input again to blur it after the keypad has been closed/animated out of view.

It seems we've added a resize observer directly to the keypad, so we no longer need a bunch of event listeners in our MathInput either!

Issue: LC-1523

## Test plan:
- Manual testing of multiple device orientations and resizes 