### PR TITLE
Darken green to match pill in label image widget

### DIFF
--- a/packages/perseus/src/widgets/label-image/marker.tsx
+++ b/packages/perseus/src/widgets/label-image/marker.tsx
@@ -288,7 +288,7 @@ const styles = StyleSheet.create({
     },
 
     markerCorrect: {
-        background: Color.green,
+        background: "#00880b", // WB green darkened by 18%
     },
 
     markerIncorrect: {


### PR DESCRIPTION
## Summary
Darker green to match correct pill color

Issue: LC-1554

## Testing strategy:
Is green darker? Good.