### PR TITLE
add locale to convertDotToTimes logic

### DIFF
--- a/.changeset/twenty-moles-nail.md
+++ b/.changeset/twenty-moles-nail.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/math-input": minor
+"@khanacademy/perseus": minor
+---
+
+Localize the multiplication symbol in MathInput

--- a/packages/math-input/src/components/keypad/__tests__/keypad.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/keypad.test.tsx
@@ -1,3 +1,4 @@
+import * as wbi18n from "@khanacademy/wonder-blocks-i18n";
 import {render, screen} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as React from "react";
@@ -147,6 +148,40 @@ describe("keypad", () => {
             <Keypad
                 onClickKey={() => {}}
                 convertDotToTimes={true}
+                onAnalyticsEvent={async () => {}}
+            />,
+        );
+
+        // Assert
+        expect(screen.getByTestId("TIMES")).toBeInTheDocument();
+    });
+
+    it(`forces CDOT in locales that require it`, () => {
+        // Arrange
+        jest.spyOn(wbi18n, "getLocale").mockReturnValue("az");
+
+        // Act
+        render(
+            <Keypad
+                onClickKey={() => {}}
+                convertDotToTimes={true}
+                onAnalyticsEvent={async () => {}}
+            />,
+        );
+
+        // Assert
+        expect(screen.getByTestId("CDOT")).toBeInTheDocument();
+    });
+
+    it(`forces TIMES in locales that require it`, () => {
+        // Arrange
+        jest.spyOn(wbi18n, "getLocale").mockReturnValue("fr");
+
+        // Act
+        render(
+            <Keypad
+                onClickKey={() => {}}
+                convertDotToTimes={false}
                 onAnalyticsEvent={async () => {}}
             />,
         );

--- a/packages/math-input/src/components/keypad/__tests__/keypad.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/keypad.test.tsx
@@ -171,6 +171,7 @@ describe("keypad", () => {
 
         // Assert
         expect(screen.getByTestId("CDOT")).toBeInTheDocument();
+        expect(screen.queryByTestId("TIMES")).not.toBeInTheDocument();
     });
 
     it(`forces TIMES in locales that require it`, () => {
@@ -188,6 +189,7 @@ describe("keypad", () => {
 
         // Assert
         expect(screen.getByTestId("TIMES")).toBeInTheDocument();
+        expect(screen.queryByTestId("CDOT")).not.toBeInTheDocument();
     });
 
     it(`hides the tabs if providing the Fraction Keypad`, () => {

--- a/packages/math-input/src/components/keypad/shared-keys.tsx
+++ b/packages/math-input/src/components/keypad/shared-keys.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import Keys from "../../data/key-configs";
+import {convertDotToTimesByLocale} from "../../utils";
 
 import {KeypadButton} from "./keypad-button";
 import {getCursorContextConfig} from "./utils";
@@ -56,7 +57,11 @@ export default function SharedKeys(props: Props) {
 
             {/* Row 2 */}
             <KeypadButton
-                keyConfig={convertDotToTimes ? Keys.TIMES : Keys.CDOT}
+                keyConfig={
+                    convertDotToTimesByLocale(!!convertDotToTimes)
+                        ? Keys.TIMES
+                        : Keys.CDOT
+                }
                 onClickKey={onClickKey}
                 coord={[4, 1]}
                 secondary

--- a/packages/math-input/src/index.ts
+++ b/packages/math-input/src/index.ts
@@ -40,6 +40,7 @@ export {
 // External API of the "Provided" keypad component
 export {keypadElementPropType} from "./components/prop-types";
 export type {KeypadAPI, KeypadConfiguration} from "./types";
+export {convertDotToTimesByLocale} from "./utils";
 
 // Key list, configuration map, and types
 export type {default as Keys} from "./data/keys";

--- a/packages/math-input/src/utils.test.ts
+++ b/packages/math-input/src/utils.test.ts
@@ -1,0 +1,33 @@
+import * as wbi18n from "@khanacademy/wonder-blocks-i18n";
+
+import {convertDotToTimesByLocale} from "./utils";
+
+describe("utils", () => {
+    describe("multiplicationSymbol", () => {
+        it("passes through convertDotToTimes in locales that don't override it", () => {
+            jest.spyOn(wbi18n, "getLocale").mockReturnValue("en");
+
+            const result1 = convertDotToTimesByLocale(true);
+            const result2 = convertDotToTimesByLocale(false);
+
+            expect(result1).toBe(true);
+            expect(result2).toBe(false);
+        });
+
+        it("overrides with false for locales that only use dot", () => {
+            jest.spyOn(wbi18n, "getLocale").mockReturnValue("az");
+
+            const result = convertDotToTimesByLocale(true);
+
+            expect(result).toBe(false);
+        });
+
+        it("overrides with true for locales that only use x", () => {
+            jest.spyOn(wbi18n, "getLocale").mockReturnValue("fr");
+
+            const result = convertDotToTimesByLocale(false);
+
+            expect(result).toBe(true);
+        });
+    });
+});

--- a/packages/math-input/src/utils.ts
+++ b/packages/math-input/src/utils.ts
@@ -34,8 +34,18 @@ const CDOT_ONLY = [
     "uz",
 ];
 const TIMES_ONLY = ["fr", "tr", "pt-pt"];
-// false: use CDOT
-// true: use TIMES
+
+/**
+ * convertDotToTimes (aka `times`) is an option the content creators have to
+ * use × (TIMES) rather than · (CDOT) for multiplication (for younger learners).
+ * Some locales _only_ use one or the other for all multiplication regardless
+ * of age.
+ *
+ * convertDotToTimesByLocale overrides convertDotToTimes for those locales.
+ *
+ * @param {boolean} convertDotToTimes - the setting set by content creators
+ * @returns {boolean} - true to convert to × (TIMES), false to use · (CDOT)
+ */
 export function convertDotToTimesByLocale(convertDotToTimes: boolean): boolean {
     const locale = getLocale();
 

--- a/packages/math-input/src/utils.ts
+++ b/packages/math-input/src/utils.ts
@@ -1,4 +1,4 @@
-import {getDecimalSeparator} from "@khanacademy/wonder-blocks-i18n";
+import {getDecimalSeparator, getLocale} from "@khanacademy/wonder-blocks-i18n";
 
 export const DecimalSeparator = {
     COMMA: ",",
@@ -15,3 +15,37 @@ export const decimalSeparator: string =
     getDecimalSeparator() === ","
         ? DecimalSeparator.COMMA
         : DecimalSeparator.PERIOD;
+
+const CDOT_ONLY = [
+    "az",
+    "cs",
+    "da",
+    "de",
+    "hu",
+    "hy",
+    "kk",
+    "ky",
+    "lt",
+    "lv",
+    "nb",
+    "sk",
+    "sr",
+    "sv",
+    "uz",
+];
+const TIMES_ONLY = ["fr", "tr", "pt-pt"];
+// false: use CDOT
+// true: use TIMES
+export function convertDotToTimesByLocale(convertDotToTimes: boolean): boolean {
+    const locale = getLocale();
+
+    if (CDOT_ONLY.includes(locale)) {
+        return false;
+    }
+
+    if (TIMES_ONLY.includes(locale)) {
+        return true;
+    }
+
+    return convertDotToTimes;
+}

--- a/packages/perseus/src/components/math-input.tsx
+++ b/packages/perseus/src/components/math-input.tsx
@@ -6,6 +6,7 @@ import {
     mathQuillInstance,
     CursorContext,
     getCursorContext,
+    convertDotToTimesByLocale,
 } from "@khanacademy/math-input";
 import Clickable from "@khanacademy/wonder-blocks-clickable";
 import Color, {fade} from "@khanacademy/wonder-blocks-color";
@@ -170,7 +171,11 @@ class MathInput extends React.Component<Props, State> {
                             // Use the specified symbol to represent multiplication
                             // TODO(alex): Add an option to disallow variables, in
                             // which case 'x' should get converted to '\\times'
-                            if (this.props.convertDotToTimes) {
+                            if (
+                                convertDotToTimesByLocale(
+                                    this.props.convertDotToTimes,
+                                )
+                            ) {
                                 value = value.replace(/\\cdot/g, "\\times");
 
                                 // Preserve cursor position in the common case:


### PR DESCRIPTION
## Summary:
Basically just a helper that overwrites `convertDotToTimes` depending on specific locales.

Issue: LC-1454

## Test plan:

Confirmed working in French at least 🤷 ([Webapp PR](https://github.com/Khan/webapp/pull/18609)). The exercise has `times` aka `convertDotToTimes` set to false, but still renders the times.
<img width="869" alt="Screenshot 2023-12-08 at 1 50 03 PM" src="https://github.com/Khan/perseus/assets/16308368/9677c7ed-b327-4e2d-bb9e-d6750ef45f2f">