### PR TITLE
Make WB label into actual label tag

### DIFF
--- a/.changeset/light-coats-wink.md
+++ b/.changeset/light-coats-wink.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Make label for hide answers switch in Label Image Widget into label tag

--- a/packages/perseus/src/widgets/label-image/hide-answers-toggle.tsx
+++ b/packages/perseus/src/widgets/label-image/hide-answers-toggle.tsx
@@ -21,7 +21,7 @@ export const HideAnswersToggle = (props: {
                 onChange={props.onChange}
                 aria-labelledby={labelId}
             />
-            <LabelMedium id={labelId} htmlFor={switchId}>
+            <LabelMedium id={labelId} htmlFor={switchId} tag="label">
                 {strings.hideAnswersToggleLabel}
             </LabelMedium>
         </View>


### PR DESCRIPTION
## Summary
Apparently, for a label to be a label, we have to specify that the label is a label.

<img width="1354" alt="Screenshot 2023-12-12 at 1 02 53 PM" src="https://github.com/Khan/perseus/assets/23404711/5e5480c7-6c22-4336-9a4d-fedff71e1c1e">

Issue: LC-1561

### Testing strategy:
Label is label