### PR TITLE
Add financial calculator checkboxes to Item Extras Editor

### DIFF
--- a/.changeset/angry-doors-argue.md
+++ b/.changeset/angry-doors-argue.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+Add financial calculators to Item Extras

--- a/.changeset/smart-spoons-move.md
+++ b/.changeset/smart-spoons-move.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Update and export PerseusAnswerArea type

--- a/packages/perseus-editor/src/__stories__/item-editor.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/item-editor.stories.tsx
@@ -1,0 +1,37 @@
+/* eslint-disable react/prop-types */
+import * as React from "react";
+
+import ItemExtrasEditor from "../item-extras-editor";
+
+import type {Meta, StoryObj} from "@storybook/react";
+
+import "../styles/perseus-editor.less";
+
+type Props = React.ComponentProps<typeof ItemExtrasEditor>;
+
+const Wrapper = (props: Props) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const {onChange, ...rest} = props;
+    const [extras, setExtras] =
+        React.useState<Partial<typeof ItemExtrasEditor.defaultProps>>(rest);
+
+    return (
+        <ItemExtrasEditor
+            {...extras}
+            onChange={(e) => setExtras((prevExtras) => ({...prevExtras, ...e}))}
+        />
+    );
+};
+
+const story: Meta<Props> = {
+    title: "Perseus/Editor/Item Extras Editor",
+    component: ItemExtrasEditor,
+    render: (args) => <Wrapper {...args} />,
+};
+export default story;
+
+type Story = StoryObj<typeof ItemExtrasEditor>;
+
+export const Default: Story = {
+    args: {...ItemExtrasEditor.defaultProps},
+};

--- a/packages/perseus-editor/src/__tests__/item-extras-editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/item-extras-editor.test.tsx
@@ -65,4 +65,50 @@ describe("ItemExtrasEditor", () => {
             periodicTableWithKey: false,
         });
     });
+
+    it("should call onChange on dependent values when financialCalculator is checked", () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+        render(
+            <ItemExtrasEditor
+                financialCalculator={false}
+                onChange={onChangeMock}
+            />,
+        );
+        const checkbox = screen.getByLabelText("Show financial calculator:");
+
+        // Act
+        userEvent.click(checkbox);
+
+        // Assert
+        expect(onChangeMock).toHaveBeenCalledWith({
+            financialCalculator: true,
+            financialCalculatorMonthlyPayment: true,
+            financialCalculatorTotalAmount: true,
+            financialCalculatorTimeToPayOff: true,
+        });
+    });
+
+    it("should call onChange on dependent values when financialCalculator is unchecked", () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+        render(
+            <ItemExtrasEditor
+                financialCalculator={true}
+                onChange={onChangeMock}
+            />,
+        );
+        const checkbox = screen.getByLabelText("Show financial calculator:");
+
+        // Act
+        userEvent.click(checkbox);
+
+        // Assert
+        expect(onChangeMock).toHaveBeenCalledWith({
+            financialCalculator: false,
+            financialCalculatorMonthlyPayment: false,
+            financialCalculatorTotalAmount: false,
+            financialCalculatorTimeToPayOff: false,
+        });
+    });
 });

--- a/packages/perseus-editor/src/item-extras-editor.tsx
+++ b/packages/perseus-editor/src/item-extras-editor.tsx
@@ -1,29 +1,16 @@
-import {components} from "@khanacademy/perseus";
+import {components, ItemExtras} from "@khanacademy/perseus";
 import * as React from "react";
+
+import type {PerseusAnswerArea} from "@khanacademy/perseus";
 
 const {InfoTip} = components;
 
-const ItemExtras = [
-    "calculator",
-    "chi2Table",
-    "financialCalculator",
-    "financialCalculatorMonthlyPayment",
-    "financialCalculatorTotalAmount",
-    "financialCalculatorTimeToPayOff",
-    "periodicTable",
-    "periodicTableWithKey",
-    "tTable",
-    "zTable",
-] as const;
-
-type ItemExtrasProps = Record<typeof ItemExtras[number], boolean>;
-
-type Props = ItemExtrasProps & {
-    onChange: (props: Partial<ItemExtrasProps>) => void;
+type Props = PerseusAnswerArea & {
+    onChange: (props: Partial<PerseusAnswerArea>) => void;
 };
 
 class ItemExtrasEditor extends React.Component<Props> {
-    static defaultProps: ItemExtrasProps = {
+    static defaultProps: PerseusAnswerArea = {
         calculator: false,
         chi2Table: false,
         financialCalculator: false,
@@ -37,6 +24,8 @@ class ItemExtrasEditor extends React.Component<Props> {
     };
 
     componentDidUpdate(prevProps: Readonly<Props>): void {
+        // If no financial calculator options are checked, uncheck the
+        // financial calculator option.
         if (
             prevProps.financialCalculator &&
             !this.props.financialCalculatorMonthlyPayment &&
@@ -49,10 +38,10 @@ class ItemExtrasEditor extends React.Component<Props> {
         }
     }
 
-    serialize: () => any = () => {
-        const data = {};
+    serialize: () => PerseusAnswerArea = () => {
+        const data = {...ItemExtrasEditor.defaultProps};
         for (const key of ItemExtras) {
-            data[key] = this.props[key];
+            data[key] = !!this.props[key];
         }
         return data;
     };
@@ -123,7 +112,7 @@ class ItemExtrasEditor extends React.Component<Props> {
                                 indent
                             />
                             <ItemExtraCheckbox
-                                label="Include time to pay off:"
+                                label="Include time-to-pay-off:"
                                 infoTip="This provides the student with the ability to view a time to pay off calculator; e.g., given a loan amount, interest rate, and monthly payment, how long will it take to pay off the loan?"
                                 checked={
                                     this.props.financialCalculatorTimeToPayOff

--- a/packages/perseus-editor/src/item-extras-editor.tsx
+++ b/packages/perseus-editor/src/item-extras-editor.tsx
@@ -3,14 +3,20 @@ import * as React from "react";
 
 const {InfoTip} = components;
 
-type ItemExtrasProps = {
-    calculator: boolean;
-    chi2Table: boolean;
-    periodicTable: boolean;
-    periodicTableWithKey: boolean;
-    tTable: boolean;
-    zTable: boolean;
-};
+const ItemExtras = [
+    "calculator",
+    "chi2Table",
+    "financialCalculator",
+    "financialCalculatorMonthlyPayment",
+    "financialCalculatorTotalAmount",
+    "financialCalculatorTimeToPayOff",
+    "periodicTable",
+    "periodicTableWithKey",
+    "tTable",
+    "zTable",
+] as const;
+
+type ItemExtrasProps = Record<typeof ItemExtras[number], boolean>;
 
 type Props = ItemExtrasProps & {
     onChange: (props: Partial<ItemExtrasProps>) => void;
@@ -20,159 +26,208 @@ class ItemExtrasEditor extends React.Component<Props> {
     static defaultProps: ItemExtrasProps = {
         calculator: false,
         chi2Table: false,
+        financialCalculator: false,
+        financialCalculatorMonthlyPayment: false,
+        financialCalculatorTotalAmount: false,
+        financialCalculatorTimeToPayOff: false,
         periodicTable: false,
         periodicTableWithKey: false,
         tTable: false,
         zTable: false,
     };
 
+    componentDidUpdate(prevProps: Readonly<Props>): void {
+        if (
+            prevProps.financialCalculator &&
+            !this.props.financialCalculatorMonthlyPayment &&
+            !this.props.financialCalculatorTotalAmount &&
+            !this.props.financialCalculatorTimeToPayOff
+        ) {
+            this.props.onChange({
+                financialCalculator: false,
+            });
+        }
+    }
+
     serialize: () => any = () => {
-        return {
-            calculator: this.props.calculator,
-            chi2Table: this.props.chi2Table,
-            periodicTable: this.props.periodicTable,
-            periodicTableWithKey: this.props.periodicTableWithKey,
-            tTable: this.props.tTable,
-            zTable: this.props.zTable,
-        };
+        const data = {};
+        for (const key of ItemExtras) {
+            data[key] = this.props[key];
+        }
+        return data;
     };
 
     render(): React.ReactNode {
         return (
             <div className="perseus-answer-editor">
                 <div className="perseus-answer-options">
-                    <div>
-                        <label>
-                            Show calculator:{" "}
-                            <input
-                                type="checkbox"
-                                checked={this.props.calculator}
+                    <ItemExtraCheckbox
+                        label="Show calculator:"
+                        infoTip="Use the calculator when completing difficult calculations is NOT the intent of the question. DON’T use the calculator when testing the student’s ability to complete different types of computations."
+                        checked={this.props.calculator}
+                        onChange={(e) => {
+                            this.props.onChange({
+                                calculator: e.target.checked,
+                            });
+                        }}
+                    />
+
+                    <ItemExtraCheckbox
+                        label="Show financial calculator:"
+                        infoTip="This provides the student with the ability to view a financial calculator, e.g., for answering financial questions. Once checked, requires at least one of the three options below to be checked."
+                        checked={this.props.financialCalculator}
+                        onChange={(e) => {
+                            this.props.onChange({
+                                financialCalculator: e.target.checked,
+                                // If the financial calculator is unchecked,
+                                // this needs to be reset. All checked by
+                                // default.
+                                financialCalculatorMonthlyPayment:
+                                    e.target.checked,
+                                financialCalculatorTotalAmount:
+                                    e.target.checked,
+                                financialCalculatorTimeToPayOff:
+                                    e.target.checked,
+                            });
+                        }}
+                    />
+
+                    {this.props.financialCalculator && (
+                        <>
+                            <ItemExtraCheckbox
+                                label="Include monthly payment:"
+                                infoTip="This provides the student with the ability to view a monthly payment calculator; e.g., given a loan amount, interest rate, and term, what is the monthly payment?"
+                                checked={
+                                    this.props.financialCalculatorMonthlyPayment
+                                }
                                 onChange={(e) => {
                                     this.props.onChange({
-                                        calculator: e.target.checked,
+                                        financialCalculatorMonthlyPayment:
+                                            e.target.checked,
                                     });
                                 }}
+                                indent
                             />
-                        </label>
-                        <InfoTip>
-                            Use the calculator when completing difficult
-                            calculations is NOT the intent of the question.
-                            DON’T use the calculator when testing the student’s
-                            ability to complete different types of computations.
-                        </InfoTip>
-                    </div>
-
-                    <div>
-                        <label>
-                            Show periodic table:{" "}
-                            <input
-                                type="checkbox"
-                                checked={this.props.periodicTable}
+                            <ItemExtraCheckbox
+                                label="Include total amount:"
+                                infoTip="This provides the student with the ability to view a total amount calculator; e.g., given a monthly payment, interest rate, and term, what is the total amount to be paid?"
+                                checked={
+                                    this.props.financialCalculatorTotalAmount
+                                }
                                 onChange={(e) => {
                                     this.props.onChange({
-                                        periodicTable: e.target.checked,
-                                        // If the periodic table is unchecked,
-                                        // this needs to be reset. If table is
-                                        // checked, it should already be false.
-                                        periodicTableWithKey: false,
+                                        financialCalculatorTotalAmount:
+                                            e.target.checked,
                                     });
                                 }}
+                                indent
                             />
-                        </label>
-                        <InfoTip>
-                            This provides the student with the ability to view a
-                            periodic table of the elements, e.g., for answering
-                            chemistry questions.
-                        </InfoTip>
-                    </div>
-
-                    {this.props.periodicTable && (
-                        <div>
-                            <label>
-                                Include key/legend with periodic table:{" "}
-                                <input
-                                    type="checkbox"
-                                    checked={this.props.periodicTableWithKey}
-                                    onChange={(e) => {
-                                        this.props.onChange({
-                                            periodicTableWithKey:
-                                                e.target.checked,
-                                        });
-                                    }}
-                                />
-                            </label>
-                            <InfoTip>
-                                Include a key for HS courses, omit for AP
-                                chemistry.
-                            </InfoTip>
-                        </div>
+                            <ItemExtraCheckbox
+                                label="Include time to pay off:"
+                                infoTip="This provides the student with the ability to view a time to pay off calculator; e.g., given a loan amount, interest rate, and monthly payment, how long will it take to pay off the loan?"
+                                checked={
+                                    this.props.financialCalculatorTimeToPayOff
+                                }
+                                onChange={(e) => {
+                                    this.props.onChange({
+                                        financialCalculatorTimeToPayOff:
+                                            e.target.checked,
+                                    });
+                                }}
+                                indent
+                            />
+                        </>
                     )}
 
-                    <div>
-                        <label>
-                            Show z table (statistics):{" "}
-                            <input
-                                type="checkbox"
-                                checked={this.props.zTable}
-                                onChange={(e) => {
-                                    this.props.onChange({
-                                        zTable: e.target.checked,
-                                    });
-                                }}
-                            />
-                        </label>
-                        <InfoTip>
-                            This provides the student with the ability to view a
-                            table of critical values for the z distribution,
-                            e.g. for answering statistics questions.
-                        </InfoTip>
-                    </div>
+                    <ItemExtraCheckbox
+                        label="Show periodic table:"
+                        infoTip="This provides the student with the ability to view a periodic table of the elements, e.g., for answering chemistry questions."
+                        checked={this.props.periodicTable}
+                        onChange={(e) => {
+                            this.props.onChange({
+                                periodicTable: e.target.checked,
+                                // If the periodic table is unchecked,
+                                // this needs to be reset. If table is
+                                // checked, it should already be false.
+                                periodicTableWithKey: false,
+                            });
+                        }}
+                    />
 
-                    <div>
-                        <label>
-                            Show t table (statistics):{" "}
-                            <input
-                                type="checkbox"
-                                checked={this.props.tTable}
-                                onChange={(e) => {
-                                    this.props.onChange({
-                                        tTable: e.target.checked,
-                                    });
-                                }}
-                            />
-                        </label>
-                        <InfoTip>
-                            This provides the student with the ability to view a
-                            table of critical values for the Student's t
-                            distribution, e.g. for answering statistics
-                            questions.
-                        </InfoTip>
-                    </div>
+                    {this.props.periodicTable && (
+                        <ItemExtraCheckbox
+                            label="Include key/legend with periodic table:"
+                            infoTip="Include a key for HS courses; omit for AP chemistry."
+                            checked={this.props.periodicTableWithKey}
+                            onChange={(e) => {
+                                this.props.onChange({
+                                    periodicTableWithKey: e.target.checked,
+                                });
+                            }}
+                            indent
+                        />
+                    )}
 
-                    <div>
-                        <label>
-                            Show chi-squared table (statistics):{" "}
-                            <input
-                                type="checkbox"
-                                checked={this.props.chi2Table}
-                                onChange={(e) => {
-                                    this.props.onChange({
-                                        chi2Table: e.target.checked,
-                                    });
-                                }}
-                            />
-                        </label>
-                        <InfoTip>
-                            This provides the student with the ability to view a
-                            table of critical values for the chi-squared
-                            distribution, e.g. for answering statistics
-                            questions.
-                        </InfoTip>
-                    </div>
+                    <ItemExtraCheckbox
+                        label="Show z table (statistics):"
+                        infoTip="This provides the student with the ability to view a table of critical values for the z distribution, e.g. for answering statistics questions."
+                        checked={this.props.zTable}
+                        onChange={(e) => {
+                            this.props.onChange({
+                                zTable: e.target.checked,
+                            });
+                        }}
+                    />
+
+                    <ItemExtraCheckbox
+                        label="Show t table (statistics):"
+                        infoTip="This provides the student with the ability to view a table of critical values for the Student's t distribution, e.g. for answering statistics questions."
+                        checked={this.props.tTable}
+                        onChange={(e) => {
+                            this.props.onChange({
+                                tTable: e.target.checked,
+                            });
+                        }}
+                    />
+
+                    <ItemExtraCheckbox
+                        label="Show chi-squared table (statistics):"
+                        infoTip="This provides the student with the ability to view a table of critical values for the chi-squared distribution, e.g. for answering statistics questions."
+                        checked={this.props.chi2Table}
+                        onChange={(e) => {
+                            this.props.onChange({
+                                chi2Table: e.target.checked,
+                            });
+                        }}
+                    />
                 </div>
             </div>
         );
     }
 }
+
+const ItemExtraCheckbox = (props: {
+    label: string;
+    infoTip: string;
+    checked: boolean;
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    indent?: boolean;
+}) => (
+    <div
+        style={{
+            marginLeft: props.indent ? "10px" : "0px",
+        }}
+    >
+        <label>
+            {props.label}
+            <input
+                type="checkbox"
+                checked={props.checked}
+                onChange={props.onChange}
+            />
+        </label>
+        <InfoTip>{props.infoTip}</InfoTip>
+    </div>
+);
 
 export default ItemExtrasEditor;

--- a/packages/perseus/src/__testdata__/graphie.testdata.ts
+++ b/packages/perseus/src/__testdata__/graphie.testdata.ts
@@ -1,13 +1,13 @@
-import type {PerseusItem} from "../perseus-types";
+import {
+    ItemExtras,
+    type PerseusAnswerArea,
+    type PerseusItem,
+} from "../perseus-types";
 
 export const itemWithPieChart: PerseusItem = {
-    answerArea: {
-        calculator: false,
-        chi2Table: false,
-        periodicTable: false,
-        tTable: false,
-        zTable: false,
-    },
+    answerArea: Object.fromEntries(
+        ItemExtras.map((extra) => [extra, false]),
+    ) as PerseusAnswerArea,
     hints: [],
     itemDataVersion: {
         major: 0,

--- a/packages/perseus/src/__testdata__/server-item-renderer.testdata.ts
+++ b/packages/perseus/src/__testdata__/server-item-renderer.testdata.ts
@@ -1,8 +1,10 @@
-import type {
-    InputNumberWidget,
-    LabelImageWidget,
-    PerseusItem,
-    PerseusRenderer,
+import {
+    ItemExtras,
+    type InputNumberWidget,
+    type LabelImageWidget,
+    type PerseusItem,
+    type PerseusRenderer,
+    type PerseusAnswerArea,
 } from "../perseus-types";
 
 export const itemWithInput: PerseusItem = {
@@ -37,13 +39,9 @@ export const itemWithInput: PerseusItem = {
 };
 
 export const labelImageItem: PerseusItem = {
-    answerArea: {
-        calculator: false,
-        chi2Table: false,
-        periodicTable: false,
-        tTable: false,
-        zTable: false,
-    },
+    answerArea: Object.fromEntries(
+        ItemExtras.map((extra) => [extra, false]),
+    ) as PerseusAnswerArea,
     _multi: null,
     answer: null,
     hints: [],

--- a/packages/perseus/src/__tests__/mock-asset-loading-widget.tsx
+++ b/packages/perseus/src/__tests__/mock-asset-loading-widget.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 
 import AssetContext from "../asset-context";
+import {ItemExtras} from "../perseus-types";
 
-import type {PerseusItem} from "../perseus-types";
+import type {PerseusAnswerArea, PerseusItem} from "../perseus-types";
 import type {WidgetExports} from "../types";
 
 export const mockedAssetItem: PerseusItem = {
@@ -20,13 +21,9 @@ export const mockedAssetItem: PerseusItem = {
             },
         },
     },
-    answerArea: {
-        calculator: false,
-        chi2Table: false,
-        periodicTable: false,
-        tTable: false,
-        zTable: false,
-    },
+    answerArea: Object.fromEntries(
+        ItemExtras.map((extra) => [extra, false]),
+    ) as PerseusAnswerArea,
     itemDataVersion: {major: 0, minor: 1},
     hints: [],
     _multi: null,

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -64,6 +64,7 @@ export {default as PerseusMarkdown} from "./perseus-markdown";
 export {
     PerseusExpressionAnswerFormConsidered,
     plotterPlotTypes,
+    ItemExtras,
 } from "./perseus-types";
 export {traverse} from "./traversal";
 export {isItemRenderableByVersion} from "./renderability";
@@ -127,6 +128,7 @@ export type {
     PerseusExpressionWidgetOptions,
     PerseusPlotterWidgetOptions,
     PerseusRenderer,
+    PerseusAnswerArea,
 } from "./perseus-types";
 export type {Coord} from "./interactive2/types";
 export type {MarkerType} from "./widgets/label-image/types";

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -62,20 +62,29 @@ export type PerseusImageDetail = {
     height: number;
 };
 
-export type PerseusAnswerArea = {
-    // The user might benefit from using a statistics Z Table like https://www.ztable.net/
-    zTable: boolean;
-    // The user might benefit from using a statistics Chi Squared Table like https://people.richland.edu/james/lecture/m170/tbl-chi.html
-    chi2Table: boolean;
-    // The user might benefit from using a statistics T Table like https://www.statisticshowto.com/tables/t-distribution-table/
-    tTable: boolean;
+export const ItemExtras = [
     // The user might benefit from using a Scientific Calculator.  Provided on Khan Academy when true
-    calculator: boolean;
+    "calculator",
+    // The user might benefit from using a statistics Chi Squared Table like https://people.richland.edu/james/lecture/m170/tbl-chi.html
+    "chi2Table",
+    // The user might benefit from using a Financial Calculator.  Provided on Khan Academy when true
+    "financialCalculator",
+    // The user might benefit from a monthly payments calculator.  Provided on Khan Academy when true
+    "financialCalculatorMonthlyPayment",
+    // The user might benefit from a total amount calculator.  Provided on Khan Academy when true
+    "financialCalculatorTotalAmount",
+    // The user might benefit from a time to pay off calculator.  Provided on Khan Academy when true
+    "financialCalculatorTimeToPayOff",
     // The user might benefit from using a Periodic Table of Elements.  Provided on Khan Academy when true
-    periodicTable: boolean;
+    "periodicTable",
     // The user might benefit from using a Periodic Table of Elements with key.  Provided on Khan Academy when true
-    periodicTableWithKey?: boolean;
-};
+    "periodicTableWithKey",
+    // The user might benefit from using a statistics T Table like https://www.statisticshowto.com/tables/t-distribution-table/
+    "tTable",
+    // The user might benefit from using a statistics Z Table like https://www.ztable.net/
+    "zTable",
+] as const;
+export type PerseusAnswerArea = Record<typeof ItemExtras[number], boolean>;
 
 type Widget<Type extends string, Options> = {
     // The "type" of widget which will define what the Options field looks like

--- a/packages/perseus/src/widgets/__testdata__/expression.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/expression.testdata.ts
@@ -1,4 +1,14 @@
 import {
+    ItemExtras,
+    type PerseusExpressionWidgetOptions,
+    type Version,
+    type PerseusItem,
+    type PerseusRenderer,
+    type ExpressionWidget,
+    type PerseusAnswerArea,
+} from "../../perseus-types";
+
+import {
     arrayOfLength,
     randomBoolean,
     randomElement,
@@ -7,14 +17,6 @@ import {
     randomSentence,
     randomWord,
 } from "./randomizers";
-
-import type {
-    PerseusExpressionWidgetOptions,
-    Version,
-    PerseusItem,
-    PerseusRenderer,
-    ExpressionWidget,
-} from "../../perseus-types";
 
 const createItemJson = (
     widgetOptions: PerseusExpressionWidgetOptions,
@@ -35,13 +37,9 @@ const createItemJson = (
         },
         _multi: null,
         answer: null,
-        answerArea: {
-            zTable: false,
-            chi2Table: false,
-            tTable: false,
-            calculator: false,
-            periodicTable: false,
-        },
+        answerArea: Object.fromEntries(
+            ItemExtras.map((extra) => [extra, false]),
+        ) as PerseusAnswerArea,
         itemDataVersion: {
             major: 0,
             minor: 1,


### PR DESCRIPTION
## Summary:

- Add financial calculator checkboxes to Item Extras
- Add an indentation to dependent checkboxes
- Slight refactor to reduce redundant code
- Added item extras story

Issue: LC-1537

Testing strategy:
Check in new story that nothing has changed except new checkboxes added.
Clicking Financial Calculators checkbox should expand three checked options. Unchecking all options unchecks parent checkbox; unchecking parent unchecks options.
