### PR TITLE
Remove unused field from PerseusAnswerArea

### DIFF
--- a/.changeset/clever-walls-lie.md
+++ b/.changeset/clever-walls-lie.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Remove new unused field from PerseusAnswerArea API

--- a/packages/perseus-editor/src/__stories__/item-editor.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/item-editor.stories.tsx
@@ -18,7 +18,10 @@ const Wrapper = (props: Props) => {
     return (
         <ItemExtrasEditor
             {...extras}
-            onChange={(e) => setExtras((prevExtras) => ({...prevExtras, ...e}))}
+            onChange={(e) => {
+                props.onChange?.(e); // to register action in storybook
+                setExtras((prevExtras) => ({...prevExtras, ...e}));
+            }}
         />
     );
 };
@@ -27,6 +30,7 @@ const story: Meta<Props> = {
     title: "Perseus/Editor/Item Extras Editor",
     component: ItemExtrasEditor,
     render: (args) => <Wrapper {...args} />,
+    argTypes: {onChange: {action: "changed"}},
 };
 export default story;
 

--- a/packages/perseus-editor/src/__tests__/item-extras-editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/item-extras-editor.test.tsx
@@ -69,12 +69,7 @@ describe("ItemExtrasEditor", () => {
     it("should call onChange on dependent values when financialCalculator is checked", () => {
         // Arrange
         const onChangeMock = jest.fn();
-        render(
-            <ItemExtrasEditor
-                financialCalculator={false}
-                onChange={onChangeMock}
-            />,
-        );
+        render(<ItemExtrasEditor onChange={onChangeMock} />);
         const checkbox = screen.getByLabelText("Show financial calculator:");
 
         // Act
@@ -82,33 +77,9 @@ describe("ItemExtrasEditor", () => {
 
         // Assert
         expect(onChangeMock).toHaveBeenCalledWith({
-            financialCalculator: true,
             financialCalculatorMonthlyPayment: true,
             financialCalculatorTotalAmount: true,
             financialCalculatorTimeToPayOff: true,
-        });
-    });
-
-    it("should call onChange on dependent values when financialCalculator is unchecked", () => {
-        // Arrange
-        const onChangeMock = jest.fn();
-        render(
-            <ItemExtrasEditor
-                financialCalculator={true}
-                onChange={onChangeMock}
-            />,
-        );
-        const checkbox = screen.getByLabelText("Show financial calculator:");
-
-        // Act
-        userEvent.click(checkbox);
-
-        // Assert
-        expect(onChangeMock).toHaveBeenCalledWith({
-            financialCalculator: false,
-            financialCalculatorMonthlyPayment: false,
-            financialCalculatorTotalAmount: false,
-            financialCalculatorTimeToPayOff: false,
         });
     });
 });

--- a/packages/perseus-editor/src/item-extras-editor.tsx
+++ b/packages/perseus-editor/src/item-extras-editor.tsx
@@ -9,11 +9,14 @@ type Props = PerseusAnswerArea & {
     onChange: (props: Partial<PerseusAnswerArea>) => void;
 };
 
-class ItemExtrasEditor extends React.Component<Props> {
+type State = {
+    financialCalculatorOptionsExpanded: boolean;
+};
+
+class ItemExtrasEditor extends React.Component<Props, State> {
     static defaultProps: PerseusAnswerArea = {
         calculator: false,
         chi2Table: false,
-        financialCalculator: false,
         financialCalculatorMonthlyPayment: false,
         financialCalculatorTotalAmount: false,
         financialCalculatorTimeToPayOff: false,
@@ -23,18 +26,20 @@ class ItemExtrasEditor extends React.Component<Props> {
         zTable: false,
     };
 
+    state = {
+        financialCalculatorOptionsExpanded: false,
+    };
+
     componentDidUpdate(prevProps: Readonly<Props>): void {
         // If no financial calculator options are checked, uncheck the
         // financial calculator option.
         if (
-            prevProps.financialCalculator &&
+            this.state.financialCalculatorOptionsExpanded &&
             !this.props.financialCalculatorMonthlyPayment &&
             !this.props.financialCalculatorTotalAmount &&
             !this.props.financialCalculatorTimeToPayOff
         ) {
-            this.props.onChange({
-                financialCalculator: false,
-            });
+            this.setState({financialCalculatorOptionsExpanded: false});
         }
     }
 
@@ -64,13 +69,16 @@ class ItemExtrasEditor extends React.Component<Props> {
                     <ItemExtraCheckbox
                         label="Show financial calculator:"
                         infoTip="This provides the student with the ability to view a financial calculator, e.g., for answering financial questions. Once checked, requires at least one of the three options below to be checked."
-                        checked={this.props.financialCalculator}
+                        checked={this.state.financialCalculatorOptionsExpanded}
                         onChange={(e) => {
+                            this.setState({
+                                financialCalculatorOptionsExpanded:
+                                    e.target.checked,
+                            });
+                            // If the financial calculator is unchecked,
+                            // this needs to be reset. All checked by
+                            // default.
                             this.props.onChange({
-                                financialCalculator: e.target.checked,
-                                // If the financial calculator is unchecked,
-                                // this needs to be reset. All checked by
-                                // default.
                                 financialCalculatorMonthlyPayment:
                                     e.target.checked,
                                 financialCalculatorTotalAmount:
@@ -81,7 +89,7 @@ class ItemExtrasEditor extends React.Component<Props> {
                         }}
                     />
 
-                    {this.props.financialCalculator && (
+                    {this.state.financialCalculatorOptionsExpanded && (
                         <>
                             <ItemExtraCheckbox
                                 label="Include monthly payment:"

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -67,8 +67,6 @@ export const ItemExtras = [
     "calculator",
     // The user might benefit from using a statistics Chi Squared Table like https://people.richland.edu/james/lecture/m170/tbl-chi.html
     "chi2Table",
-    // The user might benefit from using a Financial Calculator.  Provided on Khan Academy when true
-    "financialCalculator",
     // The user might benefit from a monthly payments calculator.  Provided on Khan Academy when true
     "financialCalculatorMonthlyPayment",
     // The user might benefit from a total amount calculator.  Provided on Khan Academy when true


### PR DESCRIPTION
One of the fields added in #867 is redundant and does not need to be exposed outside of Perseus. Switched it to component state.