### PR TITLE
Ensure that we can reopen the keypad by clicking/tapping an already focused math-input.

### DIFF
--- a/.changeset/blue-beds-fly.md
+++ b/.changeset/blue-beds-fly.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": minor
+---
+
+Ensured that tapping an already focused math input will reopen the keypad if it is closed.

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -645,8 +645,8 @@ class MathInput extends React.Component<Props, State> {
     // but don't actually simulate touch events.
     handleClick = (
         e: React.MouseEvent<HTMLDivElement>,
-        keypadActive,
-        setKeypadActive: any,
+        keypadActive: boolean,
+        setKeypadActive: (keypadActive: boolean) => void,
     ): void => {
         e.stopPropagation();
 

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -7,6 +7,7 @@ import * as React from "react";
 import ReactDOM from "react-dom";
 
 import {View} from "../../fake-react-native-web/index";
+import {KeypadContext} from "../keypad-context";
 
 import CursorHandle from "./cursor-handle";
 import {
@@ -217,6 +218,7 @@ class MathInput extends React.Component<Props, State> {
                         this.props.keypadElement.getDOMNode()
                     ) {
                         const [x, y] = [evt.clientX, evt.clientY];
+
                         // We only want to blur if the click is above the keypad,
                         // to the left of the keypad, or to the right of the keypad.
                         // The reasoning for not blurring for any clicks below the keypad is
@@ -604,9 +606,11 @@ class MathInput extends React.Component<Props, State> {
             });
     };
 
-    handleTouchStart: (arg1: React.TouchEvent<HTMLDivElement>) => void = (
-        e,
-    ) => {
+    handleTouchStart = (
+        e: React.TouchEvent<HTMLDivElement>,
+        keypadActive: boolean,
+        setKeypadActive: (keypadActive: boolean) => void,
+    ): void => {
         e.stopPropagation();
 
         // Hide the cursor handle on touch start, if the handle itself isn't
@@ -625,6 +629,11 @@ class MathInput extends React.Component<Props, State> {
             this._insertCursorAtClosestNode(touch.clientX, touch.clientY);
         }
 
+        // If we're already focused, but the keypad isn't active, activate it.
+        if (this.state.focused && !keypadActive) {
+            setKeypadActive(true);
+        }
+
         // Trigger a focus event, if we're not already focused.
         if (!this.state.focused) {
             this.focus();
@@ -634,7 +643,11 @@ class MathInput extends React.Component<Props, State> {
     // We want to allow the user to be able to focus the input via click
     // when using ChromeOS third-party browsers that use mobile user agents,
     // but don't actually simulate touch events.
-    handleClick = (e: React.MouseEvent<HTMLDivElement>): void => {
+    handleClick = (
+        e: React.MouseEvent<HTMLDivElement>,
+        keypadActive,
+        setKeypadActive: any,
+    ): void => {
         e.stopPropagation();
 
         // Hide the cursor handle on click
@@ -649,6 +662,11 @@ class MathInput extends React.Component<Props, State> {
             // Make the cursor visible and set the handle-less cursor's
             // location.
             this._insertCursorAtClosestNode(e.clientX, e.clientY);
+        }
+
+        // If we're already focused, but the keypad isn't active, activate it.
+        if (this.state.focused && !keypadActive) {
+            setKeypadActive(true);
         }
 
         // Trigger a focus event, if we're not already focused.
@@ -926,46 +944,59 @@ class MathInput extends React.Component<Props, State> {
             i18n._("Tap with one or two fingers to open keyboard");
 
         return (
-            <View
-                style={styles.input}
-                onTouchStart={this.handleTouchStart}
-                onTouchMove={this.handleTouchMove}
-                onTouchEnd={this.handleTouchEnd}
-                onClick={this.handleClick}
-                role={"textbox"}
-                ariaLabel={ariaLabel}
-            >
-                {/* NOTE(charlie): This is used purely to namespace the styles in
+            <KeypadContext.Consumer>
+                {({keypadActive, setKeypadActive}) => (
+                    <View
+                        style={styles.input}
+                        onTouchStart={(e: React.TouchEvent<HTMLDivElement>) => {
+                            this.handleTouchStart(
+                                e,
+                                keypadActive,
+                                setKeypadActive,
+                            );
+                        }}
+                        onTouchMove={this.handleTouchMove}
+                        onTouchEnd={this.handleTouchEnd}
+                        onClick={(e: React.MouseEvent<HTMLDivElement>) => {
+                            this.handleClick(e, keypadActive, setKeypadActive);
+                        }}
+                        role={"textbox"}
+                        ariaLabel={ariaLabel}
+                    >
+                        {/* NOTE(charlie): This is used purely to namespace the styles in
                 overrides.css. */}
-                <div
-                    className="keypad-input"
-                    // @ts-expect-error - TS2322 - Type 'string' is not assignable to type 'number | undefined'.
-                    tabIndex={"0"}
-                    ref={(node) => {
-                        this.inputRef = node;
-                    }}
-                    onKeyUp={this.handleKeyUp}
-                >
-                    {/* NOTE(charlie): This element must be styled with inline
+                        <div
+                            className="keypad-input"
+                            // @ts-expect-error - TS2322 - Type 'string' is not assignable to type 'number | undefined'.
+                            tabIndex={"0"}
+                            ref={(node) => {
+                                this.inputRef = node;
+                            }}
+                            onKeyUp={this.handleKeyUp}
+                        >
+                            {/* NOTE(charlie): This element must be styled with inline
                     styles rather than with Aphrodite classes, as MathQuill
                     modifies the class names on the DOM node. */}
-                    <div
-                        ref={(node) => {
-                            this._mathContainer = ReactDOM.findDOMNode(node);
-                        }}
-                        style={innerStyle}
-                    />
-                </div>
-                {focused && handle.visible && (
-                    <CursorHandle
-                        {...handle}
-                        onTouchStart={this.onCursorHandleTouchStart}
-                        onTouchMove={this.onCursorHandleTouchMove}
-                        onTouchEnd={this.onCursorHandleTouchEnd}
-                        onTouchCancel={this.onCursorHandleTouchCancel}
-                    />
+                            <div
+                                ref={(node) => {
+                                    this._mathContainer =
+                                        ReactDOM.findDOMNode(node);
+                                }}
+                                style={innerStyle}
+                            />
+                        </div>
+                        {focused && handle.visible && (
+                            <CursorHandle
+                                {...handle}
+                                onTouchStart={this.onCursorHandleTouchStart}
+                                onTouchMove={this.onCursorHandleTouchMove}
+                                onTouchEnd={this.onCursorHandleTouchEnd}
+                                onTouchCancel={this.onCursorHandleTouchCancel}
+                            />
+                        )}
+                    </View>
                 )}
-            </View>
+            </KeypadContext.Consumer>
         );
     }
 }

--- a/packages/perseus/src/widgets/__tests__/expression-mobile.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/expression-mobile.test.tsx
@@ -121,6 +121,35 @@ describe("expression mobile", () => {
         );
     });
 
+    it("shows keypad after focused input interaction", async () => {
+        render(<ConnectedRenderer />);
+
+        const input = screen.getByLabelText(
+            "Math input box Tap with one or two fingers to open keyboard",
+        );
+
+        fireEvent.touchStart(input);
+
+        // waiting because `visibility` is animated
+        await waitFor(() =>
+            expect(screen.getByRole("button", {name: "1"})).toBeVisible(),
+        );
+
+        userEvent.click(screen.getByRole("tab", {name: "Dismiss"}));
+
+        // wait for the keypad to close
+        await waitFor(() =>
+            expect(screen.queryByRole("button", {name: "1"})).toBeNull(),
+        );
+
+        fireEvent.touchStart(input);
+
+        // confirm that the keypad has reopened
+        await waitFor(() =>
+            expect(screen.getByRole("button", {name: "1"})).toBeVisible(),
+        );
+    });
+
     it("is possible to use the keypad", async () => {
         render(<ConnectedRenderer />);
 


### PR DESCRIPTION
## Summary:
When users close the keypad using the "X" button, we retain focus on the input in order to vastly improve the user experience for screen readers. Unfortunately, this caused an issue where users would be unable to re-trigger the keypad until blurring the input. 

This PR adds some logic that allows us to open the keypad if our input is currently focused, and the keypadActive is currently set to false. 

Issue: LC-1524

## Test plan:
- Manually tested by bumping perseus in webapp to this PR, and then reviewing both mobile web using Chrome Dev Tools and iOS Simulator Safari.

## Videos:
I can't seem to upload them without them resulting in downloadable files, so instead I'll add them to the Jira ticket. 

