### PR TITLE
Prevent paragraph class from being added to answer pills

### DIFF
--- a/.changeset/two-birds-refuse.md
+++ b/.changeset/two-birds-refuse.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Prevent paragraph class from being added to answer pills component

--- a/packages/perseus/src/question-paragraph.tsx
+++ b/packages/perseus/src/question-paragraph.tsx
@@ -17,7 +17,11 @@ class QuestionParagraph extends React.Component<Props> {
         // to attach some metadata to top-level QuestionParagraphs:
         return (
             <div
-                className={this.props.inline ? undefined : className}
+                className={
+                    this.props.inline
+                        ? this.props.className ?? undefined
+                        : className
+                }
                 data-perseus-component-index={this.props.translationIndex}
                 data-perseus-paragraph-index={this.props.paragraphIndex}
             >

--- a/packages/perseus/src/question-paragraph.tsx
+++ b/packages/perseus/src/question-paragraph.tsx
@@ -5,6 +5,7 @@ type Props = {
     translationIndex: number;
     paragraphIndex?: number;
     children?: React.ReactNode;
+    plainText?: boolean;
 };
 
 class QuestionParagraph extends React.Component<Props> {
@@ -16,7 +17,7 @@ class QuestionParagraph extends React.Component<Props> {
         // to attach some metadata to top-level QuestionParagraphs:
         return (
             <div
-                className={className}
+                className={this.props.plainText ? undefined : className}
                 data-perseus-component-index={this.props.translationIndex}
                 data-perseus-paragraph-index={this.props.paragraphIndex}
             >

--- a/packages/perseus/src/question-paragraph.tsx
+++ b/packages/perseus/src/question-paragraph.tsx
@@ -5,7 +5,7 @@ type Props = {
     translationIndex: number;
     paragraphIndex?: number;
     children?: React.ReactNode;
-    plainText?: boolean;
+    inline?: boolean;
 };
 
 class QuestionParagraph extends React.Component<Props> {
@@ -17,7 +17,7 @@ class QuestionParagraph extends React.Component<Props> {
         // to attach some metadata to top-level QuestionParagraphs:
         return (
             <div
-                className={this.props.plainText ? undefined : className}
+                className={this.props.inline ? undefined : className}
                 data-perseus-component-index={this.props.translationIndex}
                 data-perseus-paragraph-index={this.props.paragraphIndex}
             >

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -172,6 +172,8 @@ type Props = Partial<React.ContextType<typeof DependenciesContext>> & {
     linterContext: LinterContextProps;
     legacyPerseusLint?: ReadonlyArray<string>;
     widgets: PerseusRenderer["widgets"];
+    // Skip adding paragraph class
+    plainText?: boolean;
 };
 
 type State = {
@@ -1060,6 +1062,7 @@ class Renderer extends React.Component<Props, State> {
                 className={className}
                 translationIndex={this.translationIndex}
                 paragraphIndex={state.paragraphIndex}
+                plainText={this.props.plainText}
             >
                 <ErrorBoundary>{output}</ErrorBoundary>
             </QuestionParagraph>
@@ -1919,13 +1922,17 @@ class Renderer extends React.Component<Props, State> {
         this._isTwoColumn = false;
 
         // Parse the string of markdown to a parse tree
-        const parsedMarkdown = PerseusMarkdown.parse(content, {
-            // Recognize crowdin IDs while translating articles
-            // (This should never be hit by exercises, though if you
-            // decide you want to add a check that this is an article,
-            // go for it.)
-            isJipt: this.translationIndex != null,
-        });
+        const parsedMarkdown = this.props.plainText
+            ? PerseusMarkdown.parseInline(content, {
+                  // Recognize crowdin IDs while translating articles
+                  // (This should never be hit by exercises, though if you
+                  // decide you want to add a check that this is an article,
+                  // go for it.)
+                  isJipt: this.translationIndex != null,
+              })
+            : PerseusMarkdown.parse(content, {
+                  isJipt: this.translationIndex != null,
+              });
 
         // Optionally apply the linter to the parse tree
         if (this.props.linterContext.highlightLint) {

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -173,7 +173,7 @@ type Props = Partial<React.ContextType<typeof DependenciesContext>> & {
     legacyPerseusLint?: ReadonlyArray<string>;
     widgets: PerseusRenderer["widgets"];
     // Skip adding paragraph class
-    plainText?: boolean;
+    inline?: boolean;
 };
 
 type State = {
@@ -1062,7 +1062,7 @@ class Renderer extends React.Component<Props, State> {
                 className={className}
                 translationIndex={this.translationIndex}
                 paragraphIndex={state.paragraphIndex}
-                plainText={this.props.plainText}
+                inline={this.props.inline}
             >
                 <ErrorBoundary>{output}</ErrorBoundary>
             </QuestionParagraph>
@@ -1922,7 +1922,7 @@ class Renderer extends React.Component<Props, State> {
         this._isTwoColumn = false;
 
         // Parse the string of markdown to a parse tree
-        const parsedMarkdown = this.props.plainText
+        const parsedMarkdown = this.props.inline
             ? PerseusMarkdown.parseInline(content, {
                   // Recognize crowdin IDs while translating articles
                   // (This should never be hit by exercises, though if you

--- a/packages/perseus/src/styles/widgets/label-image.less
+++ b/packages/perseus/src/styles/widgets/label-image.less
@@ -5,38 +5,6 @@
             margin: 0;
         }
     }
-    button[id*="perseus-label-image-widget-answer-pill"],
-    div[id*="perseus-label-image-widget-answer-pill"] {
-        // Reset text content.
-        div.paragraph {
-            all: revert;
-        }
-        // Allow for padding around math content. Accounting for the negative margin here:
-        // https://github.com/Khan/perseus/blob/bafd35daee723456bf259a39b88e7638d91c8c3b/packages/perseus/src/renderer.tsx#L1176
-        div.perseus-block-math-inner {
-            margin: -5px 0 !important;
-        }
-    }
-}
-
-// Reset mobile text content for answer pills.
-@media (max-width: 767px) {
-    [id*="perseus-label-image-widget-answer-pill"] {
-        div.paragraph {
-            all: revert;
-        }
-        > div.perseus-renderer-responsive {
-            all: revert;
-        }
-    }
-
-    .framework-perseus.perseus-mobile
-        [id*="perseus-label-image-widget-answer-pill"] {
-        .perseus-renderer > .paragraph,
-        .perseus-renderer > .paragraph .paragraph {
-            all: revert;
-        }
-    }
 }
 
 .framework-perseus:not(.perseus-article).perseus-mobile {

--- a/packages/perseus/src/styles/widgets/label-image.less
+++ b/packages/perseus/src/styles/widgets/label-image.less
@@ -7,6 +7,21 @@
     }
 }
 
+// Reset mobile text content for answer pills.
+@media (max-width: 767px) {
+    [id*="perseus-label-image-widget-answer-pill"] {
+        > div.perseus-renderer-responsive {
+            all: revert;
+        }
+    }
+    .framework-perseus.perseus-mobile
+        [id*="perseus-label-image-widget-answer-pill"] {
+        mjx-container {
+            all: revert;
+        }
+    }
+}
+
 .framework-perseus:not(.perseus-article).perseus-mobile {
     .perseus-label-image-widget-instructions {
         color: initial;

--- a/packages/perseus/src/widgets/__stories__/label-image.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/label-image.stories.tsx
@@ -5,6 +5,8 @@ import {
     textQuestion,
     mathQuestion,
     numberline,
+    longTextFromArticle,
+    mixedContentQuestion,
 } from "../__testdata__/label-image.testdata";
 
 import type {PerseusRenderer} from "../../perseus-types";
@@ -59,6 +61,21 @@ export const LabelWidgetWithText = (args: StoryArgs): React.ReactElement => {
     );
 };
 
+export const LabelWidgetWithLongText = (
+    args: StoryArgs,
+): React.ReactElement => {
+    const apiOptions: APIOptions = {
+        isMobile: args.isMobile,
+    };
+
+    return (
+        <RendererWithDebugUI
+            question={applyStoryArgs(longTextFromArticle, args)}
+            apiOptions={apiOptions}
+        />
+    );
+};
+
 export const LabelWidgetWithMath = (args: StoryArgs): React.ReactElement => {
     const apiOptions: APIOptions = {
         isMobile: args.isMobile,
@@ -80,6 +97,19 @@ export const LabelImageNumberline = (args: StoryArgs): React.ReactElement => {
     return (
         <RendererWithDebugUI
             question={applyStoryArgs(numberline, args)}
+            apiOptions={apiOptions}
+        />
+    );
+};
+
+export const LabelImageMixedContent = (args: StoryArgs): React.ReactElement => {
+    const apiOptions: APIOptions = {
+        isMobile: args.isMobile,
+    };
+
+    return (
+        <RendererWithDebugUI
+            question={applyStoryArgs(mixedContentQuestion, args)}
             apiOptions={apiOptions}
         />
     );

--- a/packages/perseus/src/widgets/__testdata__/label-image.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/label-image.testdata.ts
@@ -178,3 +178,131 @@ export const numberline: PerseusRenderer = {
         },
     },
 };
+
+export const longTextFromArticle: PerseusRenderer = {
+    content: "[[☃ label-image 1]]",
+    images: {},
+    widgets: {
+        "label-image 1": {
+            type: "label-image",
+            alignment: "default",
+            static: false,
+            graded: true,
+            options: {
+                static: false,
+                choices: [
+                    "long wavelength & low frequency",
+                    "short wavelength & high frequency",
+                ],
+                imageAlt:
+                    "Section of a rainbow in the sky. From left to right, the colors appear as violet, indigo, blue, green, yellow, orange, and red.",
+                imageUrl:
+                    "https://cdn.kastatic.org/ka-content-images/227d402cb09ebc1b67f197467212fa4ab3ced5b3.jpg",
+                imageWidth: 400,
+                imageHeight: 289,
+                markers: [
+                    {
+                        answers: ["short wavelength & high frequency"],
+                        label: "Violet side of the rainbow",
+                        x: 35.8,
+                        y: 13,
+                    },
+                    {
+                        answers: ["long wavelength & low frequency"],
+                        label: "Red side of the rainbow",
+                        x: 71.8,
+                        y: 50.5,
+                    },
+                ],
+                multipleAnswers: false,
+                hideChoicesFromInstructions: true,
+            },
+            version: {
+                major: 0,
+                minor: 0,
+            },
+        },
+    },
+};
+
+export const mixedContentQuestion: PerseusRenderer = {
+    content:
+        "A beach ball floats on water. The ball is at rest.\n\n[[☃ image 1]]\n\n**Complete the free body diagram by labeling the forces acting on the ball.**\n\n[[☃ label-image 1]]",
+    images: {
+        "https://cdn.kastatic.org/ka-content-images/0fa7eefde0067d986d2e6dc377e8d2db3e1d466f.svg":
+            {
+                width: 150,
+                height: 300,
+            },
+    },
+    widgets: {
+        "image 1": {
+            type: "image",
+            alignment: "block",
+            static: false,
+            graded: true,
+            options: {
+                static: false,
+                title: "",
+                range: [
+                    [0, 10],
+                    [0, 10],
+                ],
+                box: [350, 219],
+                backgroundImage: {
+                    url: "https://cdn.kastatic.org/ka-content-images/581c7d3928ba5f81e9dc5720291ec895764cc7e8.png",
+                    width: 350,
+                    height: 219,
+                },
+                labels: [],
+                alt: "An inflated beach ball floats on the surface of water. Only a small portion of the ball is underwater.",
+                caption: "",
+            },
+            version: {
+                major: 0,
+                minor: 0,
+            },
+        },
+        "label-image 1": {
+            type: "label-image",
+            alignment: "default",
+            static: false,
+            graded: true,
+            options: {
+                static: false,
+                choices: [
+                    "lift $(F_\\text{L})$",
+                    "buoyant force $(F_\\text{B})$",
+                    "gravity $(F_\\text{g})$",
+                    "normal force $(F_\\text{N})$",
+                ],
+                imageAlt:
+                    "A model shows a square with two arrows pointing out of it. One arrow points up and another arrow points down.",
+                imageUrl:
+                    "https://cdn.kastatic.org/ka-content-images/b24e40b5a36890130acfb7bd237c4bf0d85c7b44.svg",
+                imageWidth: 150,
+                imageHeight: 300,
+                markers: [
+                    {
+                        answers: ["buoyant force $(F_\\text{B})$"],
+                        label: "An arrow that points upward from the square",
+                        x: 64.2,
+                        y: 17.6,
+                    },
+                    {
+                        answers: ["gravity $(F_\\text{g})$"],
+                        label: "An arrow that points downward from the square",
+                        x: 66.2,
+                        y: 81.8,
+                    },
+                ],
+                multipleAnswers: false,
+                hideChoicesFromInstructions: true,
+            },
+            version: {
+                major: 0,
+                minor: 0,
+            },
+        },
+    },
+};

--- a/packages/perseus/src/widgets/label-image.tsx
+++ b/packages/perseus/src/widgets/label-image.tsx
@@ -667,7 +667,7 @@ export class LabelImage extends React.Component<
                 [`margin${
                     markerPosition.charAt(0).toUpperCase() +
                     markerPosition.slice(1)
-                }`]: 5, // move pill further from marker
+                }`]: 15, // move pill further from marker
             };
 
             const showAnswerChoice =

--- a/packages/perseus/src/widgets/label-image/__stories__/answer-pill.stories.tsx
+++ b/packages/perseus/src/widgets/label-image/__stories__/answer-pill.stories.tsx
@@ -22,7 +22,7 @@ export default story;
 export const SingleAnswer = {
     args: {
         id: "1",
-        selectedAnswers: ["Answer Pill!"],
+        selectedAnswers: ["Answer Pill"],
         markerRef: null,
         side: "top",
         onClick: () => {},
@@ -42,7 +42,7 @@ export const MultipleAnswers = {
 export const Correct = {
     args: {
         id: "1",
-        selectedAnswers: ["Right Answer!"],
+        selectedAnswers: ["Right Answer"],
         showCorrectness: "correct",
         markerRef: null,
         side: "top",
@@ -53,7 +53,7 @@ export const Correct = {
 export const Incorrect = {
     args: {
         id: "1",
-        selectedAnswers: ["Wrong Answer!"],
+        selectedAnswers: ["Wrong Answer"],
         showCorrectness: "incorrect",
         markerRef: null,
         side: "top",

--- a/packages/perseus/src/widgets/label-image/answer-pill.tsx
+++ b/packages/perseus/src/widgets/label-image/answer-pill.tsx
@@ -72,7 +72,7 @@ export const AnswerPill = (props: {
                         incorrect && styles.incorrect,
                     ]}
                 >
-                    <Renderer content={answerString} />
+                    <Renderer content={answerString} plainText />
                 </Pill>
             )}
         </Popper>

--- a/packages/perseus/src/widgets/label-image/answer-pill.tsx
+++ b/packages/perseus/src/widgets/label-image/answer-pill.tsx
@@ -72,7 +72,7 @@ export const AnswerPill = (props: {
                         incorrect && styles.incorrect,
                     ]}
                 >
-                    <Renderer content={answerString} plainText />
+                    <Renderer content={answerString} inline />
                 </Pill>
             )}
         </Popper>

--- a/packages/perseus/src/widgets/passage-ref-target.tsx
+++ b/packages/perseus/src/widgets/passage-ref-target.tsx
@@ -50,8 +50,10 @@ class PassageRefTarget extends React.Component<any> {
         return (
             <Renderer
                 content={this.props.content}
-                // @ts-expect-error - TS2322 - Type '{ content: any; inline: boolean; apiOptions: any; linterContext: any; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Renderer> & Pick<Readonly<Props> & Readonly<{ children?: ReactNode; }>, "children" | ... 3 more ... | "legacyPerseusLint"> & InexactPartial<...> & InexactPartial<...>'.
-                inline={true}
+                // This was here, but the prop was not defined until now! (#873)
+                // Perhaps it once existed and was removed a long time ago.
+                // Commenting out to prevent unanticipated side effects
+                // inline={true}
                 apiOptions={this.props.apiOptions}
                 linterContext={this.props.linterContext}
             />

--- a/packages/perseus/src/widgets/passage-ref-target.tsx
+++ b/packages/perseus/src/widgets/passage-ref-target.tsx
@@ -50,8 +50,9 @@ class PassageRefTarget extends React.Component<any> {
         return (
             <Renderer
                 content={this.props.content}
-                // This was here, but the prop was not defined until now! (#873)
-                // Perhaps it once existed and was removed a long time ago.
+                // This was already here before inline was recently added (#873)
+                // It was for a different use case a long time ago:
+                // https://phabricator.khanacademy.org/D12113
                 // Commenting out to prevent unanticipated side effects
                 // inline={true}
                 apiOptions={this.props.apiOptions}


### PR DESCRIPTION
## Summary:
Rather than block paragraph styles from every avenue we come across, instead prevent them from being associated with the answer pill in the first place.

Adds a `inline` prop to `Renderer` that blocks the `paragraph` class from being added to answer pills.

### AFTER:
<img width="856" alt="Screenshot 2023-12-14 at 12 26 57 PM" src="https://github.com/Khan/perseus/assets/23404711/dd11ae59-0706-4283-b42a-a7052327d5a0">
<img width="348" alt="Screenshot 2023-12-14 at 12 59 09 PM" src="https://github.com/Khan/perseus/assets/23404711/79da8e7a-92f8-49dc-854f-1502c2a13423">

### BEFORE:
![image (8)](https://github.com/Khan/perseus/assets/23404711/0ff42e19-73c4-4bc6-b9d1-e27c3740b17f)
![image (9)](https://github.com/Khan/perseus/assets/23404711/1f2a10b5-6e9b-492e-b9d0-45f3b0847b56)

Issue: LC-1569

### Testing strategy:
Use NPM snapshot or link to check out editor and mobile view of label image widget exercises on webapp.
