### PR TITLE
add some tests for the radio editor

### DIFF
--- a/.changeset/curly-jobs-sit.md
+++ b/.changeset/curly-jobs-sit.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Add tests for RadioEditor

--- a/packages/perseus-editor/src/widgets/__stories__/radio-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/radio-editor.stories.tsx
@@ -97,12 +97,12 @@ class WithState extends React.Component<Empty, PerseusRadioWidgetOptions> {
                 <RadioEditor
                     {...this.state}
                     apiOptions={this.apiOptions}
-                    onChange={(props) =>
+                    onChange={(props) => {
                         this.setState({
                             ...this._widget.serialize(),
                             ...props,
-                        })
-                    }
+                        });
+                    }}
                     // @ts-expect-error [FEI-5003] - TS2322 - Type 'RadioEditor | null' is not assignable to type 'RadioEditor'.
                     ref={(widget) => (this._widget = widget)}
                 />

--- a/packages/perseus-editor/src/widgets/__tests__/radio-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/radio-editor.test.tsx
@@ -1,0 +1,118 @@
+import {Dependencies, ApiOptions} from "@khanacademy/perseus";
+import {render, screen} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as React from "react";
+
+import "@testing-library/jest-dom";
+
+import {testDependencies} from "../../../../../testing/test-dependencies";
+import RadioEditor from "../radio/editor";
+
+describe("radio-editor", () => {
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("should render", async () => {
+        render(
+            <RadioEditor
+                onChange={() => undefined}
+                apiOptions={ApiOptions.defaults}
+            />,
+        );
+
+        expect(
+            await screen.findByText(/Multiple selections/),
+        ).toBeInTheDocument();
+    });
+
+    it("should toggle multiple select checkbox", () => {
+        const onChangeMock = jest.fn();
+
+        render(
+            <RadioEditor
+                onChange={onChangeMock}
+                apiOptions={ApiOptions.defaults}
+            />,
+        );
+
+        userEvent.click(
+            screen.getByRole("checkbox", {
+                name: "Multiple selections",
+            }),
+        );
+
+        expect(onChangeMock).toBeCalledWith({multipleSelect: true});
+    });
+
+    it("should toggle randomize order checkbox", () => {
+        const onChangeMock = jest.fn();
+
+        render(
+            <RadioEditor
+                onChange={onChangeMock}
+                apiOptions={ApiOptions.defaults}
+            />,
+        );
+
+        userEvent.click(
+            screen.getByRole("checkbox", {
+                name: "Randomize order",
+            }),
+        );
+
+        expect(onChangeMock).toBeCalledWith({randomize: true});
+    });
+
+    it("should be possible to add answer", () => {
+        const onChangeMock = jest.fn();
+
+        render(
+            <RadioEditor
+                onChange={onChangeMock}
+                apiOptions={ApiOptions.defaults}
+            />,
+        );
+
+        userEvent.click(
+            screen.getAllByRole("link", {
+                name: "Add a choice",
+            })[0],
+        );
+
+        expect(onChangeMock).toBeCalledWith(
+            expect.objectContaining({
+                choices: [{}, {}, {isNoneOfTheAbove: false}],
+                hasNoneOfTheAbove: false,
+            }),
+            // there's some anonymous function that's also passed
+            expect.anything(),
+        );
+    });
+
+    it("should be possible to delete answer", () => {
+        const onChangeMock = jest.fn();
+
+        render(
+            <RadioEditor
+                onChange={onChangeMock}
+                apiOptions={ApiOptions.defaults}
+            />,
+        );
+
+        userEvent.click(
+            screen.getAllByRole("link", {
+                name: "Remove this choice",
+            })[0],
+        );
+
+        expect(onChangeMock).toBeCalledWith(
+            expect.objectContaining({
+                choices: [{}],
+                hasNoneOfTheAbove: false,
+            }),
+        );
+    });
+});


### PR DESCRIPTION
## Summary:
Trying to not modify _what_ I'm testing too much, just trying to add _some_ tests.

For some reason editing the text for the answers didn't trigger the `onChange` callback and I don't want to spend too much time on each of these, so I didn't test editing answers yet.