### PR TITLE
add tests for ExplanationEditor

### DIFF
--- a/.changeset/tender-tomatoes-flow.md
+++ b/.changeset/tender-tomatoes-flow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Add tests for ExplanationEditor

--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -132,7 +132,7 @@ type Props = Readonly<{
     onChange: ChangeHandler;
 }>;
 
-type DeafultProps = {
+type DefaultProps = {
     content: string;
     disabled: boolean;
     images: Record<any, any>;
@@ -157,7 +157,7 @@ class Editor extends React.Component<Props, State> {
     deferredChange: any | null | undefined;
     widgetIds: any | null | undefined;
 
-    static defaultProps: DeafultProps = {
+    static defaultProps: DefaultProps = {
         content: "",
         placeholder: "",
         widgets: {},

--- a/packages/perseus-editor/src/widgets/__stories__/explanation-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/explanation-editor.stories.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+
+import ExplanationEditor from "../explanation-editor";
+
+type StoryArgs = Record<any, any>;
+
+type Story = {
+    title: string;
+};
+
+export default {
+    title: "Perseus/Editor/Widgets/Explanation Editor",
+} as Story;
+
+export const Default = (args: StoryArgs): React.ReactElement => {
+    return <ExplanationEditor onChange={() => {}} />;
+};

--- a/packages/perseus-editor/src/widgets/__stories__/explanation-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/explanation-editor.stories.tsx
@@ -1,3 +1,4 @@
+import {action} from "@storybook/addon-actions";
 import * as React from "react";
 
 import ExplanationEditor from "../explanation-editor";
@@ -13,5 +14,5 @@ export default {
 } as Story;
 
 export const Default = (args: StoryArgs): React.ReactElement => {
-    return <ExplanationEditor onChange={() => {}} />;
+    return <ExplanationEditor onChange={action("onChange")} />;
 };

--- a/packages/perseus-editor/src/widgets/__tests__/explanation-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/explanation-editor.test.tsx
@@ -1,0 +1,59 @@
+import {Dependencies} from "@khanacademy/perseus";
+import {render, screen} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as React from "react";
+
+import "@testing-library/jest-dom";
+
+import {testDependencies} from "../../../../../testing/test-dependencies";
+import ExplanationEditor from "../explanation-editor";
+
+describe("dropdown-editor", () => {
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("should render", async () => {
+        render(<ExplanationEditor onChange={() => undefined} />);
+
+        expect(
+            await screen.findByText("Prompt to show explanation:"),
+        ).toBeInTheDocument();
+    });
+
+    it("should be possible to change prompt to show explanation", async () => {
+        const onChangeMock = jest.fn();
+
+        render(<ExplanationEditor onChange={onChangeMock} />);
+
+        const input = screen.getByRole("textbox", {
+            name: "Prompt to show explanation:",
+        });
+        userEvent.type(input, "a");
+
+        expect(onChangeMock).toBeCalledWith(
+            // The dropdown initalizes with "Explain"
+            expect.objectContaining({showPrompt: "Explaina"}),
+            undefined,
+        );
+    });
+
+    it("should be possible to change prompt to hide explanation", async () => {
+        const onChangeMock = jest.fn();
+
+        render(<ExplanationEditor onChange={onChangeMock} />);
+
+        const input = screen.getByRole("textbox", {
+            name: "Prompt to hide explanation:",
+        });
+        userEvent.type(input, "a");
+
+        expect(onChangeMock).toBeCalledWith(
+            // The dropdown initalizes with "Hide explain"
+            expect.objectContaining({hidePrompt: "Hide explanationa"}),
+            undefined,
+        );
+    });
+});


### PR DESCRIPTION
## Summary:
Most of the functionality for this is buried in the `Editor` component and I don't want to go down that rabbit hole right now.