### PR TITLE
add tests to DefinitionEditor

### DIFF
--- a/.changeset/nasty-eels-explode.md
+++ b/.changeset/nasty-eels-explode.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+add tests for DefinitionEditor

--- a/packages/perseus-editor/src/widgets/__stories__/definition-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/definition-editor.stories.tsx
@@ -1,0 +1,18 @@
+import {action} from "@storybook/addon-actions";
+import * as React from "react";
+
+import DefinitionEditor from "../definition-editor";
+
+type StoryArgs = Record<any, any>;
+
+type Story = {
+    title: string;
+};
+
+export default {
+    title: "Perseus/Editor/Widgets/Definition Editor",
+} as Story;
+
+export const Default = (args: StoryArgs): React.ReactElement => {
+    return <DefinitionEditor onChange={action("onChange")} />;
+};

--- a/packages/perseus-editor/src/widgets/__tests__/definition-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/definition-editor.test.tsx
@@ -1,0 +1,41 @@
+import {Dependencies} from "@khanacademy/perseus";
+import {render, screen} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as React from "react";
+
+import "@testing-library/jest-dom";
+
+import {testDependencies} from "../../../../../testing/test-dependencies";
+import DefinitionEditor from "../definition-editor";
+
+describe("definition-editor", () => {
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("should render", async () => {
+        render(<DefinitionEditor onChange={() => undefined} />);
+
+        expect(
+            await screen.findByText("Definition style guide"),
+        ).toBeInTheDocument();
+    });
+
+    it("should be possible to change the definition", async () => {
+        const onChangeMock = jest.fn();
+
+        render(<DefinitionEditor onChange={onChangeMock} />);
+
+        const input = screen.getByRole("textbox", {
+            name: "Word to be defined:",
+        });
+        userEvent.type(input, "a");
+
+        expect(onChangeMock).toBeCalledWith(
+            expect.objectContaining({togglePrompt: "a"}),
+            undefined,
+        );
+    });
+});


### PR DESCRIPTION
## Summary:
Seems like things that use `Changeable` are a little problematic to test since they're not calling the `onChange` callback as expected.

Looking into it, it seems like there are several tickets to refactor it: https://khanacademy.atlassian.net/browse/LC-394