### PR TITLE
Add confirmation before deleting a widget config

### DIFF
--- a/.changeset/proud-roses-sneeze.md
+++ b/.changeset/proud-roses-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+Add a confirmation before deleting a configured widget in the Exercise Editor

--- a/packages/perseus-editor/src/__tests__/editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/editor.test.tsx
@@ -1,115 +1,141 @@
-import {ApiOptions, Dependencies, Widgets} from "@khanacademy/perseus";
+import {
+    ApiOptions,
+    Dependencies,
+    Widgets,
+    widgets,
+    Util,
+} from "@khanacademy/perseus";
 import {render, screen} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as React from "react";
 import "@testing-library/jest-dom"; // Imports custom mathers
 
 import {testDependencies} from "../../../../testing/test-dependencies";
-import {wait} from "../../../../testing/wait";
-import {question1} from "../__testdata__/input-number.testdata";
 import Editor from "../editor";
+import ImageEditor from "../widgets/image-editor";
+
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
+
+const Harnessed = (props: Partial<PropsFor<typeof Editor>>) => {
+    return (
+        <Editor
+            apiOptions={ApiOptions.defaults}
+            onChange={() => {}}
+            content="[[☃ image 1]]"
+            widgets={{
+                "image 1": {
+                    type: "image",
+                    options: {
+                        backgroundImage: {
+                            url: "http://placekitten.com/200/300",
+                        },
+                    },
+                },
+            }}
+            {...props}
+        />
+    );
+};
 
 describe("Editor", () => {
+    beforeAll(() => {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const ImageWidget = widgets.find((w) => w.name === "image")!;
+        expect(ImageWidget).toBeDefined();
+        Widgets.registerWidget("image", ImageWidget);
+        Widgets.registerEditors([ImageEditor]);
+    });
+
     beforeEach(() => {
         jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
             testDependencies,
         );
     });
 
-    describe("input-number widget", () => {
-        beforeEach(async () => {
-            const [InputNumberWidget, InputNumberEditor] = await Promise.all([
-                import("@khanacademy/perseus").then((m) => m.InputNumber),
-                import("../widgets/input-number-editor").then((m) => m.default),
-            ]);
-            Widgets.registerWidgets([InputNumberWidget]);
-            Widgets.registerEditors([InputNumberEditor]);
-            jest.useRealTimers();
-        });
+    it("should delete widget if confirmed", async () => {
+        const onChangeMock = jest.fn();
+        jest.spyOn(window, "confirm").mockReturnValue(true);
 
+        // Arrange
+        render(<Harnessed onChange={onChangeMock} />);
+
+        // Act
+        userEvent.click(
+            screen.getByRole("button", {name: "Remove image widget"}),
+        );
+
+        // Assert
+        expect(onChangeMock).toHaveBeenCalledWith({content: ""});
+    });
+
+    it("should NOT delete widget if not confirmed", async () => {
+        const onChangeMock = jest.fn();
+        jest.spyOn(window, "confirm").mockReturnValue(false);
+
+        // Arrange
+        render(<Harnessed onChange={onChangeMock} />);
+
+        // Act
+        userEvent.click(
+            screen.getByRole("button", {name: "Remove image widget"}),
+        );
+
+        // Assert
+        expect(onChangeMock).not.toHaveBeenCalled();
+    });
+
+    describe("input-number widget", () => {
         test("clicking on the widget editor should open it", async () => {
             // Arrange
-            render(
-                <Editor
-                    apiOptions={ApiOptions.defaults}
-                    content={question1.content}
-                    placeholder=""
-                    widgets={question1.widgets}
-                    images={question1.images}
-                    disabled={false}
-                    widgetEnabled={true}
-                    immutableWidgets={false}
-                    showWordCount={true}
-                    warnNoPrompt={true}
-                    warnNoWidgets={true}
-                    onChange={(props) => {}}
-                />,
-            );
-            await wait();
+            render(<Harnessed />);
 
             // Act
             const widgetDisclosure = screen.getByRole("link", {
-                name: "input-number 1",
+                name: "image 1",
             });
             userEvent.click(widgetDisclosure);
-            const correctAnswerInput = screen.getByLabelText("Correct answer:");
 
             // Assert
-            expect(correctAnswerInput).toHaveValue("0.5");
+            const previewImage = screen.getByAltText("Editor preview of image");
+            expect(previewImage).toHaveAttribute(
+                "src",
+                "http://placekitten.com/200/300",
+            );
         });
 
         it("should update values", async () => {
             // Arrange
+            jest.spyOn(Util, "getImageSizeModern").mockResolvedValue([
+                200, 200,
+            ]);
+
             const changeFn = jest.fn();
-            render(
-                <Editor
-                    apiOptions={ApiOptions.defaults}
-                    content={question1.content}
-                    placeholder=""
-                    widgets={question1.widgets}
-                    images={question1.images}
-                    disabled={false}
-                    widgetEnabled={true}
-                    immutableWidgets={false}
-                    showWordCount={true}
-                    warnNoPrompt={true}
-                    warnNoWidgets={true}
-                    onChange={changeFn}
-                />,
-            );
-            await wait();
+            render(<Harnessed onChange={changeFn} />);
 
             // Act
             const widgetDisclosure = screen.getByRole("link", {
-                name: "input-number 1",
+                name: "image 1",
             });
             userEvent.click(widgetDisclosure);
-            const correctAnswerInput = screen.getByLabelText("Correct answer:");
 
-            userEvent.clear(correctAnswerInput);
-            userEvent.paste(correctAnswerInput, "0.75");
+            const captionInput = screen.getByLabelText(/Caption:/);
+
+            userEvent.clear(captionInput);
+            userEvent.type(captionInput, "A picture of kittens");
             userEvent.tab(); // blurring the input triggers onChange to be called
+            jest.runOnlyPendingTimers();
 
             // Assert
             expect(changeFn).toHaveBeenCalledWith(
                 {
                     widgets: {
-                        "input-number 1": {
+                        "image 1": expect.objectContaining({
+                            type: "image",
                             graded: true,
-                            version: {major: 0, minor: 0},
-                            static: false,
-                            type: "input-number",
-                            options: {
-                                value: 0.75,
-                                simplify: "required",
-                                size: "normal",
-                                inexact: false,
-                                maxError: 0.1,
-                                answerType: "number",
-                                rightAlign: false,
-                            },
-                            alignment: "default",
-                        },
+                            options: expect.objectContaining({
+                                caption: "A picture of kittens",
+                            }),
+                        }),
                     },
                 },
                 undefined,

--- a/packages/perseus-editor/src/__tests__/editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/editor.test.tsx
@@ -84,63 +84,59 @@ describe("Editor", () => {
         expect(onChangeMock).not.toHaveBeenCalled();
     });
 
-    describe("input-number widget", () => {
-        test("clicking on the widget editor should open it", async () => {
-            // Arrange
-            render(<Harnessed />);
+    test("clicking on the widget editor should open it", async () => {
+        // Arrange
+        render(<Harnessed />);
 
-            // Act
-            const widgetDisclosure = screen.getByRole("link", {
-                name: "image 1",
-            });
-            userEvent.click(widgetDisclosure);
-
-            // Assert
-            const previewImage = screen.getByAltText("Editor preview of image");
-            expect(previewImage).toHaveAttribute(
-                "src",
-                "http://placekitten.com/200/300",
-            );
+        // Act
+        const widgetDisclosure = screen.getByRole("link", {
+            name: "image 1",
         });
+        userEvent.click(widgetDisclosure);
 
-        it("should update values", async () => {
-            // Arrange
-            jest.spyOn(Util, "getImageSizeModern").mockResolvedValue([
-                200, 200,
-            ]);
+        // Assert
+        const previewImage = screen.getByAltText("Editor preview of image");
+        expect(previewImage).toHaveAttribute(
+            "src",
+            "http://placekitten.com/200/300",
+        );
+    });
 
-            const changeFn = jest.fn();
-            render(<Harnessed onChange={changeFn} />);
+    it("should update values", async () => {
+        // Arrange
+        jest.spyOn(Util, "getImageSizeModern").mockResolvedValue([200, 200]);
 
-            // Act
-            const widgetDisclosure = screen.getByRole("link", {
-                name: "image 1",
-            });
-            userEvent.click(widgetDisclosure);
+        const changeFn = jest.fn();
+        render(<Harnessed onChange={changeFn} />);
 
-            const captionInput = screen.getByLabelText(/Caption:/);
+        // Act
+        const widgetDisclosure = screen.getByRole("link", {
+            name: "image 1",
+        });
+        userEvent.click(widgetDisclosure);
 
-            userEvent.clear(captionInput);
-            userEvent.type(captionInput, "A picture of kittens");
-            userEvent.tab(); // blurring the input triggers onChange to be called
-            jest.runOnlyPendingTimers();
+        const captionInput = screen.getByLabelText(/Caption:/);
 
-            // Assert
-            expect(changeFn).toHaveBeenCalledWith(
-                {
-                    widgets: {
-                        "image 1": expect.objectContaining({
-                            type: "image",
-                            graded: true,
-                            options: expect.objectContaining({
-                                caption: "A picture of kittens",
-                            }),
+        userEvent.clear(captionInput);
+        userEvent.type(captionInput, "A picture of kittens");
+        userEvent.tab(); // blurring the input triggers onChange to be called
+        jest.runOnlyPendingTimers();
+
+        // Assert
+        expect(changeFn).toHaveBeenCalledWith(
+            {
+                widgets: {
+                    "image 1": expect.objectContaining({
+                        type: "image",
+                        graded: true,
+                        options: expect.objectContaining({
+                            caption: "A picture of kittens",
                         }),
-                    },
+                    }),
                 },
-                undefined,
-                undefined,
-            );
-        });
+            },
+            undefined,
+            undefined,
+        );
     });
 });

--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -293,6 +293,11 @@ class Editor extends React.Component<Props, State> {
     };
 
     _handleWidgetEditorRemove: (id: string) => void = (id: string) => {
+        // eslint-disable-next-line no-alert
+        if (!confirm("Are you sure you want to delete this item?")) {
+            return;
+        }
+
         // eslint-disable-next-line react/no-string-refs
         const textarea = this.refs.textarea;
         const re = new RegExp(widgetRegExp.replace("{id}", id), "gm");
@@ -930,6 +935,8 @@ class Editor extends React.Component<Props, State> {
             underlayPieces = [];
 
             for (let i = 0; i < pieces.length; i++) {
+                // We split on widgets so every even-numbered indexed piece is
+                // text and odd-numbered indexes are the widget references.
                 if (i % 2 === 0) {
                     // Normal text
                     underlayPieces.push(pieces[i]);


### PR DESCRIPTION
## Summary:

Adds a simple confirmation before proceeding with the widget deletion. This will hopefully prevent alot of frustration by avoiding losing work.

Issue: LC-1590

## Test plan:

Run the tests.