### PR TITLE
Add confirmation before deleting a hint

### DIFF
--- a/.changeset/shiny-pugs-jump.md
+++ b/.changeset/shiny-pugs-jump.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+Add a confirmation before deleting a hint in the Exercise Editor

--- a/packages/perseus-editor/src/__tests__/hint-editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/hint-editor.test.tsx
@@ -1,0 +1,83 @@
+import "@testing-library/jest-dom";
+import {render, screen} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as React from "react";
+
+import CombinedHintsEditor from "../hint-editor";
+
+describe("CombinedHintsEditor", () => {
+    it("should render", () => {
+        render(
+            <CombinedHintsEditor deviceType="phone" previewURL="about:blank" />,
+        );
+    });
+
+    it("should confirm before removing a hint", () => {
+        // Arrange
+        const comfirmSpy = jest.spyOn(window, "confirm").mockReturnValue(false);
+        render(
+            <CombinedHintsEditor
+                deviceType="phone"
+                previewURL="about:blank"
+                hints={[
+                    {content: "You know this one!", widgets: {}, images: {}},
+                    {content: "Ok, the answer is 3", widgets: {}, images: {}},
+                ]}
+            />,
+        );
+
+        // Act
+        userEvent.click(screen.getAllByText("Remove this hint")[0]);
+
+        // Assert
+        expect(comfirmSpy).toHaveBeenCalled();
+    });
+
+    it("should not remove the hint if not confirmed", () => {
+        // Arrange
+        jest.spyOn(window, "confirm").mockReturnValue(false);
+        const onChangeMock = jest.fn();
+        render(
+            <CombinedHintsEditor
+                deviceType="phone"
+                previewURL="about:blank"
+                hints={[
+                    {content: "You know this one!", widgets: {}, images: {}},
+                    {content: "Ok, the answer is 3", widgets: {}, images: {}},
+                ]}
+                onChange={onChangeMock}
+            />,
+        );
+
+        // Act
+        userEvent.click(screen.getAllByText("Remove this hint")[0]);
+
+        // Assert
+        expect(onChangeMock).not.toHaveBeenCalled();
+    });
+
+    it("should remove the hint if confirmed", () => {
+        // Arrange
+        jest.spyOn(window, "confirm").mockReturnValue(true);
+        const onChangeMock = jest.fn();
+        render(
+            <CombinedHintsEditor
+                deviceType="phone"
+                previewURL="about:blank"
+                hints={[
+                    {content: "You know this one!", widgets: {}, images: {}},
+                    {content: "Ok, the answer is 3", widgets: {}, images: {}},
+                ]}
+                onChange={onChangeMock}
+            />,
+        );
+
+        // Act
+        userEvent.click(screen.getAllByText("Remove this hint")[0]);
+
+        // Assert
+        expect(onChangeMock).toHaveBeenCalledWith({
+            hints: [{content: "Ok, the answer is 3", widgets: {}, images: {}}],
+        });
+    });
+});

--- a/packages/perseus-editor/src/hint-editor.tsx
+++ b/packages/perseus-editor/src/hint-editor.tsx
@@ -346,6 +346,11 @@ class CombinedHintsEditor extends React.Component<CombinedHintsEditorProps> {
     };
 
     handleHintRemove: (i: number) => void = (i: number) => {
+        // eslint-disable-next-line no-alert
+        if (!confirm("Are you sure you want to delete this hint?")) {
+            return;
+        }
+
         const hints = _(this.props.hints).clone();
         // @ts-expect-error - TS2339 - Property 'splice' does not exist on type 'Hint'.
         hints.splice(i, 1);


### PR DESCRIPTION
## Summary:

Adds a simple confirmation before proceeding with the hint is deleted. This will hopefully prevent alot of frustration by avoiding losing work.

Issue: LC-1591

## Test plan: