### PR TITLE
Convert a _bunch_ of string refs to React refs

### DIFF
--- a/.changeset/ninety-toys-visit.md
+++ b/.changeset/ninety-toys-visit.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+Convert many string refs to React refs

--- a/packages/perseus-editor/src/components/__tests__/blur-input.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/blur-input.test.tsx
@@ -4,6 +4,8 @@ import * as React from "react";
 
 import BlurInput from "../blur-input";
 
+import "@testing-library/jest-dom"; // Imports custom matchers
+
 describe("BlurInput", () => {
     it("should render", () => {
         render(<BlurInput value="Hello world!" onChange={() => {}} />);
@@ -60,6 +62,6 @@ describe("BlurInput", () => {
         ref.current?.focus();
 
         // Assert
-        expect(document.activeElement).toBe(screen.getByRole("textbox"));
+        expect(screen.getByRole("textbox")).toHaveFocus();
     });
 });

--- a/packages/perseus-editor/src/components/__tests__/blur-input.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/blur-input.test.tsx
@@ -47,4 +47,19 @@ describe("BlurInput", () => {
         // Assert
         expect(onChange).not.toHaveBeenCalledTimes(1);
     });
+
+    it("should focus input through focus function", () => {
+        const ref = React.createRef<BlurInput>();
+
+        // Arrange
+        render(
+            <BlurInput ref={ref} value="Hello world!" onChange={() => {}} />,
+        );
+
+        // Act
+        ref.current?.focus();
+
+        // Assert
+        expect(document.activeElement).toBe(screen.getByRole("textbox"));
+    });
 });

--- a/packages/perseus-editor/src/components/__tests__/blur-input.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/blur-input.test.tsx
@@ -1,0 +1,50 @@
+import {render, screen} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as React from "react";
+
+import BlurInput from "../blur-input";
+
+describe("BlurInput", () => {
+    it("should render", () => {
+        render(<BlurInput value="Hello world!" onChange={() => {}} />);
+    });
+
+    it("should call onChange prop on blur", () => {
+        // Arrange
+        const onChange = jest.fn();
+        render(<BlurInput value="Hello world!" onChange={onChange} />);
+
+        // Act
+        userEvent.type(screen.getByRole("textbox"), "Hello Khan Academy!");
+        userEvent.tab();
+
+        // Assert
+        expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("should call onChange prop when typing into input", () => {
+        // Arrange
+        const onChange = jest.fn();
+        render(<BlurInput value="Hello world!" onChange={onChange} />);
+
+        // Act
+        userEvent.type(screen.getByRole("textbox"), "Hello Khan Academy!");
+        // NO TAB
+
+        // Assert
+        expect(onChange).not.toHaveBeenCalledTimes(1);
+    });
+
+    it("should call onChange prop when pasting into input", () => {
+        // Arrange
+        const onChange = jest.fn();
+        render(<BlurInput value="Hello world!" onChange={onChange} />);
+
+        // Act
+        userEvent.paste(screen.getByRole("textbox"), "Hello Khan Academy!");
+        // NO TAB
+
+        // Assert
+        expect(onChange).not.toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/perseus-editor/src/components/blur-input.tsx
+++ b/packages/perseus-editor/src/components/blur-input.tsx
@@ -27,6 +27,8 @@ type State = {
  */
 // eslint-disable-next-line react/no-unsafe
 class BlurInput extends React.Component<Props, State> {
+    input = React.createRef<HTMLInputElement>();
+
     constructor(props: Props) {
         super(props);
         this.state = {value: this.props.value};
@@ -45,9 +47,14 @@ class BlurInput extends React.Component<Props, State> {
         this.props.onChange(e.target.value);
     };
 
+    focus() {
+        this.input.current?.focus();
+    }
+
     render(): React.ReactNode {
         return (
             <input
+                ref={this.input}
                 className={this.props.className}
                 style={this.props.style}
                 type="text"

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -69,8 +69,6 @@ type State = {
 
 class EditorPage extends React.Component<Props, State> {
     _isMounted: boolean;
-    // @ts-expect-error - TS2564 - Property 'rendererMountNode' has no initializer and is not definitely assigned in the constructor.
-    rendererMountNode: HTMLDivElement;
     renderer: any;
 
     itemEditor = React.createRef<ItemEditor>();
@@ -111,7 +109,6 @@ class EditorPage extends React.Component<Props, State> {
         // this.isMounted() but is still considered an anti-pattern.
         this._isMounted = true;
 
-        this.rendererMountNode = document.createElement("div");
         this.updateRenderer();
     }
 

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -74,6 +74,7 @@ class EditorPage extends React.Component<Props, State> {
     renderer: any;
 
     itemEditor = React.createRef<ItemEditor>();
+    hintsEditor = React.createRef<CombinedHintsEditor>();
 
     static defaultProps: {
         developerMode: boolean;
@@ -197,9 +198,7 @@ class EditorPage extends React.Component<Props, State> {
 
     getSaveWarnings(): any {
         const issues1 = this.itemEditor.current?.getSaveWarnings();
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2339 - Property 'getSaveWarnings' does not exist on type 'ReactInstance'.
-        const issues2 = this.refs.hintsEditor.getSaveWarnings();
+        const issues2 = this.hintsEditor.current?.getSaveWarnings();
         return issues1.concat(issues2);
     }
 
@@ -207,10 +206,8 @@ class EditorPage extends React.Component<Props, State> {
         if (this.props.jsonMode) {
             return this.state.json;
         }
-            // eslint-disable-next-line react/no-string-refs
-            // @ts-expect-error - TS2339 - Property 'serialize' does not exist on type 'ReactInstance'.
-            hints: this.refs.hintsEditor.serialize(options),
         return _.extend(this.itemEditor.current?.serialize(options), {
+            hints: this.hintsEditor.current?.serialize(options),
         });
     }
 
@@ -318,8 +315,7 @@ class EditorPage extends React.Component<Props, State> {
 
                 {(!this.props.developerMode || !this.props.jsonMode) && (
                     <CombinedHintsEditor
-                        // eslint-disable-next-line react/no-string-refs
-                        ref="hintsEditor"
+                        ref={this.hintsEditor}
                         itemId={this.props.itemId}
                         hints={this.props.hints}
                         imageUploader={this.props.imageUploader}

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -73,6 +73,8 @@ class EditorPage extends React.Component<Props, State> {
     rendererMountNode: HTMLDivElement;
     renderer: any;
 
+    itemEditor = React.createRef<ItemEditor>();
+
     static defaultProps: {
         developerMode: boolean;
         jsonMode: boolean;
@@ -160,9 +162,7 @@ class EditorPage extends React.Component<Props, State> {
             isMobile: touch,
         };
 
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2339 - Property 'triggerPreviewUpdate' does not exist on type 'ReactInstance'.
-        this.refs.itemEditor.triggerPreviewUpdate({
+        this.itemEditor.current?.triggerPreviewUpdate({
             type: "question",
             data: _({
                 item: this.serialize(),
@@ -176,9 +176,7 @@ class EditorPage extends React.Component<Props, State> {
                     paths: this.props.contentPaths || [],
                 },
                 reviewMode: true,
-                // eslint-disable-next-line react/no-string-refs
-                // @ts-expect-error - TS2339 - Property 'getSaveWarnings' does not exist on type 'ReactInstance'.
-                legacyPerseusLint: this.refs.itemEditor.getSaveWarnings(),
+                legacyPerseusLint: this.itemEditor.current?.getSaveWarnings(),
             }).extend(
                 _(this.props).pick(
                     "workAreaSelector",
@@ -198,9 +196,7 @@ class EditorPage extends React.Component<Props, State> {
     }
 
     getSaveWarnings(): any {
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2339 - Property 'getSaveWarnings' does not exist on type 'ReactInstance'.
-        const issues1 = this.refs.itemEditor.getSaveWarnings();
+        const issues1 = this.itemEditor.current?.getSaveWarnings();
         // eslint-disable-next-line react/no-string-refs
         // @ts-expect-error - TS2339 - Property 'getSaveWarnings' does not exist on type 'ReactInstance'.
         const issues2 = this.refs.hintsEditor.getSaveWarnings();
@@ -211,12 +207,10 @@ class EditorPage extends React.Component<Props, State> {
         if (this.props.jsonMode) {
             return this.state.json;
         }
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2339 - Property 'serialize' does not exist on type 'ReactInstance'.
-        return _.extend(this.refs.itemEditor.serialize(options), {
             // eslint-disable-next-line react/no-string-refs
             // @ts-expect-error - TS2339 - Property 'serialize' does not exist on type 'ReactInstance'.
             hints: this.refs.hintsEditor.serialize(options),
+        return _.extend(this.itemEditor.current?.serialize(options), {
         });
     }
 
@@ -308,8 +302,7 @@ class EditorPage extends React.Component<Props, State> {
 
                 {(!this.props.developerMode || !this.props.jsonMode) && (
                     <ItemEditor
-                        // eslint-disable-next-line react/no-string-refs
-                        ref="itemEditor"
+                        ref={this.itemEditor}
                         itemId={this.props.itemId}
                         question={this.props.question}
                         answerArea={this.props.answerArea}

--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -184,6 +184,9 @@ class Editor extends React.Component<Props, State> {
         // this.props.onChange during that, since it calls our parent's
         // setState
         this._sizeImages(this.props);
+        // NOTE(jeremy): We use the non-null assertion here (!) because refs
+        // are guaranteed to be up-to-date before componentDidMount or
+        // componentDidUpdate fires.
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         $(this.textarea.current!)
             // @ts-expect-error - TS2339 - Property 'on' does not exist on type 'JQueryStatic'.
@@ -438,7 +441,8 @@ class Editor extends React.Component<Props, State> {
         // type `[[im`, then tab.
         if (e.key === "Tab") {
             // We're in an event handler attached to the textarea, so the ref
-            // can't be empty/undefined!
+            // can't be empty/undefined! (which is why its safe to use the
+            // non-null-assertion here. aka the `!` suffix)
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const textarea = this.textarea.current!;
 

--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -18,7 +18,6 @@ import katex from "katex";
 // eslint-disable-next-line import/no-unassigned-import
 import "./katex-mhchem";
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import _ from "underscore";
 
 import DragTarget from "./components/drag-target";
@@ -88,8 +87,7 @@ const IMAGE_REGEX = /!\[[^\]]*\]\(([^\s)]+)[^)]*\)/g;
  * ignores captures. If you don't need captures, use String::match
  */
 const allMatches = function (regex: RegExp, str: string) {
-    // @ts-expect-error - TS2702 - 'RegExp' only refers to a type, but is being used as a namespace here.
-    const result: Array<any | RegExp.matchResult> = [];
+    const result: Array<RegExpExecArray> = [];
     // eslint-disable-next-line no-constant-condition
     while (true) {
         const match = regex.exec(str);
@@ -106,7 +104,7 @@ const allMatches = function (regex: RegExp, str: string) {
  * markdown.
  */
 const imageUrlsFromContent = function (content: string) {
-    return _.map(allMatches(IMAGE_REGEX, content), (capture) => capture[1]);
+    return allMatches(IMAGE_REGEX, content).map((capture) => capture[1]);
 };
 
 type Props = Readonly<{
@@ -157,6 +155,9 @@ class Editor extends React.Component<Props, State> {
     deferredChange: any | null | undefined;
     widgetIds: any | null | undefined;
 
+    underlay = React.createRef<HTMLDivElement>();
+    textarea = React.createRef<HTMLTextAreaElement>();
+
     static defaultProps: DefaultProps = {
         content: "",
         placeholder: "",
@@ -183,11 +184,11 @@ class Editor extends React.Component<Props, State> {
         // this.props.onChange during that, since it calls our parent's
         // setState
         this._sizeImages(this.props);
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2769 - No overload matches this call.
-        $(ReactDOM.findDOMNode(this.refs.textarea))
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        $(this.textarea.current!)
             // @ts-expect-error - TS2339 - Property 'on' does not exist on type 'JQueryStatic'.
             .on("copy cut", this._maybeCopyWidgets)
+            // @ts-expect-error - TS2769 - No overload matches this call.
             .on("paste", this._maybePasteWidgets);
     }
 
@@ -200,9 +201,7 @@ class Editor extends React.Component<Props, State> {
     }
 
     componentDidUpdate(prevProps: Props) {
-        // TODO(alpert): Maybe fix React so this isn't necessary
-        // eslint-disable-next-line react/no-string-refs
-        const textarea = ReactDOM.findDOMNode(this.refs.textarea);
+        const textarea = this.textarea.current;
 
         // Slightly unorthodox method to ensure that programmatic text changes
         // are in the browser's undo stack.
@@ -211,20 +210,11 @@ class Editor extends React.Component<Props, State> {
         // will return false. However at least in Firefox setting `value` on a
         // textbox clears the undo stack so we don't get unexpected undo
         // behavior.
-        if (this.lastUserValue !== null && textarea) {
-            /**
-             * TODO(somewhatabstract, JIRA-XXXX):
-             * textarea should be refined with an instanceof check to
-             * HTMLTextAreaElement so that these props are available.
-             */
-            // @ts-expect-error - TS2339 - Property 'focus' does not exist on type 'Element | Text'.
+        if (this.lastUserValue != null && textarea) {
             textarea.focus();
-            // @ts-expect-error - TS2339 - Property 'value' does not exist on type 'Element | Text'.
             textarea.value = this.lastUserValue;
-            // @ts-expect-error - TS2339 - Property 'selectionStart' does not exist on type 'Element | Text'.
             textarea.selectionStart = 0;
-            // @ts-expect-error - TS2339 - Property 'select' does not exist on type 'Element | Text'.
-            textarea.select(0, prevProps.content.length);
+            textarea.setSelectionRange(0, prevProps.content.length);
             if (
                 document.execCommand(
                     "insertText",
@@ -234,7 +224,6 @@ class Editor extends React.Component<Props, State> {
             ) {
                 // This command is not implemented. Fall back to setting `value`
                 // directly.
-                // @ts-expect-error - TS2339 - Property 'value' does not exist on type 'Element | Text'.
                 textarea.value = this.props.content;
             }
             this.lastUserValue = null;
@@ -293,11 +282,9 @@ class Editor extends React.Component<Props, State> {
     };
 
     _handleWidgetEditorRemove: (id: string) => void = (id: string) => {
-        // eslint-disable-next-line react/no-string-refs
-        const textarea = this.refs.textarea;
+        const textarea = this.textarea.current;
         const re = new RegExp(widgetRegExp.replace("{id}", id), "gm");
-        // @ts-expect-error - TS2339 - Property 'value' does not exist on type 'ReactInstance'.
-        this.props.onChange({content: textarea.value.replace(re, "")});
+        this.props.onChange({content: textarea?.value.replace(re, "")});
     };
 
     /**
@@ -450,11 +437,11 @@ class Editor extends React.Component<Props, State> {
         // Tab-completion of widgets. For example, to insert an image:
         // type `[[im`, then tab.
         if (e.key === "Tab") {
-            // eslint-disable-next-line react/no-string-refs
-            const textarea = ReactDOM.findDOMNode(this.refs.textarea);
+            // We're in an event handler attached to the textarea, so the ref
+            // can't be empty/undefined!
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const textarea = this.textarea.current!;
 
-            // findDOMNode can also return Text, but we know it's an element.
-            // @ts-expect-error - TS2345 - Argument of type 'Element | Text | null' is not assignable to parameter of type 'HTMLTextAreaElement'.
             const word = Util.textarea.getWordBeforeCursor(textarea);
             const matches = word.string.toLowerCase().match(shortcutRegexp);
 
@@ -645,9 +632,6 @@ class Editor extends React.Component<Props, State> {
         cursorRange: ReadonlyArray<number>,
         widgetType: string,
     ) => {
-        // eslint-disable-next-line react/no-string-refs
-        const textarea = ReactDOM.findDOMNode(this.refs.textarea);
-
         // Note: we have to use _.map here instead of Array::map
         // because the results of a .match might be null if no
         // widgets were found.
@@ -710,11 +694,13 @@ class Editor extends React.Component<Props, State> {
                 content: newContent,
                 widgets: newWidgets,
             },
-            function () {
+            () => {
+                if (!this.textarea.current) {
+                    return;
+                }
+
                 Util.textarea.moveCursor(
-                    // findDOMNode can return Text but we know this is Element
-                    // @ts-expect-error - TS2345 - Argument of type 'Element | Text | null' is not assignable to parameter of type 'HTMLTextAreaElement'.
-                    textarea,
+                    this.textarea.current,
                     // We want to put the cursor after the widget
                     // and after any added newlines
                     newContent.length - postlude.length,
@@ -724,21 +710,21 @@ class Editor extends React.Component<Props, State> {
     };
 
     _addWidget: (widgetType: string) => void = (widgetType: string) => {
-        // eslint-disable-next-line react/no-string-refs
-        const textarea = this.refs.textarea;
+        const textarea = this.textarea.current;
+        if (!textarea) {
+            return;
+        }
 
         this._addWidgetToContent(
             this.props.content,
-            // @ts-expect-error - TS2339 - Property 'selectionStart' does not exist on type 'ReactInstance'. | TS2339 - Property 'selectionEnd' does not exist on type 'ReactInstance'.
             [textarea.selectionStart, textarea.selectionEnd],
             widgetType,
         );
-        // @ts-expect-error - TS2339 - Property 'focus' does not exist on type 'ReactInstance'.
         textarea.focus();
     };
 
-    addTemplate: (e: React.SyntheticEvent<HTMLTextAreaElement>) => void = (
-        e: React.SyntheticEvent<HTMLTextAreaElement>,
+    addTemplate: (e: React.SyntheticEvent<HTMLSelectElement>) => void = (
+        e: React.SyntheticEvent<HTMLSelectElement>,
     ) => {
         const templateType = e.currentTarget.value;
         if (templateType === "") {
@@ -820,32 +806,17 @@ class Editor extends React.Component<Props, State> {
     };
 
     focus: () => void = () => {
-        // eslint-disable-next-line react/no-string-refs
-        const textarea = ReactDOM.findDOMNode(this.refs.textarea);
+        const textarea = this.textarea.current;
         if (textarea) {
-            /**
-             * TODO(somewhatabstract, JIRA-XXXX):
-             * textarea should be refined with an instanceof check to
-             * HTMLTextAreaElement so that these props are available.
-             */
-            // @ts-expect-error - TS2339 - Property 'focus' does not exist on type 'Element | Text'.
             textarea.focus();
         }
     };
 
     focusAndMoveToEnd: () => void = () => {
         this.focus();
-        // eslint-disable-next-line react/no-string-refs
-        const textarea = ReactDOM.findDOMNode(this.refs.textarea);
+        const textarea = this.textarea.current;
         if (textarea) {
-            /**
-             * TODO(somewhatabstract, JIRA-XXXX):
-             * textarea should be refined with an instanceof check to
-             * HTMLTextAreaElement so that these props are available.
-             */
-            // @ts-expect-error - TS2339 - Property 'selectionStart' does not exist on type 'Element | Text'. | TS2339 - Property 'value' does not exist on type 'Element | Text'.
             textarea.selectionStart = textarea.value.length;
-            // @ts-expect-error - TS2339 - Property 'selectionEnd' does not exist on type 'Element | Text'. | TS2339 - Property 'value' does not exist on type 'Element | Text'.
             textarea.selectionEnd = textarea.value.length;
         }
     };
@@ -1003,7 +974,6 @@ class Editor extends React.Component<Props, State> {
 
             const insertTemplateString = "Insert template\u2026";
             templatesDropDown = (
-                // @ts-expect-error - TS2322 - Type '(e: SyntheticEvent<HTMLTextAreaElement, Event>) => void' is not assignable to type 'ChangeEventHandler<HTMLSelectElement>'.
                 <select onChange={this.addTemplate}>
                     <option value="">{insertTemplateString}</option>
                     <option disabled>--</option>
@@ -1044,15 +1014,13 @@ class Editor extends React.Component<Props, State> {
         const completeTextarea = [
             <div
                 className="perseus-textarea-underlay"
-                // eslint-disable-next-line react/no-string-refs
-                ref="underlay"
+                ref={this.underlay}
                 key="underlay"
             >
                 {underlayPieces}
             </div>,
             <textarea
-                // eslint-disable-next-line react/no-string-refs
-                ref="textarea"
+                ref={this.textarea}
                 key="textarea"
                 onChange={this.handleChange}
                 onKeyDown={this._handleKeyDown}

--- a/packages/perseus-editor/src/hint-editor.tsx
+++ b/packages/perseus-editor/src/hint-editor.tsx
@@ -74,6 +74,8 @@ export class HintEditor extends React.Component<HintEditorProps> {
         showRemoveButton: true,
     };
 
+    editor = React.createRef<Editor>();
+
     handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void = (
         e: React.ChangeEvent<HTMLInputElement>,
     ) => {
@@ -81,21 +83,15 @@ export class HintEditor extends React.Component<HintEditorProps> {
     };
 
     focus: () => void = () => {
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2339 - Property 'focus' does not exist on type 'ReactInstance'.
-        this.refs.editor.focus();
+        this.editor.current?.focus();
     };
 
     getSaveWarnings: () => any = () => {
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2339 - Property 'getSaveWarnings' does not exist on type 'ReactInstance'.
-        return this.refs.editor.getSaveWarnings();
+        return this.editor.current?.getSaveWarnings();
     };
 
     serialize: (options?: any) => any = (options: any) => {
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2339 - Property 'serialize' does not exist on type 'ReactInstance'.
-        return this.refs.editor.serialize(options);
+        return this.editor.current?.serialize(options);
     };
 
     render(): React.ReactNode {
@@ -103,8 +99,7 @@ export class HintEditor extends React.Component<HintEditorProps> {
             <div className={"perseus-hint-editor " + this.props.className}>
                 {this.props.showTitle && <div className="pod-title">Hint</div>}
                 <Editor
-                    // eslint-disable-next-line react/no-string-refs
-                    ref="editor"
+                    ref={this.editor}
                     // Using the AssessmentItem content ID as the key
                     // ensures that when the user navigates to another
                     // item in the Sidebar, the question editor is
@@ -192,6 +187,9 @@ class CombinedHintEditor extends React.Component<CombinedHintEditorProps> {
         highlightLint: false,
     };
 
+    editor = React.createRef<HintEditor>();
+    frame = React.createRef<IframeContentRenderer>();
+
     componentDidMount() {
         this.updatePreview();
     }
@@ -204,9 +202,7 @@ class CombinedHintEditor extends React.Component<CombinedHintEditorProps> {
         const shouldBold =
             this.props.isLast && !/\*\*/.test(this.props.hint.content);
 
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2339 - Property 'sendNewData' does not exist on type 'ReactInstance'.
-        this.refs.frame.sendNewData({
+        this.frame.current?.sendNewData({
             type: "hint",
             data: {
                 hint: this.props.hint,
@@ -223,21 +219,15 @@ class CombinedHintEditor extends React.Component<CombinedHintEditorProps> {
     };
 
     getSaveWarnings = () => {
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2339 - Property 'getSaveWarnings' does not exist on type 'ReactInstance'.
-        return this.refs.editor.getSaveWarnings();
+        return this.editor.current?.getSaveWarnings();
     };
 
     serialize = (options: any) => {
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2339 - Property 'serialize' does not exist on type 'ReactInstance'.
-        return this.refs.editor.serialize(options);
+        return this.editor.current?.serialize(options);
     };
 
     focus = () => {
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2339 - Property 'focus' does not exist on type 'ReactInstance'.
-        this.refs.editor.focus();
+        this.editor.current?.focus();
     };
 
     render(): React.ReactNode {
@@ -252,8 +242,7 @@ class CombinedHintEditor extends React.Component<CombinedHintEditorProps> {
             >
                 <div className="perseus-editor-left-cell">
                     <HintEditor
-                        // eslint-disable-next-line react/no-string-refs
-                        ref="editor"
+                        ref={this.editor}
                         itemId={this.props.itemId}
                         isFirst={this.props.isFirst}
                         isLast={this.props.isLast}
@@ -274,8 +263,7 @@ class CombinedHintEditor extends React.Component<CombinedHintEditorProps> {
                         nochrome={true}
                     >
                         <IframeContentRenderer
-                            // eslint-disable-next-line react/no-string-refs
-                            ref="frame"
+                            ref={this.frame}
                             datasetKey="mobile"
                             datasetValue={isMobile}
                             seamless={true}

--- a/packages/perseus-editor/src/iframe-content-renderer.tsx
+++ b/packages/perseus-editor/src/iframe-content-renderer.tsx
@@ -66,6 +66,8 @@ type Props = {
 
 class IframeContentRenderer extends React.Component<Props> {
     _frame: HTMLIFrameElement | null | undefined;
+    container = React.createRef<HTMLDivElement>();
+
     // @ts-expect-error - TS2564 - Property '_isMounted' has no initializer and is not definitely assigned in the constructor.
     _isMounted: boolean;
     _lastData: any;
@@ -89,10 +91,12 @@ class IframeContentRenderer extends React.Component<Props> {
 
         updateIframeHeight[this.iframeID] = (height: any) => {
             this._lastHeight = height;
-            if (this._isMounted && this.props.seamless) {
-                // eslint-disable-next-line react/no-string-refs
-                // @ts-expect-error - TS2339 - Property 'style' does not exist on type 'ReactInstance'.
-                this.refs.container.style.height = height + "px";
+            if (
+                this._isMounted &&
+                this.props.seamless &&
+                this.container.current
+            ) {
+                this.container.current.style.height = height + "px";
             }
         };
     }
@@ -105,14 +109,12 @@ class IframeContentRenderer extends React.Component<Props> {
     }
 
     componentDidUpdate(prevProps: Props) {
-        if (!this.props.seamless) {
-            // eslint-disable-next-line react/no-string-refs
-            // @ts-expect-error - TS2339 - Property 'style' does not exist on type 'ReactInstance'.
-            this.refs.container.style.height = "100%";
-        } else {
-            // eslint-disable-next-line react/no-string-refs
-            // @ts-expect-error - TS2339 - Property 'style' does not exist on type 'ReactInstance'.
-            this.refs.container.style.height = this._lastHeight + "px";
+        if (this.container.current) {
+            if (!this.props.seamless) {
+                this.container.current.style.height = "100%";
+            } else {
+                this.container.current.style.height = this._lastHeight + "px";
+            }
         }
 
         if (prevProps.datasetValue !== this.props.datasetValue) {
@@ -131,9 +133,7 @@ class IframeContentRenderer extends React.Component<Props> {
     _prepareFrame() {
         // Don't initialize the iframe until the page has loaded
         if (this._frame) {
-            // eslint-disable-next-line react/no-string-refs
-            // @ts-expect-error - TS2339 - Property 'removeChild' does not exist on type 'ReactInstance'.
-            this.refs.container.removeChild(this._frame);
+            this.container.current?.removeChild(this._frame);
         }
 
         const frame = document.createElement("iframe");
@@ -159,9 +159,7 @@ class IframeContentRenderer extends React.Component<Props> {
             frame.dataset.lintGutter = "true";
         }
 
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2339 - Property 'appendChild' does not exist on type 'ReactInstance'.
-        this.refs.container.appendChild(frame);
+        this.container.current?.appendChild(frame);
 
         this._frame = frame;
     }
@@ -181,8 +179,9 @@ class IframeContentRenderer extends React.Component<Props> {
     }
 
     render(): React.ReactNode {
-        // eslint-disable-next-line react/no-string-refs
-        return <div ref="container" style={{width: "100%", height: "100%"}} />;
+        return (
+            <div ref={this.container} style={{width: "100%", height: "100%"}} />
+        );
     }
 }
 

--- a/packages/perseus-editor/src/item-editor.tsx
+++ b/packages/perseus-editor/src/item-editor.tsx
@@ -42,6 +42,8 @@ class ItemEditor extends React.Component<Props> {
         answerArea: {},
     };
 
+    frame = React.createRef<IframeContentRenderer>();
+
     // Notify the parent that the question or answer area has been updated.
     updateProps: ChangeHandler = (newProps, cb, silent) => {
         const props = _(this.props).pick("question", "answerArea");
@@ -50,9 +52,7 @@ class ItemEditor extends React.Component<Props> {
     };
 
     triggerPreviewUpdate: (newData?: any) => void = (newData: any) => {
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2339 - Property 'sendNewData' does not exist on type 'ReactInstance'.
-        this.refs.frame.sendNewData(newData);
+        this.frame.current?.sendNewData(newData);
     };
 
     handleEditorChange: ChangeHandler = (newProps, cb, silent) => {
@@ -124,8 +124,7 @@ class ItemEditor extends React.Component<Props> {
                                 nochrome={true}
                             >
                                 <IframeContentRenderer
-                                    // eslint-disable-next-line react/no-string-refs
-                                    ref="frame"
+                                    ref={this.frame}
                                     key={this.props.deviceType}
                                     datasetKey="mobile"
                                     datasetValue={isMobile}

--- a/packages/perseus-editor/src/item-editor.tsx
+++ b/packages/perseus-editor/src/item-editor.tsx
@@ -44,6 +44,7 @@ class ItemEditor extends React.Component<Props> {
 
     frame = React.createRef<IframeContentRenderer>();
     questionEditor = React.createRef<Editor>();
+    itemExtrasEditor = React.createRef<ItemExtrasEditor>();
 
     // Notify the parent that the question or answer area has been updated.
     updateProps: ChangeHandler = (newProps, cb, silent) => {
@@ -80,9 +81,7 @@ class ItemEditor extends React.Component<Props> {
     } = (options: any) => {
         return {
             question: this.questionEditor.current?.serialize(options),
-            // eslint-disable-next-line react/no-string-refs
-            // @ts-expect-error - TS2339 - Property 'serialize' does not exist on type 'ReactInstance'.
-            answerArea: this.refs.itemExtrasEditor.serialize(options),
+            answerArea: this.itemExtrasEditor.current?.serialize(),
             itemDataVersion: ITEM_DATA_VERSION,
         };
     };
@@ -141,8 +140,7 @@ class ItemEditor extends React.Component<Props> {
                     <div className="perseus-editor-left-cell">
                         <div className="pod-title">Question extras</div>
                         <ItemExtrasEditor
-                            // eslint-disable-next-line react/no-string-refs
-                            ref="itemExtrasEditor"
+                            ref={this.itemExtrasEditor}
                             onChange={this.handleItemExtrasChange}
                             {...this.props.answerArea}
                         />

--- a/packages/perseus-editor/src/item-editor.tsx
+++ b/packages/perseus-editor/src/item-editor.tsx
@@ -43,6 +43,7 @@ class ItemEditor extends React.Component<Props> {
     };
 
     frame = React.createRef<IframeContentRenderer>();
+    questionEditor = React.createRef<Editor>();
 
     // Notify the parent that the question or answer area has been updated.
     updateProps: ChangeHandler = (newProps, cb, silent) => {
@@ -66,9 +67,7 @@ class ItemEditor extends React.Component<Props> {
     };
 
     getSaveWarnings: () => any = () => {
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2339 - Property 'getSaveWarnings' does not exist on type 'ReactInstance'.
-        return this.refs.questionEditor.getSaveWarnings();
+        return this.questionEditor.current?.getSaveWarnings();
     };
 
     serialize: (options?: any) => {
@@ -80,9 +79,7 @@ class ItemEditor extends React.Component<Props> {
         question: any;
     } = (options: any) => {
         return {
-            // eslint-disable-next-line react/no-string-refs
-            // @ts-expect-error - TS2339 - Property 'serialize' does not exist on type 'ReactInstance'.
-            question: this.refs.questionEditor.serialize(options),
+            question: this.questionEditor.current?.serialize(options),
             // eslint-disable-next-line react/no-string-refs
             // @ts-expect-error - TS2339 - Property 'serialize' does not exist on type 'ReactInstance'.
             answerArea: this.refs.itemExtrasEditor.serialize(options),
@@ -100,8 +97,7 @@ class ItemEditor extends React.Component<Props> {
                     <div className="perseus-editor-left-cell">
                         <div className="pod-title">Question</div>
                         <Editor
-                            // eslint-disable-next-line react/no-string-refs
-                            ref="questionEditor"
+                            ref={this.questionEditor}
                             // Using the AssessmentItem content ID as the key
                             // ensures that when the user navigates to another
                             // item in the Sidebar, the question editor is

--- a/packages/perseus-editor/src/widgets/example-widget-editor.tsx
+++ b/packages/perseus-editor/src/widgets/example-widget-editor.tsx
@@ -19,6 +19,8 @@ class ExampleWidgetEditor extends React.Component<Props> {
         correct: "",
     };
 
+    input = React.createRef<HTMLInputElement>();
+
     handleAnswerChange: (arg1: React.ChangeEvent<HTMLInputElement>) => void = (
         event,
     ) => {
@@ -36,8 +38,7 @@ class ExampleWidgetEditor extends React.Component<Props> {
                     <input
                         value={this.props.correct}
                         onChange={this.handleAnswerChange}
-                        // eslint-disable-next-line react/no-string-refs
-                        ref="input"
+                        ref={this.input}
                     />
                 </label>
             </div>
@@ -49,9 +50,7 @@ class ExampleWidgetEditor extends React.Component<Props> {
     };
 
     focus: () => boolean = () => {
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2339 - Property 'focus' does not exist on type 'ReactInstance'.
-        this.refs.input.focus();
+        this.input.current?.focus();
         return true;
     };
 

--- a/packages/perseus-editor/src/widgets/example-widget.tsx
+++ b/packages/perseus-editor/src/widgets/example-widget.tsx
@@ -16,11 +16,12 @@ import _ from "underscore";
 import type {WidgetExports} from "@khanacademy/perseus";
 
 class TextInput extends React.Component<any> {
+    input = React.createRef<HTMLInputElement>();
+
     render(): React.ReactNode {
         return (
             <input
-                // eslint-disable-next-line react/no-string-refs
-                ref="input"
+                ref={this.input}
                 value={this.props.value || ""}
                 onChange={this.changeValue}
             />
@@ -28,9 +29,7 @@ class TextInput extends React.Component<any> {
     }
 
     focus = () => {
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2339 - Property 'focus' does not exist on type 'ReactInstance'.
-        this.refs.input.focus();
+        this.input.current?.focus();
         return true;
     };
 
@@ -55,6 +54,8 @@ class ExampleWidget extends React.Component<any> {
     static defaultProps: any = {
         value: "",
     };
+
+    input = React.createRef<TextInput>();
 
     /**
      * This is the widget's grading function. simpleValidate generally
@@ -98,8 +99,7 @@ class ExampleWidget extends React.Component<any> {
     render(): React.ReactNode {
         return (
             <TextInput
-                // eslint-disable-next-line react/no-string-refs
-                ref="input"
+                ref={this.input}
                 value={this.props.value}
                 // @ts-expect-error - TS2554 - Expected 3 arguments, but got 1.
                 onChange={this.change("value")}
@@ -117,9 +117,7 @@ class ExampleWidget extends React.Component<any> {
      * focused on page load.
      */
     focus: () => boolean = () => {
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2339 - Property 'focus' does not exist on type 'ReactInstance'.
-        this.refs.input.focus();
+        this.input.current?.focus();
         return true;
     };
 

--- a/packages/perseus-editor/src/widgets/graded-group-editor.tsx
+++ b/packages/perseus-editor/src/widgets/graded-group-editor.tsx
@@ -33,6 +33,9 @@ class GradedGroupEditor extends React.Component<Props> {
         hint: null,
     };
 
+    editor = React.createRef<Editor>();
+    hintEditor = React.createRef<Editor>();
+
     change: (arg1: any, arg2: any, arg3: any) => any = (...args) => {
         return Changeable.change.apply(this, args);
     };
@@ -40,9 +43,7 @@ class GradedGroupEditor extends React.Component<Props> {
     handleAddHint: () => void = () => {
         const hint = {content: ""} as const;
         this.props.onChange({hint}, () => {
-            // eslint-disable-next-line react/no-string-refs
-            // @ts-expect-error - TS2339 - Property 'focus' does not exist on type 'ReactInstance'.
-            this.refs["hint-editor"].focus();
+            this.hintEditor.current?.focus();
         });
     };
 
@@ -65,8 +66,7 @@ class GradedGroupEditor extends React.Component<Props> {
                     </label>
                 </div>
                 <Editor
-                    // eslint-disable-next-line react/no-string-refs
-                    ref="editor"
+                    ref={this.editor}
                     content={this.props.content}
                     widgets={this.props.widgets}
                     apiOptions={this.props.apiOptions}
@@ -91,8 +91,7 @@ class GradedGroupEditor extends React.Component<Props> {
                     <div className="perseus-hint-editor">
                         <div className={css(styles.hintsTitle)}>Hint</div>
                         <Editor
-                            // eslint-disable-next-line react/no-string-refs
-                            ref="hint-editor"
+                            ref={this.hintEditor}
                             content={
                                 this.props.hint ? this.props.hint.content : ""
                             }
@@ -127,9 +126,7 @@ class GradedGroupEditor extends React.Component<Props> {
     }
 
     getSaveWarnings: () => any = () => {
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2339 - Property 'getSaveWarnings' does not exist on type 'ReactInstance'.
-        return this.refs.editor.getSaveWarnings();
+        return this.editor.current?.getSaveWarnings();
     };
 
     serialize: () => {
@@ -138,15 +135,8 @@ class GradedGroupEditor extends React.Component<Props> {
     } = () => {
         return {
             title: this.props.title,
-            // eslint-disable-next-line react/no-string-refs
-            // @ts-expect-error - TS2339 - Property 'serialize' does not exist on type 'ReactInstance'.
-            ...this.refs.editor.serialize(),
-            hint:
-                // eslint-disable-next-line react/no-string-refs
-                this.refs["hint-editor"] &&
-                // eslint-disable-next-line react/no-string-refs
-                // @ts-expect-error - TS2339 - Property 'serialize' does not exist on type 'ReactInstance'.
-                this.refs["hint-editor"].serialize(),
+            ...this.editor.current?.serialize(),
+            hint: this.hintEditor.current?.serialize(),
         };
     };
 }

--- a/packages/perseus-editor/src/widgets/group-editor.tsx
+++ b/packages/perseus-editor/src/widgets/group-editor.tsx
@@ -30,6 +30,8 @@ class GroupEditor extends React.Component<Props> {
         metadata: undefined,
     };
 
+    editor = React.createRef<Editor>();
+
     render(): React.ReactNode {
         return (
             <div className="perseus-group-editor">
@@ -39,8 +41,7 @@ class GroupEditor extends React.Component<Props> {
                     {this._renderMetadataEditor()}
                 </div>
                 <Editor
-                    // eslint-disable-next-line react/no-string-refs
-                    ref="editor"
+                    ref={this.editor}
                     content={this.props.content}
                     widgets={this.props.widgets}
                     apiOptions={this.props.apiOptions}
@@ -69,15 +70,11 @@ class GroupEditor extends React.Component<Props> {
     };
 
     getSaveWarnings: () => ReadonlyArray<any> = () => {
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2339 - Property 'getSaveWarnings' does not exist on type 'ReactInstance'.
-        return this.refs.editor.getSaveWarnings();
+        return this.editor.current?.getSaveWarnings();
     };
 
     serialize: () => any = () => {
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2339 - Property 'serialize' does not exist on type 'ReactInstance'.
-        return _.extend({}, this.refs.editor.serialize(), {
+        return _.extend({}, this.editor.current?.serialize(), {
             metadata: this.props.metadata,
         });
     };

--- a/packages/perseus-editor/src/widgets/input-number-editor.tsx
+++ b/packages/perseus-editor/src/widgets/input-number-editor.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/sort-comp */
 import {components, Util} from "@khanacademy/perseus";
 import * as React from "react";
-import ReactDOM from "react-dom";
 import _ from "underscore";
 
 import BlurInput from "../components/blur-input";

--- a/packages/perseus-editor/src/widgets/input-number-editor.tsx
+++ b/packages/perseus-editor/src/widgets/input-number-editor.tsx
@@ -90,6 +90,8 @@ class InputNumberEditor extends React.Component<Props> {
         rightAlign: false,
     };
 
+    input = React.createRef<BlurInput>();
+
     handleAnswerChange: (arg1: string) => void = (str) => {
         const value = Util.firstNumericalParse(str) || 0;
         this.props.onChange({value: value});
@@ -116,8 +118,7 @@ class InputNumberEditor extends React.Component<Props> {
                         <BlurInput
                             value={"" + this.props.value}
                             onChange={this.handleAnswerChange}
-                            // eslint-disable-next-line react/no-string-refs
-                            ref="input"
+                            ref={this.input}
                         />
                     </label>
                 </div>
@@ -260,8 +261,7 @@ class InputNumberEditor extends React.Component<Props> {
     }
 
     focus: () => boolean = () => {
-        // @ts-expect-error - TS2531 - Object is possibly 'null'. | TS2339 - Property 'focus' does not exist on type 'Element | Text'.
-        ReactDOM.findDOMNode(this.refs.input).focus(); // eslint-disable-line react/no-string-refs
+        this.input.current?.focus();
         return true;
     };
 

--- a/packages/perseus-editor/src/widgets/simple-markdown-tester-editor.tsx
+++ b/packages/perseus-editor/src/widgets/simple-markdown-tester-editor.tsx
@@ -49,6 +49,8 @@ class SimpleMarkdownTesterEditor extends React.Component<SimpleMarkdownTesterEdi
         value: "",
     };
 
+    input = React.createRef<TextArea>();
+
     render(): React.ReactNode {
         return (
             <div>
@@ -59,8 +61,7 @@ class SimpleMarkdownTesterEditor extends React.Component<SimpleMarkdownTesterEdi
                             value={this.props.value}
                             // @ts-expect-error - TS2554 - Expected 3 arguments, but got 1.
                             onChange={this.change("value")}
-                            // eslint-disable-next-line react/no-string-refs
-                            ref="input"
+                            ref={this.input}
                         />
                     </div>
                 </label>
@@ -73,9 +74,7 @@ class SimpleMarkdownTesterEditor extends React.Component<SimpleMarkdownTesterEdi
     };
 
     focus: () => boolean = () => {
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2339 - Property 'focus' does not exist on type 'ReactInstance'.
-        this.refs.input.focus();
+        this.input.current?.focus();
         return true;
     };
 

--- a/packages/perseus-editor/src/widgets/simple-markdown-tester.tsx
+++ b/packages/perseus-editor/src/widgets/simple-markdown-tester.tsx
@@ -57,8 +57,6 @@ class SimpleMarkdownTester extends React.Component<Props> {
      * focused on page load.
      */
     focus: () => boolean = () => {
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2339 - Property 'focus' does not exist on type 'ReactInstance'.
         this.refs.input.focus();
         return true;
     };

--- a/packages/perseus-editor/src/widgets/simple-markdown-tester.tsx
+++ b/packages/perseus-editor/src/widgets/simple-markdown-tester.tsx
@@ -57,6 +57,8 @@ class SimpleMarkdownTester extends React.Component<Props> {
      * focused on page load.
      */
     focus: () => boolean = () => {
+        // eslint-disable-next-line react/no-string-refs
+        // @ts-expect-error - TS2339 - Property 'focus' does not exist on type 'ReactInstance'.
         this.refs.input.focus();
         return true;
     };

--- a/packages/perseus-editor/src/widgets/table-editor.tsx
+++ b/packages/perseus-editor/src/widgets/table-editor.tsx
@@ -2,7 +2,6 @@
 import {components, TableWidget, Util} from "@khanacademy/perseus";
 import PropTypes from "prop-types";
 import * as React from "react";
-import ReactDOM from "react-dom";
 import _ from "underscore";
 
 import Editor from "../editor";
@@ -36,9 +35,10 @@ class TableEditor extends React.Component<Props> {
         };
     })();
 
+    numberOfColumns = React.createRef<components.NumberInput>();
+
     focus: () => void = () => {
-        // @ts-expect-error - TS2531 - Object is possibly 'null'. | TS2339 - Property 'focus' does not exist on type 'Element | Text'.
-        ReactDOM.findDOMNode(this.refs.numberOfColumns).focus(); // eslint-disable-line react/no-string-refs
+        this.numberOfColumns.current?.focus();
     };
 
     render(): React.ReactNode {
@@ -63,8 +63,7 @@ class TableEditor extends React.Component<Props> {
                     <label>
                         Number of columns:{" "}
                         <NumberInput
-                            // eslint-disable-next-line react/no-string-refs
-                            ref="numberOfColumns"
+                            ref={this.numberOfColumns}
                             value={this.props.columns}
                             onChange={(val) => {
                                 if (val) {


### PR DESCRIPTION
## Summary:

Perseus editor code still uses alot of string refs. I went through and converted the easy/simple ones to `React.createRef<>`s. 

Sorry: This is a large-ish PR, but I hope it's fairly straightforward to review.

  * Convert all string refs in Example widget and editor to React refs
  * Convert EditorPage itemEditor ref to a React ref
  * Convert EditorPage hintsEditor ref to a React ref
  * Remove unused manually-created <div> rendererMountNode
  * Convert ItemEditor's frame ref to a React ref
  * Convert ItemEditor's questionEditor ref to a React ref
  * Convert ItemEditor's itemExtrasEditor ref to a React ref
  * Convert all string refs in Editor to React refs
  * Convert IframeContentRenderer's container ref to a React ref
  * Convert all string refs in HintEditor to React refs
  * Convert all string refs in GradedGroupEditor to React refs
  * Convert all string refs in GroupEditor to React refs
  * Convert all string refs in InputNumberEditor to React refs
  * Convert all string refs in TableEditor to React refs
  * Convert all string refs in SimpleMarkdownTestEditor to React refs
  * Convert all string refs in SimpleMarkdownTester to React refs

Issue: --none--

## Test plan:

`yarn typecheck`
`yarn test`

I also did some exploring our Editor storybook stories.