### PR TITLE
[🔥AUDIT🔥] Move Editor component into its own folder

### DIFF
--- a/packages/perseus-editor/src/__stories__/editor.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/editor.stories.tsx
@@ -16,7 +16,7 @@ import "../styles/perseus-editor.less";
 registerAllWidgetsAndEditorsForTesting(); // SIDE_EFFECTY!!!! :cry:
 
 export default {
-    title: "Perseus/Editor",
+    title: "Perseus/Editor/Editor",
 };
 
 export const Demo = (): React.ReactElement => {


### PR DESCRIPTION
## Summary:

I noticed that our `Editor` component stories live in the top-level "Editor" folder. This is not even the top-level editor (EditorPage is) so I've moved it into a folder like our other editor stories are. 

<img width="244" alt="image" src="https://github.com/Khan/perseus/assets/77138/ac7b4373-4530-4be8-aea5-d3a68289a6bf">


Issue: --none--

## Test plan: