### PR TITLE
Update OnFocusChange logic so that it returns the keypadHeight rather than the entire DomNode for the keypad

### DIFF
--- a/.changeset/empty-rabbits-mate.md
+++ b/.changeset/empty-rabbits-mate.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Updated OnFocusChange method to return the keypadHeight rather than the DOMNode

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -26,9 +26,9 @@ import MockAssetLoadingWidgetExport, {
 } from "./mock-asset-loading-widget";
 import MockWidgetExport from "./mock-widget";
 
-import type {MockAssetLoadingWidget} from "./mock-asset-loading-widget";
 import type {PerseusItem} from "../perseus-types";
 import type {APIOptions} from "../types";
+import type {MockAssetLoadingWidget} from "./mock-asset-loading-widget";
 import type {KeypadAPI} from "@khanacademy/math-input";
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
@@ -335,7 +335,7 @@ describe("server item renderer", () => {
             expect(onFocusChange).toHaveBeenCalledWith(
                 ["input-number 1"],
                 null,
-                undefined,
+                0,
                 expect.any(Object),
             );
         });
@@ -343,7 +343,15 @@ describe("server item renderer", () => {
         it("activates the keypadElement when focusing the renderer on mobile", () => {
             // Arranged
             const onFocusChange = jest.fn();
-            const keypadElementDOMNode = <div />;
+            const keypadElementDOMNode = document.createElement("div");
+
+            // We need to mock the getBoundingClientRect() method for our
+            // onFocusChange() callback to work properly.
+            keypadElementDOMNode.getBoundingClientRect = () =>
+                ({
+                    height: 250,
+                } as DOMRect);
+
             const keypadElement: KeypadAPI = {
                 getDOMNode: jest
                     .fn()
@@ -372,7 +380,7 @@ describe("server item renderer", () => {
             expect(onFocusChange).toHaveBeenCalledWith(
                 ["input-number 1"],
                 null,
-                keypadElementDOMNode,
+                250,
                 expect.any(Object),
             );
         });
@@ -399,7 +407,7 @@ describe("server item renderer", () => {
             expect(onFocusChange).toHaveBeenLastCalledWith(
                 null,
                 ["input-number 1"],
-                null,
+                0,
                 null,
             );
         });
@@ -407,7 +415,15 @@ describe("server item renderer", () => {
         it("dismisses the keypadElement when blurring the renderer on mobile", () => {
             // Arranged
             const onFocusChange = jest.fn();
-            const keypadElementDOMNode = <div />;
+            const keypadElementDOMNode = document.createElement("div");
+
+            // We need to mock the getBoundingClientRect() method for our
+            // onFocusChange() callback to work properly.
+            keypadElementDOMNode.getBoundingClientRect = () =>
+                ({
+                    height: 250,
+                } as DOMRect);
+
             const keypadElement: KeypadAPI = {
                 getDOMNode: jest
                     .fn()
@@ -440,7 +456,7 @@ describe("server item renderer", () => {
             expect(onFocusChange).toHaveBeenLastCalledWith(
                 null,
                 ["input-number 1"],
-                null,
+                0,
                 null,
             );
         });
@@ -459,7 +475,7 @@ describe("server item renderer", () => {
             expect(onFocusChange).toHaveBeenCalledWith(
                 ["input-number 1"],
                 null,
-                undefined,
+                0,
                 expect.any(Object),
             );
         });

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -26,9 +26,9 @@ import MockAssetLoadingWidgetExport, {
 } from "./mock-asset-loading-widget";
 import MockWidgetExport from "./mock-widget";
 
+import type {MockAssetLoadingWidget} from "./mock-asset-loading-widget";
 import type {PerseusItem} from "../perseus-types";
 import type {APIOptions} from "../types";
-import type {MockAssetLoadingWidget} from "./mock-asset-loading-widget";
 import type {KeypadAPI} from "@khanacademy/math-input";
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 

--- a/packages/perseus/src/article-renderer.tsx
+++ b/packages/perseus/src/article-renderer.tsx
@@ -104,21 +104,27 @@ class ArticleRenderer
                 );
         }
 
-        if (this.props.apiOptions.onFocusChange != null) {
-            this.props.apiOptions.onFocusChange(
-                this._currentFocus,
-                prevFocusPath,
-                didFocusInput ? keypadElement?.getDOMNode() : null,
-                didFocusInput ? focusedInput : null,
-            );
-        }
-
         if (keypadElement && isMobile) {
             if (didFocusInput) {
                 keypadElement.activate();
             } else {
                 keypadElement.dismiss();
             }
+        }
+
+        if (this.props.apiOptions.onFocusChange != null) {
+            const keypadDomNode = keypadElement?.getDOMNode() as HTMLElement;
+            const keypadHeight =
+                keypadDomNode && didFocusInput
+                    ? keypadDomNode.getBoundingClientRect().height
+                    : 0;
+
+            this.props.apiOptions.onFocusChange(
+                this._currentFocus,
+                prevFocusPath,
+                keypadHeight,
+                didFocusInput ? focusedInput : null,
+            );
         }
     };
 

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -180,23 +180,32 @@ export class ServerItemRenderer
                 return Util.inputPathsEqual(inputPath, this._currentFocus);
             });
 
-        if (onFocusChange != null) {
-            onFocusChange(
-                this._currentFocus,
-                prevFocus,
-                didFocusInput ? keypadElement?.getDOMNode() : null,
-                // @ts-expect-error [FEI-5003] - TS2345 - Argument of type 'false | Element | Text | null | undefined' is not assignable to parameter of type 'HTMLElement | undefined'.
-                didFocusInput &&
-                    this.questionRenderer.getDOMNodeForPath(newFocus),
-            );
-        }
-
         if (keypadElement && isMobile) {
             if (didFocusInput) {
                 keypadElement.activate();
             } else {
                 keypadElement.dismiss();
             }
+        }
+
+        if (onFocusChange != null) {
+            // First, calculate the current keypad height
+            const keypadDomNode: HTMLElement =
+                keypadElement?.getDOMNode() as HTMLElement;
+            const keypadHeight =
+                keypadDomNode && didFocusInput
+                    ? keypadDomNode.getBoundingClientRect().height
+                    : 0;
+
+            // Then call the callback
+            onFocusChange(
+                this._currentFocus,
+                prevFocus,
+                keypadHeight,
+                // @ts-expect-error [FEI-5003] - TS2345 - Argument of type 'false | Element | Text | null | undefined' is not assignable to parameter of type 'HTMLElement | undefined'.
+                didFocusInput &&
+                    this.questionRenderer.getDOMNodeForPath(newFocus),
+            );
         }
     }
 

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -12,7 +12,6 @@ import type {AnalyticsEventHandlerFn} from "@khanacademy/perseus-core";
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
 import type {Result} from "@khanacademy/wonder-blocks-data";
 import type * as React from "react";
-import type ReactDOM from "react-dom";
 
 export type FocusPath = ReadonlyArray<string> | null | undefined;
 
@@ -145,7 +144,7 @@ export type APIOptions = Readonly<{
     onFocusChange?: (
         newFocusPath: FocusPath,
         oldFocusPath: FocusPath,
-        keypadElement?: ReturnType<typeof ReactDOM.findDOMNode>,
+        keypadHeight?: number,
         focusedElement?: HTMLElement,
     ) => unknown;
     GroupMetadataEditor?: React.ComponentType<StubTagEditorType>;

--- a/packages/perseus/src/widgets/__stories__/expression.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/expression.stories.tsx
@@ -1,4 +1,5 @@
 import {KeypadContext, KeypadType} from "@khanacademy/math-input";
+import {action} from "@storybook/addon-actions";
 import * as React from "react";
 
 import {ServerItemRendererWithDebugUI} from "../../../../../testing/server-item-renderer-with-debug-ui";
@@ -46,7 +47,7 @@ const WrappedKeypadContext = ({
                             apiOptions={{
                                 isMobile: isMobile,
                                 customKeypad: customKeypad,
-                                onFocusChange: () => {},
+                                onFocusChange: action("onFocusChange"),
                             }}
                         />
                     );

--- a/packages/perseus/src/widgets/__stories__/expression.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/expression.stories.tsx
@@ -46,6 +46,7 @@ const WrappedKeypadContext = ({
                             apiOptions={{
                                 isMobile: isMobile,
                                 customKeypad: customKeypad,
+                                onFocusChange: () => {},
                             }}
                         />
                     );


### PR DESCRIPTION
## Summary:
We have recently noticed a regression related to scrolling in the mobile application after fixing an issue related to our MathInput package not updating. The issue is that we're unable to properly calculate the keypadHeight using the new keypad mounting approach. 

This PR is a partial fix for that issue by simplifying the OnFocusChange method so that it returns the keypadHeight directly, rather than the DOMNode for the keypad. This will allow us to centralize the logic and keep things DRY across Mobile Web and our Mobile App. 

Issue: LC-1575

## Test plan: 
- manual testing
- updated unit tests accordingly 