### PR TITLE
Update widget display names to better match their type names

### DIFF
--- a/.changeset/lazy-tables-listen.md
+++ b/.changeset/lazy-tables-listen.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Display names have been updated to better match type names

--- a/packages/perseus/src/widgets/iframe.tsx
+++ b/packages/perseus/src/widgets/iframe.tsx
@@ -188,7 +188,7 @@ _.extend(Iframe, {
 
 export default {
     name: "iframe",
-    displayName: "Iframe",
+    displayName: "Iframe (deprecated)",
     widget: Iframe,
     // Let's not expose it to all content creators yet
     hidden: true,

--- a/packages/perseus/src/widgets/input-number.tsx
+++ b/packages/perseus/src/widgets/input-number.tsx
@@ -403,7 +403,7 @@ const propTransform = (
 
 export default {
     name: "input-number",
-    displayName: "Number text box (old)",
+    displayName: "Input number (deprecated - use numeric input instead)",
     defaultAlignment: "inline-block",
     hidden: true,
     widget: InputNumber,

--- a/packages/perseus/src/widgets/lights-puzzle.tsx
+++ b/packages/perseus/src/widgets/lights-puzzle.tsx
@@ -352,7 +352,7 @@ const transformProps: (arg1: any) => any = function (editorProps) {
 
 export default {
     name: "lights-puzzle",
-    displayName: "Lights Puzzle",
+    displayName: "Lights puzzle (deprecated)",
     hidden: true,
     widget: LightsPuzzle,
     transform: transformProps,

--- a/packages/perseus/src/widgets/matcher.tsx
+++ b/packages/perseus/src/widgets/matcher.tsx
@@ -292,7 +292,7 @@ const styles = StyleSheet.create({
 
 export default {
     name: "matcher",
-    displayName: "Two column matcher",
+    displayName: "Matcher (two column)",
     widget: Matcher,
     isLintable: true,
 } as WidgetExports<typeof Matcher>;

--- a/packages/perseus/src/widgets/numeric-input.tsx
+++ b/packages/perseus/src/widgets/numeric-input.tsx
@@ -567,7 +567,7 @@ const propsTransform = function (
 
 export default {
     name: "numeric-input",
-    displayName: "Number text box",
+    displayName: "Numeric input",
     defaultAlignment: "inline-block",
     accessible: true,
     widget: NumericInput,

--- a/packages/perseus/src/widgets/radio.ts
+++ b/packages/perseus/src/widgets/radio.ts
@@ -146,7 +146,7 @@ const propUpgrades = {
 
 export default {
     name: "radio",
-    displayName: "Multiple choice",
+    displayName: "Radio / Multiple choice",
     accessible: true,
     widget: Radio,
     transform: transform,

--- a/packages/perseus/src/widgets/reaction-diagram.tsx
+++ b/packages/perseus/src/widgets/reaction-diagram.tsx
@@ -138,7 +138,7 @@ class ReactionDiagramWidget extends React.Component<any> {
 
 export default {
     name: "reaction-diagram",
-    displayName: "Chemical reaction",
+    displayName: "Chemical reaction diagram",
     hidden: true,
     widget: ReactionDiagramWidget,
 } as WidgetExports<typeof ReactionDiagramWidget>;

--- a/packages/perseus/src/widgets/reaction-diagram.tsx
+++ b/packages/perseus/src/widgets/reaction-diagram.tsx
@@ -138,7 +138,7 @@ class ReactionDiagramWidget extends React.Component<any> {
 
 export default {
     name: "reaction-diagram",
-    displayName: "Chemical reaction diagram",
+    displayName: "Chemical reaction diagram (deprecated)",
     hidden: true,
     widget: ReactionDiagramWidget,
 } as WidgetExports<typeof ReactionDiagramWidget>;

--- a/packages/perseus/src/widgets/sequence.tsx
+++ b/packages/perseus/src/widgets/sequence.tsx
@@ -133,7 +133,7 @@ const traverseChildWidgets = function (props: any, traverseRenderer: any): any {
 
 export default {
     name: "sequence",
-    displayName: "Graded Sequence",
+    displayName: "Graded sequence (deprecated)",
     widget: Sequence,
     traverseChildWidgets: traverseChildWidgets,
     tracking: "all",

--- a/packages/perseus/src/widgets/simulator.tsx
+++ b/packages/perseus/src/widgets/simulator.tsx
@@ -822,7 +822,7 @@ const propTransform: (arg1: any) => any = (editorProps) => {
 
 export default {
     name: "simulator",
-    displayName: "Simulator",
+    displayName: "Simulator (deprecated)",
     widget: Simulator,
     transform: propTransform,
     hidden: true,

--- a/packages/perseus/src/widgets/table.tsx
+++ b/packages/perseus/src/widgets/table.tsx
@@ -384,7 +384,7 @@ const propTransform: (arg1: any) => any = (editorProps) => {
 
 export default {
     name: "table",
-    displayName: "Table of values",
+    displayName: "Table (deprecated - use markdown table instead)",
     accessible: true,
     widget: Table,
     transform: propTransform,

--- a/packages/perseus/src/widgets/transformer.tsx
+++ b/packages/perseus/src/widgets/transformer.tsx
@@ -2931,5 +2931,6 @@ class Transformer extends React.Component<Props> {
 export default {
     name: "transformer",
     displayName: "Transformer (deprecated)",
+    hidden: true,
     widget: Transformer,
 } as WidgetExports<typeof Transformer>;

--- a/packages/perseus/src/widgets/transformer.tsx
+++ b/packages/perseus/src/widgets/transformer.tsx
@@ -2930,6 +2930,6 @@ class Transformer extends React.Component<Props> {
 
 export default {
     name: "transformer",
-    displayName: "Transformer",
+    displayName: "Transformer (deprecated)",
     widget: Transformer,
 } as WidgetExports<typeof Transformer>;

--- a/packages/perseus/src/widgets/unit.tsx
+++ b/packages/perseus/src/widgets/unit.tsx
@@ -365,7 +365,7 @@ const primUnits = function (expr) {
 
 export default {
     name: "unit-input",
-    displayName: "Unit",
+    displayName: "Unit input",
     defaultAlignment: "inline-block",
     widget: OldUnitInput,
     transform: (x: any): any => lens(x).del(["value"]).freeze(),


### PR DESCRIPTION
## Summary:
Currently, some widget display names (shown in the "add widget"
dropdown) do not match their type names (used in the editor).
This can be confusing for content writers when trying to find
and use widgets.

To fix this, some of the display names have been updated to
better match their type names. In addition, deprecated widgets
have been marked as such.

For the full list of updated names, see:
https://khanacademy.atlassian.net/l/cp/C5PWFNAe

Issue: https://khanacademy.atlassian.net/browse/LC-1566

## Test plan:
- Go to the storybook page for EditorPage (http://localhost:6006/?path=/docs/perseus-editor-editorpage--docs)
- Click on the "Add a widget..." dropdown
- Confirm that the list of widget matches the non-deprecated widgets' display names

<img width="923" alt="Screenshot 2024-01-04 at 3 17 18 PM" src="https://github.com/Khan/perseus/assets/13231763/67309a46-eb38-45a1-8f87-e98b03a59f67">

https://github.com/Khan/perseus/assets/13231763/f34d5a6d-d184-4ca1-9a8f-b398fff10df6
