### PR TITLE
Change table zebra-stripe color to Wonder Blocks offWhite

### DIFF
--- a/.changeset/dry-mugs-camp.md
+++ b/.changeset/dry-mugs-camp.md
@@ -1,0 +1,10 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Lighten the background color for odd-numbered rows of Markdown tables on
+desktop-sized screens. Previously, the color was `#ededed`; it is now
+`#f7f8fa` (Wonder Blocks offWhite).
+
+This change ensures that color-coded math expressions will have accessible
+contrast with the background.

--- a/packages/perseus/src/styles/perseus-renderer.less
+++ b/packages/perseus/src/styles/perseus-renderer.less
@@ -314,7 +314,7 @@
         tr:nth-child(odd) {
             // Doesn't work in IE8 :(
             td {
-                background-color: #f7f8fa; // Wonder Blocks offWhite
+                background-color: @offWhite;
             }
         }
     }

--- a/packages/perseus/src/styles/perseus-renderer.less
+++ b/packages/perseus/src/styles/perseus-renderer.less
@@ -314,7 +314,7 @@
         tr:nth-child(odd) {
             // Doesn't work in IE8 :(
             td {
-                background-color: #ededed;
+                background-color: #f7f8fa; // Wonder Blocks offWhite
             }
         }
     }

--- a/packages/perseus/src/styles/variables.less
+++ b/packages/perseus/src/styles/variables.less
@@ -15,6 +15,7 @@
 // TODO(charlie): DRY this up. How can we keep our global palette in sync across
 // repos?
 @white: #ffffff;
+@offWhite: #f7f8fa;
 @gray98: #fafafa;
 @gray97: #f6f7f7;
 @gray95: #f0f1f2;


### PR DESCRIPTION
## Summary:
This ensures that color-coded math expressions have accessible contrast
with the darker table rows.

Issue: https://khanacademy.atlassian.net/browse/LC-1577

Test plan:

Run storybook: `yarn storybook`.

Visit
`http://localhost:6006/?path=/story/perseus-renderers-item-renderer--label-image-item`

You should see a table of dog breeds. The background color of the
odd-numbered rows should be `#f7f8fa`.

<img width="230" alt="Screen Shot 2024-01-03 at 3 44 35 PM" src="https://github.com/Khan/perseus/assets/693920/834c0e30-dadd-4787-9b36-35e692082c29">
