### PR TITLE
Updated tests to accommodate for new setTimeout method.

### DIFF
--- a/.changeset/shy-vans-wash.md
+++ b/.changeset/shy-vans-wash.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Reworked onFocusChange logic to solve a bug on initial render.

--- a/packages/perseus/src/__stories__/article-renderer.stories.tsx
+++ b/packages/perseus/src/__stories__/article-renderer.stories.tsx
@@ -1,4 +1,5 @@
 import {KeypadContext} from "@khanacademy/math-input";
+import {action} from "@storybook/addon-actions";
 import React from "react";
 
 import {storybookDependenciesV2} from "../../../../testing/test-dependencies";
@@ -67,6 +68,7 @@ export const ExpressionArticle = ({useNewStyles}): any => (
                     apiOptions={{
                         isMobile: true,
                         customKeypad: true,
+                        onFocusChange: action("onFocusChange"),
                     }}
                     keypadElement={keypadElement}
                 />

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -392,13 +392,15 @@ describe("server item renderer", () => {
                 onFocusChange,
             });
             renderer.focus();
-            // We have _two_ different async processes that need to be resolved here
+            // We have _three_ different async processes that need to be resolved here
+            jest.runOnlyPendingTimers();
             jest.runOnlyPendingTimers();
             jest.runOnlyPendingTimers();
 
             // Act
             renderer.blur();
-            // We have _two_ different async processes that need to be resolved here
+            // We have _three_ different async processes that need to be resolved here
+            jest.runOnlyPendingTimers();
             jest.runOnlyPendingTimers();
             jest.runOnlyPendingTimers();
 
@@ -440,13 +442,15 @@ describe("server item renderer", () => {
                 {keypadElement},
             );
             renderer.focus();
-            // We have _two_ different async processes that need to be resolved here
+            // We have _three_ different async processes that need to be resolved here
+            jest.runOnlyPendingTimers();
             jest.runOnlyPendingTimers();
             jest.runOnlyPendingTimers();
 
             // Act
             renderer.blur();
-            // We have _two_ different async processes that need to be resolved here
+            // We have _three_ different async processes that need to be resolved here
+            jest.runOnlyPendingTimers();
             jest.runOnlyPendingTimers();
             jest.runOnlyPendingTimers();
 
@@ -470,6 +474,7 @@ describe("server item renderer", () => {
 
             // Act
             renderer.focusPath(["input-number 1"]);
+            jest.runOnlyPendingTimers();
 
             // Assert
             expect(onFocusChange).toHaveBeenCalledWith(

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -326,9 +326,9 @@ describe("server item renderer", () => {
 
             // Act
             const gotFocus = renderer.focus();
-            // We have _two_ different async processes that need to be resolved here
-            jest.runOnlyPendingTimers();
-            jest.runOnlyPendingTimers();
+
+            // We have some async processes that need to be resolved here
+            jest.runAllTimers();
 
             // Assert
             expect(gotFocus).toBeTrue();
@@ -370,9 +370,9 @@ describe("server item renderer", () => {
 
             // Act
             const gotFocus = renderer.focus();
-            // We have _two_ different async processes that need to be resolved here
-            jest.runOnlyPendingTimers();
-            jest.runOnlyPendingTimers();
+
+            // We have some async processes that need to be resolved here
+            jest.runAllTimers();
 
             // Assert
             expect(keypadElement.activate).toHaveBeenCalled();
@@ -392,17 +392,12 @@ describe("server item renderer", () => {
                 onFocusChange,
             });
             renderer.focus();
-            // We have _three_ different async processes that need to be resolved here
-            jest.runOnlyPendingTimers();
-            jest.runOnlyPendingTimers();
-            jest.runOnlyPendingTimers();
 
             // Act
             renderer.blur();
-            // We have _three_ different async processes that need to be resolved here
-            jest.runOnlyPendingTimers();
-            jest.runOnlyPendingTimers();
-            jest.runOnlyPendingTimers();
+
+            // We have some async processes that need to be resolved here
+            jest.runAllTimers();
 
             // Assert
             expect(onFocusChange).toHaveBeenCalledTimes(2);
@@ -442,17 +437,12 @@ describe("server item renderer", () => {
                 {keypadElement},
             );
             renderer.focus();
-            // We have _three_ different async processes that need to be resolved here
-            jest.runOnlyPendingTimers();
-            jest.runOnlyPendingTimers();
-            jest.runOnlyPendingTimers();
 
             // Act
             renderer.blur();
-            // We have _three_ different async processes that need to be resolved here
-            jest.runOnlyPendingTimers();
-            jest.runOnlyPendingTimers();
-            jest.runOnlyPendingTimers();
+
+            // We have some async processes that need to be resolved here
+            jest.runAllTimers();
 
             // Assert
             expect(keypadElement.dismiss).toHaveBeenCalled();
@@ -474,7 +464,9 @@ describe("server item renderer", () => {
 
             // Act
             renderer.focusPath(["input-number 1"]);
-            jest.runOnlyPendingTimers();
+
+            // We have some async processes that need to be resolved here
+            jest.runAllTimers();
 
             // Assert
             expect(onFocusChange).toHaveBeenCalledWith(

--- a/packages/perseus/src/article-renderer.tsx
+++ b/packages/perseus/src/article-renderer.tsx
@@ -104,27 +104,32 @@ class ArticleRenderer
                 );
         }
 
+        if (this.props.apiOptions.onFocusChange != null) {
+            const {onFocusChange} = this.props.apiOptions;
+            // Wait for the keypad to mount before getting the height
+            setTimeout(() => {
+                const keypadDomNode =
+                    keypadElement?.getDOMNode() as HTMLElement;
+                const keypadHeight =
+                    keypadDomNode && didFocusInput
+                        ? keypadDomNode.getBoundingClientRect().height
+                        : 0;
+
+                onFocusChange(
+                    this._currentFocus,
+                    prevFocusPath,
+                    keypadHeight,
+                    didFocusInput ? focusedInput : null,
+                );
+            }, 0);
+        }
+
         if (keypadElement && isMobile) {
             if (didFocusInput) {
                 keypadElement.activate();
             } else {
                 keypadElement.dismiss();
             }
-        }
-
-        if (this.props.apiOptions.onFocusChange != null) {
-            const keypadDomNode = keypadElement?.getDOMNode() as HTMLElement;
-            const keypadHeight =
-                keypadDomNode && didFocusInput
-                    ? keypadDomNode.getBoundingClientRect().height
-                    : 0;
-
-            this.props.apiOptions.onFocusChange(
-                this._currentFocus,
-                prevFocusPath,
-                keypadHeight,
-                didFocusInput ? focusedInput : null,
-            );
         }
     };
 

--- a/packages/perseus/src/article-renderer.tsx
+++ b/packages/perseus/src/article-renderer.tsx
@@ -104,8 +104,8 @@ class ArticleRenderer
                 );
         }
 
-        if (this.props.apiOptions.onFocusChange != null) {
-            const {onFocusChange} = this.props.apiOptions;
+        const {onFocusChange} = this.props.apiOptions;
+        if (onFocusChange) {
             // Wait for the keypad to mount before getting the height
             setTimeout(() => {
                 const keypadDomNode =

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -180,32 +180,35 @@ export class ServerItemRenderer
                 return Util.inputPathsEqual(inputPath, this._currentFocus);
             });
 
+        if (onFocusChange != null) {
+            // Wait for the keypad to mount before getting the height
+            setTimeout(() => {
+                // First, calculate the current keypad height
+                const keypadDomNode: HTMLElement =
+                    keypadElement?.getDOMNode() as HTMLElement;
+                const keypadHeight =
+                    keypadDomNode && didFocusInput
+                        ? keypadDomNode.getBoundingClientRect().height
+                        : 0;
+
+                // Then call the callback
+                onFocusChange(
+                    this._currentFocus,
+                    prevFocus,
+                    keypadHeight,
+                    // @ts-expect-error [FEI-5003] - TS2345 - Argument of type 'false | Element | Text | null | undefined' is not assignable to parameter of type 'HTMLElement | undefined'.
+                    didFocusInput &&
+                        this.questionRenderer.getDOMNodeForPath(newFocus),
+                );
+            }, 0);
+        }
+
         if (keypadElement && isMobile) {
             if (didFocusInput) {
                 keypadElement.activate();
             } else {
                 keypadElement.dismiss();
             }
-        }
-
-        if (onFocusChange != null) {
-            // First, calculate the current keypad height
-            const keypadDomNode: HTMLElement =
-                keypadElement?.getDOMNode() as HTMLElement;
-            const keypadHeight =
-                keypadDomNode && didFocusInput
-                    ? keypadDomNode.getBoundingClientRect().height
-                    : 0;
-
-            // Then call the callback
-            onFocusChange(
-                this._currentFocus,
-                prevFocus,
-                keypadHeight,
-                // @ts-expect-error [FEI-5003] - TS2345 - Argument of type 'false | Element | Text | null | undefined' is not assignable to parameter of type 'HTMLElement | undefined'.
-                didFocusInput &&
-                    this.questionRenderer.getDOMNodeForPath(newFocus),
-            );
         }
     }
 


### PR DESCRIPTION
## Summary:
When testing the previous keypadHeight fix during a Perseus deploy on webapp, it was discovered that the height being returned on initial render seems to be the entire view height rather than the height of our keypad. 

This PR returns us to the original setTimeout method and method call order, and ensures that we're always getting the correct keypadHeight returned. I've also updated some tests to handle the additional asynchronous call. While the setTimeout method isn't ideal, this should solve our scroll-breaking issue until we're able to completely move the scrolling logic into Perseus. 

## Test plan:
- manual testing in webapp has shown that this has solved the issue 