### PR TITLE
Introduce orderer story that uses images

### DIFF
--- a/packages/perseus/src/widgets/__stories__/orderer.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/orderer.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui";
-import {question1} from "../__testdata__/orderer.testdata";
+import {question1, questionWithImages} from "../__testdata__/orderer.testdata";
 
 export default {
     title: "Perseus/Widgets/Orderer",
@@ -11,4 +11,8 @@ type StoryArgs = Record<any, any>;
 
 export const Question1 = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={question1} />;
+};
+
+export const QuestionWithImages = (args: StoryArgs): React.ReactElement => {
+    return <RendererWithDebugUI question={questionWithImages} />;
 };

--- a/packages/perseus/src/widgets/__testdata__/orderer.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/orderer.testdata.ts
@@ -55,3 +55,69 @@ export const question2: PerseusRenderer = {
         },
     },
 };
+
+export const questionWithImages: PerseusRenderer = {
+    content: "**Put $6$ flowers in the box.**\n\n[[☃ orderer 1]]",
+    images: {},
+    widgets: {
+        "orderer 1": {
+            graded: true,
+            options: {
+                correctOptions: [
+                    {
+                        content:
+                            "![](https://ka-perseus-graphie.s3.amazonaws.com/b7a6f30d245d186cf42961677ddafa118fef5fdd.png)",
+                        widgets: {},
+                        images: {},
+                    },
+                    {
+                        content:
+                            "![](https://ka-perseus-graphie.s3.amazonaws.com/b7a6f30d245d186cf42961677ddafa118fef5fdd.png)",
+                        widgets: {},
+                        images: {},
+                    },
+                    {
+                        content:
+                            "![](https://ka-perseus-graphie.s3.amazonaws.com/b7a6f30d245d186cf42961677ddafa118fef5fdd.png)",
+                        widgets: {},
+                        images: {},
+                    },
+                    {
+                        content:
+                            "![](https://ka-perseus-graphie.s3.amazonaws.com/b7a6f30d245d186cf42961677ddafa118fef5fdd.png)",
+                        widgets: {},
+                        images: {},
+                    },
+                    {
+                        content:
+                            "![](https://ka-perseus-graphie.s3.amazonaws.com/b7a6f30d245d186cf42961677ddafa118fef5fdd.png)",
+                        widgets: {},
+                        images: {},
+                    },
+                    {
+                        content:
+                            "![](https://ka-perseus-graphie.s3.amazonaws.com/b7a6f30d245d186cf42961677ddafa118fef5fdd.png)",
+                        widgets: {},
+                        images: {},
+                    },
+                ],
+                height: "auto",
+                layout: "horizontal",
+                options: [
+                    {
+                        content:
+                            "![](https://ka-perseus-graphie.s3.amazonaws.com/b7a6f30d245d186cf42961677ddafa118fef5fdd.png)",
+                        widgets: {},
+                        images: {},
+                    },
+                ],
+                otherOptions: [],
+            },
+            type: "orderer",
+            version: {
+                major: 0,
+                minor: 0,
+            },
+        },
+    },
+};


### PR DESCRIPTION
## Summary:

Khan Academy content for early math often asks learners to demonstrate understanding of numbers by adding items to a box. Example: "Add 6 flowers to the box" ([live link](https://www.khanacademy.org/math/early-math/cc-early-math-counting-topic/cc-early-math-counting/e/counting-out-1-20-objects)).  The learner then uses the `orderer` widget to drop 6 flower images into the grey box. 

<img width="700" alt="image" src="https://github.com/Khan/perseus/assets/77138/3cb4e67f-61ea-4454-b6a8-62c68bd3ca59">


This PR adds a story that illustrates this usage of the `orderer` widget.

Issue: "none"

## Test plan:

Navigate to the story and test it out.