### PR TITLE
[🔥AUDIT🔥] Avoid divide by 0 bug from icon.tsx

### DIFF
--- a/.changeset/yellow-games-run.md
+++ b/.changeset/yellow-games-run.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix bug that caused svg to be 300px wide

--- a/packages/perseus/src/widgets/label-image/marker.tsx
+++ b/packages/perseus/src/widgets/label-image/marker.tsx
@@ -67,8 +67,8 @@ export default class Marker extends React.Component<Props> {
 
         const iconNull: IconType = {
             path: "",
-            height: 0,
-            width: 0,
+            height: 1,
+            width: 1,
         };
 
         // default dot


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
Fix a small Safari-only bug. An icon was given a width and height of 0-- calculations were applied in icon.tsx that resulted in some odd behavior in Safari. We fix that by giving height and width of 1 instead. Since the path is empty, this makes no visual difference.

Would love to switch these to WB icons, but now is not the time.

Issue: XXX-XXXX

## Test plan:
Odd behavior in safari (can't click directly on markers in a line) should be fixed.