### PR TITLE
Delete unused code from tex.ts

### DIFF
--- a/.changeset/proud-donkeys-sip.md
+++ b/.changeset/proud-donkeys-sip.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Remove unused code related to KaTeX and MathJax 2. It's no longer needed
+because all callers have upgraded to MathJax 3.

--- a/packages/perseus/src/util/tex.ts
+++ b/packages/perseus/src/util/tex.ts
@@ -40,7 +40,7 @@ export default {
 
         // Only process if it hasn't been done before, or it is forced
         if ($elem.attr("data-math-formula") == null || force) {
-            const $katexHolder = findChildOrAdd($elem, "katex-holder");
+            const $texHolder = findChildOrAdd($elem, "tex-holder");
 
             text = text != null ? text + "" : "";
 
@@ -58,7 +58,7 @@ export default {
                     children: text,
                     onRender: callback,
                 }),
-                $katexHolder[0],
+                $texHolder[0],
             );
         }
     },

--- a/packages/perseus/src/util/tex.ts
+++ b/packages/perseus/src/util/tex.ts
@@ -42,6 +42,14 @@ export default {
         if ($elem.attr("data-math-formula") == null || force) {
             const $texHolder = findChildOrAdd($elem, "tex-holder");
 
+            // If text wasn't provided, we use the cached text.
+            // TODO(benchristel): I'm not sure if text can ever be null. It's
+            // possible we don't need this check.
+            if (text == null && $elem.attr("data-math-formula")) {
+                // @ts-expect-error - TS2322 - Type 'string | undefined' is not assignable to type 'string'.
+                text = $elem.attr("data-math-formula");
+            }
+
             text = text != null ? text + "" : "";
 
             // Attempt to clean up some of the math

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/grapher.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/grapher.test.ts.snap
@@ -932,10 +932,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 220px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -944,10 +941,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 240px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -956,10 +950,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 260px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -968,10 +959,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 280px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -980,10 +968,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 300px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -992,10 +977,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 320px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1004,10 +986,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 340px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1016,10 +995,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 360px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1028,10 +1004,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 380px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1040,10 +1013,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 160px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1052,10 +1022,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 140px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1064,10 +1031,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 120px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1076,10 +1040,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 100px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1088,10 +1049,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 80px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1100,10 +1058,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 60px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1112,10 +1067,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 40px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1124,10 +1076,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 20px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1136,10 +1085,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 180px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1148,10 +1094,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 160px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1160,10 +1103,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 140px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1172,10 +1112,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 120px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1184,10 +1121,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 100px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1196,10 +1130,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 80px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1208,10 +1139,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 60px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1220,10 +1148,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 40px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1232,10 +1157,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 20px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1244,10 +1166,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 240px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1256,10 +1175,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 260px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1268,10 +1184,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 280px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1280,10 +1193,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 300px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1292,10 +1202,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 320px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1304,10 +1211,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 340px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1316,10 +1220,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 360px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1328,10 +1229,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 380px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1340,10 +1238,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 0px; fill: none;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -1352,10 +1247,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       style="position: absolute; padding: 7px; color: black; left: 400px; top: 200px; fill: none;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                   </div>
@@ -2386,10 +2278,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 220px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2398,10 +2287,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 240px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2410,10 +2296,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 260px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2422,10 +2305,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 280px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2434,10 +2314,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 300px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2446,10 +2323,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 320px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2458,10 +2332,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 340px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2470,10 +2341,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 360px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2482,10 +2350,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 380px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2494,10 +2359,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 160px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2506,10 +2368,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 140px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2518,10 +2377,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 120px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2530,10 +2386,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 100px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2542,10 +2395,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 80px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2554,10 +2404,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 60px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2566,10 +2413,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 40px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2578,10 +2422,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 20px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2590,10 +2431,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 180px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2602,10 +2440,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 160px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2614,10 +2449,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 140px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2626,10 +2458,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 120px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2638,10 +2467,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 100px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2650,10 +2476,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 80px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2662,10 +2485,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 60px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2674,10 +2494,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 40px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2686,10 +2503,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 20px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2698,10 +2512,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 240px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2710,10 +2521,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 260px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2722,10 +2530,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 280px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2734,10 +2539,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 300px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2746,10 +2548,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 320px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2758,10 +2557,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 340px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2770,10 +2566,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 360px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2782,10 +2575,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 380px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2794,10 +2584,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 200px; top: 0px; fill: none;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                     <span
@@ -2806,10 +2593,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                       style="position: absolute; padding: 7px; color: black; left: 400px; top: 200px; fill: none;"
                     >
                       <span
-                        class="katex-holder"
-                      />
-                      <span
-                        class="mathjax-holder"
+                        class="tex-holder"
                       />
                     </span>
                   </div>

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/interaction.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/interaction.test.ts.snap
@@ -230,10 +230,7 @@ exports[`interaction widget should render 1`] = `
                 style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 116.59637038983988px; top: 88.69565217391305px; fill: none;"
               >
                 <span
-                  class="katex-holder"
-                />
-                <span
-                  class="mathjax-holder"
+                  class="tex-holder"
                 />
               </span>
               <span
@@ -242,10 +239,7 @@ exports[`interaction widget should render 1`] = `
                 style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 181.46123525470475px; top: 88.69565217391305px; fill: none;"
               >
                 <span
-                  class="katex-holder"
-                />
-                <span
-                  class="mathjax-holder"
+                  class="tex-holder"
                 />
               </span>
               <span
@@ -254,10 +248,7 @@ exports[`interaction widget should render 1`] = `
                 style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 246.3261001195696px; top: 88.69565217391305px; fill: none;"
               >
                 <span
-                  class="katex-holder"
-                />
-                <span
-                  class="mathjax-holder"
+                  class="tex-holder"
                 />
               </span>
               <span
@@ -266,10 +257,7 @@ exports[`interaction widget should render 1`] = `
                 style="position: absolute; padding: 7px; color: gray; left: 19.459459459459445px; top: 26.08695652173914px; fill: none;"
               >
                 <span
-                  class="katex-holder"
-                />
-                <span
-                  class="mathjax-holder"
+                  class="tex-holder"
                 />
               </span>
               <span
@@ -278,10 +266,7 @@ exports[`interaction widget should render 1`] = `
                 style="position: absolute; padding: 7px; color: gray; left: 149.18918918918916px; top: 26.08695652173914px; fill: none;"
               >
                 <span
-                  class="katex-holder"
-                />
-                <span
-                  class="mathjax-holder"
+                  class="tex-holder"
                 />
               </span>
             </div>

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/interactive-graph.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/interactive-graph.test.ts.snap
@@ -329,10 +329,7 @@ exports[`interactive-graph widget question Shoud render predictably: after inter
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 57.142857142857146px; top: 342.8571428571429px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -341,10 +338,7 @@ exports[`interactive-graph widget question Shoud render predictably: after inter
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 57.142857142857146px; top: 342.8571428571429px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -353,10 +347,7 @@ exports[`interactive-graph widget question Shoud render predictably: after inter
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 57.142857142857146px; top: 342.8571428571429px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -365,10 +356,7 @@ exports[`interactive-graph widget question Shoud render predictably: after inter
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 269.14285714285717px; top: 126.85714285714285px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -377,10 +365,7 @@ exports[`interactive-graph widget question Shoud render predictably: after inter
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 122.85714285714286px; top: 142.85714285714286px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -389,10 +374,7 @@ exports[`interactive-graph widget question Shoud render predictably: after inter
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 257.14285714285717px; top: 248.57142857142856px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
               </div>
@@ -741,10 +723,7 @@ exports[`interactive-graph widget question Shoud render predictably: after inter
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -753,10 +732,7 @@ exports[`interactive-graph widget question Shoud render predictably: after inter
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -765,10 +741,7 @@ exports[`interactive-graph widget question Shoud render predictably: after inter
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -777,10 +750,7 @@ exports[`interactive-graph widget question Shoud render predictably: after inter
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -789,10 +759,7 @@ exports[`interactive-graph widget question Shoud render predictably: after inter
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -801,10 +768,7 @@ exports[`interactive-graph widget question Shoud render predictably: after inter
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
               </div>
@@ -1666,10 +1630,7 @@ exports[`interactive-graph widget question Shoud render predictably: after inter
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 266.6666666666667px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -1678,10 +1639,7 @@ exports[`interactive-graph widget question Shoud render predictably: after inter
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 266.6666666666667px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -1690,10 +1648,7 @@ exports[`interactive-graph widget question Shoud render predictably: after inter
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 266.6666666666667px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -1702,10 +1657,7 @@ exports[`interactive-graph widget question Shoud render predictably: after inter
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 266.6666666666667px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -1714,10 +1666,7 @@ exports[`interactive-graph widget question Shoud render predictably: after inter
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 266.6666666666667px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -1726,10 +1675,7 @@ exports[`interactive-graph widget question Shoud render predictably: after inter
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 266.6666666666667px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -1738,10 +1684,7 @@ exports[`interactive-graph widget question Shoud render predictably: after inter
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 266.6666666666667px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -1750,10 +1693,7 @@ exports[`interactive-graph widget question Shoud render predictably: after inter
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 266.6666666666667px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
               </div>
@@ -2081,10 +2021,7 @@ exports[`interactive-graph widget question Shoud render predictably: first rende
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 57.142857142857146px; top: 342.8571428571429px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -2093,10 +2030,7 @@ exports[`interactive-graph widget question Shoud render predictably: first rende
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 57.142857142857146px; top: 342.8571428571429px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -2105,10 +2039,7 @@ exports[`interactive-graph widget question Shoud render predictably: first rende
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 57.142857142857146px; top: 342.8571428571429px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -2117,10 +2048,7 @@ exports[`interactive-graph widget question Shoud render predictably: first rende
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 246.45997239142687px; top: 162.4842995185723px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -2129,10 +2057,7 @@ exports[`interactive-graph widget question Shoud render predictably: first rende
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 153.54002760857313px; top: 162.48429951857227px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -2141,10 +2066,7 @@ exports[`interactive-graph widget question Shoud render predictably: first rende
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 248.57142857142856px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
               </div>
@@ -2493,10 +2415,7 @@ exports[`interactive-graph widget question Shoud render predictably: first rende
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -2505,10 +2424,7 @@ exports[`interactive-graph widget question Shoud render predictably: first rende
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -2517,10 +2433,7 @@ exports[`interactive-graph widget question Shoud render predictably: first rende
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -2529,10 +2442,7 @@ exports[`interactive-graph widget question Shoud render predictably: first rende
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -2541,10 +2451,7 @@ exports[`interactive-graph widget question Shoud render predictably: first rende
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -2553,10 +2460,7 @@ exports[`interactive-graph widget question Shoud render predictably: first rende
                   style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 200px; top: 200px; fill: none; stroke: #6495ED;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
               </div>

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/number-line.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/number-line.test.ts.snap
@@ -306,10 +306,7 @@ exports[`number-line widget should snapshot on mobile: first mobile render 1`] =
                   style="position: absolute; padding: 7px; color: black; left: 29.999999999999993px; top: 61.2px; fill: none;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -318,10 +315,7 @@ exports[`number-line widget should snapshot on mobile: first mobile render 1`] =
                   style="position: absolute; padding: 7px; color: black; left: 58.49999999999999px; top: 61.2px; fill: none;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -330,10 +324,7 @@ exports[`number-line widget should snapshot on mobile: first mobile render 1`] =
                   style="position: absolute; padding: 7px; color: black; left: 86.99999999999999px; top: 61.2px; fill: none;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -342,10 +333,7 @@ exports[`number-line widget should snapshot on mobile: first mobile render 1`] =
                   style="position: absolute; padding: 7px; color: black; left: 115.49999999999999px; top: 61.2px; fill: none;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -354,10 +342,7 @@ exports[`number-line widget should snapshot on mobile: first mobile render 1`] =
                   style="position: absolute; padding: 7px; color: black; left: 144px; top: 61.2px; fill: none;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -366,10 +351,7 @@ exports[`number-line widget should snapshot on mobile: first mobile render 1`] =
                   style="position: absolute; padding: 7px; color: black; left: 172.5px; top: 61.2px; fill: none;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -378,10 +360,7 @@ exports[`number-line widget should snapshot on mobile: first mobile render 1`] =
                   style="position: absolute; padding: 7px; color: black; left: 201px; top: 61.2px; fill: none;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -390,10 +369,7 @@ exports[`number-line widget should snapshot on mobile: first mobile render 1`] =
                   style="position: absolute; padding: 7px; color: black; left: 229.5px; top: 61.2px; fill: none;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -402,10 +378,7 @@ exports[`number-line widget should snapshot on mobile: first mobile render 1`] =
                   style="position: absolute; padding: 7px; color: black; left: 258px; top: 61.2px; fill: none;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -414,10 +387,7 @@ exports[`number-line widget should snapshot on mobile: first mobile render 1`] =
                   style="position: absolute; padding: 7px; color: rgb(17, 172, 205); left: 29.999999999999993px; top: 61.2px; fill: none;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -426,10 +396,7 @@ exports[`number-line widget should snapshot on mobile: first mobile render 1`] =
                   style="position: absolute; padding: 7px; color: rgb(17, 172, 205); left: 258px; top: 61.2px; fill: none;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
               </div>
@@ -743,10 +710,7 @@ exports[`number-line widget should snapshot: first render 1`] = `
                   style="position: absolute; padding: 7px; color: black; left: 29.999999999999982px; top: 61.2px; fill: none;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -755,10 +719,7 @@ exports[`number-line widget should snapshot: first render 1`] = `
                   style="position: absolute; padding: 7px; color: black; left: 79.99999999999999px; top: 61.2px; fill: none;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -767,10 +728,7 @@ exports[`number-line widget should snapshot: first render 1`] = `
                   style="position: absolute; padding: 7px; color: black; left: 129.99999999999997px; top: 61.2px; fill: none;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -779,10 +737,7 @@ exports[`number-line widget should snapshot: first render 1`] = `
                   style="position: absolute; padding: 7px; color: black; left: 179.99999999999997px; top: 61.2px; fill: none;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -791,10 +746,7 @@ exports[`number-line widget should snapshot: first render 1`] = `
                   style="position: absolute; padding: 7px; color: black; left: 229.99999999999997px; top: 61.2px; fill: none;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -803,10 +755,7 @@ exports[`number-line widget should snapshot: first render 1`] = `
                   style="position: absolute; padding: 7px; color: black; left: 280px; top: 61.2px; fill: none;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -815,10 +764,7 @@ exports[`number-line widget should snapshot: first render 1`] = `
                   style="position: absolute; padding: 7px; color: black; left: 330px; top: 61.2px; fill: none;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -827,10 +773,7 @@ exports[`number-line widget should snapshot: first render 1`] = `
                   style="position: absolute; padding: 7px; color: black; left: 380px; top: 61.2px; fill: none;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -839,10 +782,7 @@ exports[`number-line widget should snapshot: first render 1`] = `
                   style="position: absolute; padding: 7px; color: black; left: 430px; top: 61.2px; fill: none;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -851,10 +791,7 @@ exports[`number-line widget should snapshot: first render 1`] = `
                   style="position: absolute; padding: 7px; color: black; left: 29.999999999999982px; top: 61.2px; fill: none;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
                 <span
@@ -863,10 +800,7 @@ exports[`number-line widget should snapshot: first render 1`] = `
                   style="position: absolute; padding: 7px; color: black; left: 430px; top: 61.2px; fill: none;"
                 >
                   <span
-                    class="katex-holder"
-                  />
-                  <span
-                    class="mathjax-holder"
+                    class="tex-holder"
                   />
                 </span>
               </div>

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/plotter.test.tsx.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/plotter.test.tsx.snap
@@ -704,10 +704,7 @@ exports[`plotter widget should snapshot basic question: initial render 1`] = `
               style="position: absolute; padding: 7px; color: black; left: 75px; top: 325px; fill: none;"
             >
               <span
-                class="katex-holder"
-              />
-              <span
-                class="mathjax-holder"
+                class="tex-holder"
               />
             </span>
             <span
@@ -716,10 +713,7 @@ exports[`plotter widget should snapshot basic question: initial render 1`] = `
               style="position: absolute; padding: 7px; color: black; left: 75px; top: 275px; fill: none;"
             >
               <span
-                class="katex-holder"
-              />
-              <span
-                class="mathjax-holder"
+                class="tex-holder"
               />
             </span>
             <span
@@ -728,10 +722,7 @@ exports[`plotter widget should snapshot basic question: initial render 1`] = `
               style="position: absolute; padding: 7px; color: black; left: 75px; top: 225px; fill: none;"
             >
               <span
-                class="katex-holder"
-              />
-              <span
-                class="mathjax-holder"
+                class="tex-holder"
               />
             </span>
             <span
@@ -740,10 +731,7 @@ exports[`plotter widget should snapshot basic question: initial render 1`] = `
               style="position: absolute; padding: 7px; color: black; left: 75px; top: 175px; fill: none;"
             >
               <span
-                class="katex-holder"
-              />
-              <span
-                class="mathjax-holder"
+                class="tex-holder"
               />
             </span>
             <span
@@ -752,10 +740,7 @@ exports[`plotter widget should snapshot basic question: initial render 1`] = `
               style="position: absolute; padding: 7px; color: black; left: 75px; top: 125px; fill: none;"
             >
               <span
-                class="katex-holder"
-              />
-              <span
-                class="mathjax-holder"
+                class="tex-holder"
               />
             </span>
             <span
@@ -764,10 +749,7 @@ exports[`plotter widget should snapshot basic question: initial render 1`] = `
               style="position: absolute; padding: 7px; color: black; left: 75px; top: 75px; fill: none;"
             >
               <span
-                class="katex-holder"
-              />
-              <span
-                class="mathjax-holder"
+                class="tex-holder"
               />
             </span>
             <span
@@ -776,10 +758,7 @@ exports[`plotter widget should snapshot basic question: initial render 1`] = `
               style="position: absolute; padding: 7px; color: black; left: 75px; top: 25px; fill: none;"
             >
               <span
-                class="katex-holder"
-              />
-              <span
-                class="mathjax-holder"
+                class="tex-holder"
               />
             </span>
             <span
@@ -788,10 +767,7 @@ exports[`plotter widget should snapshot basic question: initial render 1`] = `
               style="position: absolute; padding: 7px; color: black; left: 121.60377358490565px; top: 325px; fill: none; stroke: #71B307; transform: none; transform-origin: 100%;"
             >
               <span
-                class="katex-holder"
-              />
-              <span
-                class="mathjax-holder"
+                class="tex-holder"
               />
             </span>
             <span
@@ -800,10 +776,7 @@ exports[`plotter widget should snapshot basic question: initial render 1`] = `
               style="position: absolute; padding: 7px; color: black; left: 193.30188679245282px; top: 325px; fill: none; stroke: #71B307; transform: none; transform-origin: 100%;"
             >
               <span
-                class="katex-holder"
-              />
-              <span
-                class="mathjax-holder"
+                class="tex-holder"
               />
             </span>
             <span
@@ -812,10 +785,7 @@ exports[`plotter widget should snapshot basic question: initial render 1`] = `
               style="position: absolute; padding: 7px; color: black; left: 265px; top: 325px; fill: none; stroke: #71B307; transform: none; transform-origin: 100%;"
             >
               <span
-                class="katex-holder"
-              />
-              <span
-                class="mathjax-holder"
+                class="tex-holder"
               />
             </span>
             <span
@@ -824,10 +794,7 @@ exports[`plotter widget should snapshot basic question: initial render 1`] = `
               style="position: absolute; padding: 7px; color: black; left: 336.6981132075471px; top: 325px; fill: none; stroke: #71B307; transform: none; transform-origin: 100%;"
             >
               <span
-                class="katex-holder"
-              />
-              <span
-                class="mathjax-holder"
+                class="tex-holder"
               />
             </span>
             <span
@@ -836,10 +803,7 @@ exports[`plotter widget should snapshot basic question: initial render 1`] = `
               style="position: absolute; padding: 7px; color: black; left: 408.3962264150943px; top: 325px; fill: none; stroke: #71B307; transform: none; transform-origin: 100%;"
             >
               <span
-                class="katex-holder"
-              />
-              <span
-                class="mathjax-holder"
+                class="tex-holder"
               />
             </span>
             <span


### PR DESCRIPTION
## Summary:
There was a lot of code in this file related to our old KaTeX+MathJax2
renderer. Now that we have switched to MathJax 3, we can simplify things. I've
also deleted a couple functions that simply weren't used anywhere.

I changed the type of `processMath`'s `text` param to `string | number` because
the code that generates Graphie labels sometimes passes a number.

Issue: none

Test plan:

Review storybook stories that use TeX labels:

- Grapher widget
- Interactive Graph widget
- Number Line widget

The graph labels should display in the correct place.