### PR TITLE
Remove polar and cartToPolar from the Graphie prototype

### DIFF
--- a/.changeset/shy-nails-crash.md
+++ b/.changeset/shy-nails-crash.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Refactor graphie.ts and remove unused cartToPolar function

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -23,24 +23,7 @@ import type {Coord} from "../interactive2/types";
 
 const {processMath} = Tex;
 
-/* Convert cartesian coordinates [x, y] to polar coordinates [r,
- * theta], with theta in degrees, or in radians if angleInRadians is
- * specified.
- */
-function cartToPolar(coord: any, angleInRadians: any) {
-    const r = Math.sqrt(Math.pow(coord[0], 2) + Math.pow(coord[1], 2));
-    let theta = Math.atan2(coord[1], coord[0]);
-    // convert angle range from [-pi, pi] to [0, 2pi]
-    if (theta < 0) {
-        theta += 2 * Math.PI;
-    }
-    if (!angleInRadians) {
-        theta = (theta * 180) / Math.PI;
-    }
-    return [r, theta];
-}
-
-function polar(r: number | Coord, th: number) {
+export function polar(r: number | Coord, th: number) {
     if (typeof r === "number") {
         r = [r, r];
     }
@@ -106,11 +89,6 @@ const GraphUtils: any = {
 };
 
 const Graphie = (GraphUtils.Graphie = function () {});
-
-_.extend(Graphie.prototype, {
-    cartToPolar: cartToPolar,
-    polar: polar,
-});
 
 const labelDirections = {
     center: [-0.5, -0.5],

--- a/packages/perseus/src/util/interactive.ts
+++ b/packages/perseus/src/util/interactive.ts
@@ -31,7 +31,7 @@ import {Errors} from "../logging/log";
 import {PerseusError} from "../perseus-error";
 
 import KhanColors from "./colors";
-import GraphUtils from "./graphie";
+import GraphUtils, { polar } from "./graphie";
 import KhanMath from "./math";
 
 import type {Coord} from "../interactive2/types";
@@ -4024,7 +4024,7 @@ _.extend(MovableAngle.prototype, {
                         Math.round((angle - snapOffset) / snap) * snap +
                         snapOffset;
                     const distance = GraphUtils.getDistance(newPoint, vertex);
-                    return addPoints(vertex, graphie.polar(distance, angle));
+                    return addPoints(vertex, polar(distance, angle));
                 }
                 return true;
             };

--- a/packages/perseus/src/util/interactive.ts
+++ b/packages/perseus/src/util/interactive.ts
@@ -31,7 +31,7 @@ import {Errors} from "../logging/log";
 import {PerseusError} from "../perseus-error";
 
 import KhanColors from "./colors";
-import GraphUtils, { polar } from "./graphie";
+import GraphUtils, {polar} from "./graphie";
 import KhanMath from "./math";
 
 import type {Coord} from "../interactive2/types";

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -46,6 +46,7 @@ import type {
     SineCoefficient,
     Range,
 } from "../util/geometry";
+import { polar } from "../util/graphie";
 
 const {DeprecationMixin} = Util;
 
@@ -1216,7 +1217,7 @@ class InteractiveGraph extends React.Component<Props, State> {
                     coords[rel(-1)],
                 );
 
-                const offset = this.graphie?.polar(
+                const offset = polar(
                     side,
                     outerAngle + (onLeft ? 1 : -1) * innerAngles[0],
                 );
@@ -1263,7 +1264,7 @@ class InteractiveGraph extends React.Component<Props, State> {
                 const onLeft =
                     sign(ccw(coords[rel(-1)], coords[rel(1)], coords[i])) === 1;
 
-                const offset = this.graphie?.polar(
+                const offset = polar(
                     sides[0],
                     outerAngle + (onLeft ? 1 : -1) * innerAngle,
                 );

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -29,6 +29,7 @@ import {
     similar,
 } from "../util/geometry";
 import GraphUtils from "../util/graph-utils";
+import {polar} from "../util/graphie";
 import {getInteractiveBoxFromSizeClass} from "../util/sizing-utils";
 
 import type {Coord} from "../interactive2/types";
@@ -46,7 +47,6 @@ import type {
     SineCoefficient,
     Range,
 } from "../util/geometry";
-import { polar } from "../util/graphie";
 
 const {DeprecationMixin} = Util;
 


### PR DESCRIPTION
## Summary:
They don't depend on the Graphie object's state.

We deleted cartToPolar because it was unused.

Issue: none

## Test plan:

```
yarn cypress:ci
```

Review the Grapher and Interactive Graph docs in Storybook.