### PR TITLE
add parsePerseusJSON

### DIFF
--- a/.changeset/neat-shirts-fail.md
+++ b/.changeset/neat-shirts-fail.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+export parsePerseusJSON helper

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -80,6 +80,7 @@ export {default as KhanColors} from "./util/colors";
 export {default as preprocessTex} from "./util/katex-preprocess";
 export {registerAllWidgetsForTesting} from "./util/register-all-widgets-for-testing";
 export * as SizingUtils from "./util/sizing-utils";
+export {default as parsePerseusJSON} from "./util/parse-perseus-json";
 
 /**
  * Mixins

--- a/packages/perseus/src/util/parse-perseus-json.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json.test.ts
@@ -1,0 +1,10 @@
+import parsePerseusJSON from "./parse-perseus-json";
+
+describe("parsePerseusJSON", () => {
+    it("should parse JSON", () => {
+        const result = parsePerseusJSON(
+            `{ "question": { "content": "idk why I'm testing this" }}`,
+        );
+        expect(result.question.content).toBe("idk why I'm testing this");
+    });
+});

--- a/packages/perseus/src/util/parse-perseus-json.ts
+++ b/packages/perseus/src/util/parse-perseus-json.ts
@@ -1,0 +1,13 @@
+import type {PerseusItem} from "../perseus-types";
+
+/**
+ * Helper to parse Perseus JSON
+ * Why not just use JSON.parse? We want:
+ * - To make sure types are correct
+ * - To give us a central place to validate/transform output if needed
+ * @param {string} input - the stringified Perseus JSON
+ * @returns {PerseusItem} the parse PerseusItem object
+ */
+export default function parsePerseusJSON(input: string): PerseusItem {
+    return JSON.parse(input);
+}

--- a/packages/perseus/src/util/parse-perseus-json.ts
+++ b/packages/perseus/src/util/parse-perseus-json.ts
@@ -6,7 +6,7 @@ import type {PerseusItem} from "../perseus-types";
  * - To make sure types are correct
  * - To give us a central place to validate/transform output if needed
  * @param {string} input - the stringified Perseus JSON
- * @returns {PerseusItem} the parse PerseusItem object
+ * @returns {PerseusItem} the parsed PerseusItem object
  */
 export default function parsePerseusJSON(input: string): PerseusItem {
     return JSON.parse(input);


### PR DESCRIPTION
## Summary:
I feel a little silly about this PR, but I think it'll be useful. Just exporting a wrapper around `JSON.parse` so we have a one-stop shop for Parsing Perseus JSON needs.

Issue: LC-1656

## Test plan:
- unit test