### PR TITLE
Creation of a callback that can allow us to determine the shuffle order of various widget choices. 

### DIFF
--- a/.changeset/early-pillows-kiss.md
+++ b/.changeset/early-pillows-kiss.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Creation of a new callback that can return the WidgetsStartProps

--- a/packages/perseus/src/__testdata__/renderer.testdata.ts
+++ b/packages/perseus/src/__testdata__/renderer.testdata.ts
@@ -4,6 +4,7 @@ import type {
     InputNumberWidget,
     PerseusRenderer,
 } from "../perseus-types";
+import type {RenderProps} from "../widgets/radio/widget";
 
 export const dropdownWidget: DropdownWidget = {
     type: "dropdown",
@@ -120,3 +121,154 @@ export const mockedItem: PerseusRenderer = {
         },
     },
 } as PerseusRenderer;
+
+// Note that if this item is used, you _must_ first register the MockWidget
+export const mockedRandomItem: PerseusRenderer = {
+    content: "Mock widgets ==> [[\u2603 radio 1]] [[\u2603 radio 2]]",
+    images: {},
+    widgets: {
+        "radio 1": {
+            graded: true,
+            version: {major: 0, minor: 0},
+            static: false,
+            numCorrect: 1,
+            hasNoneOfTheAbove: false,
+            multipleSelect: false,
+            countChoices: false,
+            deselectEnabled: false,
+            type: "radio",
+            options: {
+                static: false,
+                countChoices: false,
+                deselectEnabled: false,
+                displayCount: null,
+                hasNoneOfTheAbove: false,
+                multipleSelect: false,
+                randomize: true,
+                choices: [
+                    {
+                        content: "Content 1",
+                        correct: true,
+                    },
+                    {
+                        content: "Content 2",
+                        correct: false,
+                    },
+                    {
+                        content: "Content 3",
+                        correct: false,
+                    },
+                    {
+                        content: "Content 4",
+                        correct: false,
+                    },
+                ],
+            },
+            alignment: "default",
+        },
+        "radio 2": {
+            graded: true,
+            version: {major: 0, minor: 0},
+            static: false,
+            numCorrect: 1,
+            hasNoneOfTheAbove: false,
+            multipleSelect: false,
+            countChoices: false,
+            deselectEnabled: false,
+            type: "radio",
+            options: {
+                static: false,
+                countChoices: false,
+                deselectEnabled: false,
+                displayCount: null,
+                hasNoneOfTheAbove: false,
+                multipleSelect: false,
+                randomize: true,
+                choices: [
+                    {
+                        content: "Content 1",
+                        correct: true,
+                    },
+                    {
+                        content: "Content 2",
+                        correct: false,
+                    },
+                    {
+                        content: "Content 3",
+                        correct: false,
+                    },
+                    {
+                        content: "Content 4",
+                        correct: false,
+                    },
+                ],
+            },
+            alignment: "default",
+        },
+    },
+} as PerseusRenderer;
+
+export const mockedShuffledRadioProps: {[key in string]: RenderProps} = {
+    "radio 1": {
+        numCorrect: 1,
+        countChoices: false,
+        deselectEnabled: false,
+        hasNoneOfTheAbove: false,
+        multipleSelect: false,
+        choices: [
+            {
+                content: "Content 4",
+                correct: false,
+                originalIndex: 3,
+            },
+            {
+                content: "Content 2",
+                correct: false,
+                originalIndex: 1,
+            },
+            {
+                content: "Content 1",
+                correct: true,
+                originalIndex: 0,
+            },
+
+            {
+                content: "Content 3",
+                correct: false,
+                originalIndex: 2,
+            },
+        ],
+        selectedChoices: [false, false, true, false],
+    },
+    "radio 2": {
+        numCorrect: 1,
+        countChoices: false,
+        deselectEnabled: false,
+        hasNoneOfTheAbove: false,
+        multipleSelect: false,
+        choices: [
+            {
+                content: "Content 4",
+                correct: false,
+                originalIndex: 3,
+            },
+            {
+                content: "Content 2",
+                correct: false,
+                originalIndex: 1,
+            },
+            {
+                content: "Content 1",
+                correct: true,
+                originalIndex: 0,
+            },
+
+            {
+                content: "Content 3",
+                correct: false,
+                originalIndex: 2,
+            },
+        ],
+        selectedChoices: [false, false, true, false],
+    },
+};

--- a/packages/perseus/src/__tests__/renderer.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.test.tsx
@@ -291,16 +291,16 @@ describe("renderer", () => {
             );
         });
 
-        it("should call the getAllWidgetsStartProps callback if provided in apiOptions", () => {
+        it("should call the onWidgetStartProps callback if provided in apiOptions", () => {
             // Arrange
-            const getAllWidgetsStartProps = jest.fn();
-            const apiOptions: APIOptions = {getAllWidgetsStartProps};
+            const onWidgetStartProps = jest.fn();
+            const apiOptions: APIOptions = {onWidgetStartProps};
 
             // Act
             renderQuestion(mockedRandomItem, apiOptions);
 
             // Assert
-            expect(getAllWidgetsStartProps).toHaveBeenCalledWith(
+            expect(onWidgetStartProps).toHaveBeenCalledWith(
                 mockedShuffledRadioProps,
             );
         });

--- a/packages/perseus/src/__tests__/renderer.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.test.tsx
@@ -31,6 +31,7 @@ import type {
     PerseusImageWidgetOptions,
     PerseusInputNumberWidgetOptions,
 } from "../perseus-types";
+import type {APIOptions} from "../types";
 
 // NOTE(jeremy): We can't use an automatic mock for the translation linter,
 // because one of it's "instance" methods is created using `debounce` and Jest
@@ -293,7 +294,7 @@ describe("renderer", () => {
         it("should call the getAllWidgetsStartProps callback if provided in apiOptions", () => {
             // Arrange
             const getAllWidgetsStartProps = jest.fn();
-            const apiOptions: Record<string, any> = {getAllWidgetsStartProps};
+            const apiOptions: APIOptions = {getAllWidgetsStartProps};
 
             // Act
             renderQuestion(mockedRandomItem, apiOptions);

--- a/packages/perseus/src/__tests__/renderer.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.test.tsx
@@ -14,6 +14,8 @@ import {
     question1,
     question2,
     mockedItem,
+    mockedRandomItem,
+    mockedShuffledRadioProps,
 } from "../__testdata__/renderer.testdata";
 import * as Dependencies from "../dependencies";
 import {Errors} from "../logging/log";
@@ -285,6 +287,20 @@ describe("renderer", () => {
             // Assert
             expect(screen.getByRole("button")).toHaveTextContent(
                 /^less than or equal to$/,
+            );
+        });
+
+        it("should call the getAllWidgetsStartProps callback if provided in apiOptions", () => {
+            // Arrange
+            const getAllWidgetsStartProps = jest.fn();
+            const apiOptions: Record<string, any> = {getAllWidgetsStartProps};
+
+            // Act
+            renderQuestion(mockedRandomItem, apiOptions);
+
+            // Assert
+            expect(getAllWidgetsStartProps).toHaveBeenCalledWith(
+                mockedShuffledRadioProps,
             );
         });
     });

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @khanacademy/ts-no-error-suppressions */
 /* eslint-disable react/no-unsafe */
 import * as PerseusLinter from "@khanacademy/perseus-linter";
+import {entries} from "@khanacademy/wonder-stuff-core";
 import classNames from "classnames";
 import $ from "jquery";
 import * as React from "react";
@@ -41,6 +42,7 @@ import type {
     FilterCriterion,
     FocusPath,
     PerseusScore,
+    PerseusWidgetMap,
     WidgetProps,
 } from "./types";
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
@@ -485,22 +487,21 @@ class Renderer extends React.Component<Props, State> {
     };
 
     _getAllWidgetsStartProps: (
-        allWidgetInfo: {
-            [key: string]: PerseusWidget;
-        },
+        allWidgetInfo: PerseusWidgetMap,
         props: Props,
-    ) => any = (allWidgetInfo, props) => {
+    ) => PerseusWidgetMap = (allWidgetInfo, props) => {
         const {apiOptions, problemNum} = props;
-        // @ts-expect-error - TS2345 - Argument of type '{ [key: string]: PerseusWidget; }' is not assignable to parameter of type 'Partial<Record<string, CategorizerWidget>>'.
-        const widgetsStartProps = mapObject(allWidgetInfo, (widgetInfo) => {
-            return Widgets.getRendererPropsForWidgetInfo(
+        const widgetsStartProps: PerseusWidgetMap = {};
+        entries(allWidgetInfo).forEach(([key, widgetInfo]) => {
+            widgetsStartProps[key] = Widgets.getRendererPropsForWidgetInfo(
                 widgetInfo,
                 problemNum,
             );
         });
-        if (apiOptions?.getAllWidgetsStartProps) {
-            apiOptions.getAllWidgetsStartProps(widgetsStartProps);
-        }
+
+        // Call the getAllWidgetsStartProps callback if it exists
+        apiOptions?.getAllWidgetsStartProps?.(widgetsStartProps);
+
         return widgetsStartProps;
     };
 

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -499,8 +499,8 @@ class Renderer extends React.Component<Props, State> {
             );
         });
 
-        // Call the getAllWidgetsStartProps callback if it exists
-        apiOptions?.getAllWidgetsStartProps?.(widgetsStartProps);
+        // Call the onWidgetStartProps callback if it exists
+        apiOptions?.onWidgetStartProps?.(widgetsStartProps);
 
         return widgetsStartProps;
     };

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -491,12 +491,16 @@ class Renderer extends React.Component<Props, State> {
         props: Props,
     ) => any = (allWidgetInfo, props) => {
         // @ts-expect-error - TS2345 - Argument of type '{ [key: string]: PerseusWidget; }' is not assignable to parameter of type 'Partial<Record<string, CategorizerWidget>>'.
-        return mapObject(allWidgetInfo, (widgetInfo) => {
+        const widgetStartProps = mapObject(allWidgetInfo, (widgetInfo) => {
             return Widgets.getRendererPropsForWidgetInfo(
                 widgetInfo,
                 props.problemNum,
             );
         });
+        if (props.apiOptions?.getAllWidgetsStartProps) {
+            props.apiOptions.getAllWidgetsStartProps(widgetStartProps);
+        }
+        return widgetStartProps;
     };
 
     // This is only used in _getWidgetInfo as a fallback if widgetId

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -490,15 +490,16 @@ class Renderer extends React.Component<Props, State> {
         },
         props: Props,
     ) => any = (allWidgetInfo, props) => {
+        const {apiOptions, problemNum} = props;
         // @ts-expect-error - TS2345 - Argument of type '{ [key: string]: PerseusWidget; }' is not assignable to parameter of type 'Partial<Record<string, CategorizerWidget>>'.
         const widgetsStartProps = mapObject(allWidgetInfo, (widgetInfo) => {
             return Widgets.getRendererPropsForWidgetInfo(
                 widgetInfo,
-                props.problemNum,
+                problemNum,
             );
         });
-        if (props.apiOptions?.getAllWidgetsStartProps) {
-            props.apiOptions.getAllWidgetsStartProps(widgetsStartProps);
+        if (apiOptions?.getAllWidgetsStartProps) {
+            apiOptions.getAllWidgetsStartProps(widgetsStartProps);
         }
         return widgetsStartProps;
     };

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -491,16 +491,16 @@ class Renderer extends React.Component<Props, State> {
         props: Props,
     ) => any = (allWidgetInfo, props) => {
         // @ts-expect-error - TS2345 - Argument of type '{ [key: string]: PerseusWidget; }' is not assignable to parameter of type 'Partial<Record<string, CategorizerWidget>>'.
-        const widgetStartProps = mapObject(allWidgetInfo, (widgetInfo) => {
+        const widgetsStartProps = mapObject(allWidgetInfo, (widgetInfo) => {
             return Widgets.getRendererPropsForWidgetInfo(
                 widgetInfo,
                 props.problemNum,
             );
         });
         if (props.apiOptions?.getAllWidgetsStartProps) {
-            props.apiOptions.getAllWidgetsStartProps(widgetStartProps);
+            props.apiOptions.getAllWidgetsStartProps(widgetsStartProps);
         }
-        return widgetStartProps;
+        return widgetsStartProps;
     };
 
     // This is only used in _getWidgetInfo as a fallback if widgetId

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -223,6 +223,11 @@ export type APIOptions = Readonly<{
     // keystroke caused text typed in the text area to appear in it
     // only after a good few seconds.
     editorChangeDelay?: number;
+    // This is a callback function that returns all the Widget Start Props
+    // after they have been transformed by the widget's transform function.
+    // This is useful for when we need to know how a widget has shuffled its
+    // the available choices.
+    getAllWidgetsStartProps?: (widgets: any) => any;
 }>;
 
 type TeXProps = {

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -227,7 +227,7 @@ export type APIOptions = Readonly<{
     // after they have been transformed by the widget's transform function.
     // This is useful for when we need to know how a widget has shuffled its
     // the available choices.
-    getAllWidgetsStartProps?: (widgets: any) => any;
+    getAllWidgetsStartProps?: (widgets: PerseusWidgetMap) => PerseusWidgetMap;
 }>;
 
 type TeXProps = {
@@ -452,6 +452,10 @@ export type WidgetExports<
 
     widget: T;
 }>;
+
+export type PerseusWidgetMap = {
+    [key: string]: PerseusWidget;
+};
 
 export type FilterCriterion =
     | string

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -223,11 +223,11 @@ export type APIOptions = Readonly<{
     // keystroke caused text typed in the text area to appear in it
     // only after a good few seconds.
     editorChangeDelay?: number;
-    // This is a callback function that returns all the Widget Start Props
+    // This is a callback function that returns all of the Widget props
     // after they have been transformed by the widget's transform function.
     // This is useful for when we need to know how a widget has shuffled its
     // the available choices.
-    getAllWidgetsStartProps?: (widgets: PerseusWidgetMap) => PerseusWidgetMap;
+    onWidgetStartProps?: (widgets: PerseusWidgetMap) => PerseusWidgetMap;
 }>;
 
 type TeXProps = {


### PR DESCRIPTION
## Summary:
A major pain point that we've been hitting lately for several initiatives is that there was no way to determine the shuffle order of our answers, as it happens during the exercise rendering phase. 

This PR adds a callback to apiOptions so that we can "getWidgetsStartProps", which will provide us with the current shuffled order of the answers. 

Issue: LC-1638

## Test plan:
- New test 
- Manual testing 