### PR TITLE
Remove unused parameters from plot and plotParametric

### DIFF
--- a/.changeset/yellow-melons-perform.md
+++ b/.changeset/yellow-melons-perform.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Remove unused code from Graphie drawing tools

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1419,12 +1419,9 @@ GraphUtils.createGraphie = function (el: any): Graphie {
         return $span;
     }
 
-    function plotParametric(
-        fn: (t: number) => Coord,
-        range,
-        shade,
-        fn2: (t: number) => Coord = (t) => [t, 0],
-    ) {
+    function plotParametric(fn: (t: number) => Coord, range) {
+        const shade = undefined;
+        const fn2 = (t) => [t, 0];
         // Note: fn2 should only be set if 'shade' is true, as it denotes
         // the function between which fn should have its area shaded.
         // In general, plotParametric shouldn't be used to shade the area
@@ -1521,7 +1518,9 @@ GraphUtils.createGraphie = function (el: any): Graphie {
         return paths;
     }
 
-    function plot(fn, range, swapAxes, shade, fn2) {
+    function plot(fn, range, swapAxes) {
+        const shade = undefined;
+        const fn2 = undefined;
         const min = range[0];
         const max = range[1];
         if (!thisGraphie.currentStyle["plot-points"]) {
@@ -1539,39 +1538,24 @@ GraphUtils.createGraphie = function (el: any): Graphie {
                     Errors.Internal,
                 );
             }
-            return plotParametric(
-                function (y) {
-                    return [fn(y), y];
-                },
-                range,
-                shade,
-            );
+            return plotParametric(function (y) {
+                return [fn(y), y];
+            }, range);
         }
         if (fn2) {
             if (shade) {
-                return plotParametric(
-                    function (x) {
-                        return [x, fn(x)];
-                    },
-                    range,
-                    shade,
-                    function (x) {
-                        return [x, fn2(x)];
-                    },
-                );
+                return plotParametric(function (x) {
+                    return [x, fn(x)];
+                }, range);
             }
             throw new PerseusError(
                 "fn2 should only be set when 'shade' is True.",
                 Errors.Internal,
             );
         }
-        return plotParametric(
-            function (x) {
-                return [x, fn(x)];
-            },
-            range,
-            shade,
-        );
+        return plotParametric(function (x) {
+            return [x, fn(x)];
+        }, range);
     }
 
     const drawingTools = {

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1438,7 +1438,7 @@ GraphUtils.createGraphie = function (el: any): Graphie {
             return xy;
         };
         const clippedFn = (x) => clipper(fn(x));
-        const clippedFn2 = (x: number) => clipper([x, 0]);
+        const clippedFn2 = (x: number) => [x, 0];
 
         if (!thisGraphie.currentStyle.strokeLinejoin) {
             thisGraphie.currentStyle.strokeLinejoin = "round";

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1420,7 +1420,6 @@ GraphUtils.createGraphie = function (el: any): Graphie {
     }
 
     function plotParametric(fn: (t: number) => Coord, range) {
-        const shade = undefined;
         const fn2 = (t) => [t, 0];
         // Note: fn2 should only be set if 'shade' is true, as it denotes
         // the function between which fn should have its area shaded.
@@ -1461,7 +1460,6 @@ GraphUtils.createGraphie = function (el: any): Graphie {
         let points = [];
         let lastDiff = GraphUtils.coordDiff(clippedFn(min), clippedFn2(min));
 
-        let lastFlip = min;
         for (let t = min; t <= max; t += step) {
             const top = clippedFn(t);
             const bottom = clippedFn2(t);
@@ -1479,24 +1477,9 @@ GraphUtils.createGraphie = function (el: any): Graphie {
                 isNaN(diff[1])
             ) {
                 // split the path at this point, and draw it
-                if (shade) {
-                    // @ts-expect-error - TS2345 - Argument of type 'any' is not assignable to parameter of type 'never'.
-                    points.push(top);
-
-                    // backtrack to draw paired function
-                    for (let u = t - step; u >= lastFlip; u -= step) {
-                        // @ts-expect-error - TS2345 - Argument of type 'any' is not assignable to parameter of type 'never'.
-                        points.push(clippedFn2(u));
-                    }
-                    lastFlip = t;
-                }
                 paths.push(path(points));
                 // restart the path, excluding this point
                 points = [];
-                if (shade) {
-                    // @ts-expect-error - TS2345 - Argument of type 'any' is not assignable to parameter of type 'never'.
-                    points.push(top);
-                }
             } else {
                 // otherwise, just add the point to the path
                 // @ts-expect-error - TS2345 - Argument of type 'any' is not assignable to parameter of type 'never'.
@@ -1506,13 +1489,6 @@ GraphUtils.createGraphie = function (el: any): Graphie {
             lastDiff = diff;
         }
 
-        if (shade) {
-            // backtrack to draw paired function
-            for (let u = max - step; u >= lastFlip; u -= step) {
-                // @ts-expect-error - TS2345 - Argument of type 'any' is not assignable to parameter of type 'never'.
-                points.push(clippedFn2(u));
-            }
-        }
         paths.push(path(points));
 
         return paths;

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1420,7 +1420,6 @@ GraphUtils.createGraphie = function (el: any): Graphie {
     }
 
     function plotParametric(fn: (t: number) => Coord, range) {
-        const fn2 = (t) => [t, 0];
         // Note: fn2 should only be set if 'shade' is true, as it denotes
         // the function between which fn should have its area shaded.
         // In general, plotParametric shouldn't be used to shade the area
@@ -1439,7 +1438,7 @@ GraphUtils.createGraphie = function (el: any): Graphie {
             return xy;
         };
         const clippedFn = (x) => clipper(fn(x));
-        const clippedFn2 = (x: number) => clipper(fn2(x));
+        const clippedFn2 = (x: number) => clipper(((t) => [t, 0])(x));
 
         if (!thisGraphie.currentStyle.strokeLinejoin) {
             thisGraphie.currentStyle.strokeLinejoin = "round";

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1438,7 +1438,7 @@ GraphUtils.createGraphie = function (el: any): Graphie {
             return xy;
         };
         const clippedFn = (x) => clipper(fn(x));
-        const clippedFn2 = (x: number) => clipper(((t) => [t, 0])(x));
+        const clippedFn2 = (x: number) => clipper([x, 0]);
 
         if (!thisGraphie.currentStyle.strokeLinejoin) {
             thisGraphie.currentStyle.strokeLinejoin = "round";

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1438,7 +1438,6 @@ GraphUtils.createGraphie = function (el: any): Graphie {
             return xy;
         };
         const clippedFn = (x) => clipper(fn(x));
-        const clippedFn2 = (x: number) => [x, 0];
 
         if (!thisGraphie.currentStyle.strokeLinejoin) {
             thisGraphie.currentStyle.strokeLinejoin = "round";
@@ -1457,12 +1456,11 @@ GraphUtils.createGraphie = function (el: any): Graphie {
 
         const paths = thisGraphie.raphael.set();
         let points = [];
-        let lastDiffY = clippedFn2(min)[1] - clippedFn(min)[1];
+        let lastDiffY = 0 - clippedFn(min)[1];
 
         for (let t = min; t <= max; t += step) {
             const top = clippedFn(t);
-            const bottom = clippedFn2(t);
-            const diffY = bottom[1] - top[1];
+            const diffY = 0 - top[1];
 
             // Find points where it flips
             // Create path that sketches area between the two functions

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -51,15 +51,6 @@ const GraphUtils: any = {
     },
 
     /**
-     * Return the difference between two sets of coordinates
-     */
-    coordDiff: function (startCoord, endCoord) {
-        return _.map(endCoord, function (val, i) {
-            return endCoord[i] - startCoord[i];
-        });
-    },
-
-    /**
      * Round the given coordinates to a given snap value
      * (e.g., nearest 0.2 increment)
      */

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1491,8 +1491,6 @@ GraphUtils.createGraphie = function (el: any): Graphie {
     }
 
     function plot(fn, range, swapAxes) {
-        const shade = undefined;
-        const fn2 = undefined;
         const min = range[0];
         const max = range[1];
         if (!thisGraphie.currentStyle["plot-points"]) {
@@ -1503,27 +1501,9 @@ GraphUtils.createGraphie = function (el: any): Graphie {
         }
 
         if (swapAxes) {
-            if (fn2) {
-                // TODO(charlie): support swapped axis area shading
-                throw new PerseusError(
-                    "Can't shade area between functions with swapped axes.",
-                    Errors.Internal,
-                );
-            }
             return plotParametric(function (y) {
                 return [fn(y), y];
             }, range);
-        }
-        if (fn2) {
-            if (shade) {
-                return plotParametric(function (x) {
-                    return [x, fn(x)];
-                }, range);
-            }
-            throw new PerseusError(
-                "fn2 should only be set when 'shade' is True.",
-                Errors.Internal,
-            );
         }
         return plotParametric(function (x) {
             return [x, fn(x)];

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1463,7 +1463,6 @@ GraphUtils.createGraphie = function (el: any): Graphie {
             const y = point[1];
 
             // Find points where it flips
-            // Create path that sketches area between the two functions
             if (
                 // if there is an asymptote here, meaning that the graph
                 // switches signs and has a large difference

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1457,12 +1457,12 @@ GraphUtils.createGraphie = function (el: any): Graphie {
 
         const paths = thisGraphie.raphael.set();
         let points = [];
-        let lastDiffY = GraphUtils.coordDiff(clippedFn(min), clippedFn2(min))[1];
+        let lastDiffY = clippedFn2(min)[1] - clippedFn(min)[1];
 
         for (let t = min; t <= max; t += step) {
             const top = clippedFn(t);
             const bottom = clippedFn2(t);
-            const diffY = GraphUtils.coordDiff(top, bottom)[1];
+            const diffY = bottom[1] - top[1];
 
             // Find points where it flips
             // Create path that sketches area between the two functions

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1459,8 +1459,8 @@ GraphUtils.createGraphie = function (el: any): Graphie {
         let lastY = clippedFn(min)[1];
 
         for (let t = min; t <= max; t += step) {
-            const top = clippedFn(t);
-            const y = top[1];
+            const point = clippedFn(t);
+            const y = point[1];
 
             // Find points where it flips
             // Create path that sketches area between the two functions
@@ -1480,7 +1480,7 @@ GraphUtils.createGraphie = function (el: any): Graphie {
             } else {
                 // otherwise, just add the point to the path
                 // @ts-expect-error - TS2345 - Argument of type 'any' is not assignable to parameter of type 'never'.
-                points.push(top);
+                points.push(point);
             }
 
             lastY = y;

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1458,23 +1458,23 @@ GraphUtils.createGraphie = function (el: any): Graphie {
 
         const paths = thisGraphie.raphael.set();
         let points = [];
-        let lastDiff = GraphUtils.coordDiff(clippedFn(min), clippedFn2(min));
+        let lastDiffY = GraphUtils.coordDiff(clippedFn(min), clippedFn2(min))[1];
 
         for (let t = min; t <= max; t += step) {
             const top = clippedFn(t);
             const bottom = clippedFn2(t);
-            const diff = GraphUtils.coordDiff(top, bottom);
+            const diffY = GraphUtils.coordDiff(top, bottom)[1];
 
             // Find points where it flips
             // Create path that sketches area between the two functions
             if (
                 // if there is an asymptote here, meaning that the graph
                 // switches signs and has a large difference
-                (diff[1] < 0 !== lastDiff[1] < 0 &&
-                    Math.abs(diff[1] - lastDiff[1]) >
+                (diffY < 0 !== lastDiffY < 0 &&
+                    Math.abs(diffY - lastDiffY) >
                         2 * thisGraphie.drawingTransform().pixelsPerUnitY()) ||
                 // or the function is undefined
-                isNaN(diff[1])
+                isNaN(diffY)
             ) {
                 // split the path at this point, and draw it
                 paths.push(path(points));
@@ -1486,7 +1486,7 @@ GraphUtils.createGraphie = function (el: any): Graphie {
                 points.push(top);
             }
 
-            lastDiff = diff;
+            lastDiffY = diffY;
         }
 
         paths.push(path(points));

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1456,22 +1456,22 @@ GraphUtils.createGraphie = function (el: any): Graphie {
 
         const paths = thisGraphie.raphael.set();
         let points = [];
-        let lastNegY = -clippedFn(min)[1];
+        let lastY = clippedFn(min)[1];
 
         for (let t = min; t <= max; t += step) {
             const top = clippedFn(t);
-            const negY = -top[1];
+            const y = top[1];
 
             // Find points where it flips
             // Create path that sketches area between the two functions
             if (
                 // if there is an asymptote here, meaning that the graph
                 // switches signs and has a large difference
-                (negY < 0 !== lastNegY < 0 &&
-                    Math.abs(negY - lastNegY) >
+                (y > 0 !== lastY > 0 &&
+                    Math.abs(y - lastY) >
                         2 * thisGraphie.drawingTransform().pixelsPerUnitY()) ||
                 // or the function is undefined
-                isNaN(negY)
+                isNaN(y)
             ) {
                 // split the path at this point, and draw it
                 paths.push(path(points));
@@ -1483,7 +1483,7 @@ GraphUtils.createGraphie = function (el: any): Graphie {
                 points.push(top);
             }
 
-            lastNegY = negY;
+            lastY = y;
         }
 
         paths.push(path(points));

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1456,22 +1456,22 @@ GraphUtils.createGraphie = function (el: any): Graphie {
 
         const paths = thisGraphie.raphael.set();
         let points = [];
-        let lastDiffY = 0 - clippedFn(min)[1];
+        let lastNegY = -clippedFn(min)[1];
 
         for (let t = min; t <= max; t += step) {
             const top = clippedFn(t);
-            const diffY = 0 - top[1];
+            const negY = -top[1];
 
             // Find points where it flips
             // Create path that sketches area between the two functions
             if (
                 // if there is an asymptote here, meaning that the graph
                 // switches signs and has a large difference
-                (diffY < 0 !== lastDiffY < 0 &&
-                    Math.abs(diffY - lastDiffY) >
+                (negY < 0 !== lastNegY < 0 &&
+                    Math.abs(negY - lastNegY) >
                         2 * thisGraphie.drawingTransform().pixelsPerUnitY()) ||
                 // or the function is undefined
-                isNaN(diffY)
+                isNaN(negY)
             ) {
                 // split the path at this point, and draw it
                 paths.push(path(points));
@@ -1483,7 +1483,7 @@ GraphUtils.createGraphie = function (el: any): Graphie {
                 points.push(top);
             }
 
-            lastDiffY = diffY;
+            lastNegY = negY;
         }
 
         paths.push(path(points));

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1431,13 +1431,13 @@ GraphUtils.createGraphie = function (el: any): Graphie {
         // overflow in the firefox svg renderer.  This is safe
         // since 500,000 is outside the viewport anyway.  We
         // write these functions the way we do to handle undefined.
-        const clipper = (xy) => {
+        const clip = (xy) => {
             if (Math.abs(xy[1]) > 500000) {
                 return [xy[0], Math.min(Math.max(xy[1], -500000), 500000)];
             }
             return xy;
         };
-        const clippedFn = (x) => clipper(fn(x));
+        const clippedFn = (x) => clip(fn(x));
 
         if (!thisGraphie.currentStyle.strokeLinejoin) {
             thisGraphie.currentStyle.strokeLinejoin = "round";


### PR DESCRIPTION
As I was moving methods into the Graphie class, I noticed that the shade and
fn2 params are never used. Removing them lets us simplify the code quite a bit.

Issue: https://khanacademy.atlassian.net/browse/LC-1662

## Test plan:

View the Storybook docs for Grapher, Interactive Graph, and Number Line.