### PR TITLE
Avoid exporting svgPath on GraphUtils

### DIFF
--- a/.changeset/grumpy-panthers-report.md
+++ b/.changeset/grumpy-panthers-report.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Refactor graphie.ts

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -35,54 +35,6 @@ export function polar(r: number | Coord, th: number) {
     return [r[0] * Math.cos(th), r[1] * Math.sin(th)];
 }
 
-const GraphUtils: any = {
-    unscaledSvgPath: function (points) {
-        // If this is an empty closed path, return "" instead of "z", which
-        // would give an error
-        if (points[0] === true) {
-            return "";
-        }
-        return $.map(points, function (point, i) {
-            if (point === true) {
-                return "z";
-            }
-            return (i === 0 ? "M" : "L") + point[0] + " " + point[1];
-        }).join("");
-    },
-
-    getDistance: function (point1, point2) {
-        return kpoint.distanceToPoint(point1, point2);
-    },
-
-    /**
-     * Round the given coordinates to a given snap value
-     * (e.g., nearest 0.2 increment)
-     */
-    snapCoord: function (coord, snap) {
-        return _.map(coord, function (val, i) {
-            return KhanMath.roundToNearest(snap[i], val);
-        });
-    },
-
-    // Find the angle in degrees between two or three points
-    findAngle: function (point1, point2, vertex) {
-        if (vertex === undefined) {
-            const x = point1[0] - point2[0];
-            const y = point1[1] - point2[1];
-            if (!x && !y) {
-                return 0;
-            }
-            return (180 + (Math.atan2(-y, -x) * 180) / Math.PI + 360) % 360;
-        }
-        return (
-            GraphUtils.findAngle(point1, vertex) -
-            GraphUtils.findAngle(point2, vertex)
-        );
-    },
-
-    graphs: {},
-};
-
 type RaphaelElement = any;
 interface RaphaelSet {
     push(...items: RaphaelElement[]): unknown;
@@ -1447,8 +1399,6 @@ export class Graphie {
     }
 }
 
-GraphUtils.Graphie = Graphie;
-
 const labelDirections = {
     center: [-0.5, -0.5],
     above: [-0.5, -1.0],
@@ -1509,13 +1459,63 @@ const setLabelMargins = function (span: HTMLElement, size: Coord): void {
     }
 };
 
-GraphUtils.createGraphie = function (el: any): Graphie {
-    const thisGraphie = new Graphie(el);
+const GraphUtils: any = {
+    Graphie,
 
-    // `svgPath` is independent of graphie range, so we export it independently
-    GraphUtils.svgPath = thisGraphie.svgPath;
+    createGraphie: function (el: any): Graphie {
+        const thisGraphie = new Graphie(el);
 
-    return thisGraphie;
+        // `svgPath` is independent of graphie range, so we export it independently
+        GraphUtils.svgPath = thisGraphie.svgPath;
+
+        return thisGraphie;
+    },
+
+    unscaledSvgPath: function (points) {
+        // If this is an empty closed path, return "" instead of "z", which
+        // would give an error
+        if (points[0] === true) {
+            return "";
+        }
+        return $.map(points, function (point, i) {
+            if (point === true) {
+                return "z";
+            }
+            return (i === 0 ? "M" : "L") + point[0] + " " + point[1];
+        }).join("");
+    },
+
+    getDistance: function (point1, point2) {
+        return kpoint.distanceToPoint(point1, point2);
+    },
+
+    /**
+     * Round the given coordinates to a given snap value
+     * (e.g., nearest 0.2 increment)
+     */
+    snapCoord: function (coord, snap) {
+        return _.map(coord, function (val, i) {
+            return KhanMath.roundToNearest(snap[i], val);
+        });
+    },
+
+    // Find the angle in degrees between two or three points
+    findAngle: function (point1, point2, vertex) {
+        if (vertex === undefined) {
+            const x = point1[0] - point2[0];
+            const y = point1[1] - point2[1];
+            if (!x && !y) {
+                return 0;
+            }
+            return (180 + (Math.atan2(-y, -x) * 180) / Math.PI + 360) % 360;
+        }
+        return (
+            GraphUtils.findAngle(point1, vertex) -
+            GraphUtils.findAngle(point2, vertex)
+        );
+    },
+
+    graphs: {},
 };
 
 export default GraphUtils;

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1463,12 +1463,7 @@ const GraphUtils: any = {
     Graphie,
 
     createGraphie: function (el: any): Graphie {
-        const thisGraphie = new Graphie(el);
-
-        // `svgPath` is independent of graphie range, so we export it independently
-        GraphUtils.svgPath = thisGraphie.svgPath;
-
-        return thisGraphie;
+        return new Graphie(el);
     },
 
     unscaledSvgPath: function (points) {

--- a/packages/perseus/src/util/interactive.ts
+++ b/packages/perseus/src/util/interactive.ts
@@ -3679,7 +3679,7 @@ function Ruler(graphie: any, options: any) {
     });
 
     const mouseTarget = graphie.mouselayer.path(
-        GraphUtils.svgPath([
+        graphie.svgPath([
             leftBottom,
             [left, top],
             rightTop,


### PR DESCRIPTION
The previous behavior was that GraphUtils.svgPath would draw a path scaled for
the most recently-created Graphie. That was weird, and totally unnecessary.
There was only one usage of GraphUtils.svgPath, and I've changed it to call
svgPath on the appropriate Graphie instance instead.

Issue: https://khanacademy.atlassian.net/browse/LC-1662

## Test plan:

Review Storybook docs for Interactive Graph, Grapher, and Number Line