### PR TITLE
Use built-in JS functions instead of underscore/jQuery functions

### DIFF
--- a/.changeset/short-maps-call.md
+++ b/.changeset/short-maps-call.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/kmath": patch
+"@khanacademy/perseus": patch
+---
+
+Internal: use built-in JS functions instead of underscore

--- a/packages/kmath/src/__tests__/vector.test.ts
+++ b/packages/kmath/src/__tests__/vector.test.ts
@@ -1,6 +1,31 @@
 import * as vector from "../vector";
 
 describe("kvector", function () {
+    it("vector.zip should return empty given empty", function () {
+        expect(vector.zip([], [])).toEqual([]);
+    });
+
+    it("vector.zip should create vectors from x and y coords", function () {
+        expect(vector.zip([1, 2], [3, 4])).toEqual([
+            [1, 3],
+            [2, 4],
+        ]);
+    });
+
+    it("vector.zip should ignore extra xs", function () {
+        expect(vector.zip([1, 2, 9], [3, 4])).toEqual([
+            [1, 3],
+            [2, 4],
+        ]);
+    });
+
+    it("vector.zip should ignore extra ys", function () {
+        expect(vector.zip([1, 2], [3, 4, 9])).toEqual([
+            [1, 3],
+            [2, 4],
+        ]);
+    });
+
     it("vector.add should add two 2D vectors", function () {
         const result = vector.add([1, 2], [3, 4]);
         expect(result).toStrictEqual([4, 6]);

--- a/packages/kmath/src/point.ts
+++ b/packages/kmath/src/point.ts
@@ -3,8 +3,6 @@
  * A point is an array of two numbers e.g. [0, 0].
  */
 
-import _ from "underscore";
-
 import * as knumber from "./number";
 import * as kvector from "./vector";
 

--- a/packages/kmath/src/vector.ts
+++ b/packages/kmath/src/vector.ts
@@ -3,8 +3,6 @@
  * A vector is an array of numbers e.g. [0, 3, 4].
  */
 
-import _ from "underscore";
-
 import * as knumber from "./number";
 
 type Vector = ReadonlyArray<number>;
@@ -17,6 +15,17 @@ function arrayProduct(array: ReadonlyArray<number>): number {
     return array.reduce((memo, arg) => memo * arg, 1);
 }
 
+export function zip<T>(xs: ReadonlyArray<T>, ys: ReadonlyArray<T>): [T, T][];
+export function zip<T>(...arrays: ReadonlyArray<T>[]): T[][];
+export function zip<T>(...arrays: ReadonlyArray<T>[]): T[][] {
+    const n = Math.min(...arrays.map((a) => a.length));
+    const results: T[][] = [];
+    for (let i = 0; i < n; i++) {
+        results.push(arrays.map((a) => a[i]));
+    }
+    return results;
+}
+
 /**
  * Checks if the given vector contains only numbers and, optionally, is of the
  * right dimension (length).
@@ -26,7 +35,7 @@ function arrayProduct(array: ReadonlyArray<number>): number {
  * is([1, 2, 3], 1) -> false
  */
 export function is<T>(vec: ReadonlyArray<T>, dimension?: number): boolean {
-    if (!_.isArray(vec)) {
+    if (!Array.isArray(vec)) {
         return false;
     }
     if (dimension !== undefined && vec.length !== dimension) {
@@ -46,7 +55,7 @@ export function length(v: Vector): number {
 }
 // Dot product of two vectors
 export function dot(a: Vector, b: Vector): number {
-    const zipped = _.zip(a, b);
+    const zipped = zip(a, b);
     const multiplied = zipped.map(arrayProduct);
     return arraySum(multiplied);
 }
@@ -56,14 +65,14 @@ export function dot(a: Vector, b: Vector): number {
  * add([1, 2], [3, 4]) -> [4, 6]
  */
 export function add<V extends Vector>(...vecs: ReadonlyArray<V>): V {
-    const zipped = _.zip(...vecs);
+    const zipped = zip(...vecs);
     // @ts-expect-error - TS2322 - Type 'number[]' is not assignable to type 'V'.
     return zipped.map(arraySum);
 }
 
 export function subtract<V extends Vector>(v1: V, v2: V): V {
     // @ts-expect-error - TS2322 - Type 'number[]' is not assignable to type 'V'.
-    return _.zip(v1, v2).map((dim) => dim[0] - dim[1]);
+    return zip(v1, v2).map((dim) => dim[0] - dim[1]);
 }
 
 export function negate<V extends Vector>(v: V): V {
@@ -82,12 +91,9 @@ export function scale<V extends Vector>(v1: V, scalar: number): V {
 }
 
 export function equal(v1: Vector, v2: Vector, tolerance?: number): boolean {
-    // _.zip will nicely deal with the lengths, going through
-    // the length of the longest vector. knumber.equal then
-    // returns false for any number compared to the undefined
-    // passed in if one of the vectors is shorter.
-    return _.zip(v1, v2).every((pair) =>
-        knumber.equal(pair[0], pair[1], tolerance),
+    return (
+        v1.length === v2.length &&
+        zip(v1, v2).every((pair) => knumber.equal(pair[0], pair[1], tolerance))
     );
 }
 


### PR DESCRIPTION
## Summary:
The built-in APIs have better type support, and are idiomatic.

One underscore function that has no equivalent in vanilla JS is `_.zip`.
I've reimplemented zip so we can avoid importing underscore. This gets
us more robust typechecking around zip calls.

Issue: https://khanacademy.atlassian.net/browse/LC-1662

Test plan:

Review the Storybook docs for Grapher, Interactive Graph, and Number
Line.