### PR TITLE
rename helper to parsePerseusItem

### DIFF
--- a/.changeset/wet-bags-call.md
+++ b/.changeset/wet-bags-call.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Rename helper that's not in-use yet.

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -83,7 +83,7 @@ export {
     getAnswersFromWidgets,
     injectWidgets,
 } from "./util/extract-perseus-data";
-export {default as parsePerseusJSON} from "./util/parse-perseus-json";
+export {parsePerseusItem} from "./util/parse-perseus-json";
 
 /**
  * Mixins

--- a/packages/perseus/src/util/parse-perseus-json.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json.test.ts
@@ -1,8 +1,8 @@
-import parsePerseusJSON from "./parse-perseus-json";
+import {parsePerseusItem} from "./parse-perseus-json";
 
-describe("parsePerseusJSON", () => {
+describe("parsePerseusItem", () => {
     it("should parse JSON", () => {
-        const result = parsePerseusJSON(
+        const result = parsePerseusItem(
             `{ "question": { "content": "idk why I'm testing this" }}`,
         );
         expect(result.question.content).toBe("idk why I'm testing this");

--- a/packages/perseus/src/util/parse-perseus-json.ts
+++ b/packages/perseus/src/util/parse-perseus-json.ts
@@ -1,13 +1,13 @@
 import type {PerseusItem} from "../perseus-types";
 
 /**
- * Helper to parse Perseus JSON
+ * Helper to parse PerseusItem JSON
  * Why not just use JSON.parse? We want:
  * - To make sure types are correct
  * - To give us a central place to validate/transform output if needed
- * @param {string} input - the stringified Perseus JSON
+ * @param {string} json - the stringified PerseusItem JSON
  * @returns {PerseusItem} the parsed PerseusItem object
  */
-export default function parsePerseusJSON(input: string): PerseusItem {
-    return JSON.parse(input);
+export function parsePerseusItem(json: string): PerseusItem {
+    return JSON.parse(json);
 }


### PR DESCRIPTION
## Summary:
After digging more in the Webapp code, they're parsing more than just the PerseusItem.

Renaming this so it's more explicit about what it's for.