### PR TITLE
Label Image: screen reader reads answer alongside marker

### DIFF
--- a/.changeset/plenty-tips-occur.md
+++ b/.changeset/plenty-tips-occur.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Screenreader reads Label Image Widget answer pills

--- a/packages/perseus/src/widgets/label-image.tsx
+++ b/packages/perseus/src/widgets/label-image.tsx
@@ -600,6 +600,7 @@ export class LabelImage extends React.Component<
                         disabled={disabled}
                         opener={({opened}) => (
                             <Clickable
+                                role="button"
                                 aria-expanded={opened}
                                 key={`marker-${marker.x}.${marker.y}`}
                             >

--- a/packages/perseus/src/widgets/label-image.tsx
+++ b/packages/perseus/src/widgets/label-image.tsx
@@ -598,16 +598,10 @@ export class LabelImage extends React.Component<
                         }
                         // cannot change answer choices once question is answered
                         disabled={disabled}
-                        opener={({opened, text}) => (
+                        opener={({opened}) => (
                             <Clickable
-                                role="button"
+                                aria-expanded={opened}
                                 key={`marker-${marker.x}.${marker.y}`}
-                                aria-label={
-                                    // already translated in: /widgets/graded-group.tsx
-                                    showCorrectness === "correct"
-                                        ? i18n._("Correct!")
-                                        : marker.label
-                                }
                             >
                                 {({hovered, focused, pressed}) => (
                                     <Marker

--- a/packages/perseus/src/widgets/label-image/marker.tsx
+++ b/packages/perseus/src/widgets/label-image/marker.tsx
@@ -7,6 +7,7 @@
 
 import Color from "@khanacademy/wonder-blocks-color";
 import {View, type StyleType} from "@khanacademy/wonder-blocks-core";
+import * as i18n from "@khanacademy/wonder-blocks-i18n";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
@@ -127,6 +128,7 @@ export default class Marker extends React.Component<Props> {
             answerStyles,
             hovered,
             focused,
+            label,
         } = this.props;
 
         // We cannot make dropdown openers untabbable, so we isolate tabbing
@@ -141,6 +143,8 @@ export default class Marker extends React.Component<Props> {
                         styles.marker,
                         active && !markerDisabled && styles.markerActive,
                     ]}
+                    // already translated in: /widgets/graded-group.tsx
+                    aria-label={markerDisabled ? i18n._("Correct!") : label}
                 >
                     {this.renderIcon()}
                 </View>


### PR DESCRIPTION
Moves marker label so that it's a sibling to the answer pill so that both are read. Also, ensures there is an explicit "button" label on Clickable so that we trigger the automated math label in MathJax Renderer.


https://github.com/Khan/perseus/assets/23404711/f63af37e-43e8-4b7f-b8d9-d37f737dcd16


Issue: LC-1701

Testing:
Open Safari with VoiceOver. Select an answer on Label Image Widget. Focus on marker and see that answer is read (and is accurate for math)