### PR TITLE
Fix deprecated-standin widget override of transformer widget

### DIFF
--- a/.changeset/purple-avocados-relate.md
+++ b/.changeset/purple-avocados-relate.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix bug when replacing transformer widget with deprecated-standin

--- a/.changeset/twelve-peas-add.md
+++ b/.changeset/twelve-peas-add.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Bump Perseus to version that correctly replaces transformer widget with deprecated-standin

--- a/packages/perseus-editor/src/__tests__/integration.test.ts
+++ b/packages/perseus-editor/src/__tests__/integration.test.ts
@@ -1,17 +1,5 @@
-import {Dependencies} from "@khanacademy/perseus";
-
-import {testDependencies} from "../../../../testing/test-dependencies";
-
 describe("PerseusEditor integration test", () => {
-    it("should log error if widget registration fails", async () => {
-        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
-            testDependencies,
-        );
-
-        const errorSpy = jest.spyOn(testDependencies.Log, "error");
-
-        await import("../index");
-
-        expect(errorSpy).not.toHaveBeenCalled();
+    it("entrypoint should not throw", async () => {
+        expect(async () => await import("../index")).not.toThrow();
     });
 });

--- a/packages/perseus-editor/src/__tests__/integration.test.ts
+++ b/packages/perseus-editor/src/__tests__/integration.test.ts
@@ -1,0 +1,17 @@
+import {Dependencies} from "@khanacademy/perseus";
+
+import {testDependencies} from "../../../../testing/test-dependencies";
+
+describe("PerseusEditor integration test", () => {
+    it("should log error if widget registration fails", async () => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+
+        const errorSpy = jest.spyOn(testDependencies.Log, "error");
+
+        await import("../index");
+
+        expect(errorSpy).not.toHaveBeenCalled();
+    });
+});

--- a/packages/perseus-editor/src/index.ts
+++ b/packages/perseus-editor/src/index.ts
@@ -25,6 +25,6 @@ Widgets.registerEditors(AllEditors);
 Widgets.registerWidgets(AllWidgets);
 
 Widgets.replaceEditor("transformer", "deprecated-standin");
-Widgets.replaceWidget("transformer", "deprecatd-standin");
+Widgets.replaceWidget("transformer", "deprecated-standin");
 
 export {AllEditors, AllWidgets};

--- a/packages/perseus/src/__tests__/widgets.test.ts
+++ b/packages/perseus/src/__tests__/widgets.test.ts
@@ -89,4 +89,16 @@ describe("replaceWidget", () => {
         Widgets.replaceWidget("radio", "dog-cat");
         expect(Widgets.getWidget("radio")?.name).toBe("Radio");
     });
+
+    it("Logs a message when the replacement isn't available", () => {
+        const errorSpy = jest.spyOn(testDependencies.Log, "error");
+
+        Widgets.replaceWidget("radio", "dog-cat");
+
+        expect(errorSpy).toHaveBeenCalledWith(
+            expect.stringContaining("dog-cat"),
+            "Internal",
+            undefined,
+        );
+    });
 });

--- a/packages/perseus/src/__tests__/widgets.test.ts
+++ b/packages/perseus/src/__tests__/widgets.test.ts
@@ -85,20 +85,7 @@ describe("replaceWidget", () => {
         expect(Widgets.getWidget("transformer")?.name).toBe("Radio");
     });
 
-    it("Does nothing when the replacement isn't available", () => {
-        Widgets.replaceWidget("radio", "dog-cat");
-        expect(Widgets.getWidget("radio")?.name).toBe("Radio");
-    });
-
-    it("Logs a message when the replacement isn't available", () => {
-        const errorSpy = jest.spyOn(testDependencies.Log, "error");
-
-        Widgets.replaceWidget("radio", "dog-cat");
-
-        expect(errorSpy).toHaveBeenCalledWith(
-            expect.stringContaining("dog-cat"),
-            "Internal",
-            undefined,
-        );
+    it("Throws when the replacement isn't available", () => {
+        expect(() => Widgets.replaceWidget("radio", "dog-cat")).toThrow();
     });
 });

--- a/packages/perseus/src/widgets.ts
+++ b/packages/perseus/src/widgets.ts
@@ -54,12 +54,12 @@ export const registerWidgets = (widgets: ReadonlyArray<WidgetExports>) => {
 export const replaceWidget = (name: string, replacementName: string) => {
     const substituteWidget = widgets[replacementName];
 
+    // If the replacement widget isn't found, we need to throw. Otherwise after
+    // removing the deprecated widget, we'll have data asking for a widget type
+    // that doesn't exist at all.
     if (!substituteWidget) {
-        if (Log) {
-            const errorMsg = `Failed to replace ${name} with ${replacementName}`;
-            Log.error(errorMsg, Errors.Internal);
-        }
-        return;
+        const errorMsg = `Failed to replace ${name} with ${replacementName}`;
+        throw new PerseusError(errorMsg, Errors.Internal);
     }
 
     registerWidget(name, substituteWidget);

--- a/packages/perseus/src/widgets.ts
+++ b/packages/perseus/src/widgets.ts
@@ -54,9 +54,11 @@ export const registerWidgets = (widgets: ReadonlyArray<WidgetExports>) => {
 export const replaceWidget = (name: string, replacementName: string) => {
     const substituteWidget = widgets[replacementName];
 
-    if (!substituteWidget && Log) {
-        const errorMsg = `Failed to replace ${name} with ${replacementName}`;
-        Log.error(errorMsg, Errors.Internal);
+    if (!substituteWidget) {
+        if (Log) {
+            const errorMsg = `Failed to replace ${name} with ${replacementName}`;
+            Log.error(errorMsg, Errors.Internal);
+        }
         return;
     }
 


### PR DESCRIPTION
## Summary

We recently removed the `transformer` widget by replacing it with the `deprecated-standin` widget. Unfortunately, this registration had a typo. 

This is showing up in Sentry: https://khanacademyorg.sentry.io/issues/4929063013/?project=15744

This PR fixes the typo and adds a test to ensure our entry-point widget registrations are doing things correctly. 

See: https://khanacademy.slack.com/archives/CJSB0D3BN/p1706825855657239

Issue: "none"

## Test plan:

`yarn test` passes