### PR TITLE
LC-1706: Replace MathQuill's "Math Input" label with translated string

### DIFF
--- a/.changeset/clever-steaks-bathe.md
+++ b/.changeset/clever-steaks-bathe.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+MathQuill provided a translated label

--- a/.changeset/giant-cycles-call.md
+++ b/.changeset/giant-cycles-call.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Updated tests

--- a/packages/math-input/src/components/input/mathquill-instance.ts
+++ b/packages/math-input/src/components/input/mathquill-instance.ts
@@ -1,3 +1,4 @@
+import * as i18n from "@khanacademy/wonder-blocks-i18n";
 import MathQuill from "mathquill";
 
 import type {
@@ -96,5 +97,10 @@ export function createMathField(
     const baseConfig = createBaseConfig();
     const config = configCallback ? configCallback(baseConfig) : baseConfig;
 
-    return mathQuillInstance.MathField(container, config);
+    const mathField = mathQuillInstance
+        .MathField(container, config)
+        // translated in ./math-input.tsx
+        .setAriaLabel(i18n._("Math input box")) as MathFieldInterface;
+
+    return mathField;
 }

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/input-number.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/input-number.test.ts.snap
@@ -182,7 +182,7 @@ exports[`rendering supports mobile rendering: mobile render 1`] = `
                   class="mq-textarea"
                 >
                   <span
-                    aria-label="Math Input:"
+                    aria-label="Math input box:"
                   />
                 </span>
                 <span

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/numeric-input.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/numeric-input.test.ts.snap
@@ -44,7 +44,7 @@ exports[`Numeric input widget styles differently on mobile: mobile render 1`] = 
                   class="mq-textarea"
                 >
                   <span
-                    aria-label="Math Input:"
+                    aria-label="Math input box:"
                   />
                 </span>
                 <span


### PR DESCRIPTION
The lowest-hanging fruit in our effort to internationalize the Desmos MathQuill accessibility features. Swaps out "Math Input" for our translated string, "Math input box".

<img width="1792" alt="Screenshot 2024-02-01 at 6 17 34 PM" src="https://github.com/Khan/perseus/assets/23404711/52f8238c-a5c3-41f3-91e8-97a75e935a0d">

Issue: LC-1706

Testing:
Screen reader should say "Math input box" or "Math input box: {some mathspeak}" when focused on math input.