### PR TITLE
Test and simplify normalizeOptions

### DIFF
--- a/.changeset/bright-walls-tell.md
+++ b/.changeset/bright-walls-tell.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Add tests for normalizeOptions function (used by Movable)

--- a/packages/perseus/src/interactive2/interactive-util.test.ts
+++ b/packages/perseus/src/interactive2/interactive-util.test.ts
@@ -1,0 +1,93 @@
+import InteractiveUtil from "./interactive-util";
+
+describe("normalizeOptions", () => {
+    it("wraps single functions in arrays", () => {
+        const options = {
+            add: () => {},
+            modify: () => {},
+            draw: () => {},
+            remove: () => {},
+            constraints: () => {},
+            onMoveStart: () => {},
+            onMove: () => {},
+            onMoveEnd: () => {},
+            onClick: () => {},
+        };
+        expect(InteractiveUtil.normalizeOptions(options)).toEqual({
+            add: [options.add],
+            modify: [options.modify],
+            draw: [options.draw],
+            remove: [options.remove],
+            constraints: [options.constraints],
+            onMoveStart: [options.onMoveStart],
+            onMove: [options.onMove],
+            onMoveEnd: [options.onMoveEnd],
+            onClick: [options.onClick],
+        });
+    });
+
+    it("tolerates missing properties", () => {
+        const options = {
+            add: () => {},
+        };
+        expect(InteractiveUtil.normalizeOptions(options)).toEqual({
+            add: [options.add],
+        });
+    });
+
+    it("ignores extra properties", () => {
+        const options = {
+            foo: () => {},
+        };
+        expect(InteractiveUtil.normalizeOptions(options)).toEqual({
+            foo: options.foo,
+        });
+    });
+
+    it("does not modify its argument", () => {
+        const options = {
+            add: () => {},
+        };
+        const optionsCopy = {...options};
+        InteractiveUtil.normalizeOptions(options);
+        expect(options).toEqual(optionsCopy);
+    });
+
+    it("leaves existing arrays of functions alone", () => {
+        const options = {
+            add: [() => {}],
+            modify: [() => {}],
+            draw: [() => {}],
+            remove: [() => {}],
+            onMoveStart: [() => {}],
+            onMove: [() => {}],
+            onMoveEnd: [() => {}],
+            onClick: [() => {}],
+        };
+        expect(InteractiveUtil.normalizeOptions(options)).toEqual(options);
+    });
+
+    it("flattens arrays", () => {
+        const dummyFunction = () => {};
+        const options = {
+            add: [[dummyFunction]],
+            modify: [[dummyFunction]],
+            draw: [[dummyFunction]],
+            remove: [[dummyFunction]],
+            onMoveStart: [[dummyFunction]],
+            onMove: [[dummyFunction]],
+            onMoveEnd: [[dummyFunction]],
+            onClick: [[dummyFunction]],
+        };
+        expect(InteractiveUtil.normalizeOptions(options)).toEqual({
+            add: [dummyFunction],
+            modify: [dummyFunction],
+            draw: [dummyFunction],
+            remove: [dummyFunction],
+            onMoveStart: [dummyFunction],
+            onMove: [dummyFunction],
+            onMoveEnd: [dummyFunction],
+            onClick: [dummyFunction],
+        });
+    });
+});

--- a/packages/perseus/src/interactive2/interactive-util.ts
+++ b/packages/perseus/src/interactive2/interactive-util.ts
@@ -120,7 +120,7 @@ const InteractiveUtil = {
      */
     normalizeOptions: function (options: Record<any, any>): Record<any, any> {
         const result = {...options};
-        _.each(FUNCTION_ARRAY_OPTIONS, function (eventName) {
+        FUNCTION_ARRAY_OPTIONS.forEach(function (eventName) {
             // Only propagate values which were set; not present values
             // shouldn't be added to options because we'd like them to
             // fall through to defaults

--- a/packages/perseus/src/interactive2/interactive-util.ts
+++ b/packages/perseus/src/interactive2/interactive-util.ts
@@ -52,6 +52,18 @@ function computeCanUse3dTransform(): boolean {
     return !!el.style[prefix];
 }
 
+const FUNCTION_ARRAY_OPTIONS = [
+    "add",
+    "modify",
+    "draw",
+    "remove",
+    "constraints",
+    "onMoveStart",
+    "onMove",
+    "onMoveEnd",
+    "onClick",
+];
+
 const InteractiveUtil = {
     assert: function (isTrue: boolean, message?: string) {
         if (!isTrue) {
@@ -106,24 +118,16 @@ const InteractiveUtil = {
     /**
      * Convert all function-or-array arguments to arrays of functions
      */
-    normalizeOptions: function (
-        arrayOptionNames: ReadonlyArray<string>,
-        options: Record<any, any>,
-    ): Record<any, any> {
-        // TODO(jack): Having to clone here is annoying; this
-        // function should really just modify this.state in place
-        // (and maybe be a function on MovableHelperMethods to get access
-        // to this.state), which would also be nicer because we could
-        // normalizeOptions once in this.modify
-        const result = _.clone(options);
-        _.each(arrayOptionNames, function (eventName) {
-            const funcOrArray = options[eventName];
+    normalizeOptions: function (options: Record<any, any>): Record<any, any> {
+        const result = {...options};
+        _.each(FUNCTION_ARRAY_OPTIONS, function (eventName) {
             // Only propagate values which were set; not present values
             // shouldn't be added to options because we'd like them to
             // fall through to defaults
-            if (funcOrArray !== undefined) {
-                const funcArray = InteractiveUtil.arrayify(funcOrArray);
-                result[eventName] = funcArray;
+            if (options[eventName] !== undefined) {
+                result[eventName] = InteractiveUtil.arrayify(
+                    options[eventName],
+                );
             }
         });
         return result;

--- a/packages/perseus/src/interactive2/movable-helper-methods.ts
+++ b/packages/perseus/src/interactive2/movable-helper-methods.ts
@@ -12,7 +12,6 @@ import _ from "underscore";
 
 import {Errors} from "../logging/log";
 import {PerseusError} from "../perseus-error";
-import {State as MovableState} from "./movable"
 
 /* Local helper methods. */
 
@@ -28,9 +27,12 @@ const MovableHelperMethods: any = {
     /**
      * Fire an onSomething type event to all functions in listeners
      */
-    _fireEvent: function<F extends (...args: any[]) => any>(listeners: F[], ...args: Parameters<F>) {
+    _fireEvent: function <F extends (...args: any[]) => any>(
+        listeners: F[],
+        ...args: Parameters<F>
+    ) {
         for (const listener of listeners) {
-            listener.call(this, ...args)
+            listener.call(this, ...args);
         }
     },
 

--- a/packages/perseus/src/interactive2/movable-helper-methods.ts
+++ b/packages/perseus/src/interactive2/movable-helper-methods.ts
@@ -12,6 +12,7 @@ import _ from "underscore";
 
 import {Errors} from "../logging/log";
 import {PerseusError} from "../perseus-error";
+import {State as MovableState} from "./movable"
 
 /* Local helper methods. */
 
@@ -27,8 +28,10 @@ const MovableHelperMethods: any = {
     /**
      * Fire an onSomething type event to all functions in listeners
      */
-    _fireEvent: function (listeners, currentValue, previousValue) {
-        _.invoke(listeners, "call", this, currentValue, previousValue);
+    _fireEvent: function<F extends (...args: any[]) => any>(listeners: F[], ...args: Parameters<F>) {
+        for (const listener of listeners) {
+            listener.call(this, ...args)
+        }
     },
 
     /**

--- a/packages/perseus/src/interactive2/movable-line.ts
+++ b/packages/perseus/src/interactive2/movable-line.ts
@@ -14,16 +14,6 @@ import WrappedLine from "./wrapped-line";
 const assert = InteractiveUtil.assert;
 const normalizeOptions = InteractiveUtil.normalizeOptions;
 
-const FUNCTION_ARRAY_OPTIONS = [
-    "add",
-    "draw",
-    "remove",
-    "onMoveStart",
-    "constraints",
-    "onMove",
-    "onMoveEnd",
-];
-
 // Default "props" and "state". Both are added to this.state and
 // receive magic getter methods (this.cursor() etc).
 // However, properties in DEFAULT_PROPS are updated on `modify()`,
@@ -87,7 +77,6 @@ _.extend(MovableLine.prototype, {
                 id: this.state.id,
             },
             normalizeOptions(
-                FUNCTION_ARRAY_OPTIONS,
                 // Defaults are copied from MovableLineOptions.*.standard
                 // These defaults are set here instead of DEFAULT_PROPS/STATE
                 // because they:
@@ -121,7 +110,7 @@ _.extend(MovableLine.prototype, {
         const graphie = this.graphie;
         const state = (self.state = _.extend(
             self.state,
-            normalizeOptions(FUNCTION_ARRAY_OPTIONS, options),
+            normalizeOptions(options),
         ));
 
         // Default things inside the state.normalStyle object, because

--- a/packages/perseus/src/interactive2/movable-point.tsx
+++ b/packages/perseus/src/interactive2/movable-point.tsx
@@ -69,10 +69,6 @@ const normalizeOptions = InteractiveUtil.normalizeOptions;
 
 const {processMath} = Tex;
 
-// State parameters that should be converted into an array of
-// functions
-const FUNCTION_ARRAY_OPTIONS = _.keys(MovablePointOptions);
-
 // Default "props" and "state". Both are added to this.state and
 // receive magic getter methods (this.coord() etc).
 // However, properties in DEFAULT_PROPS are updated on `modify()`,
@@ -134,7 +130,6 @@ _.extend(MovablePoint.prototype, {
                 id: this.state.id,
             },
             normalizeOptions(
-                FUNCTION_ARRAY_OPTIONS,
                 // Defaults are copied from MovablePointOptions.*.standard
                 // These defaults are set here instead of DEFAULT_PROPS/STATE
                 // because they:
@@ -216,10 +211,7 @@ _.extend(MovablePoint.prototype, {
     update: function (options) {
         const self = this;
         const graphie = self.graphie;
-        const state = _.extend(
-            self.state,
-            normalizeOptions(FUNCTION_ARRAY_OPTIONS, options),
-        );
+        const state = _.extend(self.state, normalizeOptions(options));
 
         assert(kpoint.is(state.coord));
 

--- a/packages/perseus/src/interactive2/movable-polygon.ts
+++ b/packages/perseus/src/interactive2/movable-polygon.ts
@@ -15,10 +15,6 @@ import objective_ from "./objective_";
 const assert = InteractiveUtil.assert;
 const normalizeOptions = InteractiveUtil.normalizeOptions;
 
-// State parameters that should be converted into an array of
-// functions
-const FUNCTION_ARRAY_OPTIONS = _.keys(MovablePolygonOptions);
-
 // Default "props" and "state". Both are added to this.state and
 // receive magic getter methods (this.points() etc).
 // However, properties in DEFAULT_PROPS are updated on `modify()`,
@@ -89,7 +85,6 @@ _.extend(MovablePolygon.prototype, {
                 id: this.state.id,
             },
             normalizeOptions(
-                FUNCTION_ARRAY_OPTIONS,
                 // Defaults are copied from MovablePolygonOptions.*.standard
                 // These defaults are set here instead of DEFAULT_PROPS/STATE
                 // because they:
@@ -124,10 +119,7 @@ _.extend(MovablePolygon.prototype, {
     update: function (options) {
         const self = this;
         const graphie = self.graphie;
-        const state = _.extend(
-            self.state,
-            normalizeOptions(FUNCTION_ARRAY_OPTIONS, options),
-        );
+        const state = _.extend(self.state, normalizeOptions(options));
 
         // Default things inside the state.normalStyle object, because
         // _.extend is not deep.

--- a/packages/perseus/src/interactive2/movable.ts
+++ b/packages/perseus/src/interactive2/movable.ts
@@ -22,19 +22,6 @@ const normalizeOptions = InteractiveUtil.normalizeOptions;
 
 const assert = InteractiveUtil.assert;
 
-// state parameters that should be converted into an array of
-// functions
-const FUNCTION_ARRAY_OPTIONS = [
-    "add",
-    "modify",
-    "draw",
-    "remove",
-    "onMoveStart",
-    "onMove",
-    "onMoveEnd",
-    "onClick",
-];
-
 // Default "props" and "state". Both are added to this.state and
 // receive magic getter methods (this.isHovering() etc).
 // However, properties in DEFAULT_PROPS are updated on `modify()`,
@@ -162,10 +149,7 @@ _.extend(Movable.prototype, {
         const graphie = self.graphie;
 
         const prevState = self.cloneState();
-        const state = _.extend(
-            self.state,
-            normalizeOptions(FUNCTION_ARRAY_OPTIONS, options),
-        );
+        const state = _.extend(self.state, normalizeOptions(options));
 
         // the invisible shape in front of the point that gets mouse events
         if (state.mouseTarget && !prevState.mouseTarget) {

--- a/packages/perseus/src/interactive2/movable.ts
+++ b/packages/perseus/src/interactive2/movable.ts
@@ -39,6 +39,26 @@ const DEFAULT_STATE = {
     mouseTarget: null,
 } as const;
 
+export interface State {
+    added?: boolean,
+    isHovering?: boolean,
+    isMouseOver?: boolean,
+    isDragging?: boolean,
+    // TODO(benchristel): improve types
+    mouseTarget?: unknown | null,
+    // TODO(benchristel): improve types
+    cursor: unknown | null,
+    id: string,
+    add: (() => void)[],
+    modify: (() => void)[],
+    draw: (() => void)[],
+    remove: (() => void)[],
+    onMoveStart: ((position: Coord) => void)[],
+    onMove: ((end: Coord, start: Coord) => void)[],
+    onMoveEnd: ((end: Coord, start: Coord) => void)[],
+    onClick: ((position: Coord, start: Coord) => void)[],
+}
+
 const Movable = function (graphie: Graphie, options: any): void {
     // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     _.extend(this, {
@@ -61,28 +81,26 @@ InteractiveUtil.createGettersFor(
 InteractiveUtil.addMovableHelperMethodsTo(Movable);
 
 _.extend(Movable.prototype, {
-    cloneState: function () {
-        return _.clone(this.state);
+    cloneState: function (): State {
+        return {...this.state};
     },
 
-    _createDefaultState: function () {
-        return _.extend(
-            {
-                id: this.state.id,
-                add: [],
-                modify: [],
-                draw: [],
-                remove: [],
-                onMoveStart: [],
-                onMove: [],
-                onMoveEnd: [],
-                onClick: [],
+    _createDefaultState: function (): State {
+        return {
+            id: this.state.id,
+            add: [],
+            modify: [],
+            draw: [],
+            remove: [],
+            onMoveStart: [],
+            onMove: [],
+            onMoveEnd: [],
+            onClick: [],
 
-                // We only update props here, because we want things on state to
-                // be persistent, and updated appropriately in modify()
-            },
-            DEFAULT_PROPS,
-        );
+            // We only update props here, because we want things on state to
+            // be persistent, and updated appropriately in modify()
+            ...DEFAULT_PROPS,
+        };
     },
 
     /**
@@ -91,8 +109,8 @@ _.extend(Movable.prototype, {
      *
      * Analogous to React.js's replaceProps
      */
-    modify: function (options) {
-        this.update(_.extend({}, this._createDefaultState(), options));
+    modify: function (options: Partial<State>) {
+        this.update({...this._createDefaultState(), ...options});
     },
 
     /**
@@ -102,7 +120,7 @@ _.extend(Movable.prototype, {
         assert(kpoint.is(coord));
         const self = this;
         const graphie = self.graphie;
-        const state = self.state;
+        const state: State = self.state;
 
         state.isHovering = true;
         state.isDragging = true;
@@ -144,7 +162,7 @@ _.extend(Movable.prototype, {
      *
      * Analogous to React.js's setProps
      */
-    update: function (options) {
+    update: function (options: State) {
         const self = this;
         const graphie = self.graphie;
 

--- a/packages/perseus/src/interactive2/movable.ts
+++ b/packages/perseus/src/interactive2/movable.ts
@@ -40,23 +40,23 @@ const DEFAULT_STATE = {
 } as const;
 
 export interface State {
-    added?: boolean,
-    isHovering?: boolean,
-    isMouseOver?: boolean,
-    isDragging?: boolean,
+    added?: boolean;
+    isHovering?: boolean;
+    isMouseOver?: boolean;
+    isDragging?: boolean;
     // TODO(benchristel): improve types
-    mouseTarget?: unknown | null,
+    mouseTarget?: unknown | null;
     // TODO(benchristel): improve types
-    cursor: unknown | null,
-    id: string,
-    add: (() => void)[],
-    modify: (() => void)[],
-    draw: (() => void)[],
-    remove: (() => void)[],
-    onMoveStart: ((position: Coord) => void)[],
-    onMove: ((end: Coord, start: Coord) => void)[],
-    onMoveEnd: ((end: Coord, start: Coord) => void)[],
-    onClick: ((position: Coord, start: Coord) => void)[],
+    cursor: unknown | null;
+    id: string;
+    add: (() => void)[];
+    modify: (() => void)[];
+    draw: (() => void)[];
+    remove: (() => void)[];
+    onMoveStart: ((position: Coord) => void)[];
+    onMove: ((end: Coord, start: Coord) => void)[];
+    onMoveEnd: ((end: Coord, start: Coord) => void)[];
+    onClick: ((position: Coord, start: Coord) => void)[];
 }
 
 const Movable = function (graphie: Graphie, options: any): void {


### PR DESCRIPTION
This is in preparation for making Movable an ES6 class. I attempted to do that,
but ran into problems because normalizeOptions was doing spooky magic. Hopefully
this will make the next refactoring easier.

Issue: https://khanacademy.atlassian.net/browse/LC-1662

## Test plan:

Review Storybook docs for Interactive Graph, Grapher, and Number Line