### PR TITLE
Fix Perseus so we register the transformer replacement

### DIFF
--- a/.changeset/wild-zoos-share.md
+++ b/.changeset/wild-zoos-share.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Ensure the deprecated-standin widget replaces the transformer widget which is now removed

--- a/packages/perseus/src/__tests__/init.test.ts
+++ b/packages/perseus/src/__tests__/init.test.ts
@@ -1,0 +1,10 @@
+import init from "../init";
+import {getWidget} from "../widgets";
+
+describe("init", () => {
+    it("should correctly replace the transformer widget", async () => {
+        await init({skipMathJax: true});
+
+        expect(getWidget("transformer")).not.toBeNull();
+    });
+});

--- a/packages/perseus/src/init.ts
+++ b/packages/perseus/src/init.ts
@@ -21,10 +21,7 @@ const init = function (options: PerseusOptions): Promise<undefined> {
     Widgets.registerWidgets(basicWidgets);
     Widgets.registerWidgets(extraWidgets);
 
-    // This section replaces widgets
-    // When it's time to replace the transformer widget
-    // uncomment this line
-    // Widgets.replaceWidget("transformer", "deprecated-standin");
+    Widgets.replaceWidget("transformer", "deprecated-standin");
 
     // Pass skipMathJax: true if MathJax is already loaded and configured.
     const skipMathJax = options.skipMathJax;

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -411,9 +411,13 @@ export type WidgetExports<
 > = Readonly<{
     name: string;
     displayName: string;
+
+    // Widgets should provide _one_ of these two properties only!
     // TODO: figure out how to ensure that the component returned supports
     // the `validate` method.
     getWidget?: () => T;
+    widget: T;
+
     accessible?: boolean | ((props: any) => boolean);
     /** Supresses widget from showing up in the dropdown in the content editor */
     hidden?: boolean;
@@ -449,8 +453,6 @@ export type WidgetExports<
     propUpgrades?: {
         [key: string]: (arg1: any) => any;
     }; // OldProps => NewProps,
-
-    widget: T;
 }>;
 
 export type PerseusWidgetMap = {

--- a/packages/perseus/src/widgets.ts
+++ b/packages/perseus/src/widgets.ts
@@ -170,7 +170,10 @@ export const upgradeWidgetInfoToLatestVersion = (
     oldWidgetInfo: PerseusWidget,
 ): PerseusWidget => {
     const type = oldWidgetInfo.type;
-    // TODO(LP-10707): Remove unnecessary type checking (`type` is a string)
+    // NOTE(jeremy): This looks like it could be replaced by fixing types so
+    // that `type` is non-optional. But we're seeing this in Sentry today so I
+    // suspect we have legacy data (potentially unpublished) and we should
+    // figure that out before depending solely on types.
     if (!_.isString(type)) {
         throw new PerseusError(
             "widget type must be a string, but was: " + type,


### PR DESCRIPTION
## Summary:

When we pushed out the removal of the `transformer` widget, we missed uncommenting the replacement line. This fixes it and adds a test to the Perseus init() function to ensure we do that.

Issue: "none"

## Test plan:

`yarn test`