### PR TITLE
Remove unused dependency 'performance-now' from @khanacademy/math-input

### DIFF
--- a/.changeset/gold-kings-dance.md
+++ b/.changeset/gold-kings-dance.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Remove unused dependency: performance-now

--- a/packages/math-input/package.json
+++ b/packages/math-input/package.json
@@ -21,8 +21,7 @@
     "scripts": {},
     "dependencies": {
         "@khanacademy/perseus-core": "1.4.1",
-        "mathquill": "git+https://git@github.com/Khan/mathquill.git#774bb82942c268bd56cd1024dc18b01ac4d90029",
-        "performance-now": "^0.2.0"
+        "mathquill": "git+https://git@github.com/Khan/mathquill.git#774bb82942c268bd56cd1024dc18b01ac4d90029"
     },
     "devDependencies": {
         "@khanacademy/wonder-blocks-clickable": "^4.0.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13281,11 +13281,6 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
 
-performance-now@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
-  integrity sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=
-
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"


### PR DESCRIPTION
## Summary:

This PR is largely to force a math-input bump. I'm removing a dependency that isn't used anyways (`performance-now`).  It was introduced in [D27084](http://phabricator.khanacademy.org/D27084) and removed in #523.  Just cleaning up the unused dependency now.

Issue: "none"

## Test plan: