### PR TITLE
Add Controller and Cursor types for MathQuill

### DIFF
--- a/.changeset/silent-ladybugs-pretend.md
+++ b/.changeset/silent-ladybugs-pretend.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Add types for MathQuill cursor and controller

--- a/packages/math-input/package.json
+++ b/packages/math-input/package.json
@@ -21,7 +21,7 @@
     "scripts": {},
     "dependencies": {
         "@khanacademy/perseus-core": "1.4.1",
-        "mathquill": "git+https://git@github.com/Khan/mathquill.git#774bb82942c268bd56cd1024dc18b01ac4d90029"
+        "mathquill": "git+https://git@github.com/Khan/mathquill.git#b936eba46aa77fe4c6dcb4e6a1f0efeb051d302f"
     },
     "devDependencies": {
         "@khanacademy/wonder-blocks-clickable": "^4.0.12",

--- a/packages/math-input/src/components/input/__tests__/test-math-wrapper.ts
+++ b/packages/math-input/src/components/input/__tests__/test-math-wrapper.ts
@@ -21,7 +21,9 @@ export default class TestMathWrapper extends MathWrapper {
         const selection = this.getSelection();
 
         if (selection) {
-            return selection.ends[-1][-1] === 0 && selection.ends[1][1] === 0;
+            return (
+                selection.getEnd(-1)[-1] === 0 && selection.getEnd(1)[1] === 0
+            );
         }
 
         return false;

--- a/packages/math-input/src/components/input/math-wrapper.ts
+++ b/packages/math-input/src/components/input/math-wrapper.ts
@@ -14,8 +14,6 @@
 // All of the code below is super fragile.  Please be especially careful
 // when upgrading MathQuill.
 
-import $ from "jquery";
-
 import handleBackspace from "../key-handlers/handle-backspace";
 import keyTranslator from "../key-handlers/key-translator";
 
@@ -135,7 +133,7 @@ class MathWrapper {
 
                 const pageX = x - document.body.scrollLeft;
                 const pageY = y - document.body.scrollTop;
-                controller.seek($(el), pageX, pageY).cursor.startSelection();
+                controller.seek(el, pageX, pageY).cursor.startSelection();
 
                 // Unless that would leave us mid-command, in which case, we
                 // need to adjust and place the cursor inside the parens

--- a/packages/math-input/src/components/input/mathquill-types.ts
+++ b/packages/math-input/src/components/input/mathquill-types.ts
@@ -22,13 +22,6 @@ export enum MathFieldActionType {
     MQ_END = 0,
 }
 
-/**
- * The MathQuill MathField Cursor
- * it's not part of the public API for MathQuill,
- * we reach into the internals to get it
- */
-export type MathFieldCursor = any;
-
 export type MathFieldUpdaterCallback = (
     mathField: MathFieldInterface,
     key: Key,
@@ -41,11 +34,9 @@ export type MathFieldUpdaterCallback = (
  *
  * We don't want to use the cursor and controller default type `any`
  * so we declare the types here.
- *
- * Note: This is different from the MathFieldCursor defined above.
  */
 declare module "mathquill" {
-    interface MQNode {
+    interface MQNode extends ControllerRoot {
         id: number;
         parent: NodeBase;
     }
@@ -58,12 +49,14 @@ declare module "mathquill" {
     interface NodeBase extends MQNode {
         ctrlSeq: string | undefined;
         blocks: MQNode;
+        latex(): string;
     }
 
     interface Cursor {
         parent: MQNode;
         selection: MQSelection | undefined;
-
+        select(): void;
+        endSelection(): void;
         show(): Cursor;
         hide(): Cursor;
         insAtRightEnd(root: ControllerRoot): Cursor;

--- a/packages/math-input/src/components/input/mathquill-types.ts
+++ b/packages/math-input/src/components/input/mathquill-types.ts
@@ -11,8 +11,8 @@ export type MathFieldConfig = MathQuill.v3.Config;
  * https://docs.mathquill.com/en/latest/Api_Methods/
  */
 export type MathFieldInterface = MathQuill.v3.EditableMathQuill & {
-    cursor: () => MathQuill.Cursor;
-    controller: () => MathQuill.Controller;
+    cursor: () => Cursor;
+    controller: () => Controller;
 };
 
 export enum MathFieldActionType {
@@ -44,49 +44,44 @@ export type MathFieldUpdaterCallback = (
  *
  * Note: This is different from the MathFieldCursor defined above.
  */
-declare module "MathQuill" {
-    interface MQNode {
-        id: number;
-        parent: NodeBase;
-    }
 
-    interface MQSelection {
-        id: number;
-        getEnd(dir: number): number;
-    }
+interface MQNode {
+    id: number;
+    parent: NodeBase;
+}
 
-    interface NodeBase extends MQNode {
-        ctrlSeq: string | undefined;
-        blocks: MQNode;
-    }
+interface MQSelection {
+    id: number;
+    getEnd(dir: number): number;
+}
 
-    interface Cursor {
-        parent: MQNode;
-        selection: MQSelection | undefined;
+interface NodeBase extends MQNode {
+    ctrlSeq: string | undefined;
+    blocks: MQNode;
+}
 
-        show(): Cursor;
-        hide(): Cursor;
-        insAtRightEnd(root: ControllerRoot): Cursor;
-        insRightOf(el: MQNode): Cursor;
-        insLeftOf(el: MQNode): Cursor;
-        startSelection(): void;
-    }
+interface Cursor {
+    parent: MQNode;
+    selection: MQSelection | undefined;
 
-    interface Controller {
-        parent: string;
-        root: ControllerRoot;
-        cursor: Cursor;
+    show(): Cursor;
+    hide(): Cursor;
+    insAtRightEnd(root: ControllerRoot): Cursor;
+    insRightOf(el: MQNode): Cursor;
+    insLeftOf(el: MQNode): Cursor;
+    startSelection(): void;
+}
 
-        backspace(): Controller;
-        seek(
-            targetElm: HTMLElement,
-            clientX: number,
-            _clientY: number,
-        ): Controller;
-    }
+interface Controller {
+    parent: string;
+    root: ControllerRoot;
+    cursor: Cursor;
 
-    interface ControllerRoot {
-        controller: Controller;
-        cursor?: Cursor;
-    }
+    backspace(): Controller;
+    seek(targetElm: HTMLElement, clientX: number, _clientY: number): Controller;
+}
+
+interface ControllerRoot {
+    controller: Controller;
+    cursor?: Cursor;
 }

--- a/packages/math-input/src/components/input/mathquill-types.ts
+++ b/packages/math-input/src/components/input/mathquill-types.ts
@@ -11,8 +11,8 @@ export type MathFieldConfig = MathQuill.v3.Config;
  * https://docs.mathquill.com/en/latest/Api_Methods/
  */
 export type MathFieldInterface = MathQuill.v3.EditableMathQuill & {
-    cursor: () => Cursor;
-    controller: () => Controller;
+    cursor: () => MathQuill.Cursor;
+    controller: () => MathQuill.Controller;
 };
 
 export enum MathFieldActionType {
@@ -44,44 +44,49 @@ export type MathFieldUpdaterCallback = (
  *
  * Note: This is different from the MathFieldCursor defined above.
  */
+declare module "MathQuill" {
+    interface MQNode {
+        id: number;
+        parent: NodeBase;
+    }
 
-interface MQNode {
-    id: number;
-    parent: NodeBase;
-}
+    interface MQSelection {
+        id: number;
+        getEnd(dir: number): number;
+    }
 
-interface MQSelection {
-    id: number;
-    getEnd(dir: number): number;
-}
+    interface NodeBase extends MQNode {
+        ctrlSeq: string | undefined;
+        blocks: MQNode;
+    }
 
-interface NodeBase extends MQNode {
-    ctrlSeq: string | undefined;
-    blocks: MQNode;
-}
+    interface Cursor {
+        parent: MQNode;
+        selection: MQSelection | undefined;
 
-interface Cursor {
-    parent: MQNode;
-    selection: MQSelection | undefined;
+        show(): Cursor;
+        hide(): Cursor;
+        insAtRightEnd(root: ControllerRoot): Cursor;
+        insRightOf(el: MQNode): Cursor;
+        insLeftOf(el: MQNode): Cursor;
+        startSelection(): void;
+    }
 
-    show(): Cursor;
-    hide(): Cursor;
-    insAtRightEnd(root: ControllerRoot): Cursor;
-    insRightOf(el: MQNode): Cursor;
-    insLeftOf(el: MQNode): Cursor;
-    startSelection(): void;
-}
+    interface Controller {
+        parent: string;
+        root: ControllerRoot;
+        cursor: Cursor;
 
-interface Controller {
-    parent: string;
-    root: ControllerRoot;
-    cursor: Cursor;
+        backspace(): Controller;
+        seek(
+            targetElm: HTMLElement,
+            clientX: number,
+            _clientY: number,
+        ): Controller;
+    }
 
-    backspace(): Controller;
-    seek(targetElm: HTMLElement, clientX: number, _clientY: number): Controller;
-}
-
-interface ControllerRoot {
-    controller: Controller;
-    cursor?: Cursor;
+    interface ControllerRoot {
+        controller: Controller;
+        cursor?: Cursor;
+    }
 }

--- a/packages/math-input/src/components/input/mathquill-types.ts
+++ b/packages/math-input/src/components/input/mathquill-types.ts
@@ -10,7 +10,10 @@ export type MathFieldConfig = MathQuill.v3.Config;
  * the ones listed here.
  * https://docs.mathquill.com/en/latest/Api_Methods/
  */
-export type MathFieldInterface = MathQuill.v3.EditableMathQuill;
+export type MathFieldInterface = MathQuill.v3.EditableMathQuill & {
+    cursor: () => MathQuill.Cursor;
+    controller: () => MathQuill.Controller;
+};
 
 export enum MathFieldActionType {
     WRITE = "write",
@@ -30,3 +33,60 @@ export type MathFieldUpdaterCallback = (
     mathField: MathFieldInterface,
     key: Key,
 ) => void;
+
+/**
+ * The MathQuill API (see mathuill.d.ts) does not include types
+ * for cursor() and controller(), and adding these types there
+ * in the MathQuill repo causes unexpected conflicts with other types.
+ *
+ * We don't want to use the cursor and controller default type `any`
+ * so we declare the types here.
+ *
+ * Note: This is different from the MathFieldCursor defined above.
+ */
+declare module "MathQuill" {
+    interface MQNode {
+        id: number;
+        parent: NodeBase;
+    }
+
+    interface MQSelection {
+        id: number;
+        getEnd(dir: number): number;
+    }
+
+    interface NodeBase extends MQNode {
+        ctrlSeq: string | undefined;
+        blocks: MQNode;
+    }
+
+    interface Cursor {
+        parent: MQNode;
+        selection: MQSelection | undefined;
+
+        show(): Cursor;
+        hide(): Cursor;
+        insAtRightEnd(root: ControllerRoot): Cursor;
+        insRightOf(el: MQNode): Cursor;
+        insLeftOf(el: MQNode): Cursor;
+        startSelection(): void;
+    }
+
+    interface Controller {
+        parent: string;
+        root: ControllerRoot;
+        cursor: Cursor;
+
+        backspace(): Controller;
+        seek(
+            targetElm: HTMLElement,
+            clientX: number,
+            _clientY: number,
+        ): Controller;
+    }
+
+    interface ControllerRoot {
+        controller: Controller;
+        cursor?: Cursor;
+    }
+}

--- a/packages/math-input/src/components/input/mathquill-types.ts
+++ b/packages/math-input/src/components/input/mathquill-types.ts
@@ -44,7 +44,7 @@ export type MathFieldUpdaterCallback = (
  *
  * Note: This is different from the MathFieldCursor defined above.
  */
-declare module "MathQuill" {
+declare module "mathquill" {
     interface MQNode {
         id: number;
         parent: NodeBase;

--- a/packages/math-input/src/components/key-handlers/handle-arrow.ts
+++ b/packages/math-input/src/components/key-handlers/handle-arrow.ts
@@ -6,14 +6,12 @@ import {mathQuillInstance} from "../input/mathquill-instance";
 import {MathFieldActionType} from "../input/mathquill-types";
 
 import type Key from "../../data/keys";
-import type {
-    MathFieldInterface,
-    MathFieldCursor,
-} from "../input/mathquill-types";
+import type {MathFieldInterface} from "../input/mathquill-types";
+import type MathQuill from "mathquill";
 
 function handleLeftArrow(
     mathField: MathFieldInterface,
-    cursor: MathFieldCursor,
+    cursor: MathQuill.Cursor,
 ) {
     // If we're inside a function, and just after the left parentheses, we
     // need to skip the entire function name, rather than move the cursor
@@ -43,7 +41,7 @@ function handleLeftArrow(
 
 function handleRightArrow(
     mathField: MathFieldInterface,
-    cursor: MathFieldCursor,
+    cursor: MathQuill.Cursor,
 ) {
     const command = maybeFindCommand(cursor[mathQuillInstance.R]);
     if (command) {

--- a/packages/math-input/src/components/key-handlers/handle-backspace.ts
+++ b/packages/math-input/src/components/key-handlers/handle-backspace.ts
@@ -11,14 +11,12 @@ import {
 import {mathQuillInstance} from "../input/mathquill-instance";
 import {MathFieldActionType} from "../input/mathquill-types";
 
-import type {
-    MathFieldInterface,
-    MathFieldCursor,
-} from "../input/mathquill-types";
+import type {MathFieldInterface} from "../input/mathquill-types";
+import type MathQuill from "mathquill";
 
 function handleBackspaceInNthRoot(
     mathField: MathFieldInterface,
-    cursor: MathFieldCursor,
+    cursor: MathQuill.Cursor,
 ) {
     const isAtLeftEnd =
         cursor[mathQuillInstance.L] === MathFieldActionType.MQ_END;
@@ -38,7 +36,7 @@ function handleBackspaceInNthRoot(
 
 function handleBackspaceInRootIndex(
     mathField: MathFieldInterface,
-    cursor: MathFieldCursor,
+    cursor: MathQuill.Cursor,
 ) {
     if (isInsideEmptyNode(cursor)) {
         // When deleting the index in a nthroot, we change from the nthroot
@@ -90,7 +88,7 @@ function handleBackspaceInRootIndex(
 
 function handleBackspaceInLogIndex(
     mathField: MathFieldInterface,
-    cursor: MathFieldCursor,
+    cursor: MathQuill.Cursor,
 ) {
     if (isInsideEmptyNode(cursor)) {
         const grandparent = cursor.parent.parent;
@@ -120,7 +118,7 @@ function handleBackspaceInLogIndex(
     }
 }
 
-function handleBackspaceOutsideParens(cursor: MathFieldCursor) {
+function handleBackspaceOutsideParens(cursor: MathQuill.Cursor) {
     // In this case the node with '\\left(' for its ctrlSeq
     // is the parent of the expression contained within the
     // parentheses.
@@ -155,7 +153,7 @@ function handleBackspaceOutsideParens(cursor: MathFieldCursor) {
 
 function handleBackspaceInsideParens(
     mathField: MathFieldInterface,
-    cursor: MathFieldCursor,
+    cursor: MathQuill.Cursor,
 ) {
     // Handle situations when the cursor is inside parens or a
     // command that uses parens, e.g. \log() or \tan()

--- a/yarn.lock
+++ b/yarn.lock
@@ -12007,9 +12007,9 @@ mathjax-full@3.2.2:
     mj-context-menu "^0.6.1"
     speech-rule-engine "^4.0.6"
 
-"mathquill@git+https://git@github.com/Khan/mathquill.git#774bb82942c268bd56cd1024dc18b01ac4d90029":
+"mathquill@git+https://git@github.com/Khan/mathquill.git#b936eba46aa77fe4c6dcb4e6a1f0efeb051d302f":
   version "0.10.1"
-  resolved "git+https://git@github.com/Khan/mathquill.git#774bb82942c268bd56cd1024dc18b01ac4d90029"
+  resolved "git+https://git@github.com/Khan/mathquill.git#b936eba46aa77fe4c6dcb4e6a1f0efeb051d302f"
 
 mdast-util-definitions@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Summary:
Add types for MathQuill cursor and controller in
`mathquill-types.ts`.

We couldn't get these typed in mathquill.d.ts inside
the mathquill repo without it turning into a dumpster
fire of type errors. In Perseus, they're just using
type `any` since they're not defined in the mathquill API.

Since we don't want them to use type `any`, we can just
define them here in Perseus.

This PR includes
- Cursor and Controller types in mathquill-types.ts
- Updates to other files to match the new types

Issue: https://khanacademy.atlassian.net/browse/LC-1659

## Test plan:
`yarn jest`

Storybook
- Go to http://localhost:6006/?path=/docs/math-input-components-v2-keypad-with-mathquill--docs
- Play around with the buttons and confirm that the input looks correct
- Confirm there are no console errors