### PR TITLE
Only include 'dist/' in NPM packages

### DIFF
--- a/.changeset/short-otters-confess.md
+++ b/.changeset/short-otters-confess.md
@@ -1,0 +1,14 @@
+---
+"@khanacademy/kas": patch
+"@khanacademy/kmath": patch
+"@khanacademy/math-input": patch
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-core": patch
+"@khanacademy/perseus-editor": patch
+"@khanacademy/perseus-error": patch
+"@khanacademy/perseus-linter": patch
+"@khanacademy/pure-markdown": patch
+"@khanacademy/simple-markdown": patch
+---
+
+Remove source files from the distributed NPM package

--- a/packages/kas/package.json
+++ b/packages/kas/package.json
@@ -18,6 +18,7 @@
     "module": "dist/es/index.js",
     "main": "dist/index.js",
     "source": "src/index.js",
+    "files": ["dist"],
     "scripts": {
         "gen:parsers": "node src/parser-generator.js",
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"

--- a/packages/kmath/package.json
+++ b/packages/kmath/package.json
@@ -17,6 +17,7 @@
     "module": "dist/es/index.js",
     "main": "dist/index.js",
     "source": "src/index.ts",
+    "files": ["dist"],
     "scripts": {
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
     },

--- a/packages/math-input/package.json
+++ b/packages/math-input/package.json
@@ -18,6 +18,7 @@
     "module": "dist/es/index.js",
     "main": "dist/index.js",
     "source": "src/index.ts",
+    "files": ["dist"],
     "scripts": {},
     "dependencies": {
         "@khanacademy/perseus-core": "1.4.1",

--- a/packages/perseus-core/package.json
+++ b/packages/perseus-core/package.json
@@ -18,6 +18,7 @@
     "module": "dist/es/index.js",
     "main": "dist/index.js",
     "source": "src/index.ts",
+    "files": ["dist"],
     "scripts": {
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
     },

--- a/packages/perseus-editor/package.json
+++ b/packages/perseus-editor/package.json
@@ -18,6 +18,7 @@
     "module": "dist/es/index.js",
     "main": "dist/index.js",
     "source": "src/index.ts",
+    "files": ["dist"],
     "scripts": {
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
     },

--- a/packages/perseus-error/package.json
+++ b/packages/perseus-error/package.json
@@ -18,6 +18,7 @@
     "module": "dist/es/index.js",
     "main": "dist/index.js",
     "source": "src/index.ts",
+    "files": ["dist"],
     "scripts": {
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
     },

--- a/packages/perseus-linter/package.json
+++ b/packages/perseus-linter/package.json
@@ -18,6 +18,7 @@
     "module": "dist/es/index.js",
     "main": "dist/index.js",
     "source": "src/index.ts",
+    "files": ["dist"],
     "scripts": {
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
     },

--- a/packages/perseus/package.json
+++ b/packages/perseus/package.json
@@ -18,6 +18,7 @@
     "module": "dist/es/index.js",
     "main": "dist/index.js",
     "source": "src/index.ts",
+    "files": ["dist"],
     "scripts": {
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
     },

--- a/packages/pure-markdown/package.json
+++ b/packages/pure-markdown/package.json
@@ -18,6 +18,7 @@
     "module": "dist/es/index.js",
     "main": "dist/index.js",
     "source": "src/index.ts",
+    "files": ["dist"],
     "scripts": {
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
     },

--- a/packages/simple-markdown/package.json
+++ b/packages/simple-markdown/package.json
@@ -18,6 +18,7 @@
     "module": "dist/es/index.js",
     "main": "dist/index.js",
     "source": "src/index.ts",
+    "files": ["dist"],
     "scripts": {
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
     },


### PR DESCRIPTION
## Summary:
Source files (`.ts`) were causing typechecking problems in webapp. We're
not sure exactly why they just started happening recently, but it seems
related to our improved typing around Graphie and Raphael.

Issue: none

## Test plan:

Upgrade Perseus packages to the new versions in webapp. There should be no type
errors when you run `yarn tsc -w` in services/static.