### PR TITLE
Stop propogation in math input field click in order to prevent keypad closing

### DIFF
--- a/.changeset/metal-cameras-watch.md
+++ b/.changeset/metal-cameras-watch.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Stop keypad from closing when math input field is clicked

--- a/packages/perseus/src/components/math-input.tsx
+++ b/packages/perseus/src/components/math-input.tsx
@@ -286,7 +286,12 @@ class MathInput extends React.Component<Props, State> {
                         display: "flex",
                         padding: 1,
                     }}
-                    onClick={() => {
+                    onClick={(e) => {
+                        // Prevent the click into the input from registering
+                        // so that the keypad popover doesn't close when
+                        // switching focus to the input.
+                        e.stopPropagation();
+
                         const mathField = this.mathField();
                         if (!mathField) {
                             return;


### PR DESCRIPTION
## Summary:
Currently, if a user has the keypad open and they click into the
input field, it automatically closes the keypad. This is not
the expected behavior - clicking outside the keypad should close it
EXCEPT when the clicked element is the math input.

In this PR:
- The math input field's `onClick` includes an `e.stopPropogation()`
  in order for the keypad to not read that click outside itself.
  This prevents the keypad from closing when the input is clicked.

NOTE: This will not fix the issue listed in the ticket, because that 
has to be done in [webapp](https://github.com/Khan/webapp/blob/master/services/static/javascript/guide/ui/math-editor.tsx#L278). To fix it, we can just copy the approach
from this PR.

Issue: https://khanacademy.atlassian.net/browse/LC-1410

## Test plan:

Storybook
- Go to http://localhost:6006/?path=/story/perseus-components-math-input--default-with-basic-button-set
- Open the keypad
- Click any button on the keypad
- Click into the math input field (and click again for good measure)
- Confirm that the keypad stays open
- Use a screenreader and confirm that nothing has changed between prod and this story

Webapp
- Create a snapshot release in webapp using `dev/tools/bump_perseus_version.sh -t PR974`
- Log into your khan academy account
- Check the click behavior in the math input in the expression widget (/math/cc-seventh-grade-math/cc-7th-variables-expressions/cc-7th-inequalities/e/one_step_inequalities)

### Before

(confirmed in both Perseus storybook prod and in webapp prod)

https://github.com/Khan/perseus/assets/13231763/f7314295-fefa-4443-870c-c872de346f94

### After

(confirmed in both Perseus storybook local and in webapp local)

https://github.com/Khan/perseus/assets/13231763/1867a423-9c2c-4a16-a3ee-2e9cb905c0fa

