### PR TITLE
Ensure we do yarn install before Khan/changeset-per-package

### DIFF
--- a/.changeset/polite-guests-agree.md
+++ b/.changeset/polite-guests-agree.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Adds comment that I'll back out

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -23,6 +23,12 @@ jobs:
               with:
                   fetch-depth: 0
 
+            - name: Install & cache node_modules
+              uses: ./.github/actions/shared-node-cache
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  ssh-private-key: ${{ secrets.KHAN_ACTIONS_BOT_SSH_PRIVATE_KEY }}
+
             - name: Get changed files
               uses: Khan/actions@get-changed-files-v1
               id: changed

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * Main entry point
  */
-
+// STOPSHIP: Undo this comment
 export {default as init} from "./init";
 
 export {ApiOptions, ClassNames} from "./perseus-api";


### PR DESCRIPTION
## Summary:

I noticed in a different [PR run](https://github.com/Khan/perseus/actions/runs/7823290861/job/21343971545?pr=975) that the `@changesets/cli` was being installed by `Khan/changeset-per-package`. This action checks if changesets is installed by trying to run it. This was always failing in the `node-ci` action because we didn't run `yarn install` initially! 

<img width="1043" alt="image" src="https://github.com/Khan/perseus/assets/77138/5b5fb855-a1a2-43d6-b499-5db317d6fb37">


Issue: "none"

## Test plan:

Watch the next run and it shouldn't complain about "warning "@changesets/cli" is already in "devDependencies". Please remove existing entry first before adding it to "dependencies"."