### PR TITLE
Graphie: Add tests for getMousePx and getMouseCoord

### DIFF
--- a/.changeset/purple-beans-deliver.md
+++ b/.changeset/purple-beans-deliver.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Improve types for Graphie's getMousePx and getMouseCoord functions

--- a/packages/perseus/src/util/graphie.test.ts
+++ b/packages/perseus/src/util/graphie.test.ts
@@ -8,10 +8,6 @@ import GraphUtils, {normalizeRange} from "./graphie";
 
 import type {Graphie} from "./graphie";
 
-// Yay for side-effect imports!
-// eslint-disable-next-line import/no-unassigned-import
-import "./interactive";
-
 function createMockRaphaelElement(name = "mockRaphaelElement") {
     return {
         constructor: {prototype: Raphael.el},

--- a/packages/perseus/src/util/graphie.test.ts
+++ b/packages/perseus/src/util/graphie.test.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import $ from "jquery";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import Raphael from "raphael";
 
 import {testDependencies} from "../../../../testing/test-dependencies";

--- a/packages/perseus/src/util/graphie.test.ts
+++ b/packages/perseus/src/util/graphie.test.ts
@@ -1,4 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
+import $ from "jquery";
 import Raphael from "raphael";
 
 import {testDependencies} from "../../../../testing/test-dependencies";
@@ -1319,6 +1320,40 @@ describe("Graphie drawing tools", () => {
 
             expect(onSetDrawingAreaAvailable).toHaveBeenCalledWith(false);
         });
+    });
+
+    describe("getMousePx", () => {
+        it.each([
+            [{left: 0, top: 0}, {pageX: 10, pageY: 10}, [10, 10]],
+            [{top: 10, left: 20}, {pageX: 40, pageY: 40}, [20, 30]],
+        ])(
+            "should return the mouse position in pixel coordinates relative to graph",
+            (offset, mouseEvent, expectedMousePx) => {
+                const graphie = createAndInitGraphie();
+                jest.spyOn($.fn, "offset").mockReturnValue(offset);
+
+                const mousePx = graphie.getMousePx(mouseEvent);
+
+                expect(mousePx).toEqual(expectedMousePx);
+            },
+        );
+    });
+
+    describe("getMouseCoord", () => {
+        it.each([
+            [{left: 0, top: 0}, {pageX: 10, pageY: 10}, [2, 8]],
+            [{top: 10, left: 20}, {pageX: 40, pageY: 40}, [4, 4]],
+        ])(
+            "should return mosue position in graph coordinates relative to the graph",
+            (offset, mouseEvent, expectedMousePx) => {
+                const graphie = createAndInitGraphie();
+                jest.spyOn($.fn, "offset").mockReturnValue(offset);
+
+                const mousePx = graphie.getMouseCoord(mouseEvent);
+
+                expect(mousePx).toEqual(expectedMousePx);
+            },
+        );
     });
 });
 

--- a/packages/perseus/src/util/graphie.test.ts
+++ b/packages/perseus/src/util/graphie.test.ts
@@ -8,6 +8,10 @@ import GraphUtils, {normalizeRange} from "./graphie";
 
 import type {Graphie} from "./graphie";
 
+// Yay for side-effect imports!
+// eslint-disable-next-line import/no-unassigned-import
+import "./interactive";
+
 function createMockRaphaelElement(name = "mockRaphaelElement") {
     return {
         constructor: {prototype: Raphael.el},

--- a/packages/perseus/src/util/graphie.test.ts
+++ b/packages/perseus/src/util/graphie.test.ts
@@ -1325,16 +1325,16 @@ describe("Graphie drawing tools", () => {
     describe("getMousePx", () => {
         it.each([
             [{left: 0, top: 0}, {pageX: 10, pageY: 10}, [10, 10]],
-            [{top: 10, left: 20}, {pageX: 40, pageY: 40}, [20, 30]],
+            [{left: 20, top: 10}, {pageX: 40, pageY: 40}, [20, 30]],
         ])(
             "should return the mouse position in pixel coordinates relative to graph",
-            (offset, mouseEvent, expectedMousePx) => {
+            (graphPosition, mouseEvent, expectedPixelCoord) => {
                 const graphie = createAndInitGraphie();
-                jest.spyOn($.fn, "offset").mockReturnValue(offset);
+                jest.spyOn($.fn, "offset").mockReturnValue(graphPosition);
 
                 const mousePx = graphie.getMousePx(mouseEvent);
 
-                expect(mousePx).toEqual(expectedMousePx);
+                expect(mousePx).toEqual(expectedPixelCoord);
             },
         );
     });
@@ -1342,16 +1342,26 @@ describe("Graphie drawing tools", () => {
     describe("getMouseCoord", () => {
         it.each([
             [{left: 0, top: 0}, {pageX: 10, pageY: 10}, [2, 8]],
-            [{top: 10, left: 20}, {pageX: 40, pageY: 40}, [4, 4]],
+            [{left: 20, top: 10}, {pageX: 30, pageY: 20}, [2, 8]],
         ])(
-            "should return mosue position in graph coordinates relative to the graph",
-            (offset, mouseEvent, expectedMousePx) => {
-                const graphie = createAndInitGraphie();
-                jest.spyOn($.fn, "offset").mockReturnValue(offset);
+            "should return mouse position in graph coordinates relative to the graph",
+            (graphPosition, mouseEvent, expectedGraphCoord) => {
+                const graphie = GraphUtils.createGraphie(
+                    document.createElement("div"),
+                );
+                // The graph is 50px by 50px.
+                graphie.init({
+                    range: [
+                        [0, 10],
+                        [0, 10],
+                    ],
+                    scale: 5,
+                });
+                jest.spyOn($.fn, "offset").mockReturnValue(graphPosition);
 
                 const mousePx = graphie.getMouseCoord(mouseEvent);
 
-                expect(mousePx).toEqual(expectedMousePx);
+                expect(mousePx).toEqual(expectedGraphCoord);
             },
         );
     });

--- a/packages/perseus/src/util/graphie.test.ts
+++ b/packages/perseus/src/util/graphie.test.ts
@@ -1325,11 +1325,19 @@ describe("Graphie drawing tools", () => {
 
     describe("getMousePx", () => {
         it.each([
-            [{left: 0, top: 0}, {pageX: 10, pageY: 10}, [10, 10]],
-            [{left: 20, top: 10}, {pageX: 40, pageY: 40}, [20, 30]],
+            {
+                graphPosition: {left: 0, top: 0},
+                mouseEvent: {pageX: 10, pageY: 10},
+                expectedPixelCoord: [10, 10],
+            },
+            {
+                graphPosition: {left: 20, top: 10},
+                mouseEvent: {pageX: 40, pageY: 40},
+                expectedPixelCoord: [20, 30],
+            },
         ])(
-            "should return the mouse position in pixel coordinates relative to graph",
-            (graphPosition, mouseEvent, expectedPixelCoord) => {
+            "should return pixel coordinates $expectedPixelCoord for the mouse event $mouseEvent (graph at $graphPosition)",
+            ({graphPosition, mouseEvent, expectedPixelCoord}) => {
                 const graphie = createAndInitGraphie();
                 jest.spyOn($.fn, "offset").mockReturnValue(graphPosition);
 
@@ -1342,11 +1350,19 @@ describe("Graphie drawing tools", () => {
 
     describe("getMouseCoord", () => {
         it.each([
-            [{left: 0, top: 0}, {pageX: 10, pageY: 10}, [2, 8]],
-            [{left: 20, top: 10}, {pageX: 30, pageY: 20}, [2, 8]],
+            {
+                graphPosition: {left: 0, top: 0},
+                mouseEvent: {pageX: 10, pageY: 10},
+                expectedGraphCoord: [2, 8],
+            },
+            {
+                graphPosition: {left: 20, top: 10},
+                mouseEvent: {pageX: 30, pageY: 20},
+                expectedGraphCoord: [2, 8],
+            },
         ])(
-            "should return mouse position in graph coordinates relative to the graph",
-            (graphPosition, mouseEvent, expectedGraphCoord) => {
+            "should return graph coordinates $expectedGraphCoord for the mouse event $mouseEvent (graph at $graphPosition)",
+            ({graphPosition, mouseEvent, expectedGraphCoord}) => {
                 const graphie = GraphUtils.createGraphie(
                     document.createElement("div"),
                 );

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1416,11 +1416,6 @@ export class Graphie {
     }
 
     // This is a stub that's overridden in interactive.ts
-    getMouseCoord(event: Readonly<{pageX?: number; pageY?: number}>): Coord {
-        throw new Error("getMouseCoord is a stub, and is not implemented");
-    }
-
-    // This is a stub that's overridden in interactive.ts
     addMouseLayer(options: {
         onClick?: MouseHandler;
         onMouseMove?: MouseHandler;
@@ -1444,6 +1439,16 @@ export class Graphie {
         throw new Error(
             "addToVisibleLayerWrapper is not ready. Call addMouseLayer() first.",
         );
+    }
+
+    // This is a stub that's overridden in interactive.ts
+    getMouseCoord(event: Readonly<{pageX?: number; pageY?: number}>): Coord {
+        throw new Error("getMouseCoord is a stub, and is not implemented");
+    }
+
+    // This is a stub that's overridden in interactive.ts
+    getMousePx(event: Readonly<{pageX?: number; pageY?: number}>) {
+        throw new Error("getMousePx is a stub, and is not implemented");
     }
 }
 

--- a/packages/perseus/src/util/interactive.ts
+++ b/packages/perseus/src/util/interactive.ts
@@ -196,7 +196,6 @@ _.extend(GraphUtils.Graphie.prototype, {
      * Get mouse coordinates in pixels
      */
     getMousePx: function (event: Readonly<{pageX?: number; pageY?: number}>) {
-        $(this.el).offset(); // ?
         // @ts-expect-error - TS2532 - Object is possibly 'undefined'.
         const mouseX = event.pageX - $(this.el).offset().left;
 

--- a/packages/perseus/src/util/interactive.ts
+++ b/packages/perseus/src/util/interactive.ts
@@ -196,14 +196,12 @@ _.extend(GraphUtils.Graphie.prototype, {
      * Get mouse coordinates in pixels
      */
     getMousePx: function (event: Readonly<{pageX?: number; pageY?: number}>) {
-        const graphie = this;
+        $(this.el).offset(); // ?
+        // @ts-expect-error - TS2532 - Object is possibly 'undefined'.
+        const mouseX = event.pageX - $(this.el).offset().left;
 
-        const mouseX =
-            // @ts-expect-error - TS2532 - Object is possibly 'undefined'.
-            event.pageX - $(graphie.raphael.canvas.parentNode).offset().left;
-        const mouseY =
-            // @ts-expect-error - TS2532 - Object is possibly 'undefined'.
-            event.pageY - $(graphie.raphael.canvas.parentNode).offset().top;
+        // @ts-expect-error - TS2532 - Object is possibly 'undefined'.
+        const mouseY = event.pageY - $(this.el).offset().top;
 
         return [mouseX, mouseY];
     },

--- a/packages/perseus/src/util/interactive.ts
+++ b/packages/perseus/src/util/interactive.ts
@@ -196,17 +196,19 @@ _.extend(GraphUtils.Graphie.prototype, {
      * Get mouse coordinates in pixels
      */
     getMousePx: function (event: Readonly<{pageX?: number; pageY?: number}>) {
+        const offset = $(this.el).offset();
+
         const mouseX =
             // @ts-expect-error - TS18048 - 'event.pageX' is possibly 'undefined'.
             event.pageX -
-            // @ts-expect-error - TS2532 - Object (result of .offset()) is possibly 'undefined'.
-            $(this.el).offset().left;
+            // @ts-expect-error - TS2532 - Object is possibly 'undefined'.
+            offset.left;
 
         const mouseY =
             // @ts-expect-error - TS18048 - 'event.pageY' is possibly 'undefined'.
             event.pageY -
-            // @ts-expect-error - TS2532 - Object (result of .offset()) is possibly 'undefined'.
-            $(this.el).offset().top;
+            // @ts-expect-error - TS2532 - Object is possibly 'undefined'.
+            offset.top;
 
         return [mouseX, mouseY];
     },

--- a/packages/perseus/src/util/interactive.ts
+++ b/packages/perseus/src/util/interactive.ts
@@ -196,11 +196,17 @@ _.extend(GraphUtils.Graphie.prototype, {
      * Get mouse coordinates in pixels
      */
     getMousePx: function (event: Readonly<{pageX?: number; pageY?: number}>) {
-        // @ts-expect-error - TS2532 - Object is possibly 'undefined'.
-        const mouseX = event.pageX - $(this.el).offset().left;
+        const mouseX =
+            // @ts-expect-error - TS18048 - 'event.pageX' is possibly 'undefined'.
+            event.pageX -
+            // @ts-expect-error - TS2532 - Object (result of .offset()) is possibly 'undefined'.
+            $(this.el).offset().left;
 
-        // @ts-expect-error - TS2532 - Object is possibly 'undefined'.
-        const mouseY = event.pageY - $(this.el).offset().top;
+        const mouseY =
+            // @ts-expect-error - TS18048 - 'event.pageY' is possibly 'undefined'.
+            event.pageY -
+            // @ts-expect-error - TS2532 - Object (result of .offset()) is possibly 'undefined'.
+            $(this.el).offset().top;
 
         return [mouseX, mouseY];
     },


### PR DESCRIPTION
## Summary:

This PR adds unit tests for Graphie's `getMousePx` and `getMouseCoord`. The pair of these translate an event from a mouse click to graph-relative coordinates in pixel coords (`getMousePx`) and graph coords (`getMouseCoord`).

Issue: LC-1662

## Test plan:

`yarn test`