### PR TITLE
Inject generated and localized MathSpeak into MathQuill

### DIFF
--- a/.changeset/rich-glasses-type.md
+++ b/.changeset/rich-glasses-type.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/math-input": patch
+"@khanacademy/perseus": patch
+---
+
+Inject localized MathSpeak into MathQuill

--- a/packages/math-input/package.json
+++ b/packages/math-input/package.json
@@ -24,7 +24,7 @@
     "scripts": {},
     "dependencies": {
         "@khanacademy/perseus-core": "1.4.2",
-        "mathquill": "git+https://git@github.com/Khan/mathquill.git#b936eba46aa77fe4c6dcb4e6a1f0efeb051d302f"
+        "mathquill": "git+https://git@github.com/Khan/mathquill.git#9c8ebec00c735c9f32270774f52208bf99aa164a"
     },
     "devDependencies": {
         "@khanacademy/mathjax-renderer": "git+ssh://git@github.com:Khan/mathjax-renderer.git#v1.6.2",

--- a/packages/math-input/package.json
+++ b/packages/math-input/package.json
@@ -27,6 +27,7 @@
         "mathquill": "git+https://git@github.com/Khan/mathquill.git#b936eba46aa77fe4c6dcb4e6a1f0efeb051d302f"
     },
     "devDependencies": {
+        "@khanacademy/mathjax-renderer": "git+ssh://git@github.com:Khan/mathjax-renderer.git#v1.6.2",
         "@khanacademy/wonder-blocks-clickable": "^4.0.12",
         "@khanacademy/wonder-blocks-color": "^3.0.0",
         "@khanacademy/wonder-blocks-core": "^6.3.1",
@@ -47,6 +48,7 @@
         "react-transition-group": "^4.4.1"
     },
     "peerDependencies": {
+        "@khanacademy/mathjax-renderer": "git+ssh://git@github.com:Khan/mathjax-renderer.git#v1.6.2",
         "@khanacademy/wonder-blocks-clickable": "^4.0.12",
         "@khanacademy/wonder-blocks-color": "^3.0.0",
         "@khanacademy/wonder-blocks-core": "^6.3.1",

--- a/packages/math-input/src/components/input/mathquill-instance.ts
+++ b/packages/math-input/src/components/input/mathquill-instance.ts
@@ -1,3 +1,4 @@
+import {SpeechRuleEngine} from "@khanacademy/mathjax-renderer";
 import * as i18n from "@khanacademy/wonder-blocks-i18n";
 import MathQuill from "mathquill";
 
@@ -101,6 +102,10 @@ export function createMathField(
         .MathField(container, config)
         // translated in ./math-input.tsx
         .setAriaLabel(i18n._("Math input box")) as MathFieldInterface;
+
+    SpeechRuleEngine.setup().then((SRE) => {
+        mathField.setMathspeakOverride(SRE.texToSpeech);
+    });
 
     return mathField;
 }

--- a/packages/math-input/src/components/input/mathquill-instance.ts
+++ b/packages/math-input/src/components/input/mathquill-instance.ts
@@ -2,6 +2,8 @@ import {SpeechRuleEngine} from "@khanacademy/mathjax-renderer";
 import * as i18n from "@khanacademy/wonder-blocks-i18n";
 import MathQuill from "mathquill";
 
+import {inJest} from "../../utils";
+
 import type {
     MathQuillInterface,
     MathFieldConfig,
@@ -103,9 +105,14 @@ export function createMathField(
         // translated in ./math-input.tsx
         .setAriaLabel(i18n._("Math input box")) as MathFieldInterface;
 
-    SpeechRuleEngine.setup().then((SRE) => {
-        mathField.setMathspeakOverride(SRE.texToSpeech);
-    });
+    // We should avoid running SpeechRuleEngine.setup() in Jest. It makes an
+    //   HTTP request to fetch non-english speech rules, and cannot be easily
+    //   mocked in consuming packages now that we do not bundle source code.
+    //   When it eventually times out, it will cause arbitrary test failures.
+    !inJest &&
+        SpeechRuleEngine.setup().then((SRE) =>
+            mathField.setMathspeakOverride(SRE.texToSpeech),
+        );
 
     return mathField;
 }

--- a/packages/math-input/src/utils.test.ts
+++ b/packages/math-input/src/utils.test.ts
@@ -1,6 +1,6 @@
 import * as wbi18n from "@khanacademy/wonder-blocks-i18n";
 
-import {convertDotToTimesByLocale} from "./utils";
+import {convertDotToTimesByLocale, inJest} from "./utils";
 
 describe("utils", () => {
     describe("multiplicationSymbol", () => {
@@ -28,6 +28,19 @@ describe("utils", () => {
             const result = convertDotToTimesByLocale(false);
 
             expect(result).toBe(true);
+        });
+    });
+
+    describe("inJest", () => {
+        it("returns true", () => {
+            expect(inJest).toBe(true);
+        });
+        it("prevents code from running in Jest", () => {
+            let value = 0;
+            if (!inJest) {
+                value = 1;
+            }
+            expect(value).toBe(0);
         });
     });
 });

--- a/packages/math-input/src/utils.ts
+++ b/packages/math-input/src/utils.ts
@@ -60,5 +60,7 @@ export function convertDotToTimesByLocale(convertDotToTimes: boolean): boolean {
     return convertDotToTimes;
 }
 
-// Use this to avoid running code that should not run in Jest.
-export const inJest = !!process?.env?.JEST_WORKER_ID;
+/**
+ * Use this to avoid running code that should not run in Jest.
+ **/
+export const inJest = process !== undefined && !!process?.env?.JEST_WORKER_ID;

--- a/packages/math-input/src/utils.ts
+++ b/packages/math-input/src/utils.ts
@@ -61,4 +61,4 @@ export function convertDotToTimesByLocale(convertDotToTimes: boolean): boolean {
 }
 
 // Use this to avoid running code that should not run in Jest.
-export const inJest = process.env.JEST_WORKER_ID !== undefined;
+export const inJest = !!process?.env?.JEST_WORKER_ID;

--- a/packages/math-input/src/utils.ts
+++ b/packages/math-input/src/utils.ts
@@ -64,3 +64,4 @@ export function convertDotToTimesByLocale(convertDotToTimes: boolean): boolean {
  * Use this to avoid running code that should not run in Jest.
  **/
 export const inJest = process !== undefined && !!process?.env?.JEST_WORKER_ID;
+// Explicitly checking for undefined because Cypress throws an error

--- a/packages/math-input/src/utils.ts
+++ b/packages/math-input/src/utils.ts
@@ -63,5 +63,6 @@ export function convertDotToTimesByLocale(convertDotToTimes: boolean): boolean {
 /**
  * Use this to avoid running code that should not run in Jest.
  **/
-export const inJest = process !== undefined && !!process?.env?.JEST_WORKER_ID;
+export const inJest =
+    typeof process !== "undefined" && !!process?.env?.JEST_WORKER_ID;
 // Explicitly checking for undefined because Cypress throws an error

--- a/packages/math-input/src/utils.ts
+++ b/packages/math-input/src/utils.ts
@@ -59,3 +59,6 @@ export function convertDotToTimesByLocale(convertDotToTimes: boolean): boolean {
 
     return convertDotToTimes;
 }
+
+// Use this to avoid running code that should not run in Jest.
+export const inJest = process.env.JEST_WORKER_ID !== undefined;

--- a/packages/perseus/package.json
+++ b/packages/perseus/package.json
@@ -35,7 +35,7 @@
         "@khanacademy/wonder-blocks-banner": "^3.0.33"
     },
     "devDependencies": {
-        "@khanacademy/mathjax-renderer": "git+ssh://git@github.com:Khan/mathjax-renderer.git#v1.5.1",
+        "@khanacademy/mathjax-renderer": "git+ssh://git@github.com:Khan/mathjax-renderer.git#v1.6.2",
         "@khanacademy/wonder-blocks-button": "^6.2.5",
         "@khanacademy/wonder-blocks-clickable": "^4.0.12",
         "@khanacademy/wonder-blocks-color": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2239,9 +2239,9 @@
     "@typescript-eslint/utils" "^5.60.1"
     checksync "^5.0.0"
 
-"@khanacademy/mathjax-renderer@git+ssh://git@github.com:Khan/mathjax-renderer.git#v1.5.1":
-  version "1.5.1"
-  resolved "git+ssh://git@github.com:Khan/mathjax-renderer.git#17e5f540f20a717779824a42912ad8284ce04db2"
+"@khanacademy/mathjax-renderer@git+ssh://git@github.com:Khan/mathjax-renderer.git#v1.6.2":
+  version "1.6.2"
+  resolved "git+ssh://git@github.com:Khan/mathjax-renderer.git#8bc76941309e4083a5207447c97eaf17fda15e65"
   dependencies:
     mathjax-full "3.2.2"
     mu-lambda "^0.0.3"
@@ -12007,9 +12007,9 @@ mathjax-full@3.2.2:
     mj-context-menu "^0.6.1"
     speech-rule-engine "^4.0.6"
 
-"mathquill@git+https://git@github.com/Khan/mathquill.git#b936eba46aa77fe4c6dcb4e6a1f0efeb051d302f":
+"mathquill@git+https://git@github.com/Khan/mathquill.git#9c8ebec00c735c9f32270774f52208bf99aa164a":
   version "0.10.1"
-  resolved "git+https://git@github.com/Khan/mathquill.git#b936eba46aa77fe4c6dcb4e6a1f0efeb051d302f"
+  resolved "git+https://git@github.com/Khan/mathquill.git#9c8ebec00c735c9f32270774f52208bf99aa164a"
 
 mdast-util-definitions@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Swaps out MathQuill's hardcoded English MathSpeak for localized MathSpeak generated by MathJax/SRE

Issue: LC-1710

Testing:
Open Storybook and check generated labels. They should look the same!
If you can get Storybook into another locale supported by SRE, you'll see translated MathSpeak.
If you swap out the function in `createMathField` for something that returns "poot", all of the MathSpeak will be replaced with "poot".