### PR TITLE
Restore i18n._() support for radio widget's Choice component

### DIFF
--- a/.changeset/eleven-colts-perform.md
+++ b/.changeset/eleven-colts-perform.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Wrap some radio widget strings that a learner would see in `i18n._()` calls so they can be localized.

--- a/packages/perseus/src/widgets/radio/choice.tsx
+++ b/packages/perseus/src/widgets/radio/choice.tsx
@@ -3,6 +3,7 @@ import Button from "@khanacademy/wonder-blocks-button";
 import Clickable from "@khanacademy/wonder-blocks-clickable";
 import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
+import * as i18n from "@khanacademy/wonder-blocks-i18n";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {Popover, PopoverContent} from "@khanacademy/wonder-blocks-popover";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
@@ -253,17 +254,22 @@ const Choice = function (props: ChoicePropsWithForwardRef): React.ReactElement {
                         dismissEnabled
                         content={({close}) => (
                             <PopoverContent
-                                title="Cross out"
-                                content="Cross out option"
+                                title={i18n._("Cross out")}
+                                content={i18n._("Cross out option")}
                                 closeButtonVisible
                                 actions={
                                     <View>
                                         <Strut size={Spacing.medium_16} />
                                         <Button
                                             kind="primary"
-                                            aria-label={`Cross out Choice ${getChoiceLetter(
-                                                pos,
-                                            )}`}
+                                            aria-label={i18n._(
+                                                "Cross out Choice %(letter)s",
+                                                {
+                                                    letter: getChoiceLetter(
+                                                        pos,
+                                                    ),
+                                                },
+                                            )}
                                             disabled={
                                                 apiOptions.readOnly ||
                                                 reviewMode
@@ -287,8 +293,8 @@ const Choice = function (props: ChoicePropsWithForwardRef): React.ReactElement {
                                             }}
                                         >
                                             {crossedOut
-                                                ? "Bring back"
-                                                : "Cross out"}
+                                                ? i18n._("Bring back")
+                                                : i18n._("Cross out")}
                                         </Button>
                                     </View>
                                 }
@@ -298,9 +304,10 @@ const Choice = function (props: ChoicePropsWithForwardRef): React.ReactElement {
                         {({open}) => (
                             <Clickable
                                 onClick={open}
-                                aria-label={`Open menu for Choice ${getChoiceLetter(
-                                    pos,
-                                )}`}
+                                aria-label={i18n._(
+                                    `Open menu for Choice %(letter)s`,
+                                    {letter: getChoiceLetter(pos)},
+                                )}
                                 style={{
                                     alignSelf: "center",
                                     padding: "5px",


### PR DESCRIPTION
## Summary:

While removing `perseus-legacy` from webapp (https://github.com/Khan/webapp/pull/19729/files) Adam G asked about the string removals. I assumed (incorrectly) that they were just due to removal of deprecated/unsupported features. It turns out that some were changes we've made to Perseus over time where we missed wrapping user-facing strings in `i18n._()` after a refactoring. 

This PR restores the ones that I could identify by searching Perseus for the strings being removed in Khan/webapp#19729.

Issue: "none"

## Test plan:

I searched each removed string in Khan/webapp#19729 in the Perseus repo. Each one that I found I ensured was now wrapped in `i18n._()` calls again.