### PR TITLE
Add more graph types to the dev UI

### DIFF
--- a/.changeset/ninety-socks-hang.md
+++ b/.changeset/ninety-socks-hang.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-dev-ui": minor
+---
+
+Internal: Add more graph types to the dev UI

--- a/dev/index.html
+++ b/dev/index.html
@@ -4,7 +4,9 @@
         <title>Perseus Dev UI</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <style>
-            * {box-sizing: border-box}
+            * {
+                box-sizing: border-box;
+            }
             body {
                 margin: 0;
                 font-family: sans-serif;

--- a/dev/index.html
+++ b/dev/index.html
@@ -3,6 +3,13 @@
     <head>
         <title>Perseus Dev UI</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <style>
+            * {box-sizing: border-box}
+            body {
+                margin: 0;
+                font-family: sans-serif;
+            }
+        </style>
     </head>
     <body>
         <div id="app-root"></div>

--- a/dev/index.tsx
+++ b/dev/index.tsx
@@ -15,7 +15,9 @@ import {render} from "react-dom";
 
 import {Renderer} from "../packages/perseus/src";
 import {setDependencies} from "../packages/perseus/src/dependencies";
-import * as data from "../packages/perseus/src/widgets/__testdata__/interactive-graph.testdata";
+import * as interactiveGraph from "../packages/perseus/src/widgets/__testdata__/interactive-graph.testdata";
+import * as grapher from "../packages/perseus/src/widgets/__testdata__/grapher.testdata";
+import * as numberLine from "../packages/perseus/src/widgets/__testdata__/number-line.testdata";
 import {storybookTestDependencies} from "../testing/test-dependencies";
 
 import type {APIOptions, PerseusRenderer} from "../packages/perseus/src";
@@ -23,15 +25,23 @@ import type {APIOptions, PerseusRenderer} from "../packages/perseus/src";
 import "../packages/perseus/src/styles/perseus-renderer.less";
 
 const questions = [
-    data.angleQuestion,
-    data.linearSystemQuestion,
-    data.circleQuestion,
-    data.linearQuestion,
-    data.polygonQuestion,
-    data.pointQuestion,
-    data.rayQuestion,
-    data.segmentQuestion,
-    data.sinusoidQuestion,
+    interactiveGraph.angleQuestion,
+    interactiveGraph.linearSystemQuestion,
+    interactiveGraph.circleQuestion,
+    interactiveGraph.linearQuestion,
+    interactiveGraph.polygonQuestion,
+    interactiveGraph.pointQuestion,
+    interactiveGraph.rayQuestion,
+    interactiveGraph.segmentQuestion,
+    interactiveGraph.sinusoidQuestion,
+    grapher.absoluteValueQuestion,
+    grapher.exponentialQuestion,
+    grapher.linearQuestion,
+    grapher.logarithmQuestion,
+    grapher.multipleAvailableTypesQuestion,
+    grapher.quadraticQuestion,
+    grapher.sinusoidQuestion,
+    numberLine.question1,
 ];
 
 const styles = StyleSheet.create({

--- a/dev/index.tsx
+++ b/dev/index.tsx
@@ -2,22 +2,25 @@
 import {
     useUniqueIdWithMock,
     RenderStateRoot,
-    View
+    View,
 } from "@khanacademy/wonder-blocks-core";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import Switch from "@khanacademy/wonder-blocks-switch";
+import {color} from "@khanacademy/wonder-blocks-tokens";
+import {css, StyleSheet} from "aphrodite";
 import * as React from "react";
 import {useState} from "react";
 import {render} from "react-dom";
 
-import {APIOptions, PerseusRenderer, Renderer} from "../packages/perseus/src";
+import {Renderer} from "../packages/perseus/src";
 import {setDependencies} from "../packages/perseus/src/dependencies";
 import * as data from "../packages/perseus/src/widgets/__testdata__/interactive-graph.testdata";
 import {storybookTestDependencies} from "../testing/test-dependencies";
-import {color} from "@khanacademy/wonder-blocks-tokens";
+
+import type {APIOptions, PerseusRenderer} from "../packages/perseus/src";
+
 import "../packages/perseus/src/styles/perseus-renderer.less";
-import Switch from "@khanacademy/wonder-blocks-switch";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
-import {css, StyleSheet} from "aphrodite";
 
 const questions = [
     data.angleQuestion,

--- a/dev/index.tsx
+++ b/dev/index.tsx
@@ -15,8 +15,8 @@ import {render} from "react-dom";
 
 import {Renderer} from "../packages/perseus/src";
 import {setDependencies} from "../packages/perseus/src/dependencies";
-import * as interactiveGraph from "../packages/perseus/src/widgets/__testdata__/interactive-graph.testdata";
 import * as grapher from "../packages/perseus/src/widgets/__testdata__/grapher.testdata";
+import * as interactiveGraph from "../packages/perseus/src/widgets/__testdata__/interactive-graph.testdata";
 import * as numberLine from "../packages/perseus/src/widgets/__testdata__/number-line.testdata";
 import {storybookTestDependencies} from "../testing/test-dependencies";
 

--- a/dev/index.tsx
+++ b/dev/index.tsx
@@ -1,28 +1,129 @@
 /* eslint monorepo/no-internal-import: "off", monorepo/no-relative-import: "off", import/no-relative-packages: "off" */
+import {
+    useUniqueIdWithMock,
+    RenderStateRoot,
+    View
+} from "@khanacademy/wonder-blocks-core";
 import * as React from "react";
+import {useState} from "react";
 import {render} from "react-dom";
 
-import {Renderer} from "../packages/perseus/src";
+import {APIOptions, PerseusRenderer, Renderer} from "../packages/perseus/src";
 import {setDependencies} from "../packages/perseus/src/dependencies";
-import {angleQuestion} from "../packages/perseus/src/widgets/__testdata__/interactive-graph.testdata";
+import * as data from "../packages/perseus/src/widgets/__testdata__/interactive-graph.testdata";
 import {storybookTestDependencies} from "../testing/test-dependencies";
+import {color} from "@khanacademy/wonder-blocks-tokens";
+import "../packages/perseus/src/styles/perseus-renderer.less";
+import Switch from "@khanacademy/wonder-blocks-switch";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import {css, StyleSheet} from "aphrodite";
+
+const questions = [
+    data.angleQuestion,
+    data.linearSystemQuestion,
+    data.circleQuestion,
+    data.linearQuestion,
+    data.polygonQuestion,
+    data.pointQuestion,
+    data.rayQuestion,
+    data.segmentQuestion,
+    data.sinusoidQuestion,
+];
+
+const styles = StyleSheet.create({
+    page: {
+        height: "100vh",
+        overflowY: "hidden",
+    },
+
+    header: {
+        display: "flex",
+        alignItems: "center",
+        boxShadow: "0 0 10px #0002",
+        borderBlockEnd: `1px solid ${color.offBlack32}`,
+        background: color.offBlack8,
+        padding: Spacing.small_12,
+    },
+
+    main: {
+        flexGrow: 1,
+        overflowY: "scroll",
+        paddingBlock: Spacing.xLarge_32,
+    },
+
+    cards: {
+        flexDirection: "row",
+        flexWrap: "wrap",
+        justifyContent: "center",
+    },
+
+    card: {
+        float: "left",
+        margin: 16,
+        width: 460,
+        borderRadius: 7,
+        border: "1px solid #ccc",
+    },
+});
 
 setDependencies(storybookTestDependencies);
 
 render(
-    <QuestionRenderer question={angleQuestion} />,
+    <RenderStateRoot>
+        <DevUI />
+    </RenderStateRoot>,
     document.getElementById("app-root"),
 );
 
-function QuestionRenderer(props) {
-    const {question, apiOptions = {}} = props;
+function DevUI() {
+    const ids = useUniqueIdWithMock();
+
+    const [isMobile, setIsMobile] = useState(false);
+
     return (
-        <Renderer
-            content={question.content}
-            images={question.images}
-            widgets={question.widgets}
-            problemNum={0}
-            apiOptions={apiOptions}
-        />
+        <View className={css(styles.page)}>
+            <header className={css(styles.header)}>
+                <Switch
+                    id={ids.get("mobile")}
+                    checked={isMobile}
+                    onChange={setIsMobile}
+                />
+                <Strut size={Spacing.xSmall_8} />
+                <label htmlFor={ids.get("mobile")}>Mobile</label>
+            </header>
+            <main className={css(styles.main)}>
+                <View style={styles.cards}>
+                    {questions.map((question, i) => (
+                        <QuestionRenderer
+                            key={i}
+                            question={question}
+                            apiOptions={{isMobile}}
+                        />
+                    ))}
+                </View>
+            </main>
+        </View>
+    );
+}
+
+type QuestionRendererProps = {
+    question: PerseusRenderer;
+    apiOptions?: APIOptions;
+};
+
+function QuestionRenderer({question, apiOptions = {}}: QuestionRendererProps) {
+    return (
+        <div className={css(styles.card)}>
+            <div style={{padding: 28}} className="framework-perseus">
+                <Renderer
+                    content={question.content}
+                    images={question.images}
+                    widgets={question.widgets}
+                    problemNum={0}
+                    apiOptions={apiOptions}
+                />
+            </div>
+        </div>
     );
 }

--- a/dev/package.json
+++ b/dev/package.json
@@ -23,7 +23,8 @@
         "@khanacademy/perseus-linter": "^0.3.11",
         "@khanacademy/pure-markdown": "^0.2.14",
         "@khanacademy/simple-markdown": "^0.11.3",
-        "@khanacademy/wonder-blocks-banner": "^3.0.33"
+        "@khanacademy/wonder-blocks-banner": "^3.0.33",
+        "@khanacademy/wonder-blocks-tokens": "^1.0.0"
     },
     "devDependencies": {
         "vite": "^5.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2615,6 +2615,14 @@
   resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-timing/-/wonder-blocks-timing-4.0.2.tgz#84fa99a905f0558a70e493af44a3a6885ddb844c"
   integrity sha512-LIj31jodAXOi7Yj+QJyRLTCiO4/cPDCR8DSqZbNuA/vliRuePfOjX3ci4BMhnuSyEIu1bTorvcEeASTe/M52hw==
 
+"@khanacademy/wonder-blocks-tokens@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-tokens/-/wonder-blocks-tokens-1.0.0.tgz#cd43f44eafea257a24a55650a72352c1e78d2055"
+  integrity sha512-xC/0bWocU26Hj3e8OfpG/lFEUhJNZDGaXLgpYtGTg3+EwvGXWb8JwxidOEzV0m2yxoWJAFwrsUSFMh1HULNPRQ==
+  dependencies:
+    "@khanacademy/wonder-blocks-color" "^3.0.0"
+    "@khanacademy/wonder-blocks-spacing" "^4.0.1"
+
 "@khanacademy/wonder-blocks-tooltip@^2.1.25":
   version "2.1.25"
   resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-tooltip/-/wonder-blocks-tooltip-2.1.25.tgz#71cf7c57540458cc50514e29d805a2bf263b6e5e"


### PR DESCRIPTION
Issue: https://khanacademy.atlassian.net/browse/LC-1741

## Test plan:

```
yarn dev
open http://localhost:5173
```

You should see 9 interactive graphs. Toggling the "Mobile" switch should make
some of the points have 3D shadows.

Known issue: The sinusoid graph is broken in "mobile" mode, and if you turn
mobile mode on and off again, the graph remains broken.

<img width="1904" alt="Screen Shot 2024-02-09 at 2 01 26 PM" src="https://github.com/Khan/perseus/assets/693920/e9cb7600-c3a6-4553-af72-17106435012b">
