### PR TITLE
Add python-program widget and editor

### DIFF
--- a/.changeset/nine-jobs-punch.md
+++ b/.changeset/nine-jobs-punch.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-editor": minor
+---
+
+Add a new python-program widget and its editor

--- a/packages/perseus-editor/src/all-editors.ts
+++ b/packages/perseus-editor/src/all-editors.ts
@@ -29,6 +29,7 @@ import PassageEditor from "./widgets/passage-editor";
 import PassageRefEditor from "./widgets/passage-ref-editor";
 import PassageRefTargetEditor from "./widgets/passage-ref-target-editor";
 import PlotterEditor from "./widgets/plotter-editor";
+import PythonProgramEditor from "./widgets/python-program-editor";
 import RadioEditor from "./widgets/radio/editor";
 import ReactionDiagramEditor from "./widgets/reaction-diagram-editor";
 import SequenceEditor from "./widgets/sequence-editor";
@@ -70,6 +71,7 @@ export default [
     PassageRefEditor,
     PassageRefTargetEditor,
     PlotterEditor,
+    PythonProgramEditor,
     ReactionDiagramEditor,
     SequenceEditor,
     SimpleMarkdownTesterEditor,

--- a/packages/perseus-editor/src/widgets/__stories__/python-program-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/python-program-editor.stories.tsx
@@ -1,0 +1,18 @@
+import {action} from "@storybook/addon-actions";
+import * as React from "react";
+
+import PythonProgramEditor from "../python-program-editor";
+
+type StoryArgs = Record<any, any>;
+
+type Story = {
+    title: string;
+};
+
+export default {
+    title: "Perseus/Editor/Widgets/Python Program Editor",
+} as Story;
+
+export const Default = (args: StoryArgs): React.ReactElement => {
+    return <PythonProgramEditor onChange={action("onChange")} />;
+};

--- a/packages/perseus-editor/src/widgets/__tests__/python-program-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/python-program-editor.test.tsx
@@ -6,8 +6,7 @@ import * as React from "react";
 import "@testing-library/jest-dom";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
-import PythonProgramEditor from "../python-program-editor";
-import {validateOptions} from "../python-program-editor";
+import PythonProgramEditor, {validateOptions} from "../python-program-editor";
 
 describe("python-program-editor", () => {
     beforeEach(() => {
@@ -56,19 +55,32 @@ describe("python-program-editor", () => {
         );
     });
 
-    it("should accept valid props", async () => {
+    it("should accept valid options", async () => {
         expect(validateOptions(100, "54321")).toEqual([]);
     });
 
     it("should require a program ID", async () => {
-        expect(validateOptions(100, "")).toEqual(["The program ID is required."]);
+        expect(validateOptions(100, "")).toEqual([
+            "The program ID is required.",
+        ]);
     });
 
     it("should require a positive height", async () => {
-        expect(validateOptions(-1, "54321")).toEqual(["The height must be a positive integer."]);
+        expect(validateOptions(-1, "54321")).toEqual([
+            "The height must be a positive integer.",
+        ]);
     });
 
     it("should require an integer for the height", async () => {
-        expect(validateOptions(0.5, "54321")).toEqual(["The height must be a positive integer."]);
+        expect(validateOptions(0.5, "54321")).toEqual([
+            "The height must be a positive integer.",
+        ]);
+    });
+
+    it("should require valid values for both options", async () => {
+        expect(validateOptions(0.5, "")).toEqual([
+            "The program ID is required.",
+            "The height must be a positive integer.",
+        ]);
     });
 });

--- a/packages/perseus-editor/src/widgets/__tests__/python-program-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/python-program-editor.test.tsx
@@ -33,7 +33,7 @@ describe("python-program-editor", () => {
         userEvent.type(input, "1");
 
         expect(onChangeMock).toBeCalledWith(
-            expect.objectContaining({programID: 1, height: 400}),
+            expect.objectContaining({programID: "1", height: 400}),
             undefined,
         );
     });

--- a/packages/perseus-editor/src/widgets/__tests__/python-program-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/python-program-editor.test.tsx
@@ -1,0 +1,62 @@
+import {Dependencies, ApiOptions} from "@khanacademy/perseus";
+import {render, screen} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as React from "react";
+
+import "@testing-library/jest-dom";
+
+import {testDependencies} from "../../../../../testing/test-dependencies";
+import PythonProgramEditor from "../python-program-editor";
+
+describe("python-program-editor", () => {
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("should render", async () => {
+        render(
+            <PythonProgramEditor
+                onChange={() => undefined}
+                apiOptions={ApiOptions.defaults}
+            />,
+        );
+
+        expect(
+            await screen.findByText(/user program id/i),
+        ).toBeInTheDocument();
+    });
+
+    it("should be possible to update the User Program ID", async () => {
+        const onChangeMock = jest.fn();
+
+        render(<PythonProgramEditor onChange={onChangeMock} />);
+
+        const input = screen.getByRole("textbox", {
+            name: "User Program ID:",
+        });
+
+        userEvent.type(input, "1");
+
+        expect(onChangeMock).toBeCalledWith(
+            expect.objectContaining({programID: 1, height: 400}), undefined
+        );
+    });
+
+    it("should be possible to update the height", async () => {
+        const onChangeMock = jest.fn();
+
+        render(<PythonProgramEditor onChange={onChangeMock} />);
+
+        const input = screen.getByRole("textbox", {
+            name: "Height:",
+        });
+
+        userEvent.type(input, "1");
+
+        expect(onChangeMock).toBeCalledWith(
+            expect.objectContaining({programID: null, height: 4001}), undefined
+        );
+    });
+});

--- a/packages/perseus-editor/src/widgets/__tests__/python-program-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/python-program-editor.test.tsx
@@ -7,6 +7,7 @@ import "@testing-library/jest-dom";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import PythonProgramEditor from "../python-program-editor";
+import {validateOptions} from "../python-program-editor";
 
 describe("python-program-editor", () => {
     beforeEach(() => {
@@ -53,5 +54,21 @@ describe("python-program-editor", () => {
             expect.objectContaining({programID: "", height: 4001}),
             undefined,
         );
+    });
+
+    it("should accept valid props", async () => {
+        expect(validateOptions(100, "54321")).toEqual([]);
+    });
+
+    it("should require a program ID", async () => {
+        expect(validateOptions(100, "")).toEqual(["The program ID is required."]);
+    });
+
+    it("should require a positive height", async () => {
+        expect(validateOptions(-1, "54321")).toEqual(["The height must be a positive integer."]);
+    });
+
+    it("should require an integer for the height", async () => {
+        expect(validateOptions(0.5, "54321")).toEqual(["The height must be a positive integer."]);
     });
 });

--- a/packages/perseus-editor/src/widgets/__tests__/python-program-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/python-program-editor.test.tsx
@@ -1,4 +1,4 @@
-import {Dependencies, ApiOptions} from "@khanacademy/perseus";
+import {Dependencies} from "@khanacademy/perseus";
 import {render, screen} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as React from "react";
@@ -16,16 +16,9 @@ describe("python-program-editor", () => {
     });
 
     it("should render", async () => {
-        render(
-            <PythonProgramEditor
-                onChange={() => undefined}
-                apiOptions={ApiOptions.defaults}
-            />,
-        );
+        render(<PythonProgramEditor onChange={() => undefined} />);
 
-        expect(
-            await screen.findByText(/user program id/i),
-        ).toBeInTheDocument();
+        expect(await screen.findByText(/user program id/i)).toBeInTheDocument();
     });
 
     it("should be possible to update the User Program ID", async () => {
@@ -40,7 +33,8 @@ describe("python-program-editor", () => {
         userEvent.type(input, "1");
 
         expect(onChangeMock).toBeCalledWith(
-            expect.objectContaining({programID: 1, height: 400}), undefined
+            expect.objectContaining({programID: 1, height: 400}),
+            undefined,
         );
     });
 
@@ -56,7 +50,8 @@ describe("python-program-editor", () => {
         userEvent.type(input, "1");
 
         expect(onChangeMock).toBeCalledWith(
-            expect.objectContaining({programID: null, height: 4001}), undefined
+            expect.objectContaining({programID: "", height: 4001}),
+            undefined,
         );
     });
 });

--- a/packages/perseus-editor/src/widgets/python-program-editor.tsx
+++ b/packages/perseus-editor/src/widgets/python-program-editor.tsx
@@ -1,40 +1,32 @@
-/* eslint-disable no-useless-escape */
 /**
  * This editor is for embedding Khan Academy Python programs.
  */
-
-import {
-    components,
-    Changeable,
-    EditorJsonify,
-} from "@khanacademy/perseus";
-import PropTypes from "prop-types";
+import {components, Changeable} from "@khanacademy/perseus";
 import * as React from "react";
-import _ from "underscore";
 
-import BlurInput from "../components/blur-input";
+const {NumberInput, TextInput} = components;
 
-const {NumberInput} = components;
+import type {PerseusPythonProgramWidgetOptions} from "@khanacademy/perseus";
 
-const DEFAULT_HEIGHT = 400;
+type Props = Changeable.ChangeableProps & {
+    programID: string;
+    height: number;
+};
 
-type Props = any;
+type DefaultProps = {
+    programID: Props["programID"];
+    height: Props["height"];
+};
 
 /**
  * This is the main editor for this widget, to specify all the options.
  */
 class PythonProgramEditor extends React.Component<Props> {
-    static propTypes = {
-        ...Changeable.propTypes,
-        programID: PropTypes.number,
-        height: PropTypes.number,
-    };
-
     static widgetName = "python-program" as const;
 
-    static defaultProps: any = {
-        programID: null,
-        height: DEFAULT_HEIGHT,
+    static defaultProps: DefaultProps = {
+        programID: "",
+        height: 400,
     };
 
     change: (...args: ReadonlyArray<unknown>) => any = (...args) => {
@@ -42,16 +34,18 @@ class PythonProgramEditor extends React.Component<Props> {
         return Changeable.change.apply(this, args);
     };
 
-    _handleHeightChange: (arg1: string) => void = (height) => {
-        this.change({height});
-    };
+    serialize(): PerseusPythonProgramWidgetOptions {
+        return {
+            programID: this.props.programID,
+            height: this.props.height,
+        };
+    }
 
-    _handleProgramIDChange: (arg1: string) => void = (programID) => {
-        this.change({programID});
-    };
-
-    serialize: () => any = () => {
-        return EditorJsonify.serialize.call(this);
+    getSaveWarnings: () => ReadonlyArray<string> = () => {
+        if (this.props.programID === "") {
+            return ["The program ID is missing."];
+        }
+        return [];
     };
 
     render(): React.ReactNode {
@@ -59,9 +53,8 @@ class PythonProgramEditor extends React.Component<Props> {
             <div>
                 <label>
                     User Program ID:{" "}
-                    <NumberInput
+                    <TextInput
                         value={this.props.programID}
-                        //onChange={this._handleProgramIDChange}
                         onChange={this.change("programID")}
                         placeholder="123"
                     />
@@ -71,7 +64,6 @@ class PythonProgramEditor extends React.Component<Props> {
                     Height:{" "}
                     <NumberInput
                         value={this.props.height}
-                        // onChange={this._handleHeightChange}
                         onChange={this.change("height")}
                         placeholder="400"
                     />

--- a/packages/perseus-editor/src/widgets/python-program-editor.tsx
+++ b/packages/perseus-editor/src/widgets/python-program-editor.tsx
@@ -1,0 +1,84 @@
+/* eslint-disable no-useless-escape */
+/**
+ * This editor is for embedding Khan Academy Python programs.
+ */
+
+import {
+    components,
+    Changeable,
+    EditorJsonify,
+} from "@khanacademy/perseus";
+import PropTypes from "prop-types";
+import * as React from "react";
+import _ from "underscore";
+
+import BlurInput from "../components/blur-input";
+
+const {NumberInput} = components;
+
+const DEFAULT_HEIGHT = 400;
+
+type Props = any;
+
+/**
+ * This is the main editor for this widget, to specify all the options.
+ */
+class PythonProgramEditor extends React.Component<Props> {
+    static propTypes = {
+        ...Changeable.propTypes,
+        programID: PropTypes.number,
+        height: PropTypes.number,
+    };
+
+    static widgetName = "python-program" as const;
+
+    static defaultProps: any = {
+        programID: null,
+        height: DEFAULT_HEIGHT,
+    };
+
+    change: (...args: ReadonlyArray<unknown>) => any = (...args) => {
+        // @ts-expect-error - TS2345 - Argument of type 'readonly unknown[]' is not assignable to parameter of type 'any[]'.
+        return Changeable.change.apply(this, args);
+    };
+
+    _handleHeightChange: (arg1: string) => void = (height) => {
+        this.change({height});
+    };
+
+    _handleProgramIDChange: (arg1: string) => void = (programID) => {
+        this.change({programID});
+    };
+
+    serialize: () => any = () => {
+        return EditorJsonify.serialize.call(this);
+    };
+
+    render(): React.ReactNode {
+        return (
+            <div>
+                <label>
+                    User Program ID:{" "}
+                    <NumberInput
+                        value={this.props.programID}
+                        //onChange={this._handleProgramIDChange}
+                        onChange={this.change("programID")}
+                        placeholder="123"
+                    />
+                </label>
+                <br />
+                <label>
+                    Height:{" "}
+                    <NumberInput
+                        value={this.props.height}
+                        // onChange={this._handleHeightChange}
+                        onChange={this.change("height")}
+                        placeholder="400"
+                    />
+                </label>
+            </div>
+        );
+    }
+}
+
+export default PythonProgramEditor;

--- a/packages/perseus-editor/src/widgets/python-program-editor.tsx
+++ b/packages/perseus-editor/src/widgets/python-program-editor.tsx
@@ -18,6 +18,20 @@ type DefaultProps = {
     height: Props["height"];
 };
 
+export function validateOptions(height: Props["height"], programID: Props["programID"]): ReadonlyArray<string> {
+    const errors: Array<string> = [];
+
+    if (programID === "") {
+        errors.push("The program ID is required.");
+    }
+
+    if (!Number.isInteger(height) || height < 1) {
+        errors.push("The height must be a positive integer.");
+    }
+
+    return errors;
+}
+
 /**
  * This is the main editor for this widget, to specify all the options.
  */
@@ -42,17 +56,7 @@ class PythonProgramEditor extends React.Component<Props> {
     }
 
     getSaveWarnings: () => ReadonlyArray<string> = () => {
-        const errors: Array<string> = [];
-
-        if (this.props.programID === "") {
-            errors.push("The program ID is required.");
-        }
-
-        if (!Number.isInteger(this.props.height) || this.props.height < 1) {
-            errors.push("The height must be a positive integer.");
-        }
-
-        return errors;
+        return validateOptions(this.props.height, this.props.programID);
     };
 
     render(): React.ReactNode {

--- a/packages/perseus-editor/src/widgets/python-program-editor.tsx
+++ b/packages/perseus-editor/src/widgets/python-program-editor.tsx
@@ -18,7 +18,10 @@ type DefaultProps = {
     height: Props["height"];
 };
 
-export function validateOptions(height: Props["height"], programID: Props["programID"]): ReadonlyArray<string> {
+export function validateOptions(
+    height: Props["height"],
+    programID: Props["programID"],
+): ReadonlyArray<string> {
     const errors: Array<string> = [];
 
     if (programID === "") {

--- a/packages/perseus-editor/src/widgets/python-program-editor.tsx
+++ b/packages/perseus-editor/src/widgets/python-program-editor.tsx
@@ -42,10 +42,17 @@ class PythonProgramEditor extends React.Component<Props> {
     }
 
     getSaveWarnings: () => ReadonlyArray<string> = () => {
+        let errors: Array<string> = [];
+
         if (this.props.programID === "") {
-            return ["The program ID is missing."];
+            errors.push("The program ID is required.");
         }
-        return [];
+
+        if (!Number.isInteger(this.props.height) || this.props.height < 1) {
+            errors.push("The height must be a positive integer.");
+        }
+
+        return errors;
     };
 
     render(): React.ReactNode {

--- a/packages/perseus-editor/src/widgets/python-program-editor.tsx
+++ b/packages/perseus-editor/src/widgets/python-program-editor.tsx
@@ -42,7 +42,7 @@ class PythonProgramEditor extends React.Component<Props> {
     }
 
     getSaveWarnings: () => ReadonlyArray<string> = () => {
-        let errors: Array<string> = [];
+        const errors: Array<string> = [];
 
         if (this.props.programID === "") {
             errors.push("The program ID is required.");

--- a/packages/perseus/src/extra-widgets.ts
+++ b/packages/perseus/src/extra-widgets.ts
@@ -28,6 +28,7 @@ import Passage from "./widgets/passage";
 import PassageRef from "./widgets/passage-ref";
 import PassageRefTarget from "./widgets/passage-ref-target";
 import Plotter from "./widgets/plotter";
+import PythonProgram from "./widgets/python-program";
 import ReactionDiagram from "./widgets/reaction-diagram";
 import Sequence from "./widgets/sequence";
 import Simulator from "./widgets/simulator";
@@ -64,6 +65,7 @@ export default [
     PassageRef,
     PassageRefTarget,
     Plotter,
+    PythonProgram,
     ReactionDiagram,
     Sequence,
     Simulator,

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -136,6 +136,7 @@ export type {
     PerseusInteractiveGraphWidgetOptions,
     PerseusItem,
     PerseusPlotterWidgetOptions,
+    PerseusPythonProgramWidgetOptions,
     PerseusRadioWidgetOptions,
     PerseusRenderer,
     PerseusWidget,

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -155,6 +155,8 @@ export type PassageWidget = Widget<'passage', PerseusPassageWidgetOptions>;
 // prettier-ignore
 export type PlotterWidget = Widget<'plotter', PerseusPlotterWidgetOptions>;
 // prettier-ignore
+export type PythonProgramWidget = Widget<'python-program', PerseusPythonProgramWidgetOptions>;
+// prettier-ignore
 export type RadioWidget = Widget<'radio', PerseusRadioWidgetOptions>;
 // prettier-ignore
 export type SequenceWidget = Widget<'sequence', PerseusSequenceWidgetOptions>;
@@ -217,6 +219,7 @@ export type PerseusWidget =
     | PassageRefWidget
     | PassageWidget
     | PlotterWidget
+    | PythonProgramWidget
     | RadioWidget
     | ReactionDiagramWidget
     | RefTargetWidget
@@ -1274,6 +1277,20 @@ export type PerseusCSProgramSetting = {
     // The value of the setting
     value: string;
 };
+
+export type PerseusPythonProgramWidgetOptions = {
+    // The ID of the Python program to embed
+    programID: string;
+    // The height of the widget
+    height: number | string;
+}
+
+// export type PerseusPythonIFrameWidgetOptions = {
+//     // A Python Program ID
+//     url: string;
+//     // The height of the widget
+//     height: number | string;
+// }
 
 export type PerseusIFrameWidgetOptions = {
     // A URL to display OR a CS Program ID

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -1281,8 +1281,8 @@ export type PerseusCSProgramSetting = {
 export type PerseusPythonProgramWidgetOptions = {
     // The ID of the Python program to embed
     programID: string;
-    // The height of the widget
-    height: number | string;
+    // The height of the widget in pixels
+    height: number;
 };
 
 export type PerseusIFrameWidgetOptions = {

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -1283,14 +1283,7 @@ export type PerseusPythonProgramWidgetOptions = {
     programID: string;
     // The height of the widget
     height: number | string;
-}
-
-// export type PerseusPythonIFrameWidgetOptions = {
-//     // A Python Program ID
-//     url: string;
-//     // The height of the widget
-//     height: number | string;
-// }
+};
 
 export type PerseusIFrameWidgetOptions = {
     // A URL to display OR a CS Program ID

--- a/packages/perseus/src/widgets/__stories__/python-program.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/python-program.stories.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+
+import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui";
+import {question1} from "../__testdata__/python-program.testdata";
+
+export default {
+    title: "Perseus/Widgets/Python Program",
+};
+
+type StoryArgs = Record<any, any>;
+
+export const Question1 = (args: StoryArgs): React.ReactElement => {
+    return <RendererWithDebugUI question={question1} />;
+};

--- a/packages/perseus/src/widgets/__testdata__/python-program.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/python-program.testdata.ts
@@ -1,0 +1,18 @@
+import type {PerseusRenderer} from "../../perseus-types";
+
+export const question1: PerseusRenderer = {
+    content: "[[\u2603 python-program 1]]\n\n",
+    images: {},
+    widgets: {
+        "python-program 1": {
+            version: {major: 0, minor: 0},
+            static: false,
+            type: "python-program",
+            options: {
+                height: 400,
+                programID: "5207287069147136",
+            },
+            alignment: "block",
+        },
+    },
+};

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/python-program.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/python-program.test.ts.snap
@@ -1,0 +1,65 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`python-program widget should snapshot on mobile: first mobile render 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <div
+            class="default_xu2jcg-o_O-container_1s1lg5o"
+          >
+            <iframe
+              allowfullscreen=""
+              sandbox="allow-popups allow-same-origin allow-scripts allow-top-navigation"
+              src="http://localhost:8081/python-program/5207287069147136/embedded"
+              style="height: 400px; width: 100%;"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`python-program widget should snapshot: first render 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <div
+            class="default_xu2jcg-o_O-container_1s1lg5o"
+          >
+            <iframe
+              allowfullscreen=""
+              sandbox="allow-popups allow-same-origin allow-scripts allow-top-navigation"
+              src="http://localhost:8081/python-program/5207287069147136/embedded"
+              style="height: 400px; width: 100%;"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/perseus/src/widgets/__tests__/python-program.test.ts
+++ b/packages/perseus/src/widgets/__tests__/python-program.test.ts
@@ -1,18 +1,10 @@
 import "@testing-library/jest-dom";
 
-import {testDependencies} from "../../../../../testing/test-dependencies";
-import * as Dependencies from "../../dependencies";
 import {question1} from "../__testdata__/python-program.testdata";
 
 import {renderQuestion} from "./renderQuestion";
 
 describe("python-program widget", () => {
-    beforeEach(() => {
-        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
-            testDependencies,
-        );
-    });
-
     it("should snapshot", () => {
         // Arrange
         const apiOptions = {

--- a/packages/perseus/src/widgets/__tests__/python-program.ts
+++ b/packages/perseus/src/widgets/__tests__/python-program.ts
@@ -1,0 +1,43 @@
+import "@testing-library/jest-dom";
+
+import {testDependencies} from "../../../../../testing/test-dependencies";
+import * as Dependencies from "../../dependencies";
+import {question1} from "../__testdata__/python-program.testdata";
+
+import {renderQuestion} from "./renderQuestion";
+
+describe("python-program widget", () => {
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("should snapshot", () => {
+        // Arrange
+        const apiOptions = {
+            isMobile: false,
+        } as const;
+
+        // Act
+        const {container} = renderQuestion(question1, apiOptions);
+
+        // Assert
+        expect(container).toMatchSnapshot("first render");
+    });
+
+    it("should snapshot on mobile", () => {
+        // Arrange
+        const apiOptions = {
+            isMobile: true,
+        } as const;
+
+        // Act
+        const {container} = renderQuestion(question1, apiOptions);
+
+        // Assert
+        expect(container).toMatchSnapshot("first mobile render");
+    });
+
+    // This widget doesn't have any direct behavior, it just renders an iframe
+});

--- a/packages/perseus/src/widgets/python-program.tsx
+++ b/packages/perseus/src/widgets/python-program.tsx
@@ -1,0 +1,83 @@
+/**
+ * This widget is for embedding Khan Academy Python programs.
+ */
+
+import {StyleSheet, css} from "aphrodite";
+import PropTypes from "prop-types";
+import * as React from "react";
+import _ from "underscore";
+
+import {getDependencies} from "../dependencies";
+import {isFileProtocol} from "../util/mobile-native-utils";
+import {toAbsoluteUrl} from "../util/url-utils";
+
+import type {WidgetExports} from "../types";
+
+function getUrlFromProgramID(programID: any) {
+    const {InitialRequestUrl} = getDependencies();
+
+    const path = `/python-program/${programID}/embedded`;
+
+    return toAbsoluteUrl(path);
+}
+
+/* This renders the program in an iframe. */
+class PythonProgram extends React.Component<any> {
+    static propTypes = {
+        programID: PropTypes.string,
+        height: PropTypes.number,
+    };
+
+    static defaultProps: any = {
+        height: 400,
+    };
+
+    render(): React.ReactNode {
+        if (!this.props.programID) {
+            return <div />;
+        }
+
+        let url = getUrlFromProgramID(this.props.programID);
+        let className = "perseus-python-program";
+        const style = {
+            height: this.props.height,
+            width: "100%",
+        } as const;
+
+        const sandboxOptions = [
+            "allow-popups",
+            "allow-same-origin",
+            "allow-scripts",
+            "allow-top-navigation",
+        ].join(" ");
+
+        // We sandbox the iframe so that we allowlist only the functionality
+        //  that we need. This makes it a bit safer in case some content
+        //  creator "went wild".
+        // http://www.html5rocks.com/en/tutorials/security/sandboxed-iframes/
+        return (
+            <div className={css(styles.container)}>
+                <iframe
+                    sandbox={sandboxOptions}
+                    src={url}
+                    style={style}
+                    className={className}
+                    allowFullScreen={true}
+                />
+            </div>
+        );
+    }
+}
+
+const styles = StyleSheet.create({
+    container: {
+        margin: "auto",
+        width: "100%",
+    },
+});
+
+export default {
+    name: "python-program",
+    displayName: "Python Program",
+    widget: PythonProgram,
+} as WidgetExports<typeof PythonProgram>;

--- a/packages/perseus/src/widgets/python-program.tsx
+++ b/packages/perseus/src/widgets/python-program.tsx
@@ -1,45 +1,38 @@
 /**
  * This widget is for embedding Khan Academy Python programs.
  */
-
-import {StyleSheet, css} from "aphrodite";
-import PropTypes from "prop-types";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {StyleSheet} from "aphrodite";
 import * as React from "react";
-import _ from "underscore";
 
-import {getDependencies} from "../dependencies";
-import {isFileProtocol} from "../util/mobile-native-utils";
 import {toAbsoluteUrl} from "../util/url-utils";
 
 import type {WidgetExports} from "../types";
 
 function getUrlFromProgramID(programID: any) {
-    const {InitialRequestUrl} = getDependencies();
-
     const path = `/python-program/${programID}/embedded`;
 
     return toAbsoluteUrl(path);
 }
 
-/* This renders the program in an iframe. */
-class PythonProgram extends React.Component<any> {
-    static propTypes = {
-        programID: PropTypes.string,
-        height: PropTypes.number,
-    };
+type Props = {
+    programID: string;
+    height: number;
+};
 
-    static defaultProps: any = {
+type DefaultProps = {
+    height: Props["height"];
+};
+
+/* This renders the program in an iframe. */
+class PythonProgram extends React.Component<Props> {
+    static defaultProps: DefaultProps = {
         height: 400,
     };
 
     render(): React.ReactNode {
-        if (!this.props.programID) {
-            return <div />;
-        }
-
-        let url = getUrlFromProgramID(this.props.programID);
-        let className = "perseus-python-program";
-        const style = {
+        const url = getUrlFromProgramID(this.props.programID);
+        const iframeStyle = {
             height: this.props.height,
             width: "100%",
         } as const;
@@ -56,15 +49,14 @@ class PythonProgram extends React.Component<any> {
         //  creator "went wild".
         // http://www.html5rocks.com/en/tutorials/security/sandboxed-iframes/
         return (
-            <div className={css(styles.container)}>
+            <View style={styles.container}>
                 <iframe
                     sandbox={sandboxOptions}
                     src={url}
-                    style={style}
-                    className={className}
+                    style={iframeStyle}
                     allowFullScreen={true}
                 />
-            </div>
+            </View>
         );
     }
 }


### PR DESCRIPTION
This commit adds a new widget: python-program. This widget renders
an iframe which loads an embedded Python program page. The purpose
of this widget is to add runnable Python programs to articles in
the Python course.

Issue: CL-1472

Test Plan:
- Temporarily change the iframe URL to include http://localhost:8090/.
- Run the webapp dev environment.
- Start storybook.
- Visit the Python Program story and verify that the program loads and that the
  buttons work.
![image](https://github.com/Khan/perseus/assets/37850/89379813-4fdf-406a-82f0-dc8bff51a0c2)
- Visit the Python Program Editor story and verify that it renders the two input fields.
![image](https://github.com/Khan/perseus/assets/37850/71251ee7-b7f9-435d-9d8a-52f492b1fb85)
