### PR TITLE
Enable keyboard selection of movable points

### DIFF
--- a/packages/perseus/src/interactive2/movable-point-options.ts
+++ b/packages/perseus/src/interactive2/movable-point-options.ts
@@ -60,6 +60,7 @@ const draw = {
                 radii,
                 options,
             );
+            this.state.visibleShape.wrapper.setAttribute("tabindex", "0")
 
             // @ts-expect-error - TS2339 - Property 'state' does not exist on type '{ readonly basic: (state: any, prevState: any) => void; readonly highlight: (state: any, prevState: any) => void; }'. | TS2339 - Property 'normalStyle' does not exist on type '{ readonly basic: (state: any, prevState: any) => void; readonly highlight: (state: any, prevState: any) => void; }'.
             this.state.visibleShape.attr(_.omit(this.normalStyle(), "scale"));

--- a/packages/perseus/src/util/interactive.ts
+++ b/packages/perseus/src/util/interactive.ts
@@ -969,6 +969,7 @@ _.extend(GraphUtils.Graphie.prototype, {
                     radii,
                     options,
                 );
+                movablePoint.mouseTarget.wrapper.setAttribute("tabindex", "0")
                 movablePoint.mouseTarget.attr({fill: "#000", opacity: 0.0});
             }
 


### PR DESCRIPTION
## Summary:
This is a step toward making interactive graphs keyboard- and
screen-reader-accessible.

Issue: https://khanacademy.atlassian.net/browse/LC-1666

Test plan:

```
yarn dev
open http://localhost:5173
```

Press `tab` repeatedly. The movable points on the graphs should be
selected in turn, with a visible outline on the selected point.