### PR TITLE
Update our interactionCallback to return the current user input data for Khanmigo

### DIFF
--- a/.changeset/fuzzy-nails-double.md
+++ b/.changeset/fuzzy-nails-double.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Update of interactionCallback to return current user input data

--- a/packages/perseus/src/__stories__/server-item-renderer.stories.tsx
+++ b/packages/perseus/src/__stories__/server-item-renderer.stories.tsx
@@ -6,6 +6,7 @@ import {
     itemWithInput,
     itemWithLintingError,
     labelImageItem,
+    itemWithMultipleInputs,
 } from "../__testdata__/server-item-renderer.testdata";
 import {ServerItemRenderer} from "../server-item-renderer";
 
@@ -21,6 +22,21 @@ export default {
 
 export const InputNumberItem = (args: StoryArgs): React.ReactElement => {
     return <ServerItemRendererWithDebugUI item={itemWithInput} />;
+};
+
+export const InputNumberWithInteractionCallback = (
+    args: StoryArgs,
+): React.ReactElement => {
+    return (
+        <ServerItemRendererWithDebugUI
+            item={itemWithMultipleInputs}
+            apiOptions={{
+                interactionCallback: (data) => {
+                    console.log(data);
+                },
+            }}
+        />
+    );
 };
 
 export const LabelImageItem = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus/src/__stories__/server-item-renderer.stories.tsx
+++ b/packages/perseus/src/__stories__/server-item-renderer.stories.tsx
@@ -7,7 +7,7 @@ import {
     itemWithLintingError,
     labelImageItem,
     itemWithMultipleInputNumbers,
-    itemWithMultipleWidgetTypes,
+    itemWithRadioAndExpressionWidgets,
 } from "../__testdata__/server-item-renderer.testdata";
 import {ServerItemRenderer} from "../server-item-renderer";
 
@@ -67,7 +67,7 @@ export const MultiWidgetWithInteractionCallback = (
 ): React.ReactElement => {
     return (
         <ServerItemRendererWithDebugUI
-            item={itemWithMultipleWidgetTypes}
+            item={itemWithRadioAndExpressionWidgets}
             apiOptions={{
                 interactionCallback: (data) => {
                     // We are logging the interaction callback data to the console

--- a/packages/perseus/src/__stories__/server-item-renderer.stories.tsx
+++ b/packages/perseus/src/__stories__/server-item-renderer.stories.tsx
@@ -6,7 +6,8 @@ import {
     itemWithInput,
     itemWithLintingError,
     labelImageItem,
-    itemWithMultipleInputs,
+    itemWithMultipleInputNumbers,
+    itemWithMultipleWidgetTypes,
 } from "../__testdata__/server-item-renderer.testdata";
 import {ServerItemRenderer} from "../server-item-renderer";
 
@@ -24,21 +25,6 @@ export const InputNumberItem = (args: StoryArgs): React.ReactElement => {
     return <ServerItemRendererWithDebugUI item={itemWithInput} />;
 };
 
-export const InputNumberWithInteractionCallback = (
-    args: StoryArgs,
-): React.ReactElement => {
-    return (
-        <ServerItemRendererWithDebugUI
-            item={itemWithMultipleInputs}
-            apiOptions={{
-                interactionCallback: (data) => {
-                    console.log(data);
-                },
-            }}
-        />
-    );
-};
-
 export const LabelImageItem = (args: StoryArgs): React.ReactElement => {
     return <ServerItemRendererWithDebugUI item={labelImageItem} />;
 };
@@ -54,6 +40,40 @@ export const WithLintingError = (args: StoryArgs): React.ReactElement => {
                 highlightLint: true,
                 paths: [],
                 stack: [],
+            }}
+        />
+    );
+};
+
+export const InputNumberWithInteractionCallback = (
+    args: StoryArgs,
+): React.ReactElement => {
+    return (
+        <ServerItemRendererWithDebugUI
+            item={itemWithMultipleInputNumbers}
+            apiOptions={{
+                interactionCallback: (data) => {
+                    // We are logging the interaction callback data to the console
+                    // eslint-disable-next-line no-console
+                    console.log(data);
+                },
+            }}
+        />
+    );
+};
+
+export const MultiWidgetWithInteractionCallback = (
+    args: StoryArgs,
+): React.ReactElement => {
+    return (
+        <ServerItemRendererWithDebugUI
+            item={itemWithMultipleWidgetTypes}
+            apiOptions={{
+                interactionCallback: (data) => {
+                    // We are logging the interaction callback data to the console
+                    // eslint-disable-next-line no-console
+                    console.log(data);
+                },
             }}
         />
     );

--- a/packages/perseus/src/__testdata__/server-item-renderer.testdata.ts
+++ b/packages/perseus/src/__testdata__/server-item-renderer.testdata.ts
@@ -5,6 +5,8 @@ import {
     type PerseusItem,
     type PerseusRenderer,
     type PerseusAnswerArea,
+    type ExpressionWidget,
+    type RadioWidget,
 } from "../perseus-types";
 
 export const itemWithInput: PerseusItem = {
@@ -38,7 +40,7 @@ export const itemWithInput: PerseusItem = {
     answer: null,
 };
 
-export const itemWithMultipleInputs: PerseusItem = {
+export const itemWithMultipleInputNumbers: PerseusItem = {
     question: {
         content:
             "Enter the number $$1$$ in box one: [[\u2603 input-number 1]] \n\n Enter the number $$2$$ in box two: [[\u2603 input-number 2]]",
@@ -68,6 +70,94 @@ export const itemWithMultipleInputs: PerseusItem = {
                     maxError: 0.1,
                 },
             } as InputNumberWidget,
+        },
+    },
+    hints: [
+        {content: "Hint #1", images: {}, widgets: {}},
+        {content: "Hint #2", images: {}, widgets: {}},
+        {content: "Hint #3", images: {}, widgets: {}},
+    ],
+    answerArea: null,
+    _multi: null,
+    itemDataVersion: {major: 0, minor: 0},
+    answer: null,
+};
+
+export const itemWithMultipleWidgetTypes: PerseusItem = {
+    question: {
+        content:
+            "Here's a radio widget: [[\u2603 radio 1]] \n\n Here's an expression widget: [[\u2603 expression 1]]",
+        images: {},
+        widgets: {
+            "radio 1": {
+                graded: true,
+                version: {major: 0, minor: 0},
+                static: false,
+                numCorrect: 1,
+                hasNoneOfTheAbove: false,
+                multipleSelect: false,
+                countChoices: false,
+                deselectEnabled: false,
+                type: "radio",
+                options: {
+                    static: false,
+                    countChoices: false,
+                    deselectEnabled: false,
+                    displayCount: null,
+                    hasNoneOfTheAbove: false,
+                    multipleSelect: false,
+                    randomize: true,
+                    choices: [
+                        {
+                            content: "Content 1",
+                            correct: true,
+                        },
+                        {
+                            content: "Content 2",
+                            correct: false,
+                        },
+                        {
+                            content: "Content 3",
+                            correct: false,
+                        },
+                        {
+                            content: "Content 4",
+                            correct: false,
+                        },
+                    ],
+                },
+                alignment: "default",
+            } as RadioWidget,
+            "expression 1": {
+                type: "expression",
+                graded: true,
+                version: {
+                    major: 1,
+                    minor: 0,
+                },
+                static: false,
+                options: {
+                    answerForms: [
+                        {
+                            considered: "correct",
+                            form: true,
+                            simplify: false,
+                            value: "x^2",
+                        },
+                        {
+                            considered: "wrong",
+                            form: true,
+                            simplify: false,
+                            value: "x^3",
+                        },
+                    ],
+                    times: true,
+                    buttonSets: ["basic"],
+                    functions: ["f", "g", "h"],
+                    buttonsVisible: "always",
+                    alignment: "default",
+                },
+            } as ExpressionWidget,
         },
     },
     hints: [

--- a/packages/perseus/src/__testdata__/server-item-renderer.testdata.ts
+++ b/packages/perseus/src/__testdata__/server-item-renderer.testdata.ts
@@ -7,6 +7,7 @@ import {
     type PerseusAnswerArea,
     type ExpressionWidget,
     type RadioWidget,
+    type NumericInputWidget,
 } from "../perseus-types";
 
 export const itemWithInput: PerseusItem = {
@@ -83,7 +84,60 @@ export const itemWithMultipleInputNumbers: PerseusItem = {
     answer: null,
 };
 
-export const itemWithMultipleWidgetTypes: PerseusItem = {
+export const itemWithNumericAndNumberInputs: PerseusItem = {
+    question: {
+        content:
+            "Enter the number $$1$$ in box one: [[\u2603 input-number 1]] \n\n Enter the number $$2$$ in box two: [[\u2603 numeric-input 1]]",
+        images: {},
+        widgets: {
+            "input-number 1": {
+                type: "input-number",
+                graded: true,
+                options: {
+                    answerType: "number",
+                    value: "1",
+                    simplify: "required",
+                    size: "normal",
+                    inexact: false,
+                    maxError: 0.1,
+                },
+            } as InputNumberWidget,
+            "numeric-input 1": {
+                graded: true,
+                static: false,
+                type: "numeric-input",
+                options: {
+                    coefficient: false,
+                    static: false,
+                    answers: [
+                        {
+                            status: "correct",
+                            maxError: null,
+                            strict: false,
+                            value: 1252,
+                            simplify: "required",
+                            message: "",
+                        },
+                    ],
+                    labelText: "",
+                    size: "normal",
+                },
+                alignment: "default",
+            } as NumericInputWidget,
+        },
+    },
+    hints: [
+        {content: "Hint #1", images: {}, widgets: {}},
+        {content: "Hint #2", images: {}, widgets: {}},
+        {content: "Hint #3", images: {}, widgets: {}},
+    ],
+    answerArea: null,
+    _multi: null,
+    itemDataVersion: {major: 0, minor: 0},
+    answer: null,
+};
+
+export const itemWithRadioAndExpressionWidgets: PerseusItem = {
     question: {
         content:
             "Here's a radio widget: [[\u2603 radio 1]] \n\n Here's an expression widget: [[\u2603 expression 1]]",

--- a/packages/perseus/src/__testdata__/server-item-renderer.testdata.ts
+++ b/packages/perseus/src/__testdata__/server-item-renderer.testdata.ts
@@ -38,6 +38,49 @@ export const itemWithInput: PerseusItem = {
     answer: null,
 };
 
+export const itemWithMultipleInputs: PerseusItem = {
+    question: {
+        content:
+            "Enter the number $$1$$ in box one: [[\u2603 input-number 1]] \n\n Enter the number $$2$$ in box two: [[\u2603 input-number 2]]",
+        images: {},
+        widgets: {
+            "input-number 1": {
+                type: "input-number",
+                graded: true,
+                options: {
+                    answerType: "number",
+                    value: "1",
+                    simplify: "required",
+                    size: "normal",
+                    inexact: false,
+                    maxError: 0.1,
+                },
+            } as InputNumberWidget,
+            "input-number 2": {
+                type: "input-number",
+                graded: true,
+                options: {
+                    answerType: "number",
+                    value: "2",
+                    simplify: "required",
+                    size: "normal",
+                    inexact: false,
+                    maxError: 0.1,
+                },
+            } as InputNumberWidget,
+        },
+    },
+    hints: [
+        {content: "Hint #1", images: {}, widgets: {}},
+        {content: "Hint #2", images: {}, widgets: {}},
+        {content: "Hint #3", images: {}, widgets: {}},
+    ],
+    answerArea: null,
+    _multi: null,
+    itemDataVersion: {major: 0, minor: 0},
+    answer: null,
+};
+
 export const labelImageItem: PerseusItem = {
     answerArea: Object.fromEntries(
         ItemExtras.map((extra) => [extra, false]),

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -11,6 +11,7 @@ import {
 import {
     itemWithInput,
     itemWithLintingError,
+    itemWithMultipleInputs,
     mockedItem,
 } from "../__testdata__/server-item-renderer.testdata";
 import * as Dependencies from "../dependencies";
@@ -134,19 +135,24 @@ describe("server item renderer", () => {
         expect(score.empty).toBe(false);
     });
 
-    it("calls onInteraction callback", () => {
+    it("calls onInteraction callback with the current user data", () => {
         // Arrange
         const interactionCallback = jest.fn();
-        renderQuestion(itemWithInput, {
+        renderQuestion(itemWithMultipleInputs, {
             interactionCallback,
         });
 
         // Act
-        userEvent.type(screen.getByRole("textbox"), "-42");
+        const inputs = screen.getAllByRole("textbox");
+        userEvent.type(inputs[0], "1");
+        userEvent.type(inputs[1], "2");
         jest.runOnlyPendingTimers(); // Renderer uses setTimeout setting widget props
 
         // Assert
-        expect(interactionCallback).toHaveBeenCalled();
+        expect(interactionCallback).toHaveBeenCalledWith({
+            "input-number 1": {currentValue: "1"},
+            "input-number 2": {currentValue: "2"},
+        });
     });
 
     it("should set the input value for a widget", () => {

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -11,7 +11,7 @@ import {
 import {
     itemWithInput,
     itemWithLintingError,
-    itemWithMultipleInputNumbers,
+    itemWithNumericAndNumberInputs,
     mockedItem,
 } from "../__testdata__/server-item-renderer.testdata";
 import * as Dependencies from "../dependencies";
@@ -138,7 +138,7 @@ describe("server item renderer", () => {
     it("calls onInteraction callback with the current user data", () => {
         // Arrange
         const interactionCallback = jest.fn();
-        renderQuestion(itemWithMultipleInputNumbers, {
+        renderQuestion(itemWithNumericAndNumberInputs, {
             interactionCallback,
         });
 
@@ -151,7 +151,7 @@ describe("server item renderer", () => {
         // Assert
         expect(interactionCallback).toHaveBeenCalledWith({
             "input-number 1": {currentValue: "1"},
-            "input-number 2": {currentValue: "2"},
+            "numeric-input 1": {currentValue: "2"},
         });
     });
 

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -11,7 +11,7 @@ import {
 import {
     itemWithInput,
     itemWithLintingError,
-    itemWithMultipleInputs,
+    itemWithMultipleInputNumbers,
     mockedItem,
 } from "../__testdata__/server-item-renderer.testdata";
 import * as Dependencies from "../dependencies";
@@ -138,7 +138,7 @@ describe("server item renderer", () => {
     it("calls onInteraction callback with the current user data", () => {
         // Arrange
         const interactionCallback = jest.fn();
-        renderQuestion(itemWithMultipleInputs, {
+        renderQuestion(itemWithMultipleInputNumbers, {
             interactionCallback,
         });
 

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -149,6 +149,11 @@ export class ServerItemRenderer
     ) => {
         if (newFocus != null) {
             this._setCurrentFocus(newFocus);
+
+            // Call the interactionCallback, if it exists, with the current user input data
+            this.props.apiOptions?.interactionCallback?.(
+                this.questionRenderer.getUserInputForWidgets(),
+            );
         } else {
             this._onRendererBlur(oldFocus);
         }
@@ -278,9 +283,10 @@ export class ServerItemRenderer
             questionHighlightedWidgets: withRemoved,
         });
 
-        if (this.props.apiOptions.interactionCallback) {
-            this.props.apiOptions.interactionCallback();
-        }
+        // Call the interactionCallback, if it exists, with the current user input data
+        this.props.apiOptions?.interactionCallback?.(
+            this.questionRenderer.getUserInputForWidgets(),
+        );
     };
 
     focus(): boolean | null | undefined {

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -147,7 +147,7 @@ export type APIOptions = Readonly<{
     readOnly?: boolean;
     answerableCallback?: (arg1: boolean) => unknown;
     getAnotherHint?: () => unknown;
-    interactionCallback?: () => unknown;
+    interactionCallback?: (widgetData: {[widgetId: string]: any}) => void;
     // A function that takes in the relative problem number (starts at
     // 0 and is incremented for each group widget), and the ID of the
     // group widget, then returns a react component that will be added

--- a/packages/perseus/src/widgets/__stories__/expression.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/expression.stories.tsx
@@ -48,6 +48,9 @@ const WrappedKeypadContext = ({
                                 isMobile: isMobile,
                                 customKeypad: customKeypad,
                                 onFocusChange: action("onFocusChange"),
+                                interactionCallback: (response) => {
+                                    console.log(response);
+                                },
                             }}
                         />
                     );

--- a/packages/perseus/src/widgets/__stories__/expression.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/expression.stories.tsx
@@ -48,9 +48,6 @@ const WrappedKeypadContext = ({
                                 isMobile: isMobile,
                                 customKeypad: customKeypad,
                                 onFocusChange: action("onFocusChange"),
-                                interactionCallback: (response) => {
-                                    console.log(response);
-                                },
                             }}
                         />
                     );

--- a/packages/perseus/src/widgets/__tests__/input-number.test.ts
+++ b/packages/perseus/src/widgets/__tests__/input-number.test.ts
@@ -337,18 +337,4 @@ describe("focus state", () => {
         // Assert
         expect(gotFocus).toBeTrue();
     });
-
-    it("calls the interaction callback on focus", () => {
-        const testCallback = jest.fn();
-
-        const {renderer} = renderQuestion(question, {
-            interactionCallback: testCallback,
-        });
-
-        // Act
-        renderer.focus();
-
-        // Assert
-        expect(testCallback).toHaveBeenCalled();
-    });
 });

--- a/packages/perseus/src/widgets/__tests__/numeric-input.test.ts
+++ b/packages/perseus/src/widgets/__tests__/numeric-input.test.ts
@@ -485,20 +485,6 @@ describe("Numeric input widget", () => {
         );
     });
 
-    it("calls the interaction callback on focus", () => {
-        const testCallback = jest.fn();
-
-        const {renderer} = renderQuestion(question1, {
-            interactionCallback: testCallback,
-        });
-
-        // Act
-        renderer.focus();
-
-        // Assert
-        expect(testCallback).toHaveBeenCalled();
-    });
-
     it("can be blurred", () => {
         const {renderer} = renderQuestion(question1);
 

--- a/packages/perseus/src/widgets/input-number.tsx
+++ b/packages/perseus/src/widgets/input-number.tsx
@@ -202,13 +202,6 @@ class InputNumber extends React.Component<Props> {
 
     _handleFocus: () => void = () => {
         this.props.onFocus([]);
-        // HACK(kevinb): We want to dismiss the feedback popover that webapp
-        // displays as soon as a user clicks in in the input field so we call
-        // interactionCallback directly.
-        const {interactionCallback} = this.props.apiOptions;
-        if (interactionCallback) {
-            interactionCallback();
-        }
     };
 
     _handleBlur: () => void = () => {

--- a/packages/perseus/src/widgets/numeric-input.tsx
+++ b/packages/perseus/src/widgets/numeric-input.tsx
@@ -376,13 +376,6 @@ export class NumericInput extends React.Component<Props, State> {
 
     _handleFocus: () => void = () => {
         this.props.onFocus([]);
-        // HACK(kevinb): We want to dismiss the feedback popover that webapp
-        // displays as soon as a user clicks in in the input field so we call
-        // interactionCallback directly.
-        const {interactionCallback} = this.props.apiOptions;
-        if (interactionCallback) {
-            interactionCallback();
-        }
     };
 
     _handleBlur: () => void = () => {


### PR DESCRIPTION
## Summary:
As part of our Khanmigo project, we want to be able to know what's currently been input into the widgets in our exercises. 

After some investigation, it was discovered that we already have a `interactionCallback` in our `apiOptions` that was being used to close a feedback popover in our numeric inputs. This PR updates that callback to now return the current user input data so that it can be utilized by Khanmigo to provide proactive hints and supportive content. 

Issue: LC-1754

## Test plan:
- New Stories to manually test with 
- Updated server renderer test 