### PR TITLE
Fix imports not working in Vite dev UI

### DIFF
--- a/dev/vite.config.ts
+++ b/dev/vite.config.ts
@@ -3,11 +3,13 @@ import fs from "node:fs";
 import {defineConfig} from "vite";
 import glob from "fast-glob";
 
-const aliases = {};
+// Create aliases for each package in the Perseus monorepo, so Vite knows
+// where to look when a file imports e.g. @khanacademy/perseus.
+const packageAliases = {};
 glob.sync(resolve("../packages/*/package.json")).forEach(
     (packageJsonPath) => {
         const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
-        aliases[pkg.name] = join(
+        packageAliases[pkg.name] = join(
             dirname(packageJsonPath),
             pkg.source,
         );
@@ -19,7 +21,7 @@ export default defineConfig({
         alias: {
             hubble: resolve("../vendor/hubble/hubble.js"),
             raphael: resolve("../vendor/raphael/raphael.js"),
-            ...aliases,
+            ...packageAliases,
         },
     },
     css: {

--- a/dev/vite.config.ts
+++ b/dev/vite.config.ts
@@ -1,12 +1,25 @@
-import {resolve} from "node:path";
-
+import {resolve, dirname, join} from "node:path";
+import fs from "node:fs";
 import {defineConfig} from "vite";
+import glob from "fast-glob";
+
+const aliases = {};
+glob.sync(resolve("../packages/*/package.json")).forEach(
+    (packageJsonPath) => {
+        const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+        aliases[pkg.name] = join(
+            dirname(packageJsonPath),
+            pkg.source,
+        );
+    },
+);
 
 export default defineConfig({
     resolve: {
         alias: {
             hubble: resolve("../vendor/hubble/hubble.js"),
             raphael: resolve("../vendor/raphael/raphael.js"),
+            ...aliases,
         },
     },
     css: {

--- a/dev/vite.config.ts
+++ b/dev/vite.config.ts
@@ -1,20 +1,16 @@
-import {resolve, dirname, join} from "node:path";
 import fs from "node:fs";
-import {defineConfig} from "vite";
+import {resolve, dirname, join} from "node:path";
+
 import glob from "fast-glob";
+import {defineConfig} from "vite";
 
 // Create aliases for each package in the Perseus monorepo, so Vite knows
 // where to look when a file imports e.g. @khanacademy/perseus.
 const packageAliases = {};
-glob.sync(resolve("../packages/*/package.json")).forEach(
-    (packageJsonPath) => {
-        const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
-        packageAliases[pkg.name] = join(
-            dirname(packageJsonPath),
-            pkg.source,
-        );
-    },
-);
+glob.sync(resolve("../packages/*/package.json")).forEach((packageJsonPath) => {
+    const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+    packageAliases[pkg.name] = join(dirname(packageJsonPath), pkg.source);
+});
 
 export default defineConfig({
     resolve: {


### PR DESCRIPTION
## Summary:

The dev UI was broken for fresh clones of the Perseus repo. Vite spewed
tons of errors that looked like:

```
[ERROR] Failed to resolve entry for package "@khanacademy/simple-markdown". The package may have incorrect main/module/exports specified in its package.json. [plugin vite:dep-scan]
```

I don't know why I'm not seeing this error in my local copy of the repo.
Removing the `node_modules/.vite` cache and `yarn install --force` was
not sufficient to repro. I can only repro on a fresh clone.

The fix involves creating aliases for all packages in the Perseus
monorepo so Vite knows where to find them. I took a similar approach to
the one used in `.storybook/main.ts`.

Issue: none

Test plan:

```
cd /tmp
git clone git@github.com:khan/perseus.git
cd perseus
yarn install
yarn dev
open http://localhost:5173
```

You should see a webpage with many interactive graphs.