### PR TITLE
Parse markdown list when rendering in JIPT context

### DIFF
--- a/.changeset/blue-actors-pull.md
+++ b/.changeset/blue-actors-pull.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/pure-markdown": minor
+---
+
+Revert disabling markdown parser list rule in JIPT context

--- a/packages/perseus/src/__tests__/perseus-markdown.test.ts
+++ b/packages/perseus/src/__tests__/perseus-markdown.test.ts
@@ -453,69 +453,6 @@ describe("perseus markdown", () => {
 
         it.each([
             {
-                content: "1. test\n\n" + "2. boo\n\n",
-                expected: [
-                    {
-                        type: "paragraph",
-                        content: [
-                            {
-                                type: "text",
-                                content: "1",
-                            },
-                            {
-                                type: "text",
-                                content: ". test",
-                            },
-                        ],
-                    },
-                    {
-                        type: "paragraph",
-                        content: [
-                            {
-                                type: "text",
-                                content: "2",
-                            },
-                            {
-                                type: "text",
-                                content: ". boo",
-                            },
-                        ],
-                    },
-                ],
-            },
-            {
-                content: "* test\n\n" + "* boo\n\n",
-                expected: [
-                    {
-                        type: "paragraph",
-                        content: [
-                            {
-                                type: "text",
-                                content: "* test",
-                            },
-                        ],
-                    },
-                    {
-                        type: "paragraph",
-                        content: [
-                            {
-                                type: "text",
-                                content: "* boo",
-                            },
-                        ],
-                    },
-                ],
-            },
-        ])("should ignore lists in jipt mode", ({content, expected}) => {
-            // Arrange, Act
-            const parsed = parse(content, {isJipt: true});
-
-            // Assert
-            expect(parsed).toEqual(expected);
-        });
-
-        it.each([
-            {
                 content: "$",
                 expected: [
                     {

--- a/packages/pure-markdown/src/__tests__/index.test.ts
+++ b/packages/pure-markdown/src/__tests__/index.test.ts
@@ -441,69 +441,6 @@ describe("pure markdown", () => {
 
         it.each([
             {
-                content: "1. test\n\n" + "2. boo\n\n",
-                expected: [
-                    {
-                        type: "paragraph",
-                        content: [
-                            {
-                                type: "text",
-                                content: "1",
-                            },
-                            {
-                                type: "text",
-                                content: ". test",
-                            },
-                        ],
-                    },
-                    {
-                        type: "paragraph",
-                        content: [
-                            {
-                                type: "text",
-                                content: "2",
-                            },
-                            {
-                                type: "text",
-                                content: ". boo",
-                            },
-                        ],
-                    },
-                ],
-            },
-            {
-                content: "* test\n\n" + "* boo\n\n",
-                expected: [
-                    {
-                        type: "paragraph",
-                        content: [
-                            {
-                                type: "text",
-                                content: "* test",
-                            },
-                        ],
-                    },
-                    {
-                        type: "paragraph",
-                        content: [
-                            {
-                                type: "text",
-                                content: "* boo",
-                            },
-                        ],
-                    },
-                ],
-            },
-        ])("should ignore lists in jipt mode", ({content, expected}) => {
-            // Arrange, Act
-            const parsed = parse(content, {isJipt: true});
-
-            // Assert
-            expect(parsed).toEqual(expected);
-        });
-
-        it.each([
-            {
                 content: "$",
                 expected: [
                     {

--- a/packages/pure-markdown/src/index.ts
+++ b/packages/pure-markdown/src/index.ts
@@ -279,22 +279,6 @@ export const pureMarkdownRules = {
             /^ *>[^\n]+(\n( *>)?[^\n]+)*\n{2,}/,
         ) as any,
     },
-    list: {
-        ...SimpleMarkdown.defaultRules.list,
-        match: (source: any, state: any, prevCapture: any): any => {
-            // Since lists can contain double newlines and we have special
-            // handling of double newlines while parsing jipt content, just
-            // disable the list parser.
-            if (state.isJipt) {
-                return null;
-            }
-            return SimpleMarkdown.defaultRules.list.match(
-                source,
-                state,
-                prevCapture,
-            );
-        },
-    },
     // The lint rule never actually matches anything.
     // We check for lint after parsing, and, if we find any, we
     // transform the tree to add lint nodes. This rule is here


### PR DESCRIPTION
## Summary:
It was noticed that we're not properly previewing lists in the Translation Editor.
Leading to confusion for our translators as to how correctly translate the markdown.

![article_list_before](https://github.com/Khan/perseus/assets/4722598/f6da5dde-4a00-45cc-b7f1-76b6a2936cb8)

The preview is even more confusing when lists are nested.

![exercise_nested_lists_before](https://github.com/Khan/perseus/assets/4722598/b4229d14-f708-43b9-a07b-90edf742946c)

After investigating the code in both webapp and perseus repos, I found this commit from 2016: https://github.com/Khan/webapp/commit/0708615029644f6eb7d29a3d4c361344b281d577

Reverting it appears to resolve the preview issue when rendering in JIPT context.

![article_list_after](https://github.com/Khan/perseus/assets/4722598/c4a948d3-d751-4fa1-ab48-80f00556cd23)

![exercise_nested_lists_after](https://github.com/Khan/perseus/assets/4722598/22210d04-e729-4ddb-9642-780c39b36b49)

The original commit summary reads:

> When translating perseus articles, we split up the text of the article
into paragraphs by splitting at double-newlines.

Yes indeed, we do this in two places:

- In [webapp](https://github.com/Khan/webapp/blob/c7fd0d7893c05e3a04d96b1154ac586e6e43d25d/services/static/javascript/manticore-package/manticore-utils.ts#L514) we split the `crwdns...:0...crwdne...:0` strings that are used in the initial preview rendering.
- Then in [perseus](https://github.com/Khan/perseus/blob/ede8afab152a0d9c285ac7512ffefa926732c2e1/packages/perseus/src/renderer.tsx#L987) we split again, this time the translated strings that are replaced in the DOM by Crowdin's [jipt.js](https://github.com/Khan/webapp/blob/c7fd0d7893c05e3a04d96b1154ac586e6e43d25d/services/static/third_party/jipt/jipt.js) integration.

So far so good. The summary continues:

> However, lists can also have double newlines in them, which can cause problems. This change just disables
the parsing of lists while doing jipt stuff.

This is where I have been racking my brain to find an example of such a case
in our translation database.

Since this "disabling" via `isJipt` state passed into `PerseusMarkdown.parse[Inline]`
only applies when rendering in JIPT context, I searched the database for any Crowdin
`crwdns...:0...crwdne...:0` strings that contain double-newlines - I was not able to find any.

Under normal rendering Perseus handles markdown lists as-is just fine, this
implies that the original issue must have applied to just these Crowdin strings,
breaking the `jipt.js` integration in some way, preventing it from replacing with translations in the DOM?

In this "fix" I chose to revert this "disabling" as I cannot find any _current_
Crowdin strings that might be affected. I'm inclined to deploy this and wait for
reports from our translators of preview regressions. I'm guessing that if this
breaks something obvious, it would be noticed right away.

In such a case a more involved fix might be to "enable" the list parsing rule
_after_ `replaceJiptContent` has been called to replace the initial-render Crowdin
string. This might require adding an additional state, as `isJipt` controls another
[crowdinId](https://github.com/Khan/perseus/blob/ede8afab152a0d9c285ac7512ffefa926732c2e1/packages/pure-markdown/src/index.ts#L148) rule in the markdown parser.

Issue: https://khanacademy.atlassian.net/browse/CP-7983

Test Plan:
 - Pull this change into webapp
 - Open Article Translator and verify strings with markdown list formatted correctly
  - `/devadmin/translations/edit/es/Article/xa0ed5200/preview`
 - Open Exercise Translator and verify strings with markdown list formatted correctly
  - `/devadmin/translations/edit/es/Exercise/xc13c1f966be9a7a6/by-order`
 - Open WYWIWYG and verify strings with markdown list are formatted correctly
  - `/science/biology/classical-genetics/variations-on-mendelian-genetics/a/multiple-alleles-incomplete-dominance-and-codominance?lang=en-pt`