### PR TITLE
[Bug Fixes] Numerous issues with the Number-line widget

### DIFF
--- a/.changeset/old-humans-confess.md
+++ b/.changeset/old-humans-confess.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/math-input": minor
+"@khanacademy/perseus": minor
+---
+
+Bug fixes to ensure that users can properly interact with the numberline widget

--- a/packages/math-input/src/components/__tests__/integration.test.tsx
+++ b/packages/math-input/src/components/__tests__/integration.test.tsx
@@ -115,6 +115,22 @@ describe("math input integration", () => {
         expect(screen.getByRole("button", {name: "1"})).toBeVisible();
     });
 
+    it("shows the keypad after input is focused via tab", async () => {
+        render(<ConnectedMathInput />);
+
+        const input = screen.getByLabelText(
+            "Math input box Tap with one or two fingers to open keyboard",
+        );
+
+        userEvent.tab();
+
+        await waitFor(() => {
+            expect(screen.getByRole("button", {name: "4"})).toBeVisible();
+        });
+
+        expect(screen.getByRole("button", {name: "1"})).toBeVisible();
+    });
+
     it("shows the keypad after input click-interaction", async () => {
         render(<ConnectedMathInput />);
 

--- a/packages/math-input/src/components/__tests__/integration.test.tsx
+++ b/packages/math-input/src/components/__tests__/integration.test.tsx
@@ -116,14 +116,17 @@ describe("math input integration", () => {
     });
 
     it("shows the keypad after input is focused via tab", async () => {
+        // Arrange
         render(<ConnectedMathInput />);
 
-        const input = screen.getByLabelText(
+        screen.getByLabelText(
             "Math input box Tap with one or two fingers to open keyboard",
         );
 
+        // Act
         userEvent.tab();
 
+        // Assert
         await waitFor(() => {
             expect(screen.getByRole("button", {name: "4"})).toBeVisible();
         });

--- a/packages/math-input/src/components/__tests__/integration.test.tsx
+++ b/packages/math-input/src/components/__tests__/integration.test.tsx
@@ -115,25 +115,6 @@ describe("math input integration", () => {
         expect(screen.getByRole("button", {name: "1"})).toBeVisible();
     });
 
-    it("shows the keypad after input is focused via tab", async () => {
-        // Arrange
-        render(<ConnectedMathInput />);
-
-        screen.getByLabelText(
-            "Math input box Tap with one or two fingers to open keyboard",
-        );
-
-        // Act
-        userEvent.tab();
-
-        // Assert
-        await waitFor(() => {
-            expect(screen.getByRole("button", {name: "4"})).toBeVisible();
-        });
-
-        expect(screen.getByRole("button", {name: "1"})).toBeVisible();
-    });
-
     it("shows the keypad after input click-interaction", async () => {
         render(<ConnectedMathInput />);
 

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -330,7 +330,7 @@ class MathInput extends React.Component<Props, State> {
         }
     };
 
-    blur: (e?: React.SyntheticEvent) => void = (e) => {
+    blur: () => void = () => {
         this.mathField.blur();
 
         this.setState((prevState) => {

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -46,7 +46,6 @@ type HandleState = {
 type State = {
     focused: boolean;
     handle: HandleState;
-    showFocusStyle: boolean;
 };
 
 // eslint-disable-next-line react/no-unsafe
@@ -77,7 +76,6 @@ class MathInput extends React.Component<Props, State> {
 
     state: State = {
         focused: false,
-        showFocusStyle: false,
         handle: {
             animateIntoPosition: false,
             visible: false,
@@ -363,7 +361,7 @@ class MathInput extends React.Component<Props, State> {
         this.mathField.focus();
         this.props?.onFocus();
 
-        this.setState({focused: true, showFocusStyle: true}, () => {
+        this.setState({focused: true}, () => {
             // NOTE(charlie): We use `setTimeout` to allow for a layout pass to
             // occur. Otherwise, the keypad is measured incorrectly. Ideally,
             // we'd use requestAnimationFrame here, but it's unsupported on
@@ -919,13 +917,13 @@ class MathInput extends React.Component<Props, State> {
     };
 
     render(): React.ReactNode {
-        const {showFocusStyle, handle} = this.state;
+        const {focused, handle} = this.state;
         const {style} = this.props;
 
         const innerStyle = {
             ...inlineStyles.innerContainer,
             borderWidth: this.getBorderWidthPx(),
-            ...(showFocusStyle
+            ...(focused
                 ? {
                       borderColor: Color.blue,
                   }
@@ -987,7 +985,7 @@ class MathInput extends React.Component<Props, State> {
                                 style={innerStyle}
                             />
                         </div>
-                        {showFocusStyle && handle.visible && (
+                        {focused && handle.visible && (
                             <CursorHandle
                                 {...handle}
                                 onTouchStart={this.onCursorHandleTouchStart}

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -625,9 +625,9 @@ class MathInput extends React.Component<Props, State> {
             this.focus();
         }
 
-        // If the user clicked on the input using a mouse, we want to
-        // set the focus to the inputRef so that the keyUp event will
-        // be triggered when the user types on the keyboard.
+        // If the user clicked on the input using a mouse or tap gesture,
+        // we want to set the focus to the inputRef so that the keyUp
+        // event will be triggered when the user types on the keyboard.
         // This is necessary to support Chromebooks as they use mobile user
         // agents, do not simulate touch events, and have physical keyboards.
         this.inputRef?.focus();
@@ -667,9 +667,9 @@ class MathInput extends React.Component<Props, State> {
             this.focus();
         }
 
-        // If the user clicked on the input using a mouse, we want to
-        // set the focus to the inputRef so that the keyUp event will
-        // be triggered when the user types on the keyboard.
+        // If the user clicked on the input using a mouse or tap gesture,
+        // we want to set the focus to the inputRef so that the keyUp
+        // event will be triggered when the user types on the keyboard.
         // This is necessary to support Chromebooks as they use mobile user
         // agents, do not simulate touch events, and have physical keyboards.
         this.inputRef?.focus();

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -46,6 +46,7 @@ type HandleState = {
 type State = {
     focused: boolean;
     handle: HandleState;
+    showFocusStyle: boolean;
 };
 
 // eslint-disable-next-line react/no-unsafe
@@ -76,6 +77,7 @@ class MathInput extends React.Component<Props, State> {
 
     state: State = {
         focused: false,
+        showFocusStyle: false,
         handle: {
             animateIntoPosition: false,
             visible: false,
@@ -330,7 +332,16 @@ class MathInput extends React.Component<Props, State> {
 
     blur: (e?: React.SyntheticEvent) => void = (e) => {
         this.mathField.blur();
-        this.setState({focused: false, handle: {visible: false}});
+
+        this.setState((prevState) => {
+            return {
+                showFocusStyle: false,
+                handle: {
+                    visible: false,
+                },
+                focused: prevState.focused,
+            };
+        });
     };
 
     focus: (setKeypadActive: (keypadActive: boolean) => void) => void = (
@@ -367,7 +378,7 @@ class MathInput extends React.Component<Props, State> {
         this.props?.onFocus();
         setKeypadActive(true);
 
-        this.setState({focused: true}, () => {
+        this.setState({focused: true, showFocusStyle: true}, () => {
             // NOTE(charlie): We use `setTimeout` to allow for a layout pass to
             // occur. Otherwise, the keypad is measured incorrectly. Ideally,
             // we'd use requestAnimationFrame here, but it's unsupported on
@@ -923,13 +934,13 @@ class MathInput extends React.Component<Props, State> {
     };
 
     render(): React.ReactNode {
-        const {focused, handle} = this.state;
+        const {showFocusStyle, handle} = this.state;
         const {style} = this.props;
 
         const innerStyle = {
             ...inlineStyles.innerContainer,
             borderWidth: this.getBorderWidthPx(),
-            ...(focused
+            ...(showFocusStyle
                 ? {
                       borderColor: Color.blue,
                   }
@@ -995,7 +1006,7 @@ class MathInput extends React.Component<Props, State> {
                                 style={innerStyle}
                             />
                         </div>
-                        {focused && handle.visible && (
+                        {showFocusStyle && handle.visible && (
                             <CursorHandle
                                 {...handle}
                                 onTouchStart={this.onCursorHandleTouchStart}

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -857,7 +857,7 @@ class MathInput extends React.Component<Props, State> {
             const value = this.mathField.getContent();
             if (this.props.value !== value) {
                 this.mathField.setContent(this.props.value);
-                this.props.onChange(value, false);
+                this.props.onChange(value, () => {});
                 this._hideCursorHandle();
             }
         }

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -182,6 +182,8 @@ class MathInput extends React.Component<Props, State> {
             // multi-touch.
             if (this.state.focused && this.didTouchOutside && !this.didScroll) {
                 this.blur();
+                this.mathField.blur();
+                this.props.onBlur && this.props.onBlur();
             }
 
             this.didTouchOutside = false;
@@ -211,6 +213,7 @@ class MathInput extends React.Component<Props, State> {
                         // in which case we don't want to dismiss the keypad on check.
                         if (!isWithinKeypadBounds(x, y)) {
                             this.blur();
+                            this.props.onBlur && this.props.onBlur();
                         }
                     }
                 }
@@ -325,13 +328,14 @@ class MathInput extends React.Component<Props, State> {
         }
     };
 
-    blur: () => void = () => {
+    blur: (e?: React.SyntheticEvent) => void = (e) => {
         this.mathField.blur();
-        this.props.onBlur && this.props.onBlur();
         this.setState({focused: false, handle: {visible: false}});
     };
 
-    focus: () => void = () => {
+    focus: (setKeypadActive: (keypadActive: boolean) => void) => void = (
+        setKeypadActive,
+    ) => {
         // Pass this component's handleKey method to the keypad so it can call
         // it whenever it needs to trigger a keypress action.
         this.props.keypadElement?.setKeyHandler((key) => {
@@ -359,7 +363,9 @@ class MathInput extends React.Component<Props, State> {
         });
 
         this.mathField.focus();
+
         this.props?.onFocus();
+        setKeypadActive(true);
 
         this.setState({focused: true}, () => {
             // NOTE(charlie): We use `setTimeout` to allow for a layout pass to
@@ -622,7 +628,7 @@ class MathInput extends React.Component<Props, State> {
 
         // Trigger a focus event, if we're not already focused.
         if (!this.state.focused) {
-            this.focus();
+            this.focus(setKeypadActive);
         }
 
         // If the user clicked on the input using a mouse or tap gesture,
@@ -664,7 +670,7 @@ class MathInput extends React.Component<Props, State> {
 
         // Trigger a focus event, if we're not already focused.
         if (!this.state.focused) {
-            this.focus();
+            this.focus(setKeypadActive);
         }
 
         // If the user clicked on the input using a mouse or tap gesture,
@@ -972,6 +978,10 @@ class MathInput extends React.Component<Props, State> {
                             ref={(node) => {
                                 this.inputRef = node;
                             }}
+                            onFocus={() => {
+                                this.focus(setKeypadActive);
+                            }}
+                            onBlur={this.blur}
                             onKeyUp={this.handleKeyUp}
                         >
                             {/* NOTE(charlie): This element must be styled with inline

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -360,6 +360,7 @@ class MathInput extends React.Component<Props, State> {
 
         this.mathField.focus();
         this.props?.onFocus();
+
         this.setState({focused: true}, () => {
             // NOTE(charlie): We use `setTimeout` to allow for a layout pass to
             // occur. Otherwise, the keypad is measured incorrectly. Ideally,
@@ -623,6 +624,13 @@ class MathInput extends React.Component<Props, State> {
         if (!this.state.focused) {
             this.focus();
         }
+
+        // If the user clicked on the input using a mouse, we want to
+        // set the focus to the inputRef so that the keyUp event will
+        // be triggered when the user types on the keyboard.
+        // This is necessary to support Chromebooks as they use mobile user
+        // agents, do not simulate touch events, and have physical keyboards.
+        this.inputRef?.focus();
     };
 
     // We want to allow the user to be able to focus the input via click
@@ -658,6 +666,13 @@ class MathInput extends React.Component<Props, State> {
         if (!this.state.focused) {
             this.focus();
         }
+
+        // If the user clicked on the input using a mouse, we want to
+        // set the focus to the inputRef so that the keyUp event will
+        // be triggered when the user types on the keyboard.
+        // This is necessary to support Chromebooks as they use mobile user
+        // agents, do not simulate touch events, and have physical keyboards.
+        this.inputRef?.focus();
     };
 
     handleTouchMove: (arg1: React.TouchEvent<HTMLDivElement>) => void = (e) => {

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -184,8 +184,6 @@ class MathInput extends React.Component<Props, State> {
             // multi-touch.
             if (this.state.focused && this.didTouchOutside && !this.didScroll) {
                 this.blur();
-                this.mathField.blur();
-                this.props.onBlur && this.props.onBlur();
             }
 
             this.didTouchOutside = false;
@@ -215,7 +213,6 @@ class MathInput extends React.Component<Props, State> {
                         // in which case we don't want to dismiss the keypad on check.
                         if (!isWithinKeypadBounds(x, y)) {
                             this.blur();
-                            this.props.onBlur && this.props.onBlur();
                         }
                     }
                 }
@@ -332,21 +329,11 @@ class MathInput extends React.Component<Props, State> {
 
     blur: () => void = () => {
         this.mathField.blur();
-
-        this.setState((prevState) => {
-            return {
-                showFocusStyle: false,
-                handle: {
-                    visible: false,
-                },
-                focused: prevState.focused,
-            };
-        });
+        this.props.onBlur && this.props.onBlur();
+        this.setState({focused: false, handle: {visible: false}});
     };
 
-    focus: (setKeypadActive: (keypadActive: boolean) => void) => void = (
-        setKeypadActive,
-    ) => {
+    focus: () => void = () => {
         // Pass this component's handleKey method to the keypad so it can call
         // it whenever it needs to trigger a keypress action.
         this.props.keypadElement?.setKeyHandler((key) => {
@@ -374,9 +361,7 @@ class MathInput extends React.Component<Props, State> {
         });
 
         this.mathField.focus();
-
         this.props?.onFocus();
-        setKeypadActive(true);
 
         this.setState({focused: true, showFocusStyle: true}, () => {
             // NOTE(charlie): We use `setTimeout` to allow for a layout pass to
@@ -639,7 +624,7 @@ class MathInput extends React.Component<Props, State> {
 
         // Trigger a focus event, if we're not already focused.
         if (!this.state.focused) {
-            this.focus(setKeypadActive);
+            this.focus();
         }
 
         // If the user clicked on the input using a mouse or tap gesture,
@@ -681,7 +666,7 @@ class MathInput extends React.Component<Props, State> {
 
         // Trigger a focus event, if we're not already focused.
         if (!this.state.focused) {
-            this.focus(setKeypadActive);
+            this.focus();
         }
 
         // If the user clicked on the input using a mouse or tap gesture,
@@ -989,10 +974,6 @@ class MathInput extends React.Component<Props, State> {
                             ref={(node) => {
                                 this.inputRef = node;
                             }}
-                            onFocus={() => {
-                                this.focus(setKeypadActive);
-                            }}
-                            onBlur={this.blur}
                             onKeyUp={this.handleKeyUp}
                         >
                             {/* NOTE(charlie): This element must be styled with inline

--- a/packages/perseus/src/widgets/__stories__/number-line.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/number-line.stories.tsx
@@ -1,7 +1,13 @@
+import {KeypadContext, MobileKeypad} from "@khanacademy/math-input";
 import * as React from "react";
 
 import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui";
-import {question1} from "../__testdata__/number-line.testdata";
+import {ServerItemRendererWithDebugUI} from "../../../../../testing/server-item-renderer-with-debug-ui";
+import {question1, question2} from "../__testdata__/number-line.testdata";
+
+import TestKeypadContextWrapper from "./test-keypad-context-wrapper";
+
+import type {PerseusAnswerArea, PerseusItem} from "../../perseus-types";
 
 export default {
     title: "Perseus/Widgets/Number Line",
@@ -11,4 +17,43 @@ type StoryArgs = Record<any, any>;
 
 export const Question1 = (args: StoryArgs): React.ReactElement => {
     return <RendererWithDebugUI question={question1} />;
+};
+
+export const ShowTickController = (args: StoryArgs): React.ReactElement => {
+    return <RendererWithDebugUI question={question2} />;
+};
+
+export const ShowTickControllerMobile = (
+    args: StoryArgs,
+): React.ReactElement => {
+    return (
+        <TestKeypadContextWrapper>
+            <KeypadContext.Consumer>
+                {({keypadElement}) => {
+                    return (
+                        <ServerItemRendererWithDebugUI
+                            item={
+                                {
+                                    question: question2,
+                                    _multi: null,
+                                    answer: null,
+                                    answerArea: null,
+                                    itemDataVersion: {
+                                        major: 0,
+                                        minor: 1,
+                                    },
+                                    hints: [],
+                                } as PerseusItem
+                            }
+                            apiOptions={{
+                                isMobile: true,
+                                customKeypad: true,
+                            }}
+                            keypadElement={keypadElement}
+                        />
+                    );
+                }}
+            </KeypadContext.Consumer>
+        </TestKeypadContextWrapper>
+    );
 };

--- a/packages/perseus/src/widgets/__stories__/number-line.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/number-line.stories.tsx
@@ -1,4 +1,4 @@
-import {KeypadContext, MobileKeypad} from "@khanacademy/math-input";
+import {KeypadContext} from "@khanacademy/math-input";
 import * as React from "react";
 
 import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui";
@@ -7,7 +7,7 @@ import {question1, question2} from "../__testdata__/number-line.testdata";
 
 import TestKeypadContextWrapper from "./test-keypad-context-wrapper";
 
-import type {PerseusAnswerArea, PerseusItem} from "../../perseus-types";
+import type {PerseusItem} from "../../perseus-types";
 
 export default {
     title: "Perseus/Widgets/Number Line",

--- a/packages/perseus/src/widgets/__testdata__/number-line.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/number-line.testdata.ts
@@ -28,3 +28,33 @@ export const question1: PerseusRenderer = {
         },
     },
 };
+
+export const question2: PerseusRenderer = {
+    content:
+        "$E=2.5$\n\n**Move the dot to $-E$ on the number line.**\n\n\n[[\u2603 number-line 1]]",
+    images: {},
+    widgets: {
+        "number-line 1": {
+            type: "number-line",
+            alignment: "default",
+            static: false,
+            graded: true,
+            options: {
+                static: false,
+                range: [0, 1],
+                labelRange: [null, null],
+                labelStyle: "improper",
+                labelTicks: false,
+                divisionRange: [1, 12],
+                numDivisions: 1,
+                snapDivisions: 1,
+                tickStep: null,
+                correctRel: "eq",
+                correctX: 0.5,
+                initialX: null,
+                showTooltip: false,
+                isTickCtrl: true,
+            },
+        },
+    },
+};


### PR DESCRIPTION
## Summary:
This PR fixes two issues related to the number line widget (MOB-5422 & MOB-5416). It also adds a storybook story to help test number-lines, as we didn't have anything showing the widget with "isTickCtrl" set to "True". 

MOB-5422 
This is solved by programmatically focusing on the input element during click and tap events so that the onKeyUp handler can be fired correctly for keyboard events. 

MOB-5416 
This is solved by fixing a callback in math input, where we were returning "false" rather than a proper callback. 

Issue: MOB-5422 & MOB-5416

## Test plan:
- manual 