### PR TITLE
Set Expression widget's `accessible` field to true.

### DIFF
--- a/.changeset/popular-laws-knock.md
+++ b/.changeset/popular-laws-knock.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Expression widget is marked as `accessible` internally. This will stop disabling the "requires screen or mouse" checkbox in the exercise editor for exercises that use expression widget.

--- a/packages/perseus/src/widgets/expression.tsx
+++ b/packages/perseus/src/widgets/expression.tsx
@@ -687,6 +687,7 @@ ExpressionWithDependencies.getOneCorrectAnswerFromRubric =
 export default {
     name: "expression",
     displayName: "Expression / Equation",
+    accessible: true,
     defaultAlignment: "inline-block",
     widget: ExpressionWithDependencies,
     transform: (widgetOptions: PerseusExpressionWidgetOptions): RenderProps => {


### PR DESCRIPTION
## Summary:

Now that expression widget is screenreader accessible, we want to mark it as such.
This will make it so that the exercise editor will not auto-check and auto-disable the
"requires screen or mouse" checkbox when the expression widget is used.

This will change the value of `hasViolatingWidgets` in [item-controls.tsx](https://github.com/Khan/webapp/blob/6d54f60f3a3bbb0758e4d499f9eb123ff27d6ef5/services/static/javascript/perseus-one-package/item-controls.tsx#L670-L682) where the
checkbox is rendered.

NOTE: This will just make it so that the checkbox won't auto-disable. It will _not_
update the existing values to reflect Expression now being accessible. A backfill
will still be necessary for that with our current architecture.

Issue: none

## Test plan:
N/A?

### Checkbox in question

![Screenshot 2024-02-14 at 5 29 03 PM](https://github.com/Khan/perseus/assets/13231763/11cf372b-eee8-4ee4-b5c7-6a402b7e544f)
