### PR TITLE
Allow movable points to be selected with the tab key

### DIFF
--- a/packages/perseus/src/interactive2/wrapped-ellipse.ts
+++ b/packages/perseus/src/interactive2/wrapped-ellipse.ts
@@ -1,29 +1,11 @@
 import {vector as kvector} from "@khanacademy/kmath";
-import Clickable from "@khanacademy/wonder-blocks-clickable";
-import * as React from "react";
-import {useLayoutEffect, useRef} from "react";
 import _ from "underscore";
-
-import reactRender from "../util/react-render";
 
 import InteractiveUtil from "./interactive-util";
 import WrappedDrawing from "./wrapped-drawing";
 
 import type {Coord} from "./types";
 import type {VisibleShape} from "./wrapped-drawing";
-
-function MountInDiv(props): React.ReactElement {
-    const {element, style, onClick} = props;
-    const containerRef = useRef<HTMLDivElement>(null);
-    useLayoutEffect(() => {
-        if (containerRef.current != null) {
-            // labelFn(containerRef.current);
-            containerRef.current.innerHTML = "";
-            containerRef.current.appendChild(element);
-        }
-    }, [containerRef, element]);
-    return <div ref={containerRef} style={style} onClick={onClick} />;
-}
 
 const DEFAULT_OPTIONS = {
     maxScale: 1,
@@ -71,21 +53,6 @@ class WrappedEllipse extends WrappedDrawing {
             // movable wrapper so that when moved the browser does not scroll page
             this.wrapper.style.touchAction = "none";
 
-            // Option 2: instead of addToMouseLayerWrapper(this.wrapper)
-            // we could do addToMouseLayerWrapper(reactRoot)
-            reactRender(
-                <Clickable
-                    style={{
-                        width: this.wrapper.style.width,
-                        height: this.wrapper.style.height,
-                    }}
-                >
-                    {() => (
-                        <MountInDiv element={fixedEllipse.raphaelContainer} />
-                    )}
-                </Clickable>,
-                this.wrapper,
-            );
             this.graphie.addToMouseLayerWrapper(this.wrapper);
         } else {
             this.graphie.addToVisibleLayerWrapper(this.wrapper);

--- a/packages/perseus/src/interactive2/wrapped-ellipse.tsx
+++ b/packages/perseus/src/interactive2/wrapped-ellipse.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import {vector as kvector} from "@khanacademy/kmath";
 import _ from "underscore";
 
@@ -6,6 +7,22 @@ import WrappedDrawing from "./wrapped-drawing";
 
 import type {Coord} from "./types";
 import type {VisibleShape} from "./wrapped-drawing";
+import reactRender from "../util/react-render";
+import Clickable from "@khanacademy/wonder-blocks-clickable";
+import { useLayoutEffect, useRef } from "react";
+
+function MountInDiv(props): React.ReactElement {
+    const {element, style, onClick, labelFn} = props;
+    const containerRef = useRef<HTMLElement>(null);
+    useLayoutEffect(() => {
+        if (containerRef.current != null) {
+            // labelFn(containerRef.current);
+            containerRef.current.innerHTML = "";
+            containerRef.current.appendChild(element);
+        }
+    }, [containerRef, element]);
+    return <span ref={containerRef} style={style} onClick={onClick} />;
+}
 
 const DEFAULT_OPTIONS = {
     maxScale: 1,
@@ -53,7 +70,11 @@ class WrappedEllipse extends WrappedDrawing {
             // movable wrapper so that when moved the browser does not scroll page
             this.wrapper.style.touchAction = "none";
 
-            this.graphie.addToMouseLayerWrapper(this.wrapper);
+            // Option 2: instead of addToMouseLayerWrapper(this.wrapper)
+            // we could do addToMouseLayerWrapper(reactRoot)
+            const reactRoot = document.createElement("div")
+            reactRender(<Clickable>{() => <MountInDiv element={this.wrapper} />}</Clickable>, reactRoot);
+            this.graphie.addToMouseLayerWrapper(reactRoot);
         } else {
             this.graphie.addToVisibleLayerWrapper(this.wrapper);
         }

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -46,7 +46,11 @@ interface RaphaelElement {
     };
 }
 
-type PositionedShape = {wrapper: HTMLDivElement; visibleShape: RaphaelElement};
+type PositionedShape = {
+    wrapper: HTMLDivElement;
+    raphaelContainer: HTMLDivElement;
+    visibleShape: RaphaelElement;
+};
 
 export type StyleParams = {
     fill?: string;
@@ -736,10 +740,12 @@ export class Graphie {
                 left: left + "px",
                 top: top + "px",
             });
-            // wrapper.setAttribute("data-graphie-type", "ellipse");
+
+            const raphaelContainer = document.createElement("div");
+            wrapper.appendChild(raphaelContainer);
 
             // Create Raphael canvas
-            const localRaphael = Raphael(wrapper, width, height);
+            const localRaphael = Raphael(raphaelContainer, width, height);
             const visibleShape = localRaphael.ellipse(
                 width / 2,
                 height / 2,
@@ -748,8 +754,9 @@ export class Graphie {
             );
 
             return {
-                wrapper: wrapper,
-                visibleShape: visibleShape,
+                wrapper,
+                raphaelContainer,
+                visibleShape,
             };
         });
     }
@@ -834,6 +841,7 @@ export class Graphie {
 
         return {
             wrapper: wrapper,
+            raphaelContainer: wrapper,
             visibleShape: visibleShape,
         };
     }
@@ -925,6 +933,7 @@ export class Graphie {
 
         return {
             wrapper: wrapper,
+            raphaelContainer: wrapper,
             visibleShape: visibleShape,
         };
     }
@@ -1522,7 +1531,6 @@ export class Graphie {
 
         // Add functions for adding to wrappers
         this.addToMouseLayerWrapper = (el: any) => {
-            // Option 1: create React root wrapping el in ClickableBehavior
             this._mouselayerWrapper?.appendChild(el);
         };
         this.addToVisibleLayerWrapper = (el: any) => {

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1522,6 +1522,7 @@ export class Graphie {
 
         // Add functions for adding to wrappers
         this.addToMouseLayerWrapper = (el: any) => {
+            // Option 1: create React root wrapping el in ClickableBehavior
             this._mouselayerWrapper?.appendChild(el);
         };
         this.addToVisibleLayerWrapper = (el: any) => {


### PR DESCRIPTION
Issue: https://khanacademy.atlassian.net/browse/LC-1668

## Test plan:

- Open the interactive graph dev UI (`yarn dev`)
- Press Tab repeatedly
- You should see each movable point get selected in turn. The selected point
  should have a blue outline.