### PR TITLE
Update ArticleRenderer to split sections into paragraphs in JIPT context

### DIFF
--- a/.changeset/beige-trees-itch.md
+++ b/.changeset/beige-trees-itch.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/pure-markdown": minor
+---
+
+In JIPT context rendering split sections into paragraphs in ArticleRenderer

--- a/packages/perseus/src/__stories__/article-renderer.stories.tsx
+++ b/packages/perseus/src/__stories__/article-renderer.stories.tsx
@@ -7,7 +7,7 @@ import {
     singleSectionArticle,
     multiSectionArticle,
     passageArticle,
-    articleWithExpression,
+    articleSectionWithExpression,
     multiSectionArticleWithExpression,
 } from "../__testdata__/article-renderer.testdata";
 import ArticleRenderer from "../article-renderer";
@@ -62,7 +62,7 @@ export const ExpressionArticle = ({useNewStyles}): any => (
                     ref={(node) => {
                         setRenderer(node);
                     }}
-                    json={articleWithExpression}
+                    json={articleSectionWithExpression}
                     dependencies={storybookDependenciesV2}
                     useNewStyles={useNewStyles}
                     apiOptions={{

--- a/packages/perseus/src/__testdata__/article-renderer.testdata.ts
+++ b/packages/perseus/src/__testdata__/article-renderer.testdata.ts
@@ -59,7 +59,7 @@ export const passageArticle: PerseusRenderer = {
     },
 };
 
-export const articleWithExpression: PerseusRenderer = {
+export const articleSectionWithExpression: PerseusRenderer = {
     content:
         "### Practice Problem\n\n$8\\cdot(11i+2)=$ [[☃ expression 1]]  \n*Your answer should be a complex number in the form $a+bi$ where $a$ and $b$ are real numbers.*",
     images: {},

--- a/packages/perseus/src/__tests__/article-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/article-renderer.test.tsx
@@ -12,11 +12,12 @@ import {
     testDependencies,
     testDependenciesV2,
 } from "../../../../testing/test-dependencies";
-import {articleWithExpression} from "../__testdata__/article-renderer.testdata";
+import {articleSectionWithExpression} from "../__testdata__/article-renderer.testdata";
 import ArticleRenderer from "../article-renderer";
 import * as Dependencies from "../dependencies";
 import {ApiOptions} from "../perseus-api";
 
+import type {PerseusRenderer} from "../perseus-types";
 import type {APIOptions} from "../types";
 
 function KeypadWithContext() {
@@ -38,6 +39,9 @@ function KeypadWithContext() {
 // the ArticleRenderer instead of Renderer
 export const RenderArticle = (
     apiOptions: APIOptions = Object.freeze({}),
+    json:
+        | PerseusRenderer
+        | ReadonlyArray<PerseusRenderer> = articleSectionWithExpression,
 ): {
     container: HTMLElement;
     renderer: ArticleRenderer;
@@ -53,7 +57,7 @@ export const RenderArticle = (
                                 renderer = node;
                                 setRenderer(node);
                             }}
-                            json={articleWithExpression}
+                            json={json}
                             dependencies={testDependenciesV2}
                             apiOptions={{...apiOptions}}
                             keypadElement={keypadElement}
@@ -92,19 +96,37 @@ describe("article renderer", () => {
         jest.runOnlyPendingTimers();
     });
 
-    it("should render the content", () => {
+    it("should render the content for a section", () => {
         // Arrange and Act
-        RenderArticle({
-            ...ApiOptions.defaults,
-            isMobile: false,
-            customKeypad: false,
-        });
+        RenderArticle(
+            {
+                ...ApiOptions.defaults,
+                isMobile: false,
+                customKeypad: false,
+            },
+            articleSectionWithExpression,
+        );
 
         // Assert
         expect(screen.getByRole("textbox")).toBeInTheDocument();
     });
 
-    it("should render the content in JIPT context", () => {
+    it("should render the content for a section as list", () => {
+        // Arrange and Act
+        RenderArticle(
+            {
+                ...ApiOptions.defaults,
+                isMobile: false,
+                customKeypad: false,
+            },
+            [articleSectionWithExpression],
+        );
+
+        // Assert
+        expect(screen.getByRole("textbox")).toBeInTheDocument();
+    });
+
+    it("should render the content for a section in JIPT context", () => {
         // Arrange
         jest.spyOn(Dependencies, "getDependencies").mockReturnValue({
             ...testDependencies,
@@ -114,11 +136,37 @@ describe("article renderer", () => {
         });
 
         // Act
-        RenderArticle({
-            ...ApiOptions.defaults,
-            isMobile: false,
-            customKeypad: false,
+        RenderArticle(
+            {
+                ...ApiOptions.defaults,
+                isMobile: false,
+                customKeypad: false,
+            },
+            articleSectionWithExpression,
+        );
+
+        // Assert
+        expect(screen.getByRole("textbox")).toBeInTheDocument();
+    });
+
+    it("should render the content for a section as list in JIPT context", () => {
+        // Arrange
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue({
+            ...testDependencies,
+            JIPT: {
+                useJIPT: true,
+            },
         });
+
+        // Act
+        RenderArticle(
+            {
+                ...ApiOptions.defaults,
+                isMobile: false,
+                customKeypad: false,
+            },
+            [articleSectionWithExpression],
+        );
 
         // Assert
         expect(screen.getByRole("textbox")).toBeInTheDocument();

--- a/packages/perseus/src/__tests__/article-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/article-renderer.test.tsx
@@ -104,6 +104,26 @@ describe("article renderer", () => {
         expect(screen.getByRole("textbox")).toBeInTheDocument();
     });
 
+    it("should render the content in JIPT context", () => {
+        // Arrange
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue({
+            ...testDependencies,
+            JIPT: {
+                useJIPT: true,
+            },
+        });
+
+        // Act
+        RenderArticle({
+            ...ApiOptions.defaults,
+            isMobile: false,
+            customKeypad: false,
+        });
+
+        // Assert
+        expect(screen.getByRole("textbox")).toBeInTheDocument();
+    });
+
     it("should call the onFocusChanged callback when an input is focused", async () => {
         // Arrange
         const answerableCallback = jest.fn();

--- a/packages/perseus/src/article-renderer.tsx
+++ b/packages/perseus/src/article-renderer.tsx
@@ -7,7 +7,8 @@ import * as PerseusLinter from "@khanacademy/perseus-linter";
 import classNames from "classnames";
 import * as React from "react";
 
-import {DependenciesContext} from "./dependencies";
+import {DependenciesContext, getDependencies} from "./dependencies";
+import JiptParagraphs from "./jipt-paragraphs";
 import {ClassNames as ApiClassNames, ApiOptions} from "./perseus-api";
 import Renderer from "./renderer";
 import Util from "./util";
@@ -162,9 +163,32 @@ class ArticleRenderer
     };
 
     _sections: () => any = () => {
-        return Array.isArray(this.props.json)
+        const sections = Array.isArray(this.props.json)
             ? this.props.json
             : [this.props.json];
+
+        // In JIPT context we split sections to paragraphs in order match the
+        // translatable strings found on Crowdin when rendering articles in
+        // the WYSIWYG mode for translation. This is needed for the jipt.js
+        // integration in order to attribute the rendered strings on Crowdin.
+        if (getDependencies().JIPT.useJIPT) {
+            const paragraphs: Array<PerseusRenderer> = [];
+
+            for (const section of sections) {
+                JiptParagraphs.parseToArray(section.content).forEach(
+                    (paragraph) => {
+                        paragraphs.push({
+                            ...section,
+                            content: paragraph,
+                        });
+                    },
+                );
+            }
+
+            return paragraphs;
+        }
+
+        return sections;
     };
 
     render(): React.ReactNode {


### PR DESCRIPTION
## Summary:
This is a continuation to https://github.com/Khan/perseus/pull/996, where "disabling" of the `list` rule was removed
from the markdown parser in order to correctly render lists in JIPT context.

However, that change broke Article preview rendering in the Translation Editor,
due to a mismatch in paragraph indexes. Causing the `jipt.js` integration to not
be able to attribute rendered strings to translations on Crowdin. This is fixed in: https://github.com/Khan/webapp/pull/19917

With these two changes in place the Translation Editor is now rendering markdown
lists correctly without any other regression.

Unfortunately this is not case for articles containing markdown lists rendered in
the WYSIWYG. These are regressed due to the same paragraph index mismatch,
as unlike the Translation Editor, the JIPT WYSIWYG renders articles using `ArticleRenderer`
(same as normal page rendering.)

![cp-7983-broken-article-wysiwyg](https://github.com/Khan/perseus/assets/4722598/5c17a78b-6d30-4c36-89a4-02d8e187281e)

To fix this, we apply the same change of splitting article sections into paragraphs
when rendering in JIPT context. This enables the `jipt.js` integration to attribute
the strings in the DOM to translations on Crowdin.

![cp-7983-article-wysiwyg](https://github.com/Khan/perseus/assets/4722598/28117516-4311-42b4-b764-557dd7634819)

Issue: https://khanacademy.atlassian.net/browse/CP-7983

Test Plan:
 - Open any article in any KA locale site and verify rendering is unaffected
 - Open any article in WYSIWYG and verify there are no regressions to rendering
 - Open article with a markdown list in WYSIWYG and verify lists are rendered correctly
   - `/science/biology/classical-genetics/variations-on-mendelian-genetics/a/multiple-alleles-incomplete-dominance-and-codominance?lang=en-pt`