### PR TITLE
Fix Spacebar Usage on Explanation Widget

### DIFF
--- a/.changeset/cyan-dots-compete.md
+++ b/.changeset/cyan-dots-compete.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix Spacebar Usage on Explanation Widget

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/explanation.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/explanation.test.ts.snap
@@ -20,18 +20,18 @@ exports[`Explanation should snapshot for article when expanded: expanded 1`] = `
           <div
             class="container_167wsvl"
           >
-            <div
-              class="linkContainer_36rlri-o_O-articleLink_17wlykh"
+            <button
+              aria-disabled="false"
+              class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4"
+              data-test-id="expand-button"
+              type="button"
             >
-              <a
-                aria-expanded="true"
-                class="explanationLink_7n4oib"
-                href="javascript:void(0)"
-                role="button"
+              <div
+                class="default_xu2jcg-o_O-linkContainer_36rlri-o_O-explanationLink_7n4oib-o_O-articleLink_17wlykh"
               >
                 [Hide explanation!]
-              </a>
-            </div>
+              </div>
+            </button>
             <div
               class="content_z5b02x-o_O-contentExpanded_1c06cap"
             >
@@ -190,18 +190,18 @@ exports[`Explanation should snapshot for article: initial render 1`] = `
           <div
             class="container_167wsvl"
           >
-            <div
-              class="linkContainer_36rlri-o_O-articleLink_17wlykh"
+            <button
+              aria-disabled="false"
+              class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4"
+              data-test-id="expand-button"
+              type="button"
             >
-              <a
-                aria-expanded="false"
-                class="explanationLink_7n4oib"
-                href="javascript:void(0)"
-                role="button"
+              <div
+                class="default_xu2jcg-o_O-linkContainer_36rlri-o_O-explanationLink_7n4oib-o_O-articleLink_17wlykh"
               >
                 [Explanation]
-              </a>
-            </div>
+              </div>
+            </button>
           </div>
         </div>
         
@@ -342,18 +342,18 @@ exports[`Explanation should snapshot when expanded: expanded 1`] = `
           <div
             class="container_167wsvl"
           >
-            <div
-              class="linkContainer_36rlri-o_O-exerciseLink_574wt1"
+            <button
+              aria-disabled="false"
+              class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4"
+              data-test-id="expand-button"
+              type="button"
             >
-              <a
-                aria-expanded="true"
-                class="explanationLink_7n4oib"
-                href="javascript:void(0)"
-                role="button"
+              <div
+                class="default_xu2jcg-o_O-linkContainer_36rlri-o_O-explanationLink_7n4oib-o_O-exerciseLink_574wt1"
               >
                 [Hide explanation!]
-              </a>
-            </div>
+              </div>
+            </button>
             <div
               class="content_z5b02x-o_O-contentExpanded_1c06cap"
             >
@@ -402,18 +402,18 @@ exports[`Explanation should snapshot: initial render 1`] = `
           <div
             class="container_167wsvl"
           >
-            <div
-              class="linkContainer_36rlri-o_O-exerciseLink_574wt1"
+            <button
+              aria-disabled="false"
+              class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4"
+              data-test-id="expand-button"
+              type="button"
             >
-              <a
-                aria-expanded="false"
-                class="explanationLink_7n4oib"
-                href="javascript:void(0)"
-                role="button"
+              <div
+                class="default_xu2jcg-o_O-linkContainer_36rlri-o_O-explanationLink_7n4oib-o_O-exerciseLink_574wt1"
               >
                 [Explanation]
-              </a>
-            </div>
+              </div>
+            </button>
           </div>
         </div>
         

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/explanation.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/explanation.test.ts.snap
@@ -22,6 +22,7 @@ exports[`Explanation should snapshot for article when expanded: expanded 1`] = `
           >
             <button
               aria-disabled="false"
+              aria-expanded="true"
               class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4"
               type="button"
             >
@@ -191,6 +192,7 @@ exports[`Explanation should snapshot for article: initial render 1`] = `
           >
             <button
               aria-disabled="false"
+              aria-expanded="false"
               class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4"
               type="button"
             >
@@ -342,6 +344,7 @@ exports[`Explanation should snapshot when expanded: expanded 1`] = `
           >
             <button
               aria-disabled="false"
+              aria-expanded="true"
               class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4"
               type="button"
             >
@@ -401,6 +404,7 @@ exports[`Explanation should snapshot: initial render 1`] = `
           >
             <button
               aria-disabled="false"
+              aria-expanded="false"
               class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4"
               type="button"
             >

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/explanation.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/explanation.test.ts.snap
@@ -23,7 +23,6 @@ exports[`Explanation should snapshot for article when expanded: expanded 1`] = `
             <button
               aria-disabled="false"
               class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4"
-              data-test-id="expand-button"
               type="button"
             >
               <div
@@ -193,7 +192,6 @@ exports[`Explanation should snapshot for article: initial render 1`] = `
             <button
               aria-disabled="false"
               class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4"
-              data-test-id="expand-button"
               type="button"
             >
               <div
@@ -345,7 +343,6 @@ exports[`Explanation should snapshot when expanded: expanded 1`] = `
             <button
               aria-disabled="false"
               class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4"
-              data-test-id="expand-button"
               type="button"
             >
               <div
@@ -405,7 +402,6 @@ exports[`Explanation should snapshot: initial render 1`] = `
             <button
               aria-disabled="false"
               class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4"
-              data-test-id="expand-button"
               type="button"
             >
               <div

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/explanation.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/explanation.test.ts.snap
@@ -27,7 +27,7 @@ exports[`Explanation should snapshot for article when expanded: expanded 1`] = `
               type="button"
             >
               <div
-                class="default_xu2jcg-o_O-linkContainer_36rlri-o_O-explanationLink_7n4oib-o_O-articleLink_17wlykh"
+                class="default_xu2jcg-o_O-explanationLink_7n4oib-o_O-articleLink_17wlykh"
               >
                 [Hide explanation!]
               </div>
@@ -197,7 +197,7 @@ exports[`Explanation should snapshot for article: initial render 1`] = `
               type="button"
             >
               <div
-                class="default_xu2jcg-o_O-linkContainer_36rlri-o_O-explanationLink_7n4oib-o_O-articleLink_17wlykh"
+                class="default_xu2jcg-o_O-explanationLink_7n4oib-o_O-articleLink_17wlykh"
               >
                 [Explanation]
               </div>
@@ -349,7 +349,7 @@ exports[`Explanation should snapshot when expanded: expanded 1`] = `
               type="button"
             >
               <div
-                class="default_xu2jcg-o_O-linkContainer_36rlri-o_O-explanationLink_7n4oib-o_O-exerciseLink_574wt1"
+                class="default_xu2jcg-o_O-explanationLink_7n4oib-o_O-exerciseLink_574wt1"
               >
                 [Hide explanation!]
               </div>
@@ -409,7 +409,7 @@ exports[`Explanation should snapshot: initial render 1`] = `
               type="button"
             >
               <div
-                class="default_xu2jcg-o_O-linkContainer_36rlri-o_O-explanationLink_7n4oib-o_O-exerciseLink_574wt1"
+                class="default_xu2jcg-o_O-explanationLink_7n4oib-o_O-exerciseLink_574wt1"
               >
                 [Explanation]
               </div>

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group.test.ts.snap
@@ -420,7 +420,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                             type="button"
                           >
                             <div
-                              class="default_xu2jcg-o_O-linkContainer_36rlri-o_O-explanationLink_7n4oib-o_O-exerciseLink_574wt1"
+                              class="default_xu2jcg-o_O-explanationLink_7n4oib-o_O-exerciseLink_574wt1"
                             >
                               [Hint]
                             </div>

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group.test.ts.snap
@@ -415,8 +415,8 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                         >
                           <button
                             aria-disabled="false"
+                            aria-expanded="false"
                             class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4"
-                            data-test-id="expand-button"
                             type="button"
                           >
                             <div

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group.test.ts.snap
@@ -413,18 +413,18 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                         <div
                           class="container_167wsvl"
                         >
-                          <div
-                            class="linkContainer_36rlri-o_O-exerciseLink_574wt1"
+                          <button
+                            aria-disabled="false"
+                            class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4"
+                            data-test-id="expand-button"
+                            type="button"
                           >
-                            <a
-                              aria-expanded="false"
-                              class="explanationLink_7n4oib"
-                              href="javascript:void(0)"
-                              role="button"
+                            <div
+                              class="default_xu2jcg-o_O-linkContainer_36rlri-o_O-explanationLink_7n4oib-o_O-exerciseLink_574wt1"
                             >
                               [Hint]
-                            </a>
-                          </div>
+                            </div>
+                          </button>
                         </div>
                       </div>
                     </div>

--- a/packages/perseus/src/widgets/__tests__/explanation.test.ts
+++ b/packages/perseus/src/widgets/__tests__/explanation.test.ts
@@ -120,7 +120,7 @@ describe("Explanation", function () {
         renderQuestion(question1);
 
         // Act
-        const expandLink = screen.getByRole("button", {expanded: false});
+        const expandLink = screen.getByTestId("expand-button");
         userEvent.click(expandLink);
 
         // Assert
@@ -133,9 +133,9 @@ describe("Explanation", function () {
         renderQuestion(question1);
 
         // Act
-        const expandLink = screen.getByRole("button", {expanded: false});
+        const expandLink = screen.getByTestId("expand-button");
         userEvent.click(expandLink); // expand and then
-        const collapseLink = screen.getByRole("button", {expanded: true});
+        const collapseLink = screen.getByTestId("expand-button");
         userEvent.click(collapseLink); // collapse
 
         // Assert

--- a/packages/perseus/src/widgets/__tests__/explanation.test.ts
+++ b/packages/perseus/src/widgets/__tests__/explanation.test.ts
@@ -115,28 +115,77 @@ describe("Explanation", function () {
         expect(container).toMatchSnapshot("expanded");
     });
 
-    it("can be expanded", function () {
+    it("can be expanded and collapsed with a mouse click", function () {
         // Arrange
         renderQuestion(question1);
 
-        // Act
-        const expandLink = screen.getByTestId("expand-button");
-        userEvent.click(expandLink);
+        // Act - expand with a click
+        const expandButton = screen.getByRole("button", {
+            name: "[Explanation]",
+        });
+        userEvent.click(expandButton);
 
         // Assert
         // get asserts if it doesn't find a single matching element
         expect(screen.getByText("This is an explanation")).toBeVisible();
+
+        // Act - collapse with a click
+        const collapseButton = screen.getByRole("button", {
+            name: "[Hide explanation!]",
+        });
+        userEvent.click(collapseButton); // collapse
+
+        // Assert
+        expect(screen.queryByText("This is an explanation")).toBeNull();
     });
 
-    it("can be collapsed", function () {
+    it("can be expanded and collapsed with the keyboard - Enter key", function () {
         // Arrange
         renderQuestion(question1);
 
-        // Act
-        const expandLink = screen.getByTestId("expand-button");
-        userEvent.click(expandLink); // expand and then
-        const collapseLink = screen.getByTestId("expand-button");
-        userEvent.click(collapseLink); // collapse
+        // Act - expand with a click
+        const expandButton = screen.getByRole("button", {
+            name: "[Explanation]",
+        });
+        expandButton.focus();
+        userEvent.keyboard("{Enter}");
+
+        // Assert
+        // get asserts if it doesn't find a single matching element
+        expect(screen.getByText("This is an explanation")).toBeVisible();
+
+        // Act - collapse with a click
+        const collapseButton = screen.getByRole("button", {
+            name: "[Hide explanation!]",
+        });
+        collapseButton.focus();
+        userEvent.keyboard("{Enter}");
+
+        // Assert
+        expect(screen.queryByText("This is an explanation")).toBeNull();
+    });
+
+    it("can be expanded and collapsed with the keyboard - Space bar", function () {
+        // Arrange
+        renderQuestion(question1);
+
+        // Act - expand with a click
+        const expandButton = screen.getByRole("button", {
+            name: "[Explanation]",
+        });
+        expandButton.focus();
+        userEvent.keyboard(" ");
+
+        // Assert
+        // get asserts if it doesn't find a single matching element
+        expect(screen.getByText("This is an explanation")).toBeVisible();
+
+        // Act - collapse with a click
+        const collapseButton = screen.getByRole("button", {
+            name: "[Hide explanation!]",
+        });
+        collapseButton.focus();
+        userEvent.keyboard(" ");
 
         // Assert
         expect(screen.queryByText("This is an explanation")).toBeNull();

--- a/packages/perseus/src/widgets/explanation.tsx
+++ b/packages/perseus/src/widgets/explanation.tsx
@@ -111,10 +111,9 @@ class Explanation extends React.Component<Props, State> {
                 </div>
             );
         } else {
-            const viewStyling = [styles.linkContainer, styles.explanationLink];
-            viewStyling.push(
-                isArticle ? styles.articleLink : styles.exerciseLink,
-            );
+            const viewStyling = isArticle
+                ? [styles.explanationLink, styles.articleLink]
+                : [styles.explanationLink, styles.exerciseLink];
             promptContainer = (
                 <Clickable
                     onClick={onClick}

--- a/packages/perseus/src/widgets/explanation.tsx
+++ b/packages/perseus/src/widgets/explanation.tsx
@@ -1,5 +1,8 @@
 /* eslint-disable react/sort-comp */
 import {linterContextDefault} from "@khanacademy/perseus-linter";
+import Clickable from "@khanacademy/wonder-blocks-clickable";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {Body} from "@khanacademy/wonder-blocks-typography";
 import {StyleSheet, css} from "aphrodite";
 import * as React from "react";
 import _ from "underscore";
@@ -139,22 +142,24 @@ class Explanation extends React.Component<Props, State> {
                 // NOTE: For exercises, the baseElements `Link` is an
                 // anchor tag, see: `perseus-api.jsx`.
                 linkContainer = (
-                    <div
+                    <Clickable
                         className={css(
                             styles.linkContainer,
                             styles.exerciseLink,
                         )}
+                        onClick={onClick}
                     >
-                        <Link
-                            className={css(styles.explanationLink)}
-                            href={href}
-                            onClick={onClick}
-                            role="button"
-                            aria-expanded={this.state.expanded}
-                        >
-                            {`[${linkAnchor}]`}
-                        </Link>
-                    </div>
+                        {({hovered, pressed}) => (
+                            <View
+                                style={[
+                                    hovered && styles.hovered,
+                                    pressed && styles.pressed,
+                                ]}
+                            >
+                                <Body>{`[${linkAnchor}]`}</Body>
+                            </View>
+                        )}
+                    </Clickable>
                 );
             }
         }

--- a/packages/perseus/src/widgets/explanation.tsx
+++ b/packages/perseus/src/widgets/explanation.tsx
@@ -156,7 +156,9 @@ class Explanation extends React.Component<Props, State> {
                                     pressed && styles.pressed,
                                 ]}
                             >
-                                <Body>{`[${linkAnchor}]`}</Body>
+                                <Body className={css(styles.explanationLink)}>
+                                    {`[${linkAnchor}]`}
+                                </Body>
                             </View>
                         )}
                     </Clickable>

--- a/packages/perseus/src/widgets/explanation.tsx
+++ b/packages/perseus/src/widgets/explanation.tsx
@@ -2,7 +2,6 @@
 import {linterContextDefault} from "@khanacademy/perseus-linter";
 import Clickable from "@khanacademy/wonder-blocks-clickable";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {Body} from "@khanacademy/wonder-blocks-typography";
 import {StyleSheet, css} from "aphrodite";
 import * as React from "react";
 import _ from "underscore";
@@ -72,14 +71,13 @@ class Explanation extends React.Component<Props, State> {
     };
 
     render(): React.ReactNode {
-        const {Link} = this.props.apiOptions.baseElements;
         const {isArticle, isMobile} = this.props.apiOptions;
 
-        const linkAnchor = this.state.expanded
+        const promptText = this.state.expanded
             ? this.props.hidePrompt
             : this.props.showPrompt;
 
-        let linkContainer;
+        let promptContainer: React.ReactNode;
 
         // TODO(diedra): This isn't a valid href;
         // change this to a button that looks like a link.
@@ -87,7 +85,7 @@ class Explanation extends React.Component<Props, State> {
         const onClick = this._onClick;
 
         if (isMobile) {
-            linkContainer = (
+            promptContainer = (
                 <div className={css(styles.linkContainer)}>
                     <a
                         className={css(styles.mobileExplanationLink)}
@@ -96,7 +94,7 @@ class Explanation extends React.Component<Props, State> {
                         role="button"
                         aria-expanded={this.state.expanded}
                     >
-                        {linkAnchor}
+                        {promptText}
                     </a>
                     {this.state.expanded && (
                         <svg className={css(styles.disclosureArrow)}>
@@ -113,57 +111,15 @@ class Explanation extends React.Component<Props, State> {
                 </div>
             );
         } else {
-            if (isArticle) {
-                // NOTE: For articles, the baseElements `Link` may is either be
-                // an anchor tag (if rendered in a modal) or a Wonder Blocks
-                // link component in lesson page, see: `article-page.jsx`.
-                linkContainer = (
-                    <div
-                        className={css(
-                            styles.linkContainer,
-                            styles.articleLink,
-                        )}
-                    >
-                        <Link
-                            className={css(styles.explanationLink)}
-                            // HACK(michaelpolyak): WB Link doesn't passthrough
-                            // class name.
-                            style={styles.explanationLink}
-                            href={href}
-                            onClick={onClick}
-                            role="button"
-                            aria-expanded={this.state.expanded}
-                        >
-                            {`[${linkAnchor}]`}
-                        </Link>
-                    </div>
-                );
-            } else {
-                // NOTE: For exercises, the baseElements `Link` is an
-                // anchor tag, see: `perseus-api.jsx`.
-                linkContainer = (
-                    <Clickable
-                        className={css(
-                            styles.linkContainer,
-                            styles.exerciseLink,
-                        )}
-                        onClick={onClick}
-                    >
-                        {({hovered, pressed}) => (
-                            <View
-                                style={[
-                                    hovered && styles.hovered,
-                                    pressed && styles.pressed,
-                                ]}
-                            >
-                                <Body className={css(styles.explanationLink)}>
-                                    {`[${linkAnchor}]`}
-                                </Body>
-                            </View>
-                        )}
-                    </Clickable>
-                );
-            }
+            const viewStyling = [styles.linkContainer, styles.explanationLink];
+            viewStyling.push(
+                isArticle ? styles.articleLink : styles.exerciseLink,
+            );
+            promptContainer = (
+                <Clickable onClick={onClick} testId="expand-button">
+                    {() => <View style={viewStyling}>{`[${promptText}]`}</View>}
+                </Clickable>
+            );
         }
 
         const expandedStyle = isMobile
@@ -172,7 +128,7 @@ class Explanation extends React.Component<Props, State> {
 
         return (
             <div className={css(styles.container)}>
-                {linkContainer}
+                {promptContainer}
                 {this.state.expanded && (
                     <div
                         className={css(

--- a/packages/perseus/src/widgets/explanation.tsx
+++ b/packages/perseus/src/widgets/explanation.tsx
@@ -116,7 +116,10 @@ class Explanation extends React.Component<Props, State> {
                 isArticle ? styles.articleLink : styles.exerciseLink,
             );
             promptContainer = (
-                <Clickable onClick={onClick}>
+                <Clickable
+                    onClick={onClick}
+                    aria-expanded={this.state.expanded}
+                >
                     {() => <View style={viewStyling}>{`[${promptText}]`}</View>}
                 </Clickable>
             );

--- a/packages/perseus/src/widgets/explanation.tsx
+++ b/packages/perseus/src/widgets/explanation.tsx
@@ -116,7 +116,7 @@ class Explanation extends React.Component<Props, State> {
                 isArticle ? styles.articleLink : styles.exerciseLink,
             );
             promptContainer = (
-                <Clickable onClick={onClick} testId="expand-button">
+                <Clickable onClick={onClick}>
                     {() => <View style={viewStyling}>{`[${promptText}]`}</View>}
                 </Clickable>
             );


### PR DESCRIPTION
## Summary:
The explanation widget should respond to keyboard interactions such that both the Enter/Return key and the spacebar activate it. This bug calls out that the spacebar is instead scrolling the page (see "Before" video), which is the default browser behavior. Changing the widget container from `<Link>` to `<Clickable>` improves semantics and properly handles keystrokes (it is now a `<button>` element instead of an `<a>` element).

Issue: LC-212

## Test plan:
1. Open the Perseus Storybook (locally: `http://localhost:6006/?path=/story/perseus-widgets-explanation--question-1`)
1. Using the keyboard, tab until the text "[Explanation]" is in focus.
    * To avoid numerous tab keystrokes, you can click the "explanation" word prior to the widget, then press the tab key to advance focus to the widget.
1. With the "[Explanation]" widget in focus, press the spacebar.
    * The extra text associated with the widget should now be showing.
    * The focus indicator should still be on the "[Explanation]" widget.
1. Press the spacebar again.
    * The extra text associated with the widget should now be hidden.
1. The same steps using the Enter key instead of the spacebar should yield the same results.

## Affected Behavior:
### Before - Spacebar scrolls the page

https://github.com/Khan/perseus/assets/13896410/5c63dc9a-dff2-4420-9560-a89ffe854680


### After - Spacebar now activates the widget

https://github.com/Khan/perseus/assets/13896410/d20a345a-a177-49e9-828d-788149827a7f

