### PR TITLE
Add stories for GraphSettings and InteractiveGraphEditor

### DIFF
--- a/.changeset/plenty-zoos-smash.md
+++ b/.changeset/plenty-zoos-smash.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Correct type for `valid` prop from `boolean` to `boolean | string`

--- a/packages/perseus-editor/src/components/__stories__/graph-settings.argtypes.ts
+++ b/packages/perseus-editor/src/components/__stories__/graph-settings.argtypes.ts
@@ -42,7 +42,7 @@ export default {
     },
     backgroundImage: {
         control: {
-            type: "text",
+            type: "object",
         },
     },
     markings: {

--- a/packages/perseus-editor/src/components/__stories__/graph-settings.argtypes.ts
+++ b/packages/perseus-editor/src/components/__stories__/graph-settings.argtypes.ts
@@ -1,0 +1,84 @@
+export default {
+    editableSettings: {
+        control: {
+            type: "array",
+            options: ["canvas", "graph", "snap", "image", "measure"],
+        },
+    },
+    box: {
+        control: {
+            type: "array",
+        },
+    },
+    range: {
+        control: {
+            type: "object",
+        },
+    },
+    labels: {
+        control: {
+            type: "object",
+        },
+    },
+    step: {
+        control: {
+            type: "object",
+        },
+    },
+    gridStep: {
+        control: {
+            type: "object",
+        },
+    },
+    snapStep: {
+        control: {
+            type: "object",
+        },
+    },
+    valid: {
+        control: {
+            type: "text",
+        },
+    },
+    backgroundImage: {
+        control: {
+            type: "text",
+        },
+    },
+    markings: {
+        control: {
+            type: "select",
+        },
+        table: {
+            defaultValue: {summary: "graph"},
+            type: {
+                summary: '"graph" | "grid" | "none"',
+            },
+        },
+        type: {
+            name: "enum",
+            value: ["graph", "grid", "none"],
+            required: false,
+        },
+    },
+    rulerLabel: {
+        control: {
+            type: "text",
+        },
+    },
+    rulerTicks: {
+        control: {
+            type: "number",
+        },
+    },
+    showTooltips: {
+        control: {
+            type: "boolean",
+        },
+    },
+    onChange: {
+        control: {
+            type: "function",
+        },
+    },
+};

--- a/packages/perseus-editor/src/components/__stories__/graph-settings.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/graph-settings.stories.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+
+import GraphSettings from "../graph-settings";
+
+import GraphSettingsArgTypes from "./graph-settings.argtypes";
+
+export default {
+    title: "Perseus/Editor/Components/Graph Settings",
+    component: GraphSettings,
+    argTypes: GraphSettingsArgTypes,
+};
+
+export const Default = (args): React.ReactElement => {
+    return <GraphSettings {...args} />;
+};
+
+Default.args = {
+    // Separating the array props out because trying to editing them in
+    // the controls panel without a default value causes the story to crash.
+    range: [
+        [-10, 10],
+        [-10, 10],
+    ],
+};

--- a/packages/perseus-editor/src/widgets/__stories__/interactive-graph-editor.argtypes.ts
+++ b/packages/perseus-editor/src/widgets/__stories__/interactive-graph-editor.argtypes.ts
@@ -1,0 +1,180 @@
+export default {
+    apiOptions: {
+        control: {
+            type: "object",
+        },
+        type: {
+            name: "object",
+            required: true,
+        },
+    },
+
+    labels: {
+        control: {
+            type: "array",
+        },
+        type: {
+            name: "ReadonlyArray<string>",
+            required: false,
+        },
+    },
+
+    range: {
+        control: {
+            type: "array",
+        },
+        type: {
+            name: "[Range, Range]",
+            required: false,
+        },
+    },
+
+    step: {
+        control: {
+            type: "array",
+        },
+        type: {
+            name: "[number, number]",
+            required: false,
+        },
+    },
+
+    gridStep: {
+        control: {
+            type: "array",
+        },
+        type: {
+            name: "[number, number]",
+            required: true,
+        },
+    },
+
+    snapStep: {
+        control: {
+            type: "array",
+        },
+        type: {
+            name: "[number, number]",
+            required: true,
+        },
+    },
+
+    box: {
+        control: {
+            type: "array",
+        },
+        type: {
+            name: "[number, number]",
+            required: true,
+        },
+    },
+
+    valid: {
+        control: {
+            type: "text",
+        },
+        type: {
+            name: "string",
+            required: false,
+        },
+    },
+
+    backgroundImage: {
+        control: {
+            type: "object",
+        },
+        type: {
+            name: "PerseusImageBackground",
+            required: false,
+        },
+    },
+
+    markings: {
+        control: {
+            type: "select",
+        },
+        table: {
+            defaultValue: {summary: "graph"},
+            type: {
+                summary: '"graph" | "grid" | "none"',
+            },
+        },
+        type: {
+            name: "enum",
+            value: ["graph", "grid", "none"],
+            required: false,
+        },
+    },
+
+    showProtractor: {
+        control: {
+            type: "boolean",
+        },
+        type: {
+            name: "boolean",
+            required: false,
+        },
+    },
+
+    showRuler: {
+        control: {
+            type: "boolean",
+        },
+        type: {
+            name: "boolean",
+            required: false,
+        },
+    },
+
+    rulerLabel: {
+        control: {
+            type: "text",
+        },
+        type: {
+            name: "string",
+            required: false,
+        },
+    },
+
+    rulerTicks: {
+        control: {
+            type: "number",
+        },
+        type: {
+            name: "number",
+            required: false,
+        },
+    },
+
+    correct: {
+        control: {
+            // Non-editable in the controls panel because it
+            // breaks the story.
+            type: null,
+        },
+        type: {
+            name: "object",
+            required: false,
+        },
+    },
+
+    graph: {
+        control: {
+            type: "object",
+        },
+        type: {
+            name: "object",
+            required: true,
+        },
+    },
+
+    onChange: {
+        control: {
+            type: "function",
+        },
+        type: {
+            name: "(props: Partial<Props>) => void",
+            required: true,
+        },
+    },
+};

--- a/packages/perseus-editor/src/widgets/__stories__/interactive-graph-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/interactive-graph-editor.stories.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+
+import InteractiveGraphEditor from "../interactive-graph-editor";
+
+import InteractiveGraphEditorArgTypes from "./interactive-graph-editor.argtypes";
+
+export default {
+    title: "Perseus/Editor/Widgets/Interactive Graph Editor",
+    component: InteractiveGraphEditor,
+    argTypes: InteractiveGraphEditorArgTypes,
+};
+
+export const Default = (args): React.ReactElement => {
+    return <InteractiveGraphEditor {...args} />;
+};
+
+Default.args = {
+    // Separating the array props out because trying to editing them in
+    // the controls panel without a default value causes the story to crash.
+    box: [288, 288],
+    gridStep: [1, 1],
+    labels: ["x", "y"],
+    range: [
+        [-10, 10],
+        [-10, 10],
+    ],
+    snapStep: [1, 1],
+    step: [1, 1],
+};

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
@@ -80,24 +80,24 @@ type Props = {
     /**
      * The range of the graph in the x and y directions.
      */
-    range: [Range, Range]; // x, y
+    range: [x: Range, y: Range];
     /**
      * How far apart the tick marks on the axes are in the x and y
      * directions.
      */
-    step: [number, number]; // x, y
+    step: [x: number, y: number];
     /**
      * How far apart the grid lines are in the x and y directions.
      */
-    gridStep: [number, number]; // x, y
+    gridStep: [x: number, y: number];
     /**
      * How far apart the snap-to points are in the x and y directions.
      */
-    snapStep: [number, number]; // x, y
+    snapStep: [x: number, y: number];
     /**
      * The size of the graph in pixels.
      */
-    box: [number, number]; // x, y
+    box: [x: number, y: number];
 
     /**
      * An error message to display in the graph area, or true if the
@@ -135,6 +135,9 @@ type Props = {
      * The number of ticks to display on the ruler.
      */
     rulerTicks: number;
+    /**
+     * The data for checking if an answer is correct.
+     */
     correct: any; // TODO(jeremy)
 
     /**

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
@@ -73,23 +73,73 @@ const FieldLabel = (props: {children: string}) => {
 type Props = {
     apiOptions: APIOptionsWithDefaults;
 
+    /**
+     * The labels for the x and y axes.
+     */
     labels: ReadonlyArray<string>;
+    /**
+     * The range of the graph in the x and y directions.
+     */
     range: [Range, Range]; // x, y
+    /**
+     * How far apart the tick marks on the axes are in the x and y
+     * directions.
+     */
     step: [number, number]; // x, y
+    /**
+     * How far apart the grid lines are in the x and y directions.
+     */
     gridStep: [number, number]; // x, y
+    /**
+     * How far apart the snap-to points are in the x and y directions.
+     */
     snapStep: [number, number]; // x, y
+    /**
+     * The size of the graph in pixels.
+     */
     box: [number, number]; // x, y
 
-    valid: boolean;
+    /**
+     * An error message to display in the graph area, or true if the
+     * graph is valid.
+     */
+    valid: string | boolean;
+    /**
+     * The background image to display in the graph area and its properties.
+     */
     backgroundImage: PerseusImageBackground;
+    /**
+     * The type of markings to display on the graph.
+     * - graph: shows the axes and the grid lines
+     * - grid: shows only the grid lines
+     * - none: shows no markings
+     */
     markings: string; // TODO(jeremy)
+    /**
+     * Whether to show the protractor on the graph.
+     */
     showProtractor: boolean;
+    /**
+     * Whether to show the ruler on the graph.
+     */
     showRuler: boolean;
+    /**
+     * Whether to show tooltips on the graph.
+     */
     showTooltips: boolean;
+    /**
+     * The label to display on the ruler, if any.
+     */
     rulerLabel: string;
+    /**
+     * The number of ticks to display on the ruler.
+     */
     rulerTicks: number;
     correct: any; // TODO(jeremy)
 
+    /**
+     * The graph to display in the graph area.
+     */
     graph: InteractiveGraphProps["graph"];
     onChange: (props: Partial<Props>) => void;
 };

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
@@ -159,6 +159,12 @@ type DefaultProps = {
     correct: Props["correct"];
 };
 
+/**
+ * An editor for the InteractiveGraph widget, which allows the user to
+ * specify the graph's properties and the correct answer.
+ *
+ * Used in the exercise editor.
+ */
 class InteractiveGraphEditor extends React.Component<Props> {
     displayName = "InteractiveGraphEditor";
     className = "perseus-widget-interactive-graph";


### PR DESCRIPTION
## Summary:
Right now, there aren't really stories for GraphSettings
or InteractiveGraphEditor.

Adding them here so that it's easier to visually test
them later.

Note: I added prop comments in interactive-graph-editor.tsx
so that storybook automatically uses those props. I didn't do
that for graph-settings.tsx yet here, because that will be
converted to a React class soon. It will be easier to add the
prop comments after that conversion.

Issue: https://khanacademy.atlassian.net/browse/LC-1702

## Test plan:
Graph Settings
http://localhost:6006/?path=/docs/perseus-editor-components-graph-settings--docs

InteractiveGraphEditor
http://localhost:6006/?path=/docs/perseus-editor-widgets-interactive-graph-editor--docs

### Graph Settings story + control panel

<img width="1093" alt="Screenshot 2024-02-26 at 8 25 52 PM" src="https://github.com/Khan/perseus/assets/13231763/e42fdfc1-20c2-48e5-9c2f-272ad9b30c3f">

<img width="1046" alt="Screenshot 2024-02-26 at 8 26 06 PM" src="https://github.com/Khan/perseus/assets/13231763/cdff650f-47e4-41c0-ac13-0686e6d75b18">

### Interactive Graph Editor story + control panel

<img width="1044" alt="Screenshot 2024-02-26 at 8 26 24 PM" src="https://github.com/Khan/perseus/assets/13231763/58c665e7-5647-444a-b25a-320664439c2d">

<img width="1063" alt="Screenshot 2024-02-26 at 8 26 32 PM" src="https://github.com/Khan/perseus/assets/13231763/28b92be2-37af-475d-95cc-2325622cf2a1">

<img width="1038" alt="Screenshot 2024-02-26 at 8 26 37 PM" src="https://github.com/Khan/perseus/assets/13231763/fd5fea4b-d51d-4de4-a028-816e753c889b">
