### PR TITLE
Create InteractiveGraphSettings component (copied from GraphSettings)

### DIFF
--- a/.changeset/late-cooks-kick.md
+++ b/.changeset/late-cooks-kick.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+Create InteractiveGraphSettings to be used in InteractiveGraphEditor in place of GraphSettings

--- a/packages/perseus-editor/src/components/__stories__/interactive-graph-settings.argtypes.ts
+++ b/packages/perseus-editor/src/components/__stories__/interactive-graph-settings.argtypes.ts
@@ -1,0 +1,84 @@
+export default {
+    editableSettings: {
+        control: {
+            type: "array",
+            options: ["canvas", "graph", "snap", "image", "measure"],
+        },
+    },
+    box: {
+        control: {
+            type: "array",
+        },
+    },
+    range: {
+        control: {
+            type: "object",
+        },
+    },
+    labels: {
+        control: {
+            type: "object",
+        },
+    },
+    step: {
+        control: {
+            type: "object",
+        },
+    },
+    gridStep: {
+        control: {
+            type: "object",
+        },
+    },
+    snapStep: {
+        control: {
+            type: "object",
+        },
+    },
+    valid: {
+        control: {
+            type: "text",
+        },
+    },
+    backgroundImage: {
+        control: {
+            type: "object",
+        },
+    },
+    markings: {
+        control: {
+            type: "select",
+        },
+        table: {
+            defaultValue: {summary: "graph"},
+            type: {
+                summary: '"graph" | "grid" | "none"',
+            },
+        },
+        type: {
+            name: "enum",
+            value: ["graph", "grid", "none"],
+            required: false,
+        },
+    },
+    rulerLabel: {
+        control: {
+            type: "text",
+        },
+    },
+    rulerTicks: {
+        control: {
+            type: "number",
+        },
+    },
+    showTooltips: {
+        control: {
+            type: "boolean",
+        },
+    },
+    onChange: {
+        control: {
+            type: "function",
+        },
+    },
+};

--- a/packages/perseus-editor/src/components/__stories__/interactive-graph-settings.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/interactive-graph-settings.stories.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+
+import InteractiveGraphSettings from "../interactive-graph-settings";
+
+import InteractiveGraphSettingsArgTypes from "./interactive-graph-settings.argtypes";
+
+export default {
+    title: "Perseus/Editor/Components/Interactive Graph Settings",
+    component: InteractiveGraphSettings,
+    argTypes: InteractiveGraphSettingsArgTypes,
+};
+
+export const Default = (args): React.ReactElement => {
+    return <InteractiveGraphSettings {...args} />;
+};
+
+Default.args = {
+    // Separating the array props out because trying to editing them in
+    // the controls panel without a default value causes the story to crash.
+    range: [
+        [-10, 10],
+        [-10, 10],
+    ],
+};

--- a/packages/perseus-editor/src/components/__tests__/interactive-graph-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/interactive-graph-settings.test.tsx
@@ -1,0 +1,759 @@
+import {Dependencies, Util} from "@khanacademy/perseus";
+import {render, screen, waitFor, fireEvent} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as React from "react";
+
+import {testDependencies} from "../../../../../testing/test-dependencies";
+import InteractiveGraphSettings from "../interactive-graph-settings";
+
+import "@testing-library/jest-dom"; // Imports custom matchers
+
+describe("InteractiveGraphSettings", () => {
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    test("displays canvas settings", () => {
+        // Arrange
+
+        // Act
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["canvas"]}
+                onChange={() => {}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByText("Canvas size (x,y pixels)"),
+        ).toBeInTheDocument();
+    });
+
+    test("displays graph settings", () => {
+        // Arrange
+
+        // Act
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["graph"]}
+                onChange={() => {}}
+            />,
+        );
+
+        // Assert
+        expect(screen.getByText("x Label")).toBeInTheDocument();
+        expect(screen.getByText("y Label")).toBeInTheDocument();
+        expect(screen.getByText("Markings:")).toBeInTheDocument();
+    });
+
+    test("displays nothing if snap is by itself", () => {
+        // Arrange
+
+        // Act
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["snap"]}
+                onChange={() => {}}
+            />,
+        );
+
+        // Assert
+        expect(screen.queryByText("Snap Step")).toBeNull();
+    });
+
+    test("displays snap settings", () => {
+        // Arrange
+
+        // Act
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["graph", "snap"]}
+                onChange={() => {}}
+            />,
+        );
+
+        // Assert
+        expect(screen.getByText("Snap Step")).toBeInTheDocument();
+    });
+
+    test("displays image settings", () => {
+        // Arrange
+
+        // Act
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["image"]}
+                onChange={() => {}}
+            />,
+        );
+
+        // Assert
+        expect(screen.getByText("Background image:")).toBeInTheDocument();
+    });
+
+    test("displays measure settings", () => {
+        // Arrange
+
+        // Act
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["measure"]}
+                onChange={() => {}}
+            />,
+        );
+
+        // Assert
+        expect(screen.getByText("Show ruler")).toBeInTheDocument();
+        expect(screen.getByText("Show protractor")).toBeInTheDocument();
+    });
+
+    test("displays all settings", () => {
+        // Arrange
+
+        // Act
+        render(
+            <InteractiveGraphSettings
+                editableSettings={[
+                    "canvas",
+                    "graph",
+                    "snap",
+                    "image",
+                    "measure",
+                ]}
+                onChange={() => {}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByText("Canvas size (x,y pixels)"),
+        ).toBeInTheDocument();
+        expect(screen.getByText("x Label")).toBeInTheDocument();
+        expect(screen.getByText("y Label")).toBeInTheDocument();
+        expect(screen.getByText("Markings:")).toBeInTheDocument();
+        expect(screen.getByText("Snap Step")).toBeInTheDocument();
+        expect(screen.getByText("Background image:")).toBeInTheDocument();
+        expect(screen.getByText("Show ruler")).toBeInTheDocument();
+        expect(screen.getByText("Show protractor")).toBeInTheDocument();
+    });
+
+    test("calls onChange when markings are changed", () => {
+        // Arrange
+        const onChange = jest.fn();
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["graph"]}
+                onChange={onChange}
+            />,
+        );
+
+        // Act
+        const button = screen.getByRole("button", {name: "Grid"});
+        button.click();
+
+        // Assert
+        expect(onChange).toHaveBeenCalledWith(
+            expect.objectContaining({markings: "grid"}),
+            undefined,
+        );
+    });
+
+    test("calls onChange when ruler label is changed", () => {
+        // Arrange
+        const onChange = jest.fn();
+
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["measure"]}
+                showRuler={true}
+                onChange={onChange}
+            />,
+        );
+
+        // Act
+        const select = screen.getByRole("combobox", {name: "Ruler label:"});
+        userEvent.selectOptions(select, ["cm"]);
+
+        // Assert
+        expect(onChange).toHaveBeenCalledWith(
+            expect.objectContaining({rulerLabel: "cm"}),
+            undefined,
+        );
+    });
+
+    test("calls onChange when rulerTicks is changed", () => {
+        // Arrange
+        const onChange = jest.fn();
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["measure"]}
+                showRuler={true}
+                onChange={onChange}
+            />,
+        );
+
+        // Act
+        const select = screen.getByRole("combobox", {name: "Ruler ticks:"});
+        userEvent.selectOptions(select, ["4"]);
+
+        // Assert
+        // TODO: use this pattern everywhere else too
+        expect(onChange).toBeCalledWith(
+            expect.objectContaining({rulerTicks: 4}),
+            undefined,
+        );
+    });
+
+    test("calls onChange when background image is changed", async () => {
+        // Arrange
+        // TODO(nisha): Figure out how to use fake timers for this.
+        jest.useRealTimers();
+        const onChange = jest.fn();
+        const mockImplementation = (url, cb: (width, height) => void) => {
+            cb(100, 100);
+        };
+        jest.spyOn(Util, "getImageSize").mockImplementation(mockImplementation);
+
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["image"]}
+                onChange={onChange}
+            />,
+        );
+
+        // Act
+        const input = screen.getByRole("textbox");
+        userEvent.type(input, "https://example.com/image.png");
+        userEvent.tab();
+
+        // Assert
+        await waitFor(() =>
+            expect(onChange).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    backgroundImage: expect.objectContaining({
+                        url: "https://example.com/image.png",
+                    }),
+                }),
+                undefined,
+            ),
+        );
+    });
+
+    test("validates background image size", async () => {
+        // Arrange
+        // TODO(nisha): Figure out how to use fake timers for this.
+        jest.useRealTimers();
+        const onChange = jest.fn();
+        const mockImplementation = (url, cb: (width, height) => void) => {
+            // Large image should be invalid
+            cb(1000, 1000);
+        };
+        jest.spyOn(Util, "getImageSize").mockImplementation(mockImplementation);
+
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["image"]}
+                onChange={onChange}
+            />,
+        );
+
+        // Act
+        const input = screen.getByRole("textbox");
+        userEvent.type(input, "https://example.com/image.png");
+        userEvent.tab();
+
+        // Assert
+        await waitFor(() =>
+            expect(onChange).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    valid: "Image must be smaller than 450px x 450px.",
+                }),
+                undefined,
+            ),
+        );
+    });
+
+    test("calls onChange with null background image if background image input is empty", async () => {
+        // Arrange
+        // TODO(nisha): Figure out how to use fake timers for this.
+        jest.useRealTimers();
+        const onChange = jest.fn();
+        const mockImplementation = (url, cb: (width, height) => void) => {};
+        jest.spyOn(Util, "getImageSize").mockImplementation(mockImplementation);
+
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["image"]}
+                onChange={onChange}
+            />,
+        );
+
+        // Act
+        const input = screen.getByRole("textbox");
+        userEvent.type(input, "");
+        userEvent.tab();
+
+        // Assert
+        await waitFor(() =>
+            expect(onChange).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    backgroundImage: expect.objectContaining({
+                        url: null,
+                    }),
+                }),
+                undefined,
+            ),
+        );
+    });
+
+    test("does not update background image until input is blurred", async () => {
+        // Arrange
+        // TODO(nisha): Figure out how to use fake timers for this.
+        jest.useRealTimers();
+        const onChange = jest.fn();
+
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["image"]}
+                onChange={onChange}
+            />,
+        );
+
+        // Act
+        const input = screen.getByRole("textbox");
+        input.focus();
+        // Disabling this because we need to test keypress events that are
+        // unfortunately being used in legacy code.
+        // eslint-disable-next-line testing-library/prefer-user-event
+        fireEvent.keyPress(input, {key: "a", code: "KeyA", charCode: 97});
+
+        // Assert
+        expect(onChange).not.toHaveBeenCalled();
+
+        userEvent.tab();
+        await waitFor(() => expect(onChange).toHaveBeenCalled());
+    });
+
+    test("calls onChange when protractor label is changed", () => {
+        // Arrange
+        const onChange = jest.fn();
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["measure"]}
+                showProtractor={true}
+                onChange={onChange}
+            />,
+        );
+
+        // Act
+        const checkbox = screen.getByRole("checkbox", {
+            name: "Show protractor",
+        });
+        checkbox.click();
+
+        // Assert
+        expect(onChange).toHaveBeenCalledWith(
+            expect.objectContaining({showProtractor: false}),
+            undefined,
+        );
+    });
+
+    test("Calls onChange when x range is changed and valid", async () => {
+        // Arrange
+        // TODO(nisha): Figure out how to use fake timers for this.
+        jest.useRealTimers();
+        const onChange = jest.fn();
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["graph"]}
+                onChange={onChange}
+            />,
+        );
+
+        // Act
+        const input = screen.getByRole("textbox", {name: "x Range"});
+        userEvent.clear(input);
+        userEvent.paste(input, "0");
+
+        // Assert
+        await waitFor(() =>
+            expect(onChange).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    range: [
+                        [0, 10],
+                        [-10, 10],
+                    ],
+                    valid: true,
+                }),
+                undefined,
+            ),
+        );
+    });
+
+    test("Calls onChange when y range is changed and valid", async () => {
+        // Arrange
+        // TODO(nisha): Figure out how to use fake timers for this.
+        jest.useRealTimers();
+        const onChange = jest.fn();
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["graph"]}
+                onChange={onChange}
+            />,
+        );
+
+        // Act
+        const input = screen.getByRole("textbox", {name: "y Range"});
+        userEvent.clear(input);
+        userEvent.paste(input, "0");
+
+        // Assert
+        await waitFor(() =>
+            expect(onChange).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    range: [
+                        [-10, 10],
+                        [0, 10],
+                    ],
+                    valid: true,
+                }),
+                undefined,
+            ),
+        );
+    });
+
+    test("validates range input when left is bigger than right", async () => {
+        // Arrange
+        // TODO(nisha): Figure out how to use fake timers for this.
+        jest.useRealTimers();
+        const onChange = jest.fn();
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["graph"]}
+                onChange={onChange}
+            />,
+        );
+
+        // Act
+        const input = screen.getByRole("textbox", {name: "x Range"});
+        userEvent.clear(input);
+        userEvent.paste(input, "20");
+
+        // Assert
+        await waitFor(() =>
+            expect(onChange).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    range: [
+                        [-10, 10],
+                        [-10, 10],
+                    ],
+                    valid: "Range must have a higher number on the right",
+                }),
+                undefined,
+            ),
+        );
+    });
+
+    test("Calls onChange when step value is changed and valid", async () => {
+        // Arrange
+        // TODO(nisha): Figure out how to use fake timers for this.
+        jest.useRealTimers();
+        const onChange = jest.fn();
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["graph"]}
+                onChange={onChange}
+            />,
+        );
+
+        // Act
+        const input = screen.getByRole("textbox", {name: "Tick Step"});
+        userEvent.clear(input);
+        userEvent.paste(input, "2");
+
+        // Assert
+        await waitFor(() =>
+            expect(onChange).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    step: [2, 1],
+                    valid: true,
+                }),
+                undefined,
+            ),
+        );
+    });
+
+    test("validates step value when tick step is too large", async () => {
+        // Arrange
+        // TODO(nisha): Figure out how to use fake timers for this.
+        jest.useRealTimers();
+        const onChange = jest.fn();
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["graph"]}
+                onChange={onChange}
+            />,
+        );
+
+        // Act
+        const input = screen.getByRole("textbox", {name: "Tick Step"});
+        userEvent.clear(input);
+        userEvent.paste(input, "20");
+
+        // Assert
+        await waitFor(() =>
+            expect(onChange).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    step: [1, 1],
+                    valid: "Step is too large, there must be at least 3 ticks.",
+                }),
+                undefined,
+            ),
+        );
+    });
+
+    test("validates step value when tick step is too small", async () => {
+        // Arrange
+        // TODO(nisha): Figure out how to use fake timers for this.
+        jest.useRealTimers();
+        const onChange = jest.fn();
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["graph"]}
+                range={[
+                    [-100, 100],
+                    [-100, 100],
+                ]}
+                onChange={onChange}
+            />,
+        );
+
+        // Act
+        const input = screen.getByRole("textbox", {name: "Tick Step"});
+        userEvent.clear(input);
+        userEvent.paste(input, "2");
+
+        // Assert
+        await waitFor(() =>
+            expect(onChange).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    step: [1, 1],
+                    valid: "Step is too small, there can be at most 20 ticks.",
+                }),
+                undefined,
+            ),
+        );
+    });
+
+    test("Calls onChange when snap step is changed and valid", async () => {
+        // Arrange
+        // TODO(nisha): Figure out how to use fake timers for this.
+        jest.useRealTimers();
+        const onChange = jest.fn();
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["graph", "snap"]}
+                onChange={onChange}
+            />,
+        );
+
+        // Act
+        const input = screen.getByRole("textbox", {name: "Snap Step"});
+        userEvent.clear(input);
+        userEvent.paste(input, "2");
+        userEvent.tab();
+
+        // Assert
+        await waitFor(() =>
+            expect(onChange).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    snapStep: [2, 1],
+                    valid: true,
+                }),
+                undefined,
+            ),
+        );
+    });
+
+    test("validates when the snap step is too large", async () => {
+        // Arrange
+        // TODO(nisha): Figure out how to use fake timers for this.
+        jest.useRealTimers();
+        const onChange = jest.fn();
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["graph", "snap"]}
+                onChange={onChange}
+            />,
+        );
+
+        // Act
+        const input = screen.getByRole("textbox", {name: "Snap Step"});
+        userEvent.clear(input);
+        userEvent.paste(input, "100");
+        userEvent.tab();
+
+        // Assert
+        await waitFor(() =>
+            expect(onChange).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    snapStep: [1, 1],
+                    valid: "Snap step is too large, there must be at least 5 ticks.",
+                }),
+                undefined,
+            ),
+        );
+    });
+
+    test("Calls onChange when grid step is changed and valid", async () => {
+        // Arrange
+        // TODO(nisha): Figure out how to use fake timers for this.
+        jest.useRealTimers();
+        const onChange = jest.fn();
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["graph"]}
+                onChange={onChange}
+            />,
+        );
+
+        // Act
+        const input = screen.getByRole("textbox", {name: "Grid Step"});
+        userEvent.clear(input);
+        userEvent.paste(input, "2");
+        userEvent.tab();
+
+        // Assert
+        await waitFor(() =>
+            expect(onChange).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    gridStep: [2, 1],
+                    valid: true,
+                }),
+                undefined,
+            ),
+        );
+    });
+
+    test("validates when the grid step is too large", async () => {
+        // Arrange
+        // TODO(nisha): Figure out how to use fake timers for this.
+        jest.useRealTimers();
+        const onChange = jest.fn();
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["graph"]}
+                onChange={onChange}
+            />,
+        );
+
+        // Act
+        const input = screen.getByRole("textbox", {name: "Grid Step"});
+        userEvent.clear(input);
+        userEvent.paste(input, "100");
+        userEvent.tab();
+
+        // Assert
+        await waitFor(() =>
+            expect(onChange).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    gridStep: [1, 1],
+                    valid: "Grid step is too large, there must be at least 3 ticks.",
+                }),
+                undefined,
+            ),
+        );
+    });
+
+    test("Calls onChange when the x label is changed", async () => {
+        // Arrange
+        // TODO(nisha): Figure out how to use fake timers for this.
+        jest.useRealTimers();
+        const onChange = jest.fn();
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["graph"]}
+                onChange={onChange}
+            />,
+        );
+
+        // Act
+        const input = screen.getByRole("textbox", {name: "x Label"});
+        userEvent.clear(input);
+        userEvent.paste(input, "time");
+        userEvent.tab();
+
+        // Assert
+        await waitFor(() =>
+            expect(onChange).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    labels: ["time", "y"],
+                }),
+                undefined,
+            ),
+        );
+    });
+
+    test("Calls onChange when the y label is changed", async () => {
+        // Arrange
+        // TODO(nisha): Figure out how to use fake timers for this.
+        jest.useRealTimers();
+        const onChange = jest.fn();
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["graph"]}
+                onChange={onChange}
+            />,
+        );
+
+        // Act
+        const input = screen.getByRole("textbox", {name: "y Label"});
+        userEvent.clear(input);
+        userEvent.paste(input, "count");
+        userEvent.tab();
+
+        // Assert
+        await waitFor(() =>
+            expect(onChange).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    labels: ["x", "count"],
+                }),
+                undefined,
+            ),
+        );
+    });
+
+    test("Calls onChange when the canvas size is changed and valid", async () => {
+        // Arrange
+        // TODO(nisha): Figure out how to use fake timers for this.
+        jest.useRealTimers();
+        const onChange = jest.fn();
+        render(
+            <InteractiveGraphSettings
+                editableSettings={["canvas"]}
+                onChange={onChange}
+            />,
+        );
+
+        // Act
+        const input = screen.getByRole("textbox", {
+            name: "Canvas size (x,y pixels)",
+        });
+        userEvent.clear(input);
+        userEvent.paste(input, "300");
+        userEvent.tab();
+
+        // Assert
+        await waitFor(() =>
+            expect(onChange).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    box: [300, 288],
+                }),
+                undefined,
+            ),
+        );
+    });
+});

--- a/packages/perseus-editor/src/components/__tests__/interactive-graph-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/interactive-graph-settings.test.tsx
@@ -61,7 +61,7 @@ describe("InteractiveGraphSettings", () => {
         );
 
         // Assert
-        expect(screen.queryByText("Snap Step")).toBeNull();
+        expect(screen.queryByText("Snap Step")).not.toBeInTheDocument();
     });
 
     test("displays snap settings", () => {
@@ -200,7 +200,6 @@ describe("InteractiveGraphSettings", () => {
         userEvent.selectOptions(select, ["4"]);
 
         // Assert
-        // TODO: use this pattern everywhere else too
         expect(onChange).toBeCalledWith(
             expect.objectContaining({rulerTicks: 4}),
             undefined,
@@ -212,10 +211,10 @@ describe("InteractiveGraphSettings", () => {
         // TODO(nisha): Figure out how to use fake timers for this.
         jest.useRealTimers();
         const onChange = jest.fn();
-        const mockImplementation = (url, cb: (width, height) => void) => {
+        const mockGetImageSize = (url, cb: (width, height) => void) => {
             cb(100, 100);
         };
-        jest.spyOn(Util, "getImageSize").mockImplementation(mockImplementation);
+        jest.spyOn(Util, "getImageSize").mockImplementation(mockGetImageSize);
 
         render(
             <InteractiveGraphSettings
@@ -247,11 +246,11 @@ describe("InteractiveGraphSettings", () => {
         // TODO(nisha): Figure out how to use fake timers for this.
         jest.useRealTimers();
         const onChange = jest.fn();
-        const mockImplementation = (url, cb: (width, height) => void) => {
+        const mockGetImageSize = (url, cb: (width, height) => void) => {
             // Large image should be invalid
             cb(1000, 1000);
         };
-        jest.spyOn(Util, "getImageSize").mockImplementation(mockImplementation);
+        jest.spyOn(Util, "getImageSize").mockImplementation(mockGetImageSize);
 
         render(
             <InteractiveGraphSettings
@@ -281,8 +280,8 @@ describe("InteractiveGraphSettings", () => {
         // TODO(nisha): Figure out how to use fake timers for this.
         jest.useRealTimers();
         const onChange = jest.fn();
-        const mockImplementation = (url, cb: (width, height) => void) => {};
-        jest.spyOn(Util, "getImageSize").mockImplementation(mockImplementation);
+        const mockGetImageSize = (url, cb: (width, height) => void) => {};
+        jest.spyOn(Util, "getImageSize").mockImplementation(mockGetImageSize);
 
         render(
             <InteractiveGraphSettings
@@ -332,9 +331,6 @@ describe("InteractiveGraphSettings", () => {
 
         // Assert
         expect(onChange).not.toHaveBeenCalled();
-
-        userEvent.tab();
-        await waitFor(() => expect(onChange).toHaveBeenCalled());
     });
 
     test("calls onChange when protractor label is changed", () => {

--- a/packages/perseus-editor/src/components/interactive-graph-settings.tsx
+++ b/packages/perseus-editor/src/components/interactive-graph-settings.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/forbid-prop-types, react/no-unsafe */
 /**
- * Used in the editors for the Grapher and Interaction widgets.
+ * Used in the editor for the InteractiveGraph widget.
  */
 import {
     components,
@@ -28,8 +28,8 @@ function numSteps(range: any, step: any) {
     return Math.floor((range[1] - range[0]) / step);
 }
 
-const GraphSettings = createReactClass({
-    displayName: "GraphSettings",
+const InteractiveGraphSettings = createReactClass({
+    displayName: "InteractiveGraphSettings",
 
     propTypes: {
         ...Changeable.propTypes,
@@ -636,4 +636,4 @@ const GraphSettings = createReactClass({
     },
 });
 
-export default GraphSettings;
+export default InteractiveGraphSettings;

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
@@ -14,8 +14,8 @@ import * as React from "react";
 import _ from "underscore";
 
 import GraphPointsCountSelector from "../components/graph-points-count-selector";
-import GraphSettings from "../components/graph-settings";
 import GraphTypeSelector from "../components/graph-type-selector";
+import InteractiveGraphSettings from "../components/interactive-graph-settings";
 import SegmentCountSelector from "../components/segment-count-selector";
 import {parsePointCount} from "../util/points";
 
@@ -459,7 +459,7 @@ class InteractiveGraphEditor extends React.Component<Props> {
                         </p>
                     </InfoTip>
                 </Row>
-                <GraphSettings
+                <InteractiveGraphSettings
                     box={getInteractiveBoxFromSizeClass(sizeClass)}
                     range={this.props.range}
                     labels={this.props.labels}


### PR DESCRIPTION
## Summary:

We are going to be making changes to interactive graph, which will also require updating InteractiveGraphEditor and therefore GraphSettings. Since GraphSettings is also used for the Grapher and Interaction widgets, we don't want to change it too much. To avoid breaking changes, we're breaking graph settings related to interactive graph into its own file, interactive-graph settings.

This PR just involves copying the file over. Modernizing the file and additional changes will come in following PRs.

- Create the .tsx, .test.tsx, .stories.tsx, and .argtypes.tsx files for InteractiveGraphSettings, copied over from GraphSettings.
- Update the files to say `interactive graph settings` instead of `graph settings` where applicable.
- Add comments at the top of the files explaining which widgets they're related to.

Issue: https://khanacademy.atlassian.net/browse/LC-1702

## Test plan:
`yarn jest`
`yarn typecheck`