### PR TITLE
Update interactive-graph-settings.tsx to React class component

### DIFF
--- a/.changeset/nervous-news-cheat.md
+++ b/.changeset/nervous-news-cheat.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Udpate InteractiveGraphSettings to React class. Update `markings` to be "graph" | "grid" | "none" instead of string.

--- a/.changeset/nervous-news-cheat.md
+++ b/.changeset/nervous-news-cheat.md
@@ -3,4 +3,4 @@
 "@khanacademy/perseus-editor": patch
 ---
 
-Udpate InteractiveGraphSettings to React class. Update `markings` to be "graph" | "grid" | "none" instead of string.
+Update InteractiveGraphSettings to React class. Update `markings` to be "graph" | "grid" | "none" instead of string.

--- a/packages/perseus-editor/src/components/interactive-graph-settings.tsx
+++ b/packages/perseus-editor/src/components/interactive-graph-settings.tsx
@@ -127,21 +127,21 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
         this._isMounted = false;
     }
 
-    change(...args) {
+    change = (...args) => {
         return Changeable.change.apply(this, args);
-    }
+    };
 
     // TODO(aria): Make either a wrapper for standard events to work
     // with this.change, or make these use some TextInput/NumberInput box
-    changeRulerLabel(e) {
+    changeRulerLabel = (e) => {
         this.change({rulerLabel: e.target.value});
-    }
+    };
 
-    changeRulerTicks(e) {
+    changeRulerTicks = (e) => {
         this.change({rulerTicks: +e.target.value});
-    }
+    };
 
-    changeBackgroundUrl(e) {
+    changeBackgroundUrl = (e) => {
         // Only continue on blur or "enter"
         if (e.type === "keypress" && e.key !== "Enter") {
             return;
@@ -171,15 +171,15 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
         } else {
             setUrl(null, 0, 0);
         }
-    }
+    };
 
-    renderLabelChoices(choices) {
+    renderLabelChoices = (choices) => {
         return _.map(choices, function (nameAndValue) {
             return <option value={nameAndValue[1]}>{nameAndValue[0]}</option>;
         });
-    }
+    };
 
-    validRange(range) {
+    validRange = (range) => {
         const numbers = _.every(range, function (num) {
             return _.isFinite(num);
         });
@@ -190,9 +190,9 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
             return "Range must have a higher number on the right";
         }
         return true;
-    }
+    };
 
-    validateStepValue(settings) {
+    validateStepValue = (settings) => {
         const {step, range, name, minTicks, maxTicks} = settings;
 
         if (!_.isFinite(step)) {
@@ -216,9 +216,9 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
             );
         }
         return true;
-    }
+    };
 
-    validSnapStep(step, range) {
+    validSnapStep = (step, range) => {
         return this.validateStepValue({
             step: step,
             range: range,
@@ -226,9 +226,9 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
             minTicks: 5,
             maxTicks: 60,
         });
-    }
+    };
 
-    validGridStep(step, range) {
+    validGridStep = (step, range) => {
         return this.validateStepValue({
             step: step,
             range: range,
@@ -236,9 +236,9 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
             minTicks: 3,
             maxTicks: 60,
         });
-    }
+    };
 
-    validStep(step, range) {
+    validStep = (step, range) => {
         return this.validateStepValue({
             step: step,
             range: range,
@@ -246,9 +246,9 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
             minTicks: 3,
             maxTicks: 20,
         });
-    }
+    };
 
-    validBackgroundImageSize(image) {
+    validBackgroundImageSize = (image) => {
         // Ignore empty images
         if (!image.url) {
             return true;
@@ -260,9 +260,9 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
             return "Image must be smaller than 450px x 450px.";
         }
         return true;
-    }
+    };
 
-    validateGraphSettings(range, step, gridStep, snapStep, image) {
+    validateGraphSettings = (range, step, gridStep, snapStep, image) => {
         const self = this;
         let msg;
         const goodRange = _.every(range, function (range) {
@@ -299,16 +299,16 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
             return msg;
         }
         return true;
-    }
+    };
 
-    changeLabel(i, e) {
+    changeLabel = (i, e) => {
         const val = e.target.value;
         const labels = this.state.labelsTextbox.slice();
         labels[i] = val;
         this.setState({labelsTextbox: labels}, this.changeGraph);
-    }
+    };
 
-    changeRange(i, values) {
+    changeRange = (i, values) => {
         const ranges = this.state.rangeTextbox.slice();
         ranges[i] = values;
         const step = this.state.stepTextbox.slice();
@@ -334,17 +334,17 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
             },
             this.changeGraph,
         );
-    }
+    };
 
-    changeStep(step) {
+    changeStep = (step) => {
         this.setState({stepTextbox: step}, this.changeGraph);
-    }
+    };
 
-    changeSnapStep(snapStep) {
+    changeSnapStep = (snapStep) => {
         this.setState({snapStepTextbox: snapStep}, this.changeGraph);
-    }
+    };
 
-    changeGridStep(gridStep) {
+    changeGridStep = (gridStep) => {
         this.setState(
             {
                 gridStepTextbox: gridStep,
@@ -354,9 +354,9 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
             },
             this.changeGraph,
         );
-    }
+    };
 
-    changeGraph() {
+    changeGraph = () => {
         const labels = this.state.labelsTextbox;
         const range = _.map(this.state.rangeTextbox, function (range) {
             return _.map(range, Number);
@@ -395,7 +395,7 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
                 valid: validationResult, // a string message, not false
             });
         }
-    }
+    };
 
     render() {
         const scale = [

--- a/packages/perseus-editor/src/components/interactive-graph-settings.tsx
+++ b/packages/perseus-editor/src/components/interactive-graph-settings.tsx
@@ -1,4 +1,7 @@
 /* eslint-disable react/forbid-prop-types, react/no-unsafe */
+/**
+ * Used in the editor for the InteractiveGraph widget.
+ */
 import {
     components,
     interactiveSizes,

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
@@ -114,7 +114,7 @@ type Props = {
      * - grid: shows only the grid lines
      * - none: shows no markings
      */
-    markings: string; // TODO(jeremy)
+    markings: "graph" | "grid" | "none";
     /**
      * Whether to show the protractor on the graph.
      */

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -538,7 +538,7 @@ export type PerseusInteractiveGraphWidgetOptions = {
     // An optional image to use in the background
     backgroundImage?: PerseusImageBackground;
     // What to show on the graph.  "graph", "grid", or "none"
-    markings: string;
+    markings: "graph" | "grid" | "none";
     // How to label the X and Y axis.  default: ["x", "y"]
     labels: ReadonlyArray<string>;
     // Whether to show the Protractor tool overlayed on top of the graph


### PR DESCRIPTION
## Summary:
This PR is pretty much the same as https://github.com/Khan/perseus/pull/1009.

The changes from that PR got rolled back, and now interactive-graph-settings.tsx
has been split out as a copy of graph-settings.tsx.

Instead of updating graph-settings.tsx, we're keeping that as is as it will
only be used by deprecated components. interactive-graph-settings.tsx will
continue to be updated along with InteractiveGraph.

To make these updates easier, we're making InteractiveGraphSettings a
React class component instead of it using the old `createReactClass` const.

- Update InteractiveGraphSettings to be a React class
- Add types
- Use arrow functions so `this` binds correctly

Additional cleanup coming in a following PR.

Issue: https://khanacademy.atlassian.net/browse/LC-1702

## Test plan:
`yarn jest packages/perseus-editor/src/components/__tests__/interactive-graph-settings.test.tsx`
`yarn typecheck`