### PR TITLE
Add instructions to the flipbook UI

### DIFF
--- a/dev/flipbook.tsx
+++ b/dev/flipbook.tsx
@@ -20,6 +20,14 @@ import type {APIOptions, PerseusRenderer} from "../packages/perseus/src";
 
 import "../packages/perseus/src/styles/perseus-renderer.less";
 
+const exampleCommands = `
+# copy all questions
+cat data/questions/*/*/* | pbcopy
+
+# copy all segment questions
+grep -rl '"type":"segment"' data/questions/ | xargs cat | pbcopy
+`.trim();
+
 export function Flipbook() {
     const [state, dispatch] = useReducer(flipbookModelReducer, {
         questions: "",
@@ -30,6 +38,24 @@ export function Flipbook() {
 
     return (
         <View style={{padding: Spacing.medium_16}}>
+            <details open>
+                <summary>Instructions (click to show/hide)</summary>
+                <ol>
+                    <li>
+                        <p>
+                            Run a command like one of the following to copy
+                            question data to your clipboard.
+                        </p>
+                        <code>
+                            <pre>{exampleCommands}</pre>
+                        </code>
+                    </li>
+                    <li>
+                        <p>Paste the data in the box below.</p>
+                    </li>
+                </ol>
+            </details>
+
             <textarea
                 wrap={"off"}
                 rows={10}


### PR DESCRIPTION
Issue: none

## Test plan:

```
yarn dev
open http://localhost:5173
```

- Click the "flipbook" link.
- You should be able to follow the instructions and get graphs rendering on the
  page.

<img width="1008" alt="Screen Shot 2024-02-27 at 2 28 59 PM" src="https://github.com/Khan/perseus/assets/693920/5502f429-73fa-4e43-9e09-28c8abb7749c">
