### PR TITLE
[🔥AUDIT🔥] Fix Storybook deployed on GH Pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "storybook": "storybook dev -p 6006",
     "start": "storybook dev -p 6006",
     "build-storybook": "storybook build",
+    "post:build-storybook": "touch ./storybook-static/.nojekyll",
     "cypress": "cypress open --component",
     "cypress:ci": "cross-env BABEL_COVERAGE=1 cypress run --component --env CYPRESS_COVERAGE=1",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "storybook": "storybook dev -p 6006",
     "start": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "postbuild-storybook": "touch ./storybook-static/.nojekyll",
+    "postbuild-storybook": "install -d ./storybook-static/.nojekyll",
     "cypress": "cypress open --component",
     "cypress:ci": "cross-env BABEL_COVERAGE=1 cypress run --component --env CYPRESS_COVERAGE=1",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "storybook": "storybook dev -p 6006",
     "start": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "post:build-storybook": "touch ./storybook-static/.nojekyll",
+    "postbuild-storybook": "touch ./storybook-static/.nojekyll",
     "cypress": "cypress open --component",
     "cypress:ci": "cross-env BABEL_COVERAGE=1 cypress run --component --env CYPRESS_COVERAGE=1",
     "format": "prettier --write .",


### PR DESCRIPTION
## Summary:

We just switched to using Vite with Storybook. Vite outputs files that have an underscore prefix and Github has some native Jekyll support that ignores these types of files. 

I found a Github issue where the poster found [the issue](https://github.com/storybookjs/storybook/issues/21711#issuecomment-1496464011).  That linked to a Github article explaining the behaviour. 

So this PR adds a `poststorybook-build` script to the `package.json` file which emits the `.nojekyll` file into the `storybook-static` folder before publishing. 

Issue: "none"

## Test plan:

I have no way to test this without landing and releasing it, so that's how I'll test