### PR TITLE
Update actions to Node v20 compatible versions

### DIFF
--- a/.github/actions/shared-node-cache/action.yml
+++ b/.github/actions/shared-node-cache/action.yml
@@ -17,11 +17,11 @@ inputs:
 runs:
     using: "composite"
     steps:
-        - uses: webfactory/ssh-agent@v0.7.0
+        - uses: webfactory/ssh-agent@v0.9.0
           with:
               ssh-private-key: ${{ inputs.ssh-private-key }}
 
         - name: Use Node.js ${{ inputs.node-version }} & Install & cache node_modules
-          uses: Khan/actions@shared-node-cache-v0
+          uses: Khan/actions@shared-node-cache-v1
           with:
               node-version: ${{ inputs.node-version }}

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -37,7 +37,7 @@ jobs:
                   matchAllGlobs: true # Default is to match any of the globs, which ends up matching all files
                   conjunctive: true # Only match files that match all of the above
 
-            - uses: webfactory/ssh-agent@v0.7.0
+            - uses: webfactory/ssh-agent@v0.9.0
               with:
                   ssh-private-key: ${{ secrets.KHAN_ACTIONS_BOT_SSH_PRIVATE_KEY }}
 


### PR DESCRIPTION
## Summary:

I noticed warnings when looking at a Github action run about Node 16 reaching end of life soon.  This PR bumps two of the noted actions to their latest version so they run on Node 20. I'm not sure if there'll be more, but I'll tackle those in a second PR if there are. 

Issue: "none"

## Test plan: