### PR TITLE
Clarify what versions of React the project supports

### DIFF
--- a/.changeset/plenty-forks-sing.md
+++ b/.changeset/plenty-forks-sing.md
@@ -1,0 +1,8 @@
+---
+"@khanacademy/math-input": patch
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+"@khanacademy/simple-markdown": patch
+---
+
+Update package.json to make supported React version ranges clear

--- a/packages/math-input/package.json
+++ b/packages/math-input/package.json
@@ -41,8 +41,8 @@
         "katex": "^0.11.1",
         "perseus-build-settings": "^0.3.0",
         "prop-types": "15.6.1",
-        "react": "^16.8.0",
-        "react-dom": "^16.8.0",
+        "react": ">= 16.14.0 < 17",
+        "react-dom": ">= 16.14.0 < 17",
         "react-router": "^5.2.1",
         "react-router-dom": "^5.3.0",
         "react-transition-group": "^4.4.1"
@@ -61,8 +61,8 @@
         "jquery": "^2.1.1",
         "katex": "^0.11.1",
         "prop-types": "15.6.1",
-        "react": "^16.8.0",
-        "react-dom": "^16.8.0",
+        "react": ">= 16.14.0 < 17",
+        "react-dom": ">= 16.14.0 < 17",
         "react-router": "^5.2.1",
         "react-router-dom": "^5.3.0",
         "react-transition-group": "^4.4.1"

--- a/packages/perseus-editor/package.json
+++ b/packages/perseus-editor/package.json
@@ -49,8 +49,8 @@
         "katex": "^0.11.1",
         "perseus-build-settings": "^0.3.0",
         "prop-types": "^15.6.1",
-        "react": "16.14.0",
-        "react-dom": "16.14.0",
+        "react": ">= 16.14.0 < 17",
+        "react-dom": ">= 16.14.0 < 17",
         "underscore": "^1.4.4"
     },
     "peerDependencies": {
@@ -69,8 +69,8 @@
         "create-react-class": "^15.6.3",
         "jquery": "^2.1.1",
         "prop-types": "^15.6.1",
-        "react": "16.14.0",
-        "react-dom": "16.14.0",
+        "react": ">= 16.14.0 < 17",
+        "react-dom": ">= 16.14.0 < 17",
         "underscore": "^1.4.4"
     },
     "keywords": []

--- a/packages/perseus/package.json
+++ b/packages/perseus/package.json
@@ -68,8 +68,8 @@
         "lodash.debounce": "^4.0.8",
         "perseus-build-settings": "^0.3.0",
         "prop-types": "^15.6.1",
-        "react": "16.14.0",
-        "react-dom": "16.14.0",
+        "react": ">= 16.14.0 < 17",
+        "react-dom": ">= 16.14.0 < 17",
         "react-popper": "^2.0.0",
         "underscore": "^1.4.4"
     },
@@ -102,8 +102,8 @@
         "jquery": "^2.1.1",
         "lodash.debounce": "^4.0.8",
         "prop-types": "^15.6.1",
-        "react": "16.14.0",
-        "react-dom": "16.14.0",
+        "react": ">= 16.14.0 < 17",
+        "react-dom": ">= 16.14.0 < 17",
         "react-popper": "^2.0.0",
         "underscore": "^1.4.4"
     },

--- a/packages/simple-markdown/package.json
+++ b/packages/simple-markdown/package.json
@@ -34,8 +34,8 @@
         "typescript": "^3.6.4"
     },
     "peerDependencies": {
-        "react": "16.14.0",
-        "react-dom": "16.14.0"
+        "react": ">= 16.14.0 < 17",
+        "react-dom": ">= 16.14.0 < 17"
     },
     "keywords": [
         "markdown"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13285,7 +13285,7 @@ react-docgen@^7.0.0:
     resolve "^1.22.1"
     strip-indent "^4.0.0"
 
-react-dom@16.14.0, react-dom@^16.13.1, react-dom@^16.8.0:
+react-dom@16.14.0, "react-dom@>= 16.14.0 < 17", react-dom@^16.13.1:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
   integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
@@ -13478,7 +13478,7 @@ react-window@^1.8.5:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@16.14.0, react@^16.13.1, react@^16.8.0:
+react@16.14.0, "react@>= 16.14.0 < 17", react@^16.13.1:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
   integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==


### PR DESCRIPTION
## Summary:

We received a [PR](https://github.com/Khan/perseus/pull/1031) that opened up the versions of React for simple-markdown a bit. This was a good idea so I've created a PR to clarify what versions of React we support.

When we complete the React v18 migration, we'll need to update these, but this puts the ranges in place so we're prepared.

Issue: "none"

## Test plan: