### PR TITLE
Fix fin calc editor bug

### DIFF
--- a/.changeset/gold-bats-count.md
+++ b/.changeset/gold-bats-count.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Fix bug that would cause Financial Calculator options to appear unchecked on initial render

--- a/packages/perseus-editor/src/__tests__/item-extras-editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/item-extras-editor.test.tsx
@@ -88,4 +88,31 @@ describe("ItemExtrasEditor", () => {
             financialCalculatorTimeToPayOff: true,
         });
     });
+
+    it("when fin calc option checked, should render with expanded options and expected option checked", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+        render(
+            <ItemExtrasEditor
+                onChange={onChangeMock}
+                financialCalculatorMonthlyPayment={true}
+            />,
+        );
+        const checkbox = screen.getByLabelText("Show financial calculator:");
+        const monthlyPaymentCheckbox = screen.getByLabelText(
+            "Include monthly payment:",
+        );
+        const totalAmountCheckbox = screen.getByLabelText(
+            "Include total amount:",
+        );
+        const timeToPayOffCheckbox = screen.getByLabelText(
+            "Include time-to-pay-off:",
+        );
+
+        // Assert
+        expect(checkbox).toBeChecked();
+        expect(monthlyPaymentCheckbox).toBeChecked();
+        expect(totalAmountCheckbox).not.toBeChecked();
+        expect(timeToPayOffCheckbox).not.toBeChecked();
+    });
 });

--- a/packages/perseus-editor/src/item-extras-editor.tsx
+++ b/packages/perseus-editor/src/item-extras-editor.tsx
@@ -26,18 +26,24 @@ class ItemExtrasEditor extends React.Component<Props, State> {
         zTable: false,
     };
 
+    finCalcOptions = [
+        this.props.financialCalculatorMonthlyPayment,
+        this.props.financialCalculatorTotalAmount,
+        this.props.financialCalculatorTimeToPayOff,
+    ];
+
     state = {
-        financialCalculatorOptionsExpanded: false,
+        financialCalculatorOptionsExpanded: this.finCalcOptions.some(
+            (opt) => opt === true,
+        ),
     };
 
-    componentDidUpdate(prevProps: Readonly<Props>): void {
+    componentDidUpdate(): void {
         // If no financial calculator options are checked, uncheck the
         // financial calculator option.
         if (
             this.state.financialCalculatorOptionsExpanded &&
-            !this.props.financialCalculatorMonthlyPayment &&
-            !this.props.financialCalculatorTotalAmount &&
-            !this.props.financialCalculatorTimeToPayOff
+            !this.finCalcOptions.some((option) => option === true)
         ) {
             this.setState({financialCalculatorOptionsExpanded: false});
         }
@@ -76,7 +82,7 @@ class ItemExtrasEditor extends React.Component<Props, State> {
                                     e.target.checked,
                             });
                             // If the financial calculator is unchecked,
-                            // this needs to be reset. All checked by
+                            // these need to be reset. All checked by
                             // default.
                             this.props.onChange({
                                 financialCalculatorMonthlyPayment:

--- a/packages/perseus-editor/src/item-extras-editor.tsx
+++ b/packages/perseus-editor/src/item-extras-editor.tsx
@@ -26,17 +26,27 @@ class ItemExtrasEditor extends React.Component<Props, State> {
         zTable: false,
     };
 
-    finCalcOptions = [
-        this.props.financialCalculatorMonthlyPayment,
-        this.props.financialCalculatorTotalAmount,
-        this.props.financialCalculatorTimeToPayOff,
-    ];
+    finCalcOptions: Array<boolean> = [];
 
     state = {
-        financialCalculatorOptionsExpanded: this.finCalcOptions.some(
-            (opt) => opt === true,
-        ),
+        financialCalculatorOptionsExpanded: false,
     };
+
+    constructor(props: Props) {
+        super(props);
+
+        this.finCalcOptions = [
+            props.financialCalculatorMonthlyPayment,
+            props.financialCalculatorTotalAmount,
+            props.financialCalculatorTimeToPayOff,
+        ];
+
+        this.state = {
+            financialCalculatorOptionsExpanded: this.finCalcOptions.some(
+                (opt) => opt === true,
+            ),
+        };
+    }
 
     componentDidUpdate(): void {
         // If no financial calculator options are checked, uncheck the


### PR DESCRIPTION
Summary:

The financial calculator appeared to be unchecked if the component reloaded. This was caused by the `financialCalculatorOptionsExpanded` defaulting to "off" despite props. Instead, we will set it to "true" if any of the Financial Calculator Options are set to true.

Also fixes minor comment typos.

Issue: LC-1797

Testing:
Unit test that checks if expected items are present and checked passes-- did not pass before these changes.
To test in the editor experience, check Financial Calculator, click the Preview tab, then return. Financial Calculator appears to be unchecked, even though the checked state is true in the JSON data.