### PR TITLE
Try new, simpler (hopefully) GH Publish approach for Storybook

### DIFF
--- a/.github/actions/storybook-to-gh-pages/action.yml
+++ b/.github/actions/storybook-to-gh-pages/action.yml
@@ -1,0 +1,32 @@
+name: 'Deploy Storybook to GitHub Pages'
+description: 'Build and deploy Storybook to GitHub pages'
+branding:
+  icon: upload-cloud
+  color: red
+outputs:
+  page_url:
+    description: "The URL of the page"
+    value: ${{ steps.deploy.outputs.page_url }}
+
+runs:
+  using: 'composite'
+
+  steps:
+    - name: Build Storybook
+      shell: bash
+      run: yarn build-storybook
+
+    - name: Ensure .nojekyll file
+      shell: bash
+      run: install -d storybook-static/.nojekyll
+
+    - name: Upload Storybook artifacts
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: storybook-static
+
+    - id: deploy # So we can ref output variables
+      name: Deploy to GitHub Pages
+      uses: actions/deploy-pages@v4
+      with:
+        token: ${{ github.token }}

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -279,6 +279,26 @@ jobs:
             - name: Extract strings
               run: yarn extract-strings
 
+    test_gh_publish:
+        name: TEST - Publish Storybook to Github Pages
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                os: [ubuntu-latest]
+                node-version: [20.x]
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Install & cache node_modules
+              uses: ./.github/actions/shared-node-cache
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  ssh-private-key: ${{ secrets.KHAN_ACTIONS_BOT_SSH_PRIVATE_KEY }}
+
+            - id: deploy-to-gh-pages
+              name: Deploy to GitHub pages
+              uses: ./.github/actions/storybook-to-gh-pages
+
     publish_snapshot:
         name: Publish npm snapshot
         # We don't publish snapshots on draft PRs or

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,17 +47,9 @@ jobs:
                   node-version: ${{ matrix.node-version }}
                   ssh-private-key: ${{ secrets.KHAN_ACTIONS_BOT_SSH_PRIVATE_KEY }}
 
-            - name: Build Storybook
-              # Generate a static version of storybook inside "storybook-static/"
-              run: yarn build-storybook
-
-            - name: Deploy to GitHub pages
-              uses: JamesIves/github-pages-deploy-action@v4.5.0
-              with:
-                  # The branch the action should deploy to.
-                  branch: gh-pages
-                  # The folder the action should deploy.
-                  folder: storybook-static
+            - id: deploy-to-gh-pages
+              name: Deploy to GitHub pages
+              uses: ./.github/actions/storybook-to-gh-pages
 
             - name: Create Release Pull Request or Publish to npm
               id: changesets


### PR DESCRIPTION
## Summary:

I'm having issues with the [action](https://github.com/JamesIves/github-pages-deploy-action) we're using to publish Storybook to Github Pages. It seemingly supports having a `.nojekyll` file, but after adding  it to the `gh-pages` branch (as they instruct) and pushing it, the next build blew the file away and broke Storybook again. 

So I'm trying a different action that's more tailored to deploying Storybook to Github Pages ([here](https://github.com/bitovi/github-actions-storybook-to-github-pages)). 

The action is slightly dated so I've "vendored" it in as it's a simple file. This will allow us to customize any other things we need. By and large, it simply delegates to a pair of official Github actions, so that feels like a more reliable approach anyways. 

Issue: "none"

## Test plan: