### PR TITLE
Change mathquill import from github url to tarball url

### DIFF
--- a/.changeset/purple-gorillas-attend.md
+++ b/.changeset/purple-gorillas-attend.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Switch from github URL to tarball for MathQuill dependency

--- a/packages/math-input/package.json
+++ b/packages/math-input/package.json
@@ -24,7 +24,7 @@
     "scripts": {},
     "dependencies": {
         "@khanacademy/perseus-core": "1.4.2",
-        "mathquill": "git+https://git@github.com/Khan/mathquill.git#2060bab7813edde638c0af25920caa6ed73c2b13"
+        "mathquill": "https://github.com/Khan/mathquill/releases/download/v1.0.0/mathquill-v1.0.0.tgz"
     },
     "devDependencies": {
         "@khanacademy/mathjax-renderer": "git+ssh://git@github.com:Khan/mathjax-renderer.git#v1.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11418,9 +11418,9 @@ mathjax-full@3.2.2:
     mj-context-menu "^0.6.1"
     speech-rule-engine "^4.0.6"
 
-"mathquill@git+https://git@github.com/Khan/mathquill.git#2060bab7813edde638c0af25920caa6ed73c2b13":
+"mathquill@https://github.com/Khan/mathquill/releases/download/v1.0.0/mathquill-v1.0.0.tgz":
   version "0.10.1"
-  resolved "git+https://git@github.com/Khan/mathquill.git#2060bab7813edde638c0af25920caa6ed73c2b13"
+  resolved "https://github.com/Khan/mathquill/releases/download/v1.0.0/mathquill-v1.0.0.tgz#6acb1b4742bea24861e866d11f8b170bdb0c6014"
 
 mdast-util-definitions@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
An apparent bug in yarn classic will attempt to install dev dependencies of deps installed using github URLs during github actions in webapp.

An error is thrown during build because a new dev dependency of MathQuill requires node 18 or higher, and webapp actions currently use 16

So, we need to run `yarn pack`, add the new tarball to a Github release, and install from a url instead

Issue: n/a

Testing:
No errors in Perseus nor in webapp CI