### PR TITLE
Fixing InteractionCallback calling too frequently 

### DIFF
--- a/.changeset/empty-impalas-watch.md
+++ b/.changeset/empty-impalas-watch.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Fixing the frequency that we're calling interactionCallback

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -149,11 +149,6 @@ export class ServerItemRenderer
     ) => {
         if (newFocus != null) {
             this._setCurrentFocus(newFocus);
-
-            // Call the interactionCallback, if it exists, with the current user input data
-            this.props.apiOptions?.interactionCallback?.(
-                this.questionRenderer.getUserInputForWidgets(),
-            );
         } else {
             this._onRendererBlur(oldFocus);
         }


### PR DESCRIPTION
## Summary:
This PR fixes an issue where our hints or helpful popups were being immediately closed, in a glitchy manner. 

Previously I had a poor understanding of when we were intending to call the interactionCallback. Looking at several widgets (numeric-input, input-number), they had been calling the interactionCallback both on answer update AND on focus. After reviewing all the widgets, I suspect that the logic I saw in numeric-input/input-number was actually a bug and not how we want to be using the interactionCallback! 

As a result, I have removed the interactionCallback from the onFocus method in our server-item-renderer. While we will no longer be dismissing the popover **on focus** for numeric-input and input-number, I now believe that this historical functionality was unintended. 

Issue: LEMS-1804

## Test plan:
- Manually tested PR in Webapp, and can confirm that it fixes the issue. 