### PR TITLE
Debounce Perseus Math Input Updates

### DIFF
--- a/.changeset/grumpy-ducks-smell.md
+++ b/.changeset/grumpy-ducks-smell.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Added debounce to math input update

--- a/.changeset/thin-deers-unite.md
+++ b/.changeset/thin-deers-unite.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Renormed tests for Perseus Math Input debounce

--- a/packages/perseus-editor/src/__stories__/editor-page.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/editor-page.stories.tsx
@@ -26,9 +26,38 @@ export const Demo = (): React.ReactElement => {
     const [answerArea, setAnswerArea] = React.useState<
         PerseusAnswerArea | undefined | null
     >();
-    const [question, setQuestion] = React.useState<
-        PerseusRenderer | undefined
-    >();
+    const [question, setQuestion] = React.useState<PerseusRenderer | undefined>(
+        {
+            content: "[[☃ expression 1]]",
+            images: {},
+            widgets: {
+                "expression 1": {
+                    type: "expression",
+                    alignment: "default",
+                    static: false,
+                    graded: true,
+                    options: {
+                        answerForms: [
+                            {
+                                value: "++++",
+                                form: true,
+                                simplify: false,
+                                considered: "correct",
+                                key: "0",
+                            },
+                        ],
+                        buttonSets: ["basic", "prealgebra"],
+                        functions: ["f", "g", "h"],
+                        times: true,
+                    },
+                    version: {
+                        major: 1,
+                        minor: 0,
+                    },
+                },
+            },
+        },
+    );
     const [hints, setHints] = React.useState<ReadonlyArray<Hint> | undefined>();
 
     return (

--- a/packages/perseus-editor/src/__stories__/editor-page.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/editor-page.stories.tsx
@@ -26,38 +26,9 @@ export const Demo = (): React.ReactElement => {
     const [answerArea, setAnswerArea] = React.useState<
         PerseusAnswerArea | undefined | null
     >();
-    const [question, setQuestion] = React.useState<PerseusRenderer | undefined>(
-        {
-            content: "[[☃ expression 1]]",
-            images: {},
-            widgets: {
-                "expression 1": {
-                    type: "expression",
-                    alignment: "default",
-                    static: false,
-                    graded: true,
-                    options: {
-                        answerForms: [
-                            {
-                                value: "++++",
-                                form: true,
-                                simplify: false,
-                                considered: "correct",
-                                key: "0",
-                            },
-                        ],
-                        buttonSets: ["basic", "prealgebra"],
-                        functions: ["f", "g", "h"],
-                        times: true,
-                    },
-                    version: {
-                        major: 1,
-                        minor: 0,
-                    },
-                },
-            },
-        },
-    );
+    const [question, setQuestion] = React.useState<
+        PerseusRenderer | undefined
+    >();
     const [hints, setHints] = React.useState<ReadonlyArray<Hint> | undefined>();
 
     return (

--- a/packages/perseus-editor/src/widgets/__tests__/expression-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/expression-editor.test.tsx
@@ -18,10 +18,12 @@ describe("expression-editor", () => {
         jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
             testDependencies,
         );
+        jest.useFakeTimers();
     });
 
     it("should render", async () => {
         render(<ExpressionEditor onChange={() => undefined} />);
+        jest.runOnlyPendingTimers();
 
         expect(await screen.findByText(/Add new answer/)).toBeInTheDocument();
     });
@@ -54,6 +56,7 @@ describe("expression-editor", () => {
                 answerForms={answerForms}
             />,
         );
+        jest.runOnlyPendingTimers();
 
         expect(await screen.findByText(/π/)).toBeInTheDocument();
     });
@@ -62,6 +65,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(<ExpressionEditor onChange={onChangeMock} />);
+        jest.runOnlyPendingTimers();
 
         await userEvent.click(
             screen.getByRole("checkbox", {
@@ -76,6 +80,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(<ExpressionEditor onChange={onChangeMock} functions={[]} />);
+        jest.runOnlyPendingTimers();
 
         const input = screen.getByRole("textbox", {
             name: "Function variables:",
@@ -90,6 +95,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(<ExpressionEditor onChange={onChangeMock} />);
+        jest.runOnlyPendingTimers();
 
         await userEvent.click(
             screen.getByRole("checkbox", {
@@ -112,6 +118,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(<ExpressionEditor onChange={onChangeMock} />);
+        jest.runOnlyPendingTimers();
 
         await userEvent.click(
             screen.getByRole("checkbox", {
@@ -128,6 +135,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(<ExpressionEditor onChange={onChangeMock} />);
+        jest.runOnlyPendingTimers();
 
         await userEvent.click(
             screen.getByRole("checkbox", {
@@ -144,6 +152,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(<ExpressionEditor onChange={onChangeMock} />);
+        jest.runOnlyPendingTimers();
 
         await userEvent.click(
             screen.getByRole("checkbox", {
@@ -160,6 +169,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(<ExpressionEditor onChange={onChangeMock} />);
+        jest.runOnlyPendingTimers();
 
         await userEvent.click(
             screen.getByRole("checkbox", {
@@ -176,6 +186,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(<ExpressionEditor onChange={onChangeMock} />);
+        jest.runOnlyPendingTimers();
 
         await userEvent.click(
             screen.getByRole("checkbox", {
@@ -192,6 +203,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(<ExpressionEditor onChange={onChangeMock} />);
+        jest.runOnlyPendingTimers();
 
         await userEvent.click(
             screen.getByRole("button", {
@@ -235,6 +247,7 @@ describe("expression-editor", () => {
                 ]}
             />,
         );
+        jest.runOnlyPendingTimers();
 
         await userEvent.click(
             screen.getByRole("switch", {
@@ -247,6 +260,7 @@ describe("expression-editor", () => {
                 name: "9",
             }),
         );
+        jest.runOnlyPendingTimers();
 
         expect(onChangeMock).toBeCalledWith(
             {
@@ -294,6 +308,7 @@ describe("expression-editor", () => {
                 ]}
             />,
         );
+        jest.runOnlyPendingTimers();
 
         await userEvent.click(
             screen.getByRole("checkbox", {
@@ -337,6 +352,7 @@ describe("expression-editor", () => {
                 ]}
             />,
         );
+        jest.runOnlyPendingTimers();
 
         await userEvent.click(
             screen.getByRole("checkbox", {
@@ -380,6 +396,7 @@ describe("expression-editor", () => {
                 ]}
             />,
         );
+        jest.runOnlyPendingTimers();
 
         await userEvent.click(
             screen.getByRole("button", {

--- a/packages/perseus/src/components/__tests__/math-input.test.tsx
+++ b/packages/perseus/src/components/__tests__/math-input.test.tsx
@@ -25,6 +25,7 @@ describe("Perseus' MathInput", () => {
         jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
             testDependencies,
         );
+        jest.useFakeTimers();
     });
 
     it("renders", () => {
@@ -37,6 +38,7 @@ describe("Perseus' MathInput", () => {
                 analytics={{onAnalyticsEvent: () => Promise.resolve()}}
             />,
         );
+        jest.runOnlyPendingTimers();
 
         // Assert
         expect(screen.getByLabelText("test")).toBeInTheDocument();
@@ -52,9 +54,11 @@ describe("Perseus' MathInput", () => {
                 analytics={{onAnalyticsEvent: () => Promise.resolve()}}
             />,
         );
+        jest.runOnlyPendingTimers();
 
         // Act
         await userEvent.type(screen.getByRole("textbox"), "12345");
+        jest.runOnlyPendingTimers();
 
         // Assert
         expect(mockOnChange).toHaveBeenLastCalledWith("12345");
@@ -70,6 +74,7 @@ describe("Perseus' MathInput", () => {
                 analytics={{onAnalyticsEvent: () => Promise.resolve()}}
             />,
         );
+        jest.runOnlyPendingTimers();
 
         // Act
         screen.getByRole("switch").click();
@@ -78,6 +83,7 @@ describe("Perseus' MathInput", () => {
         await userEvent.click(screen.getByRole("button", {name: "2"}));
         await userEvent.click(screen.getByRole("button", {name: "Minus"}));
         await userEvent.click(screen.getByRole("button", {name: "3"}));
+        jest.runOnlyPendingTimers();
 
         // Assert
         expect(mockOnChange).toHaveBeenLastCalledWith("1+2-3");
@@ -93,6 +99,7 @@ describe("Perseus' MathInput", () => {
                 analytics={{onAnalyticsEvent: () => Promise.resolve()}}
             />,
         );
+        jest.runOnlyPendingTimers();
 
         // Act
         // focusing the input triggers the popover
@@ -102,6 +109,7 @@ describe("Perseus' MathInput", () => {
         await userEvent.click(screen.getByRole("button", {name: "2"}));
         await userEvent.click(screen.getByRole("button", {name: "Divide"}));
         await userEvent.click(screen.getByRole("button", {name: "3"}));
+        jest.runOnlyPendingTimers();
 
         // Assert
         expect(mockOnChange).toHaveBeenLastCalledWith("1+2\\div3");
@@ -116,6 +124,7 @@ describe("Perseus' MathInput", () => {
                 analytics={{onAnalyticsEvent: () => Promise.resolve()}}
             />,
         );
+        jest.runOnlyPendingTimers();
 
         // Act
         // focusing the input triggers the popover
@@ -135,6 +144,7 @@ describe("Perseus' MathInput", () => {
                 analytics={{onAnalyticsEvent: () => Promise.resolve()}}
             />,
         );
+        jest.runOnlyPendingTimers();
 
         // Act
         // focusing the input triggers the popover
@@ -144,6 +154,7 @@ describe("Perseus' MathInput", () => {
         await userEvent.tab(); // to whole keypad
         await userEvent.tab(); // to "1" button
         await userEvent.keyboard("{enter}");
+        jest.runOnlyPendingTimers();
 
         // Assert
         expect(screen.getByRole("textbox")).not.toHaveFocus();

--- a/packages/perseus/src/components/math-input.tsx
+++ b/packages/perseus/src/components/math-input.tsx
@@ -157,7 +157,7 @@ class MathInput extends React.Component<Props, State> {
                 (baseConfig) => ({
                     ...baseConfig,
                     handlers: {
-                        edit: (mathField: MathFieldInterface) => {
+                        edit: debounce((mathField: MathFieldInterface) => {
                             // This handler is guaranteed to be called on change, but
                             // unlike React it sometimes generates false positives.
                             // One of these is on initialization (with an empty string
@@ -199,7 +199,7 @@ class MathInput extends React.Component<Props, State> {
                             this.setState({
                                 cursorContext: getCursorContext(mathField),
                             });
-                        },
+                        }, 100),
                         enter: () => {
                             // NOTE(kevinb): This isn't how answers to exercises are
                             // submitted.  The actual mechanism for this can be found
@@ -397,6 +397,21 @@ const MathInputIcon = ({hovered, focused, active}) => {
             </svg>
         </View>
     );
+};
+
+const debounce = <T extends unknown[]>(
+    func: (...args: T) => void,
+    delay: number,
+): ((...args: T) => void) => {
+    let timer: number | null = null;
+    return (...args: T) => {
+        if (timer) {
+            clearTimeout(timer);
+        }
+        timer = window.setTimeout(() => {
+            func(...args);
+        }, delay);
+    };
 };
 
 const mapButtonSets = (buttonSets?: LegacyButtonSets) => {

--- a/packages/perseus/src/components/math-input.tsx
+++ b/packages/perseus/src/components/math-input.tsx
@@ -20,6 +20,8 @@ import $ from "jquery";
 import * as React from "react";
 import _ from "underscore";
 
+import {debounce} from "../util/debounce";
+
 import type {LegacyButtonSets} from "../perseus-types";
 import type {PerseusDependenciesV2} from "../types";
 import type {Keys, MathFieldInterface} from "@khanacademy/math-input";
@@ -397,21 +399,6 @@ const MathInputIcon = ({hovered, focused, active}) => {
             </svg>
         </View>
     );
-};
-
-const debounce = <T extends unknown[]>(
-    func: (...args: T) => void,
-    delay: number,
-): ((...args: T) => void) => {
-    let timer: number | null = null;
-    return (...args: T) => {
-        if (timer) {
-            clearTimeout(timer);
-        }
-        timer = window.setTimeout(() => {
-            func(...args);
-        }, delay);
-    };
 };
 
 const mapButtonSets = (buttonSets?: LegacyButtonSets) => {

--- a/packages/perseus/src/util/debounce.ts
+++ b/packages/perseus/src/util/debounce.ts
@@ -1,0 +1,14 @@
+export const debounce = <T extends unknown[]>(
+    func: (...args: T) => void,
+    delay: number,
+): ((...args: T) => void) => {
+    let timer: number | null = null;
+    return (...args: T) => {
+        if (timer) {
+            clearTimeout(timer);
+        }
+        timer = window.setTimeout(() => {
+            func(...args);
+        }, delay);
+    };
+};

--- a/packages/perseus/src/widgets/__tests__/expression.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/expression.test.tsx
@@ -26,9 +26,10 @@ const renderAndAnswer = async (
     input: string,
     isCorrect: boolean,
 ) => {
+    jest.useFakeTimers();
     const {renderer} = renderQuestion(itemData.question);
-
     await userEvent.type(screen.getByRole("textbox"), input);
+    jest.runOnlyPendingTimers();
 
     return renderer;
 };
@@ -84,11 +85,12 @@ const assertInvalid = async (
     input: string,
     message?: string,
 ) => {
+    jest.useFakeTimers();
     const {renderer} = renderQuestion(itemData.question);
     if (input.length) {
         await userEvent.type(screen.getByRole("textbox"), input);
     }
-
+    jest.runOnlyPendingTimers();
     expect(renderer).toHaveInvalidInput();
 };
 
@@ -461,14 +463,17 @@ describe("interaction", () => {
         jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
             testDependencies,
         );
+        jest.useFakeTimers();
     });
 
     it("sets input value directly", () => {
         // arrange
         const {renderer} = renderQuestion(expressionItem2.question);
+        jest.runOnlyPendingTimers();
 
         // act
         renderer.setInputValue(["expression 1"], "123-x", () => {});
+        jest.runOnlyPendingTimers();
         const score = renderer.guessAndScore()[1];
 
         // Assert
@@ -482,8 +487,10 @@ describe("interaction", () => {
     it("has a developer facility for inserting", () => {
         // arrange
         const {renderer} = renderQuestion(expressionItem2.question);
+        jest.runOnlyPendingTimers();
         const expression = renderer.findWidgets("expression 1")[0];
         expression.insert("x+1");
+        jest.runOnlyPendingTimers();
 
         // act
         const score = renderer.score();
@@ -501,6 +508,7 @@ describe("error tooltip", () => {
         jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
             testDependencies,
         );
+        jest.useFakeTimers();
     });
 
     it("shows error text in tooltip", async () => {
@@ -510,6 +518,7 @@ describe("error tooltip", () => {
 
         // Act
         expression.insert("x&&&&&^1");
+        jest.runOnlyPendingTimers();
         screen.getByRole("textbox").blur();
         renderer.guessAndScore();
 
@@ -527,6 +536,7 @@ describe("error tooltip", () => {
 
         // Act
         expression.insert("sen(x)");
+        jest.runOnlyPendingTimers();
         screen.getByRole("textbox").blur();
         renderer.guessAndScore();
 


### PR DESCRIPTION
## Summary

Accounts for a bug in the editor in consuming webapp code, which uses the `facebook/flux` library and cannot handle immediate updates.

The new, accessible MathQuill update comes with a feature that reformats/disambiguates certain TeX and immediately updates itself. For example, `x^2` immediately updates to `x^{2}`.

### Issue
LEMS-1805

### Testing
Open any exercise with multiple "malformed" TeX in the editor. There are examples in [the ticket](https://khanacademy.atlassian.net/browse/LEMS-1805). The editor should load without `flux` throwing errors and halting the render.