### PR TITLE
Make the entire line of a movable segment draggable

### DIFF
--- a/.changeset/light-baboons-smell.md
+++ b/.changeset/light-baboons-smell.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+You can now move the movable line segments on Mafs graphs by dragging anywhere on the line.

--- a/packages/perseus/package.json
+++ b/packages/perseus/package.json
@@ -33,7 +33,7 @@
         "@khanacademy/pure-markdown": "^0.3.0",
         "@khanacademy/simple-markdown": "^0.11.3",
         "@khanacademy/wonder-blocks-banner": "^3.0.33",
-        "mafs": "^0.18.0"
+        "mafs": "https://github.com/Khan/mafs/releases/download/v0.18.1%2Bbuild-cd8b2467893342ba0b02100073fe21f93f8b1125/mafs-0.18.1.tgz"
     },
     "devDependencies": {
         "@khanacademy/mathjax-renderer": "git+ssh://git@github.com:Khan/mathjax-renderer.git#v1.6.2",

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
@@ -60,7 +60,7 @@ const SegmentView = (props: {
         onMove: (newPoint: vec.Vector2) => {
             onMoveSegment(vec.sub(newPoint, midpoint));
         },
-        constrain: identity,
+        constrain: (p) => p,
     });
 
     const {viewTransform, userTransform} = useTransformContext();
@@ -125,8 +125,4 @@ function SVGLine(props: {
             style={style}
         />
     );
-}
-
-function identity<T>(x: T): T {
-    return x;
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
@@ -1,6 +1,7 @@
 import Color from "@khanacademy/wonder-blocks-color";
-import {Line, MovablePoint, vec} from "mafs";
+import {Line, MovablePoint, vec, useMovable, useTransformContext} from "mafs";
 import * as React from "react";
+import {useRef} from "react";
 
 import {moveControlPoint, moveSegment} from "../interactive-graph-action";
 
@@ -46,20 +47,24 @@ const SegmentView = (props: {
     onMovePoint: (endpointIndex: number, destination: vec.Vector2) => unknown;
     onMoveSegment: (delta: vec.Vector2) => unknown;
 }) => {
-    const [pt1, pt2] = props.segment;
-
+    const {onMoveSegment, segment: [pt1, pt2]} = props;
     const midpoint = vec.midpoint(pt1, pt2);
+    const segment = useRef<SVGGElement>(null);
+    const {dragging: draggingSegment} = useMovable({
+        gestureTarget: segment,
+        point: midpoint,
+        onMove: (newPoint: vec.Vector2) => {
+            props.onMoveSegment(vec.sub(newPoint, midpoint));
+        },
+        constrain: identity,
+    })
 
     return (
         <>
-            <Line.Segment point1={pt1} point2={pt2} />
-            <MovablePoint
-                point={midpoint}
-                color={Color.blue}
-                onMove={(newPoint) => {
-                    props.onMoveSegment(vec.sub(newPoint, midpoint));
-                }}
-            />
+            <g ref={segment} tabIndex={0}>
+                <Line.Segment point1={pt1} point2={pt2} weight={10} color={"transparent"}/>
+                <Line.Segment point1={pt1} point2={pt2} />
+            </g>
             <MovablePoint
                 point={pt1}
                 color={Color.blue}
@@ -77,3 +82,7 @@ const SegmentView = (props: {
         </>
     );
 };
+
+function identity<T>(x: T): T {
+    return x
+}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
@@ -59,11 +59,30 @@ const SegmentView = (props: {
         constrain: identity,
     })
 
+    const { viewTransform: pixelMatrix, userTransform } = useTransformContext()
+    const transform = vec.matrixMult(pixelMatrix, userTransform)
+
+    const scaledPoint1 = vec.transform(pt1, transform)
+    const scaledPoint2 = vec.transform(pt2, transform)
+
     return (
         <>
-            <g ref={segment} tabIndex={0}>
-                <Line.Segment point1={pt1} point2={pt2} weight={10} color={"transparent"}/>
-                <Line.Segment point1={pt1} point2={pt2} />
+            <g ref={segment} tabIndex={0} className="movable-segment" style={{cursor: draggingSegment ? "grabbing" : "grab"}}>
+                <line
+                    x1={scaledPoint1[0]}
+                    y1={scaledPoint1[1]}
+                    x2={scaledPoint2[0]}
+                    y2={scaledPoint2[1]}
+                    strokeWidth={10}
+                    style={{stroke: "transparent"}}
+                />
+                <line
+                    x1={scaledPoint1[0]}
+                    y1={scaledPoint1[1]}
+                    x2={scaledPoint2[0]}
+                    y2={scaledPoint2[1]}
+                    style={{ stroke: "var(--mafs-segment-stroke-color)", strokeWidth: "var(--mafs-segment-stroke-weight)" }}
+                />
             </g>
             <MovablePoint
                 point={pt1}

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -6,7 +6,7 @@
     --mafs-bg: transparent;
     --mafs-fg: rgb(33, 36, 44); /* WB color.offBlack */
 
-    --mafs-line-color: var(--mafs-fg);
+    --mafs-line-color: rgb(33, 36, 44, 0.64); /* WB color.offBlack64 */
     --grid-line-subdivision-color: rgba(33, 36, 44, 0.16);
 
     --mafs-blue: #1865f2; /* WB color.blue */
@@ -14,4 +14,19 @@
     --mafs-green: #00a60e; /* WB color.green */
     --mafs-violet: #9059ff; /* WB color.purple */
     --mafs-yellow: #ffb100; /* WB color.gold */
+}
+
+.MafsView .movable-segment {
+    --mafs-segment-stroke-color: var(--mafs-line-color);
+    --mafs-segment-stroke-weight: 2px;
+}
+
+.MafsView .movable-segment:is(:focus-visible, :hover) {
+    outline: none;
+    --mafs-segment-stroke-color: var(--mafs-blue);
+    --mafs-segment-stroke-weight: 4px;
+}
+
+.MafsView .movable-segment:focus {
+    outline: none;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11293,10 +11293,9 @@ lz-string@^1.4.4:
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
   integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
 
-mafs@^0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/mafs/-/mafs-0.18.0.tgz#47903b63282502798903a9180677b58bfbddadea"
-  integrity sha512-cOYBzS6YuK7yglSE2vLsaSKwb/fTyw/aKkpti+Zy4nD6Ru61JmxBG1NcjWJfxNu36xy/qyO3qM8MiPWRB2IVMw==
+"mafs@https://github.com/Khan/mafs/releases/download/v0.18.1%2Bbuild-cd8b2467893342ba0b02100073fe21f93f8b1125/mafs-0.18.1.tgz":
+  version "0.18.1"
+  resolved "https://github.com/Khan/mafs/releases/download/v0.18.1%2Bbuild-cd8b2467893342ba0b02100073fe21f93f8b1125/mafs-0.18.1.tgz#986a72d339ac62dec18492684cf76d3bacf311bc"
   dependencies:
     "@use-gesture/react" "^10.2.27"
     computer-modern "^0.1.2"


### PR DESCRIPTION
## Summary:
Issue: https://khanacademy.atlassian.net/browse/LEMS-1672

Test plan:

```
yarn dev
open http://localhost:5173
```

- Check the "Segment" box in the feature flags dropdown.
- You should be able to drag the movable segment in the first graph with
  the mouse.
- You should be able to tab to the segment and move it with the arrow
  keys.


https://github.com/Khan/perseus/assets/693920/fc727409-0cf5-4c10-b0ca-b10c45451c62

