### PR TITLE
Dev Tooling: Better mobile support

### DIFF
--- a/dev/gallery.tsx
+++ b/dev/gallery.tsx
@@ -107,7 +107,10 @@ export function Gallery() {
                 </nav>
             </header>
             <main className={css(styles.main)}>
-                <View style={styles.cards}>
+                <View
+                    style={styles.cards}
+                    className={isMobile ? "perseus-mobile" : ""}
+                >
                     {questions.map((question, i) => (
                         <QuestionRenderer
                             key={i}

--- a/testing/renderer-with-debug-ui.tsx
+++ b/testing/renderer-with-debug-ui.tsx
@@ -1,8 +1,10 @@
 /* eslint-disable @khanacademy/ts-no-error-suppressions */
 import Button from "@khanacademy/wonder-blocks-button";
-import {View} from "@khanacademy/wonder-blocks-core";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
+import Switch from "@khanacademy/wonder-blocks-switch";
 import {HeadingSmall} from "@khanacademy/wonder-blocks-typography";
+import deviceMobile from "@phosphor-icons/core/regular/device-mobile.svg";
 import * as React from "react";
 import ReactJson from "react-json-view";
 
@@ -28,22 +30,43 @@ export const RendererWithDebugUI = ({
     registerAllWidgetsForTesting();
     const ref = React.useRef<Renderer | null | undefined>(null);
     const [state, setState] = React.useState<any>(null);
+    const [isMobile, setIsMobile] = React.useState(false);
 
     return (
         <SideBySide
-            leftTitle="Widget"
+            leftTitle={
+                <View
+                    style={{
+                        flexDirection: "row",
+                        alignItems: "center",
+                        width: "100%",
+                    }}
+                >
+                    Widget
+                    <View style={{marginLeft: "auto"}}>
+                        <Switch
+                            id={ids.get("mobile")}
+                            icon={<PhosphorIcon icon={deviceMobile} />}
+                            checked={isMobile}
+                            onChange={setIsMobile}
+                        />
+                    </View>
+                </View>
+            }
             left={
-                <>
-                    <Renderer
-                        // @ts-expect-error - TS2322 - Type 'MutableRefObject<Renderer | null | undefined>' is not assignable to type 'LegacyRef<Renderer> | undefined'.
-                        ref={ref}
-                        content={question.content}
-                        images={question.images}
-                        widgets={question.widgets}
-                        problemNum={0}
-                        apiOptions={apiOptions}
-                        reviewMode={reviewMode}
-                    />
+                <View>
+                    <View className={isMobile ? "perseus-mobile" : ""}>
+                        <Renderer
+                            // @ts-expect-error - TS2322 - Type 'MutableRefObject<Renderer | null | undefined>' is not assignable to type 'LegacyRef<Renderer> | undefined'.
+                            ref={ref}
+                            content={question.content}
+                            images={question.images}
+                            widgets={question.widgets}
+                            problemNum={0}
+                            apiOptions={{...apiOptions, isMobile}}
+                            reviewMode={reviewMode}
+                        />
+                    </View>
                     <View style={{flexDirection: "row", alignItems: "center"}}>
                         <Button
                             onClick={() => {
@@ -84,7 +107,7 @@ export const RendererWithDebugUI = ({
                             />
                         </>
                     )}
-                </>
+                </View>
             }
             jsonObject={question}
         />

--- a/testing/renderer-with-debug-ui.tsx
+++ b/testing/renderer-with-debug-ui.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @khanacademy/ts-no-error-suppressions */
 import Button from "@khanacademy/wonder-blocks-button";
+import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Switch from "@khanacademy/wonder-blocks-switch";
@@ -45,7 +46,6 @@ export const RendererWithDebugUI = ({
                     Widget
                     <View style={{marginLeft: "auto"}}>
                         <Switch
-                            id={ids.get("mobile")}
                             icon={<PhosphorIcon icon={deviceMobile} />}
                             checked={isMobile}
                             onChange={setIsMobile}

--- a/testing/side-by-side.tsx
+++ b/testing/side-by-side.tsx
@@ -39,15 +39,17 @@ const SideBySide = ({
 const styles = {
     sideBySide: {
         display: "flex",
+        flexWrap: "wrap",
         flexDirection: "row",
     },
     leftPanel: {
         paddingRight: "30px",
-        flexGrow: 1,
+        flexBasis: "400px",
     },
     rightPanel: {
         flexGrow: 1,
         maxWidth: "50%",
+        flexBasis: "400px",
         padding: "5px",
     },
     code: {

--- a/testing/side-by-side.tsx
+++ b/testing/side-by-side.tsx
@@ -1,10 +1,11 @@
 import {View} from "@khanacademy/wonder-blocks-core";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
 import {HeadingMedium} from "@khanacademy/wonder-blocks-typography";
 import * as React from "react";
 import ReactJson from "react-json-view";
 
 type Props = {
-    leftTitle: string;
+    leftTitle: React.ReactNode;
     left: React.ReactNode;
     rightTitle?: string;
     jsonObject: any;
@@ -45,6 +46,7 @@ const styles = {
     leftPanel: {
         paddingRight: "30px",
         flexBasis: "400px",
+        margin: Spacing.medium_16,
     },
     rightPanel: {
         flexGrow: 1,

--- a/testing/side-by-side.tsx
+++ b/testing/side-by-side.tsx
@@ -44,22 +44,16 @@ const styles = {
         display: "flex",
         flexWrap: "wrap",
         flexDirection: "row",
+        gap: Spacing.large_24,
+        padding: `0px ${Spacing.large_24}px`,
     },
     leftPanel: {
-        paddingRight: "30px",
-        margin: Spacing.medium_16,
         flexBasis: `${interactiveSizes.defaultBoxSize}px`,
     },
     rightPanel: {
         flexGrow: 1,
         flexBasis: `${interactiveSizes.defaultBoxSize}px`,
         maxWidth: "50%",
-        padding: "5px",
-    },
-    code: {
-        fontSize: "10pt",
-        marginTop: "22px",
-        fontFamily: "monospace",
     },
 } as const;
 

--- a/testing/side-by-side.tsx
+++ b/testing/side-by-side.tsx
@@ -4,6 +4,8 @@ import {HeadingMedium} from "@khanacademy/wonder-blocks-typography";
 import * as React from "react";
 import ReactJson from "react-json-view";
 
+import {interactiveSizes} from "../packages/perseus/src/styles/constants";
+
 type Props = {
     leftTitle: React.ReactNode;
     left: React.ReactNode;
@@ -45,13 +47,13 @@ const styles = {
     },
     leftPanel: {
         paddingRight: "30px",
-        flexBasis: "400px",
         margin: Spacing.medium_16,
+        flexBasis: `${interactiveSizes.defaultBoxSize}px`,
     },
     rightPanel: {
         flexGrow: 1,
+        flexBasis: `${interactiveSizes.defaultBoxSize}px`,
         maxWidth: "50%",
-        flexBasis: "400px",
         padding: "5px",
     },
     code: {


### PR DESCRIPTION
## Summary:

This PR improves our mobile support for our dev tooling (both Storybook and the custom Dev UI):

  * Adds the `perseus-mobile` class to the parent div of the renderers. Some of our Perseus styling depends on an ancestor node having the `perseus-mobile` class in order to render for mobile.
  * Adds a mobile switch to the `RendererWithDebugUI` component so we can manually flip to mobile rendering in Storybook (already exists in the Dev UI)

Finally, I've changed the`SideBySide` component slightly so that the right panel will move below the left panel on narrower screens. This will make inspecting a story with mobile emulation on much cleaner (the right panel, usually the Perseus JSON, would overlap the left panel previously).

### Dev UI (with mobile)

<img width="400" alt="image" src="https://github.com/Khan/perseus/assets/77138/64bed67f-d1a6-4fde-b01e-ab72bfc2759e">

### Storybook (with mobile) 

<img width="400" alt="image" src="https://github.com/Khan/perseus/assets/77138/6d4a56be-3b99-4f86-909b-9542d996d5a9">

### Inspecting a Story with mobile emulation enabled

<img width="1512" alt="image" src="https://github.com/Khan/perseus/assets/77138/8ed91304-62ba-4115-87bf-12f9ebe370ef">





Issue: "none"

## Test plan: