### PR TITLE
Style movable points and segments on Mafs graphs

### DIFF
--- a/.changeset/fast-buckets-wave.md
+++ b/.changeset/fast-buckets-wave.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Adjust styling of the movable points and line segments on the Mafs segment graph

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
@@ -1,9 +1,9 @@
-import Color from "@khanacademy/wonder-blocks-color";
-import {MovablePoint, vec, useMovable, useTransformContext} from "mafs";
+import {vec, useMovable, useTransformContext} from "mafs";
 import * as React from "react";
 import {useRef} from "react";
 
 import {moveControlPoint, moveSegment} from "../interactive-graph-action";
+import {MovablePoint} from "../movable-point";
 
 import type {Segment, SegmentGraphState} from "../interactive-graph-state";
 import type {MafsGraphProps} from "../types";
@@ -64,10 +64,10 @@ const SegmentView = (props: {
     });
 
     const {viewTransform, userTransform} = useTransformContext();
-    const transform = vec.matrixMult(viewTransform, userTransform);
+    const transformToPx = vec.matrixMult(viewTransform, userTransform);
 
-    const scaledPoint1 = vec.transform(pt1, transform);
-    const scaledPoint2 = vec.transform(pt2, transform);
+    const pt1Px = vec.transform(pt1, transformToPx);
+    const pt2Px = vec.transform(pt2, transformToPx);
 
     return (
         <>
@@ -79,13 +79,13 @@ const SegmentView = (props: {
             >
                 {/* This transparent line creates a nice big click target. */}
                 <SVGLine
-                    start={scaledPoint1}
-                    end={scaledPoint2}
+                    start={pt1Px}
+                    end={pt2Px}
                     style={{stroke: "transparent", strokeWidth: 30}}
                 />
                 <SVGLine
-                    start={scaledPoint1}
-                    end={scaledPoint2}
+                    start={pt1Px}
+                    end={pt2Px}
                     style={{
                         stroke: "var(--mafs-segment-stroke-color)",
                         strokeWidth: "var(--mafs-segment-stroke-weight)",
@@ -94,14 +94,12 @@ const SegmentView = (props: {
             </g>
             <MovablePoint
                 point={pt1}
-                color={Color.blue}
                 onMove={(newPoint) => {
                     props.onMovePoint(0, newPoint);
                 }}
             />
             <MovablePoint
                 point={pt2}
-                color={Color.blue}
                 onMove={(newPoint) => {
                     props.onMovePoint(1, newPoint);
                 }}

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -14,6 +14,9 @@
     --mafs-green: #00a60e; /* WB color.green */
     --mafs-violet: #9059ff; /* WB color.purple */
     --mafs-yellow: #ffb100; /* WB color.gold */
+
+    /* overridden on a per-point basis */
+    --movable-point-color: var(--mafs-blue);
 }
 
 .MafsView .movable-segment {
@@ -29,4 +32,35 @@
 
 .MafsView .movable-segment:focus {
     outline: none;
+}
+
+.MafsView .movable-point-hitbox {
+    fill: transparent;
+}
+
+.MafsView .movable-point-center {
+    transition: r 0.2s ease;
+}
+
+.MafsView .movable-point-halo {
+    fill: var(--movable-point-color);
+    opacity: 0.25;
+    filter: drop-shadow(0 5px 5px #0008);
+}
+
+.MafsView .movable-point-ring {
+    fill: #fff;
+}
+
+.MafsView .movable-point:hover .movable-point-center {
+    r: 8px;
+}
+
+.MafsView .movable-point:focus .movable-point-halo {
+    outline: 2px solid blue;
+    border-radius: 12px;
+}
+
+.MafsView .movable-point:focus .movable-point-ring {
+    fill: transparent;
 }

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -38,7 +38,7 @@
     fill: transparent;
 }
 
-.MafsView .movable-point-center {
+.MafsView :is(.movable-point-center, .movable-point-ring, .movable-point-halo) {
     transition: r 0.2s ease;
 }
 
@@ -56,11 +56,15 @@
     r: 8px;
 }
 
-.MafsView .movable-point:focus .movable-point-halo {
-    outline: 2px solid blue;
-    border-radius: 12px;
+.MafsView .movable-point:hover .movable-point-ring {
+    r: 10px;
 }
 
-.MafsView .movable-point:focus .movable-point-ring {
-    fill: transparent;
+.MafsView .movable-point:hover .movable-point-halo {
+    r: 13px;
+}
+
+.MafsView .movable-point:focus-visible .movable-point-halo {
+    outline: 2px solid blue;
+    border-radius: 99px;
 }

--- a/packages/perseus/src/widgets/interactive-graphs/movable-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/movable-point.tsx
@@ -1,0 +1,52 @@
+import Color from "@khanacademy/wonder-blocks-color";
+import {vec, useMovable, useTransformContext} from "mafs";
+import * as React from "react";
+import {useRef} from "react";
+
+type Props = {
+    point: vec.Vector2;
+    onMove: (newPoint: vec.Vector2) => unknown;
+};
+
+export const MovablePoint = (props: Props) => {
+    const hitboxRef = useRef<SVGCircleElement>(null);
+    const {point, onMove} = props;
+
+    useMovable({
+        gestureTarget: hitboxRef,
+        point,
+        onMove,
+        constrain: (p) => p,
+    });
+
+    const {viewTransform, userTransform} = useTransformContext();
+    const transformToPx = vec.matrixMult(viewTransform, userTransform);
+    const [x, y] = vec.transform(point, transformToPx);
+
+    return (
+        <g
+            ref={hitboxRef}
+            className="movable-point"
+            tabIndex={0}
+            style={
+                {
+                    cursor: "grab",
+                    touchAction: "none",
+                    outline: "none",
+                    "--movable-point-color": Color.blue,
+                } as any
+            }
+        >
+            <circle className="movable-point-hitbox" r={30} cx={x} cy={y} />
+            <circle className="movable-point-halo" r={11} cx={x} cy={y} />
+            <circle className="movable-point-ring" r={8} cx={x} cy={y} />
+            <circle
+                className="movable-point-center"
+                r={6}
+                cx={x}
+                cy={y}
+                style={{fill: Color.blue}}
+            />
+        </g>
+    );
+};


### PR DESCRIPTION
## Summary:
See this slack thread for designs and discussion:
https://khanacademy.slack.com/archives/C067UM1QAR4/p1709847469823399

Issue: LEMS-1672

Test plan:

```
yarn dev
open http://localhost:5173
```

Check the "segment" box in the dropdown at the top of the screen to
switch to the Mafs version of the segment graph.

You should be able to move the points and line segment with the mouse
and keyboard. The hover and focus states of the points should be clearly distinct.
The line segment should be highlighted blue when focused.