### PR TITLE
Make Mafs line segment color offBlack64

### DIFF
--- a/.changeset/two-flowers-heal.md
+++ b/.changeset/two-flowers-heal.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix color of Mafs line segments

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -23,7 +23,7 @@
 }
 
 .MafsView .movable-segment {
-    --mafs-segment-stroke-color: var(--mafs-line-color);
+    --mafs-segment-stroke-color: rgba(33, 36, 44, 0.64); /* offBlack64 */;
     --mafs-segment-stroke-weight: 2px;
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -6,6 +6,8 @@
     --mafs-bg: transparent;
     --mafs-fg: rgb(33, 36, 44); /* WB color.offBlack */
 
+    --mafs-line-color: rgba(33, 36, 44, 0.16); /* WB color.offBlack16*/
+
     --mafs-blue: #1865f2; /* WB color.blue */
     --mafs-red: #d92916; /* WB color.red */
     --mafs-green: #00a60e; /* WB color.green */
@@ -21,7 +23,7 @@
 }
 
 .MafsView .movable-segment {
-    --mafs-segment-stroke-color: rgba(33, 36, 44, 0.64);
+    --mafs-segment-stroke-color: var(--mafs-line-color);
     --mafs-segment-stroke-weight: 2px;
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -23,7 +23,7 @@
 }
 
 .MafsView .movable-segment {
-    --mafs-segment-stroke-color: rgba(33, 36, 44, 0.64); /* offBlack64 */;
+    --mafs-segment-stroke-color: rgba(33, 36, 44, 0.64); /* offBlack64 */
     --mafs-segment-stroke-weight: 2px;
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -6,8 +6,6 @@
     --mafs-bg: transparent;
     --mafs-fg: rgb(33, 36, 44); /* WB color.offBlack */
 
-    --mafs-line-color: rgba(33, 36, 44, 0.16); /* WB color.offBlack16*/
-
     --mafs-blue: #1865f2; /* WB color.blue */
     --mafs-red: #d92916; /* WB color.red */
     --mafs-green: #00a60e; /* WB color.green */
@@ -23,7 +21,7 @@
 }
 
 .MafsView .movable-segment {
-    --mafs-segment-stroke-color: var(--mafs-line-color);
+    --mafs-segment-stroke-color: rgba(33, 36, 44, 0.64);
     --mafs-segment-stroke-weight: 2px;
 }
 


### PR DESCRIPTION
## Summary:
We changed it (accidentally) to offBlack16 in
https://github.com/Khan/perseus/pull/1067. This commit fixes it.

Issue: none

Test plan:

View the Mafs segment graph in Storybook (http://localhost:6006/?path=/story/perseus-widgets-interactive-graph--segment-with-mafs-and-locked-points).
Verify that the segment is a darker gray than the gridlines.
<img width="472" alt="Screen Shot 2024-03-13 at 6 11 27 PM" src="https://github.com/Khan/perseus/assets/693920/855b2366-8b97-46cd-9811-4d23d5d73755">
