### PR TITLE
LC->LEMS: Update Slack notification channel name for Perseus releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
               uses: rtCamp/action-slack-notify@v2
               env:
                   SLACK_WEBHOOK: ${{ secrets.SLACK_EXERCISENEXT_WEBHOOK }}
-                  SLACK_CHANNEL: team-lc-perseus
+                  SLACK_CHANNEL: team-lems-perseus
                   SLACK_MSG_AUTHOR: ${{ github.event.pull_request.user.login }}
                   SLACK_USERNAME: GithubGoose
                   SLACK_ICON_EMOJI: ":goose:"
@@ -91,7 +91,7 @@ jobs:
               uses: rtCamp/action-slack-notify@v2
               env:
                   SLACK_WEBHOOK: ${{ secrets.SLACK_EXERCISENEXT_WEBHOOK }}
-                  SLACK_CHANNEL: team-lc-perseus
+                  SLACK_CHANNEL: team-lems-perseus
                   SLACK_MSG_AUTHOR: ${{ github.event.pull_request.user.login }}
                   SLACK_USERNAME: GithubGoose
                   SLACK_ICON_EMOJI: ":goose:"


### PR DESCRIPTION
## Summary:

Updates the release notification slack channel from `#team-lc-perseus` to `#team-lems-perseus`. The Slack channel has already been renamed so this is safe to land/deploy as soon as it's approved. 

Issue: LEMS-1821

## Test plan: