### PR TITLE
Fix MathJax dependency

### DIFF
--- a/.changeset/wicked-cameras-rescue.md
+++ b/.changeset/wicked-cameras-rescue.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Move mathjax-renderer dependency from perseus package to root

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@jest/globals": "^29.7.0",
     "@khanacademy/eslint-config": "^3.0.1",
     "@khanacademy/eslint-plugin": "^2.1.1",
+    "@khanacademy/mathjax-renderer": "git+ssh://git@github.com:Khan/mathjax-renderer.git#v1.6.2",
     "@khanacademy/wonder-blocks-button": "6.2.8",
     "@khanacademy/wonder-blocks-i18n": "^2.0.2",
     "@khanacademy/wonder-blocks-layout": "^2.0.27",

--- a/packages/perseus/package.json
+++ b/packages/perseus/package.json
@@ -36,7 +36,6 @@
         "mafs": "https://github.com/Khan/mafs/releases/download/v0.18.1%2Bbuild-cd8b2467893342ba0b02100073fe21f93f8b1125/mafs-0.18.1.tgz"
     },
     "devDependencies": {
-        "@khanacademy/mathjax-renderer": "git+ssh://git@github.com:Khan/mathjax-renderer.git#v1.6.2",
         "@khanacademy/wonder-blocks-button": "^6.2.8",
         "@khanacademy/wonder-blocks-clickable": "^4.1.0",
         "@khanacademy/wonder-blocks-color": "^3.0.0",


### PR DESCRIPTION
## Summary:
The mathjax-renderer dependency is needed for Storybook test rendering. As such, it should be added to the root package.json instead of the Perseus package package.json. This commit makes that change.

Issue: LEMS-1820

## Test plan:
- Confirm all checks pass
- Confirm with Learning Equity that they are now able to upgrade