### PR TITLE
Handle the case where matchMedia is not defined

### DIFF
--- a/.changeset/tricky-dolphins-double.md
+++ b/.changeset/tricky-dolphins-double.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix a bug in the Explanation widget that was causing SSR to error out.

--- a/packages/perseus/src/widgets/__tests__/explanation.test.ts
+++ b/packages/perseus/src/widgets/__tests__/explanation.test.ts
@@ -191,6 +191,24 @@ describe("Explanation", function () {
         );
     });
 
+    it("does NOT use transitions when matchMedia is not available", async () => {
+        // e.g. during SSR in webapp
+        const fakeWindow = Object.create(window);
+        fakeWindow.matchMedia = undefined;
+        jest.spyOn(window, "window", "get").mockReturnValue(fakeWindow as any);
+        renderQuestion(question1);
+
+        // Act - expand
+        await userEvent.click(
+            screen.getByRole("button", {name: "Explanation"}),
+        );
+
+        // Assert - don't transition when revealing
+        expect(screen.getByTestId("content-container").className).not.toContain(
+            "transitionExpanded",
+        );
+    });
+
     it("does NOT use transitions when the user prefers reduced motion", async () => {
         // Arrange
         jest.spyOn(window, "matchMedia").mockImplementation(
@@ -206,7 +224,7 @@ describe("Explanation", function () {
             screen.getByRole("button", {name: "Explanation"}),
         );
 
-        // Assert - transition when revealing
+        // Assert - don't transition when revealing
         expect(screen.getByTestId("content-container").className).not.toContain(
             "transitionExpanded",
         );
@@ -216,7 +234,7 @@ describe("Explanation", function () {
             screen.getByRole("button", {name: "Hide explanation!"}),
         );
 
-        // Assert - transition when concealing
+        // Assert - don't transition when concealing
         expect(screen.getByTestId("content-container").className).not.toContain(
             "transitionCollapsed",
         );

--- a/packages/perseus/src/widgets/explanation.tsx
+++ b/packages/perseus/src/widgets/explanation.tsx
@@ -84,7 +84,9 @@ class Explanation extends React.Component<Props, State> {
 
         const caretIcon = this.state.expanded ? caretUp : caretDown;
 
-        const allowTransition = mediaQueryIsMatched("(prefers-reduced-motion: no-preference)");
+        const allowTransition = mediaQueryIsMatched(
+            "(prefers-reduced-motion: no-preference)",
+        );
 
         // Special styling is needed to fit the button in a block of text without throwing off the line spacing.
         // While the button is not normally included in a block of text, it needs to be able to accommodate such a case.

--- a/packages/perseus/src/widgets/explanation.tsx
+++ b/packages/perseus/src/widgets/explanation.tsx
@@ -37,6 +37,13 @@ type State = {
     expanded: boolean;
 };
 
+function mediaQueryIsMatched(mediaQuery: string): boolean {
+    if (typeof window.matchMedia !== "function") {
+        return false;
+    }
+    return window.matchMedia(mediaQuery).matches;
+}
+
 class Explanation extends React.Component<Props, State> {
     static defaultProps: DefaultProps = {
         showPrompt: "Explain",
@@ -77,9 +84,7 @@ class Explanation extends React.Component<Props, State> {
 
         const caretIcon = this.state.expanded ? caretUp : caretDown;
 
-        const allowTransition = window.matchMedia(
-            "(prefers-reduced-motion: no-preference)",
-        ).matches;
+        const allowTransition = mediaQueryIsMatched("(prefers-reduced-motion: no-preference)");
 
         // Special styling is needed to fit the button in a block of text without throwing off the line spacing.
         // While the button is not normally included in a block of text, it needs to be able to accommodate such a case.

--- a/packages/perseus/src/widgets/explanation.tsx
+++ b/packages/perseus/src/widgets/explanation.tsx
@@ -109,7 +109,7 @@ class Explanation extends React.Component<Props, State> {
 
         return (
             <UniqueIDProvider
-                mockOnFirstRender={false}
+                mockOnFirstRender={true}
                 scope="explanation-widget"
             >
                 {(ids) => (


### PR DESCRIPTION
## Summary:
This is relevant for e.g. SSR in webapp. Previously, we were seeing an
error during SSR when there was an Explanation widget on the page.

Issue: none

Test plan:

- Install a dev build of Perseus in local webapp
- `make serve-ssr`
- As a pre-phantom user (no cookies) with JS disabled in your browser,
  visit
  `/internal-courses/test-everything-qe-sandbox/xa527aaa0ed54bca0:test-everything-1/xa527aaa0ed54bca0:te-explanation/a/explanation-article`
- You should not see an error. The article should render.