### PR TITLE
Migrate `Ray` graph type to Mafs

### DIFF
--- a/.changeset/wet-yaks-pay.md
+++ b/.changeset/wet-yaks-pay.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-dev-ui": patch
+"@khanacademy/perseus": patch
+---
+
+Migrate `ray` interactive graph type to mafs behind feature flag

--- a/dev/gallery.tsx
+++ b/dev/gallery.tsx
@@ -101,6 +101,7 @@ export function Gallery() {
                     <OptionItem value="linear" label="Linear" />
                     <OptionItem value="linear-system" label="Linear System" />
                     <OptionItem value="point" label="Point" />
+                    <OptionItem value="ray" label="Ray" />
                 </MultiSelect>
                 <Strut size={Spacing.medium_16} />
                 <nav>

--- a/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
@@ -537,6 +537,57 @@ export const rayQuestion: PerseusRenderer = {
     },
 };
 
+export const rayQuestionWithDefaultCorrect: PerseusRenderer = {
+    content:
+        "**Move the ray so it has an endpoint at point $\\text{B}$ and goes through point $\\text{A}$. Then complete the statement below.**\n\n[[☃ interactive-graph 1]]",
+    images: {},
+    widgets: {
+        "interactive-graph 1": {
+            alignment: "default",
+            graded: true,
+            options: {
+                backgroundImage: {
+                    bottom: 0,
+                    height: 400,
+                    left: 0,
+                    scale: "1",
+                    url: "https://ka-perseus-graphie.s3.amazonaws.com/140993e12589b317f7bdbd667555ef1c48b26911.png",
+                    width: 400,
+                },
+                correct: {
+                    coords: [
+                        [-5, 5],
+                        [5, 5],
+                    ],
+                    type: "ray",
+                },
+                graph: {
+                    type: "ray",
+                },
+                gridStep: [1, 1],
+                labels: ["x", "y"],
+                markings: "none",
+                range: [
+                    [-10, 10],
+                    [-10, 10],
+                ],
+                rulerLabel: "",
+                rulerTicks: 10,
+                showProtractor: false,
+                showRuler: false,
+                snapStep: [0.5, 0.5],
+                step: [1, 1],
+            },
+            static: false,
+            type: "interactive-graph",
+            version: {
+                major: 0,
+                minor: 0,
+            },
+        },
+    },
+};
+
 export const segmentQuestion: PerseusRenderer = {
     content:
         "Line segment $\\overline{OG}$ is rotated $180^\\circ$ about the point $(-2,4)$.  \n\n**Draw the image of this rotation using the interactive graph.**\n\n*The direction of a rotation by a positive angle is counter-clockwise.* \n\n[[☃ interactive-graph 1]]\n\n",

--- a/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
+++ b/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
@@ -19,7 +19,7 @@ import {
 import {renderQuestion} from "./renderQuestion";
 
 import type {Coord} from "../../interactive2/types";
-import type {PerseusGraphType, PerseusRenderer} from "../../perseus-types";
+import type {PerseusRenderer} from "../../perseus-types";
 import type Renderer from "../../renderer";
 import type {APIOptions} from "../../types";
 import type {UserEvent} from "@testing-library/user-event";

--- a/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
+++ b/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
@@ -9,13 +9,11 @@ import * as Dependencies from "../../dependencies";
 import {ApiOptions} from "../../perseus-api";
 import {
     questionsAndAnswers,
-    segmentQuestion,
     segmentWithLockedPointsQuestion,
     segmentQuestionDefaultCorrect,
-    linearQuestion,
     linearQuestionWithDefaultCorrect,
     linearSystemQuestionWithDefaultCorrect,
-    linearSystemQuestion,
+    rayQuestionWithDefaultCorrect,
 } from "../__testdata__/interactive-graph.testdata";
 
 import {renderQuestion} from "./renderQuestion";
@@ -131,6 +129,7 @@ describe("mafs graphs", () => {
         "segment",
         "linear",
         "linear-system",
+        "ray",
     ];
 
     const graphTypeFlags = graphsTypesToEnable.reduce((acc, type) => {
@@ -141,6 +140,63 @@ describe("mafs graphs", () => {
     const apiOptions = {
         flags: {mafs: graphTypeFlags},
     };
+
+    describe.each([
+        segmentQuestionDefaultCorrect,
+        linearQuestionWithDefaultCorrect,
+        linearSystemQuestionWithDefaultCorrect,
+        rayQuestionWithDefaultCorrect,
+    ])("segment", (question) => {
+        it("should render", () => {
+            renderQuestion(question, apiOptions);
+        });
+
+        it("should reject when has not been interacteracted with", () => {
+            // Arrange
+            const {renderer} = renderQuestion(question, apiOptions);
+
+            // Act
+            // no action
+
+            // Assert
+            expect(renderer).toHaveInvalidInput();
+        });
+
+        it("rejects incorrect answer", async () => {
+            // Arrange
+            const {renderer, container} = renderQuestion(question, apiOptions);
+
+            // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+            const movablePoints = container.querySelectorAll(
+                "circle.movable-point-hitbox",
+            );
+
+            // Act
+            await userEvent.type(movablePoints[1], "{arrowup}");
+
+            // Assert
+            await waitFor(() => {
+                expect(renderer).toHaveBeenAnsweredIncorrectly();
+            });
+        });
+
+        it("accepts correct answer", async () => {
+            const {renderer, container} = renderQuestion(question, apiOptions);
+
+            // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+            const movablePoints = container.querySelectorAll(
+                "circle.movable-point-hitbox",
+            );
+
+            // Act
+            await userEvent.type(movablePoints[1], "{arrowup}{arrowdown}");
+
+            // Assert
+            await waitFor(() => {
+                expect(renderer).toHaveBeenAnsweredCorrectly();
+            });
+        });
+    });
 
     describe("locked layer", () => {
         it("should render locked points", async () => {
@@ -178,189 +234,6 @@ describe("mafs graphs", () => {
             // Assert
             expect(points[0]).toHaveStyle({fill: color.red, stroke: color.red});
             expect(points[1]).toHaveStyle({fill: color.red, stroke: color.red});
-        });
-    });
-
-    describe("segment", () => {
-        it("should render", () => {
-            renderQuestion(segmentQuestion, apiOptions);
-        });
-
-        it("should reject when has not been interacteracted with", () => {
-            // Arrange
-            const {renderer} = renderQuestion(
-                segmentQuestionDefaultCorrect,
-                apiOptions,
-            );
-
-            // Act
-            // no action
-
-            // Assert
-            expect(renderer).toHaveInvalidInput();
-        });
-
-        it("rejects incorrect answer", async () => {
-            // Arrange
-            const {renderer, container} = renderQuestion(
-                segmentQuestion,
-                apiOptions,
-            );
-
-            // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-            const movablePoints = container.querySelectorAll(
-                "circle.movable-point-hitbox",
-            );
-
-            // Act
-            await userEvent.type(movablePoints[1], "{arrowup}{arrowdown}");
-
-            // Assert
-            await waitFor(() => {
-                expect(renderer).toHaveBeenAnsweredIncorrectly();
-            });
-        });
-
-        it("accepts correct answer", async () => {
-            const {renderer, container} = renderQuestion(
-                segmentQuestionDefaultCorrect,
-                apiOptions,
-            );
-
-            // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-            const movablePoints = container.querySelectorAll(
-                "circle.movable-point-hitbox",
-            );
-
-            // Act
-            await userEvent.type(movablePoints[1], "{arrowup}{arrowdown}");
-
-            // Assert
-            await waitFor(() => {
-                expect(renderer).toHaveBeenAnsweredCorrectly();
-            });
-        });
-    });
-
-    describe("linear", () => {
-        it("should render", () => {
-            renderQuestion(linearQuestion, apiOptions);
-        });
-
-        it("should reject when has not been interacteracted with", () => {
-            // Arrange
-            const {renderer} = renderQuestion(
-                linearQuestionWithDefaultCorrect,
-                apiOptions,
-            );
-
-            // Act
-            // no action
-
-            // Assert
-            expect(renderer).toHaveInvalidInput();
-        });
-
-        it("rejects incorrect answer", async () => {
-            // Arrange
-            const {renderer, container} = renderQuestion(
-                linearQuestion,
-                apiOptions,
-            );
-
-            // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-            const movablePoints = container.querySelectorAll(
-                "circle.movable-point-hitbox",
-            );
-
-            // Act
-            await userEvent.type(movablePoints[1], "{arrowup}{arrowdown}");
-
-            // Assert
-            await waitFor(() => {
-                expect(renderer).toHaveBeenAnsweredIncorrectly();
-            });
-        });
-
-        it("accepts correct answer", async () => {
-            const {renderer, container} = renderQuestion(
-                linearQuestionWithDefaultCorrect,
-                apiOptions,
-            );
-
-            // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-            const movablePoints = container.querySelectorAll(
-                "circle.movable-point-hitbox",
-            );
-
-            // Act
-            await userEvent.type(movablePoints[1], "{arrowup}{arrowdown}");
-
-            // Assert
-            await waitFor(() => {
-                expect(renderer).toHaveBeenAnsweredCorrectly();
-            });
-        });
-    });
-
-    describe("linear-system", () => {
-        it("should render", () => {
-            renderQuestion(linearQuestion, apiOptions);
-        });
-
-        it("should reject when has not been interacteracted with", () => {
-            // Arrange
-            const {renderer} = renderQuestion(
-                linearSystemQuestionWithDefaultCorrect,
-                apiOptions,
-            );
-
-            // Act
-            // no action
-
-            // Assert
-            expect(renderer).toHaveInvalidInput();
-        });
-
-        it("rejects incorrect answer", async () => {
-            // Arrange
-            const {renderer, container} = renderQuestion(
-                linearSystemQuestion,
-                apiOptions,
-            );
-
-            // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-            const movablePoints = container.querySelectorAll(
-                "circle.movable-point-hitbox",
-            );
-
-            // Act
-            await userEvent.type(movablePoints[1], "{arrowup}{arrowdown}");
-
-            // Assert
-            await waitFor(() => {
-                expect(renderer).toHaveBeenAnsweredIncorrectly();
-            });
-        });
-
-        it("accepts correct answer", async () => {
-            const {renderer, container} = renderQuestion(
-                linearSystemQuestionWithDefaultCorrect,
-                apiOptions,
-            );
-
-            // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-            const movablePoints = container.querySelectorAll(
-                "circle.movable-point-hitbox",
-            );
-
-            // Act
-            await userEvent.type(movablePoints[1], "{arrowup}{arrowdown}");
-
-            // Assert
-            await waitFor(() => {
-                expect(renderer).toHaveBeenAnsweredCorrectly();
-            });
         });
     });
 });

--- a/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
+++ b/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
@@ -125,12 +125,12 @@ describe("mafs graphs", () => {
     });
 
     // Add types to this array as you test them
-    const graphsTypesToEnable: readonly PerseusGraphType["type"][] = [
+    const graphsTypesToEnable = [
         "segment",
         "linear",
         "linear-system",
         "ray",
-    ];
+    ] as const;
 
     const graphTypeFlags = graphsTypesToEnable.reduce((acc, type) => {
         acc[type] = true;
@@ -141,62 +141,74 @@ describe("mafs graphs", () => {
         flags: {mafs: graphTypeFlags},
     };
 
-    describe.each([
-        segmentQuestionDefaultCorrect,
-        linearQuestionWithDefaultCorrect,
-        linearSystemQuestionWithDefaultCorrect,
-        rayQuestionWithDefaultCorrect,
-    ])("graph type", (question) => {
-        it("should render", () => {
-            renderQuestion(question, apiOptions);
-        });
+    const graphQuestionRenderers: {
+        [K in (typeof graphsTypesToEnable)[number]]: PerseusRenderer;
+    } = {
+        segment: segmentQuestionDefaultCorrect,
+        linear: linearQuestionWithDefaultCorrect,
+        "linear-system": linearSystemQuestionWithDefaultCorrect,
+    };
 
-        it("should reject when has not been interacteracted with", () => {
-            // Arrange
-            const {renderer} = renderQuestion(question, apiOptions);
-
-            // Act
-            // no action
-
-            // Assert
-            expect(renderer).toHaveInvalidInput();
-        });
-
-        it("rejects incorrect answer", async () => {
-            // Arrange
-            const {renderer, container} = renderQuestion(question, apiOptions);
-
-            // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-            const movablePoints = container.querySelectorAll(
-                "circle.movable-point-hitbox",
-            );
-
-            // Act
-            await userEvent.type(movablePoints[1], "{arrowup}");
-
-            // Assert
-            await waitFor(() => {
-                expect(renderer).toHaveBeenAnsweredIncorrectly();
+    describe.each(Object.entries(graphQuestionRenderers))(
+        "graph type %s",
+        (_type, question) => {
+            it("should render", () => {
+                renderQuestion(question, apiOptions);
             });
-        });
 
-        it("accepts correct answer", async () => {
-            const {renderer, container} = renderQuestion(question, apiOptions);
+            it("should reject when has not been interacteracted with", () => {
+                // Arrange
+                const {renderer} = renderQuestion(question, apiOptions);
 
-            // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-            const movablePoints = container.querySelectorAll(
-                "circle.movable-point-hitbox",
-            );
+                // Act
+                // no action
 
-            // Act
-            await userEvent.type(movablePoints[1], "{arrowup}{arrowdown}");
-
-            // Assert
-            await waitFor(() => {
-                expect(renderer).toHaveBeenAnsweredCorrectly();
+                // Assert
+                expect(renderer).toHaveInvalidInput();
             });
-        });
-    });
+
+            it("rejects incorrect answer", async () => {
+                // Arrange
+                const {renderer, container} = renderQuestion(
+                    question,
+                    apiOptions,
+                );
+
+                // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+                const movablePoints = container.querySelectorAll(
+                    "circle.movable-point-hitbox",
+                );
+
+                // Act
+                await userEvent.type(movablePoints[1], "{arrowup}");
+
+                // Assert
+                await waitFor(() => {
+                    expect(renderer).toHaveBeenAnsweredIncorrectly();
+                });
+            });
+
+            it("accepts correct answer", async () => {
+                const {renderer, container} = renderQuestion(
+                    question,
+                    apiOptions,
+                );
+
+                // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+                const movablePoints = container.querySelectorAll(
+                    "circle.movable-point-hitbox",
+                );
+
+                // Act
+                await userEvent.type(movablePoints[1], "{arrowup}{arrowdown}");
+
+                // Assert
+                await waitFor(() => {
+                    expect(renderer).toHaveBeenAnsweredCorrectly();
+                });
+            });
+        },
+    );
 
     describe("locked layer", () => {
         it("should render locked points", async () => {

--- a/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
+++ b/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
@@ -147,6 +147,7 @@ describe("mafs graphs", () => {
         segment: segmentQuestionDefaultCorrect,
         linear: linearQuestionWithDefaultCorrect,
         "linear-system": linearSystemQuestionWithDefaultCorrect,
+        ray: rayQuestionWithDefaultCorrect,
     };
 
     describe.each(Object.entries(graphQuestionRenderers))(

--- a/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
+++ b/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
@@ -146,7 +146,7 @@ describe("mafs graphs", () => {
         linearQuestionWithDefaultCorrect,
         linearSystemQuestionWithDefaultCorrect,
         rayQuestionWithDefaultCorrect,
-    ])("segment", (question) => {
+    ])("graph type", (question) => {
         it("should render", () => {
             renderQuestion(question, apiOptions);
         });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/index.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/index.ts
@@ -1,2 +1,3 @@
 export {SegmentGraph} from "./segment";
 export {LinearGraph} from "./linear";
+export {RayGraph} from "./ray";

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
@@ -47,7 +47,8 @@ export const LinearGraph = (props: LinearGraphProps) => {
 
 const LineView = (props: InteractiveLineProps & {stroke: string}) => {
     const {
-        onMoveLine: onMoveSegment,
+        onMoveLine,
+        onMovePoint,
         collinearPair: [start, end],
         range,
         stroke,
@@ -58,7 +59,7 @@ const LineView = (props: InteractiveLineProps & {stroke: string}) => {
             <MovableLine
                 start={start}
                 end={end}
-                onMove={onMoveSegment}
+                onMove={onMoveLine}
                 extend={{
                     start: true,
                     end: true,
@@ -69,14 +70,14 @@ const LineView = (props: InteractiveLineProps & {stroke: string}) => {
             <StyledMovablePoint
                 point={start}
                 onMove={(newPoint) => {
-                    props.onMovePoint(0, newPoint);
+                    onMovePoint(0, newPoint);
                 }}
                 color={stroke}
             />
             <StyledMovablePoint
                 point={end}
                 onMove={(newPoint) => {
-                    props.onMovePoint(1, newPoint);
+                    onMovePoint(1, newPoint);
                 }}
                 color={stroke}
             />

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/ray.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/ray.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+
+import {moveControlPoint, moveSegment} from "../interactive-graph-action";
+
+import {MovableLine} from "./components/movable-line";
+import {StyledMovablePoint} from "./components/movable-point";
+
+import type {MafsGraphProps, RayGraphState} from "../types";
+import type {vec} from "mafs";
+
+type Props = MafsGraphProps<RayGraphState>;
+
+export const RayGraph = (props: Props) => {
+    const {dispatch} = props;
+    const {coords: lines, range} = props.graphState;
+
+    // a ray only has one line
+    const [start, end] = lines[0];
+
+    const handleMoveLine = (delta: vec.Vector2) =>
+        dispatch(moveSegment(0, delta));
+    const handleMovePoint = (newPoint: vec.Vector2, pointIndex: number) =>
+        dispatch(moveControlPoint(0, pointIndex, newPoint));
+
+    return (
+        <>
+            <MovableLine
+                start={start}
+                end={end}
+                onMove={handleMoveLine}
+                extend={{
+                    end: true,
+                    start: false,
+                    range,
+                }}
+            />
+            <StyledMovablePoint
+                point={start}
+                onMove={(newPoint) => handleMovePoint(newPoint, 0)}
+            />
+            <StyledMovablePoint
+                point={end}
+                onMove={(newPoint) => handleMovePoint(newPoint, 1)}
+            />
+        </>
+    );
+};

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/types.ts
@@ -1,10 +1,10 @@
 import type {CollinearTuple} from "../../../perseus-types";
-import type {vec} from "mafs";
+import type {Interval, vec} from "mafs";
 
 export interface InteractiveLineProps {
     collinearPair: Readonly<CollinearTuple>;
     snaps: [number, number];
-    range: [[number, number], [number, number]];
+    range: [x: Interval, y: Interval];
     onMovePoint: (endpointIndex: number, destination: vec.Vector2) => unknown;
     onMoveLine: (delta: vec.Vector2) => unknown;
 }

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-reducer.ts
@@ -151,8 +151,8 @@ function setAtIndex<T, A extends readonly T[]>(args: {
     index: number;
     newValue: A[number];
 }): A {
-    const {array, index, newValue} = args;
-    const copy: T[] = [...(array || [])];
+    const {array = [], index, newValue} = args;
+    const copy: T[] = [...array];
     copy[index] = newValue;
     // restoring readonly to array
     return copy as unknown as A;

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-state.ts
@@ -29,16 +29,16 @@ export function initializeGraphState(params: {
                 snapStep,
                 coords: getDefaultSegments({graph, step, range}),
             };
-        // Ray can also fall through into this case-- same type, same default coords
         case "linear":
         case "linear-system":
+        case "ray":
             return {
                 type: graph.type,
                 hasBeenInteractedWith: false,
                 range,
                 snapStep,
-                // A linear graph has a single tuple of points, while a linear
-                // system has two tuples of points.
+                // Linear and ray graphs have a single tuple of points, while a
+                // linear system has two tuples of points.
                 coords: getLineCoords(graph, range, step),
             };
     }
@@ -96,9 +96,9 @@ export function getGradableGraph<GraphType extends PerseusGraphType>(
                 ...initialGraph,
                 coords: state.coords,
             };
-        // RAY has the same type as below; can fall through
         // coords: CollinearTuple
         case state.type === "linear" && initialGraph.type === "linear":
+        case state.type === "ray" && initialGraph.type === "ray":
             return {
                 ...initialGraph,
                 coords: state.coords?.[0],

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -4,7 +4,7 @@ import {Mafs} from "mafs";
 import * as React from "react";
 
 import GraphLockedLayer from "./graph-locked-layer";
-import {LinearGraph, SegmentGraph} from "./graphs";
+import {LinearGraph, RayGraph, SegmentGraph} from "./graphs";
 import {Grid} from "./grid";
 import {interactiveGraphReducer} from "./interactive-graph-reducer";
 import {
@@ -32,6 +32,8 @@ const renderGraph = (props: {
         case "linear":
         case "linear-system":
             return <LinearGraph graphState={state} dispatch={dispatch} />;
+        case "ray":
+            return <RayGraph graphState={state} dispatch={dispatch} />;
         default:
             return new UnreachableCaseError(type);
     }

--- a/packages/perseus/src/widgets/interactive-graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/types.ts
@@ -1,6 +1,8 @@
 import type {InteractiveGraphAction} from "./interactive-graph-action";
 import type {
+    CollinearTuple,
     PerseusGraphTypeLinearSystem,
+    PerseusGraphTypeRay,
     PerseusGraphTypeSegment,
     PerseusInteractiveGraphWidgetOptions,
 } from "../../perseus-types";
@@ -17,7 +19,10 @@ export type MafsGraphProps<T extends InteractiveGraphState> = {
     dispatch: (action: InteractiveGraphAction) => unknown;
 };
 
-export type InteractiveGraphState = SegmentGraphState | LinearGraphState;
+export type InteractiveGraphState =
+    | SegmentGraphState
+    | LinearGraphState
+    | RayGraphState;
 
 export interface InteractiveGraphStateCommon {
     hasBeenInteractedWith: boolean;
@@ -33,4 +38,9 @@ export type SegmentGraphState = InteractiveGraphStateCommon &
 export type LinearGraphState = InteractiveGraphStateCommon &
     Pick<PerseusGraphTypeLinearSystem, "coords"> & {
         type: "linear" | "linear-system";
+    };
+
+export type RayGraphState = InteractiveGraphStateCommon &
+    Pick<PerseusGraphTypeRay, "type"> & {
+        coords: readonly CollinearTuple[];
     };


### PR DESCRIPTION
## Summary
Adds `Ray` graph type behind a feature flag.

Also refactors tests to iterate over questions and reduce repetition.

https://github.com/Khan/perseus/assets/23404711/52c0a1d8-05f1-4fcc-a081-9eb917cf0796

### Issues
LEMS-1823

### Testing
Fire up `yarn dev` and activate the flag.