### PR TITLE
Display question JSON in the interactive graph flipbook

### DIFF
--- a/dev/flipbook.tsx
+++ b/dev/flipbook.tsx
@@ -96,23 +96,30 @@ function SideBySideQuestionRenderer({
     apiOptions = {},
 }: QuestionRendererProps) {
     return (
-        <View
-            className="framework-perseus"
-            style={{
-                flexDirection: "row",
-                padding: Spacing.xLarge_32,
-                gap: Spacing.small_12,
-            }}
-        >
-            <GradableRenderer
-                question={question}
-                apiOptions={{...apiOptions, flags: {mafs: false}}}
-            />
-            <GradableRenderer
-                question={question}
-                apiOptions={{...apiOptions, flags: {mafs: {segment: true}}}}
-            />
-        </View>
+        <>
+            <View
+                className="framework-perseus"
+                style={{
+                    flexDirection: "row",
+                    padding: Spacing.xLarge_32,
+                    gap: Spacing.small_12,
+                }}
+            >
+                <GradableRenderer
+                    question={question}
+                    apiOptions={{...apiOptions, flags: {mafs: false}}}
+                />
+                <GradableRenderer
+                    question={question}
+                    apiOptions={{...apiOptions, flags: {mafs: {segment: true}}}}
+                />
+            </View>
+            <p>
+                <pre style={{whiteSpace: "pre-wrap"}}>
+                    <code>{JSON.stringify(question)}</code>
+                </pre>
+            </p>
+        </>
     );
 }
 


### PR DESCRIPTION
## Summary:
This makes it much easier to report bugs against specific questions. You can
copy the JSON into the bug report.

Issue: none

## Test plan:

- `yarn dev`
- Visit http://localhost:5173/#flipbook
- Follow the instructions onscreen to load data
- You should see the JSON for the current question displayed at the bottom of
  the page