### PR TITLE
Ensure that our mobile math input can be visibly focused via tab

### DIFF
--- a/.changeset/old-humans-confess.md
+++ b/.changeset/old-humans-confess.md
@@ -3,4 +3,4 @@
 "@khanacademy/perseus": minor
 ---
 
-Bug fixes to ensure that users can properly interact with the numberline widget
+Bug fixes to ensure that users can properly focus a math input on mobile devices

--- a/.changeset/old-humans-confess.md
+++ b/.changeset/old-humans-confess.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/math-input": minor
+"@khanacademy/perseus": minor
+---
+
+Bug fixes to ensure that users can properly interact with the numberline widget

--- a/packages/math-input/src/components/__tests__/integration.test.tsx
+++ b/packages/math-input/src/components/__tests__/integration.test.tsx
@@ -130,7 +130,7 @@ describe("math input integration", () => {
         );
 
         // Act
-        userEvent.tab();
+        await userEvent.tab();
 
         // Assert
         await waitFor(() => {

--- a/packages/math-input/src/components/__tests__/integration.test.tsx
+++ b/packages/math-input/src/components/__tests__/integration.test.tsx
@@ -122,6 +122,7 @@ describe("math input integration", () => {
     });
 
     it("shows the keypad after input is focused via tab", async () => {
+<<<<<<< HEAD
         // Arrange
         render(<ConnectedMathInput />);
 
@@ -133,6 +134,16 @@ describe("math input integration", () => {
         userEvent.tab();
 
         // Assert
+=======
+        render(<ConnectedMathInput />);
+
+        const input = screen.getByLabelText(
+            "Math input box Tap with one or two fingers to open keyboard",
+        );
+
+        userEvent.tab();
+
+>>>>>>> 487cf019 (Tab focus fix after discussion with A11Y/Design)
         await waitFor(() => {
             expect(screen.getByRole("button", {name: "4"})).toBeVisible();
         });

--- a/packages/math-input/src/components/__tests__/integration.test.tsx
+++ b/packages/math-input/src/components/__tests__/integration.test.tsx
@@ -122,14 +122,17 @@ describe("math input integration", () => {
     });
 
     it("shows the keypad after input is focused via tab", async () => {
+        // Arrange
         render(<ConnectedMathInput />);
 
-        const input = screen.getByLabelText(
+        screen.getByLabelText(
             "Math input box Tap with one or two fingers to open keyboard",
         );
 
+        // Act
         userEvent.tab();
 
+        // Assert
         await waitFor(() => {
             expect(screen.getByRole("button", {name: "4"})).toBeVisible();
         });

--- a/packages/math-input/src/components/__tests__/integration.test.tsx
+++ b/packages/math-input/src/components/__tests__/integration.test.tsx
@@ -122,7 +122,6 @@ describe("math input integration", () => {
     });
 
     it("shows the keypad after input is focused via tab", async () => {
-<<<<<<< HEAD
         // Arrange
         render(<ConnectedMathInput />);
 
@@ -134,16 +133,6 @@ describe("math input integration", () => {
         userEvent.tab();
 
         // Assert
-=======
-        render(<ConnectedMathInput />);
-
-        const input = screen.getByLabelText(
-            "Math input box Tap with one or two fingers to open keyboard",
-        );
-
-        userEvent.tab();
-
->>>>>>> 487cf019 (Tab focus fix after discussion with A11Y/Design)
         await waitFor(() => {
             expect(screen.getByRole("button", {name: "4"})).toBeVisible();
         });

--- a/packages/math-input/src/components/__tests__/integration.test.tsx
+++ b/packages/math-input/src/components/__tests__/integration.test.tsx
@@ -121,6 +121,22 @@ describe("math input integration", () => {
         expect(screen.getByRole("button", {name: "1"})).toBeVisible();
     });
 
+    it("shows the keypad after input is focused via tab", async () => {
+        render(<ConnectedMathInput />);
+
+        const input = screen.getByLabelText(
+            "Math input box Tap with one or two fingers to open keyboard",
+        );
+
+        userEvent.tab();
+
+        await waitFor(() => {
+            expect(screen.getByRole("button", {name: "4"})).toBeVisible();
+        });
+
+        expect(screen.getByRole("button", {name: "1"})).toBeVisible();
+    });
+
     it("shows the keypad after input click-interaction", async () => {
         render(<ConnectedMathInput />);
 

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -626,9 +626,15 @@ class MathInput extends React.Component<Props, State> {
             this.focus();
         }
 
+<<<<<<< HEAD
         // If the user clicked on the input using a mouse or tap gesture,
         // we want to set the focus to the inputRef so that the keyUp
         // event will be triggered when the user types on the keyboard.
+=======
+        // If the user clicked on the input using a mouse, we want to
+        // set the focus to the inputRef so that the keyUp event will
+        // be triggered when the user types on the keyboard.
+>>>>>>> 92f3bd38 (Fix for the issue where keyboard events were not firing when the user uses a mouse to click into the input.)
         // This is necessary to support Chromebooks as they use mobile user
         // agents, do not simulate touch events, and have physical keyboards.
         this.inputRef?.focus();
@@ -668,9 +674,15 @@ class MathInput extends React.Component<Props, State> {
             this.focus();
         }
 
+<<<<<<< HEAD
         // If the user clicked on the input using a mouse or tap gesture,
         // we want to set the focus to the inputRef so that the keyUp
         // event will be triggered when the user types on the keyboard.
+=======
+        // If the user clicked on the input using a mouse, we want to
+        // set the focus to the inputRef so that the keyUp event will
+        // be triggered when the user types on the keyboard.
+>>>>>>> 92f3bd38 (Fix for the issue where keyboard events were not firing when the user uses a mouse to click into the input.)
         // This is necessary to support Chromebooks as they use mobile user
         // agents, do not simulate touch events, and have physical keyboards.
         this.inputRef?.focus();

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -626,15 +626,9 @@ class MathInput extends React.Component<Props, State> {
             this.focus();
         }
 
-<<<<<<< HEAD
         // If the user clicked on the input using a mouse or tap gesture,
         // we want to set the focus to the inputRef so that the keyUp
         // event will be triggered when the user types on the keyboard.
-=======
-        // If the user clicked on the input using a mouse, we want to
-        // set the focus to the inputRef so that the keyUp event will
-        // be triggered when the user types on the keyboard.
->>>>>>> 92f3bd38 (Fix for the issue where keyboard events were not firing when the user uses a mouse to click into the input.)
         // This is necessary to support Chromebooks as they use mobile user
         // agents, do not simulate touch events, and have physical keyboards.
         this.inputRef?.focus();
@@ -674,15 +668,9 @@ class MathInput extends React.Component<Props, State> {
             this.focus();
         }
 
-<<<<<<< HEAD
         // If the user clicked on the input using a mouse or tap gesture,
         // we want to set the focus to the inputRef so that the keyUp
         // event will be triggered when the user types on the keyboard.
-=======
-        // If the user clicked on the input using a mouse, we want to
-        // set the focus to the inputRef so that the keyUp event will
-        // be triggered when the user types on the keyboard.
->>>>>>> 92f3bd38 (Fix for the issue where keyboard events were not firing when the user uses a mouse to click into the input.)
         // This is necessary to support Chromebooks as they use mobile user
         // agents, do not simulate touch events, and have physical keyboards.
         this.inputRef?.focus();

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -187,8 +187,6 @@ class MathInput extends React.Component<Props, State> {
                 this.blur();
                 this.mathField.blur();
                 this.props.onBlur && this.props.onBlur();
-                this.mathField.blur();
-                this.props.onBlur && this.props.onBlur();
             }
 
             this.didTouchOutside = false;
@@ -333,7 +331,7 @@ class MathInput extends React.Component<Props, State> {
         }
     };
 
-    blur: (e?: React.SyntheticEvent) => void = (e) => {
+    blur: () => void = () => {
         this.mathField.blur();
 
         this.setState((prevState) => {

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -19,7 +19,7 @@ import MathWrapper from "./math-wrapper";
 import {scrollIntoView} from "./scroll-into-view";
 import {mathQuillStrings} from "./strings";
 
-import type {Cursor, KeypadAPI} from "../../types";
+import type {Cursor, KeypadAPI, KeypadContextType} from "../../types";
 
 const constrainingFrictionFactor = 0.8;
 
@@ -189,7 +189,7 @@ class MathInput extends React.Component<Props, State> {
             if (this.state.focused && this.didTouchOutside && !this.didScroll) {
                 this.blur();
                 this.mathField.blur();
-                this.props.onBlur && this.props.onBlur();
+                this.props.onBlur?.();
             }
 
             this.didTouchOutside = false;
@@ -337,18 +337,15 @@ class MathInput extends React.Component<Props, State> {
     blur: () => void = () => {
         this.mathField.blur();
 
-        this.setState((prevState) => {
-            return {
-                showInputFocusStyle: false,
-                handle: {
-                    visible: false,
-                },
-                focused: prevState.focused,
-            };
+        this.setState({
+            showInputFocusStyle: false,
+            handle: {
+                visible: false,
+            },
         });
     };
 
-    focus: (setKeypadActive: (keypadActive: boolean) => void) => void = (
+    focus: (setKeypadActive: KeypadContextType["setKeypadActive"]) => void = (
         setKeypadActive,
     ) => {
         // Pass this component's handleKey method to the keypad so it can call
@@ -615,8 +612,8 @@ class MathInput extends React.Component<Props, State> {
 
     handleTouchStart = (
         e: React.TouchEvent<HTMLDivElement>,
-        keypadActive: boolean,
-        setKeypadActive: (keypadActive: boolean) => void,
+        keypadActive: KeypadContextType["keypadActive"],
+        setKeypadActive: KeypadContextType["setKeypadActive"],
     ): void => {
         e.stopPropagation();
 
@@ -659,8 +656,8 @@ class MathInput extends React.Component<Props, State> {
     // but don't actually simulate touch events.
     handleClick = (
         e: React.MouseEvent<HTMLDivElement>,
-        keypadActive: boolean,
-        setKeypadActive: (keypadActive: boolean) => void,
+        keypadActive: KeypadContextType["keypadActive"],
+        setKeypadActive: KeypadContextType["setKeypadActive"],
     ): void => {
         e.stopPropagation();
 

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -183,6 +183,8 @@ class MathInput extends React.Component<Props, State> {
             // multi-touch.
             if (this.state.focused && this.didTouchOutside && !this.didScroll) {
                 this.blur();
+                this.mathField.blur();
+                this.props.onBlur && this.props.onBlur();
             }
 
             this.didTouchOutside = false;
@@ -212,6 +214,7 @@ class MathInput extends React.Component<Props, State> {
                         // in which case we don't want to dismiss the keypad on check.
                         if (!isWithinKeypadBounds(x, y)) {
                             this.blur();
+                            this.props.onBlur && this.props.onBlur();
                         }
                     }
                 }
@@ -326,13 +329,14 @@ class MathInput extends React.Component<Props, State> {
         }
     };
 
-    blur: () => void = () => {
+    blur: (e?: React.SyntheticEvent) => void = (e) => {
         this.mathField.blur();
-        this.props.onBlur && this.props.onBlur();
         this.setState({focused: false, handle: {visible: false}});
     };
 
-    focus: () => void = () => {
+    focus: (setKeypadActive: (keypadActive: boolean) => void) => void = (
+        setKeypadActive,
+    ) => {
         // Pass this component's handleKey method to the keypad so it can call
         // it whenever it needs to trigger a keypress action.
         this.props.keypadElement?.setKeyHandler((key) => {
@@ -360,7 +364,9 @@ class MathInput extends React.Component<Props, State> {
         });
 
         this.mathField.focus();
+
         this.props?.onFocus();
+        setKeypadActive(true);
 
         this.setState({focused: true}, () => {
             // NOTE(charlie): We use `setTimeout` to allow for a layout pass to
@@ -623,7 +629,7 @@ class MathInput extends React.Component<Props, State> {
 
         // Trigger a focus event, if we're not already focused.
         if (!this.state.focused) {
-            this.focus();
+            this.focus(setKeypadActive);
         }
 
         // If the user clicked on the input using a mouse or tap gesture,
@@ -665,7 +671,7 @@ class MathInput extends React.Component<Props, State> {
 
         // Trigger a focus event, if we're not already focused.
         if (!this.state.focused) {
-            this.focus();
+            this.focus(setKeypadActive);
         }
 
         // If the user clicked on the input using a mouse or tap gesture,
@@ -973,6 +979,10 @@ class MathInput extends React.Component<Props, State> {
                             ref={(node) => {
                                 this.inputRef = node;
                             }}
+                            onFocus={() => {
+                                this.focus(setKeypadActive);
+                            }}
+                            onBlur={this.blur}
                             onKeyUp={this.handleKeyUp}
                         >
                             {/* NOTE(charlie): This element must be styled with inline

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -45,9 +45,12 @@ type HandleState = {
 };
 
 type State = {
+    // Whether the input is currently the focused element.
     focused: boolean;
     handle: HandleState;
-    showFocusStyle: boolean;
+    // Whether to show the focus style for the input. We are handling this separately, as
+    // we want the input to appear focused even when the focus is actually on the keypad.
+    showInputFocusStyle: boolean;
 };
 
 // eslint-disable-next-line react/no-unsafe
@@ -78,7 +81,7 @@ class MathInput extends React.Component<Props, State> {
 
     state: State = {
         focused: false,
-        showFocusStyle: false,
+        showInputFocusStyle: false,
         handle: {
             animateIntoPosition: false,
             visible: false,
@@ -336,7 +339,7 @@ class MathInput extends React.Component<Props, State> {
 
         this.setState((prevState) => {
             return {
-                showFocusStyle: false,
+                showInputFocusStyle: false,
                 handle: {
                     visible: false,
                 },
@@ -379,7 +382,7 @@ class MathInput extends React.Component<Props, State> {
         this.props?.onFocus();
         setKeypadActive(true);
 
-        this.setState({focused: true, showFocusStyle: true}, () => {
+        this.setState({focused: true, showInputFocusStyle: true}, () => {
             // NOTE(charlie): We use `setTimeout` to allow for a layout pass to
             // occur. Otherwise, the keypad is measured incorrectly. Ideally,
             // we'd use requestAnimationFrame here, but it's unsupported on
@@ -935,13 +938,13 @@ class MathInput extends React.Component<Props, State> {
     };
 
     render(): React.ReactNode {
-        const {showFocusStyle, handle} = this.state;
+        const {showInputFocusStyle, handle} = this.state;
         const {style} = this.props;
 
         const innerStyle = {
             ...inlineStyles.innerContainer,
             borderWidth: this.getBorderWidthPx(),
-            ...(showFocusStyle
+            ...(showInputFocusStyle
                 ? {
                       borderColor: Color.blue,
                   }
@@ -1007,7 +1010,7 @@ class MathInput extends React.Component<Props, State> {
                                 style={innerStyle}
                             />
                         </div>
-                        {showFocusStyle && handle.visible && (
+                        {showInputFocusStyle && handle.visible && (
                             <CursorHandle
                                 {...handle}
                                 onTouchStart={this.onCursorHandleTouchStart}

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -47,6 +47,7 @@ type HandleState = {
 type State = {
     focused: boolean;
     handle: HandleState;
+    showFocusStyle: boolean;
 };
 
 // eslint-disable-next-line react/no-unsafe
@@ -77,6 +78,7 @@ class MathInput extends React.Component<Props, State> {
 
     state: State = {
         focused: false,
+        showFocusStyle: false,
         handle: {
             animateIntoPosition: false,
             visible: false,
@@ -331,7 +333,16 @@ class MathInput extends React.Component<Props, State> {
 
     blur: (e?: React.SyntheticEvent) => void = (e) => {
         this.mathField.blur();
-        this.setState({focused: false, handle: {visible: false}});
+
+        this.setState((prevState) => {
+            return {
+                showFocusStyle: false,
+                handle: {
+                    visible: false,
+                },
+                focused: prevState.focused,
+            };
+        });
     };
 
     focus: (setKeypadActive: (keypadActive: boolean) => void) => void = (
@@ -368,7 +379,7 @@ class MathInput extends React.Component<Props, State> {
         this.props?.onFocus();
         setKeypadActive(true);
 
-        this.setState({focused: true}, () => {
+        this.setState({focused: true, showFocusStyle: true}, () => {
             // NOTE(charlie): We use `setTimeout` to allow for a layout pass to
             // occur. Otherwise, the keypad is measured incorrectly. Ideally,
             // we'd use requestAnimationFrame here, but it's unsupported on
@@ -924,13 +935,13 @@ class MathInput extends React.Component<Props, State> {
     };
 
     render(): React.ReactNode {
-        const {focused, handle} = this.state;
+        const {showFocusStyle, handle} = this.state;
         const {style} = this.props;
 
         const innerStyle = {
             ...inlineStyles.innerContainer,
             borderWidth: this.getBorderWidthPx(),
-            ...(focused
+            ...(showFocusStyle
                 ? {
                       borderColor: Color.blue,
                   }
@@ -996,7 +1007,7 @@ class MathInput extends React.Component<Props, State> {
                                 style={innerStyle}
                             />
                         </div>
-                        {focused && handle.visible && (
+                        {showFocusStyle && handle.visible && (
                             <CursorHandle
                                 {...handle}
                                 onTouchStart={this.onCursorHandleTouchStart}

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -187,6 +187,8 @@ class MathInput extends React.Component<Props, State> {
                 this.blur();
                 this.mathField.blur();
                 this.props.onBlur && this.props.onBlur();
+                this.mathField.blur();
+                this.props.onBlur && this.props.onBlur();
             }
 
             this.didTouchOutside = false;
@@ -331,7 +333,7 @@ class MathInput extends React.Component<Props, State> {
         }
     };
 
-    blur: () => void = () => {
+    blur: (e?: React.SyntheticEvent) => void = (e) => {
         this.mathField.blur();
 
         this.setState((prevState) => {

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -331,7 +331,7 @@ class MathInput extends React.Component<Props, State> {
         }
     };
 
-    blur: (e?: React.SyntheticEvent) => void = (e) => {
+    blur: () => void = () => {
         this.mathField.blur();
 
         this.setState((prevState) => {

--- a/packages/perseus/src/__tests__/article-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/article-renderer.test.tsx
@@ -4,7 +4,8 @@ import {
     MobileKeypad,
 } from "@khanacademy/math-input";
 import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
-import {screen, render, fireEvent, waitFor} from "@testing-library/react";
+import {screen, render, waitFor} from "@testing-library/react";
+import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
 import {
@@ -187,7 +188,7 @@ describe("article renderer", () => {
             "Math input box Tap with one or two fingers to open keyboard",
         );
 
-        fireEvent.touchStart(input);
+        userEventLib.click(input);
 
         await waitFor(() => {
             expect(screen.getByRole("button", {name: "4"})).toBeVisible();

--- a/packages/perseus/src/__tests__/article-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/article-renderer.test.tsx
@@ -4,8 +4,7 @@ import {
     MobileKeypad,
 } from "@khanacademy/math-input";
 import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
-import {screen, render, waitFor} from "@testing-library/react";
-import {userEvent as userEventLib} from "@testing-library/user-event";
+import {screen, render, fireEvent, waitFor} from "@testing-library/react";
 import * as React from "react";
 
 import {
@@ -188,11 +187,16 @@ describe("article renderer", () => {
             "Math input box Tap with one or two fingers to open keyboard",
         );
 
-        userEventLib.click(input);
+        fireEvent.touchStart(input);
 
+        // Assert
         await waitFor(() => {
             expect(screen.getByRole("button", {name: "4"})).toBeVisible();
         });
-        expect(answerableCallback).toHaveBeenCalled();
+
+        // We also need to wait for the onFocusChange callback to be called
+        await waitFor(() => {
+            expect(answerableCallback).toHaveBeenCalled();
+        });
     });
 });

--- a/packages/perseus/src/widgets/__stories__/number-line.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/number-line.stories.tsx
@@ -57,3 +57,12 @@ export const ShowTickControllerMobile = (
         </TestKeypadContextWrapper>
     );
 };
+
+export const Question2 = (args: StoryArgs): React.ReactElement => {
+    return (
+        <RendererWithDebugUI
+            apiOptions={{isMobile: true, customKeypad: true}}
+            question={question2}
+        />
+    );
+};

--- a/packages/perseus/src/widgets/__stories__/number-line.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/number-line.stories.tsx
@@ -1,4 +1,4 @@
-import {KeypadContext, MobileKeypad} from "@khanacademy/math-input";
+import {KeypadContext} from "@khanacademy/math-input";
 import * as React from "react";
 
 import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui";
@@ -7,7 +7,7 @@ import {question1, question2} from "../__testdata__/number-line.testdata";
 
 import TestKeypadContextWrapper from "./test-keypad-context-wrapper";
 
-import type {PerseusAnswerArea, PerseusItem} from "../../perseus-types";
+import type {PerseusItem} from "../../perseus-types";
 
 export default {
     title: "Perseus/Widgets/Number Line",

--- a/packages/perseus/src/widgets/__stories__/number-line.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/number-line.stories.tsx
@@ -1,4 +1,4 @@
-import {KeypadContext} from "@khanacademy/math-input";
+import {KeypadContext, MobileKeypad} from "@khanacademy/math-input";
 import * as React from "react";
 
 import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui";
@@ -7,7 +7,7 @@ import {question1, question2} from "../__testdata__/number-line.testdata";
 
 import TestKeypadContextWrapper from "./test-keypad-context-wrapper";
 
-import type {PerseusItem} from "../../perseus-types";
+import type {PerseusAnswerArea, PerseusItem} from "../../perseus-types";
 
 export default {
     title: "Perseus/Widgets/Number Line",
@@ -55,14 +55,5 @@ export const ShowTickControllerMobile = (
                 }}
             </KeypadContext.Consumer>
         </TestKeypadContextWrapper>
-    );
-};
-
-export const Question2 = (args: StoryArgs): React.ReactElement => {
-    return (
-        <RendererWithDebugUI
-            apiOptions={{isMobile: true, customKeypad: true}}
-            question={question2}
-        />
     );
 };


### PR DESCRIPTION
## Summary:
This PR updates our Math Input to ensure that we're properly displaying the focus styling on the input when it is focused via a tab event. This was done by adding a state for `showInputFocusStyle` that is separate from the original `focused` state. 

This was required, as we have several cases where we _don't_ want to remove focus styling from the input, such as when the user moves the focus to the keypad by tabbing or clicking a button. The `focused` state will now indicate whether the input is the actively focused DOM element, and `showInputFocusStyle` will indicate whether we want the input to _appear_ focused. This allows for a smoother and more natural interaction between our Math Input and our Keypad. 

Issue: MOB-5431

## Video example of new focus handling:
https://github.com/Khan/perseus/assets/12463099/cc6ab02b-5c9b-46da-9bc3-d36580869b50

## Test plan:
- New test 
- Automatic tests
- Manual Testing 