### PR TITLE
Upgrade to TypeScript 5

### DIFF
--- a/.changeset/gold-ears-repeat.md
+++ b/.changeset/gold-ears-repeat.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/simple-markdown": patch
+---
+
+Tooling: Upgrade projects to use TypeScript v5.4.2

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "sloc": "^0.2.1",
     "storybook": "^7.6.17",
     "style-loader": "^3.3.3",
-    "typescript": "4.9.5",
+    "typescript": "^5.4.2",
     "typescript-coverage-report": "^0.7.0",
     "vite-plugin-istanbul": "^5.0.0",
     "vite-plugin-turbosnap": "^1.0.3",

--- a/packages/perseus/src/interactive2/objective_.ts
+++ b/packages/perseus/src/interactive2/objective_.ts
@@ -42,9 +42,9 @@ const pluck = function (table: any, subKey: string): any {
  * {a: 2, b: 3}
  */
 const mapObject = function <K extends string, V, U>(
-    obj: Partial<Record<K, V>>,
+    obj: Record<K, V>,
     lambda: (arg1: V, arg2: K) => U,
-): Partial<Record<K, U>> {
+): Record<K, U> {
     const result: Record<string, any> = {};
     _.each(_.keys(obj), function (key) {
         // @ts-expect-error - TS2345 - Argument of type 'string' is not assignable to parameter of type 'K'.
@@ -64,7 +64,7 @@ const mapObject = function <K extends string, V, U>(
 const mapObjectFromArray = function <K extends string, V>(
     arr: ReadonlyArray<K>,
     lambda: (arg1: K) => V,
-): Partial<Record<K, V>> {
+): Record<K, V> {
     const result: Record<string, any> = {};
     _.each(arr, function (elem) {
         result[elem] = lambda(elem);

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -477,7 +477,6 @@ class Renderer extends React.Component<Props, State> {
     _getAllWidgetsInfo: (props: Props) => PerseusWidgetsMap = (
         props: Props,
     ) => {
-        // @ts-expect-error - TS2345 - Argument of type '{ [key: string]: PerseusWidget; }' is not assignable to parameter of type 'Partial<Record<string, CategorizerWidget>>'.
         return mapObject(props.widgets, (widgetInfo, widgetId) => {
             if (!widgetInfo.type || !widgetInfo.alignment) {
                 const newValues: Record<string, any> = {};

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -346,7 +346,6 @@ export class ServerItemRenderer
         const qScore = this.questionRenderer.scoreWidgets();
         const qGuess = this.questionRenderer.getUserInputForWidgets();
         const state = this.questionRenderer.getSerializedState();
-        // @ts-expect-error - TS2322 - Type 'Partial<Record<string, KEScore>>' is not assignable to type '{ [key: string]: KEScore; }'. | TS2345 - Argument of type '{ [widgetId: string]: PerseusScore; }' is not assignable to parameter of type 'Partial<Record<string, { type: "invalid"; message?: string | null | undefined; suppressAlmostThere?: boolean | null | undefined; }>>'.
         return mapObject(qScore, (score, id) => {
             return Util.keScoreFromPerseusScore(score, qGuess[id], state);
         });

--- a/packages/simple-markdown/package.json
+++ b/packages/simple-markdown/package.json
@@ -25,13 +25,10 @@
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
     },
     "dependencies": {
-        "@khanacademy/perseus-core": "1.4.2",
-        "@types/react": ">=16.0.0"
+        "@khanacademy/perseus-core": "1.4.2"
     },
     "devDependencies": {
-        "@types/react-dom": ">=16.0.0",
-        "perseus-build-settings": "^0.3.0",
-        "typescript": "^3.6.4"
+        "perseus-build-settings": "^0.3.0"
     },
     "peerDependencies": {
         "react": "16.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15526,15 +15526,15 @@ typescript-coverage-report@^0.7.0:
     semantic-ui-react "^0.88.2"
     type-coverage-core "^2.23.0"
 
-typescript@4.9.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
-
 typescript@^3.6.4:
   version "3.9.10"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
+
+typescript@^5.4.2:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.2.tgz#0ae9cebcfae970718474fe0da2c090cad6577372"
+  integrity sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==
 
 ua-parser-js@^0.7.30:
   version "0.7.31"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4668,14 +4668,14 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.6.tgz#7cb33992049fd7340d5b10c0098e104184dfcd2a"
   integrity sha512-+0autS93xyXizIYiyL02FCY8N+KkKPhILhcUSA276HxzreZ16kl+cmwvV2qAM/PuCCwPXzOXOWhiPcw20uSFcA==
 
-"@types/react-dom@16", "@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0":
+"@types/react-dom@16", "@types/react-dom@<18.0.0":
   version "16.9.18"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.18.tgz#1fda8b84370b1339d639a797a84c16d5a195b419"
   integrity sha512-lmNARUX3+rNF/nmoAFqasG0jAA7q6MeGZK/fdeLwY3kAA4NPgHHrG5bNQe2B5xmD4B+x6Z6h0rEJQ7MEEgQxsw==
   dependencies:
     "@types/react" "^16"
 
-"@types/react@16", "@types/react@>=16", "@types/react@>=16.0.0", "@types/react@^16":
+"@types/react@16", "@types/react@>=16", "@types/react@^16":
   version "16.14.35"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.35.tgz#9d3cf047d85aca8006c4776693124a5be90ee429"
   integrity sha512-NUEiwmSS1XXtmBcsm1NyRRPYjoZF2YTE89/5QiLt5mlGffYK9FQqOKuOLuXNrjPQV04oQgaZG+Yq02ZfHoFyyg==
@@ -15525,11 +15525,6 @@ typescript-coverage-report@^0.7.0:
     rimraf "^3.0.2"
     semantic-ui-react "^0.88.2"
     type-coverage-core "^2.23.0"
-
-typescript@^3.6.4:
-  version "3.9.10"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
-  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
 typescript@^5.4.2:
   version "5.4.2"


### PR DESCRIPTION
## Summary:

Very small change, but this upgrades the Perseus repo to TypeScript v5.4.2. 

Issue: LEMS-1846

## Test plan:

`yarn tsc`
`yarn coverage:types`
`yarn build:types`

Install the snapshot package in one of the consuming applications and typecheck.