### PR TITLE
Testing Library: enable prefer-explicit-assert rule and fix violations

### DIFF
--- a/.changeset/three-jars-cheer.md
+++ b/.changeset/three-jars-cheer.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Test updates

--- a/.changeset/three-jars-cheer.md
+++ b/.changeset/three-jars-cheer.md
@@ -1,5 +1,0 @@
----
-"@khanacademy/perseus": patch
----
-
-Test updates

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -322,8 +322,7 @@ module.exports = {
          */
         "testing-library/await-async-queries": "error",
         "testing-library/prefer-user-event": "error",
-        // TODO(jeremy): It might be nice to enable
-        // "testing-library/prefer-explicit-assert": "error",
+        "testing-library/prefer-explicit-assert": "error",
 
         // These rules results in a lot of false positives
         "testing-library/render-result-naming-convention": "off",

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -33,7 +33,7 @@ jobs:
               with:
                   changed-files: ${{ steps.changed.outputs.files }}
                   files: "packages/, config/build/" # Only look for changes in packages, build
-                  globs: "!(**/__tests__/*), !(**/__testdata__/*), !(**/__stories__/*), !(**/dist/*)" # Ignore test files
+                  globs: "!(**/__tests__/*), !(**/__testdata__/*), !(**/__stories__/*), !(**/dist/*), !(**/*.test.ts), !(**/*.test.tsx)" # Ignore test files
                   matchAllGlobs: true # Default is to match any of the globs, which ends up matching all files
                   conjunctive: true # Only match files that match all of the above
 

--- a/packages/perseus/src/__tests__/renderer.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.test.tsx
@@ -638,10 +638,6 @@ describe("renderer", () => {
 
             // Act
             const {container} = renderQuestion(question, apiOptions);
-            // KaTeX renders async, so we have to wait until it's done.
-            await waitFor(() => {
-                screen.getByText("1 + 2");
-            });
 
             // Assert
             expect(container).toMatchSnapshot();
@@ -661,10 +657,6 @@ describe("renderer", () => {
 
             // Act
             const {container} = renderQuestion(question, apiOptions);
-            // KaTeX renders async, so we have to wait until it's done.
-            await waitFor(() => {
-                screen.getByText("1 + 2");
-            });
 
             // Assert
             expect(container).toMatchSnapshot();
@@ -684,10 +676,6 @@ describe("renderer", () => {
 
             // Act
             const {container} = renderQuestion(question, apiOptions);
-            // KaTeX renders async, so we have to wait until it's done.
-            await waitFor(() => {
-                screen.getByText("1 + 2");
-            });
 
             // Assert
             // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
@@ -718,7 +706,7 @@ describe("renderer", () => {
 
             // Assert
             await waitFor(() => {
-                screen.getByText("1 + 2");
+                expect(screen.getByText("1 + 2")).toBeInTheDocument();
             });
             expect(container).toMatchSnapshot();
         });
@@ -736,10 +724,9 @@ describe("renderer", () => {
             renderQuestion(question);
 
             // Assert
-            // KaTeX renders async, so we use waitFor() have to wait until it's done.
-            await waitFor(() => {
-                screen.getByText(/\\begin\{aligned\}.*\\end\{aligned\}/);
-            });
+            expect(
+                screen.getByText(/\\begin\{aligned\}.*\\end\{aligned\}/),
+            ).toBeInTheDocument();
         });
     });
 

--- a/packages/perseus/src/components/__tests__/zoomable.test.tsx
+++ b/packages/perseus/src/components/__tests__/zoomable.test.tsx
@@ -359,7 +359,7 @@ describe("Zoomable", () => {
             screen.getByText("Some zoomable text").innerHTML =
                 "Some more zoomable text";
             await waitFor(() => {
-                screen.getByText("Some more zoomable text");
+                screen.queryByText("Some more zoomable text");
             });
 
             // Assert
@@ -384,7 +384,7 @@ describe("Zoomable", () => {
             screen.getByText("Some zoomable text").innerHTML =
                 "Some more zoomable text";
             await waitFor(() => {
-                screen.getByText("Some more zoomable text");
+                screen.queryByText("Some more zoomable text");
             });
 
             // Assert
@@ -412,7 +412,7 @@ describe("Zoomable", () => {
             screen.getByText("Some zoomable text").innerHTML =
                 "Some more zoomable text";
             await waitFor(() => {
-                screen.getByText("Some more zoomable text");
+                screen.queryByText("Some more zoomable text");
             });
 
             // Assert

--- a/packages/perseus/src/widgets/video-transcript-link.test.tsx
+++ b/packages/perseus/src/widgets/video-transcript-link.test.tsx
@@ -52,7 +52,7 @@ describe("VideoTranscriptLink", () => {
 
         // Assert
         // Find by Text test will fail if the indicated text is missing
-        await screen.findByText("Youtube Video Title");
+        expect(screen.getByText("Youtube Video Title")).toBeInTheDocument();
     });
 
     it("renders the title with slug video name when provided a slug-id", async () => {
@@ -60,7 +60,7 @@ describe("VideoTranscriptLink", () => {
         render(<VideoTranscriptLink location="slug-video-id" />);
 
         // Assert
-        await screen.findByText("Slug Video Title");
+        expect(screen.getByText("Slug Video Title")).toBeInTheDocument();
     });
 
     it("renders the button with the correct link", async () => {
@@ -68,7 +68,7 @@ describe("VideoTranscriptLink", () => {
         render(<VideoTranscriptLink location="slug-video-id" />);
 
         // Assert
-        await screen.findByText("Slug Video Title");
+        expect(screen.getByText("Slug Video Title")).toBeInTheDocument();
         await expect(screen.getByRole("link")).toHaveAttribute(
             "href",
             "/transcript/contentId",
@@ -82,7 +82,7 @@ describe("VideoTranscriptLink", () => {
         );
 
         // Assert
-        await screen.findByText("Youtube Video Title");
+        expect(screen.getByText("Youtube Video Title")).toBeInTheDocument();
     });
 
     it("can parse a youtube URL with userID text", async () => {
@@ -92,7 +92,7 @@ describe("VideoTranscriptLink", () => {
         );
 
         // Assert
-        await screen.findByText("Youtube Video Title");
+        expect(screen.getByText("Youtube Video Title")).toBeInTheDocument();
     });
 
     it("can parse a youtube URL with location/language text", async () => {
@@ -102,7 +102,7 @@ describe("VideoTranscriptLink", () => {
         );
 
         // Assert
-        await screen.findByText("Youtube Video Title");
+        expect(screen.getByText("Youtube Video Title")).toBeInTheDocument();
     });
 
     it("can parse a youtube URL with a time stamp", async () => {
@@ -112,7 +112,7 @@ describe("VideoTranscriptLink", () => {
         );
 
         // Assert
-        await screen.findByText("Youtube Video Title");
+        expect(screen.getByText("Youtube Video Title")).toBeInTheDocument();
     });
 
     it("can parse an embed youtube URL", async () => {
@@ -122,7 +122,7 @@ describe("VideoTranscriptLink", () => {
         );
 
         // Assert
-        await screen.findByText("Youtube Video Title");
+        expect(screen.getByText("Youtube Video Title")).toBeInTheDocument();
     });
 
     it("can parse a shorthand youtube URL", async () => {
@@ -130,7 +130,7 @@ describe("VideoTranscriptLink", () => {
         render(<VideoTranscriptLink location="http://youtu.be/5qap5aO4i9A" />);
 
         // Assert
-        await screen.findByText("Youtube Video Title");
+        expect(screen.getByText("Youtube Video Title")).toBeInTheDocument();
     });
 
     it("should link to /transcript/videoNotFound if the URL is not a youtube URL", () => {


### PR DESCRIPTION
## Summary:

After updating ESLint & Friends (#1096) to latest, we got a new testing-library/eslint-plugin-testing-library rule named: `testing-library/prefer-explicit-assert`. This rule requires that there is an explicit `expect()` to assert presenve of a DOM node instead of just using the implicit `getBy()`. 

🔉 I'm on the fence if this is a net benefit. **Please weigh in**.

Issue: LEMS-1847

## Test plan:

Review the changes in this PR. Which looks better? Before or after?