### PR TITLE
Get the interactive graph flipbook ready for QE testing

### DIFF
--- a/dev/editable-controlled-input.tsx
+++ b/dev/editable-controlled-input.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import {useState} from "react";
+
+type InputElementProps = JSX.LibraryManagedAttributes<
+    "input",
+    React.ComponentProps<"input">
+>;
+
+type Props = Omit<InputElementProps, "value" | "onInput"> & {
+    value: string;
+    onInput: (newValue: string) => unknown;
+};
+
+// The term "controlled input", in React, refers to an input element or
+// component whose displayed value is determined by its props, rather than by
+// the input's internal state. An EditableControlledInput is controlled as long
+// as it does not have focus. While it is focused, it becomes editable and emits
+// onInput events.
+export function EditableControlledInput(props: Props): React.ReactElement {
+    const {value, onInput, ...restOfProps} = props;
+    const [focused, setFocused] = useState(false);
+    const [wipValue, setWipValue] = useState("");
+    return (
+        <input
+            {...restOfProps}
+            value={focused ? wipValue : value}
+            onChange={(e) => {
+                setWipValue(e.target.value);
+                onInput(e.target.value);
+            }}
+            onFocus={() => {
+                setWipValue(value);
+                setFocused(true);
+            }}
+            onBlur={() => {
+                setFocused(false);
+            }}
+        />
+    );
+}

--- a/dev/flipbook-model.test.ts
+++ b/dev/flipbook-model.test.ts
@@ -6,6 +6,7 @@ import {
     setQuestions,
     selectQuestions,
     removeCurrentQuestion,
+    jumpToQuestion,
 } from "./flipbook-model";
 
 import type {FlipbookModel} from "./flipbook-model";
@@ -77,6 +78,42 @@ describe("next/previous", () => {
             questions: "",
             requestedIndex: 0,
         });
+    });
+});
+
+describe("jumpToQuestion", () => {
+    it("does nothing given a non-numeric value", () => {
+        const state: FlipbookModel = {questions: "foo", requestedIndex: 0};
+        const action = jumpToQuestion("blah");
+
+        expect(flipbookModelReducer(state, action)).toEqual({
+            questions: "foo",
+            requestedIndex: 0,
+        });
+    });
+
+    it("does nothing given a negative value", () => {});
+
+    it("does nothing given zero", () => {
+        // jumpToQuestion accepts raw user input, which uses 1-based indexing,
+        // not 0-based. So 0 is not a valid input.
+        const state: FlipbookModel = {
+            questions: "foo\nbar\nbaz",
+            requestedIndex: 2,
+        };
+        const action = jumpToQuestion("0");
+
+        expect(flipbookModelReducer(state, action).requestedIndex).toBe(2);
+    });
+
+    it("jumps to the given question by 1-based index", () => {
+        const state: FlipbookModel = {
+            questions: "foo\nbar\nbaz",
+            requestedIndex: 0,
+        };
+        const action = jumpToQuestion("3");
+
+        expect(flipbookModelReducer(state, action).requestedIndex).toBe(2);
     });
 });
 

--- a/dev/flipbook-model.test.ts
+++ b/dev/flipbook-model.test.ts
@@ -111,9 +111,9 @@ describe("jumpToQuestion", () => {
             questions: "foo\nbar\nbaz",
             requestedIndex: 0,
         };
-        const action = jumpToQuestion("3");
+        const action = jumpToQuestion("2");
 
-        expect(flipbookModelReducer(state, action).requestedIndex).toBe(2);
+        expect(flipbookModelReducer(state, action).requestedIndex).toBe(1);
     });
 });
 

--- a/dev/flipbook-model.test.ts
+++ b/dev/flipbook-model.test.ts
@@ -5,6 +5,7 @@ import {
     previous,
     setQuestions,
     selectQuestions,
+    removeCurrentQuestion,
 } from "./flipbook-model";
 
 import type {FlipbookModel} from "./flipbook-model";
@@ -20,7 +21,9 @@ describe("flipbookModelReducer", () => {
             requestedIndex: 42,
         });
     });
+});
 
+describe("next/previous", () => {
     it("goes to the next question", () => {
         const model: FlipbookModel = {
             questions: `{}\n{}`,
@@ -75,7 +78,9 @@ describe("flipbookModelReducer", () => {
             requestedIndex: 0,
         });
     });
+});
 
+describe("setQuestions", () => {
     it("replaces the questions string", () => {
         const model: FlipbookModel = {
             questions: "",
@@ -84,6 +89,40 @@ describe("flipbookModelReducer", () => {
         expect(flipbookModelReducer(model, setQuestions("{}"))).toEqual({
             questions: "{}",
             requestedIndex: 0,
+        });
+    });
+});
+
+describe("removeCurrentQuestion", () => {
+    it("does nothing when there are no questions", () => {
+        const model: FlipbookModel = {questions: "", requestedIndex: 0};
+        expect(flipbookModelReducer(model, removeCurrentQuestion)).toEqual({
+            questions: "",
+            requestedIndex: 0,
+        });
+    });
+
+    it("removes the first question when the requestedIndex is 0", () => {
+        const model: FlipbookModel = {questions: "one\ntwo", requestedIndex: 0};
+        expect(flipbookModelReducer(model, removeCurrentQuestion)).toEqual({
+            questions: "two",
+            requestedIndex: 0,
+        });
+    });
+
+    it("removes the second question when the requestedIndex is 1", () => {
+        const model: FlipbookModel = {questions: "one\ntwo", requestedIndex: 1};
+        expect(flipbookModelReducer(model, removeCurrentQuestion)).toEqual({
+            questions: "one",
+            requestedIndex: 1,
+        });
+    });
+
+    it("removes the last question when the index is high out of bounds", () => {
+        const model: FlipbookModel = {questions: "one\ntwo", requestedIndex: 9};
+        expect(flipbookModelReducer(model, removeCurrentQuestion)).toEqual({
+            questions: "one",
+            requestedIndex: 9,
         });
     });
 });

--- a/dev/flipbook-model.ts
+++ b/dev/flipbook-model.ts
@@ -50,33 +50,12 @@ export function flipbookModelReducer(
     action: Action,
 ): FlipbookModel {
     switch (action.type) {
-        case "next": {
-            return {
-                ...state,
-                requestedIndex: clampIndex(
-                    state.requestedIndex + 1,
-                    selectQuestions(state),
-                ),
-            };
-        }
-        case "previous": {
-            return {
-                ...state,
-                requestedIndex: clampIndex(
-                    state.requestedIndex - 1,
-                    selectQuestions(state),
-                ),
-            };
-        }
-        case "jump-to-index": {
-            return {
-                ...state,
-                requestedIndex: clampIndex(
-                    action.index,
-                    selectQuestions(state),
-                ),
-            };
-        }
+        case "next":
+            return updateIndex(state, (index) => index + 1);
+        case "previous":
+            return updateIndex(state, (index) => index - 1);
+        case "jump-to-index":
+            return updateIndex(state, () => action.index);
         case "set-questions": {
             return {
                 ...state,
@@ -95,6 +74,15 @@ export function flipbookModelReducer(
         }
     }
     return state;
+}
+
+function updateIndex(state: FlipbookModel, update: (index: number) => number) {
+    const currIndex = selectCurrentQuestionIndex(state);
+    const questions = selectQuestions(state);
+    return {
+        ...state,
+        requestedIndex: clampIndex(update(currIndex), questions),
+    }
 }
 
 function clampIndex(index: number, array: unknown[]): number {

--- a/dev/flipbook-model.ts
+++ b/dev/flipbook-model.ts
@@ -14,14 +14,27 @@ export type FlipbookModel = {
 // ---------------------------------------------------------------------------
 
 export type Action =
+    | {type: "noop"}
     | {type: "next"}
     | {type: "previous"}
     | {type: "set-questions"; questions: string}
-    | {type: "remove-current-question"};
+    | {type: "remove-current-question"}
+    | {type: "jump-to-index"; index: number};
 
 export const next: Action = {type: "next"};
 
 export const previous: Action = {type: "previous"};
+
+export const jumpToQuestion = (rawUserInput: string): Action => {
+    if (!isPositiveInteger(rawUserInput)) {
+        return {type: "noop"};
+    }
+
+    return {
+        type: "jump-to-index",
+        index: parseInt(rawUserInput, 10),
+    };
+};
 
 export function setQuestions(questions: string): Action {
     return {type: "set-questions", questions};
@@ -51,6 +64,15 @@ export function flipbookModelReducer(
                 ...state,
                 requestedIndex: clampIndex(
                     state.requestedIndex - 1,
+                    selectQuestions(state),
+                ),
+            };
+        }
+        case "jump-to-index": {
+            return {
+                ...state,
+                requestedIndex: clampIndex(
+                    action.index,
                     selectQuestions(state),
                 ),
             };
@@ -129,4 +151,8 @@ function parseQuestion(json): PerseusRenderer {
             images: {},
         };
     }
+}
+
+function isPositiveInteger(s: string): boolean {
+    return /^\d+$/.test(s) && +s > 0;
 }

--- a/dev/flipbook-model.ts
+++ b/dev/flipbook-model.ts
@@ -76,6 +76,12 @@ export function flipbookModelReducer(
     return state;
 }
 
+// updateIndex immutably updates the `requestedIndex` of the given `state`,
+// ensuring that the resulting index is valid and in-bounds.
+// The given `update` function is used to determine the new index. The index
+// passed to `update` is the current *effective* index, which may be different
+// from the requested index. Unlike the requested index, the effective index is
+// guaranteed to be in-bounds.
 function updateIndex(state: FlipbookModel, update: (index: number) => number) {
     const currIndex = selectCurrentQuestionIndex(state);
     const questions = selectQuestions(state);

--- a/dev/flipbook-model.ts
+++ b/dev/flipbook-model.ts
@@ -32,7 +32,7 @@ export const jumpToQuestion = (rawUserInput: string): Action => {
 
     return {
         type: "jump-to-index",
-        index: parseInt(rawUserInput, 10),
+        index: parseInt(rawUserInput, 10) - 1,
     };
 };
 
@@ -88,7 +88,7 @@ function updateIndex(state: FlipbookModel, update: (index: number) => number) {
     return {
         ...state,
         requestedIndex: clampIndex(update(currIndex), questions),
-    }
+    };
 }
 
 function clampIndex(index: number, array: unknown[]): number {

--- a/dev/flipbook.tsx
+++ b/dev/flipbook.tsx
@@ -13,8 +13,11 @@ import {
     flipbookModelReducer,
     next,
     previous,
+    removeCurrentQuestion,
+    selectCurrentQuestionIndex,
     selectCurrentQuestion,
     setQuestions,
+    selectNumQuestions,
 } from "./flipbook-model";
 
 import type {
@@ -40,6 +43,8 @@ export function Flipbook() {
     });
 
     const question = selectCurrentQuestion(state);
+    const numQuestions = selectNumQuestions(state);
+    const index = selectCurrentQuestionIndex(state);
 
     const noTextEntered = state.questions.trim() === "";
 
@@ -53,13 +58,22 @@ export function Flipbook() {
                 onChange={(e) => dispatch(setQuestions(e.target.value))}
             />
             <Strut size={Spacing.small_12} />
-            <View style={{flexDirection: "row"}}>
+            <View style={{flexDirection: "row", alignItems: "baseline"}}>
                 <Button kind="secondary" onClick={() => dispatch(previous)}>
                     Previous
                 </Button>
                 <Strut size={Spacing.xxSmall_6} />
                 <Button kind="secondary" onClick={() => dispatch(next)}>
                     Next
+                </Button>
+                <Strut size={Spacing.medium_16} />
+                <Progress zeroBasedIndex={index} total={numQuestions} />
+                <Strut size={Spacing.medium_16} />
+                <Button
+                    kind="tertiary"
+                    onClick={() => dispatch(removeCurrentQuestion)}
+                >
+                    Discard question
                 </Button>
             </View>
             <div style={{display: noTextEntered ? "block" : "none"}}>
@@ -156,5 +170,20 @@ function GradableRenderer(props: QuestionRendererProps) {
                 Check answer
             </Button>
         </View>
+    );
+}
+
+type ProgressProps = {
+    zeroBasedIndex: number;
+    total: number;
+};
+
+function Progress(props: ProgressProps) {
+    const {zeroBasedIndex, total} = props;
+    const indexToDisplay = Math.min(total, zeroBasedIndex + 1);
+    return (
+        <div>
+            {indexToDisplay} of {total}
+        </div>
     );
 }

--- a/dev/flipbook.tsx
+++ b/dev/flipbook.tsx
@@ -9,6 +9,7 @@ import {useReducer, useRef} from "react";
 import {Renderer} from "../packages/perseus/src";
 import {isCorrect} from "../packages/perseus/src/util";
 
+import {EditableControlledInput} from "./editable-controlled-input";
 import {
     flipbookModelReducer,
     next,
@@ -18,6 +19,7 @@ import {
     selectCurrentQuestion,
     setQuestions,
     selectNumQuestions,
+    jumpToQuestion,
 } from "./flipbook-model";
 
 import type {
@@ -67,7 +69,11 @@ export function Flipbook() {
                     Next
                 </Button>
                 <Strut size={Spacing.medium_16} />
-                <Progress zeroBasedIndex={index} total={numQuestions} />
+                <Progress
+                    zeroBasedIndex={index}
+                    total={numQuestions}
+                    onIndexChanged={(input) => dispatch(jumpToQuestion(input))}
+                />
                 <Strut size={Spacing.medium_16} />
                 <Button
                     kind="tertiary"
@@ -176,14 +182,20 @@ function GradableRenderer(props: QuestionRendererProps) {
 type ProgressProps = {
     zeroBasedIndex: number;
     total: number;
+    onIndexChanged: (rawUserInput: string) => unknown;
 };
 
 function Progress(props: ProgressProps) {
-    const {zeroBasedIndex, total} = props;
+    const {zeroBasedIndex, total, onIndexChanged} = props;
     const indexToDisplay = Math.min(total, zeroBasedIndex + 1);
     return (
         <div>
-            {indexToDisplay} of {total}
+            <EditableControlledInput
+                value={String(indexToDisplay)}
+                onInput={onIndexChanged}
+                style={{width: "4em", textAlign: "right"}}
+            />
+            &nbsp;of {total}
         </div>
     );
 }

--- a/dev/flipbook.tsx
+++ b/dev/flipbook.tsx
@@ -1,5 +1,6 @@
 /* eslint monorepo/no-internal-import: "off", monorepo/no-relative-import: "off", import/no-relative-packages: "off" */
 import Button from "@khanacademy/wonder-blocks-button";
+import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Spacing from "@khanacademy/wonder-blocks-spacing";
@@ -82,6 +83,7 @@ export function Flipbook() {
                     Discard question
                 </Button>
             </View>
+            <Strut size={Spacing.small_12} />
             <div style={{display: noTextEntered ? "block" : "none"}}>
                 <h2>Instructions</h2>
                 <ol>
@@ -121,8 +123,9 @@ function SideBySideQuestionRenderer({
                 className="framework-perseus"
                 style={{
                     flexDirection: "row",
-                    padding: Spacing.xLarge_32,
-                    gap: Spacing.small_12,
+                    padding: Spacing.medium_16,
+                    gap: Spacing.medium_16,
+                    background: "#f8f8f8",
                 }}
             >
                 <GradableRenderer
@@ -157,7 +160,14 @@ function GradableRenderer(props: QuestionRendererProps) {
     }
 
     return (
-        <View style={{alignItems: "flex-start"}}>
+        <View
+            style={{
+                alignItems: "flex-start",
+                overflow: "hidden",
+                background: Color.white,
+                padding: Spacing.medium_16,
+            }}
+        >
             <Renderer
                 ref={rendererRef}
                 content={question.content}

--- a/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
@@ -14,12 +14,17 @@ import {
     segmentWithLockedPointsQuestion,
     sinusoidQuestion,
 } from "../__testdata__/interactive-graph.testdata";
+import {Flipbook} from "@khanacademy/perseus-dev-ui/flipbook";
 
 export default {
     title: "Perseus/Widgets/Interactive Graph",
 };
 
 type StoryArgs = Record<any, any>;
+
+export const SideBySideFlipbook = (args: StoryArgs): React.ReactElement => (
+    <Flipbook/>
+)
 
 export const Angle = (args: StoryArgs): React.ReactElement => (
     <RendererWithDebugUI question={angleQuestion} />


### PR DESCRIPTION
QE has a lot on their plate right now, so we need to use their time
efficiently.

This PR makes the Interactive Graph flipbook available via Storybook,
so QE testers will be able to access it at https://khan.github.io/perseus.

I've also made some quality-of-life improvements to the flipbook to make
testing easier. The main one being that you can now see the index of the
question you're viewing, and jump to any question by index.

Issue: none

## Test plan:

- `yarn storybook`
- `open https://localhost:6006`
- Search for "Flipbook"
- You should be able to paste JSON from the WIP
  [test plan](https://khanacademy.atlassian.net/wiki/spaces/LC/pages/2738520299/Test+plan+for+segment+graph)
  into the box and flip through the questions.