### PR TITLE
Migrate ViewportResizer and DeviceFramer to functional components

### DIFF
--- a/packages/perseus-editor/src/components/__stories__/device-framer.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/device-framer.stories.tsx
@@ -1,0 +1,54 @@
+import type {Meta, StoryObj} from "@storybook/react";
+
+import DeviceFramer from "../device-framer";
+import {color} from "@khanacademy/wonder-blocks-tokens";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+
+const meta: Meta<typeof DeviceFramer> = {
+    component: DeviceFramer,
+    title: "Perseus/Editor/Components/Device Framer",
+};
+
+export default meta;
+type Story = StoryObj<typeof DeviceFramer>;
+
+const SampleContent = () => {
+    return (
+        <div
+            style={{
+                backgroundColor: color.blue,
+                color: color.offWhite,
+                width: "90%",
+                height: "300px",
+                padding: Spacing.medium_16,
+            }}
+        >
+            The DeviceFramer controls the size of the content inside the frame.
+            So there's not much to look at here except how large each device
+            type's size is.
+        </div>
+    );
+};
+export const Phone: Story = {
+    render: () => (
+        <DeviceFramer deviceType="phone" nochrome>
+            <SampleContent />
+        </DeviceFramer>
+    ),
+};
+
+export const Tablet: Story = {
+    render: () => (
+        <DeviceFramer deviceType="tablet" nochrome>
+            <SampleContent />
+        </DeviceFramer>
+    ),
+};
+
+export const Desktop: Story = {
+    render: () => (
+        <DeviceFramer deviceType="desktop" nochrome>
+            <SampleContent />
+        </DeviceFramer>
+    ),
+};

--- a/packages/perseus-editor/src/components/__stories__/viewport-resizer.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/viewport-resizer.stories.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+
+import ViewportResizer from "../viewport-resizer";
+import {action} from "@storybook/addon-actions";
+
+import type {Meta, StoryFn} from "@storybook/react";
+import {DeviceType} from "@khanacademy/perseus";
+
+const meta: Meta<typeof ViewportResizer> = {
+    component: ViewportResizer,
+    title: "Perseus/Editor/Components/Viewport Resizer",
+};
+
+export default meta;
+type Story = StoryFn<typeof ViewportResizer>;
+
+export const Controlled: Story = () => {
+    const [deviceType, setDeviceType] = React.useState<DeviceType>("phone");
+    return (
+        <ViewportResizer
+            deviceType={deviceType}
+            onViewportSizeChanged={(newDeviceType) => {
+                action("onViewportSizeChanged")(newDeviceType);
+                setDeviceType(newDeviceType);
+            }}
+        />
+    );
+};

--- a/packages/perseus-editor/src/components/device-framer.tsx
+++ b/packages/perseus-editor/src/components/device-framer.tsx
@@ -2,8 +2,7 @@
  * A component that displays its contents inside a device frame.
  */
 
-import {constants} from "@khanacademy/perseus";
-import PropTypes from "prop-types";
+import {DeviceType, constants} from "@khanacademy/perseus";
 import * as React from "react";
 
 const SCREEN_SIZES = {
@@ -24,52 +23,47 @@ const SCREEN_SIZES = {
     },
 } as const;
 
-type Props = any;
+type Props = React.PropsWithChildren<{
+    deviceType?: DeviceType;
+    nochrome: boolean;
+}>;
 
-class DeviceFramer extends React.Component<Props> {
-    static propTypes = {
-        children: PropTypes.element.isRequired,
-        deviceType: PropTypes.oneOf([
-            constants.devices.PHONE,
-            constants.devices.TABLET,
-            constants.devices.DESKTOP,
-        ]).isRequired,
-        // TODO(kevinb) rename to variableHeight
-        nochrome: PropTypes.bool,
-    };
-
-    render(): React.ReactNode {
-        const deviceType = this.props.deviceType;
-
-        if (this.props.nochrome) {
-            // Render content inside a variable height iframe.  Used on the
-            // "edit" table of the content editor. In this mode, PerseusFrame
-            // will draw the border and reserve space on the right for
-            // lint indicators.
-            return (
-                <div>
-                    <div
-                        key="screen"
-                        style={{
-                            width:
-                                SCREEN_SIZES[deviceType].framedWidth +
-                                2 * constants.perseusFrameBorderWidth +
-                                constants.lintGutterWidth,
-                        }}
-                    >
-                        <div>{this.props.children}</div>
-                    </div>
+const DeviceFramer = ({
+    children,
+    deviceType = "phone",
+    nochrome,
+}: Props): React.ReactElement => {
+    if (nochrome) {
+        // Render content inside a variable height iframe.  Used on the
+        // "edit" table of the content editor. In this mode, PerseusFrame
+        // will draw the border and reserve space on the right for
+        // lint indicators.
+        return (
+            <div>
+                <div
+                    key="screen"
+                    style={{
+                        overflow: "scroll",
+                        width:
+                            SCREEN_SIZES[deviceType].framedWidth +
+                            2 * constants.perseusFrameBorderWidth +
+                            constants.lintGutterWidth,
+                    }}
+                >
+                    <div>{children}</div>
                 </div>
-            );
-        }
-        const scale =
-            SCREEN_SIZES[deviceType].framedWidth /
-            SCREEN_SIZES[deviceType].width;
+            </div>
+        );
+    }
+    const scale =
+        SCREEN_SIZES[deviceType].framedWidth / SCREEN_SIZES[deviceType].width;
 
-        // In this mode we draw our own border and don't reserve
-        // space for a lint gutter.
-        const screenStyle = {
+    // In this mode we draw our own border and don't reserve
+    // space for a lint gutter.
+    const screenStyle = React.useMemo(
+        () => ({
             backgroundColor: "white",
+            overflow: "scroll",
             color: "black",
             textAlign: "left",
             width: SCREEN_SIZES[deviceType].width,
@@ -77,14 +71,19 @@ class DeviceFramer extends React.Component<Props> {
             border: "solid 1px #CCC",
             margin: 8,
             zoom: scale,
-        } as const;
+        }),
+        [deviceType],
+    );
 
-        return (
-            <div key="screen" className="screen" style={screenStyle}>
-                {this.props.children}
-            </div>
-        );
-    }
-}
+    return (
+        <div
+            key="screen"
+            className="screen"
+            style={{...screenStyle, textAlign: "start"}}
+        >
+            {children}
+        </div>
+    );
+};
 
 export default DeviceFramer;

--- a/packages/perseus-editor/src/components/viewport-resizer.tsx
+++ b/packages/perseus-editor/src/components/viewport-resizer.tsx
@@ -3,7 +3,6 @@
  * Renders three buttons: "Phone", "Tablet", and "Desktop".
  */
 import {components, constants, icons} from "@khanacademy/perseus";
-import PropTypes from "prop-types";
 import * as React from "react";
 
 import type {DeviceType} from "@khanacademy/perseus";
@@ -13,60 +12,51 @@ const {devices} = constants;
 const {iconDesktop, iconMobilePhone, iconTablet} = icons;
 
 type Props = {
+    /** The current device type that is selected. */
     deviceType: DeviceType;
-    onViewportSizeChanged: (arg1: DeviceType) => unknown;
+    /**
+     * A callback that is passed (width, height) as the dimensions of the
+     * viewport to resize to.
+     */
+    onViewportSizeChanged: (deviceType: DeviceType) => unknown;
 };
 
-class ViewportResizer extends React.Component<Props> {
-    static propTypes = {
-        // The current device type that is selected.
-        deviceType: PropTypes.string.isRequired,
-        // A callback that is passed (width, height) as the dimensions of the
-        // viewport to resize to.
-        onViewportSizeChanged: PropTypes.func.isRequired,
-    };
+const ViewportResizer = (props: Props) => {
+    const phoneButtonContents = (
+        <span>
+            <InlineIcon {...iconMobilePhone} /> Phone
+        </span>
+    );
+    const tabletButtonContents = (
+        <span>
+            <InlineIcon {...iconTablet} /> Tablet
+        </span>
+    );
+    const desktopButtonContents = (
+        <span>
+            <InlineIcon {...iconDesktop} /> Desktop
+        </span>
+    );
 
-    handleChange: (value: DeviceType) => void = (value: DeviceType) => {
-        this.props.onViewportSizeChanged(value);
-    };
-
-    render(): React.ReactNode {
-        const phoneButtonContents = (
-            <span>
-                <InlineIcon {...iconMobilePhone} /> Phone
-            </span>
-        );
-        const tabletButtonContents = (
-            <span>
-                <InlineIcon {...iconTablet} /> Tablet
-            </span>
-        );
-        const desktopButtonContents = (
-            <span>
-                <InlineIcon {...iconDesktop} /> Desktop
-            </span>
-        );
-
-        // TODO(david): Allow input of custom viewport sizes.
-        return (
-            <span className="viewport-resizer">
-                Viewport:{" "}
-                <ButtonGroup
-                    value={this.props.deviceType}
-                    allowEmpty={false}
-                    buttons={[
-                        {value: devices.PHONE, content: phoneButtonContents},
-                        {value: devices.TABLET, content: tabletButtonContents},
-                        {
-                            value: devices.DESKTOP,
-                            content: desktopButtonContents,
-                        },
-                    ]}
-                    onChange={this.handleChange}
-                />
-            </span>
-        );
-    }
-}
+    // TODO(david): Allow input of custom viewport sizes.
+    return (
+        <span className="viewport-resizer">
+            Viewport:{" "}
+            <ButtonGroup
+                value={props.deviceType}
+                allowEmpty={false}
+                buttons={[
+                    {value: devices.PHONE, content: phoneButtonContents},
+                    {value: devices.TABLET, content: tabletButtonContents},
+                    {
+                        value: devices.DESKTOP,
+                        content: desktopButtonContents,
+                    },
+                ]}
+                onChange={props.onViewportSizeChanged}
+            />
+        </span>
+    );
+};
 
 export default ViewportResizer;


### PR DESCRIPTION
## Summary:

This PR migrates two small editor components to be functionnal components and adds stories for them. I started into these components because I thought they might be useful in our main ServerItemRenderer stories so that we can easily change the viewport to be what our content editors use. 

  * Migrate ViewportResizer to functional component and add stories for it
  * Migrate DeviceFramer to functional component and add stories for it

Issue: "none"

## Test plan: