### PR TITLE
Graph dev ui: add navigation back to gallery from flipbook

### DIFF
--- a/dev/flipbook.tsx
+++ b/dev/flipbook.tsx
@@ -22,6 +22,7 @@ import {
     selectNumQuestions,
     jumpToQuestion,
 } from "./flipbook-model";
+import {Header} from "./header";
 
 import type {
     APIOptions,
@@ -52,58 +53,75 @@ export function Flipbook() {
     const noTextEntered = state.questions.trim() === "";
 
     return (
-        <View style={{padding: spacing.medium_16}}>
-            <textarea
-                wrap={"off"}
-                rows={10}
-                style={{width: "100%"}}
-                value={state.questions}
-                onChange={(e) => dispatch(setQuestions(e.target.value))}
-            />
-            <View style={{flexDirection: "row", alignItems: "baseline"}}>
-                <Button kind="secondary" onClick={() => dispatch(previous)}>
-                    Previous
-                </Button>
-                <Strut size={spacing.xxSmall_6} />
-                <Button kind="secondary" onClick={() => dispatch(next)}>
-                    Next
-                </Button>
-                <Strut size={spacing.medium_16} />
-                <Progress
-                    zeroBasedIndex={index}
-                    total={numQuestions}
-                    onIndexChanged={(input) => dispatch(jumpToQuestion(input))}
-                />
-                <Strut size={spacing.medium_16} />
-                <Button
-                    kind="tertiary"
-                    onClick={() => dispatch(removeCurrentQuestion)}
+        <>
+            <Header>
+                <View
+                    style={{
+                        flexDirection: "row",
+                        alignItems: "center",
+                        flexBasis: "max-content",
+                    }}
                 >
-                    Discard question
-                </Button>
+                    <nav>
+                        <a href="/">Gallery</a>
+                    </nav>
+                </View>
+            </Header>
+            <View style={{padding: spacing.medium_16}}>
+                <textarea
+                    wrap={"off"}
+                    rows={10}
+                    style={{width: "100%"}}
+                    value={state.questions}
+                    onChange={(e) => dispatch(setQuestions(e.target.value))}
+                />
+                <View style={{flexDirection: "row", alignItems: "baseline"}}>
+                    <Button kind="secondary" onClick={() => dispatch(previous)}>
+                        Previous
+                    </Button>
+                    <Strut size={spacing.xxSmall_6} />
+                    <Button kind="secondary" onClick={() => dispatch(next)}>
+                        Next
+                    </Button>
+                    <Strut size={spacing.medium_16} />
+                    <Progress
+                        zeroBasedIndex={index}
+                        total={numQuestions}
+                        onIndexChanged={(input) =>
+                            dispatch(jumpToQuestion(input))
+                        }
+                    />
+                    <Strut size={spacing.medium_16} />
+                    <Button
+                        kind="tertiary"
+                        onClick={() => dispatch(removeCurrentQuestion)}
+                    >
+                        Discard question
+                    </Button>
+                </View>
+                <Strut size={spacing.small_12} />
+                <div style={{display: noTextEntered ? "block" : "none"}}>
+                    <h2>Instructions</h2>
+                    <ol>
+                        <li>
+                            <p>
+                                Run a command like one of the following to copy
+                                question data to your clipboard.
+                            </p>
+                            <code>
+                                <pre>{exampleCommands}</pre>
+                            </code>
+                        </li>
+                        <li>
+                            <p>Paste the data in the box above.</p>
+                        </li>
+                    </ol>
+                </div>
+                {question != null && (
+                    <SideBySideQuestionRenderer question={question} />
+                )}
             </View>
-            <Strut size={spacing.small_12} />
-            <div style={{display: noTextEntered ? "block" : "none"}}>
-                <h2>Instructions</h2>
-                <ol>
-                    <li>
-                        <p>
-                            Run a command like one of the following to copy
-                            question data to your clipboard.
-                        </p>
-                        <code>
-                            <pre>{exampleCommands}</pre>
-                        </code>
-                    </li>
-                    <li>
-                        <p>Paste the data in the box above.</p>
-                    </li>
-                </ol>
-            </div>
-            {question != null && (
-                <SideBySideQuestionRenderer question={question} />
-            )}
-        </View>
+        </>
     );
 }
 

--- a/dev/gallery.tsx
+++ b/dev/gallery.tsx
@@ -4,7 +4,7 @@ import {OptionItem, MultiSelect} from "@khanacademy/wonder-blocks-dropdown";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import SearchField from "@khanacademy/wonder-blocks-search-field";
 import Switch from "@khanacademy/wonder-blocks-switch";
-import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {css, StyleSheet} from "aphrodite";
 import * as React from "react";
 import {useEffect, useMemo, useState} from "react";
@@ -13,6 +13,8 @@ import {Renderer} from "../packages/perseus/src";
 import * as grapher from "../packages/perseus/src/widgets/__testdata__/grapher.testdata";
 import * as interactiveGraph from "../packages/perseus/src/widgets/__testdata__/interactive-graph.testdata";
 import * as numberLine from "../packages/perseus/src/widgets/__testdata__/number-line.testdata";
+
+import {Header} from "./header";
 
 import type {APIOptions, PerseusRenderer} from "../packages/perseus/src";
 
@@ -44,19 +46,16 @@ const styles = StyleSheet.create({
         overflowY: "hidden",
     },
 
-    header: {
-        display: "flex",
-        alignItems: "center",
-        boxShadow: "0 0 10px #0002",
-        borderBlockEnd: `1px solid ${color.offBlack32}`,
-        background: color.offBlack8,
-        padding: spacing.small_12,
-    },
-
     main: {
         flexGrow: 1,
         overflowY: "scroll",
         paddingBlock: spacing.xLarge_32,
+    },
+
+    headerItem: {
+        flexDirection: "row",
+        alignItems: "center",
+        flexBasis: "max-content",
     },
 
     cards: {
@@ -118,42 +117,50 @@ export function Gallery() {
 
     return (
         <View className={css(styles.page)}>
-            <header className={css(styles.header)}>
-                <Switch
-                    id={mobileId}
-                    checked={isMobile}
-                    onChange={setIsMobile}
-                />
-                <Strut size={spacing.xSmall_8} />
-                <label htmlFor={mobileId}>Mobile</label>
-                <Strut size={spacing.medium_16} />
-                <MultiSelect
-                    id={flagsId}
-                    onChange={setMafsFlags}
-                    selectedValues={mafsFlags}
-                >
-                    <OptionItem value="segment" label="Segment" />
-                    <OptionItem value="linear" label="Linear" />
-                    <OptionItem value="linear-system" label="Linear System" />
-                    <OptionItem value="point" label="Point" />
-                    <OptionItem value="ray" label="Ray" />
-                    <OptionItem value="polygon" label="Polygon" />
-                </MultiSelect>
-                <Strut size={spacing.xSmall_8} />
-                <label htmlFor={flagsId}>Mafs Flags</label>
-                <Strut size={spacing.medium_16} />
-                <SearchField
-                    id={searchId}
-                    value={search}
-                    onChange={setSearch}
-                />
-                <Strut size={spacing.xSmall_8} />
-                <label htmlFor={searchId}>Search Types</label>
-                <Strut size={spacing.medium_16} />
-                <nav>
-                    <a href="#flipbook">Flipbook</a>
-                </nav>
-            </header>
+            <Header>
+                <View style={styles.headerItem}>
+                    <nav>
+                        <a href="#flipbook">Flipbook</a>
+                    </nav>
+                </View>
+                <View style={styles.headerItem}>
+                    <SearchField
+                        id={searchId}
+                        value={search}
+                        onChange={setSearch}
+                    />
+                    <Strut size={spacing.xSmall_8} />
+                    <label htmlFor={searchId}>Search Types</label>
+                </View>
+                <View style={styles.headerItem}>
+                    <MultiSelect
+                        id={flagsId}
+                        onChange={setMafsFlags}
+                        selectedValues={mafsFlags}
+                    >
+                        <OptionItem value="segment" label="Segment" />
+                        <OptionItem value="linear" label="Linear" />
+                        <OptionItem
+                            value="linear-system"
+                            label="Linear System"
+                        />
+                        <OptionItem value="point" label="Point" />
+                        <OptionItem value="ray" label="Ray" />
+                        <OptionItem value="polygon" label="Polygon" />
+                    </MultiSelect>
+                    <Strut size={spacing.xSmall_8} />
+                    <label htmlFor={flagsId}>Mafs Flags</label>
+                </View>
+                <View style={styles.headerItem}>
+                    <Switch
+                        id={mobileId}
+                        checked={isMobile}
+                        onChange={setIsMobile}
+                    />
+                    <Strut size={spacing.xSmall_8} />
+                    <label htmlFor={mobileId}>Mobile</label>
+                </View>
+            </Header>
             <main className={css(styles.main)}>
                 <View
                     style={styles.cards}

--- a/dev/header.tsx
+++ b/dev/header.tsx
@@ -1,0 +1,21 @@
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {css, StyleSheet} from "aphrodite";
+import * as React from "react";
+
+const styles = StyleSheet.create({
+    header: {
+        display: "flex",
+        alignItems: "center",
+        boxShadow: "0 0 10px #0002",
+        borderBlockEnd: `1px solid ${color.offBlack32}`,
+        background: color.offBlack8,
+        padding: spacing.small_12,
+        justifyContent: "space-between",
+        flexDirection: "row-reverse",
+        flexWrap: "wrap",
+    },
+});
+
+export const Header = ({children}) => (
+    <header className={css(styles.header)}>{children}</header>
+);


### PR DESCRIPTION
Makes header its own component, adds it to flipbook, and adds link back to gallery.

To keep item placement consistent and also to make header more flexible, items spread to take up header space and wrap when container becomes too narrow.

Row order is reversed so that the lone item in the flipbook nav is in the same place as in gallery (top right).

https://github.com/Khan/perseus/assets/23404711/3541b0d8-e64e-42a0-a197-da6e9483d5dc
