### PR TITLE
Fix test following eslint changes

### DIFF
--- a/.changeset/wild-points-float.md
+++ b/.changeset/wild-points-float.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Test fix following eslint rule change

--- a/packages/math-input/src/components/__tests__/integration.test.tsx
+++ b/packages/math-input/src/components/__tests__/integration.test.tsx
@@ -125,14 +125,18 @@ describe("math input integration", () => {
         // Arrange
         render(<ConnectedMathInput />);
 
-        screen.getByLabelText(
+        // The textbox role and label is on the wrapper; tabIndex=0 is on first child
+        const input = screen.getByLabelText(
             "Math input box Tap with one or two fingers to open keyboard",
-        );
+            // eslint-disable-next-line testing-library/no-node-access
+        ).firstElementChild;
 
         // Act
         await userEvent.tab();
 
         // Assert
+        expect(input).toHaveFocus();
+
         await waitFor(() => {
             expect(screen.getByRole("button", {name: "4"})).toBeVisible();
         });


### PR DESCRIPTION
One test failed because of an `eslint` error due to new (and welcome!) rules.

An element was asserted as existing by only a query, which violates the rule. Also, the test didn't explicitly assert that the element was focused per the test title. This ensures that the expected element has focus.