### PR TITLE
Fix grid rendering bug

### DIFF
--- a/.changeset/tender-knives-jam.md
+++ b/.changeset/tender-knives-jam.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Bug fix: mafs grid should render when there is a legacy background and markings other than "none"

--- a/packages/perseus/src/widgets/interactive-graphs/legacy-grid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/legacy-grid.tsx
@@ -7,14 +7,16 @@ import {interactiveSizes} from "../../styles/constants";
 
 import type {PerseusImageBackground} from "../../perseus-types";
 
+interface Props {
+    box: [number, number];
+    backgroundImage?: PerseusImageBackground;
+}
+
 /**
  * If a graphie URL is provided in `backgroundImage`, will return the rendered graphie background.
  * Otherwise, returns `null`.
  */
-export const getLegacyGrid = (
-    box: [number, number],
-    backgroundImage?: PerseusImageBackground,
-) => {
+export const LegacyGrid = ({box, backgroundImage}: Props) => {
     const {url, width, height} = backgroundImage ?? {};
     if (url && typeof url === "string") {
         const scale = box[0] / interactiveSizes.defaultBoxSize;

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 import GraphLockedLayer from "./graph-locked-layer";
 import {LinearGraph, PolygonGraph, RayGraph, SegmentGraph} from "./graphs";
 import {Grid} from "./grid";
-import {getLegacyGrid} from "./legacy-grid";
+import {LegacyGrid} from "./legacy-grid";
 import {interactiveGraphReducer} from "./reducer/interactive-graph-reducer";
 import {
     getGradableGraph,
@@ -46,8 +46,6 @@ export const MafsGraph = React.forwardRef<
     React.PropsWithChildren<InteractiveGraphProps> & {box: [number, number]}
 >((props, ref) => {
     const [width, height] = props.box;
-    const legacyGrid = getLegacyGrid([width, height], props.backgroundImage);
-
     const [state, dispatch] = React.useReducer(
         interactiveGraphReducer,
         props,
@@ -66,7 +64,10 @@ export const MafsGraph = React.forwardRef<
                 position: "relative",
             }}
         >
-            {legacyGrid}
+            <LegacyGrid
+                box={props.box}
+                backgroundImage={props.backgroundImage}
+            />
             <View
                 style={{
                     position: "absolute",
@@ -86,7 +87,7 @@ export const MafsGraph = React.forwardRef<
                     height={height}
                 >
                     {/* Background layer */}
-                    {!legacyGrid && <Grid {...props} />}
+                    <Grid {...props} />
 
                     {/* Locked layer */}
                     {props.lockedFigures && (


### PR DESCRIPTION
## Summary
Allows `markings` prop to determine whether the mafs grid renders. Previously, it was both `markings` and the presence or absensce of a "LegacyGrid". However, sometimes a grid was rendered in the component and the "LegacyGrid" just contained labels, and in this case we are not rendering a grid.

### Issue
LEMS-1843

## Test
Run `yarn dev` and to open graph dev ui, navigate to `Flipbook`.
Paste in the following Perseus data:
```json
{"content":"Line segments $\\overline{PQ}$ and $\\overline{RS}$ undergo the translation $T_{(2,-12)}$. \n\n**Below, modify the other line segments to create the image of this translation.** \n\n\n[[☃ interactive-graph 3]]\n\n","images":{},"widgets":{"interactive-graph 3":{"alignment":"default","graded":true,"options":{"backgroundImage":{"bottom":0,"height":400,"left":0,"scale":1,"url":"web+graphie://ka-perseus-graphie.s3.amazonaws.com/568ab9cb556740e9691aad6292dbcf659223653d","width":400},"correct":{"coords":[[[5,-4],[7,-7]],[[1,-7],[4,-7]]],"numSegments":2,"type":"segment"},"graph":{"numSegments":2,"type":"segment"},"gridStep":[1,1],"labels":["x","y"],"markings":"graph","range":[[-10,10],[-10,10]],"rulerLabel":"","rulerTicks":10,"showProtractor":false,"showRuler":false,"snapStep":[1,1],"step":[1,1]},"static":false,"type":"interactive-graph","version":{"major":0,"minor":0}}}}
```
Ensure that a grid has been rendered.