### PR TITLE
Ensure default segments are positioned correctly on Mafs graphs

### DIFF
--- a/.changeset/twenty-ads-type.md
+++ b/.changeset/twenty-ads-type.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix a bug in Mafs graphs where default segments were sometimes incorrectly positioned

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
@@ -105,7 +105,10 @@ describe("initializeGraphState", () => {
         // tiny. So instead, we position the segment in approximately the same
         // *visual* position as (-5, 5), (5, 5), whatever that maps to in graph
         // coordinates.
-        const scale = [[-1000, 1000], [-1000, 1000]]
+        const scale = [
+            [-1000, 1000],
+            [-1000, 1000],
+        ];
         const state = initializeGraphState({
             range: [
                 [-1000, 1000],
@@ -115,6 +118,11 @@ describe("initializeGraphState", () => {
             snapStep: [1, 1],
             graph: {type: "segment", numSegments: 1},
         });
-        expect(state.coords).toEqual([[[-500, 500], [500, 500]]]);
+        expect(state.coords).toEqual([
+            [
+                [-500, 500],
+                [500, 500],
+            ],
+        ]);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
@@ -105,10 +105,6 @@ describe("initializeGraphState", () => {
         // tiny. So instead, we position the segment in approximately the same
         // *visual* position as (-5, 5), (5, 5), whatever that maps to in graph
         // coordinates.
-        const scale = [
-            [-1000, 1000],
-            [-1000, 1000],
-        ];
         const state = initializeGraphState({
             range: [
                 [-1000, 1000],

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
@@ -96,4 +96,25 @@ describe("initializeGraphState", () => {
             [-2, -4],
         ]);
     });
+
+    it("puts the segments in the same place regardless of graph scale", () => {
+        // When the graph bounds are the default of x: (-10, 10), y: (-10, 10),
+        // the first segment gets drawn from (-5, 5) to (5, 5). If the graph
+        // scale were (-1000, 1000), (-1000, 1000), though, we wouldn't want to
+        // keep the same segment position; the segment would be unclickably
+        // tiny. So instead, we position the segment in approximately the same
+        // *visual* position as (-5, 5), (5, 5), whatever that maps to in graph
+        // coordinates.
+        const scale = [[-1000, 1000], [-1000, 1000]]
+        const state = initializeGraphState({
+            range: [
+                [-1000, 1000],
+                [-1000, 1000],
+            ],
+            step: [1, 1],
+            snapStep: [1, 1],
+            graph: {type: "segment", numSegments: 1},
+        });
+        expect(state.coords).toEqual([[[-500, 500], [500, 500]]]);
+    });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -124,12 +124,17 @@ const getDefaultSegments = ({
         }
     };
 
+    const defaultRange: [Interval, Interval] = [
+        [-10, 10],
+        [-10, 10],
+    ];
+
     return ys(graph.numSegments).map((y) => {
         let endpoints: [Coord, Coord] = [
             [-5, y],
             [5, y],
         ];
-        endpoints = normalizeCoords(endpoints, range);
+        endpoints = normalizeCoords(endpoints, defaultRange);
         endpoints = normalizePoints(range, step, endpoints);
         return endpoints;
     });


### PR DESCRIPTION
## Summary:
Previously, there was a discrepancy between our `getDefaultSegments`
function and the equivalent code in the legacy InteractiveGraph.
`getDefaultSegments` was not "normalizing" the points correctly (see the
test added in this commit for an explanation of why we do this).

This commit ports the legacy behavior over.

Issue: https://khanacademy.atlassian.net/browse/LEMS-1841

Test plan:

See the linked issue for repro steps. The bug should not repro!