### PR TITLE
[🔥AUDIT🔥] Add linear Mafs flag to flipbook

### DIFF
--- a/.changeset/hip-shoes-repair.md
+++ b/.changeset/hip-shoes-repair.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-dev-ui": patch
+"@khanacademy/perseus": patch
+---
+
+Internal: consolidate definition of Mafs-supported interactive graph types

--- a/dev/flipbook.tsx
+++ b/dev/flipbook.tsx
@@ -135,7 +135,15 @@ function SideBySideQuestionRenderer({
                     question={question}
                     apiOptions={{
                         ...apiOptions,
-                        flags: {mafs: {segment: true, linear: true}},
+                        flags: {
+                            mafs: {
+                                segment: true,
+                                linear: true,
+                                "linear-system": true,
+                                polygon: true,
+                                ray: true,
+                            },
+                        },
                     }}
                 />
             </View>

--- a/dev/flipbook.tsx
+++ b/dev/flipbook.tsx
@@ -30,6 +30,9 @@ import type {
 } from "../packages/perseus/src";
 
 import "../packages/perseus/src/styles/perseus-renderer.less";
+import {
+    trueForAllMafsSupportedGraphTypes
+} from "../packages/perseus/src/widgets/interactive-graphs/mafs-supported-graph-types";
 
 const exampleCommands = `
 # copy all questions
@@ -133,18 +136,7 @@ function SideBySideQuestionRenderer({
                 />
                 <GradableRenderer
                     question={question}
-                    apiOptions={{
-                        ...apiOptions,
-                        flags: {
-                            mafs: {
-                                segment: true,
-                                linear: true,
-                                "linear-system": true,
-                                polygon: true,
-                                ray: true,
-                            },
-                        },
-                    }}
+                    apiOptions={{...apiOptions, flags: {mafs: trueForAllMafsSupportedGraphTypes}}}
                 />
             </View>
             <p>

--- a/dev/flipbook.tsx
+++ b/dev/flipbook.tsx
@@ -9,6 +9,7 @@ import {useReducer, useRef} from "react";
 
 import {Renderer} from "../packages/perseus/src";
 import {isCorrect} from "../packages/perseus/src/util";
+import {trueForAllMafsSupportedGraphTypes} from "../packages/perseus/src/widgets/interactive-graphs/mafs-supported-graph-types";
 
 import {EditableControlledInput} from "./editable-controlled-input";
 import {
@@ -30,7 +31,6 @@ import type {
 } from "../packages/perseus/src";
 
 import "../packages/perseus/src/styles/perseus-renderer.less";
-import {trueForAllMafsSupportedGraphTypes} from "../packages/perseus/src/widgets/interactive-graphs/mafs-supported-graph-types";
 
 const exampleCommands = `
 # copy all questions

--- a/dev/flipbook.tsx
+++ b/dev/flipbook.tsx
@@ -30,9 +30,7 @@ import type {
 } from "../packages/perseus/src";
 
 import "../packages/perseus/src/styles/perseus-renderer.less";
-import {
-    trueForAllMafsSupportedGraphTypes
-} from "../packages/perseus/src/widgets/interactive-graphs/mafs-supported-graph-types";
+import {trueForAllMafsSupportedGraphTypes} from "../packages/perseus/src/widgets/interactive-graphs/mafs-supported-graph-types";
 
 const exampleCommands = `
 # copy all questions
@@ -136,7 +134,10 @@ function SideBySideQuestionRenderer({
                 />
                 <GradableRenderer
                     question={question}
-                    apiOptions={{...apiOptions, flags: {mafs: trueForAllMafsSupportedGraphTypes}}}
+                    apiOptions={{
+                        ...apiOptions,
+                        flags: {mafs: trueForAllMafsSupportedGraphTypes},
+                    }}
                 />
             </View>
             <p>

--- a/dev/flipbook.tsx
+++ b/dev/flipbook.tsx
@@ -133,7 +133,10 @@ function SideBySideQuestionRenderer({
                 />
                 <GradableRenderer
                     question={question}
-                    apiOptions={{...apiOptions, flags: {mafs: {segment: true}}}}
+                    apiOptions={{
+                        ...apiOptions,
+                        flags: {mafs: {segment: true, linear: true}},
+                    }}
                 />
             </View>
             <p>

--- a/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
+++ b/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
@@ -17,6 +17,7 @@ import {
     rayQuestionWithDefaultCorrect,
     polygonQuestionDefaultCorrect,
 } from "../__testdata__/interactive-graph.testdata";
+import {trueForAllMafsSupportedGraphTypes} from "../interactive-graphs/mafs-supported-graph-types";
 
 import {renderQuestion} from "./renderQuestion";
 
@@ -24,11 +25,8 @@ import type {Coord} from "../../interactive2/types";
 import type {PerseusRenderer} from "../../perseus-types";
 import type Renderer from "../../renderer";
 import type {APIOptions} from "../../types";
+import type {mafsSupportedGraphTypes} from "../interactive-graphs/mafs-supported-graph-types";
 import type {UserEvent} from "@testing-library/user-event";
-import {
-    mafsSupportedGraphTypes,
-    trueForAllMafsSupportedGraphTypes,
-} from "../interactive-graphs/mafs-supported-graph-types";
 
 const updateWidgetState = (renderer: Renderer, widgetId: string, update) => {
     const state = clone(renderer.getSerializedState());

--- a/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
+++ b/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
@@ -25,6 +25,10 @@ import type {PerseusRenderer} from "../../perseus-types";
 import type Renderer from "../../renderer";
 import type {APIOptions} from "../../types";
 import type {UserEvent} from "@testing-library/user-event";
+import {
+    mafsSupportedGraphTypes,
+    trueForAllMafsSupportedGraphTypes
+} from "../interactive-graphs/mafs-supported-graph-types";
 
 const updateWidgetState = (renderer: Renderer, widgetId: string, update) => {
     const state = clone(renderer.getSerializedState());
@@ -127,25 +131,12 @@ describe("mafs graphs", () => {
     });
 
     // Add types to this array as you test them
-    const graphsTypesToEnable = [
-        "segment",
-        "linear",
-        "linear-system",
-        "ray",
-        "polygon",
-    ] as const;
-
-    const graphTypeFlags = graphsTypesToEnable.reduce((acc, type) => {
-        acc[type] = true;
-        return acc;
-    }, {});
-
     const apiOptions = {
-        flags: {mafs: graphTypeFlags},
+        flags: {mafs: trueForAllMafsSupportedGraphTypes},
     };
 
     const graphQuestionRenderers: {
-        [K in (typeof graphsTypesToEnable)[number]]: PerseusRenderer;
+        [K in (typeof mafsSupportedGraphTypes)[number]]: PerseusRenderer;
     } = {
         segment: segmentQuestionDefaultCorrect,
         linear: linearQuestionWithDefaultCorrect,

--- a/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
+++ b/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
@@ -27,7 +27,7 @@ import type {APIOptions} from "../../types";
 import type {UserEvent} from "@testing-library/user-event";
 import {
     mafsSupportedGraphTypes,
-    trueForAllMafsSupportedGraphTypes
+    trueForAllMafsSupportedGraphTypes,
 } from "../interactive-graphs/mafs-supported-graph-types";
 
 const updateWidgetState = (renderer: Renderer, widgetId: string, update) => {

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-supported-graph-types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-supported-graph-types.ts
@@ -6,7 +6,7 @@ export const mafsSupportedGraphTypes = [
     "polygon",
 ] as const;
 
-export type MafsSupportedGraphType = typeof mafsSupportedGraphTypes[number];
+export type MafsSupportedGraphType = (typeof mafsSupportedGraphTypes)[number];
 
 // Pass these to the `flags` property of the `apiOptions` prop of the Renderer
 // component, e.g.:
@@ -14,8 +14,13 @@ export type MafsSupportedGraphType = typeof mafsSupportedGraphTypes[number];
 // ```
 // apiOptions={{flags: {mafs: trueForAllMafsSupportedGraphTypes}}}
 // ```
-export const trueForAllMafsSupportedGraphTypes: Record<MafsSupportedGraphType, true> = mafsSupportedGraphTypes.reduce((acc, type) => {
-    acc[type] = true;
-    return acc;
-}, {} as Record<MafsSupportedGraphType, true>);
-
+export const trueForAllMafsSupportedGraphTypes: Record<
+    MafsSupportedGraphType,
+    true
+> = mafsSupportedGraphTypes.reduce(
+    (acc, type) => {
+        acc[type] = true;
+        return acc;
+    },
+    {} as Record<MafsSupportedGraphType, true>,
+);

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-supported-graph-types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-supported-graph-types.ts
@@ -1,0 +1,21 @@
+export const mafsSupportedGraphTypes = [
+    "segment",
+    "linear",
+    "linear-system",
+    "ray",
+    "polygon",
+] as const;
+
+export type MafsSupportedGraphType = typeof mafsSupportedGraphTypes[number];
+
+// Pass these to the `flags` property of the `apiOptions` prop of the Renderer
+// component, e.g.:
+//
+// ```
+// apiOptions={{flags: {mafs: trueForAllMafsSupportedGraphTypes}}}
+// ```
+export const trueForAllMafsSupportedGraphTypes: Record<MafsSupportedGraphType, true> = mafsSupportedGraphTypes.reduce((acc, type) => {
+    acc[type] = true;
+    return acc;
+}, {} as Record<MafsSupportedGraphType, true>);
+


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

This lets you see the Mafs rendering of linear graphs side-by-side with the
legacy rendering in the flipbook UI.

Issue: none

## Test plan:

```
yarn dev
open http://localhost:5173/#flipbook
grep -rl '"type":"linear"' data/questions/ | xargs cat | pbcopy
```

Paste the data on your clipboard into the flipbook. The graphs on the right
should be rendered by Mafs.