### PR TITLE
Storybook - Organize Categories

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -9,45 +9,58 @@ import {
     storybookDependenciesV2,
 } from "../testing/test-dependencies";
 
+import type {Preview} from "@storybook/react";
+
 // IMPORTANT: This code runs ONCE per story file, not per story within that file.
 // If you want code to run once per story, see `StorybookWrapper`.
 
 Dependencies.setDependencies(storybookTestDependencies);
 
-// These decorators apply to all stories, both inside and outside the fixture
-// framework.
-export const decorators = [
-    (Story) => (
-        <RenderStateRoot>
-            <DependenciesContext.Provider value={storybookDependenciesV2}>
-                <Story />
-            </DependenciesContext.Provider>
-        </RenderStateRoot>
-    ),
-];
-
-// These parameters apply to all stories, both inside and outside the fixture
-// framework.
-export const parameters = {
-    // TODO(somewhatabstract): This actions configuration does not appear to be
-    // working as expected. That's probably OK since the new framework I'm
-    // putting in place doesn't need it as we'll have an explicit log call that
-    // ties into the actions API; however, the non-framework stories need it to
-    // work so we might want to look more into that. I tried a bunch of things
-    // to get this working, but nothing seems to do the trick. I suspect we
-    // need to specify this in a different place or the name of the field has
-    // changed (RANT: just another reason I hate export-based APIs).
-    actions: {argTypesRegex: "^on[A-Z].*"},
-    controls: {
-        matchers: {
-            color: /(background|color)$/i,
-            date: /Date$/,
+const preview: Preview = {
+    // These decorators apply to all stories, both inside and outside the
+    // fixture framework.
+    decorators: [
+        (Story) => (
+            <RenderStateRoot>
+                <DependenciesContext.Provider value={storybookDependenciesV2}>
+                    <Story />
+                </DependenciesContext.Provider>
+            </RenderStateRoot>
+        ),
+    ],
+    // These parameters apply to all stories, both inside and outside the fixture
+    // framework.
+    parameters: {
+        options: {
+            storySort: {
+                order: ["Perseus", "Perseus Editor", "Math-Input", "*"],
+            },
         },
+        // TODO(somewhatabstract): This actions configuration does not appear to be
+        // working as expected. That's probably OK since the new framework I'm
+        // putting in place doesn't need it as we'll have an explicit log call that
+        // ties into the actions API; however, the non-framework stories need it to
+        // work so we might want to look more into that. I tried a bunch of things
+        // to get this working, but nothing seems to do the trick. I suspect we
+        // need to specify this in a different place or the name of the field has
+        // changed (RANT: just another reason I hate export-based APIs).
+        actions: {argTypesRegex: "^on[A-Z].*"},
+        controls: {
+            matchers: {
+                color: /(background|color)$/i,
+                date: /Date$/,
+            },
+        },
+        backgrounds: {
+            // Add WB colors as background options. :)
+            values: Object.entries(color).map(([name, value]) => ({
+                name,
+                value,
+            })),
+        },
+        // Disables Chromatic's snapshotting on a global level
+        chromatic: {disableSnapshot: true},
     },
-    backgrounds: {
-        // Add WB colors as background options. :)
-        values: Object.entries(color).map(([name, value]) => ({name, value})),
-    },
-    // Disables Chromatic's snapshotting on a global level
-    chromatic: {disableSnapshot: true},
 };
+
+export default preview;

--- a/packages/math-input/src/components/__tests__/integration.test.tsx
+++ b/packages/math-input/src/components/__tests__/integration.test.tsx
@@ -125,19 +125,11 @@ describe("math input integration", () => {
         // Arrange
         render(<ConnectedMathInput />);
 
-<<<<<<< HEAD
-        expect(
-            screen.getByLabelText(
-                "Math input box Tap with one or two fingers to open keyboard",
-            ),
-        ).toBeVisible();
-=======
         // The textbox role and label is on the wrapper; tabIndex=0 is on first child
         const input = screen.getByLabelText(
             "Math input box Tap with one or two fingers to open keyboard",
             // eslint-disable-next-line testing-library/no-node-access
         ).firstElementChild;
->>>>>>> main
 
         // Act
         await userEvent.tab();

--- a/packages/math-input/src/components/__tests__/integration.test.tsx
+++ b/packages/math-input/src/components/__tests__/integration.test.tsx
@@ -125,9 +125,11 @@ describe("math input integration", () => {
         // Arrange
         render(<ConnectedMathInput />);
 
-        screen.getByLabelText(
-            "Math input box Tap with one or two fingers to open keyboard",
-        );
+        expect(
+            screen.getByLabelText(
+                "Math input box Tap with one or two fingers to open keyboard",
+            ),
+        ).toBeVisible();
 
         // Act
         await userEvent.tab();

--- a/packages/perseus-editor/src/__stories__/editor-page.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/editor-page.stories.tsx
@@ -14,7 +14,7 @@ import type {
 registerAllWidgetsAndEditorsForTesting(); // SIDE_EFFECTY!!!! :cry:
 
 export default {
-    title: "Perseus/Editor/EditorPage",
+    title: "Perseus Editor/EditorPage",
 };
 
 const onChangeAction = action("onChange");

--- a/packages/perseus-editor/src/__stories__/editor.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/editor.stories.tsx
@@ -14,7 +14,7 @@ import type {PerseusRenderer} from "@khanacademy/perseus";
 registerAllWidgetsAndEditorsForTesting(); // SIDE_EFFECTY!!!! :cry:
 
 export default {
-    title: "Perseus/Editor/Editor",
+    title: "Perseus Editor/Editor",
 };
 
 export const Demo = (): React.ReactElement => {

--- a/packages/perseus-editor/src/__stories__/item-editor.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/item-editor.stories.tsx
@@ -27,7 +27,7 @@ const Wrapper = (props: Props) => {
 };
 
 const story: Meta<Props> = {
-    title: "Perseus/Editor/Item Extras Editor",
+    title: "Perseus Editor/Item Extras Editor",
     component: ItemExtrasEditor,
     render: (args) => <Wrapper {...args} />,
     argTypes: {onChange: {action: "changed"}},

--- a/packages/perseus-editor/src/__stories__/tex-error-view.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/tex-error-view.stories.tsx
@@ -4,7 +4,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 
 const meta: Meta<typeof TexErrorView> = {
     component: TexErrorView,
-    title: "Perseus/Editor/TexErrorView",
+    title: "Perseus Editor/TexErrorView",
 };
 
 export default meta;

--- a/packages/perseus-editor/src/components/__stories__/blur-input.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/blur-input.stories.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import BlurInput from "../blur-input";
 
 export default {
-    title: "Perseus/Editor/Components/Blur Input",
+    title: "Perseus Editor/Components/Blur Input",
 };
 
 export const Default = (): React.ReactElement => {

--- a/packages/perseus-editor/src/components/__stories__/graph-settings.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/graph-settings.stories.tsx
@@ -5,7 +5,7 @@ import GraphSettings from "../graph-settings";
 import GraphSettingsArgTypes from "./graph-settings.argtypes";
 
 export default {
-    title: "Perseus/Editor/Components/Graph Settings",
+    title: "Perseus Editor/Components/Graph Settings",
     component: GraphSettings,
     argTypes: GraphSettingsArgTypes,
 };

--- a/packages/perseus-editor/src/components/__stories__/interactive-graph-settings.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/interactive-graph-settings.stories.tsx
@@ -7,7 +7,7 @@ import InteractiveGraphSettingsArgTypes from "./interactive-graph-settings.argty
 import type {StoryObj} from "@storybook/react";
 
 export default {
-    title: "Perseus/Editor/Components/Interactive Graph Settings",
+    title: "Perseus Editor/Components/Interactive Graph Settings",
     component: InteractiveGraphSettings,
     argTypes: InteractiveGraphSettingsArgTypes,
 };

--- a/packages/perseus-editor/src/components/__stories__/section-control-button.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/section-control-button.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus/Editor/Components/Section Control Button",
+    title: "Perseus Editor/Components/Section Control Button",
 } as Story;
 
 export const ButtonForEditingSectionsOfContentWithInArticleEditor = (

--- a/packages/perseus-editor/src/diffs/__stories__/structured-item-diff.stories.tsx
+++ b/packages/perseus-editor/src/diffs/__stories__/structured-item-diff.stories.tsx
@@ -16,7 +16,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus/Editor/Diffs/Structured Item Diff",
+    title: "Perseus Editor/Diffs/Structured Item Diff",
     decorators: [
         (StoryComponent) => (
             <Wrapper>

--- a/packages/perseus-editor/src/diffs/__stories__/tags-diff.stories.tsx
+++ b/packages/perseus-editor/src/diffs/__stories__/tags-diff.stories.tsx
@@ -14,7 +14,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus/Editor/Diffs/Tags Diff",
+    title: "Perseus Editor/Diffs/Tags Diff",
     decorators: [
         (StoryComponent) => (
             <Wrapper>

--- a/packages/perseus-editor/src/diffs/__stories__/text-diff.stories.tsx
+++ b/packages/perseus-editor/src/diffs/__stories__/text-diff.stories.tsx
@@ -14,7 +14,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus/Editor/Diffs/Text Diff",
+    title: "Perseus Editor/Diffs/Text Diff",
     decorators: [
         (StoryComponent) => (
             <Wrapper>

--- a/packages/perseus-editor/src/widgets/__stories__/categorizer-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/categorizer-editor.stories.tsx
@@ -11,7 +11,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus/Editor/Widgets/Categorizer Editor",
+    title: "Perseus Editor/Widgets/Categorizer Editor",
 } as Story;
 
 export const Default = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus-editor/src/widgets/__stories__/definition-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/definition-editor.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus/Editor/Widgets/Definition Editor",
+    title: "Perseus Editor/Widgets/Definition Editor",
 } as Story;
 
 export const Default = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus-editor/src/widgets/__stories__/dropdown-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/dropdown-editor.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus/Editor/Widgets/Dropdown Editor",
+    title: "Perseus Editor/Widgets/Dropdown Editor",
 } as Story;
 
 export const Default = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus-editor/src/widgets/__stories__/explanation-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/explanation-editor.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus/Editor/Widgets/Explanation Editor",
+    title: "Perseus Editor/Widgets/Explanation Editor",
 } as Story;
 
 export const Default = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus-editor/src/widgets/__stories__/expression-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/expression-editor.stories.tsx
@@ -17,7 +17,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus/Editor/Widgets/Expression Editor",
+    title: "Perseus Editor/Widgets/Expression Editor",
 } as Story;
 
 // TODO(FEI-5054): Figure out how to get global .d.ts files working with monorepos

--- a/packages/perseus-editor/src/widgets/__stories__/image-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/image-editor.stories.tsx
@@ -17,7 +17,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus/Editor/Widgets/Image Editor",
+    title: "Perseus Editor/Widgets/Image Editor",
 } as Story;
 
 const styles = StyleSheet.create({

--- a/packages/perseus-editor/src/widgets/__stories__/input-number-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/input-number-editor.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus/Editor/Widgets/InputNumber Editor",
+    title: "Perseus Editor/Widgets/InputNumber Editor",
 } as Story;
 
 export const Default = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus-editor/src/widgets/__stories__/interaction-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/interaction-editor.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus/Editor/Widgets/Interaction Editor",
+    title: "Perseus Editor/Widgets/Interaction Editor",
 } as Story;
 
 export const Default = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus-editor/src/widgets/__stories__/interactive-graph-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/interactive-graph-editor.stories.tsx
@@ -7,7 +7,7 @@ import InteractiveGraphEditorArgTypes from "./interactive-graph-editor.argtypes"
 import type {Meta, StoryObj} from "@storybook/react";
 
 export default {
-    title: "Perseus/Editor/Widgets/Interactive Graph Editor",
+    title: "Perseus Editor/Widgets/Interactive Graph Editor",
     component: InteractiveGraphEditor,
     argTypes: InteractiveGraphEditorArgTypes,
 } as Meta<typeof InteractiveGraphEditor>;

--- a/packages/perseus-editor/src/widgets/__stories__/label-image-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/label-image-editor.stories.tsx
@@ -16,7 +16,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus/Editor/Widgets/Label Image Editor",
+    title: "Perseus Editor/Widgets/Label Image Editor",
 } as Story;
 
 const styles = StyleSheet.create({

--- a/packages/perseus-editor/src/widgets/__stories__/matcher-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/matcher-editor.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus/Editor/Widgets/Matcher Editor",
+    title: "Perseus Editor/Widgets/Matcher Editor",
 } as Story;
 
 export const Default = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus-editor/src/widgets/__stories__/number-line-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/number-line-editor.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus/Editor/Widgets/Number Line Editor",
+    title: "Perseus Editor/Widgets/Number Line Editor",
 } as Story;
 
 export const Default = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus-editor/src/widgets/__stories__/numeric-input-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/numeric-input-editor.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus/Editor/Widgets/NumericInput Editor",
+    title: "Perseus Editor/Widgets/NumericInput Editor",
 } as Story;
 
 export const Default = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus-editor/src/widgets/__stories__/python-program-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/python-program-editor.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus/Editor/Widgets/Python Program Editor",
+    title: "Perseus Editor/Widgets/Python Program Editor",
 } as Story;
 
 export const Default = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus-editor/src/widgets/__stories__/radio-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/radio-editor.stories.tsx
@@ -20,7 +20,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus/Editor/Widgets/Radio Editor",
+    title: "Perseus Editor/Widgets/Radio Editor",
 } as Story;
 
 const styles = StyleSheet.create({

--- a/packages/perseus-editor/src/widgets/__stories__/sorter-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/sorter-editor.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus/Editor/Widgets/Sorter Editor",
+    title: "Perseus Editor/Widgets/Sorter Editor",
 } as Story;
 
 export const Default = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus-editor/src/widgets/label-image/__stories__/answer-choices.stories.tsx
+++ b/packages/perseus-editor/src/widgets/label-image/__stories__/answer-choices.stories.tsx
@@ -11,7 +11,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus/Editor/Widgets/Label Image/Answer Choices",
+    title: "Perseus Editor/Widgets/Label Image/Answer Choices",
 } as Story;
 
 const styles = StyleSheet.create({

--- a/packages/perseus-editor/src/widgets/label-image/__stories__/behavior.stories.tsx
+++ b/packages/perseus-editor/src/widgets/label-image/__stories__/behavior.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus/Editor/Widgets/Label Image/Behavior",
+    title: "Perseus Editor/Widgets/Label Image/Behavior",
 } as Story;
 
 export const Default = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus-editor/src/widgets/label-image/__stories__/marker.stories.tsx
+++ b/packages/perseus-editor/src/widgets/label-image/__stories__/marker.stories.tsx
@@ -11,7 +11,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus/Editor/Widgets/Label Image/Marker",
+    title: "Perseus Editor/Widgets/Label Image/Marker",
 } as Story;
 
 const styles = StyleSheet.create({

--- a/packages/perseus-editor/src/widgets/label-image/__stories__/question-markers.stories.tsx
+++ b/packages/perseus-editor/src/widgets/label-image/__stories__/question-markers.stories.tsx
@@ -12,7 +12,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus/Editor/Widgets/Label Image/Question Markers",
+    title: "Perseus Editor/Widgets/Label Image/Question Markers",
 } as Story;
 
 const styles = StyleSheet.create({

--- a/packages/perseus-editor/src/widgets/label-image/__stories__/select-image.stories.tsx
+++ b/packages/perseus-editor/src/widgets/label-image/__stories__/select-image.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus/Editor/Widgets/Label Image/Select Image",
+    title: "Perseus Editor/Widgets/Label Image/Select Image",
 } as Story;
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
## Summary:

This PR makes two small changes to how the Storybook stories are organized:

  1. I have set an explicit order of the Categories (the top-level nodes in the sidebar)
  2. I have split out all Perseus Editor stories into their own category to match the package breakdown. It always confused me that the editor components were intermingled with the Perseus components.


<img width="234" alt="image" src="https://github.com/Khan/perseus/assets/77138/8d76cf8c-c28f-4ee7-8ae8-aba6b38fcffa">


Issue: "none"

## Test plan:

`yarn start` - review the sidebar