### PR TITLE
Fix aspect ratio for Mafs graphs with nonsquare bounds

### DIFF
--- a/.changeset/selfish-tips-dream.md
+++ b/.changeset/selfish-tips-dream.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix a rendering bug in Mafs interactive graphs that have unequal x and y ranges

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -76,6 +76,7 @@ export const MafsGraph = React.forwardRef<
                 }}
             >
                 <Mafs
+                    preserveAspectRatio={false}
                     viewBox={{
                         x: props.range[0],
                         y: props.range[1],


### PR DESCRIPTION
Our legacy graph makes the grid non-square rather than fudge the ranges of the X and Y axes.
This commit makes Mafs graphs do the same.

Issue: https://khanacademy.atlassian.net/browse/LEMS-1853

## Test plan:

Paste the data below into the interactive graph flipbook. The ranges of the X and Y axes should be the same
for both the legacy and Mafs graphs.

```
{"content":"आप एक देश से दूसरे देश यात्रा करने के लिए सबके लिए खुले सड़क राजमार्ग पर गाड़ी चला रहे हैं, $60$ मील प्रति घंटा स्थिर गति में गाड़ी दौड़ रही है \n\n**रेखा का झुकाव इस संबंध को क्या दर्शाता है?**\n\nझुकाव [[☃ input-number 1]] है I\n\n **आलेख का अनुपातिक संबंध \n$d=60t\\,$ है Iजो आपकी यात्रा की दूरी $d$ (मील में ) समय $t$ की अवधि (घंटों में) बताता है जब से आप ने $60\\, \\text{mph}$ चलना शुरू किया था**\n\n\n\n\n\n\n\n[[☃ interactive-graph 1]]\n\n\n","images":{},"widgets":{"input-number 1":{"graded":true,"options":{"answerType":"number","inexact":false,"maxError":0.1,"simplify":"required","size":"small","value":"60"},"type":"input-number","version":{"major":0,"minor":0}},"interactive-graph 1":{"graded":true,"options":{"backgroundImage":{"bottom":0,"height":425,"left":0,"scale":1,"url":"https://ka-perseus-graphie.s3.amazonaws.com/e873a2844e0f055a21f9b5170525f15b5d42228e.png","width":425},"correct":{"coords":[[0,0],[1,60]],"type":"linear"},"graph":{"type":"linear"},"gridStep":[0.5,5],"labels":["x","y"],"markings":"none","range":[[-1,8],[-10,100]],"rulerLabel":"","rulerTicks":10,"showProtractor":false,"showRuler":false,"snapStep":[0.25,2.5],"step":[1,10]},"type":"interactive-graph","version":{"major":0,"minor":0}}}}
```
<img width="831" alt="Screen Shot 2024-03-21 at 12 25 59 PM" src="https://github.com/Khan/perseus/assets/693920/5d87bd2c-b837-4346-b216-61d7ad8aef1f">

