### PR TITLE
Refactor addWidget function to use a string ID

### DIFF
--- a/packages/perseus/src/util/snowman-utils.test.ts
+++ b/packages/perseus/src/util/snowman-utils.test.ts
@@ -1,7 +1,6 @@
 import {
     addWidget,
     getAllWidgetIds,
-    WidgetType,
     getQuestionWidgetIds,
     getAllWidgetTypes,
     getWidgetRegex,
@@ -77,9 +76,8 @@ describe("getQuestionWidgetIds", () => {
     it("returns all question widgets in a string", () => {
         // Arrange
         const questionContent = `${addWidget(
-            WidgetType.NumericInput,
-            1,
-        )} foo ${addWidget(WidgetType.Radio, 1)}`;
+            "numeric-input 1",
+        )} foo ${addWidget("radio 1")}`;
 
         // Act
         const questionWidget = getQuestionWidgetIds(questionContent);
@@ -91,9 +89,8 @@ describe("getQuestionWidgetIds", () => {
     it("does not return non-question widgets", () => {
         // Arrange
         const questionContent = `${addWidget(
-            WidgetType.NumericInput,
-            1,
-        )} ${addWidget(WidgetType.Video, 1)} ${addWidget(WidgetType.Radio, 1)}`;
+            "numeric-input 1",
+        )} ${addWidget("video 1")} ${addWidget("radio 1")}`;
 
         // Act
         const questionWidgetNames = getQuestionWidgetIds(questionContent);
@@ -107,13 +104,11 @@ describe("addWidget", () => {
     it("correctly adds a widget placeholder", () => {
         // Arrange
         const content = "Please answer this question [[☃ radio 1]]";
-        const testWidgetType = WidgetType.Radio;
-        const testWidgetInstance = 1;
+        const testWidgetId = "radio 1";
 
         // Act
         const newContent = `Please answer this question ${addWidget(
-            testWidgetType,
-            testWidgetInstance,
+            testWidgetId,
         )}`;
 
         // Assert

--- a/packages/perseus/src/util/snowman-utils.ts
+++ b/packages/perseus/src/util/snowman-utils.ts
@@ -67,15 +67,14 @@ export function getWidgetRegex() {
 }
 
 /**
- * Add a widget placeholder using the provided widget type and instance number.
- * ex. addWidget(WidgetType.Radio, 1) => "[[☃ radio 1]]"
+ * Add a widget placeholder using the widget ID.
+ * ex. addWidget("radio 1") => "[[☃ radio 1]]"
  *
- * @param {WidgetType} widgetType
- * @param {number} instance
+ * @param {string} id
  * @returns {string}
  */
-export function addWidget(widgetType: WidgetType, instance: number): string {
-    return `[[☃ ${widgetType} ${String(instance)}]]`;
+export function addWidget(id: string): string {
+    return `[[☃ ${id}]]`;
 }
 
 /**


### PR DESCRIPTION
## Summary:
Small refactor to the `addWidget` function. It no longer separates the widget ID into two and instead uses one string for the ID. This change is part of the goal to not determine widget type based on breaking up the ID for each widget.

Issue: LEMS-1856

## Test plan:
- Confirm all checks pass