### PR TITLE
Enable concurrency on most Github action workflows

### DIFF
--- a/.github/workflows/node-ci-main.yml
+++ b/.github/workflows/node-ci-main.yml
@@ -12,7 +12,7 @@ on:
 # workflow.
 # See https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
-    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    group: ${{ github.workflow }}
     cancel-in-progress: false
 
 # Our jobs run like this to minimize wasting resource cycles:

--- a/.github/workflows/node-ci-main.yml
+++ b/.github/workflows/node-ci-main.yml
@@ -7,6 +7,14 @@ on:
             - changeset-release/*
             - feature/*
 
+# When a PR is landed to main, we want to ensure that all of these jobs run and
+# that they all complete before the next PR's changes are processed by this
+# workflow.
+# See https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: false
+
 # Our jobs run like this to minimize wasting resource cycles:
 #   1. Prime caches for primary configuration.  This way subsequent jobs
 #      can run in parallel but rely on this primed cache.

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -8,6 +8,12 @@ on:
         # The rest are the defaults.
         types: [edited, opened, synchronize, reopened]
 
+# When a new revision is pushed to a PR, cancel all in-progress CI runs for that
+# PR. See https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
 jobs:
     changeset:
         name: Check for .changeset entries for all changed files

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -10,6 +10,8 @@ on:
     push:
         branches: [main]
 
+# When a new revision is pushed to a PR, cancel all in-progress CI runs for that
+# PR. See https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true


### PR DESCRIPTION
## Summary:

This PR enables [concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency) for the `node-ci-main.yml` and `node-ci.yml` Github Action workflow files. 

For `node-ci-main.yml` concurrency is enabled but `cancel-in-progress` is `false`. This is so that all workflow jobs run for a landed PR before the next PR's changes are processed. This ensures that we get updated coverage metrics for every PR that is landed. 

For `node-ci.yml` concurrency is enabled _and_ `cancel-in-progress` is `true`. This should save us some Github Action processing time and $$$. 

Issue: LEMS-1761

## Test plan:

There's not much to test other than watching how things go on subsequent PRs after this is landed. 

I checked that there are no steps that'd be affected by being interrupted in `node-ci.yml` and turning off concurrency should just make things work better in `node-ci-main.yml` as we'll avoid race conditions that could happen due to two PRs landing very close together.