### PR TITLE
Refactor getGradableGraph

### DIFF
--- a/.changeset/dull-shrimps-grow.md
+++ b/.changeset/dull-shrimps-grow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Refactor getGradableGraph

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -2367,10 +2367,12 @@ class InteractiveGraph extends React.Component<Props, State> {
         // circle's center/radius fields. When those fields are absent, skip
         // all these checks; just go mark the answer as empty.
         const hasValue = !!(
-            // @ts-expect-error - TS2339 - Property 'coords' does not exist on type 'PerseusGraphType'.
-            userInput.coords ||
-            // @ts-expect-error - TS2339 - Property 'center' does not exist on type 'PerseusGraphType'. | TS2339 - Property 'radius' does not exist on type 'PerseusGraphType'.
-            (userInput.center && userInput.radius)
+            (
+                // @ts-expect-error - TS2339 - Property 'coords' does not exist on type 'PerseusGraphType'.
+                userInput.coords ||
+                // @ts-expect-error - TS2339 - Property 'center' does not exist on type 'PerseusGraphType'. | TS2339 - Property 'radius' does not exist on type 'PerseusGraphType'.
+                (userInput.center && userInput.radius)
+            )
         );
 
         if (userInput.type === rubric.correct.type && hasValue) {

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -2359,9 +2359,7 @@ class InteractiveGraph extends React.Component<Props, State> {
     }
 
     static validate(
-        // TODO(kevinb): rename state to userInput
-        // state === userInput
-        state: PerseusGraphType,
+        userInput: PerseusGraphType,
         rubric: Rubric,
         component: any,
     ): PerseusScore {
@@ -2369,15 +2367,15 @@ class InteractiveGraph extends React.Component<Props, State> {
         // circle's center/radius fields. When those fields are absent, skip
         // all these checks; just go mark the answer as empty.
         // @ts-expect-error - TS2339 - Property 'coords' does not exist on type 'PerseusGraphType'. | TS2339 - Property 'center' does not exist on type 'PerseusGraphType'. | TS2339 - Property 'radius' does not exist on type 'PerseusGraphType'.
-        const hasValue = !!(state.coords || (state.center && state.radius));
+        const hasValue = !!(userInput.coords || (userInput.center && userInput.radius));
 
-        if (state.type === rubric.correct.type && hasValue) {
+        if (userInput.type === rubric.correct.type && hasValue) {
             if (
-                state.type === "linear" &&
+                userInput.type === "linear" &&
                 rubric.correct.type === "linear" &&
-                state.coords != null
+                userInput.coords != null
             ) {
-                const guess = state.coords;
+                const guess = userInput.coords;
                 const correct = rubric.correct.coords;
 
                 // If both of the guess points are on the correct line, it's
@@ -2396,11 +2394,11 @@ class InteractiveGraph extends React.Component<Props, State> {
                     };
                 }
             } else if (
-                state.type === "linear-system" &&
+                userInput.type === "linear-system" &&
                 rubric.correct.type === "linear-system" &&
-                state.coords != null
+                userInput.coords != null
             ) {
-                const guess = state.coords;
+                const guess = userInput.coords;
                 const correct = rubric.correct.coords as ReadonlyArray<
                     ReadonlyArray<Coord>
                 >;
@@ -2423,12 +2421,12 @@ class InteractiveGraph extends React.Component<Props, State> {
                     };
                 }
             } else if (
-                state.type === "quadratic" &&
+                userInput.type === "quadratic" &&
                 rubric.correct.type === "quadratic" &&
-                state.coords != null
+                userInput.coords != null
             ) {
                 // If the parabola coefficients match, it's correct.
-                const guessCoeffs = this.getQuadraticCoefficients(state.coords);
+                const guessCoeffs = this.getQuadraticCoefficients(userInput.coords);
                 const correctCoeffs = this.getQuadraticCoefficients(
                     // @ts-expect-error - TS2345 - Argument of type 'readonly Coord[] | undefined' is not assignable to parameter of type 'readonly Coord[]'.
                     rubric.correct.coords,
@@ -2442,11 +2440,11 @@ class InteractiveGraph extends React.Component<Props, State> {
                     };
                 }
             } else if (
-                state.type === "sinusoid" &&
+                userInput.type === "sinusoid" &&
                 rubric.correct.type === "sinusoid" &&
-                state.coords != null
+                userInput.coords != null
             ) {
-                const guessCoeffs = this.getSinusoidCoefficients(state.coords);
+                const guessCoeffs = this.getSinusoidCoefficients(userInput.coords);
                 const correctCoeffs = this.getSinusoidCoefficients(
                     // @ts-expect-error - TS2345 - Argument of type 'readonly Coord[] | undefined' is not assignable to parameter of type 'readonly Coord[]'.
                     rubric.correct.coords,
@@ -2466,12 +2464,12 @@ class InteractiveGraph extends React.Component<Props, State> {
                     };
                 }
             } else if (
-                state.type === "circle" &&
+                userInput.type === "circle" &&
                 rubric.correct.type === "circle"
             ) {
                 if (
-                    deepEq(state.center, rubric.correct.center) &&
-                    eq(state.radius, rubric.correct.radius)
+                    deepEq(userInput.center, rubric.correct.center) &&
+                    eq(userInput.radius, rubric.correct.radius)
                 ) {
                     return {
                         type: "points",
@@ -2481,15 +2479,15 @@ class InteractiveGraph extends React.Component<Props, State> {
                     };
                 }
             } else if (
-                state.type === "point" &&
+                userInput.type === "point" &&
                 rubric.correct.type === "point" &&
-                state.coords != null
+                userInput.coords != null
             ) {
                 let correct = InteractiveGraph.getPointCoords(
                     rubric.correct,
                     component,
                 );
-                const guess = state.coords?.slice();
+                const guess = userInput.coords?.slice();
                 correct = correct.slice();
                 // Everything's already rounded so we shouldn't need to do an
                 // eq() comparison but _.isEqual(0, -0) is false, so we'll use
@@ -2507,11 +2505,11 @@ class InteractiveGraph extends React.Component<Props, State> {
                     };
                 }
             } else if (
-                state.type === "polygon" &&
+                userInput.type === "polygon" &&
                 rubric.correct.type === "polygon" &&
-                state.coords != null
+                userInput.coords != null
             ) {
-                const guess: Array<Coord> = state.coords?.slice();
+                const guess: Array<Coord> = userInput.coords?.slice();
                 // @ts-expect-error - TS2322 - Type 'Coord[] | undefined' is not assignable to type 'Coord[]'.
                 const correct: Array<Coord> = rubric.correct.coords?.slice();
 
@@ -2538,11 +2536,11 @@ class InteractiveGraph extends React.Component<Props, State> {
                     };
                 }
             } else if (
-                state.type === "segment" &&
+                userInput.type === "segment" &&
                 rubric.correct.type === "segment" &&
-                state.coords != null
+                userInput.coords != null
             ) {
-                let guess = state.coords.slice();
+                let guess = userInput.coords.slice();
                 let correct = rubric.correct.coords?.slice();
                 guess = _.invoke(guess, "sort").sort();
                 // @ts-expect-error - TS2345 - Argument of type '(readonly Coord[])[] | undefined' is not assignable to parameter of type 'Collection<any>'.
@@ -2556,11 +2554,11 @@ class InteractiveGraph extends React.Component<Props, State> {
                     };
                 }
             } else if (
-                state.type === "ray" &&
+                userInput.type === "ray" &&
                 rubric.correct.type === "ray" &&
-                state.coords != null
+                userInput.coords != null
             ) {
-                const guess = state.coords;
+                const guess = userInput.coords;
                 const correct = rubric.correct.coords;
                 if (
                     // @ts-expect-error - TS2532 - Object is possibly 'undefined'.
@@ -2576,10 +2574,10 @@ class InteractiveGraph extends React.Component<Props, State> {
                     };
                 }
             } else if (
-                state.type === "angle" &&
+                userInput.type === "angle" &&
                 rubric.correct.type === "angle"
             ) {
-                const guess = state.coords;
+                const guess = userInput.coords;
                 const correct = rubric.correct.coords;
 
                 let match;
@@ -2620,7 +2618,7 @@ class InteractiveGraph extends React.Component<Props, State> {
 
         // The input wasn't correct, so check if it's a blank input or if it's
         // actually just wrong
-        if (!hasValue || _.isEqual(state, rubric.graph)) {
+        if (!hasValue || _.isEqual(userInput, rubric.graph)) {
             // We're where we started.
             return {
                 type: "invalid",

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -2366,9 +2366,10 @@ class InteractiveGraph extends React.Component<Props, State> {
         // When nothing has moved, there will neither be coords nor the
         // circle's center/radius fields. When those fields are absent, skip
         // all these checks; just go mark the answer as empty.
-        // @ts-expect-error - TS2339 - Property 'coords' does not exist on type 'PerseusGraphType'. | TS2339 - Property 'center' does not exist on type 'PerseusGraphType'. | TS2339 - Property 'radius' does not exist on type 'PerseusGraphType'.
         const hasValue = !!(
+            // @ts-expect-error - TS2339 - Property 'coords' does not exist on type 'PerseusGraphType'.
             userInput.coords ||
+            // @ts-expect-error - TS2339 - Property 'center' does not exist on type 'PerseusGraphType'. | TS2339 - Property 'radius' does not exist on type 'PerseusGraphType'.
             (userInput.center && userInput.radius)
         );
 

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -2366,13 +2366,11 @@ class InteractiveGraph extends React.Component<Props, State> {
         // When nothing has moved, there will neither be coords nor the
         // circle's center/radius fields. When those fields are absent, skip
         // all these checks; just go mark the answer as empty.
-        const hasValue = !!(
-            (
-                // @ts-expect-error - TS2339 - Property 'coords' does not exist on type 'PerseusGraphType'.
-                userInput.coords ||
+        const hasValue = Boolean(
+            // @ts-expect-error - TS2339 - Property 'coords' does not exist on type 'PerseusGraphType'.
+            userInput.coords ||
                 // @ts-expect-error - TS2339 - Property 'center' does not exist on type 'PerseusGraphType'. | TS2339 - Property 'radius' does not exist on type 'PerseusGraphType'.
-                (userInput.center && userInput.radius)
-            )
+                (userInput.center && userInput.radius),
         );
 
         if (userInput.type === rubric.correct.type && hasValue) {

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -2367,7 +2367,10 @@ class InteractiveGraph extends React.Component<Props, State> {
         // circle's center/radius fields. When those fields are absent, skip
         // all these checks; just go mark the answer as empty.
         // @ts-expect-error - TS2339 - Property 'coords' does not exist on type 'PerseusGraphType'. | TS2339 - Property 'center' does not exist on type 'PerseusGraphType'. | TS2339 - Property 'radius' does not exist on type 'PerseusGraphType'.
-        const hasValue = !!(userInput.coords || (userInput.center && userInput.radius));
+        const hasValue = !!(
+            userInput.coords ||
+            (userInput.center && userInput.radius)
+        );
 
         if (userInput.type === rubric.correct.type && hasValue) {
             if (
@@ -2426,7 +2429,9 @@ class InteractiveGraph extends React.Component<Props, State> {
                 userInput.coords != null
             ) {
                 // If the parabola coefficients match, it's correct.
-                const guessCoeffs = this.getQuadraticCoefficients(userInput.coords);
+                const guessCoeffs = this.getQuadraticCoefficients(
+                    userInput.coords,
+                );
                 const correctCoeffs = this.getQuadraticCoefficients(
                     // @ts-expect-error - TS2345 - Argument of type 'readonly Coord[] | undefined' is not assignable to parameter of type 'readonly Coord[]'.
                     rubric.correct.coords,
@@ -2444,7 +2449,9 @@ class InteractiveGraph extends React.Component<Props, State> {
                 rubric.correct.type === "sinusoid" &&
                 userInput.coords != null
             ) {
-                const guessCoeffs = this.getSinusoidCoefficients(userInput.coords);
+                const guessCoeffs = this.getSinusoidCoefficients(
+                    userInput.coords,
+                );
                 const correctCoeffs = this.getSinusoidCoefficients(
                     // @ts-expect-error - TS2345 - Argument of type 'readonly Coord[] | undefined' is not assignable to parameter of type 'readonly Coord[]'.
                     rubric.correct.coords,

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -69,37 +69,52 @@ export function initializeGraphState(params: {
 export function getGradableGraph<GraphType extends PerseusGraphType>(
     state: InteractiveGraphState,
     initialGraph: GraphType,
-): GraphType {
+): PerseusGraphType {
     if (!state.hasBeenInteractedWith) {
-        return initialGraph;
+        return {type: initialGraph.type};
     }
-    switch (true) {
-        // coords: Array of CollinearTuple
-        case state.type === "linear-system" &&
-            initialGraph.type === "linear-system":
-        case state.type === "segment" && initialGraph.type === "segment":
-            return {
-                ...initialGraph,
-                coords: state.coords,
-            };
-        // coords: CollinearTuple
-        case state.type === "linear" && initialGraph.type === "linear":
-        case state.type === "ray" && initialGraph.type === "ray":
-            return {
-                ...initialGraph,
-                coords: state.coords?.[0],
-            };
-        case state.type === "polygon" && initialGraph.type === "polygon":
-            return {
-                ...initialGraph,
-                coords: state.coords,
-            };
-        default:
-            throw new Error(
-                "Mafs is not yet implemented for graph type: " +
-                    initialGraph.type,
-            );
+
+    if (
+        initialGraph.type === "linear-system" &&
+        state.type === "linear-system"
+    ) {
+        return {
+            ...initialGraph,
+            coords: state.coords,
+        };
     }
+
+    if (state.type === "segment" && initialGraph.type === "segment") {
+        return {
+            ...initialGraph,
+            coords: state.coords,
+        };
+    }
+
+    if (state.type === "linear" && initialGraph.type === "linear") {
+        return {
+            ...initialGraph,
+            coords: state.coords?.[0],
+        };
+    }
+
+    if (state.type === "ray" && initialGraph.type === "ray") {
+        return {
+            ...initialGraph,
+            coords: state.coords?.[0],
+        };
+    }
+
+    if (state.type === "polygon" && initialGraph.type === "polygon") {
+        return {
+            ...initialGraph,
+            coords: state.coords,
+        };
+    }
+
+    throw new Error(
+        "Mafs is not yet implemented for graph type: " + initialGraph.type,
+    );
 }
 
 const getDefaultSegments = ({

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -66,9 +66,9 @@ export function initializeGraphState(params: {
 
 // TS v4 doesn't narrow return types, while v5 does.
 // Instead of updating to v5, using generic type to relate input and output types.
-export function getGradableGraph<GraphType extends PerseusGraphType>(
+export function getGradableGraph(
     state: InteractiveGraphState,
-    initialGraph: GraphType,
+    initialGraph: PerseusGraphType,
 ): PerseusGraphType {
     if (!state.hasBeenInteractedWith) {
         return {type: initialGraph.type};


### PR DESCRIPTION
## Summary:
...and avoid returning coords if hasBeenInteractedWith is false.

The new structure allows us to avoid returning the coords property when
it is set on the initial graph. If coords is set, it makes the question
appear to have been answered even if the user never interacted with it.

Issue: https://khanacademy.atlassian.net/browse/LEMS-1776

Test plan:

`yarn test`

Co-authored-by: Mark Fitzgerald <markfitzgerald@khanacademy.org>