### PR TITLE
Mount a new Renderer when the current question changes in the flipbook

### DIFF
--- a/dev/flipbook-model.ts
+++ b/dev/flipbook-model.ts
@@ -107,19 +107,29 @@ function clampIndex(index: number, array: unknown[]): number {
 // Selectors
 // ---------------------------------------------------------------------------
 
+export const selectQuestionsAsJSON = cache((state: FlipbookModel): string[] => {
+    return state.questions
+        .split("\n")
+        .map((s) => s.trim())
+        .filter(Boolean);
+});
+
 export const selectQuestions = cache(
     (state: FlipbookModel): PerseusRenderer[] => {
-        return state.questions
-            .split("\n")
-            .map((s) => s.trim())
-            .filter(Boolean)
-            .map(parseQuestion);
+        return selectQuestionsAsJSON(state).map(parseQuestion);
     },
 );
 
 export const selectCurrentQuestion = cache(
     (state: FlipbookModel): PerseusRenderer | null => {
         const questions = selectQuestions(state);
+        return questions[selectCurrentQuestionIndex(state)] ?? null;
+    },
+);
+
+export const selectCurrentQuestionAsJSON = cache(
+    (state: FlipbookModel): string | null => {
+        const questions = selectQuestionsAsJSON(state);
         return questions[selectCurrentQuestionIndex(state)] ?? null;
     },
 );

--- a/dev/flipbook.tsx
+++ b/dev/flipbook.tsx
@@ -22,6 +22,7 @@ import {
     setQuestions,
     selectNumQuestions,
     jumpToQuestion,
+    selectCurrentQuestionAsJSON,
 } from "./flipbook-model";
 import {Header} from "./header";
 
@@ -47,6 +48,7 @@ export function Flipbook() {
         requestedIndex: 0,
     });
 
+    const questionJSON = selectCurrentQuestionAsJSON(state);
     const question = selectCurrentQuestion(state);
     const numQuestions = selectNumQuestions(state);
     const index = selectCurrentQuestionIndex(state);
@@ -119,7 +121,13 @@ export function Flipbook() {
                     </ol>
                 </div>
                 {question != null && (
-                    <SideBySideQuestionRenderer question={question} />
+                    // Passing a key here ensures that the graph state is
+                    // cleared out if a new graph is rendered at the same DOM
+                    // location as a previous graph.
+                    <SideBySideQuestionRenderer
+                        key={questionJSON}
+                        question={question}
+                    />
                 )}
             </View>
         </>


### PR DESCRIPTION
This change ensures that state from the previous question is cleared out
when displaying the new question. If we don't use a key, then sometimes
interactive graph elements will "carry over" from one question to the next.

This is an example of the master/detail pattern in React. See:
https://seanconnolly.dev/react-master-detail-pattern

Issue: none

## Test plan:

Paste this JSON into the flipbook:

```
{"content":"**Use the line segments to connect all possible pairs of the points $\\text{A}$, $\\text{B}$, and $\\text{C}$. Then complete the statement below. **\n\n[[☃ interactive-graph 1]]\n\nThese are line segments because they each have [[☃ dropdown 1]] and continue forever in [[☃ dropdown 2]].","images":{},"widgets":{"dropdown 1":{"alignment":"default","graded":true,"options":{"choices":[{"content":"zero endpoints","correct":false},{"content":"one endpoint","correct":false},{"content":"two endpoints","correct":true}],"placeholder":"","static":false},"static":false,"type":"dropdown","version":{"major":0,"minor":0}},"dropdown 2":{"alignment":"default","graded":true,"options":{"choices":[{"content":"zero directions","correct":true},{"content":"one direction","correct":false},{"content":"two directions","correct":false}],"placeholder":"","static":false},"static":false,"type":"dropdown","version":{"major":0,"minor":0}},"interactive-graph 1":{"alignment":"default","graded":true,"options":{"backgroundImage":{"bottom":0,"height":400,"left":0,"scale":"1","url":"https://ka-perseus-graphie.s3.amazonaws.com/009bde8c529cd0f9c8fea990aac9937603b26526.png","width":400},"correct":{"coords":[[[0,6],[6,-6]],[[-6,-6],[0,6]],[[-6,-6],[6,-6]]],"numSegments":3,"type":"segment"},"graph":{"numSegments":3,"type":"segment"},"gridStep":[1,1],"labels":["x","y"],"markings":"none","range":[[-10,10],[-10,10]],"rulerLabel":"","rulerTicks":10,"showProtractor":false,"showRuler":false,"snapStep":[0.5,0.5],"step":[1,1]},"static":false,"type":"interactive-graph","version":{"major":0,"minor":0}}}}
{"content":"**रेखाखंडों का इस्तेमाल करते हुए $\\text{A}$, $\\text{B}$ और $\\text{C}$ बिंदुओं के सभी संभावित युग्मों को जोड़िए| फिर निम्नलिखित कथन को पूरा कीजिए। **\n\n[[☃ interactive-graph 1]]\n\n ये रेखाखंड होंगीं क्योंकि प्रत्येक के पास [[☃ dropdown 1]] है और ये निरंतर [[☃ dropdown 2]] में जाती हैं।","images":{},"widgets":{"dropdown 1":{"alignment":"default","graded":true,"options":{"choices":[{"content":"शून्य अंत्य बिंदु","correct":false},{"content":"एक अंत्य बिंदु","correct":false},{"content":"दो अंत्य बिंदु","correct":true}],"placeholder":"","static":false},"static":false,"type":"dropdown","version":{"major":0,"minor":0}},"dropdown 2":{"alignment":"default","graded":true,"options":{"choices":[{"content":"शून्य दिशा ","correct":true},{"content":"एक ही दिशा","correct":false},{"content":"दो दिशाएँ","correct":false}],"placeholder":"","static":false},"static":false,"type":"dropdown","version":{"major":0,"minor":0}},"interactive-graph 1":{"alignment":"default","graded":true,"options":{"backgroundImage":{"bottom":0,"height":400,"left":0,"scale":"1","url":"https://ka-perseus-graphie.s3.amazonaws.com/009bde8c529cd0f9c8fea990aac9937603b26526.png","width":400},"correct":{"coords":[[[0,6],[6,-6]],[[-6,-6],[0,6]],[[-6,-6],[6,-6]]],"numSegments":3,"type":"segment"},"graph":{"numSegments":3,"type":"segment"},"gridStep":[1,1],"labels":["x","y"],"markings":"none","range":[[-10,10],[-10,10]],"rulerLabel":"","rulerTicks":10,"showProtractor":false,"showRuler":false,"snapStep":[0.5,0.5],"step":[1,1]},"static":false,"type":"interactive-graph","version":{"major":0,"minor":0}}}}
```

Move a line on the Mafs graph and then click "next". You should see the
question change (it should be in Hindi) and your moved line should not
persist.