### PR TITLE
Port the "point" interactive graph type (with fixed number of points) to Mafs

### DIFF
--- a/.changeset/smart-otters-study.md
+++ b/.changeset/smart-otters-study.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Port the Point interactive graph type to Mafs

--- a/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
@@ -426,6 +426,62 @@ export const pointQuestion: PerseusRenderer = {
     },
 };
 
+export const pointQuestionWithDefaultCorrect: PerseusRenderer = {
+    content:
+        "We want to find the zeros of this polynomial:\n\n$p(x)=x(2x+5)(x+1)$\n\n**Plot all the zeros ($x$-intercepts) of the polynomial in the interactive graph.**\n\n[[\u2603 interactive-graph 1]]",
+    images: {},
+    widgets: {
+        "interactive-graph 1": {
+            graded: true,
+            version: {
+                major: 0,
+                minor: 0,
+            },
+            static: false,
+            type: "interactive-graph",
+            options: {
+                rulerTicks: 10,
+                showProtractor: false,
+                graph: {
+                    type: "point",
+                    coords: [
+                        [0, 0],
+                        [-2.5, 0],
+                        [-1, 0],
+                    ],
+                },
+                snapStep: [0.5, 0.5],
+                labels: ["x", "y"],
+                step: [1, 1],
+                gridStep: [0.5, 0.5],
+                backgroundImage: {
+                    url: "web+graphie://ka-perseus-graphie.s3.amazonaws.com/9e825947f778170369f22da5f87239cbf4c1ebe3",
+                    width: 425,
+                    height: 425,
+                },
+                range: [
+                    [-10, 10],
+                    [-10, 10],
+                ],
+                showRuler: false,
+                markings: "none",
+                showTooltips: false,
+                rulerLabel: "",
+                correct: {
+                    coords: [
+                        [0, 0],
+                        [-2.5, 0],
+                        [-1, 0],
+                    ],
+                    numPoints: "unlimited",
+                    type: "point",
+                },
+            },
+            alignment: "default",
+        },
+    },
+};
+
 export const polygonQuestion: PerseusRenderer = {
     content:
         "**Drag the vertices of the triangle below to draw a right triangle with side lengths $3$, $4$, and $5$.** \n[[\u2603 interactive-graph 1]] \n",

--- a/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
+++ b/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
@@ -15,7 +15,8 @@ import {
     linearQuestionWithDefaultCorrect,
     linearSystemQuestionWithDefaultCorrect,
     rayQuestionWithDefaultCorrect,
-    polygonQuestionDefaultCorrect, pointQuestionWithDefaultCorrect,
+    polygonQuestionDefaultCorrect,
+    pointQuestionWithDefaultCorrect,
 } from "../__testdata__/interactive-graph.testdata";
 import {trueForAllMafsSupportedGraphTypes} from "../interactive-graphs/mafs-supported-graph-types";
 

--- a/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
+++ b/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
@@ -15,7 +15,7 @@ import {
     linearQuestionWithDefaultCorrect,
     linearSystemQuestionWithDefaultCorrect,
     rayQuestionWithDefaultCorrect,
-    polygonQuestionDefaultCorrect,
+    polygonQuestionDefaultCorrect, pointQuestionWithDefaultCorrect,
 } from "../__testdata__/interactive-graph.testdata";
 import {trueForAllMafsSupportedGraphTypes} from "../interactive-graphs/mafs-supported-graph-types";
 
@@ -141,6 +141,7 @@ describe("mafs graphs", () => {
         "linear-system": linearSystemQuestionWithDefaultCorrect,
         ray: rayQuestionWithDefaultCorrect,
         polygon: polygonQuestionDefaultCorrect,
+        point: pointQuestionWithDefaultCorrect,
     };
 
     describe.each(Object.entries(graphQuestionRenderers))(
@@ -150,7 +151,7 @@ describe("mafs graphs", () => {
                 renderQuestion(question, apiOptions);
             });
 
-            it("should reject when has not been interacteracted with", () => {
+            it("should reject when has not been interacted with", () => {
                 // Arrange
                 const {renderer} = renderQuestion(question, apiOptions);
 

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -1813,10 +1813,6 @@ class InteractiveGraph extends React.Component<Props, State> {
             return (
                 <MafsGraph
                     {...this.props}
-                    // Passing a key here ensures that the graph state is
-                    // cleared out if a new graph is rendered at the same DOM
-                    // location as a previous graph.
-                    key={JSON.stringify(this.props.graph)}
                     ref={this.mafsRef}
                     gridStep={gridStep}
                     snapStep={snapStep}

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -1813,6 +1813,10 @@ class InteractiveGraph extends React.Component<Props, State> {
             return (
                 <MafsGraph
                     {...this.props}
+                    // Passing a key here ensures that the graph state is
+                    // cleared out if a new graph is rendered at the same DOM
+                    // location as a previous graph.
+                    key={JSON.stringify(this.props.graph)}
                     ref={this.mafsRef}
                     gridStep={gridStep}
                     snapStep={snapStep}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import {PointGraphState, MafsGraphProps} from "../types";
+import {StyledMovablePoint} from "./components/movable-point";
+import {movePoint} from "../interactive-graph-action";
+
+type PointGraphProps = MafsGraphProps<PointGraphState>;
+
+export function PointGraph(props: PointGraphProps) {
+    const {dispatch} = props;
+    return <>
+        {props.graphState.coords.map((point, i) => (
+            <StyledMovablePoint key={i} point={point} onMove={(destination) => dispatch(movePoint(i, destination))} />
+        ))}
+    </>
+}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
@@ -1,15 +1,26 @@
 import * as React from "react";
-import {PointGraphState, MafsGraphProps} from "../types";
+
+import {movePoint} from "../reducer/interactive-graph-action";
+
 import {StyledMovablePoint} from "./components/movable-point";
-import {movePoint} from "../interactive-graph-action";
+
+import type {PointGraphState, MafsGraphProps} from "../types";
 
 type PointGraphProps = MafsGraphProps<PointGraphState>;
 
 export function PointGraph(props: PointGraphProps) {
     const {dispatch} = props;
-    return <>
-        {props.graphState.coords.map((point, i) => (
-            <StyledMovablePoint key={i} point={point} onMove={(destination) => dispatch(movePoint(i, destination))} />
-        ))}
-    </>
+    return (
+        <>
+            {props.graphState.coords.map((point, i) => (
+                <StyledMovablePoint
+                    key={i}
+                    point={point}
+                    onMove={(destination) =>
+                        dispatch(movePoint(i, destination))
+                    }
+                />
+            ))}
+        </>
+    );
 }

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -37,6 +37,8 @@ const renderGraph = (props: {
             return <RayGraph graphState={state} dispatch={dispatch} />;
         case "polygon":
             return <PolygonGraph graphState={state} dispatch={dispatch} />;
+        case "point":
+            throw "Fixme";
         default:
             return new UnreachableCaseError(type);
     }

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -6,6 +6,7 @@ import * as React from "react";
 import GraphLockedLayer from "./graph-locked-layer";
 import {LinearGraph, PolygonGraph, RayGraph, SegmentGraph} from "./graphs";
 import {SvgDefs} from "./graphs/components/text-label";
+import {PointGraph} from "./graphs/point";
 import {Grid} from "./grid";
 import {LegacyGrid} from "./legacy-grid";
 import {interactiveGraphReducer} from "./reducer/interactive-graph-reducer";
@@ -20,7 +21,6 @@ import type {Widget} from "../../renderer";
 
 import "mafs/core.css";
 import "./mafs-styles.css";
-import {PointGraph} from "./graphs/point";
 
 const renderGraph = (props: {
     state: InteractiveGraphState;

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -20,6 +20,7 @@ import type {Widget} from "../../renderer";
 
 import "mafs/core.css";
 import "./mafs-styles.css";
+import {PointGraph} from "./graphs/point";
 
 const renderGraph = (props: {
     state: InteractiveGraphState;
@@ -38,7 +39,7 @@ const renderGraph = (props: {
         case "polygon":
             return <PolygonGraph graphState={state} dispatch={dispatch} />;
         case "point":
-            throw "Fixme";
+            return <PointGraph graphState={state} dispatch={dispatch} />;
         default:
             return new UnreachableCaseError(type);
     }

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-supported-graph-types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-supported-graph-types.ts
@@ -4,6 +4,7 @@ export const mafsSupportedGraphTypes = [
     "linear-system",
     "ray",
     "polygon",
+    "point",
 ] as const;
 
 export type MafsSupportedGraphType = (typeof mafsSupportedGraphTypes)[number];

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
@@ -1,6 +1,10 @@
 import type {vec} from "mafs";
 
-export type InteractiveGraphAction = MoveControlPoint | MoveLine | MoveAll;
+export type InteractiveGraphAction =
+    | MoveControlPoint
+    | MoveLine
+    | MoveAll
+    | MovePoint;
 
 export const MOVE_CONTROL_POINT = "move-control-point";
 export interface MoveControlPoint {
@@ -48,3 +52,18 @@ export const moveAll = (delta: vec.Vector2): MoveAll => ({
     type: MOVE_ALL,
     delta,
 });
+
+// TODO: consolidate with moveAll?
+export const MOVE_POINT = "move-point";
+interface MovePoint {
+    type: typeof MOVE_POINT;
+    index: number;
+    destination: vec.Vector2;
+}
+export function movePoint(index: number, destination: vec.Vector2): MovePoint {
+    return {
+        type: MOVE_POINT,
+        index,
+        destination,
+    };
+}

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
@@ -53,7 +53,6 @@ export const moveAll = (delta: vec.Vector2): MoveAll => ({
     delta,
 });
 
-// TODO: consolidate with moveAll?
 export const MOVE_POINT = "move-point";
 interface MovePoint {
     type: typeof MOVE_POINT;

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -230,4 +230,41 @@ describe("movePoint", () => {
 
         expect(updated.coords[0]).toEqual([5, 6]);
     });
+
+    it("snaps to the snap grid", () => {
+        const state: InteractiveGraphState = {
+            ...basePointGraphState,
+            snapStep: [3, 4],
+            coords: [[0, 0]],
+        };
+
+        const updated = interactiveGraphReducer(
+            state,
+            movePoint(0, [-2, -2.5]),
+        );
+
+        expect(updated.coords[0]).toEqual([-3, -4]);
+    });
+
+    it("keeps points within the graph bounds", () => {
+        const state: InteractiveGraphState = {
+            ...basePointGraphState,
+            coords: [[0, 0]],
+        };
+
+        const updated = interactiveGraphReducer(state, movePoint(0, [99, 99]));
+
+        expect(updated.coords[0]).toEqual([9, 9]);
+    });
+
+    it("sets hasBeenInteractedWith", () => {
+        const state: InteractiveGraphState = {
+            ...basePointGraphState,
+            coords: [[1, 2]],
+        };
+
+        const updated = interactiveGraphReducer(state, movePoint(0, [1, 1]));
+
+        expect(updated.hasBeenInteractedWith).toBe(true);
+    });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -46,7 +46,7 @@ describe("moveControlPoint", () => {
             moveControlPoint(0, [5, 6], 0),
         );
 
-        expect(updated.coords?.[0]).toEqual([
+        expect(updated.coords[0]).toEqual([
             [5, 6],
             [3, 4],
         ]);
@@ -88,7 +88,7 @@ describe("moveControlPoint", () => {
         );
 
         // Assert: the move was canceled
-        expect(updated.coords?.[0]).toEqual([
+        expect(updated.coords[0]).toEqual([
             [1, 1],
             [2, 2],
         ]);
@@ -113,7 +113,7 @@ describe("moveControlPoint", () => {
 
         // Assert: x snaps to the nearest whole number; y snaps to the nearest
         // multiple of 2.
-        expect(updated.coords?.[0][0]).toEqual([2, 6]);
+        expect(updated.coords[0][0]).toEqual([2, 6]);
     });
 
     it("constrains points to be at least one snap step within the graph bounds", () => {
@@ -137,7 +137,7 @@ describe("moveControlPoint", () => {
             moveControlPoint(0, [99, 99], 0),
         );
 
-        expect(updated.coords?.[0][0]).toEqual([4.5, 7.5]);
+        expect(updated.coords[0][0]).toEqual([4.5, 7.5]);
     });
 });
 
@@ -155,7 +155,7 @@ describe("moveSegment", () => {
 
         const updated = interactiveGraphReducer(state, moveLine(0, [5, -3]));
 
-        expect(updated.coords?.[0]).toEqual([
+        expect(updated.coords[0]).toEqual([
             [6, -1],
             [8, 1],
         ]);
@@ -174,7 +174,7 @@ describe("moveSegment", () => {
 
         const updated = interactiveGraphReducer(state, moveLine(0, [0.5, 0.5]));
 
-        expect(updated.coords?.[0]).toEqual([
+        expect(updated.coords[0]).toEqual([
             [2, 3],
             [4, 5],
         ]);
@@ -193,7 +193,7 @@ describe("moveSegment", () => {
 
         const updated = interactiveGraphReducer(state, moveLine(0, [99, 99]));
 
-        expect(updated.coords?.[0]).toEqual([
+        expect(updated.coords[0]).toEqual([
             [7, 7],
             [9, 9],
         ]);
@@ -228,7 +228,7 @@ describe("movePoint", () => {
 
         const updated = interactiveGraphReducer(state, movePoint(0, [5, 6]));
 
-        expect(updated.coords?.[0]).toEqual([5, 6]);
+        expect(updated.coords[0]).toEqual([5, 6]);
     });
 
     it("snaps to the snap grid", () => {
@@ -243,7 +243,7 @@ describe("movePoint", () => {
             movePoint(0, [-2, -2.5]),
         );
 
-        expect(updated.coords?.[0]).toEqual([-3, -4]);
+        expect(updated.coords[0]).toEqual([-3, -4]);
     });
 
     it("keeps points within the graph bounds", () => {
@@ -254,7 +254,7 @@ describe("movePoint", () => {
 
         const updated = interactiveGraphReducer(state, movePoint(0, [99, 99]));
 
-        expect(updated.coords?.[0]).toEqual([9, 9]);
+        expect(updated.coords[0]).toEqual([9, 9]);
     });
 
     it("sets hasBeenInteractedWith", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -46,7 +46,7 @@ describe("moveControlPoint", () => {
             moveControlPoint(0, [5, 6], 0),
         );
 
-        expect(updated.coords[0]).toEqual([
+        expect(updated.coords?.[0]).toEqual([
             [5, 6],
             [3, 4],
         ]);
@@ -88,7 +88,7 @@ describe("moveControlPoint", () => {
         );
 
         // Assert: the move was canceled
-        expect(updated.coords[0]).toEqual([
+        expect(updated.coords?.[0]).toEqual([
             [1, 1],
             [2, 2],
         ]);
@@ -113,7 +113,7 @@ describe("moveControlPoint", () => {
 
         // Assert: x snaps to the nearest whole number; y snaps to the nearest
         // multiple of 2.
-        expect(updated.coords[0][0]).toEqual([2, 6]);
+        expect(updated.coords?.[0][0]).toEqual([2, 6]);
     });
 
     it("constrains points to be at least one snap step within the graph bounds", () => {
@@ -137,7 +137,7 @@ describe("moveControlPoint", () => {
             moveControlPoint(0, [99, 99], 0),
         );
 
-        expect(updated.coords[0][0]).toEqual([4.5, 7.5]);
+        expect(updated.coords?.[0][0]).toEqual([4.5, 7.5]);
     });
 });
 
@@ -155,7 +155,7 @@ describe("moveSegment", () => {
 
         const updated = interactiveGraphReducer(state, moveLine(0, [5, -3]));
 
-        expect(updated.coords[0]).toEqual([
+        expect(updated.coords?.[0]).toEqual([
             [6, -1],
             [8, 1],
         ]);
@@ -174,7 +174,7 @@ describe("moveSegment", () => {
 
         const updated = interactiveGraphReducer(state, moveLine(0, [0.5, 0.5]));
 
-        expect(updated.coords[0]).toEqual([
+        expect(updated.coords?.[0]).toEqual([
             [2, 3],
             [4, 5],
         ]);
@@ -193,7 +193,7 @@ describe("moveSegment", () => {
 
         const updated = interactiveGraphReducer(state, moveLine(0, [99, 99]));
 
-        expect(updated.coords[0]).toEqual([
+        expect(updated.coords?.[0]).toEqual([
             [7, 7],
             [9, 9],
         ]);
@@ -228,7 +228,7 @@ describe("movePoint", () => {
 
         const updated = interactiveGraphReducer(state, movePoint(0, [5, 6]));
 
-        expect(updated.coords[0]).toEqual([5, 6]);
+        expect(updated.coords?.[0]).toEqual([5, 6]);
     });
 
     it("snaps to the snap grid", () => {
@@ -243,7 +243,7 @@ describe("movePoint", () => {
             movePoint(0, [-2, -2.5]),
         );
 
-        expect(updated.coords[0]).toEqual([-3, -4]);
+        expect(updated.coords?.[0]).toEqual([-3, -4]);
     });
 
     it("keeps points within the graph bounds", () => {
@@ -254,7 +254,7 @@ describe("movePoint", () => {
 
         const updated = interactiveGraphReducer(state, movePoint(0, [99, 99]));
 
-        expect(updated.coords[0]).toEqual([9, 9]);
+        expect(updated.coords?.[0]).toEqual([9, 9]);
     });
 
     it("sets hasBeenInteractedWith", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -1,4 +1,8 @@
-import {moveControlPoint, moveLine} from "./interactive-graph-action";
+import {
+    moveControlPoint,
+    movePoint,
+    moveLine,
+} from "./interactive-graph-action";
 import {interactiveGraphReducer} from "./interactive-graph-reducer";
 
 import type {InteractiveGraphState} from "../types";
@@ -6,6 +10,17 @@ import type {InteractiveGraphState} from "../types";
 const baseSegmentGraphState: InteractiveGraphState = {
     hasBeenInteractedWith: false,
     type: "segment",
+    range: [
+        [-10, 10],
+        [-10, 10],
+    ],
+    snapStep: [1, 1],
+    coords: [],
+};
+
+const basePointGraphState: InteractiveGraphState = {
+    hasBeenInteractedWith: false,
+    type: "point",
     range: [
         [-10, 10],
         [-10, 10],
@@ -198,5 +213,21 @@ describe("moveSegment", () => {
         const updated = interactiveGraphReducer(state, moveLine(0, [1, 1]));
 
         expect(updated.hasBeenInteractedWith).toBe(true);
+    });
+});
+
+describe("movePoint", () => {
+    it("moves the point with the given index", () => {
+        const state: InteractiveGraphState = {
+            ...basePointGraphState,
+            coords: [
+                [1, 2],
+                [3, 4],
+            ],
+        };
+
+        const updated = interactiveGraphReducer(state, movePoint(0, [5, 6]));
+
+        expect(updated.coords[0]).toEqual([5, 6]);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -3,10 +3,11 @@ import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
 import {vec} from "mafs";
 
 import {
-    MOVE_CONTROL_POINT,
     type InteractiveGraphAction,
     MOVE_ALL,
+    MOVE_CONTROL_POINT,
     MOVE_LINE,
+    MOVE_POINT,
 } from "./interactive-graph-action";
 
 import type {CollinearTuple} from "../../../perseus-types";
@@ -146,6 +147,23 @@ export function interactiveGraphReducer<
                 coords: newCoords,
             };
         }
+        case MOVE_POINT:
+            return {
+                ...state,
+                hasBeenInteractedWith: true,
+                coords: setAtIndex({
+                    array: state.coords,
+                    index: action.index,
+                    newValue: snap({
+                        snapStep: state.snapStep,
+                        point: bound({
+                            point: action.destination,
+                            range: state.range,
+                            snapStep: state.snapStep,
+                        }),
+                    }),
+                }),
+            };
         default:
             throw new UnreachableCaseError(action);
     }

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
@@ -1,5 +1,6 @@
 import {initializeGraphState} from "./interactive-graph-state";
-import {Interval, vec} from "mafs";
+
+import type {Interval, vec} from "mafs";
 
 const baseGraphData = {
     range: [

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
@@ -8,7 +8,7 @@ const baseGraphData = {
     ] as [Interval, Interval],
     step: [1, 1] as vec.Vector2,
     snapStep: [1, 1] as vec.Vector2,
-}
+};
 
 describe("initializeGraphState for segment graphs", () => {
     it("sets the range and snapStep", () => {
@@ -134,7 +134,7 @@ describe("initializeGraphState for point graphs", () => {
         });
 
         expect(graph.coords).toEqual([[0, 0]]);
-    })
+    });
 
     it("uses the coordinates in graph.coord if present", () => {
         const graph = initializeGraphState({
@@ -145,12 +145,15 @@ describe("initializeGraphState for point graphs", () => {
         expect(graph.coords).toEqual([[5, 6]]);
     });
 
-    it.each([2, 3, 4, 5, 6])("provides %d default coords when the graph requests %d points", (n) => {
-        const graph = initializeGraphState({
-            ...baseGraphData,
-            graph: {type: "point", numPoints: n},
-        });
+    it.each([2, 3, 4, 5, 6])(
+        "provides %d default coords when the graph requests %d points",
+        (n) => {
+            const graph = initializeGraphState({
+                ...baseGraphData,
+                graph: {type: "point", numPoints: n},
+            });
 
-        expect(graph.coords).toHaveLength(n);
-    });
+            expect(graph.coords).toHaveLength(n);
+        },
+    );
 });

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
@@ -10,8 +10,7 @@ const baseGraphData = {
     snapStep: [1, 1] as vec.Vector2,
 }
 
-// STOPSHIP: split these tests into a describe for each graph type
-describe("initializeGraphState", () => {
+describe("initializeGraphState for segment graphs", () => {
     it("sets the range and snapStep", () => {
         const state = initializeGraphState({
             range: [
@@ -29,7 +28,7 @@ describe("initializeGraphState", () => {
         expect(state.snapStep).toEqual([2, 3]);
     });
 
-    it("puts a default segment on a segment graph", () => {
+    it("adds a default segment", () => {
         const state = initializeGraphState({
             ...baseGraphData,
             graph: {type: "segment"},
@@ -39,52 +38,6 @@ describe("initializeGraphState", () => {
                 [-5, 5],
                 [5, 5],
             ],
-        ]);
-    });
-
-    it("puts a default line on a line graph", () => {
-        const state = initializeGraphState({
-            ...baseGraphData,
-            graph: {type: "linear-system"},
-        });
-        expect(state.coords).toEqual([
-            [
-                [-5, 5],
-                [5, 5],
-            ],
-            [
-                [-5, -5],
-                [5, -5],
-            ],
-        ]);
-    });
-
-    it("puts a default polygon on a polygon graph", () => {
-        const state = initializeGraphState({
-            ...baseGraphData,
-            graph: {type: "polygon"},
-        });
-        expect(state.coords).toEqual([
-            [3, -2],
-            [0, 4],
-            [-3, -2],
-        ]);
-    });
-
-    it("puts an 8-sided polygon on a polygon graph", () => {
-        const state = initializeGraphState({
-            ...baseGraphData,
-            graph: {type: "polygon", numSides: 8},
-        });
-        expect(state.coords).toEqual([
-            [2, -4],
-            [4, -2],
-            [4, 2],
-            [2, 4],
-            [-2, 4],
-            [-4, 2],
-            [-4, -2],
-            [-2, -4],
         ]);
     });
 
@@ -112,8 +65,60 @@ describe("initializeGraphState", () => {
             ],
         ]);
     });
+});
 
-    it("uses any coords already present on a point graph", () => {
+describe("initializeGraphState for line graphs", () => {
+    it("adds a default line", () => {
+        const state = initializeGraphState({
+            ...baseGraphData,
+            graph: {type: "linear-system"},
+        });
+        expect(state.coords).toEqual([
+            [
+                [-5, 5],
+                [5, 5],
+            ],
+            [
+                [-5, -5],
+                [5, -5],
+            ],
+        ]);
+    });
+});
+
+describe("initializeGraphState for polygon graphs", () => {
+    it("adds a default polygon", () => {
+        const state = initializeGraphState({
+            ...baseGraphData,
+            graph: {type: "polygon"},
+        });
+        expect(state.coords).toEqual([
+            [3, -2],
+            [0, 4],
+            [-3, -2],
+        ]);
+    });
+
+    it("adds an 8-sided polygon", () => {
+        const state = initializeGraphState({
+            ...baseGraphData,
+            graph: {type: "polygon", numSides: 8},
+        });
+        expect(state.coords).toEqual([
+            [2, -4],
+            [4, -2],
+            [4, 2],
+            [2, 4],
+            [-2, 4],
+            [-4, 2],
+            [-4, -2],
+            [-2, -4],
+        ]);
+    });
+});
+
+describe("initializeGraphState for point graphs", () => {
+    it("uses any coords already present", () => {
         const graph = initializeGraphState({
             ...baseGraphData,
             graph: {type: "point", coords: [[1, 2]]},
@@ -122,7 +127,7 @@ describe("initializeGraphState", () => {
         expect(graph.coords).toEqual([[1, 2]]);
     });
 
-    it("provides default coords when a point graph requests one point", () => {
+    it("provides default coords when a the graph requests one point", () => {
         const graph = initializeGraphState({
             ...baseGraphData,
             graph: {type: "point", numPoints: 1},
@@ -140,7 +145,7 @@ describe("initializeGraphState", () => {
         expect(graph.coords).toEqual([[5, 6]]);
     });
 
-    it.each([2, 3, 4, 5, 6])("provides %d default coords when a point graph requests %d points", (n) => {
+    it.each([2, 3, 4, 5, 6])("provides %d default coords when the graph requests %d points", (n) => {
         const graph = initializeGraphState({
             ...baseGraphData,
             graph: {type: "point", numPoints: n},

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
@@ -1,4 +1,14 @@
 import {initializeGraphState} from "./interactive-graph-state";
+import {Interval, vec} from "mafs";
+
+const baseGraphData = {
+    range: [
+        [-10, 10],
+        [-10, 10],
+    ] as [Interval, Interval],
+    step: [1, 1] as vec.Vector2,
+    snapStep: [1, 1] as vec.Vector2,
+}
 
 // STOPSHIP: split these tests into a describe for each graph type
 describe("initializeGraphState", () => {
@@ -21,12 +31,7 @@ describe("initializeGraphState", () => {
 
     it("puts a default segment on a segment graph", () => {
         const state = initializeGraphState({
-            range: [
-                [-10, 10],
-                [-10, 10],
-            ],
-            step: [1, 1],
-            snapStep: [1, 1],
+            ...baseGraphData,
             graph: {type: "segment"},
         });
         expect(state.coords).toEqual([
@@ -39,12 +44,7 @@ describe("initializeGraphState", () => {
 
     it("puts a default line on a line graph", () => {
         const state = initializeGraphState({
-            range: [
-                [-10, 10],
-                [-10, 10],
-            ],
-            step: [1, 1],
-            snapStep: [1, 1],
+            ...baseGraphData,
             graph: {type: "linear-system"},
         });
         expect(state.coords).toEqual([
@@ -61,12 +61,7 @@ describe("initializeGraphState", () => {
 
     it("puts a default polygon on a polygon graph", () => {
         const state = initializeGraphState({
-            range: [
-                [-10, 10],
-                [-10, 10],
-            ],
-            step: [1, 1],
-            snapStep: [1, 1],
+            ...baseGraphData,
             graph: {type: "polygon"},
         });
         expect(state.coords).toEqual([
@@ -78,12 +73,7 @@ describe("initializeGraphState", () => {
 
     it("puts an 8-sided polygon on a polygon graph", () => {
         const state = initializeGraphState({
-            range: [
-                [-10, 10],
-                [-10, 10],
-            ],
-            step: [1, 1],
-            snapStep: [1, 1],
+            ...baseGraphData,
             graph: {type: "polygon", numSides: 8},
         });
         expect(state.coords).toEqual([
@@ -125,12 +115,7 @@ describe("initializeGraphState", () => {
 
     it("uses any coords already present on a point graph", () => {
         const graph = initializeGraphState({
-            range: [
-                [-10, 10],
-                [-10, 10],
-            ],
-            step: [1, 1],
-            snapStep: [1, 1],
+            ...baseGraphData,
             graph: {type: "point", coords: [[1, 2]]},
         });
 
@@ -139,12 +124,7 @@ describe("initializeGraphState", () => {
 
     it("provides default coords when a point graph requests one point", () => {
         const graph = initializeGraphState({
-            range: [
-                [-10, 10],
-                [-10, 10],
-            ],
-            step: [1, 1],
-            snapStep: [1, 1],
+            ...baseGraphData,
             graph: {type: "point", numPoints: 1},
         });
 
@@ -153,12 +133,7 @@ describe("initializeGraphState", () => {
 
     it("uses the coordinates in graph.coord if present", () => {
         const graph = initializeGraphState({
-            range: [
-                [-10, 10],
-                [-10, 10],
-            ],
-            step: [1, 1],
-            snapStep: [1, 1],
+            ...baseGraphData,
             graph: {type: "point", numPoints: 1, coord: [5, 6]},
         });
 
@@ -167,12 +142,7 @@ describe("initializeGraphState", () => {
 
     it.each([2, 3, 4, 5, 6])("provides %d default coords when a point graph requests %d points", (n) => {
         const graph = initializeGraphState({
-            range: [
-                [-10, 10],
-                [-10, 10],
-            ],
-            step: [1, 1],
-            snapStep: [1, 1],
+            ...baseGraphData,
             graph: {type: "point", numPoints: n},
         });
 

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
@@ -1,5 +1,6 @@
 import {initializeGraphState} from "./interactive-graph-state";
 
+// STOPSHIP: split these tests into a describe for each graph type
 describe("initializeGraphState", () => {
     it("sets the range and snapStep", () => {
         const state = initializeGraphState({
@@ -120,5 +121,61 @@ describe("initializeGraphState", () => {
                 [500, 500],
             ],
         ]);
+    });
+
+    it("uses any coords already present on a point graph", () => {
+        const graph = initializeGraphState({
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            step: [1, 1],
+            snapStep: [1, 1],
+            graph: {type: "point", coords: [[1, 2]]},
+        });
+
+        expect(graph.coords).toEqual([[1, 2]]);
+    });
+
+    it("provides default coords when a point graph requests one point", () => {
+        const graph = initializeGraphState({
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            step: [1, 1],
+            snapStep: [1, 1],
+            graph: {type: "point", numPoints: 1},
+        });
+
+        expect(graph.coords).toEqual([[0, 0]]);
+    })
+
+    it("uses the coordinates in graph.coord if present", () => {
+        const graph = initializeGraphState({
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            step: [1, 1],
+            snapStep: [1, 1],
+            graph: {type: "point", numPoints: 1, coord: [5, 6]},
+        });
+
+        expect(graph.coords).toEqual([[5, 6]]);
+    });
+
+    it.each([2, 3, 4, 5, 6])("provides %d default coords when a point graph requests %d points", (n) => {
+        const graph = initializeGraphState({
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            step: [1, 1],
+            snapStep: [1, 1],
+            graph: {type: "point", numPoints: n},
+        });
+
+        expect(graph.coords).toHaveLength(n);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -60,8 +60,7 @@ export function initializeGraphState(params: {
                 hasBeenInteractedWith: false,
                 range,
                 snapStep,
-                // TODO: getDefaultPoints({graph, step, range}),
-                coords: graph.coords ?? [],
+                coords: getDefaultPoints({graph, step, range}),
             };
         case "angle":
         case "circle":

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -3,6 +3,7 @@ import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
 import {normalizeCoords, normalizePoints} from "../utils";
 
 import type {
+    PerseusGraphTypePoint,
     PerseusGraphType,
     PerseusGraphTypeSegment,
     CollinearTuple,
@@ -14,7 +15,6 @@ import type {
 import type {InitializeGraphStateParams, InteractiveGraphState} from "../types";
 import type {Coord} from "@khanacademy/perseus";
 import type {Interval, vec} from "mafs";
-import {PerseusGraphTypePoint} from "../../perseus-types";
 
 export function initializeGraphState(params: {
     range: [Interval, Interval];
@@ -75,9 +75,15 @@ export function initializeGraphState(params: {
     }
 }
 
-const getDefaultPoints = (
-    {graph, range, step}: {graph:PerseusGraphTypePoint, range: [Interval, Interval], step: Coord},
-): ReadonlyArray<Coord> => {
+const getDefaultPoints = ({
+    graph,
+    range,
+    step,
+}: {
+    graph: PerseusGraphTypePoint;
+    range: [Interval, Interval];
+    step: Coord;
+}): ReadonlyArray<Coord> => {
     const numPoints = graph.numPoints || 1;
     let coords = graph.coords;
 
@@ -85,53 +91,53 @@ const getDefaultPoints = (
         return coords;
     }
     switch (numPoints) {
-    case 1:
-        // Back in the day, one point's coords were in graph.coord
-        coords = [graph.coord || [0, 0]];
-        break;
-    case 2:
-        coords = [
-            [-5, 0],
-            [5, 0],
-        ];
-        break;
-    case 3:
-        coords = [
-            [-5, 0],
-            [0, 0],
-            [5, 0],
-        ];
-        break;
-    case 4:
-        coords = [
-            [-6, 0],
-            [-2, 0],
-            [2, 0],
-            [6, 0],
-        ];
-        break;
-    case 5:
-        coords = [
-            [-6, 0],
-            [-3, 0],
-            [0, 0],
-            [3, 0],
-            [6, 0],
-        ];
-        break;
-    case 6:
-        coords = [
-            [-5, 0],
-            [-3, 0],
-            [-1, 0],
-            [1, 0],
-            [3, 0],
-            [5, 0],
-        ];
-        break;
-    default:
-        coords = [];
-        break;
+        case 1:
+            // Back in the day, one point's coords were in graph.coord
+            coords = [graph.coord || [0, 0]];
+            break;
+        case 2:
+            coords = [
+                [-5, 0],
+                [5, 0],
+            ];
+            break;
+        case 3:
+            coords = [
+                [-5, 0],
+                [0, 0],
+                [5, 0],
+            ];
+            break;
+        case 4:
+            coords = [
+                [-6, 0],
+                [-2, 0],
+                [2, 0],
+                [6, 0],
+            ];
+            break;
+        case 5:
+            coords = [
+                [-6, 0],
+                [-3, 0],
+                [0, 0],
+                [3, 0],
+                [6, 0],
+            ];
+            break;
+        case 6:
+            coords = [
+                [-5, 0],
+                [-3, 0],
+                [-1, 0],
+                [1, 0],
+                [3, 0],
+                [5, 0],
+            ];
+            break;
+        default:
+            coords = [];
+            break;
     }
     // Transform coords from their -10 to 10 space to 0 to 1
     // because of the old graph.coord, and also it's easier.
@@ -141,7 +147,7 @@ const getDefaultPoints = (
     ]);
 
     return normalizePoints(range, step, newCoords);
-}
+};
 
 // TS v4 doesn't narrow return types, while v5 does.
 // Instead of updating to v5, using generic type to relate input and output types.

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -14,6 +14,7 @@ import type {
 import type {InitializeGraphStateParams, InteractiveGraphState} from "../types";
 import type {Coord} from "@khanacademy/perseus";
 import type {Interval, vec} from "mafs";
+import {PerseusGraphTypePoint} from "../../perseus-types";
 
 export function initializeGraphState(params: {
     range: [Interval, Interval];
@@ -53,8 +54,16 @@ export function initializeGraphState(params: {
                 showSides: Boolean(graph.showSides),
                 coords: getPolygonCoords({graph, range, step}),
             };
-        case "angle":
         case "point":
+            return {
+                type: graph.type,
+                hasBeenInteractedWith: false,
+                range,
+                snapStep,
+                // TODO: getDefaultPoints({graph, step, range}),
+                coords: graph.coords ?? [],
+            };
+        case "angle":
         case "circle":
         case "sinusoid":
         case "quadratic":
@@ -64,6 +73,74 @@ export function initializeGraphState(params: {
         default:
             throw new UnreachableCaseError(graph);
     }
+}
+
+const getDefaultPoints = (
+    {graph, range, step}: {graph:PerseusGraphTypePoint, range: [Interval, Interval], step: Coord},
+): ReadonlyArray<Coord> => {
+    const numPoints = graph.numPoints || 1;
+    let coords = graph.coords;
+
+    if (coords) {
+        return coords;
+    }
+    switch (numPoints) {
+    case 1:
+        // Back in the day, one point's coords were in graph.coord
+        coords = [graph.coord || [0, 0]];
+        break;
+    case 2:
+        coords = [
+            [-5, 0],
+            [5, 0],
+        ];
+        break;
+    case 3:
+        coords = [
+            [-5, 0],
+            [0, 0],
+            [5, 0],
+        ];
+        break;
+    case 4:
+        coords = [
+            [-6, 0],
+            [-2, 0],
+            [2, 0],
+            [6, 0],
+        ];
+        break;
+    case 5:
+        coords = [
+            [-6, 0],
+            [-3, 0],
+            [0, 0],
+            [3, 0],
+            [6, 0],
+        ];
+        break;
+    case 6:
+        coords = [
+            [-5, 0],
+            [-3, 0],
+            [-1, 0],
+            [1, 0],
+            [3, 0],
+            [5, 0],
+        ];
+        break;
+    default:
+        coords = [];
+        break;
+    }
+    // Transform coords from their -10 to 10 space to 0 to 1
+    // because of the old graph.coord, and also it's easier.
+    const newCoords = normalizeCoords(coords, [
+        [-10, 10],
+        [-10, 10],
+    ]);
+
+    return normalizePoints(range, step, newCoords);
 }
 
 // TS v4 doesn't narrow return types, while v5 does.

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -196,6 +196,13 @@ export function getGradableGraph(
         };
     }
 
+    if (state.type === "point" && initialGraph.type === "point") {
+        return {
+            ...initialGraph,
+            coords: state.coords,
+        };
+    }
+
     throw new Error(
         "Mafs is not yet implemented for graph type: " + initialGraph.type,
     );

--- a/packages/perseus/src/widgets/interactive-graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/types.ts
@@ -28,7 +28,8 @@ export type InteractiveGraphState =
     | SegmentGraphState
     | LinearGraphState
     | RayGraphState
-    | PolygonGraphState;
+    | PolygonGraphState
+    | PointGraphState;
 
 export interface InteractiveGraphStateCommon {
     hasBeenInteractedWith: boolean;
@@ -46,6 +47,11 @@ export interface SegmentGraphState extends InteractiveGraphStateCommon {
 export interface LinearGraphState extends InteractiveGraphStateCommon {
     type: "linear" | "linear-system";
     coords: ReadonlyArray<CollinearTuple>;
+}
+
+export interface PointGraphState extends InteractiveGraphStateCommon {
+    type: "point";
+    coords: ReadonlyArray<Coord>;
 }
 
 export interface RayGraphState extends InteractiveGraphStateCommon {


### PR DESCRIPTION
Issue: https://khanacademy.atlassian.net/browse/LEMS-1776

## Test plan:

Run this command to get data for point graphs with fixed numbers of points
onto your clipboard:

```
grep -rl '"type":"point"' data/questions/ | xargs cat | grep -v unlimited | pbcopy
```

Then paste the data into the flipbook (`yarn dev`,
`http://localhost:5173/#flipbook`).

You should be able to move the points and answer questions successfully.

There is a known bug with keyboard interaction on some of the graphs:
https://khanacademy.atlassian.net/browse/LEMS-1885

Co-authored-by: Mark Fitzgerald <markfitzgerald@khanacademy.org>