### PR TITLE
Make `coords` required on interactive graph state types

### DIFF
--- a/.changeset/proud-eagles-hope.md
+++ b/.changeset/proud-eagles-hope.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: revise types used for interactive graph state

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -2495,7 +2495,7 @@ class InteractiveGraph extends React.Component<Props, State> {
                     rubric.correct,
                     component,
                 );
-                const guess = userInput.coords?.slice();
+                const guess = userInput.coords.slice();
                 correct = correct.slice();
                 // Everything's already rounded so we shouldn't need to do an
                 // eq() comparison but _.isEqual(0, -0) is false, so we'll use

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -31,7 +31,7 @@ describe("moveControlPoint", () => {
             moveControlPoint(0, [5, 6], 0),
         );
 
-        expect(updated.coords?.[0]).toEqual([
+        expect(updated.coords[0]).toEqual([
             [5, 6],
             [3, 4],
         ]);
@@ -73,7 +73,7 @@ describe("moveControlPoint", () => {
         );
 
         // Assert: the move was canceled
-        expect(updated.coords?.[0]).toEqual([
+        expect(updated.coords[0]).toEqual([
             [1, 1],
             [2, 2],
         ]);
@@ -98,7 +98,7 @@ describe("moveControlPoint", () => {
 
         // Assert: x snaps to the nearest whole number; y snaps to the nearest
         // multiple of 2.
-        expect(updated.coords?.[0][0]).toEqual([2, 6]);
+        expect(updated.coords[0][0]).toEqual([2, 6]);
     });
 
     it("constrains points to be at least one snap step within the graph bounds", () => {
@@ -122,7 +122,7 @@ describe("moveControlPoint", () => {
             moveControlPoint(0, [99, 99], 0),
         );
 
-        expect(updated.coords?.[0][0]).toEqual([4.5, 7.5]);
+        expect(updated.coords[0][0]).toEqual([4.5, 7.5]);
     });
 });
 
@@ -140,7 +140,7 @@ describe("moveSegment", () => {
 
         const updated = interactiveGraphReducer(state, moveLine(0, [5, -3]));
 
-        expect(updated.coords?.[0]).toEqual([
+        expect(updated.coords[0]).toEqual([
             [6, -1],
             [8, 1],
         ]);
@@ -159,7 +159,7 @@ describe("moveSegment", () => {
 
         const updated = interactiveGraphReducer(state, moveLine(0, [0.5, 0.5]));
 
-        expect(updated.coords?.[0]).toEqual([
+        expect(updated.coords[0]).toEqual([
             [2, 3],
             [4, 5],
         ]);
@@ -178,7 +178,7 @@ describe("moveSegment", () => {
 
         const updated = interactiveGraphReducer(state, moveLine(0, [99, 99]));
 
-        expect(updated.coords?.[0]).toEqual([
+        expect(updated.coords[0]).toEqual([
             [7, 7],
             [9, 9],
         ]);

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -89,7 +89,7 @@ export function interactiveGraphReducer<
             if (action.itemIndex === undefined) {
                 throw new Error("Please provide index of line to move");
             }
-            const currentLine = state.coords?.[action.itemIndex];
+            const currentLine = state.coords[action.itemIndex];
             if (!currentLine) {
                 throw new Error("No line to move");
             }

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -45,10 +45,12 @@ export function initializeGraphState(params: {
             };
         case "polygon":
             return {
+                type: "polygon",
                 hasBeenInteractedWith: false,
                 range,
                 snapStep,
-                ...graph,
+                showAngles: Boolean(graph.showAngles),
+                showSides: Boolean(graph.showSides),
                 coords: getPolygonCoords({graph, range, step}),
             };
         case "angle":
@@ -94,14 +96,14 @@ export function getGradableGraph(
     if (state.type === "linear" && initialGraph.type === "linear") {
         return {
             ...initialGraph,
-            coords: state.coords?.[0],
+            coords: state.coords[0],
         };
     }
 
     if (state.type === "ray" && initialGraph.type === "ray") {
         return {
             ...initialGraph,
-            coords: state.coords?.[0],
+            coords: state.coords[0],
         };
     }
 

--- a/packages/perseus/src/widgets/interactive-graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/types.ts
@@ -10,6 +10,7 @@ import type {
 } from "../../perseus-types";
 import type {WidgetProps} from "../../types";
 import type {Interval, vec} from "mafs";
+import {Coord} from "@khanacademy/perseus";
 
 export type InteractiveGraphProps = WidgetProps<
     PerseusInteractiveGraphWidgetOptions,
@@ -41,18 +42,24 @@ export interface InteractiveGraphStateCommon {
     snapStep: vec.Vector2;
 }
 
-export type SegmentGraphState = InteractiveGraphStateCommon &
-    Omit<PerseusGraphTypeSegment, "numSegments">;
+export interface SegmentGraphState extends InteractiveGraphStateCommon {
+    type: "segment";
+    coords: ReadonlyArray<CollinearTuple>;
+}
 
-export type LinearGraphState = InteractiveGraphStateCommon &
-    Omit<PerseusGraphTypeLinearSystem, "type"> & {
-        type: "linear" | "linear-system";
-    };
+export interface LinearGraphState extends InteractiveGraphStateCommon {
+    type: "linear" | "linear-system";
+    coords: ReadonlyArray<CollinearTuple>;
+}
 
-export type RayGraphState = InteractiveGraphStateCommon &
-    Omit<PerseusGraphTypeRay, "coords"> & {
-        coords: readonly CollinearTuple[];
-    };
+export interface RayGraphState extends InteractiveGraphStateCommon {
+    type: "ray";
+    coords: ReadonlyArray<CollinearTuple>;
+}
 
-export type PolygonGraphState = InteractiveGraphStateCommon &
-    PerseusGraphTypePolygon;
+export interface PolygonGraphState extends InteractiveGraphStateCommon {
+    type: "polygon";
+    showAngles: boolean;
+    showSides: boolean;
+    coords: ReadonlyArray<Coord>;
+}

--- a/packages/perseus/src/widgets/interactive-graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/types.ts
@@ -2,15 +2,11 @@ import type {InteractiveGraphAction} from "./reducer/interactive-graph-action";
 import type {
     CollinearTuple,
     PerseusGraphType,
-    PerseusGraphTypeLinearSystem,
-    PerseusGraphTypePolygon,
-    PerseusGraphTypeRay,
-    PerseusGraphTypeSegment,
     PerseusInteractiveGraphWidgetOptions,
 } from "../../perseus-types";
 import type {WidgetProps} from "../../types";
+import type {Coord} from "@khanacademy/perseus";
 import type {Interval, vec} from "mafs";
-import {Coord} from "@khanacademy/perseus";
 
 export type InteractiveGraphProps = WidgetProps<
     PerseusInteractiveGraphWidgetOptions,


### PR DESCRIPTION
## Summary:
This lets us remove some null checks.

The new types are more specific about exactly which fields are relevant
to the state. Previously, some of the state types included fields from
the graph definitions that were not needed. I'm hopeful that the new
types will be more straightforward for new contributors to the project
to understand.

Issue: none

Test plan:

`yarn tsc && yarn test`