### PR TITLE
Flipbook: persist questions input in local storage while working

### DIFF
--- a/dev/flipbook-model.test.ts
+++ b/dev/flipbook-model.test.ts
@@ -7,6 +7,7 @@ import {
     selectQuestions,
     removeCurrentQuestion,
     jumpToQuestion,
+    loadQuestionsFromStorage,
 } from "./flipbook-model";
 
 import type {FlipbookModel} from "./flipbook-model";
@@ -125,6 +126,40 @@ describe("setQuestions", () => {
         };
         expect(flipbookModelReducer(model, setQuestions("{}"))).toEqual({
             questions: "{}",
+            requestedIndex: 0,
+        });
+    });
+});
+
+describe("loadQuestionsFromStorage", () => {
+    it("does not replace an existing questions string", () => {
+        const model: FlipbookModel = {
+            questions: "hello world",
+            requestedIndex: 0,
+        };
+        expect(
+            flipbookModelReducer(
+                model,
+                loadQuestionsFromStorage("hello universe"),
+            ),
+        ).toEqual({
+            questions: "hello world",
+            requestedIndex: 0,
+        });
+    });
+
+    it("does update empty questions string", () => {
+        const model: FlipbookModel = {
+            questions: "",
+            requestedIndex: 0,
+        };
+        expect(
+            flipbookModelReducer(
+                model,
+                loadQuestionsFromStorage("hello universe"),
+            ),
+        ).toEqual({
+            questions: "hello universe",
             requestedIndex: 0,
         });
     });

--- a/dev/flipbook-model.ts
+++ b/dev/flipbook-model.ts
@@ -19,7 +19,8 @@ export type Action =
     | {type: "previous"}
     | {type: "set-questions"; questions: string}
     | {type: "remove-current-question"}
-    | {type: "jump-to-index"; index: number};
+    | {type: "jump-to-index"; index: number}
+    | {type: "load-questions-from-storage"; questions: string};
 
 export const next: Action = {type: "next"};
 
@@ -38,6 +39,10 @@ export const jumpToQuestion = (rawUserInput: string): Action => {
 
 export function setQuestions(questions: string): Action {
     return {type: "set-questions", questions};
+}
+
+export function loadQuestionsFromStorage(questions: string): Action {
+    return {type: "load-questions-from-storage", questions};
 }
 
 export const removeCurrentQuestion: Action = {type: "remove-current-question"};
@@ -61,6 +66,14 @@ export function flipbookModelReducer(
                 ...state,
                 questions: action.questions,
             };
+        }
+        case "load-questions-from-storage": {
+            return state.questions || !action.questions
+                ? state
+                : {
+                      ...state,
+                      questions: action.questions,
+                  };
         }
         case "remove-current-question": {
             const indexToRemove = selectCurrentQuestionIndex(state);

--- a/dev/flipbook.tsx
+++ b/dev/flipbook.tsx
@@ -23,6 +23,7 @@ import {
     selectNumQuestions,
     jumpToQuestion,
     selectCurrentQuestionAsJSON,
+    loadQuestionsFromStorage,
 } from "./flipbook-model";
 import {Header} from "./header";
 
@@ -59,13 +60,14 @@ export function Flipbook() {
     const noTextEntered = questionsState === "";
 
     useEffect(() => {
-        const localStorageQuestions = localStorage.getItem(LS_QUESTIONS_KEY);
-        if (noTextEntered && localStorageQuestions) {
-            dispatch(setQuestions(localStorageQuestions));
-        }
+        const localStorageQuestions =
+            localStorage.getItem(LS_QUESTIONS_KEY) || "";
+        dispatch(loadQuestionsFromStorage(localStorageQuestions));
+    }, []);
 
+    useEffect(() => {
         localStorage.setItem(LS_QUESTIONS_KEY, questionsState);
-    }, [noTextEntered, questionsState]);
+    }, [questionsState]);
 
     function handleDiscardQuestion() {
         dispatch(removeCurrentQuestion);

--- a/dev/flipbook.tsx
+++ b/dev/flipbook.tsx
@@ -69,11 +69,6 @@ export function Flipbook() {
         localStorage.setItem(LS_QUESTIONS_KEY, questionsState);
     }, [questionsState]);
 
-    function handleDiscardQuestion() {
-        dispatch(removeCurrentQuestion);
-        localStorage.removeItem(LS_QUESTIONS_KEY);
-    }
-
     return (
         <>
             <Header>
@@ -114,7 +109,10 @@ export function Flipbook() {
                         }
                     />
                     <Strut size={spacing.medium_16} />
-                    <Button kind="tertiary" onClick={handleDiscardQuestion}>
+                    <Button
+                        kind="tertiary"
+                        onClick={() => dispatch(removeCurrentQuestion)}
+                    >
                         Discard question
                     </Button>
                 </View>

--- a/dev/flipbook.tsx
+++ b/dev/flipbook.tsx
@@ -23,7 +23,6 @@ import {
     selectNumQuestions,
     jumpToQuestion,
     selectCurrentQuestionAsJSON,
-    selectQuestionsAsJSON,
 } from "./flipbook-model";
 import {Header} from "./header";
 
@@ -51,25 +50,22 @@ export function Flipbook() {
         requestedIndex: 0,
     });
 
-    const allQuestionsJSON = selectQuestionsAsJSON(state);
     const questionJSON = selectCurrentQuestionAsJSON(state);
     const question = selectCurrentQuestion(state);
     const numQuestions = selectNumQuestions(state);
     const index = selectCurrentQuestionIndex(state);
 
-    const noTextEntered = state.questions.trim() === "";
+    const questionsState = state.questions.trim();
+    const noTextEntered = questionsState === "";
 
     useEffect(() => {
         const localStorageQuestions = localStorage.getItem(LS_QUESTIONS_KEY);
-        if (!allQuestionsJSON?.length && localStorageQuestions) {
+        if (noTextEntered && localStorageQuestions) {
             dispatch(setQuestions(localStorageQuestions));
         }
 
-        localStorage.setItem(
-            LS_QUESTIONS_KEY,
-            allQuestionsJSON?.join("\n") || "",
-        );
-    }, [allQuestionsJSON]);
+        localStorage.setItem(LS_QUESTIONS_KEY, questionsState);
+    }, [noTextEntered, questionsState]);
 
     function handleDiscardQuestion() {
         dispatch(removeCurrentQuestion);


### PR DESCRIPTION
## Summary:
This is more a POC to check interest, but I noticed that when I was making changes in Perseus that Flipbook wasn't keeping the questions data I had given it. That meant I had to:

1. Make a change
2. Wait for Flipbook to reload
3. Copy/paste data
4. Check my work
5. Repeat

By stashing the data in local storage, the data persists after a reload.