### PR TITLE
Storybook: Prevent Vite from inlining SVGs

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -4,10 +4,6 @@ import {mergeConfig} from "vite";
 
 import type {StorybookConfig} from "@storybook/react-vite";
 
-function getAbsolutePath(value: string): any {
-    return dirname(require.resolve(join(value, "package.json")));
-}
-
 const config: StorybookConfig = {
     framework: "@storybook/react-vite",
 

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -4,6 +4,10 @@ import {mergeConfig} from "vite";
 
 import type {StorybookConfig} from "@storybook/react-vite";
 
+function getAbsolutePath(value: string): any {
+    return dirname(require.resolve(join(value, "package.json")));
+}
+
 const config: StorybookConfig = {
     framework: "@storybook/react-vite",
 
@@ -41,6 +45,17 @@ const config: StorybookConfig = {
     viteFinal: async (config, {configType}) => {
         return mergeConfig(config, {
             ...viteConfig,
+            build: {
+                // Vite 5 has a bug with how it builds `url(data: )` urls when
+                // it inlines SVGs. Given this is mostly used for static
+                // storybook builds, we just tell Vite to never inline assets.
+                // here.
+                // Feature introduced here: https://github.com/vitejs/vite/pull/14643
+                //
+                assetsInlineLimit: (file) => {
+                    return !file.endsWith(".svg");
+                },
+            },
             // Fix from: https://github.com/storybookjs/storybook/issues/25256#issuecomment-1866441206
             assetsInclude: ["/sb-preview/runtime.js"],
             plugins:
@@ -55,6 +70,9 @@ const config: StorybookConfig = {
         });
     },
 
+    core: {
+        disableTelemetry: true,
+    },
     docs: {
         autodocs: true,
     },

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -70,9 +70,6 @@ const config: StorybookConfig = {
         });
     },
 
-    core: {
-        disableTelemetry: true,
-    },
     docs: {
         autodocs: true,
     },


### PR DESCRIPTION
## Summary:

Mark noticed that the new @phosphor icons were not showing up in Storybook on Github Pages (`khan.github.com/pereseus`). 

I tracked it down to a feature introduced in Vite 5 (vitejs/vite#15534), but it seems like it has bugs ([#15378](https://github.com/vitejs/vite/issues/15378) and [#15444](https://github.com/vitejs/vite/issues/15444)). 

I don't see how we could "quote" the URL as it's handed of to Wonder Blocks which seems to be handling the import correctly. 

So instead we'll just force Vite to never inline SVGs using Vite's `assetsInlineLimit` (https://vitejs.dev/config/build-options#build-assetsinlinelimit) option. 

Issue: LEMS-1887

## Test plan:

I haven't tested on GH Pages yet, but I did the following and verified that there are now svg files in the build output folder:

```sh
yarn build-storybook
ls storybook-static/assets
```