### PR TITLE
Refactor the Mafs interactive graph state to accommodate circle graphs

### DIFF
--- a/.changeset/five-crabs-teach.md
+++ b/.changeset/five-crabs-teach.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Refactor the InteractiveGraphState type to accommodate circle graphs

--- a/package.json
+++ b/package.json
@@ -155,5 +155,8 @@
     "cypress:ci": "cross-env BABEL_COVERAGE=1 cypress run --component --env CYPRESS_COVERAGE=1",
     "format": "prettier --write .",
     "typecheck": "tsc"
+  },
+  "dependencies": {
+    "tiny-invariant": "^1.3.1"
   }
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -1,11 +1,7 @@
 import {Polygon, useMovable, vec} from "mafs";
 import * as React from "react";
 
-import {
-    moveAll,
-    moveControlPoint,
-    movePoint
-} from "../reducer/interactive-graph-action";
+import {moveAll, movePoint} from "../reducer/interactive-graph-action";
 import {TARGET_SIZE} from "../utils";
 
 import {Angle} from "./components/angle";

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -1,7 +1,11 @@
 import {Polygon, useMovable, vec} from "mafs";
 import * as React from "react";
 
-import {moveAll, moveControlPoint} from "../reducer/interactive-graph-action";
+import {
+    moveAll,
+    moveControlPoint,
+    movePoint
+} from "../reducer/interactive-graph-action";
 import {TARGET_SIZE} from "../utils";
 
 import {Angle} from "./components/angle";
@@ -110,7 +114,7 @@ export const PolygonGraph = (props: Props) => {
                     key={"point-" + i}
                     point={point}
                     onMove={(destination: vec.Vector2) =>
-                        dispatch(moveControlPoint(i, destination))
+                        dispatch(movePoint(i, destination))
                     }
                     data-testid={type + i}
                 />

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -40,6 +40,8 @@ const renderGraph = (props: {
             return <PolygonGraph graphState={state} dispatch={dispatch} />;
         case "point":
             return <PointGraph graphState={state} dispatch={dispatch} />;
+        case "circle":
+            throw new Error("the circle graph type is not yet implemented");
         default:
             return new UnreachableCaseError(type);
     }

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
@@ -54,7 +54,7 @@ export const moveAll = (delta: vec.Vector2): MoveAll => ({
 });
 
 export const MOVE_POINT = "move-point";
-interface MovePoint {
+export interface MovePoint {
     type: typeof MOVE_POINT;
     index: number;
     destination: vec.Vector2;

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
@@ -9,15 +9,14 @@ export type InteractiveGraphAction =
 export const MOVE_CONTROL_POINT = "move-control-point";
 export interface MoveControlPoint {
     type: typeof MOVE_CONTROL_POINT;
-    /* Only necessary if there is an array of objects that contain points, such as collinear tuples (segments, lines). */
-    itemIndex?: number;
+    itemIndex: number;
     pointIndex: number;
     destination: vec.Vector2;
 }
 export function moveControlPoint(
     pointIndex: number,
     destination: vec.Vector2,
-    itemIndex?: number,
+    itemIndex: number,
 ): MoveControlPoint {
     return {
         type: MOVE_CONTROL_POINT,

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -6,6 +6,7 @@ import {
 import {interactiveGraphReducer} from "./interactive-graph-reducer";
 
 import type {InteractiveGraphState} from "../types";
+import invariant from "tiny-invariant";
 
 const baseSegmentGraphState: InteractiveGraphState = {
     hasBeenInteractedWith: false,
@@ -46,6 +47,7 @@ describe("moveControlPoint", () => {
             moveControlPoint(0, [5, 6], 0),
         );
 
+        invariant(updated.type === "segment");
         expect(updated.coords[0]).toEqual([
             [5, 6],
             [3, 4],
@@ -87,6 +89,7 @@ describe("moveControlPoint", () => {
             moveControlPoint(0, [2, 2], 0),
         );
 
+        invariant(updated.type === "segment");
         // Assert: the move was canceled
         expect(updated.coords[0]).toEqual([
             [1, 1],
@@ -111,7 +114,9 @@ describe("moveControlPoint", () => {
             moveControlPoint(0, [1.5, 6.6], 0),
         );
 
-        // Assert: x snaps to the nearest whole number; y snaps to the nearest
+        // Assert
+        invariant(updated.type === "segment");
+        // x snaps to the nearest whole number; y snaps to the nearest
         // multiple of 2.
         expect(updated.coords[0][0]).toEqual([2, 6]);
     });
@@ -137,6 +142,7 @@ describe("moveControlPoint", () => {
             moveControlPoint(0, [99, 99], 0),
         );
 
+        invariant(updated.type === "segment");
         expect(updated.coords[0][0]).toEqual([4.5, 7.5]);
     });
 });
@@ -155,6 +161,7 @@ describe("moveSegment", () => {
 
         const updated = interactiveGraphReducer(state, moveLine(0, [5, -3]));
 
+        invariant(updated.type === "segment");
         expect(updated.coords[0]).toEqual([
             [6, -1],
             [8, 1],
@@ -174,6 +181,7 @@ describe("moveSegment", () => {
 
         const updated = interactiveGraphReducer(state, moveLine(0, [0.5, 0.5]));
 
+        invariant(updated.type === "segment");
         expect(updated.coords[0]).toEqual([
             [2, 3],
             [4, 5],
@@ -193,6 +201,7 @@ describe("moveSegment", () => {
 
         const updated = interactiveGraphReducer(state, moveLine(0, [99, 99]));
 
+        invariant(updated.type === "segment");
         expect(updated.coords[0]).toEqual([
             [7, 7],
             [9, 9],
@@ -228,6 +237,7 @@ describe("movePoint", () => {
 
         const updated = interactiveGraphReducer(state, movePoint(0, [5, 6]));
 
+        invariant(updated.type === "point");
         expect(updated.coords[0]).toEqual([5, 6]);
     });
 
@@ -243,6 +253,7 @@ describe("movePoint", () => {
             movePoint(0, [-2, -2.5]),
         );
 
+        invariant(updated.type === "point");
         expect(updated.coords[0]).toEqual([-3, -4]);
     });
 
@@ -254,6 +265,7 @@ describe("movePoint", () => {
 
         const updated = interactiveGraphReducer(state, movePoint(0, [99, 99]));
 
+        invariant(updated.type === "point");
         expect(updated.coords[0]).toEqual([9, 9]);
     });
 

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -1,3 +1,5 @@
+import invariant from "tiny-invariant";
+
 import {
     moveControlPoint,
     movePoint,
@@ -6,7 +8,6 @@ import {
 import {interactiveGraphReducer} from "./interactive-graph-reducer";
 
 import type {InteractiveGraphState} from "../types";
-import invariant from "tiny-invariant";
 
 const baseSegmentGraphState: InteractiveGraphState = {
     hasBeenInteractedWith: false,

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -7,7 +7,11 @@ import {
     MOVE_ALL,
     MOVE_CONTROL_POINT,
     MOVE_LINE,
-    MOVE_POINT, MoveAll, MoveControlPoint, MoveLine, MovePoint,
+    MOVE_POINT,
+    MoveAll,
+    MoveControlPoint,
+    MoveLine,
+    MovePoint,
 } from "./interactive-graph-action";
 
 import type {CollinearTuple} from "../../../perseus-types";
@@ -19,7 +23,10 @@ const isCollinearTuples = (
     coords: readonly CollinearTuple[] | readonly vec.Vector2[],
 ): coords is readonly CollinearTuple[] => Array.isArray(coords[0][0]);
 
-function doMoveControlPoint(state: InteractiveGraphState, action: MoveControlPoint): InteractiveGraphState {
+function doMoveControlPoint(
+    state: InteractiveGraphState,
+    action: MoveControlPoint,
+): InteractiveGraphState {
     const {snapStep, range} = state;
     switch (state.type) {
         case "segment":
@@ -27,7 +34,9 @@ function doMoveControlPoint(state: InteractiveGraphState, action: MoveControlPoi
         case "linear-system":
         case "ray": {
             if (action.itemIndex == null) {
-                throw new Error("MoveControlPoint.itemIndex cannot be null when moving a point on a line")
+                throw new Error(
+                    "MoveControlPoint.itemIndex cannot be null when moving a point on a line",
+                );
             }
             const newCoords = updateAtIndex({
                 array: state.coords,
@@ -86,13 +95,16 @@ function doMoveControlPoint(state: InteractiveGraphState, action: MoveControlPoi
             };
         }
         case "circle":
-            throw "FIXME implement circle reducer"
+            throw "FIXME implement circle reducer";
         default:
-            throw new UnreachableCaseError(state)
+            throw new UnreachableCaseError(state);
     }
 }
 
-function doMoveLine(state: InteractiveGraphState, action: MoveLine): InteractiveGraphState {
+function doMoveLine(
+    state: InteractiveGraphState,
+    action: MoveLine,
+): InteractiveGraphState {
     const {snapStep, range} = state;
     switch (state.type) {
         case "segment":
@@ -142,7 +154,10 @@ function doMoveLine(state: InteractiveGraphState, action: MoveLine): Interactive
     }
 }
 
-function doMoveAll(state: InteractiveGraphState, action: MoveAll): InteractiveGraphState {
+function doMoveAll(
+    state: InteractiveGraphState,
+    action: MoveAll,
+): InteractiveGraphState {
     const {snapStep, range} = state;
     switch (state.type) {
         case "polygon": {
@@ -167,7 +182,10 @@ function doMoveAll(state: InteractiveGraphState, action: MoveAll): InteractiveGr
     }
 }
 
-function doMovePoint(state: InteractiveGraphState, action: MovePoint): InteractiveGraphState {
+function doMovePoint(
+    state: InteractiveGraphState,
+    action: MovePoint,
+): InteractiveGraphState {
     switch (state.type) {
         case "point": {
             return {
@@ -193,7 +211,10 @@ function doMovePoint(state: InteractiveGraphState, action: MovePoint): Interacti
 }
 
 // Generic type makes returned state match input state
-export function interactiveGraphReducer(state: InteractiveGraphState, action: InteractiveGraphAction): InteractiveGraphState {
+export function interactiveGraphReducer(
+    state: InteractiveGraphState,
+    action: InteractiveGraphAction,
+): InteractiveGraphState {
     const {snapStep, range} = state;
     switch (action.type) {
         case MOVE_CONTROL_POINT:

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -8,20 +8,32 @@ import {
     MOVE_CONTROL_POINT,
     MOVE_LINE,
     MOVE_POINT,
-    MoveAll,
-    MoveControlPoint,
-    MoveLine,
-    MovePoint,
+    type MoveAll,
+    type MoveControlPoint,
+    type MoveLine,
+    type MovePoint,
 } from "./interactive-graph-action";
 
-import type {CollinearTuple} from "../../../perseus-types";
 import type {InteractiveGraphState, PairOfPoints} from "../types";
 import type {Interval} from "mafs";
 
-/** Determine if coords is type CollinearTuple[] */
-const isCollinearTuples = (
-    coords: readonly CollinearTuple[] | readonly vec.Vector2[],
-): coords is readonly CollinearTuple[] => Array.isArray(coords[0][0]);
+export function interactiveGraphReducer(
+    state: InteractiveGraphState,
+    action: InteractiveGraphAction,
+): InteractiveGraphState {
+    switch (action.type) {
+        case MOVE_CONTROL_POINT:
+            return doMoveControlPoint(state, action);
+        case MOVE_LINE:
+            return doMoveLine(state, action);
+        case MOVE_ALL:
+            return doMoveAll(state, action);
+        case MOVE_POINT:
+            return doMovePoint(state, action);
+        default:
+            throw new UnreachableCaseError(action);
+    }
+}
 
 function doMoveControlPoint(
     state: InteractiveGraphState,
@@ -58,14 +70,8 @@ function doMoveControlPoint(
 
             // Cannot type narrow both conditions within function parameters,
             // so this may seem redundant, but it's necessary for type safety.
-            const coordsToCheck =
-                isCollinearTuples(newCoords) && action.itemIndex !== undefined
-                    ? newCoords[action.itemIndex]
-                    : newCoords;
-            if (
-                !isCollinearTuples(coordsToCheck) &&
-                coordsOverlap(coordsToCheck)
-            ) {
+            const coordsToCheck = newCoords[action.itemIndex];
+            if (coordsOverlap(coordsToCheck)) {
                 return state;
             }
             return {
@@ -95,7 +101,7 @@ function doMoveControlPoint(
             };
         }
         case "circle":
-            throw "FIXME implement circle reducer";
+            throw new Error("FIXME implement circle reducer");
         default:
             throw new UnreachableCaseError(state);
     }
@@ -207,26 +213,6 @@ function doMovePoint(
         }
         default:
             return state;
-    }
-}
-
-// Generic type makes returned state match input state
-export function interactiveGraphReducer(
-    state: InteractiveGraphState,
-    action: InteractiveGraphAction,
-): InteractiveGraphState {
-    const {snapStep, range} = state;
-    switch (action.type) {
-        case MOVE_CONTROL_POINT:
-            return doMoveControlPoint(state, action);
-        case MOVE_LINE:
-            return doMoveLine(state, action);
-        case MOVE_ALL:
-            return doMoveAll(state, action);
-        case MOVE_POINT:
-            return doMovePoint(state, action);
-        default:
-            throw new UnreachableCaseError(action);
     }
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -194,7 +194,6 @@ function doMovePoint(
             throw new Error(
                 "The movePoint action is only for point and polygon graphs",
             );
-            return state;
     }
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -1,6 +1,5 @@
 import {vector as kvector} from "@khanacademy/kmath";
 import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
-import type {Interval} from "mafs";
 import {vec} from "mafs";
 
 import {
@@ -16,6 +15,7 @@ import {
 } from "./interactive-graph-action";
 
 import type {InteractiveGraphState, PairOfPoints} from "../types";
+import type {Interval} from "mafs";
 
 export function interactiveGraphReducer(
     state: InteractiveGraphState,
@@ -77,7 +77,9 @@ function doMoveControlPoint(
             throw new Error("FIXME implement circle reducer");
         case "point":
         case "polygon":
-            throw new Error(`Don't use moveControlPoint for ${state.type} graphs. Use movePoint instead!`)
+            throw new Error(
+                `Don't use moveControlPoint for ${state.type} graphs. Use movePoint instead!`,
+            );
         default:
             throw new UnreachableCaseError(state);
     }
@@ -189,7 +191,9 @@ function doMovePoint(
             };
         }
         default:
-            throw new Error("The movePoint action is only for point and polygon graphs")
+            throw new Error(
+                "The movePoint action is only for point and polygon graphs",
+            );
             return state;
     }
 }

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -68,8 +68,6 @@ function doMoveControlPoint(
                     }),
             });
 
-            // Cannot type narrow both conditions within function parameters,
-            // so this may seem redundant, but it's necessary for type safety.
             const coordsToCheck = newCoords[action.itemIndex];
             if (coordsOverlap(coordsToCheck)) {
                 return state;

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
@@ -1,6 +1,7 @@
 import {initializeGraphState} from "./interactive-graph-state";
 
 import type {Interval, vec} from "mafs";
+import invariant from "tiny-invariant";
 
 const baseGraphData = {
     range: [
@@ -34,6 +35,9 @@ describe("initializeGraphState for segment graphs", () => {
             ...baseGraphData,
             graph: {type: "segment"},
         });
+
+        // Narrow the type of `graph` so TS knows it will have `coords`.
+        invariant(state.type === "segment");
         expect(state.coords).toEqual([
             [
                 [-5, 5],
@@ -59,6 +63,9 @@ describe("initializeGraphState for segment graphs", () => {
             snapStep: [1, 1],
             graph: {type: "segment", numSegments: 1},
         });
+
+        // Narrow the type of `graph` so TS knows it will have `coords`.
+        invariant(state.type === "segment");
         expect(state.coords).toEqual([
             [
                 [-500, 500],
@@ -74,6 +81,9 @@ describe("initializeGraphState for line graphs", () => {
             ...baseGraphData,
             graph: {type: "linear-system"},
         });
+
+        // Narrow the type of `graph` so TS knows it will have `coords`.
+        invariant(state.type === "linear-system");
         expect(state.coords).toEqual([
             [
                 [-5, 5],
@@ -93,6 +103,9 @@ describe("initializeGraphState for polygon graphs", () => {
             ...baseGraphData,
             graph: {type: "polygon"},
         });
+
+        // Narrow the type of `graph` so TS knows it will have `coords`.
+        invariant(state.type === "polygon");
         expect(state.coords).toEqual([
             [3, -2],
             [0, 4],
@@ -105,6 +118,9 @@ describe("initializeGraphState for polygon graphs", () => {
             ...baseGraphData,
             graph: {type: "polygon", numSides: 8},
         });
+
+        // Narrow the type of `graph` so TS knows it will have `coords`.
+        invariant(state.type === "polygon");
         expect(state.coords).toEqual([
             [2, -4],
             [4, -2],
@@ -125,6 +141,8 @@ describe("initializeGraphState for point graphs", () => {
             graph: {type: "point", coords: [[1, 2]]},
         });
 
+        // Narrow the type of `graph` so TS knows it will have `coords`.
+        invariant(graph.type === "point");
         expect(graph.coords).toEqual([[1, 2]]);
     });
 
@@ -134,6 +152,8 @@ describe("initializeGraphState for point graphs", () => {
             graph: {type: "point", numPoints: 1},
         });
 
+        // Narrow the type of `graph` so TS knows it will have `coords`.
+        invariant(graph.type === "point");
         expect(graph.coords).toEqual([[0, 0]]);
     });
 
@@ -143,6 +163,8 @@ describe("initializeGraphState for point graphs", () => {
             graph: {type: "point", numPoints: 1, coord: [5, 6]},
         });
 
+        // Narrow the type of `graph` so TS knows it will have `coords`.
+        invariant(graph.type === "point");
         expect(graph.coords).toEqual([[5, 6]]);
     });
 
@@ -154,6 +176,8 @@ describe("initializeGraphState for point graphs", () => {
                 graph: {type: "point", numPoints: n},
             });
 
+            // Narrow the type of `graph` so TS knows it will have `coords`.
+            invariant(graph.type === "point");
             expect(graph.coords).toHaveLength(n);
         },
     );

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
@@ -1,7 +1,8 @@
+import invariant from "tiny-invariant";
+
 import {initializeGraphState} from "./interactive-graph-state";
 
 import type {Interval, vec} from "mafs";
-import invariant from "tiny-invariant";
 
 const baseGraphData = {
     range: [

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -14,7 +14,7 @@ import type {
 import type {
     InitializeGraphStateParams,
     InteractiveGraphState,
-    PairOfPoints
+    PairOfPoints,
 } from "../types";
 import type {Coord} from "@khanacademy/perseus";
 import type {Interval, vec} from "mafs";

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -6,13 +6,16 @@ import type {
     PerseusGraphTypePoint,
     PerseusGraphType,
     PerseusGraphTypeSegment,
-    CollinearTuple,
     PerseusGraphTypeRay,
     PerseusGraphTypeLinear,
     PerseusGraphTypeLinearSystem,
     PerseusGraphTypePolygon,
 } from "../../../perseus-types";
-import type {InitializeGraphStateParams, InteractiveGraphState} from "../types";
+import type {
+    InitializeGraphStateParams,
+    InteractiveGraphState,
+    PairOfPoints
+} from "../types";
 import type {Coord} from "@khanacademy/perseus";
 import type {Interval, vec} from "mafs";
 
@@ -82,9 +85,9 @@ const getDefaultPoints = ({
     graph: PerseusGraphTypePoint;
     range: [Interval, Interval];
     step: Coord;
-}): ReadonlyArray<Coord> => {
+}): Coord[] => {
     const numPoints = graph.numPoints || 1;
-    let coords = graph.coords;
+    let coords = graph.coords?.slice();
 
     if (coords) {
         return coords;
@@ -212,7 +215,7 @@ const getDefaultSegments = ({
     graph,
     range,
     step,
-}: InitializeGraphStateParams<PerseusGraphTypeSegment>): CollinearTuple[] => {
+}: InitializeGraphStateParams<PerseusGraphTypeSegment>): PairOfPoints[] => {
     const ys = (n?: number) => {
         switch (n) {
             case 2:
@@ -246,7 +249,7 @@ const getDefaultSegments = ({
     });
 };
 
-const defaultLinearCoords: readonly CollinearTuple[] = [
+const defaultLinearCoords: [Coord, Coord][] = [
     [
         [0.25, 0.75],
         [0.75, 0.75],
@@ -263,7 +266,7 @@ const getLineCoords = ({
     step,
 }: InitializeGraphStateParams<
     PerseusGraphTypeRay | PerseusGraphTypeLinear | PerseusGraphTypeLinearSystem
->): CollinearTuple[] =>
+>): PairOfPoints[] =>
     // Return two lines for a linear system, one for a ray or linear
     graph.coords ?? graph.type === "linear-system"
         ? defaultLinearCoords.map((collinear) =>
@@ -275,8 +278,8 @@ const getPolygonCoords = ({
     graph,
     range,
     step,
-}: InitializeGraphStateParams<PerseusGraphTypePolygon>): readonly Coord[] => {
-    let coords = graph.coords;
+}: InitializeGraphStateParams<PerseusGraphTypePolygon>): Coord[] => {
+    let coords = graph.coords?.slice();
     if (coords) {
         return coords;
     }

--- a/packages/perseus/src/widgets/interactive-graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/types.ts
@@ -1,6 +1,5 @@
 import type {InteractiveGraphAction} from "./reducer/interactive-graph-action";
 import type {
-    CollinearTuple,
     PerseusGraphType,
     PerseusInteractiveGraphWidgetOptions,
 } from "../../perseus-types";

--- a/packages/perseus/src/widgets/interactive-graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/types.ts
@@ -29,7 +29,8 @@ export type InteractiveGraphState =
     | LinearGraphState
     | RayGraphState
     | PolygonGraphState
-    | PointGraphState;
+    | PointGraphState
+    | CircleGraphState;
 
 export interface InteractiveGraphStateCommon {
     hasBeenInteractedWith: boolean;
@@ -41,27 +42,35 @@ export interface InteractiveGraphStateCommon {
 
 export interface SegmentGraphState extends InteractiveGraphStateCommon {
     type: "segment";
-    coords: ReadonlyArray<CollinearTuple>;
+    coords: PairOfPoints[];
 }
 
 export interface LinearGraphState extends InteractiveGraphStateCommon {
     type: "linear" | "linear-system";
-    coords: ReadonlyArray<CollinearTuple>;
+    coords: PairOfPoints[];
 }
 
 export interface PointGraphState extends InteractiveGraphStateCommon {
     type: "point";
-    coords: ReadonlyArray<Coord>;
+    coords: Coord[];
 }
 
 export interface RayGraphState extends InteractiveGraphStateCommon {
     type: "ray";
-    coords: ReadonlyArray<CollinearTuple>;
+    coords: PairOfPoints[];
 }
 
 export interface PolygonGraphState extends InteractiveGraphStateCommon {
     type: "polygon";
     showAngles: boolean;
     showSides: boolean;
-    coords: ReadonlyArray<Coord>;
+    coords: Coord[];
 }
+
+export interface CircleGraphState extends InteractiveGraphStateCommon {
+    type: "circle";
+    center: Coord;
+    radius: number;
+}
+
+export type PairOfPoints = [Coord, Coord];

--- a/packages/perseus/src/widgets/interactive-graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/utils.ts
@@ -8,7 +8,7 @@ import type {PerseusInteractiveGraphWidgetOptions} from "../../perseus-types";
 export const TARGET_SIZE = 44;
 
 // same as pointsFromNormalized in interactive-graph.tsx
-export const normalizePoints = <A extends ReadonlyArray<Coord>>(
+export const normalizePoints = <A extends Coord[]>(
     range: PerseusInteractiveGraphWidgetOptions["range"],
     step: PerseusInteractiveGraphWidgetOptions["step"],
     coordsList: A,
@@ -32,7 +32,7 @@ export const normalizePoints = <A extends ReadonlyArray<Coord>>(
     ) as any;
 
 // same as normalizeCoords in interactive-graph.tsx
-export const normalizeCoords = <A extends ReadonlyArray<Coord>>(
+export const normalizeCoords = <A extends Coord[]>(
     coordsList: A,
     ranges: PerseusInteractiveGraphWidgetOptions["range"],
 ): A =>


### PR DESCRIPTION
This doesn't actually implement the circle graph; that will be done
in a future PR.

This PR adds a library, `tiny-invariant`, which helps us narrow TypeScript types
in tests. We already depend on this library indirectly via react-router and Mafs,
so we don't need an ADR to use it.

Issue: https://khanacademy.atlassian.net/browse/LEMS-1828

## Test plan:

`yarn test`