### PR TITLE
Mafs callback on change (interactive graph editor change bug)

### DIFF
--- a/.changeset/nice-pens-scream.md
+++ b/.changeset/nice-pens-scream.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Provide graph state to onChange callback in Mafs

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -7,6 +7,7 @@ import type {
     PerseusWidgetsMap,
 } from "./perseus-types";
 import type {SizeClass} from "./util/sizing-utils";
+import type {InteractiveGraphState} from "./widgets/interactive-graphs/types";
 import type {KeypadAPI} from "@khanacademy/math-input";
 import type {AnalyticsEventHandlerFn} from "@khanacademy/perseus-core";
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
@@ -94,6 +95,8 @@ export type ChangeHandler = (
         selected?: number;
         // perseus-all-package/widgets/grapher.jsx
         plot?: any;
+        // Interactive Graph callback (see legacy: interactive-graph.tsx)
+        graph?: InteractiveGraphState;
     },
     callback?: () => unknown | null | undefined,
     silent?: boolean,

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -44,7 +44,12 @@ import type {
     PerseusInteractiveGraphWidgetOptions,
 } from "../perseus-types";
 import type {Widget} from "../renderer";
-import type {PerseusScore, WidgetExports, WidgetProps} from "../types";
+import type {
+    ChangeHandler,
+    PerseusScore,
+    WidgetExports,
+    WidgetProps,
+} from "../types";
 import type {
     QuadraticCoefficient,
     SineCoefficient,
@@ -1312,7 +1317,7 @@ class LegacyInteractiveGraph extends React.Component<Props, State> {
         this.onChange({graph: graph});
     };
 
-    onChange: (arg1: any) => void = (data) => {
+    onChange: ChangeHandler = (data) => {
         this.props.onChange(data);
         this.props.trackInteraction();
     };
@@ -1657,6 +1662,7 @@ class LegacyInteractiveGraph extends React.Component<Props, State> {
 
         $(this.angle).on("move", () => {
             this.onChange({
+                // @ts-expect-error Type '{ coords: any; type: "angle"; showAngles?: boolean | undefined; allowReflexAngles?: boolean | undefined; angleOffsetDeg?: number | undefined; snapDegrees?: number | undefined; match?: "congruent" | undefined; }' is not assignable to type 'InteractiveGraphState | undefined'.
                 graph: {...graph, coords: this.angle?.getClockwiseCoords()},
             });
         });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
@@ -29,11 +29,11 @@ export const SegmentGraph = (props: SegmentProps) => {
                     onMovePoint={(
                         endpointIndex: number,
                         destination: vec.Vector2,
-                    ) =>
+                    ) => {
                         dispatch(
                             moveControlPoint(endpointIndex, destination, i),
-                        )
-                    }
+                        );
+                    }}
                     data-testid={"segment" + i}
                 />
             ))}

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -22,28 +22,6 @@ function getBaseMafsGraphProps(): MafsWrapperProps {
         containerSizeClass: "small",
         onChange: () => {},
     };
-
-    // const widgetBaseProps: InteractiveGraphProps = {
-    //     ...mafsGraphBaseProps,
-    //     alignment: null,
-    //     apiOptions: {
-    //         ...ApiOptions.defaults,
-    //     },
-    //     containerSizeClass: "small",
-    //     findWidgets: () => [],
-    //     isLastUsedWidget: false,
-    //     onBlur: () => {},
-    //     onChange: () => {},
-    //     onFocus: () => {},
-    //     problemNum: 1,
-    //     reviewModeRubric: {
-    //         ...mafsGraphBaseProps,
-    //     },
-    //     static: true,
-    //     trackInteraction: () => {},
-    //     widgetId: "mafs-graph",
-    //     linterContext: {} as any,
-    // };
 }
 
 describe("MafsGraph", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -2,56 +2,48 @@ import {render} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import React from "react";
 
-import {ApiOptions} from "../../perseus-api";
-
 import {MafsGraph} from "./mafs-graph";
 
-import type {InteractiveGraphProps} from "./types";
-import type {PerseusInteractiveGraphWidgetOptions} from "../../perseus-types";
+import type {MafsWrapperProps} from "./mafs-graph";
 import type {UserEvent} from "@testing-library/user-event";
 
-function getBaseMafsGraphProps(): InteractiveGraphProps {
-    const mafsGraphBaseProps: PerseusInteractiveGraphWidgetOptions = {
+function getBaseMafsGraphProps(): MafsWrapperProps {
+    return {
+        box: [400, 400],
         step: [1, 1],
         gridStep: [1, 1],
         snapStep: [1, 1],
         markings: "graph",
-        labels: [],
-        showProtractor: false,
-        showRuler: false,
-        rulerLabel: "",
         range: [
             [-10, 10],
             [-10, 10],
         ],
         graph: {type: "segment"},
-        correct: {type: "segment"},
-        rulerTicks: 4,
-    };
-
-    const widgetBaseProps: InteractiveGraphProps = {
-        ...mafsGraphBaseProps,
-        alignment: null,
-        apiOptions: {
-            ...ApiOptions.defaults,
-        },
         containerSizeClass: "small",
-        findWidgets: () => [],
-        isLastUsedWidget: false,
-        onBlur: () => {},
         onChange: () => {},
-        onFocus: () => {},
-        problemNum: 1,
-        reviewModeRubric: {
-            ...mafsGraphBaseProps,
-        },
-        static: true,
-        trackInteraction: () => {},
-        widgetId: "mafs-graph",
-        linterContext: {} as any,
     };
 
-    return widgetBaseProps;
+    // const widgetBaseProps: InteractiveGraphProps = {
+    //     ...mafsGraphBaseProps,
+    //     alignment: null,
+    //     apiOptions: {
+    //         ...ApiOptions.defaults,
+    //     },
+    //     containerSizeClass: "small",
+    //     findWidgets: () => [],
+    //     isLastUsedWidget: false,
+    //     onBlur: () => {},
+    //     onChange: () => {},
+    //     onFocus: () => {},
+    //     problemNum: 1,
+    //     reviewModeRubric: {
+    //         ...mafsGraphBaseProps,
+    //     },
+    //     static: true,
+    //     trackInteraction: () => {},
+    //     widgetId: "mafs-graph",
+    //     linterContext: {} as any,
+    // };
 }
 
 describe("MafsGraph", () => {
@@ -63,9 +55,7 @@ describe("MafsGraph", () => {
     });
 
     it("renders", () => {
-        const {container} = render(
-            <MafsGraph {...getBaseMafsGraphProps()} box={[400, 400]} />,
-        );
+        const {container} = render(<MafsGraph {...getBaseMafsGraphProps()} />);
 
         // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
         const movablePoints = container.querySelectorAll(
@@ -81,7 +71,6 @@ describe("MafsGraph", () => {
         const {container} = render(
             <MafsGraph
                 {...getBaseMafsGraphProps()}
-                box={[400, 400]}
                 onChange={mockChangeHandler}
             />,
         );

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -1,4 +1,4 @@
-import {screen, render, waitFor} from "@testing-library/react";
+import {render} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import React from "react";
 
@@ -63,9 +63,16 @@ describe("MafsGraph", () => {
     });
 
     it("renders", () => {
-        render(<MafsGraph {...getBaseMafsGraphProps()} box={[400, 400]} />);
+        const {container} = render(
+            <MafsGraph {...getBaseMafsGraphProps()} box={[400, 400]} />,
+        );
 
-        expect(screen.getByTestId("mafs-graph__wrapper")).toBeInTheDocument();
+        // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+        const movablePoints = container.querySelectorAll(
+            "circle.movable-point-hitbox",
+        );
+
+        expect(movablePoints).not.toBe(0);
     });
 
     it("calls onChange when using graph", async () => {
@@ -86,8 +93,6 @@ describe("MafsGraph", () => {
 
         await userEvent.type(movablePoints[1], "{arrowup}");
 
-        await waitFor(() => {
-            expect(mockChangeHandler).toHaveBeenCalled();
-        });
+        expect(mockChangeHandler).toHaveBeenCalled();
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -1,0 +1,93 @@
+import {screen, render, waitFor} from "@testing-library/react";
+import {userEvent as userEventLib} from "@testing-library/user-event";
+import React from "react";
+
+import {ApiOptions} from "../../perseus-api";
+
+import {MafsGraph} from "./mafs-graph";
+
+import type {InteractiveGraphProps} from "./types";
+import type {PerseusInteractiveGraphWidgetOptions} from "../../perseus-types";
+import type {UserEvent} from "@testing-library/user-event";
+
+function getBaseMafsGraphProps(): InteractiveGraphProps {
+    const mafsGraphBaseProps: PerseusInteractiveGraphWidgetOptions = {
+        step: [1, 1],
+        gridStep: [1, 1],
+        snapStep: [1, 1],
+        markings: "graph",
+        labels: [],
+        showProtractor: false,
+        showRuler: false,
+        rulerLabel: "",
+        range: [
+            [-10, 10],
+            [-10, 10],
+        ],
+        graph: {type: "segment"},
+        correct: {type: "segment"},
+        rulerTicks: 4,
+    };
+
+    const widgetBaseProps: InteractiveGraphProps = {
+        ...mafsGraphBaseProps,
+        alignment: null,
+        apiOptions: {
+            ...ApiOptions.defaults,
+        },
+        containerSizeClass: "small",
+        findWidgets: () => [],
+        isLastUsedWidget: false,
+        onBlur: () => {},
+        onChange: () => {},
+        onFocus: () => {},
+        problemNum: 1,
+        reviewModeRubric: {
+            ...mafsGraphBaseProps,
+        },
+        static: true,
+        trackInteraction: () => {},
+        widgetId: "mafs-graph",
+        linterContext: {} as any,
+    };
+
+    return widgetBaseProps;
+}
+
+describe("MafsGraph", () => {
+    let userEvent: UserEvent;
+    beforeEach(() => {
+        userEvent = userEventLib.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+    });
+
+    it("renders", () => {
+        render(<MafsGraph {...getBaseMafsGraphProps()} box={[400, 400]} />);
+
+        expect(screen.getByTestId("mafs-graph__wrapper")).toBeInTheDocument();
+    });
+
+    it("calls onChange when using graph", async () => {
+        const mockChangeHandler = jest.fn();
+
+        const {container} = render(
+            <MafsGraph
+                {...getBaseMafsGraphProps()}
+                box={[400, 400]}
+                onChange={mockChangeHandler}
+            />,
+        );
+
+        // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+        const movablePoints = container.querySelectorAll(
+            "circle.movable-point-hitbox",
+        );
+
+        await userEvent.type(movablePoints[1], "{arrowup}");
+
+        await waitFor(() => {
+            expect(mockChangeHandler).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -23,6 +23,20 @@ import type {Widget} from "../../renderer";
 import "mafs/core.css";
 import "./mafs-styles.css";
 
+export type MafsWrapperProps = {
+    box: [number, number];
+    backgroundImage?: InteractiveGraphProps["backgroundImage"];
+    graph: InteractiveGraphProps["graph"];
+    lockedFigures?: InteractiveGraphProps["lockedFigures"];
+    range: InteractiveGraphProps["range"];
+    snapStep: InteractiveGraphProps["snapStep"];
+    step: InteractiveGraphProps["step"];
+    gridStep: InteractiveGraphProps["gridStep"];
+    containerSizeClass: InteractiveGraphProps["containerSizeClass"];
+    markings: InteractiveGraphProps["markings"];
+    onChange: InteractiveGraphProps["onChange"];
+};
+
 const renderGraph = (props: {
     state: InteractiveGraphState;
     dispatch: (action: InteractiveGraphAction) => unknown;
@@ -50,7 +64,7 @@ const renderGraph = (props: {
 
 export const MafsGraph = React.forwardRef<
     Partial<Widget>,
-    React.PropsWithChildren<InteractiveGraphProps> & {box: [number, number]}
+    React.PropsWithChildren<MafsWrapperProps>
 >((props, ref) => {
     const [width, height] = props.box;
     const [state, dispatch] = React.useReducer(

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -2,6 +2,7 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
 import {Mafs} from "mafs";
 import * as React from "react";
+import {useEffect, useRef} from "react";
 
 import GraphLockedLayer from "./graph-locked-layer";
 import {LinearGraph, PolygonGraph, RayGraph, SegmentGraph} from "./graphs";
@@ -57,6 +58,14 @@ export const MafsGraph = React.forwardRef<
         props,
         initializeGraphState,
     );
+    const prevState = useRef<InteractiveGraphState>(state);
+
+    useEffect(() => {
+        if (prevState.current !== state) {
+            props.onChange({graph: state});
+        }
+        prevState.current = state;
+    }, [props, state]);
 
     React.useImperativeHandle(ref, () => ({
         getUserInput: () => getGradableGraph(state, props.graph),

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -78,7 +78,6 @@ export const MafsGraph = React.forwardRef<
                 height,
                 position: "relative",
             }}
-            testId="mafs-graph__wrapper"
         >
             <LegacyGrid
                 box={props.box}

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -78,6 +78,7 @@ export const MafsGraph = React.forwardRef<
                 height,
                 position: "relative",
             }}
+            testId="mafs-graph__wrapper"
         >
             <LegacyGrid
                 box={props.box}


### PR DESCRIPTION
## Summary:
I don't know if this is the preferred way to do things, but it works

https://github.com/Khan/perseus/assets/16308368/ade4f43a-798a-4b75-bd63-23b05d43b944

Issue: LEMS-1882

## Test plan:
- In Perseus SB, go to: Interactive Graph Editor / With Locked point
  - `?path=/story/perseus-editor-widgets-interactive-graph-editor--with-locked-points`
- Move a point
- Note the "Correct answer" field updates as you modify the graph