### PR TITLE
Split grid vs tick step

### DIFF
--- a/.changeset/loud-suns-beg.md
+++ b/.changeset/loud-suns-beg.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Make grid and tick steps act independently in Mafs charts

--- a/packages/perseus/src/widgets/interactive-graphs/grid.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/grid.test.ts
@@ -1,0 +1,72 @@
+import {lineLabelText} from "./grid";
+
+import type {vec} from "mafs";
+
+describe("grid", () => {
+    describe("lineLabelText", () => {
+        it("shows tick label on correct step", () => {
+            // Arrange
+            const number = 2;
+            const tickStep = 2;
+            const range: vec.Vector2 = [-10, 10];
+
+            // Act
+            const result = lineLabelText(number, tickStep, range);
+
+            // Assert
+            expect(result).toBe("2");
+        });
+
+        it("returns empty string on incorrect step", () => {
+            // Arrange
+            const number = 3;
+            const tickStep = 2;
+            const range: vec.Vector2 = [-10, 10];
+
+            // Act
+            const result = lineLabelText(number, tickStep, range);
+
+            // Assert
+            expect(result).toBe("");
+        });
+
+        it("returns empty string for -1", () => {
+            // Arrange
+            const number = -1;
+            const tickStep = 1;
+            const range: vec.Vector2 = [-10, 10];
+
+            // Act
+            const result = lineLabelText(number, tickStep, range);
+
+            // Assert
+            expect(result).toBe("");
+        });
+
+        it("returns empty string for range min", () => {
+            // Arrange
+            const range: vec.Vector2 = [-10, 10];
+            const tickStep = 1;
+            const number = range[0];
+
+            // Act
+            const result = lineLabelText(number, tickStep, range);
+
+            // Assert
+            expect(result).toBe("");
+        });
+
+        it("returns empty string for range max", () => {
+            // Arrange
+            const range: vec.Vector2 = [-10, 10];
+            const tickStep = 1;
+            const number = range[1];
+
+            // Act
+            const result = lineLabelText(number, tickStep, range);
+
+            // Assert
+            expect(result).toBe("");
+        });
+    });
+});

--- a/packages/perseus/src/widgets/interactive-graphs/grid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/grid.tsx
@@ -46,7 +46,7 @@ export const lineLabelText = (
  * @param {GridProps} props
  * @param {number} axisIndex which axis we're getting options for
  */
-export const axisOptions = (
+const axisOptions = (
     props: Omit<GridProps, "containerSizeClass">,
     axisIndex: number,
 ) => {

--- a/packages/perseus/src/widgets/interactive-graphs/grid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/grid.tsx
@@ -7,7 +7,7 @@ import type {SizeClass} from "../../util/sizing-utils";
 import type {vec} from "mafs";
 
 interface GridProps {
-    step: vec.Vector2;
+    tickStep: vec.Vector2;
     gridStep: vec.Vector2;
     range: [[number, number], [number, number]];
     containerSizeClass: SizeClass;
@@ -50,7 +50,7 @@ const axisOptions = (
     props: Omit<GridProps, "containerSizeClass">,
     axisIndex: number,
 ) => {
-    const axisStep = props.step[axisIndex];
+    const axisStep = props.tickStep[axisIndex];
     const axisRange = props.range[axisIndex];
     return {
         axis: props.markings === "graph",

--- a/packages/perseus/src/widgets/interactive-graphs/grid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/grid.tsx
@@ -14,24 +14,39 @@ interface GridProps {
     markings: "graph" | "grid" | "none";
 }
 
-const renderLineLabel = (
+/**
+ * lineLabelText get the text that should
+ * be displayed for a specific tick place
+ *
+ * @param {number} n the tick number
+ * @param {number} tickStep how frequently a label should appear
+ * @param {vec.Vector2} range the min/max range on the axis
+ */
+export const lineLabelText = (
     n: number,
-    axisTickStep: number,
-    axisRange: vec.Vector2,
-) => {
-    const [min, max] = axisRange;
-    const isOnStep = n % axisTickStep === 0;
+    tickStep: number,
+    range: vec.Vector2,
+): string => {
+    const [min, max] = range;
+    const isOnStep = n % tickStep === 0;
     const isNegativeOne = n === -1;
     const isMin = n === min;
     const isMax = n === max;
     const shouldRender = isOnStep && !isNegativeOne && !isMin && !isMax;
-    return shouldRender ? n : "";
+    return shouldRender ? `${n}` : "";
 };
 
-// axisIndex is for grabbing data in an array that contains
-// data for multiple axes. For example range: [[-10, 10], [-10, 10]]
-// range[0] is data for the x axis and range[1] is data for the y axis
-const axisOptions = (
+/**
+ * axisOptions determine axis options for Mafs
+ *
+ * axisIndex is for grabbing data in an array that contains
+ * data for multiple axes. For example range: [[-10, 10], [-10, 10]]
+ * range[0] is data for the x axis and range[1] is data for the y axis
+ *
+ * @param {GridProps} props
+ * @param {number} axisIndex which axis we're getting options for
+ */
+export const axisOptions = (
     props: Omit<GridProps, "containerSizeClass">,
     axisIndex: number,
 ) => {
@@ -40,7 +55,7 @@ const axisOptions = (
     return {
         axis: props.markings === "graph",
         lines: props.gridStep[axisIndex],
-        labels: (n: number) => renderLineLabel(n, axisStep, axisRange),
+        labels: (n: number) => lineLabelText(n, axisStep, axisRange),
     };
 };
 

--- a/packages/perseus/src/widgets/interactive-graphs/grid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/grid.tsx
@@ -4,30 +4,48 @@ import * as React from "react";
 import AxisArrows from "./axis-arrows";
 
 import type {SizeClass} from "../../util/sizing-utils";
+import type {vec} from "mafs";
 
 interface GridProps {
-    step: [number, number];
-    gridStep: [number, number];
+    step: vec.Vector2;
+    gridStep: vec.Vector2;
     range: [[number, number], [number, number]];
     containerSizeClass: SizeClass;
     markings: "graph" | "grid" | "none";
 }
 
-const renderLineLabel = (n: number, [min, max]: [number, number]) =>
-    n !== -1 && n !== min && n !== max;
+const renderLineLabel = (
+    n: number,
+    axisTickStep: number,
+    axisRange: vec.Vector2,
+) => {
+    const [min, max] = axisRange;
+    const isOnStep = n % axisTickStep === 0;
+    const isNegativeOne = n === -1;
+    const isMin = n === min;
+    const isMax = n === max;
+    const shouldRender = isOnStep && !isNegativeOne && !isMin && !isMax;
+    return shouldRender ? n : "";
+};
 
+// axisIndex is for grabbing data in an array that contains
+// data for multiple axes. For example range: [[-10, 10], [-10, 10]]
+// range[0] is data for the x axis and range[1] is data for the y axis
 const axisOptions = (
     props: Omit<GridProps, "containerSizeClass">,
-    index: number,
-) => ({
-    axis: props.markings === "graph",
-    lines: props.step[index],
-    subdivisions: props.step[index] / props.gridStep[index],
-    labels: (n: number) => (renderLineLabel(n, props.range[index]) ? n : ""),
-});
+    axisIndex: number,
+) => {
+    const axisStep = props.step[axisIndex];
+    const axisRange = props.range[axisIndex];
+    return {
+        axis: props.markings === "graph",
+        lines: props.gridStep[axisIndex],
+        labels: (n: number) => renderLineLabel(n, axisStep, axisRange),
+    };
+};
 
-export const Grid = (props: GridProps) =>
-    props.markings === "none" ? null : (
+export const Grid = (props: GridProps) => {
+    return props.markings === "none" ? null : (
         <>
             <Coordinates.Cartesian
                 xAxis={axisOptions(props, 0)}
@@ -36,3 +54,4 @@ export const Grid = (props: GridProps) =>
             {props.markings === "graph" && <AxisArrows />}
         </>
     );
+};

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -4,10 +4,10 @@ import React from "react";
 
 import {MafsGraph} from "./mafs-graph";
 
-import type {MafsWrapperProps} from "./mafs-graph";
+import type {Props as MafsGraphProps} from "./mafs-graph";
 import type {UserEvent} from "@testing-library/user-event";
 
-function getBaseMafsGraphProps(): MafsWrapperProps {
+function getBaseMafsGraphProps(): MafsGraphProps {
     return {
         box: [400, 400],
         step: [1, 1],

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -24,7 +24,7 @@ import type {Widget} from "../../renderer";
 import "mafs/core.css";
 import "./mafs-styles.css";
 
-export type MafsWrapperProps = {
+export type Props = {
     box: [number, number];
     backgroundImage?: InteractiveGraphProps["backgroundImage"];
     graph: InteractiveGraphProps["graph"];
@@ -65,7 +65,7 @@ const renderGraph = (props: {
 
 export const MafsGraph = React.forwardRef<
     Partial<Widget>,
-    React.PropsWithChildren<MafsWrapperProps>
+    React.PropsWithChildren<Props>
 >((props, ref) => {
     const [width, height] = props.box;
     const [state, dispatch] = React.useReducer(
@@ -127,7 +127,13 @@ export const MafsGraph = React.forwardRef<
                         <SvgDefs />
 
                         {/* Background layer */}
-                        <Grid {...props} />
+                        <Grid
+                            tickStep={props.step}
+                            gridStep={props.gridStep}
+                            range={props.range}
+                            containerSizeClass={props.containerSizeClass}
+                            markings={props.markings}
+                        />
 
                         {/* Locked layer */}
                         {props.lockedFigures && (


### PR DESCRIPTION
## Summary:
Separate out Grid Step from Tick Step in Mafs charts

https://github.com/Khan/perseus/assets/16308368/51bdb324-a763-4859-9d68-906a394b7f32

Issue: [LEMS-1883](https://khanacademy.atlassian.net/browse/LEMS-1883)

## Test plan:
- Go to "With Locked Points"
  - `?path=/story/perseus-editor-widgets-interactive-graph-editor--with-locked-points`
- Change grid step and note it has minimal effect on tick step
- Change tick step and note it doesn't affect grid step

[LEMS-1883]: https://khanacademy.atlassian.net/browse/LEMS-1883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ