### PR TITLE
Ensure graphs in the dev gallery have stable React keys

### DIFF
--- a/dev/gallery.tsx
+++ b/dev/gallery.tsx
@@ -20,7 +20,7 @@ import type {APIOptions, PerseusRenderer} from "../packages/perseus/src";
 
 import "../packages/perseus/src/styles/perseus-renderer.less";
 
-const questions = [
+const questions: [PerseusRenderer, number][] = pairWithIndices([
     interactiveGraph.segmentQuestion,
     interactiveGraph.pointQuestion,
     interactiveGraph.angleQuestion,
@@ -41,7 +41,7 @@ const questions = [
     grapher.quadraticQuestion,
     grapher.sinusoidQuestion,
     numberLine.question1,
-];
+]);
 
 const styles = StyleSheet.create({
     page: {
@@ -170,12 +170,12 @@ export function Gallery() {
                     className={isMobile ? "perseus-mobile" : ""}
                 >
                     {questions
-                        .filter((question) =>
+                        .filter(([question]: [PerseusRenderer, number]) =>
                             search
                                 ? graphTypeContainsText(question, search)
                                 : true,
                         )
-                        .map((question, i) => (
+                        .map(([question, i]) => (
                             <QuestionRenderer
                                 key={i}
                                 question={question}
@@ -239,3 +239,7 @@ const graphTypeContainsText = (
             return false;
     }
 };
+
+function pairWithIndices<T>(a: T[]): [T, number][] {
+    return a.map((elem, index) => [elem, index]);
+}


### PR DESCRIPTION
## Summary:
This fixes a bug. Repro steps:

1. Run `yarn dev` and visit `http://localhost:5173`
2. Ensure all Mafs flags are turned OFF and the searchbar is clear.
3. Paste the text `poly` into the searchbar.

Expected: All graphs render without errors.

Actual: One graph crashes to the Renderer arrow boundary (red circle
with exclamation).

The bug happened because a segment graph component got reused for a
polygon graph. The component gets into a weird state when this happens
and crashes. Ensuring each graph has a stable key fixes the bug because
now each component renders the same graph for its whole lifetime.

Issue: none

Test plan:

Follow the repro steps above and confirm that the bug does not repro.