### PR TITLE
Fix Safari clipping the focus circle on the movable point

### DIFF
--- a/.changeset/forty-tomatoes-lick.md
+++ b/.changeset/forty-tomatoes-lick.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix focus ring on movable points in interactive-graph widget

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
@@ -50,6 +50,7 @@ export const StyledMovablePoint = (props: Props) => {
             />
             <circle className="movable-point-halo" cx={x} cy={y} />
             <circle className="movable-point-ring" cx={x} cy={y} />
+            <circle className="movable-point-focus-outline" cx={x} cy={y} />
             <circle
                 className="movable-point-center"
                 cx={x}

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -82,6 +82,8 @@
 }
 
 .MafsView .movable-point:focus-visible .movable-point-halo {
-    outline: 2px solid blue;
+    outline: 3px solid var(--movable-point-color);
+    /* Safari workaround to avoid the focus circle being clipped */
+    outline-offset: -3px;
     border-radius: 99px;
 }

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -21,6 +21,7 @@
     --movable-point-ring-radius: calc(2px + var(--movable-point-center-radius));
     --movable-point-halo-radius: calc(3px + var(--movable-point-ring-radius));
     --movable-point-hover-expansion: 2px;
+    --movable-point-focus-ring-offset: 2px;
 
     --movable-line-stroke-color: var(--mafs-blue);
     --movable-line-stroke-weight: 2px;
@@ -42,7 +43,13 @@
     fill: transparent;
 }
 
-.MafsView :is(.movable-point-center, .movable-point-ring, .movable-point-halo) {
+.MafsView
+    :is(
+        .movable-point-center,
+        .movable-point-ring,
+        .movable-point-halo,
+        .movable-point-focus-outline
+    ) {
     transition: r 0.15s ease-out;
 }
 
@@ -81,9 +88,24 @@
     );
 }
 
-.MafsView .movable-point:focus-visible .movable-point-halo {
-    outline: 3px solid var(--movable-point-color);
-    /* Safari workaround to avoid the focus circle being clipped */
-    outline-offset: -3px;
-    border-radius: 99px;
+.MafsView .movable-point .movable-point-focus-outline {
+    visibility: hidden;
+    r: calc(
+        var(--movable-point-halo-radius) +
+            var(--movable-point-focus-ring-offset)
+    );
+    stroke-width: 2px;
+    fill: none;
+    stroke: var(--mafs-blue);
+}
+
+.MafsView .movable-point:hover .movable-point-focus-outline {
+    r: calc(
+        var(--movable-point-hover-expansion) + var(--movable-point-halo-radius) +
+            var(--movable-point-focus-ring-offset)
+    );
+}
+
+.MafsView .movable-point:focus-visible .movable-point-focus-outline {
+    visibility: visible;
 }


### PR DESCRIPTION
## Summary:

We noticed that the focus ring on movable points was being clipped on Safari 17.2.1. This wasn't happening on Safari 16 (older) nor Safari Technology Preview (newer).

We were able to re-work how the focus ring was drawn and arrive at something that looks exactly the same but works on all browsers. 

Design spec: https://www.figma.com/file/JroPokeCLBv2VRIw3GPvY5/LC---Interactive-graph-widget?type=design&node-id=855-9644&mode=design&t=f6QWv1t1RXJtI6ky-4

Issue: LEMS-1889

## Test plan:

`yarn start`
Navigate to: http://localhost:6006/?path=/story/perseus-widgets-interactive-graph--segment-with-mafs-and-locked-points
Press `{tab}` on the keyboard until one of the movable points is focused.
Note that the focus ring (outside of the light-blue "halo") is a full circle and not clipped.

## Screenshot (fixed)

<img width="240" alt="image" src="https://github.com/Khan/perseus/assets/77138/62786caf-a26c-4b54-9375-1395d120b6ca">


Co-authored-by: Ben Christel <benchristel@khanacademy.org>
Co-authored-by: Sarah Third <sarahthird@khanacademy.org>