### PR TITLE
Fix type for `onWidgetStartProps`

### DIFF
--- a/.changeset/strange-frogs-share.md
+++ b/.changeset/strange-frogs-share.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix return type for callback function `onWidgetStartProps`

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -262,7 +262,7 @@ export type APIOptions = Readonly<{
      * This is useful for when we need to know how a widget has shuffled its
      * the available choices.
      */
-    onWidgetStartProps?: (widgets: PerseusWidgetsMap) => PerseusWidgetsMap;
+    onWidgetStartProps?: (widgets: PerseusWidgetsMap) => void;
 }>;
 
 type TeXProps = {


### PR DESCRIPTION
Nothing is done with the returned `widgets` for this function, and consuming the callback as typed requires some weird hacky implementation, like:

```
        onWidgetStartProps: (widgets) =>
            setWidgetsStateMap(widgets) as unknown as Perseus.PerseusWidgetsMap,
```
or
```
        onWidgetStartProps: (widgets) => {
                setWidgetsStateMap(widgets);
                return widgets;
            },
```

Correcting the type allows for its intended use, like:
```
        onWidgetStartProps: (widgets) => setWidgetsStateMap(widgets),
```
or
```
        onWidgetStartProps: setWidgetsStateMap,
```