### PR TITLE
Helper: find questions in `data` that match a predicate

### DIFF
--- a/data/find-questions.js
+++ b/data/find-questions.js
@@ -1,0 +1,81 @@
+/**
+ * To use this:
+ * - Modify `predicateCallback` to look for questions that
+ *   match your requirements
+ * - run: node find-questions.js
+ */
+
+const Path = require("path");
+const fs = require("fs");
+
+// ==========================
+// MODIFY THIS WHEN SEARCHING
+// ==========================
+
+/**
+ * predicateCallback used to check if the given question matches
+ * the rules you're looking for
+ *
+ * @param {PerseusRenderer} q the question to check
+ * @returns {boolean} whether the question is a match
+ */
+function predicateCallback(q) {
+    // Look through each widget in the question
+    for (let widget of Object.values(q.widgets)) {
+        // Skip everything that's not an interactive-graph
+        if (widget.type !== "interactive-graph") continue;
+
+        // Make sure the interactive-graph has the data we're comparing
+        if (!widget?.options?.gridStep || !widget?.options.step) continue;
+
+        // Do that actual check
+        const [xGridStep, yGridStep] = widget.options.gridStep;
+        const [xTickStep, yTickStep] = widget.options.step;
+        if (xGridStep > xTickStep || yGridStep > yTickStep) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+// ================================
+// DON'T MODIFY THIS WHEN SEARCHING
+// ================================
+
+// Find all `.json` files in a directory (recursive)
+const jsonFiles = [];
+function findJsonFiles(dir) {
+    fs.readdirSync(dir).forEach((file) => {
+        const absolutePath = Path.join(dir, file);
+        if (fs.statSync(absolutePath).isDirectory()) {
+            return findJsonFiles(absolutePath);
+        } else if (absolutePath.endsWith(".json")) {
+            return jsonFiles.push(absolutePath);
+        }
+    });
+}
+
+// Open and parse JSON files, check if it passes
+// the predicate match, and if so store it in the output array
+const output = [];
+function checkFiles() {
+    for (let fileName of jsonFiles) {
+        const data = fs.readFileSync(fileName, "utf8");
+        const json = JSON.parse(data);
+        if (predicateCallback(json)) {
+            output.push(data);
+        }
+    }
+}
+
+function main() {
+    findJsonFiles("./questions");
+    checkFiles();
+
+    // output in a copy/paste-able way
+    // so it can be dropped into flipbook
+    console.log(output.join("\n"));
+}
+
+main();

--- a/data/find-questions.js
+++ b/data/find-questions.js
@@ -50,22 +50,22 @@ function predicateCallback(q) {
 // ================================
 
 // Find all `.json` files in a directory (recursive)
-const jsonFiles = [];
-function findJsonFiles(dir) {
+function findJsonFiles(dir, accumulator = []) {
     fs.readdirSync(dir).forEach((file) => {
         const absolutePath = Path.join(dir, file);
         if (fs.statSync(absolutePath).isDirectory()) {
-            return findJsonFiles(absolutePath);
+            return findJsonFiles(absolutePath, accumulator);
         } else if (absolutePath.endsWith(".json")) {
-            return jsonFiles.push(absolutePath);
+            return accumulator.push(absolutePath);
         }
     });
+    return accumulator;
 }
 
 // Open and parse JSON files, check if it passes
 // the predicate match, and if so store it in the output array
-const output = [];
-function checkFiles() {
+function checkFiles(jsonFiles) {
+    const output = [];
     for (const fileName of jsonFiles) {
         const data = fs.readFileSync(fileName, "utf8");
         const json = JSON.parse(data);
@@ -73,16 +73,17 @@ function checkFiles() {
             output.push(data);
         }
     }
+    return output;
 }
 
 function main() {
-    findJsonFiles("./questions");
-    checkFiles();
+    const jsonFiles = findJsonFiles("./questions");
+    const matches = checkFiles(jsonFiles);
 
     // output in a copy/paste-able way
     // so it can be dropped into flipbook
     /* eslint-disable no-console */
-    console.log(output.join("\n"));
+    console.log(matches.join("\n"));
 }
 
 main();

--- a/data/find-questions.js
+++ b/data/find-questions.js
@@ -5,8 +5,10 @@
  * - run: node find-questions.js
  */
 
-const Path = require("path");
+/* eslint-disable import/no-commonjs */
+/* eslint-disable @typescript-eslint/no-var-requires */
 const fs = require("fs");
+const Path = require("path");
 
 // ==========================
 // MODIFY THIS WHEN SEARCHING
@@ -21,12 +23,16 @@ const fs = require("fs");
  */
 function predicateCallback(q) {
     // Look through each widget in the question
-    for (let widget of Object.values(q.widgets)) {
+    for (const widget of Object.values(q.widgets)) {
         // Skip everything that's not an interactive-graph
-        if (widget.type !== "interactive-graph") continue;
+        if (widget.type !== "interactive-graph") {
+            continue;
+        }
 
         // Make sure the interactive-graph has the data we're comparing
-        if (!widget?.options?.gridStep || !widget?.options.step) continue;
+        if (!widget?.options?.gridStep || !widget?.options.step) {
+            continue;
+        }
 
         // Do that actual check
         const [xGridStep, yGridStep] = widget.options.gridStep;
@@ -60,7 +66,7 @@ function findJsonFiles(dir) {
 // the predicate match, and if so store it in the output array
 const output = [];
 function checkFiles() {
-    for (let fileName of jsonFiles) {
+    for (const fileName of jsonFiles) {
         const data = fs.readFileSync(fileName, "utf8");
         const json = JSON.parse(data);
         if (predicateCallback(json)) {
@@ -75,6 +81,7 @@ function main() {
 
     // output in a copy/paste-able way
     // so it can be dropped into flipbook
+    /* eslint-disable no-console */
     console.log(output.join("\n"));
 }
 

--- a/data/find-questions.ts
+++ b/data/find-questions.ts
@@ -1,14 +1,16 @@
+#!/usr/bin/env -S node -r @swc-node/register
+
 /**
  * To use this:
  * - Modify `predicateCallback` to look for questions that
  *   match your requirements
- * - run: node find-questions.js
+ * - run: ./find-questions.js
  */
 
-/* eslint-disable import/no-commonjs */
-/* eslint-disable @typescript-eslint/no-var-requires */
-const fs = require("fs");
-const Path = require("path");
+import fs from "fs";
+import path from "path";
+
+import type {PerseusRenderer} from "@khanacademy/perseus";
 
 // ==========================
 // MODIFY THIS WHEN SEARCHING
@@ -21,7 +23,7 @@ const Path = require("path");
  * @param {PerseusRenderer} q the question to check
  * @returns {boolean} whether the question is a match
  */
-function predicateCallback(q) {
+function predicateCallback(q: PerseusRenderer) {
     // Look through each widget in the question
     for (const widget of Object.values(q.widgets)) {
         // Skip everything that's not an interactive-graph
@@ -50,9 +52,9 @@ function predicateCallback(q) {
 // ================================
 
 // Find all `.json` files in a directory (recursive)
-function findJsonFiles(dir, accumulator = []) {
+function findJsonFiles(dir, accumulator: string[] = []) {
     fs.readdirSync(dir).forEach((file) => {
-        const absolutePath = Path.join(dir, file);
+        const absolutePath = path.join(dir, file);
         if (fs.statSync(absolutePath).isDirectory()) {
             return findJsonFiles(absolutePath, accumulator);
         } else if (absolutePath.endsWith(".json")) {
@@ -65,7 +67,7 @@ function findJsonFiles(dir, accumulator = []) {
 // Open and parse JSON files, check if it passes
 // the predicate match, and if so store it in the output array
 function checkFiles(jsonFiles) {
-    const output = [];
+    const output: string[] = [];
     for (const fileName of jsonFiles) {
         const data = fs.readFileSync(fileName, "utf8");
         const json = JSON.parse(data);


### PR DESCRIPTION
## Summary:
I thought maybe this would be helpful. I needed a way to find questions where grid step was greater than our tick step.

The idea is this can be modified as needed to help other people find the data they need.

I know `jq` exists, but I'd rather stick to my JS roots.