### PR TITLE
math-input: upgrade mathquill to v1.0.1

### DIFF
--- a/.changeset/cold-mugs-pay.md
+++ b/.changeset/cold-mugs-pay.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Upgrade mathquill dependency to v1.0.1 to fix Symbola font references

--- a/packages/math-input/package.json
+++ b/packages/math-input/package.json
@@ -24,7 +24,7 @@
     "scripts": {},
     "dependencies": {
         "@khanacademy/perseus-core": "1.4.2",
-        "mathquill": "https://github.com/Khan/mathquill/releases/download/v1.0.0/mathquill-v1.0.0.tgz"
+        "mathquill": "https://github.com/Khan/mathquill/releases/download/v1.0.1/mathquill-1.0.1.tgz"
     },
     "devDependencies": {
         "@khanacademy/mathjax-renderer": "git+ssh://git@github.com:Khan/mathjax-renderer.git#v1.6.2",

--- a/packages/math-input/src/index.ts
+++ b/packages/math-input/src/index.ts
@@ -26,9 +26,9 @@ export {CursorContext} from "./components/input/cursor-contexts";
 // Helper to get cursor context from MathField
 export {getCursorContext} from "./components/input/mathquill-helpers";
 
-// Wrapper around v1 and v2 mobile keypads to switch between them
+// The mobile keypad
 export {MobileKeypad} from "./components/keypad";
-// Unwrapped v2 keypad for desktop
+// The unwrapped desktop keypad
 export {default as DesktopKeypad} from "./components/keypad";
 
 // Context used to pass data/refs around

--- a/yarn.lock
+++ b/yarn.lock
@@ -11844,9 +11844,9 @@ mathjax-full@3.2.2:
     mj-context-menu "^0.6.1"
     speech-rule-engine "^4.0.6"
 
-"mathquill@https://github.com/Khan/mathquill/releases/download/v1.0.0/mathquill-v1.0.0.tgz":
-  version "0.10.1"
-  resolved "https://github.com/Khan/mathquill/releases/download/v1.0.0/mathquill-v1.0.0.tgz#6acb1b4742bea24861e866d11f8b170bdb0c6014"
+"mathquill@https://github.com/Khan/mathquill/releases/download/v1.0.1/mathquill-1.0.1.tgz":
+  version "1.0.1"
+  resolved "https://github.com/Khan/mathquill/releases/download/v1.0.1/mathquill-1.0.1.tgz#277202655fd60bfeb7eb4a38dcdecc5da8b6dfbf"
 
 mdast-util-definitions@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Summary:

We've had a very long-standing issue where the Mathquill package referenced its fonts using an absolute path (eg. `/fonts/Symbola.woff2`). This has been difficult (let's be real, unsolved) for our build systems to deal with for most of the time we've been using Mathquill. 

Today we fix it! Mathquill v1.0.1 now references its fonts using relative paths, which are then trivially resolved by our build tools (be it Webpack, Rollup, or Vite).

Issue: LEMS-375

## Test plan:

Run `yarn start`
Navigate to http://localhost:6006/?path=/story/math-input-full-mobile-mathinput--wrapped
Open the browser dev tools and switch to the Network tab. Filter on "Symbola" and note that at least one of the "Symbola" fonts were successfully loaded.

|   | Before | After |
| - | ------ | ----- |
| UI |  <img width="84" alt="image" src="https://github.com/Khan/perseus/assets/77138/7718799d-45f0-478c-a734-72986bc5a653"> | <img width="92" alt="image" src="https://github.com/Khan/perseus/assets/77138/f9c57007-489a-4f62-b37d-ac3efaee7038"> |
| Actual font | <img width="273" alt="image" src="https://github.com/Khan/perseus/assets/77138/9d69b29c-0e34-4ff0-9cce-7d1521dc3c03"> | <img width="248" alt="image" src="https://github.com/Khan/perseus/assets/77138/bb47a116-78af-46d3-a61a-0d5ec301e5ea"> |
| Network Tab | <img width="300" alt="before" src="https://github.com/Khan/perseus/assets/77138/35bffc11-309f-4750-948a-0bb04e3b22ae"> | <img width="300" alt="after" src="https://github.com/Khan/perseus/assets/77138/5333d40e-eb92-4926-bcdf-922bc8ca81fc"> |

