### PR TITLE
Increase the size of MovablePoint hitboxes to 48px

### DIFF
--- a/.changeset/breezy-mice-lick.md
+++ b/.changeset/breezy-mice-lick.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix hitbox size of movable points on Mafs interactive graphs, to match the legacy graphs

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
@@ -3,7 +3,6 @@ import {useMovable} from "mafs";
 import * as React from "react";
 import {useRef} from "react";
 
-import {TARGET_SIZE} from "../../utils";
 import {useTransform} from "../use-transform";
 
 import type {vec} from "mafs";
@@ -13,6 +12,10 @@ type Props = {
     onMove: (newPoint: vec.Vector2) => unknown;
     color?: string;
 };
+
+// The hitbox size of 48px by 48px is preserved from the legacy interactive
+// graph.
+const hitboxSizePx = 48;
 
 export const StyledMovablePoint = (props: Props) => {
     const hitboxRef = useRef<SVGCircleElement>(null);
@@ -41,10 +44,9 @@ export const StyledMovablePoint = (props: Props) => {
                 } as any
             }
         >
-            {/* Radius of 22 creates 44x44 click/touch target: AAA WCAG compliant */}
             <circle
                 className="movable-point-hitbox"
-                r={TARGET_SIZE / 2}
+                r={hitboxSizePx / 2}
                 cx={x}
                 cy={y}
             />


### PR DESCRIPTION
## Summary:
This is a holdover from the legacy interactive graph. 44px is WCAG AAA,
but there's no reason not to go up to 48px since that's the existing
behavior.

Issue: https://khanacademy.atlassian.net/browse/LEMS-1895

Test plan:

View a segment graph in the dev UI. Inspect one of the point hitboxes.
It should be 48 by 48 pixels.