### PR TITLE
Fix bug when a segment endpoint is dragged after the question is graded

### DIFF
--- a/.changeset/cuddly-shrimps-rule.md
+++ b/.changeset/cuddly-shrimps-rule.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fixed a bug where the wrong point moved if you dragged the endpoint of an interactive line segment after grading the question

--- a/packages/perseus/src/__tests__/util.test.ts
+++ b/packages/perseus/src/__tests__/util.test.ts
@@ -55,3 +55,27 @@ describe("#constrainedTickStepsFromTickSteps", () => {
         expect(result).toEqual([5, 5]);
     });
 });
+
+describe("deepClone", () => {
+    it("does nothing to a primitive", () => {
+        expect(Util.deepClone(3)).toBe(3);
+    });
+
+    it("copies an array", () => {
+        const input = [1, 2, 3];
+
+        const result = Util.deepClone(input);
+
+        expect(result).toEqual(input);
+        expect(result).not.toBe(input);
+    });
+
+    it("recursively clones array elements", () => {
+        const input = [[1]];
+
+        const result = Util.deepClone(input);
+
+        expect(result).toEqual(input);
+        expect(result[0]).not.toBe(input[0]);
+    });
+});

--- a/packages/perseus/src/util.ts
+++ b/packages/perseus/src/util.ts
@@ -919,6 +919,23 @@ const unescapeMathMode: (label: string) => string = (label) =>
 
 const random: RNG = seededRNG(new Date().getTime() & 0xffffffff);
 
+// TODO(benchristel): in the future, we may want to make deepClone work for
+// Record<string, Cloneable> as well. Currently, it only does arrays.
+type Cloneable =
+    | null
+    | undefined
+    | boolean
+    | string
+    | number
+    | Cloneable[]
+    | readonly Cloneable[];
+function deepClone<T extends Cloneable>(obj: T): T {
+    if (Array.isArray(obj)) {
+        return obj.map(deepClone) as T;
+    }
+    return obj;
+}
+
 const Util = {
     inputPathsEqual,
     nestedMap,
@@ -965,6 +982,7 @@ const Util = {
     textarea,
     unescapeMathMode,
     random,
+    deepClone,
 } as const;
 
 export default Util;

--- a/packages/perseus/src/widgets/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.test.tsx
@@ -171,6 +171,8 @@ describe("InteractiveGraph.validate on a segment question", () => {
 
         InteractiveGraph.widget.validate(guess, rubric, null);
 
+        // Narrow the type of `rubric.correct` to segment graph; otherwise TS
+        // thinks it might not have a `coords` property.
         invariant(rubric.correct.type === "segment");
         expect(rubric.correct.coords).toEqual([
             [

--- a/packages/perseus/src/widgets/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.test.tsx
@@ -1,0 +1,182 @@
+import invariant from "tiny-invariant";
+
+import InteractiveGraph, {type Rubric} from "./interactive-graph";
+
+import type {PerseusGraphType} from "@khanacademy/perseus";
+
+function createRubric(graph: PerseusGraphType): Rubric {
+    return {graph, correct: graph};
+}
+
+describe("InteractiveGraph.validate on a segment question", () => {
+    it("marks the answer invalid if guess.coords is missing", () => {
+        const guess: PerseusGraphType = {type: "segment"};
+        const rubric: Rubric = createRubric({
+            type: "segment",
+            coords: [
+                [
+                    [0, 0],
+                    [1, 1],
+                ],
+            ],
+        });
+
+        const result = InteractiveGraph.widget.validate(guess, rubric, null);
+
+        expect(result).toEqual({
+            type: "invalid",
+            message: null,
+        });
+    });
+
+    it("does not award points if guess.coords is wrong", () => {
+        const guess: PerseusGraphType = {
+            type: "segment",
+            coords: [
+                [
+                    [99, 0],
+                    [1, 1],
+                ],
+            ],
+        };
+        const rubric: Rubric = createRubric({
+            type: "segment",
+            coords: [
+                [
+                    [0, 0],
+                    [1, 1],
+                ],
+            ],
+        });
+
+        const result = InteractiveGraph.widget.validate(guess, rubric, null);
+
+        expect(result).toEqual({
+            type: "points",
+            earned: 0,
+            total: 1,
+            message: null,
+        });
+    });
+
+    it("awards points if guess.coords is right", () => {
+        const guess: PerseusGraphType = {
+            type: "segment",
+            coords: [
+                [
+                    [0, 0],
+                    [1, 1],
+                ],
+            ],
+        };
+        const rubric: Rubric = createRubric({
+            type: "segment",
+            coords: [
+                [
+                    [0, 0],
+                    [1, 1],
+                ],
+            ],
+        });
+
+        const result = InteractiveGraph.widget.validate(guess, rubric, null);
+
+        expect(result).toEqual({
+            type: "points",
+            earned: 1,
+            total: 1,
+            message: null,
+        });
+    });
+
+    it("allows points of a segment to be specified in reverse order", () => {
+        const guess: PerseusGraphType = {
+            type: "segment",
+            coords: [
+                [
+                    [1, 1],
+                    [0, 0],
+                ],
+            ],
+        };
+        const rubric: Rubric = createRubric({
+            type: "segment",
+            coords: [
+                [
+                    [0, 0],
+                    [1, 1],
+                ],
+            ],
+        });
+
+        const result = InteractiveGraph.widget.validate(guess, rubric, null);
+
+        expect(result).toEqual({
+            type: "points",
+            earned: 1,
+            total: 1,
+            message: null,
+        });
+    });
+
+    it("does not modify the `guess` data", () => {
+        const guess: PerseusGraphType = {
+            type: "segment",
+            coords: [
+                [
+                    [1, 1],
+                    [0, 0],
+                ],
+            ],
+        };
+        const rubric: Rubric = createRubric({
+            type: "segment",
+            coords: [
+                [
+                    [0, 0],
+                    [1, 1],
+                ],
+            ],
+        });
+
+        InteractiveGraph.widget.validate(guess, rubric, null);
+
+        expect(guess.coords).toEqual([
+            [
+                [1, 1],
+                [0, 0],
+            ],
+        ]);
+    });
+
+    it("does not modify the `rubric` data", () => {
+        const guess: PerseusGraphType = {
+            type: "segment",
+            coords: [
+                [
+                    [1, 1],
+                    [0, 0],
+                ],
+            ],
+        };
+        const rubric: Rubric = createRubric({
+            type: "segment",
+            coords: [
+                [
+                    [1, 1],
+                    [0, 0],
+                ],
+            ],
+        });
+
+        InteractiveGraph.widget.validate(guess, rubric, null);
+
+        invariant(rubric.correct.type === "segment");
+        expect(rubric.correct.coords).toEqual([
+            [
+                [1, 1],
+                [0, 0],
+            ],
+        ]);
+    });
+});

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -126,7 +126,10 @@ const makeInvalidTypeError = (
 };
 
 type RenderProps = PerseusInteractiveGraphWidgetOptions; // There's no transform function in exports
-type Rubric = PerseusInteractiveGraphWidgetOptions;
+export type Rubric = {
+    correct: PerseusGraphType;
+    graph: PerseusGraphType;
+};
 type Props = WidgetProps<RenderProps, Rubric>;
 type State = any;
 type DefaultProps = {
@@ -2554,8 +2557,8 @@ class InteractiveGraph extends React.Component<Props, State> {
                 rubric.correct.type === "segment" &&
                 userInput.coords != null
             ) {
-                let guess = userInput.coords.slice();
-                let correct = rubric.correct.coords?.slice();
+                let guess = Util.deepClone(userInput.coords);
+                let correct = Util.deepClone(rubric.correct?.coords);
                 guess = _.invoke(guess, "sort").sort();
                 // @ts-expect-error - TS2345 - Argument of type '(readonly Coord[])[] | undefined' is not assignable to parameter of type 'Collection<any>'.
                 correct = _.invoke(correct, "sort").sort();


### PR DESCRIPTION
## Summary:
Repro steps for the bug:

- View a segment graph question (e.g. the JSON below)

```
{"content":"The graph of $y=h(x)$ is a line segment joining the points $(1,9)$ and $(3,2)$. \n\n**Drag the endpoints of the segment below to graph $y=h^{-1}(x)$.\n **\n\n[[☃ interactive-graph 1]]","images":{},"widgets":{"interactive-graph 1":{"alignment":"default","graded":true,"options":{"backgroundImage":{"bottom":0,"height":425,"left":0,"scale":1,"url":"web+graphie://ka-perseus-graphie.s3.amazonaws.com/a82b4098da55c75b68d2c1fd9f348923b8935ccb","width":425},"correct":{"coords":[[[9,1],[2,3]]],"type":"segment"},"graph":{"type":"segment"},"gridStep":[1,1],"labels":["x","y"],"markings":"none","range":[[-10,10],[-10,10]],"rulerLabel":"","rulerTicks":10,"showProtractor":false,"showRuler":false,"snapStep":[0.5,0.5],"step":[1,1]},"type":"interactive-graph","version":{"major":0,"minor":0}}}}
```

- Drag the leftmost point of the segment to the right, so the
  left-to-right order of the points is reversed.
- Grade the question (it doesn't matter if your answer is correct or
  incorrect)
- Drag one of the points with the mouse

Expected: the point you drag moves.

Actual: the *other point* moves.

The bug happened because the grading code mutated arrays from the graph
state. This commit fixes that by cloning the arrays before mutating
them.

Issue: https://khanacademy.atlassian.net/browse/LEMS-1900

Test plan:

Visit the interactive graph flipbook (`yarn dev`) and follow the repro
steps. The bug should not repro.