### PR TITLE
Fix HTML validation warning in the dev UI

### DIFF
--- a/.changeset/tender-peaches-deny.md
+++ b/.changeset/tender-peaches-deny.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-dev-ui": patch
+---
+
+Fix HTML validation error that was logged to the JS console in the dev UI

--- a/dev/flipbook.tsx
+++ b/dev/flipbook.tsx
@@ -180,11 +180,11 @@ function SideBySideQuestionRenderer({
                     }}
                 />
             </View>
-            <p>
+            <div>
                 <pre style={{whiteSpace: "pre-wrap"}}>
                     <code>{JSON.stringify(question)}</code>
                 </pre>
-            </p>
+            </div>
         </>
     );
 }


### PR DESCRIPTION
## Summary:
The warning was logged to the JS console. It said that nesting a `<pre>` tag inside a `<p>` is not allowed.

This commit fixes the warning by using a `<div>` instead of a `<p>`.

Issue: none

Test plan:

- `yarn dev`
- `open 'http://localhost:5173#flipbook'`
- Follow the instructions onscreen to get some question JSON into the UI

No errors or warnings should be logged to the JS console.