### PR TITLE
New Interactive Graph Axis Tick Labels (rendered with the MathJax font)

### DIFF
--- a/.changeset/grumpy-coats-jump.md
+++ b/.changeset/grumpy-coats-jump.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Inclusion of new MathJax-rendered tick labels for interactive graph.

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -614,13 +614,14 @@ export type PerseusImageLabel = {
 };
 
 export type PerseusInteractiveGraphWidgetOptions = {
-    // The tick steps. default [1, 1]
+    // Where the little black axis lines & labels (ticks) should render.
+    // Also known as the tick step. default [1, 1]
     // NOTE(kevinb): perseus_data.go defines this as Array<number>
     step: [number, number];
-    // The steps in the grid. default [1, 1]
+    // Where the grid lines on the graph will render. default [1, 1]
     // NOTE(kevinb): perseus_data.go defines this as Array<number>
     gridStep: [number, number];
-    // The snap steps. default [0.5, 0.5]
+    // Where the graph points will lock to when they are dragged. default [0.5, 0.5]
     // NOTE(kevinb): perseus_data.go defines this as Array<number>
     snapStep: [number, number];
     // An optional image to use in the background

--- a/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
@@ -97,7 +97,6 @@ export function generateTickLocations(
 type Props = {
     tickStep: [number, number];
     range: [[number, number], [number, number]];
-    graphSize: vec.Vector2;
 };
 
 export const AxisTicks = (props: Props) => {

--- a/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
@@ -71,6 +71,8 @@ export const AxisTicks = (props: Props) => {
     const [yMin, yMax] = range[1];
 
     const yTickStep = props.tickStep[1];
+
+    const yTickStep = props.tickStep[1];
     const xTickStep = props.tickStep[0];
 
     const yGridTicks = generateTickLocations(yTickStep, yMin, yMax);

--- a/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
@@ -1,6 +1,4 @@
 import * as React from "react";
-import "@khanacademy/mathjax-renderer/src/css/mathjax.css";
-import "@khanacademy/mathjax-renderer/src/css/safari-hacks.css";
 
 import {useTransform} from "./graphs/use-transform";
 

--- a/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
@@ -17,8 +17,6 @@ const YGridTick = ({y}: {y: number}) => {
     const pointOnAxis: vec.Vector2 = [0, y];
     const [[xPosition, yPosition]] = useTransform(pointOnAxis);
 
-    const labelString = y < 0 ? y.toString() : " " + y.toString();
-
     return (
         <g className="y-axis-ticks">
             <line
@@ -40,7 +38,7 @@ const YGridTick = ({y}: {y: number}) => {
                     x={xPosition - 10}
                     y={yPosition + 5}
                 >
-                    {labelString}
+                    {y.toString()}
                 </text>
             )}
         </g>
@@ -51,7 +49,6 @@ const XGridTick = ({x}: {x: number}) => {
     const pointOnAxis: vec.Vector2 = [x, 0];
     const [[xPosition, yPosition]] = useTransform(pointOnAxis);
 
-    const labelString = x < 0 ? x.toString() : x.toString();
     return (
         <g className="x-axis-ticks">
             <line
@@ -73,7 +70,7 @@ const XGridTick = ({x}: {x: number}) => {
                     x={xPosition}
                     y={yPosition + 25}
                 >
-                    {labelString}
+                    {x.toString()}
                 </text>
             )}
         </g>

--- a/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
@@ -1,7 +1,9 @@
 import * as React from "react";
 
 import {useTransform} from "./graphs/use-transform";
+import useGraphState from "./reducer/use-graph-state";
 
+import type {GridProps} from "./grid";
 import type {vec} from "mafs";
 
 const tickSize = 10;

--- a/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
@@ -71,8 +71,6 @@ export const AxisTicks = (props: Props) => {
     const [yMin, yMax] = range[1];
 
     const yTickStep = props.tickStep[1];
-
-    const yTickStep = props.tickStep[1];
     const xTickStep = props.tickStep[0];
 
     const yGridTicks = generateTickLocations(yTickStep, yMin, yMax);

--- a/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
@@ -1,9 +1,7 @@
 import * as React from "react";
 
 import {useTransform} from "./graphs/use-transform";
-import useGraphState from "./reducer/use-graph-state";
 
-import type {GridProps} from "./grid";
 import type {vec} from "mafs";
 
 const tickSize = 10;

--- a/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
@@ -1,8 +1,9 @@
-import {MathJaxRenderer} from "@khanacademy/mathjax-renderer";
 import * as React from "react";
 
 import "@khanacademy/mathjax-renderer/src/css/mathjax.css";
 import "@khanacademy/mathjax-renderer/src/css/safari-hacks.css";
+import {getDependencies} from "../../dependencies";
+
 import {useTransform} from "./graphs/use-transform";
 
 import type {vec} from "mafs";
@@ -14,29 +15,12 @@ const tickStyle: React.CSSProperties = {
     strokeWidth: 1,
 };
 
-const mathJaxRenderer = new MathJaxRenderer({
-    // shouldFixUnicodeLayout ensures that non-ASCII text is correctly
-    // measured and positioned in e.g. \overbrace and \underbrace expressions.
-    // Set shouldFixUnicodeLayout to false if you're rendering in an
-    // environment without a layout engine, e.g. jsdom.
-    shouldFixUnicodeLayout: true,
-    fontURL: "https://cdn.kastatic.org/fonts/mathjax",
-});
-
-const createMathJaxElement = (label: string) => {
-    mathJaxRenderer.updateStyles();
-    const {domElement} = mathJaxRenderer.render(label);
-    return domElement;
-};
-
 const YGridTick = ({y}: {y: number}) => {
+    const {TeX} = getDependencies();
     const pointOnAxis: vec.Vector2 = [0, y];
     const [[xPosition, yPosition]] = useTransform(pointOnAxis);
 
     const labelString = y < 0 ? `\\llap{-}` + Math.abs(y) : y.toString();
-
-    const mathJaxElement = createMathJaxElement(labelString);
-
     const labelXPosition = y === -1 ? startPtPx[0] - 22 : startPtPx[0] - 15;
 
     return (
@@ -50,16 +34,18 @@ const YGridTick = ({y}: {y: number}) => {
             />
             <foreignObject
                 height={20}
-                width={20}
+                width={50}
                 x={labelXPosition}
                 y={startPtPx[1] - 15}
-                dangerouslySetInnerHTML={{__html: mathJaxElement.outerHTML}}
-            />
+            >
+                <TeX>{labelString}</TeX>
+            </foreignObject>
         </g>
     );
 };
 
 const XGridTick = ({x}: {x: number}) => {
+    const {TeX} = getDependencies();
     const pointOnAxis: vec.Vector2 = [x, 0];
     const [[xPosition, yPosition]] = useTransform(pointOnAxis);
 
@@ -68,7 +54,7 @@ const XGridTick = ({x}: {x: number}) => {
             <g className="x-axis-ticks">
                 <line
                     x1={startPtPx[0]}
-                    y1={startPtPx[1]}
+                    y1={startPtPx[1] + 10}
                     x2={endPtPx[0]}
                     y2={endPtPx[1]}
                     style={tickStyle}
@@ -78,8 +64,6 @@ const XGridTick = ({x}: {x: number}) => {
     }
 
     const labelString = x < 0 ? `\\llap{-}` + Math.abs(x) : x.toString();
-
-    const mathJaxElement = createMathJaxElement(labelString);
 
     return (
         <g className="x-axis-ticks">
@@ -92,11 +76,12 @@ const XGridTick = ({x}: {x: number}) => {
             />
             <foreignObject
                 height={20}
-                width={20}
+                width={50}
                 x={startPtPx[0] - 8}
-                y={startPtPx[1] + 5}
-                dangerouslySetInnerHTML={{__html: mathJaxElement.outerHTML}}
-            />
+                y={startPtPx[1] + 10}
+            >
+                <TeX>{labelString}</TeX>
+            </foreignObject>
         </g>
     );
 };

--- a/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
@@ -21,7 +21,20 @@ const YGridTick = ({y}: {y: number}) => {
     const [[xPosition, yPosition]] = useTransform(pointOnAxis);
 
     const labelString = y < 0 ? `\\llap{-}` + Math.abs(y) : y.toString();
-    const labelXPosition = y === -1 ? startPtPx[0] - 22 : startPtPx[0] - 15;
+
+    if (y === -1) {
+        return (
+            <g className="x-axis-ticks">
+                <line
+                    x1={startPtPx[0]}
+                    y1={startPtPx[1]}
+                    x2={endPtPx[0]}
+                    y2={endPtPx[1]}
+                    style={tickStyle}
+                />
+            </g>
+        );
+    }
 
     return (
         <g className="y-axis-ticks">
@@ -35,8 +48,8 @@ const YGridTick = ({y}: {y: number}) => {
             <foreignObject
                 height={20}
                 width={50}
-                x={labelXPosition}
-                y={startPtPx[1] - 15}
+                x={startPtPx[0] - 15}
+                y={startPtPx[1] - 10}
             >
                 <TeX>{labelString}</TeX>
             </foreignObject>
@@ -54,7 +67,7 @@ const XGridTick = ({x}: {x: number}) => {
             <g className="x-axis-ticks">
                 <line
                     x1={startPtPx[0]}
-                    y1={startPtPx[1] + 10}
+                    y1={startPtPx[1]}
                     x2={endPtPx[0]}
                     y2={endPtPx[1]}
                     style={tickStyle}

--- a/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
@@ -1,5 +1,8 @@
+import {MathJaxRenderer} from "@khanacademy/mathjax-renderer";
 import * as React from "react";
 
+import "@khanacademy/mathjax-renderer/src/css/mathjax.css";
+import "@khanacademy/mathjax-renderer/src/css/safari-hacks.css";
 import {useTransform} from "./graphs/use-transform";
 
 import type {vec} from "mafs";
@@ -11,9 +14,30 @@ const tickStyle: React.CSSProperties = {
     strokeWidth: 1,
 };
 
+const mathJaxRenderer = new MathJaxRenderer({
+    // shouldFixUnicodeLayout ensures that non-ASCII text is correctly
+    // measured and positioned in e.g. \overbrace and \underbrace expressions.
+    // Set shouldFixUnicodeLayout to false if you're rendering in an
+    // environment without a layout engine, e.g. jsdom.
+    shouldFixUnicodeLayout: true,
+    fontURL: "https://cdn.kastatic.org/fonts/mathjax",
+});
+
+const createMathJaxElement = (label: string) => {
+    mathJaxRenderer.updateStyles();
+    const {domElement} = mathJaxRenderer.render(label);
+    return domElement;
+};
+
 const YGridTick = ({y}: {y: number}) => {
     const pointOnAxis: vec.Vector2 = [0, y];
     const [[xPosition, yPosition]] = useTransform(pointOnAxis);
+
+    const labelString = y < 0 ? `\\llap{-}` + Math.abs(y) : y.toString();
+
+    const mathJaxElement = createMathJaxElement(labelString);
+
+    const labelXPosition = y === -1 ? startPtPx[0] - 22 : startPtPx[0] - 15;
 
     return (
         <g className="y-axis-ticks">
@@ -24,6 +48,13 @@ const YGridTick = ({y}: {y: number}) => {
                 y2={yPosition}
                 style={tickStyle}
             />
+            <foreignObject
+                height={20}
+                width={20}
+                x={labelXPosition}
+                y={startPtPx[1] - 15}
+                dangerouslySetInnerHTML={{__html: mathJaxElement.outerHTML}}
+            />
         </g>
     );
 };
@@ -31,6 +62,24 @@ const YGridTick = ({y}: {y: number}) => {
 const XGridTick = ({x}: {x: number}) => {
     const pointOnAxis: vec.Vector2 = [x, 0];
     const [[xPosition, yPosition]] = useTransform(pointOnAxis);
+
+    if (x === -1) {
+        return (
+            <g className="x-axis-ticks">
+                <line
+                    x1={startPtPx[0]}
+                    y1={startPtPx[1]}
+                    x2={endPtPx[0]}
+                    y2={endPtPx[1]}
+                    style={tickStyle}
+                />
+            </g>
+        );
+    }
+
+    const labelString = x < 0 ? `\\llap{-}` + Math.abs(x) : x.toString();
+
+    const mathJaxElement = createMathJaxElement(labelString);
 
     return (
         <g className="x-axis-ticks">
@@ -40,6 +89,13 @@ const XGridTick = ({x}: {x: number}) => {
                 x2={xPosition}
                 y2={yPosition - tickSize / 2}
                 style={tickStyle}
+            />
+            <foreignObject
+                height={20}
+                width={20}
+                x={startPtPx[0] - 8}
+                y={startPtPx[1] + 5}
+                dangerouslySetInnerHTML={{__html: mathJaxElement.outerHTML}}
             />
         </g>
     );

--- a/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 
 import "@khanacademy/mathjax-renderer/src/css/mathjax.css";
 import "@khanacademy/mathjax-renderer/src/css/safari-hacks.css";
+import {useEffect, useState} from "react";
+
 import {getDependencies} from "../../dependencies";
 
 import {useTransform} from "./graphs/use-transform";
@@ -115,6 +117,12 @@ type Props = {
 
 export const AxisTicks = (props: Props) => {
     const range = props.range;
+    const [yOffSet, setYoffSet] = useState(0);
+    useEffect(() => {
+        window.addEventListener("scroll", () => {
+            setYoffSet(window.scrollY);
+        });
+    });
     const [xMin, xMax] = range[0];
     const [yMin, yMax] = range[1];
 
@@ -127,10 +135,22 @@ export const AxisTicks = (props: Props) => {
     return (
         <g className="axis-ticks">
             {yGridTicks.map((y) => {
-                return <YGridTick y={y} key={`y-grid-tick-${y}`} />;
+                return (
+                    <YGridTick
+                        y={y}
+                        key={`y-grid-tick-${y}`}
+                        yOffSet={yOffSet}
+                    />
+                );
             })}
             {xGridTicks.map((x) => {
-                return <XGridTick x={x} key={`x-grid-tick-${x}`} />;
+                return (
+                    <XGridTick
+                        x={x}
+                        key={`x-grid-tick-${x}`}
+                        yOffSet={yOffSet}
+                    />
+                );
             })}
         </g>
     );

--- a/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
@@ -1,13 +1,10 @@
 import * as React from "react";
 import "@khanacademy/mathjax-renderer/src/css/mathjax.css";
 import "@khanacademy/mathjax-renderer/src/css/safari-hacks.css";
-import {useEffect, useState} from "react";
 
 import {useTransform} from "./graphs/use-transform";
 
 import type {vec} from "mafs";
-
-import {use} from "chai";
 
 const tickSize = 10;
 
@@ -107,29 +104,10 @@ type Props = {
     range: [[number, number], [number, number]];
     graphSize: vec.Vector2;
 };
-/**
- * Given the range and a dimension, come up with the appropriate
- * scale.
- * Example:
- *      scaleFromExtent([-25, 25], 500) // returns 10
- */
-function scaleFromExtent(
-    extent: [number, number],
-    dimensionConstraint: number,
-): number {
-    const span = extent[1] - extent[0];
-    const scale = dimensionConstraint / span;
-    return scale;
-}
 
 export const AxisTicks = (props: Props) => {
     const range = props.range;
-    const [yOffSet, setYoffSet] = useState(0);
-    useEffect(() => {
-        window.addEventListener("scroll", () => {
-            setYoffSet(window.scrollY);
-        });
-    });
+
     const [xMin, xMax] = range[0];
     const [yMin, yMax] = range[1];
 
@@ -139,37 +117,13 @@ export const AxisTicks = (props: Props) => {
     const yGridTicks = generateTickLocations(yTickStep, yMin, yMax);
     const xGridTicks = generateTickLocations(xTickStep, xMin, xMax);
 
-    const dimensionConstraint = 500;
-
-    // Okay so I want to find out how many pixels a step is
-    // from the origin / center axis. If it's greater than 30
-    // then we can show the unity label.
-
-    // how do I get the full grid width?
-    const [width, height] = props.graphSize;
-
-    // Okay so we have the width. That should be divided by the
-    // grid step to get the number of pixels per step.
-
     return (
         <g className="axis-ticks">
             {yGridTicks.map((y) => {
-                return (
-                    <YGridTick
-                        y={y}
-                        key={`y-grid-tick-${y}`}
-                        yOffSet={yOffSet}
-                    />
-                );
+                return <YGridTick y={y} key={`y-grid-tick-${y}`} />;
             })}
             {xGridTicks.map((x) => {
-                return (
-                    <XGridTick
-                        x={x}
-                        key={`x-grid-tick-${x}`}
-                        yOffSet={yOffSet}
-                    />
-                );
+                return <XGridTick x={x} key={`x-grid-tick-${x}`} />;
             })}
         </g>
     );

--- a/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
@@ -20,21 +20,10 @@ const YGridTick = ({y}: {y: number}) => {
     const pointOnAxis: vec.Vector2 = [0, y];
     const [[xPosition, yPosition]] = useTransform(pointOnAxis);
 
+    // We want to make sure to use the llap command to ensure that the negative
+    // sign is not included in the width of the label. This is important for
+    // ensuring that the labels are correctly positioned.
     const labelString = y < 0 ? `\\llap{-}` + Math.abs(y) : y.toString();
-
-    if (y === -1) {
-        return (
-            <g className="x-axis-ticks">
-                <line
-                    x1={startPtPx[0]}
-                    y1={startPtPx[1]}
-                    x2={endPtPx[0]}
-                    y2={endPtPx[1]}
-                    style={tickStyle}
-                />
-            </g>
-        );
-    }
 
     return (
         <g className="y-axis-ticks">
@@ -45,14 +34,20 @@ const YGridTick = ({y}: {y: number}) => {
                 y2={yPosition}
                 style={tickStyle}
             />
-            <foreignObject
-                height={20}
-                width={50}
-                x={startPtPx[0] - 15}
-                y={startPtPx[1] - 10}
-            >
-                <TeX>{labelString}</TeX>
-            </foreignObject>
+            {
+                // TODO (LEMS-1891): Negative one is a special case as the labels can
+                // overlap with the axis line. We should handle this case more gracefully.
+            }
+            {y !== -1 && (
+                <foreignObject
+                    height={20}
+                    width={50}
+                    x={xPosition - 20}
+                    y={yPosition - 10}
+                >
+                    <TeX>{labelString}</TeX>
+                </foreignObject>
+            )}
         </g>
     );
 };
@@ -62,20 +57,9 @@ const XGridTick = ({x}: {x: number}) => {
     const pointOnAxis: vec.Vector2 = [x, 0];
     const [[xPosition, yPosition]] = useTransform(pointOnAxis);
 
-    if (x === -1) {
-        return (
-            <g className="x-axis-ticks">
-                <line
-                    x1={startPtPx[0]}
-                    y1={startPtPx[1]}
-                    x2={endPtPx[0]}
-                    y2={endPtPx[1]}
-                    style={tickStyle}
-                />
-            </g>
-        );
-    }
-
+    // We want to make sure to use the llap command to ensure that the negative
+    // sign is not included in the width of the label. This is important for
+    // ensuring that the labels are correctly positioned.
     const labelString = x < 0 ? `\\llap{-}` + Math.abs(x) : x.toString();
 
     return (
@@ -87,14 +71,20 @@ const XGridTick = ({x}: {x: number}) => {
                 y2={yPosition - tickSize / 2}
                 style={tickStyle}
             />
-            <foreignObject
-                height={20}
-                width={50}
-                x={startPtPx[0] - 8}
-                y={startPtPx[1] + 10}
-            >
-                <TeX>{labelString}</TeX>
-            </foreignObject>
+            {
+                // TODO (LEMS-1891): Negative one is a special case as the labels can
+                // overlap with the axis line. We should handle this case more gracefully.
+            }
+            {x !== -1 && (
+                <foreignObject
+                    height={20}
+                    width={50}
+                    x={xPosition - 8}
+                    y={yPosition + 10}
+                >
+                    <TeX>{labelString}</TeX>
+                </foreignObject>
+            )}
         </g>
     );
 };
@@ -105,9 +95,13 @@ export function generateTickLocations(
     max: number,
 ): number[] {
     const ticks: number[] = [];
+
+    // Add ticks in the positive direction
     for (let i = 0 + tickStep; i < max; i += tickStep) {
         ticks.push(i);
     }
+
+    // Add ticks in the negative direction
     for (let i = 0 - tickStep; i > min; i -= tickStep) {
         ticks.push(i);
     }

--- a/packages/perseus/src/widgets/interactive-graphs/grid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/grid.tsx
@@ -8,6 +8,11 @@ import type {GraphRange} from "../../perseus-types";
 import type {SizeClass} from "../../util/sizing-utils";
 import type {vec} from "mafs";
 
+/*
+gridStep: where the lines on the grid show up
+tickStep: where the little black lines should up (just called tick)
+snapStep: where the points will lock to when they are dragging
+*/
 export interface GridProps {
     tickStep: vec.Vector2;
     gridStep: vec.Vector2;

--- a/packages/perseus/src/widgets/interactive-graphs/grid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/grid.tsx
@@ -58,8 +58,6 @@ const axisOptions = (
     props: Omit<GridProps, "containerSizeClass">,
     axisIndex: number,
 ) => {
-    const axisStep = props.tickStep[axisIndex];
-    const axisRange = props.range[axisIndex];
     return {
         axis: props.markings === "graph",
         lines: props.gridStep[axisIndex],

--- a/packages/perseus/src/widgets/interactive-graphs/grid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/grid.tsx
@@ -13,7 +13,7 @@ gridStep: where the lines on the grid show up
 tickStep: where the little black lines should up (just called tick)
 snapStep: where the points will lock to when they are dragging
 */
-export interface GridProps {
+interface GridProps {
     tickStep: vec.Vector2;
     gridStep: vec.Vector2;
     range: GraphRange;

--- a/packages/perseus/src/widgets/interactive-graphs/grid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/grid.tsx
@@ -8,11 +8,6 @@ import type {GraphRange} from "../../perseus-types";
 import type {SizeClass} from "../../util/sizing-utils";
 import type {vec} from "mafs";
 
-/*
-gridStep: Where the lines on the grid will render.
-tickStep: Where the little black axis lines & labels (ticks) should render. (e.g. 1, 2, 3, 4, 5)
-snapStep: Where the graph points will lock to when they are dragged.
-*/
 interface GridProps {
     tickStep: vec.Vector2;
     gridStep: vec.Vector2;

--- a/packages/perseus/src/widgets/interactive-graphs/grid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/grid.tsx
@@ -68,16 +68,15 @@ const axisOptions = (
 export const Grid = (props: GridProps) => {
     return props.markings === "none" ? null : (
         <>
+            <Coordinates.Cartesian
+                xAxis={axisOptions(props, 0)}
+                yAxis={axisOptions(props, 1)}
+            />
             <AxisTicks
                 range={props.range}
                 tickStep={props.tickStep}
                 graphSize={props.graphSize}
             />
-            <Coordinates.Cartesian
-                xAxis={axisOptions(props, 0)}
-                yAxis={axisOptions(props, 1)}
-            />
-
             {props.markings === "graph" && <AxisArrows />}
         </>
     );

--- a/packages/perseus/src/widgets/interactive-graphs/grid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/grid.tsx
@@ -14,7 +14,6 @@ interface GridProps {
     range: GraphRange;
     containerSizeClass: SizeClass;
     markings: "graph" | "grid" | "none";
-    graphSize: vec.Vector2;
 }
 
 /**
@@ -67,11 +66,7 @@ export const Grid = (props: GridProps) => {
                 xAxis={axisOptions(props, 0)}
                 yAxis={axisOptions(props, 1)}
             />
-            <AxisTicks
-                range={props.range}
-                tickStep={props.tickStep}
-                graphSize={props.graphSize}
-            />
+            <AxisTicks range={props.range} tickStep={props.tickStep} />
             {props.markings === "graph" && <AxisArrows />}
         </>
     );

--- a/packages/perseus/src/widgets/interactive-graphs/grid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/grid.tsx
@@ -19,6 +19,7 @@ interface GridProps {
     range: GraphRange;
     containerSizeClass: SizeClass;
     markings: "graph" | "grid" | "none";
+    graphSize: vec.Vector2;
 }
 
 /**
@@ -69,11 +70,16 @@ const axisOptions = (
 export const Grid = (props: GridProps) => {
     return props.markings === "none" ? null : (
         <>
+            <AxisTicks
+                range={props.range}
+                tickStep={props.tickStep}
+                graphSize={props.graphSize}
+            />
             <Coordinates.Cartesian
                 xAxis={axisOptions(props, 0)}
                 yAxis={axisOptions(props, 1)}
             />
-            <AxisTicks range={props.range} tickStep={props.tickStep} />
+
             {props.markings === "graph" && <AxisArrows />}
         </>
     );

--- a/packages/perseus/src/widgets/interactive-graphs/grid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/grid.tsx
@@ -9,9 +9,9 @@ import type {SizeClass} from "../../util/sizing-utils";
 import type {vec} from "mafs";
 
 /*
-gridStep: where the lines on the grid show up
-tickStep: where the little black lines should up (just called tick)
-snapStep: where the points will lock to when they are dragging
+gridStep: Where the lines on the grid will render.
+tickStep: Where the little black axis lines & labels (ticks) should render. (e.g. 1, 2, 3, 4, 5)
+snapStep: Where the graph points will lock to when they are dragged.
 */
 interface GridProps {
     tickStep: vec.Vector2;

--- a/packages/perseus/src/widgets/interactive-graphs/grid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/grid.tsx
@@ -62,7 +62,7 @@ const axisOptions = (
     return {
         axis: props.markings === "graph",
         lines: props.gridStep[axisIndex],
-        labels: (n: number) => lineLabelText(n, axisStep, axisRange),
+        labels: false as const,
     };
 };
 

--- a/packages/perseus/src/widgets/interactive-graphs/grid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/grid.tsx
@@ -8,7 +8,7 @@ import type {GraphRange} from "../../perseus-types";
 import type {SizeClass} from "../../util/sizing-utils";
 import type {vec} from "mafs";
 
-interface GridProps {
+export interface GridProps {
     tickStep: vec.Vector2;
     gridStep: vec.Vector2;
     range: GraphRange;

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -167,7 +167,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                             range={props.range}
                             containerSizeClass={props.containerSizeClass}
                             markings={props.markings}
-                            graphSize={[width, height]}
+                            graphSize={props.box}
                         />
 
                         {/* Locked layer */}

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -167,7 +167,6 @@ export const MafsGraph = (props: MafsGraphProps) => {
                             range={props.range}
                             containerSizeClass={props.containerSizeClass}
                             markings={props.markings}
-                            graphSize={props.box}
                         />
 
                         {/* Locked layer */}

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -167,6 +167,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                             range={props.range}
                             containerSizeClass={props.containerSizeClass}
                             markings={props.markings}
+                            graphSize={[width, height]}
                         />
 
                         {/* Locked layer */}

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -125,7 +125,13 @@
     visibility: visible;
 }
 
+@font-face {
+    font-family: Mafs-MJXTEX;
+    src: url("https://cdn.kastatic.org/fonts/mathjax/MathJax_Main-Regular.woff")
+        format("woff");
+}
+
 .MafsView .axis-ticks text {
     font-size: 14px;
-    font-family: "MJXTEX";
+    font-family: "Mafs-MJXTEX";
 }

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -125,21 +125,7 @@
     visibility: visible;
 }
 
-.MafsView .mathjax-wrapper {
-    font-size: 12px !important;
-    left: 5px;
-    position: fixed;
-}
-
-.MafsView .mathjax-selectable {
-    position: relative;
-}
-
-.MafsView .mathjax-selectable svg {
-    position: fixed !important;
-}
-
 .MafsView .axis-ticks text {
-    font-size: 14px !important;
+    font-size: 14px;
     font-family: "MJXTEX";
 }

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -136,3 +136,8 @@
 .MafsView .mafs-shadow .mafs-axis:last-child {
     transform: translate(-25px, 0);
 }
+.MafsView .mathjax-wrapper {
+    font-size: 10px !important;
+    left: 5px;
+    position: fixed;
+}

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -125,10 +125,6 @@
     visibility: visible;
 }
 
-.MafsView .axis-ticks foreignObject {
-    overflow: visible;
-}
-
 .MafsView .mathjax-wrapper {
     font-size: 12px !important;
     left: 5px;
@@ -138,6 +134,12 @@
 .MafsView .mathjax-selectable {
     position: relative;
 }
+
 .MafsView .mathjax-selectable svg {
     position: fixed !important;
+}
+
+.MafsView .axis-ticks text {
+    font-size: 12px !important;
+    font-family: "MJXTEX";
 }

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -140,6 +140,6 @@
 }
 
 .MafsView .axis-ticks text {
-    font-size: 12px !important;
+    font-size: 14px !important;
     font-family: "MJXTEX";
 }

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -124,3 +124,15 @@
 .MafsView .movable-point:focus-visible .movable-point-focus-outline {
     visibility: visible;
 }
+
+.MafsView .mafs-axis text {
+    font-size: 12px;
+}
+
+.MafsView .mafs-shadow .mafs-axis:first-child {
+    transform: translate(0, 5px);
+}
+
+.MafsView .mafs-shadow .mafs-axis:last-child {
+    transform: translate(-25px, 0);
+}

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -125,8 +125,8 @@
     visibility: visible;
 }
 
-.MafsView .mafs-axis text {
-    font-size: 12px;
+.MafsView .axis-ticks foreignObject {
+    overflow: visible;
 }
 
 .MafsView .mafs-shadow .mafs-axis:first-child {
@@ -137,7 +137,7 @@
     transform: translate(-25px, 0);
 }
 .MafsView .mathjax-wrapper {
-    font-size: 10px !important;
+    font-size: 12px !important;
     left: 5px;
     position: fixed;
 }

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -134,3 +134,10 @@
     left: 5px;
     position: fixed;
 }
+
+.MafsView .mathjax-selectable {
+    position: relative;
+}
+.MafsView .mathjax-selectable svg {
+    position: fixed !important;
+}

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -129,13 +129,6 @@
     overflow: visible;
 }
 
-.MafsView .mafs-shadow .mafs-axis:first-child {
-    transform: translate(0, 5px);
-}
-
-.MafsView .mafs-shadow .mafs-axis:last-child {
-    transform: translate(-25px, 0);
-}
 .MafsView .mathjax-wrapper {
     font-size: 12px !important;
     left: 5px;


### PR DESCRIPTION
## Summary:
This PR adds a new approach to rendering our interactive graph axis tick labels. In order to ensure that we can support cases where the [tickSteps are less than the gridSteps](https://khanacademy.atlassian.net/browse/LEMS-1890), we're now manually rendering these labels. 

The labels have also been updated to render using the `MathJax_Main-Regular` (or `MJXTEX`) font. 

NOTE: There's still a bug regarding overlapping labels on the initial negative axis points, but that will be tackled in [LEMS-1891](https://khanacademy.atlassian.net/browse/LEMS-1891). 

Issue: LEMS-1878

## Test plan:
- manual testing in flipbook using all edge cases 
- manual testing in webapp to ensure the fonts are still correctly identified 

## Screen shots:
![Screenshot 2024-04-10 at 4 18 44 PM](https://github.com/Khan/perseus/assets/12463099/9d98524c-873b-4f35-8d84-d6e3d4d0d59a)

![Screenshot 2024-04-10 at 4 19 34 PM](https://github.com/Khan/perseus/assets/12463099/09180d65-60f9-438b-b696-b143a3dd3ad3)

![Screenshot 2024-04-10 at 4 20 05 PM](https://github.com/Khan/perseus/assets/12463099/d2ddbc8a-3152-4346-9f22-42241fe37f03)



[LEMS-1891]: https://khanacademy.atlassian.net/browse/LEMS-1891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ