### PR TITLE
Update workflows to use Node 20-ready actions

### DIFF
--- a/.github/actions/shared-node-cache/action.yml
+++ b/.github/actions/shared-node-cache/action.yml
@@ -22,6 +22,6 @@ runs:
               ssh-private-key: ${{ inputs.ssh-private-key }}
 
         - name: Use Node.js ${{ inputs.node-version }} & Install & cache node_modules
-          uses: Khan/actions@shared-node-cache-v1
+          uses: Khan/actions@shared-node-cache-v2
           with:
               node-version: ${{ inputs.node-version }}

--- a/.github/workflows/gerald-pr.yml
+++ b/.github/workflows/gerald-pr.yml
@@ -7,7 +7,7 @@ jobs:
     gerald:
         runs-on: ubuntu-latest
         steps:
-            - uses: Khan/actions@gerald-pr-v0
+            - uses: Khan/actions@gerald-pr-v3
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   admin-token: ${{ secrets.KHAN_ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/node-ci-main.yml
+++ b/.github/workflows/node-ci-main.yml
@@ -61,7 +61,7 @@ jobs:
               run: yarn coverage
 
             - name: Upload Coverage
-              uses: codecov/codecov-action@v3
+              uses: codecov/codecov-action@v4
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   files: ./coverage/coverage-final.json

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -30,11 +30,11 @@ jobs:
                   fetch-depth: 0
 
             - name: Get changed files
-              uses: Khan/actions@get-changed-files-v1
+              uses: Khan/actions@get-changed-files-v2
               id: changed
 
             - name: Filter out files that don't need a changeset
-              uses: Khan/actions@filter-files-v0
+              uses: Khan/actions@filter-files-v1
               id: match
               with:
                   changed-files: ${{ steps.changed.outputs.files }}
@@ -70,7 +70,7 @@ jobs:
                   ssh-private-key: ${{ secrets.KHAN_ACTIONS_BOT_SSH_PRIVATE_KEY }}
 
             - name: Get All Changed Files
-              uses: Khan/actions@get-changed-files-v1
+              uses: Khan/actions@get-changed-files-v2
               id: changed
 
             - name: Check formatting
@@ -79,14 +79,14 @@ jobs:
 
             - id: js-files
               name: Find .js(x)/.ts(x) changed files
-              uses: Khan/actions@filter-files-v0
+              uses: Khan/actions@filter-files-v1
               with:
                   changed-files: ${{ steps.changed.outputs.files }}
                   extensions: ".js,.jsx,.ts,.tsx"
                   files: "yarn.lock"
 
             - id: eslint-reset
-              uses: Khan/actions@filter-files-v0
+              uses: Khan/actions@filter-files-v1
               name: Files that would trigger a full eslint run
               with:
                   changed-files: ${{ steps.changed.outputs.files }}
@@ -111,7 +111,7 @@ jobs:
 
             # Run tests for our target matrix
             - id: jest-reset
-              uses: Khan/actions@filter-files-v0
+              uses: Khan/actions@filter-files-v1
               name: Files that would trigger a full jest run
               with:
                   changed-files: ${{ steps.changed.outputs.files }}
@@ -226,7 +226,7 @@ jobs:
             # shows the results from only one of the reports which would make it appear
             # as though coverage dropped a lot.
             - name: Upload Coverage
-              uses: codecov/codecov-action@v3
+              uses: codecov/codecov-action@v4
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   files: ./coverage-final.json,./out.json
@@ -334,7 +334,7 @@ jobs:
             # Note: these two actions are locked to the latest version that were
             # published when I created this yml file (just for security).
             - name: Find existing comment
-              uses: peter-evans/find-comment@034abe94d3191f9c89d870519735beae326f2bdb
+              uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e
               id: find-comment
               with:
                   issue-number: ${{ github.event.pull_request.number }}
@@ -343,7 +343,7 @@ jobs:
 
             - name: Create or update npm snapshot comment - success
               if: steps.publish-snapshot.outputs.npm_snapshot_tag != ''
-              uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d
+              uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
               with:
                   issue-number: ${{ github.event.pull_request.number }}
                   comment-id: ${{ steps.find-comment.outputs.comment-id }}
@@ -369,7 +369,7 @@ jobs:
 
             - name: Create or update npm snapshot comment - failure
               if: steps.publish-snapshot.outputs.npm_snapshot_tag == ''
-              uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d
+              uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
               with:
                   issue-number: ${{ github.event.pull_request.number }}
                   comment-id: ${{ steps.find-comment.outputs.comment-id }}

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -39,7 +39,7 @@ jobs:
                   ssh-private-key: ${{ secrets.KHAN_ACTIONS_BOT_SSH_PRIVATE_KEY }}
 
             - name: Publish to Chromatic
-              uses: chromaui/action@latest
+              uses: chromaui/action@v11
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   projectToken: ${{ secrets.CHROMATIC_APP_CODE }}


### PR DESCRIPTION
## Summary:
This updates the workflows to use action versions that have been updated to use Node 20. This should mean no more Node 16 deprecation warnings.

Issue: FEI-5484

## Test plan:
Put this up and check the workflows run without Node 16 deprecation warnings.