### PR TITLE
Adjust Button Styling to Match Intended UI from Content

### DIFF
--- a/.changeset/short-swans-accept.md
+++ b/.changeset/short-swans-accept.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Style adjustments for Explanation widget button

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/explanation.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/explanation.test.ts.snap
@@ -21,12 +21,12 @@ exports[`Explanation should snapshot when expanded: expanded 1`] = `
             aria-controls="uid-explanation-widget-1-content"
             aria-disabled="false"
             aria-expanded="true"
-            class="button_vr44p2-o_O-shared_lwskrm-o_O-default_1hl5pu8-o_O-small_14crccx-o_O-inlineStyles_156hg9l"
+            class="button_vr44p2-o_O-shared_lwskrm-o_O-default_1hl5pu8-o_O-small_14crccx-o_O-inlineStyles_1s8anjv"
             role="button"
             type="button"
           >
             <span
-              class="text_f1191h-o_O-LabelSmall_hl4zs1-o_O-text_6kf3xs-o_O-textWithFocus_e296pg-o_O-hover_1nzvkun-o_O-inlineStyles_9jc5f7"
+              class="text_f1191h-o_O-LabelSmall_hl4zs1-o_O-text_6kf3xs-o_O-textWithFocus_e296pg-o_O-hover_1nzvkun-o_O-inlineStyles_egvfd8"
             >
               Hide explanation!
             </span>
@@ -94,12 +94,12 @@ exports[`Explanation should snapshot: initial render 1`] = `
             aria-controls="uid-explanation-widget-0-content"
             aria-disabled="false"
             aria-expanded="false"
-            class="button_vr44p2-o_O-shared_lwskrm-o_O-default_1hl5pu8-o_O-small_14crccx-o_O-inlineStyles_156hg9l"
+            class="button_vr44p2-o_O-shared_lwskrm-o_O-default_1hl5pu8-o_O-small_14crccx-o_O-inlineStyles_1s8anjv"
             role="button"
             type="button"
           >
             <span
-              class="text_f1191h-o_O-LabelSmall_hl4zs1-o_O-text_6kf3xs-o_O-textWithFocus_e296pg-o_O-inlineStyles_9jc5f7"
+              class="text_f1191h-o_O-LabelSmall_hl4zs1-o_O-text_6kf3xs-o_O-textWithFocus_e296pg-o_O-inlineStyles_egvfd8"
             >
               Explanation
             </span>

--- a/packages/perseus/src/widgets/explanation.tsx
+++ b/packages/perseus/src/widgets/explanation.tsx
@@ -92,6 +92,7 @@ class Explanation extends React.Component<Props, State> {
         // While the button is not normally included in a block of text, it needs to be able to accommodate such a case.
         const buttonStyleOverrides = {
             height: "auto",
+            lineHeight: "inherit",
             marginLeft: "-2px", // transfer space on the left side to the padding
             marginRight: "2px", // adds space between the right border and any text that follows
             paddingLeft: "2px", // adds space between the left border and the button text
@@ -99,7 +100,8 @@ class Explanation extends React.Component<Props, State> {
 
         const labelStyle = {
             fontSize: "18px",
-            lineHeight: "20px",
+            lineHeight: "inherit",
+            "text-align": "left",
             // The following property adjusts the large space between the button text and the caret icon.
             // Since we are unable to adjust the styling of the icon (where the extra space exists),
             //      we are adjusting it on the text label by using a negative margin.


### PR DESCRIPTION
## Summary:
Adjust button styling to be left-aligned, and to use the line spacing of the surrounding text.

Issue: none

## Before:
![Screenshot 2024-04-08 at 1 09 13 PM](https://github.com/Khan/perseus/assets/13896410/24903f01-2977-4dfe-b5f2-f9bdea4d2595)


## After:
![Screenshot 2024-04-08 at 1 08 12 PM](https://github.com/Khan/perseus/assets/13896410/8932bb33-064a-4c1b-a4d5-9927c7379d05)

