### PR TITLE
Update focus style for line segments to match designs

### DIFF
--- a/.changeset/twenty-onions-love.md
+++ b/.changeset/twenty-onions-love.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Update the style of focused lines in Mafs interactive graphs

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -73,6 +73,18 @@ export const MovableLine = (props: Props) => {
                 <SVGLine
                     start={startPtPx}
                     end={endPtPx}
+                    className="movable-line-focus-outline"
+                    style={{}}
+                />
+                <SVGLine
+                    start={startPtPx}
+                    end={endPtPx}
+                    className="movable-line-focus-outline-gap"
+                    style={{}}
+                />
+                <SVGLine
+                    start={startPtPx}
+                    end={endPtPx}
                     style={{
                         stroke,
                         strokeWidth: "var(--movable-line-stroke-weight)",
@@ -93,10 +105,12 @@ export const MovableLine = (props: Props) => {
 function SVGLine(props: {
     start: vec.Vector2;
     end: vec.Vector2;
-    style: SVGProps<SVGLineElement>["style"];
+    style?: SVGProps<SVGLineElement>["style"];
+    className?: string;
     dragging?: boolean;
 }) {
-    const {start, end, style, dragging} = props;
+    const {start, end, style, dragging, className} = props;
+    const draggingClass = dragging ? "movable-dragging" : "";
     return (
         <line
             x1={start[0]}
@@ -104,7 +118,7 @@ function SVGLine(props: {
             x2={end[0]}
             y2={end[1]}
             style={style}
-            className={dragging ? "movable-dragging" : undefined}
+            className={`${className} ${draggingClass}`}
         />
     );
 }

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -38,7 +38,9 @@
     outline: none;
 }
 
-.MafsView .movable-line :is(.movable-line-focus-outline, .movable-line-focus-outline-gap) {
+.MafsView
+    .movable-line
+    :is(.movable-line-focus-outline, .movable-line-focus-outline-gap) {
     stroke: transparent;
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -28,15 +28,28 @@
     --movable-line-stroke-weight-active: 4px;
 }
 
-.MafsView .movable-line:is(:focus-visible, :hover),
+.MafsView .movable-line:hover,
 .movable-dragging {
-    outline: none;
     --movable-line-stroke-weight: var(--movable-line-stroke-weight-active);
 }
 
 .MafsView .movable-line:focus,
 .movable-polygon:focus {
     outline: none;
+}
+
+.MafsView .movable-line :is(.movable-line-focus-outline, .movable-line-focus-outline-gap) {
+    stroke: transparent;
+}
+
+.MafsView .movable-line:focus-visible .movable-line-focus-outline {
+    stroke: var(--mafs-blue);
+    stroke-width: 10px;
+}
+
+.MafsView .movable-line:focus-visible .movable-line-focus-outline-gap {
+    stroke: white;
+    stroke-width: 6px;
 }
 
 .MafsView .movable-point-hitbox {


### PR DESCRIPTION
Issue: https://khanacademy.atlassian.net/browse/LEMS-1892

## Test plan:

- `yarn dev`
- `open http://localhost:5173`
- Enable Mafs for segment graphs
- tab to the line segment
- the line should be outlined in blue

<img width="442" alt="Screen Shot 2024-04-09 at 11 31 01 AM" src="https://github.com/Khan/perseus/assets/693920/26507410-55a1-4ace-8598-40fdadf26803">
