### PR TITLE
Restore Padding Around Mafs Graph (Match Legacy Position)

### DIFF
--- a/.changeset/late-birds-smash.md
+++ b/.changeset/late-birds-smash.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Restore Padding Around Mafs Graph

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -120,6 +120,8 @@ export const MafsGraph = React.forwardRef<
                     width,
                     height,
                     position: "relative",
+                    padding: "25px 25px 0 0",
+                    boxSizing: "content-box",
                 }}
             >
                 <LegacyGrid


### PR DESCRIPTION
## Summary:
Add styling that provides the legacy padding at the top and the right of the graph.

Issue: LEMS-1901

## Test plan: