### PR TITLE
Split MafsGraph into two pieces to make it easier to test

### DIFF
--- a/.changeset/heavy-carrots-carry.md
+++ b/.changeset/heavy-carrots-carry.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Split MafsGraph into MafsGraph and StatefulMafsGraph

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -32,7 +32,7 @@ import GraphUtils from "../util/graph-utils";
 import {polar} from "../util/graphie";
 import {getInteractiveBoxFromSizeClass} from "../util/sizing-utils";
 
-import {MafsGraph} from "./interactive-graphs";
+import {StatefulMafsGraph} from "./interactive-graphs";
 
 import type {Coord} from "../interactive2/types";
 import type {
@@ -1820,7 +1820,7 @@ class InteractiveGraph extends React.Component<Props, State> {
                 this.props.snapStep || Util.snapStepFromGridStep(gridStep);
 
             return (
-                <MafsGraph
+                <StatefulMafsGraph
                     {...this.props}
                     ref={this.mafsRef}
                     gridStep={gridStep}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -58,6 +58,7 @@ export const MovableLine = (props: Props) => {
                 ref={line}
                 tabIndex={0}
                 className="movable-line"
+                data-test-id="movable-line"
                 style={{cursor: dragging ? "grabbing" : "grab"}}
             >
                 {/**
@@ -76,6 +77,7 @@ export const MovableLine = (props: Props) => {
                         strokeWidth: "var(--movable-line-stroke-weight)",
                     }}
                     dragging={dragging}
+                    data-test-id="movable-line__line"
                 />
             </g>
 
@@ -94,9 +96,10 @@ function SVGLine(props: {
     style: SVGProps<SVGLineElement>["style"];
     dragging?: boolean;
 }) {
-    const {start, end, style, dragging} = props;
+    const {start, end, style, dragging, ...rest} = props;
     return (
         <line
+            {...rest}
             x1={start[0]}
             y1={start[1]}
             x2={end[0]}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -2,8 +2,7 @@ import {vec, useMovable, Vector} from "mafs";
 import {useRef} from "react";
 import * as React from "react";
 
-import useGraphState from "../../reducer/use-graph-state";
-import {TARGET_SIZE, snap} from "../../utils";
+import {TARGET_SIZE} from "../../utils";
 import {useTransform} from "../use-transform";
 import {getRayIntersectionCoords} from "../utils";
 
@@ -26,7 +25,6 @@ type Props = {
 };
 
 export const MovableLine = (props: Props) => {
-    const {state} = useGraphState();
     const {start, end, onMove, extend, stroke = defaultStroke} = props;
     const midpoint = vec.midpoint(start, end);
 
@@ -51,7 +49,9 @@ export const MovableLine = (props: Props) => {
         onMove: (newPoint) => {
             onMove(vec.sub(newPoint, midpoint));
         },
-        constrain: (p) => snap(state.snapStep, p),
+        constrain: (p) => {
+            return p;
+        },
     });
 
     return (

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -77,7 +77,7 @@ export const MovableLine = (props: Props) => {
                         strokeWidth: "var(--movable-line-stroke-weight)",
                     }}
                     dragging={dragging}
-                    data-test-id="movable-line__line"
+                    testId="movable-line__line"
                 />
             </g>
 
@@ -95,17 +95,18 @@ function SVGLine(props: {
     end: vec.Vector2;
     style: SVGProps<SVGLineElement>["style"];
     dragging?: boolean;
+    testId?: string;
 }) {
-    const {start, end, style, dragging, ...rest} = props;
+    const {start, end, style, dragging, testId} = props;
     return (
         <line
-            {...rest}
             x1={start[0]}
             y1={start[1]}
             x2={end[0]}
             y2={end[1]}
             style={style}
             className={dragging ? "movable-dragging" : undefined}
+            data-test-id={testId}
         />
     );
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -49,9 +49,7 @@ export const MovableLine = (props: Props) => {
         onMove: (newPoint) => {
             onMove(vec.sub(newPoint, midpoint));
         },
-        constrain: (p) => {
-            return p;
-        },
+        constrain: (p) => p,
     });
 
     return (

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
@@ -46,6 +46,7 @@ export const StyledMovablePoint = (props: Props) => {
                     "--movable-point-color": color,
                 } as any
             }
+            data-test-id="movable-point"
         >
             <circle
                 className="movable-point-hitbox"
@@ -60,6 +61,7 @@ export const StyledMovablePoint = (props: Props) => {
                 cx={x}
                 cy={y}
                 style={{fill: color}}
+                data-test-id="movable-point__center"
             />
         </g>
     );

--- a/packages/perseus/src/widgets/interactive-graphs/index.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/index.ts
@@ -1,1 +1,1 @@
-export {MafsGraph} from "./mafs-graph";
+export {StatefulMafsGraph} from "./mafs-graph";

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -9,6 +9,7 @@ import {interactiveGraphReducer} from "./reducer/interactive-graph-reducer";
 import type {Props as MafsGraphProps} from "./mafs-graph";
 import type {InteractiveGraphState} from "./types";
 import type {UserEvent} from "@testing-library/user-event";
+import type {vec} from "mafs";
 
 function getBaseMafsGraphProps(): MafsGraphProps {
     return {
@@ -82,6 +83,16 @@ function map(
     );
 }
 
+function graphToPixel(
+    num: number,
+    range: vec.Vector2 = [-10, 10],
+    fullPixelSpace: number = 400,
+) {
+    const [rangeMin, rangeMax] = range;
+    const halfPixelSpace = fullPixelSpace / 2;
+    return map(num, rangeMin, rangeMax, halfPixelSpace * -1, halfPixelSpace);
+}
+
 describe("MafsGraph", () => {
     let userEvent: UserEvent;
     beforeEach(() => {
@@ -121,16 +132,16 @@ describe("MafsGraph", () => {
         const line = screen.getByTestId("movable-line__line");
 
         expect(line).toBeInTheDocument();
-        expect(line.getAttribute("x1")).toBe("0");
-        expect(line.getAttribute("y1")).toBe("0");
 
         // Map graph coordinates to SVG coordinates
-        const halfXBox = baseMafsGraphProps.box[0] / 2;
-        const halfYBox = baseMafsGraphProps.box[1] / 2;
-        const expectedX2 = map(-7, -10, 10, halfXBox * -1, halfXBox);
-        const expectedY2 = map(0.5, -10, 10, halfYBox * -1, halfYBox) * -1;
-        expect(line.getAttribute("x2")).toBe(`${expectedX2}`);
-        expect(line.getAttribute("y2")).toBe(`${expectedY2}`);
+        const expectedX1 = graphToPixel(0);
+        const expectedY1 = graphToPixel(0) * -1;
+        const expectedX2 = graphToPixel(-7);
+        const expectedY2 = graphToPixel(0.5) * -1;
+        expect(line.getAttribute("x1")).toBe(expectedX1 + "");
+        expect(line.getAttribute("y1")).toBe(expectedY1 + "");
+        expect(line.getAttribute("x2")).toBe(expectedX2 + "");
+        expect(line.getAttribute("y2")).toBe(expectedY2 + "");
     });
 
     /**
@@ -181,10 +192,8 @@ describe("MafsGraph", () => {
         const point = screen.getByTestId("movable-point__center");
 
         // Map graph coordinates to SVG coordinates
-        const halfXBox = baseMafsGraphProps.box[0] / 2;
-        const halfYBox = baseMafsGraphProps.box[1] / 2;
-        const expectedCX = map(4, -10, 10, halfXBox * -1, halfXBox);
-        const expectedCY = map(2, -10, 10, halfYBox * -1, halfYBox) * -1;
+        const expectedCX = graphToPixel(4);
+        const expectedCY = graphToPixel(2) * -1;
         expect(point.getAttribute("cx")).toBe(`${expectedCX}`);
         expect(point.getAttribute("cy")).toBe(`${expectedCY}`);
     });
@@ -244,12 +253,10 @@ describe("MafsGraph", () => {
         expect(line).toBeInTheDocument();
 
         // Map graph coordinates to SVG coordinates
-        const halfXBox = baseMafsGraphProps.box[0] / 2;
-        const halfYBox = baseMafsGraphProps.box[1] / 2;
-        const expectedX1 = map(-7, -10, 10, halfXBox * -1, halfXBox);
-        const expectedY1 = map(0, -10, 10, halfYBox * -1, halfYBox) * -1;
-        const expectedX2 = map(0, -10, 10, halfXBox * -1, halfXBox);
-        const expectedY2 = map(-0.5, -10, 10, halfYBox * -1, halfYBox) * -1;
+        const expectedX1 = graphToPixel(-7);
+        const expectedY1 = graphToPixel(0) * -1;
+        const expectedX2 = graphToPixel(0);
+        const expectedY2 = graphToPixel(-0.5) * -1;
 
         expect(line.getAttribute("x1")).toBe(`${expectedX1}`);
         expect(line.getAttribute("y1")).toBe(`${expectedY1}`);

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -70,7 +70,7 @@ describe("StatefulMafsGraph", () => {
     });
 });
 
-function map(
+function linearMap(
     num: number,
     startMin: number,
     startMax: number,
@@ -90,7 +90,13 @@ function graphToPixel(
 ) {
     const [rangeMin, rangeMax] = range;
     const halfPixelSpace = fullPixelSpace / 2;
-    return map(num, rangeMin, rangeMax, halfPixelSpace * -1, halfPixelSpace);
+    return linearMap(
+        num,
+        rangeMin,
+        rangeMax,
+        halfPixelSpace * -1,
+        halfPixelSpace,
+    );
 }
 
 describe("MafsGraph", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -1,10 +1,13 @@
-import {render} from "@testing-library/react";
+import {screen, render} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import React from "react";
 
-import {StatefulMafsGraph} from "./mafs-graph";
+import {MafsGraph, StatefulMafsGraph} from "./mafs-graph";
+import {moveLine, movePoint} from "./reducer/interactive-graph-action";
+import {interactiveGraphReducer} from "./reducer/interactive-graph-reducer";
 
 import type {Props as MafsGraphProps} from "./mafs-graph";
+import type {InteractiveGraphState} from "./types";
 import type {UserEvent} from "@testing-library/user-event";
 
 function getBaseMafsGraphProps(): MafsGraphProps {
@@ -24,7 +27,7 @@ function getBaseMafsGraphProps(): MafsGraphProps {
     };
 }
 
-describe("MafsGraph", () => {
+describe("StatefulMafsGraph", () => {
     let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
@@ -63,5 +66,194 @@ describe("MafsGraph", () => {
         await userEvent.type(movablePoints[1], "{arrowup}");
 
         expect(mockChangeHandler).toHaveBeenCalled();
+    });
+});
+
+function map(
+    num: number,
+    startMin: number,
+    startMax: number,
+    targetMin: number,
+    targetMax: number,
+): number {
+    return (
+        ((num - startMin) / (startMax - startMin)) * (targetMax - targetMin) +
+        targetMin
+    );
+}
+
+describe("MafsGraph", () => {
+    let userEvent: UserEvent;
+    beforeEach(() => {
+        userEvent = userEventLib.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+    });
+
+    it("renders", () => {
+        const mockDispatch = jest.fn();
+        const state: InteractiveGraphState = {
+            type: "segment",
+            hasBeenInteractedWith: true,
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            snapStep: [0.5, 0.5],
+            coords: [
+                [
+                    [0, 0],
+                    [-7, 0.5],
+                ],
+            ],
+        };
+
+        const baseMafsGraphProps = getBaseMafsGraphProps();
+
+        render(
+            <MafsGraph
+                state={state}
+                dispatch={mockDispatch}
+                {...baseMafsGraphProps}
+            />,
+        );
+
+        const line = screen.getByTestId("movable-line__line");
+
+        expect(line).toBeInTheDocument();
+        expect(line.getAttribute("x1")).toBe("0");
+        expect(line.getAttribute("y1")).toBe("0");
+
+        // Map graph coordinates to SVG coordinates
+        const halfXBox = baseMafsGraphProps.box[0] / 2;
+        const halfYBox = baseMafsGraphProps.box[1] / 2;
+        const expectedX2 = map(-7, -10, 10, halfXBox * -1, halfXBox);
+        const expectedY2 = map(0.5, -10, 10, halfYBox * -1, halfYBox) * -1;
+        expect(line.getAttribute("x2")).toBe(`${expectedX2}`);
+        expect(line.getAttribute("y2")).toBe(`${expectedY2}`);
+    });
+
+    /**
+     * regression LEMS-1885
+     * Important parts of this test:
+     * - large snap setting (>1)
+     * - arrowing with the keyboard moves point
+     */
+    it("point snap works with large snap gaps", async () => {
+        const mockDispatch = jest.fn();
+        const state: InteractiveGraphState = {
+            type: "point",
+            hasBeenInteractedWith: true,
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            snapStep: [2, 2],
+            coords: [[2, 2]],
+        };
+
+        const baseMafsGraphProps = getBaseMafsGraphProps();
+
+        const {rerender} = render(
+            <MafsGraph
+                state={state}
+                dispatch={mockDispatch}
+                {...baseMafsGraphProps}
+            />,
+        );
+
+        const group = screen.getByTestId("movable-point");
+        group.focus();
+        await userEvent.keyboard("[ArrowRight]");
+        const action = movePoint(0, [4, 2]);
+        expect(mockDispatch).toHaveBeenCalledWith(action);
+
+        const updatedState = interactiveGraphReducer(state, action);
+
+        rerender(
+            <MafsGraph
+                state={updatedState}
+                dispatch={mockDispatch}
+                {...baseMafsGraphProps}
+            />,
+        );
+
+        const point = screen.getByTestId("movable-point__center");
+
+        // Map graph coordinates to SVG coordinates
+        const halfXBox = baseMafsGraphProps.box[0] / 2;
+        const halfYBox = baseMafsGraphProps.box[1] / 2;
+        const expectedCX = map(4, -10, 10, halfXBox * -1, halfXBox);
+        const expectedCY = map(2, -10, 10, halfYBox * -1, halfYBox) * -1;
+        expect(point.getAttribute("cx")).toBe(`${expectedCX}`);
+        expect(point.getAttribute("cy")).toBe(`${expectedCY}`);
+    });
+
+    /**
+     * regression LEMS-1907
+     * Important parts of this test:
+     * - midpoint of line not on a snap step (snap: 0.5, midpoint: 0.25)
+     * - line starts at [-7, 0.5], [0, 0]
+     * - arrowing down with the keyboard moves line down
+     */
+    it("MovableLine not constrained by snap", async () => {
+        const mockDispatch = jest.fn();
+        const state: InteractiveGraphState = {
+            type: "segment",
+            hasBeenInteractedWith: true,
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            snapStep: [0.5, 0.5],
+            coords: [
+                [
+                    [-7, 0.5],
+                    [0, 0],
+                ],
+            ],
+        };
+
+        const baseMafsGraphProps = getBaseMafsGraphProps();
+
+        const {rerender} = render(
+            <MafsGraph
+                state={state}
+                dispatch={mockDispatch}
+                {...baseMafsGraphProps}
+            />,
+        );
+
+        const group = screen.getByTestId("movable-line");
+        group.focus();
+        await userEvent.keyboard("[ArrowDown]");
+        const action = moveLine(0, [0, -0.4]);
+        expect(mockDispatch).toHaveBeenCalledWith(action);
+
+        const updatedState = interactiveGraphReducer(state, action);
+
+        rerender(
+            <MafsGraph
+                state={updatedState}
+                dispatch={mockDispatch}
+                {...baseMafsGraphProps}
+            />,
+        );
+
+        const line = screen.getByTestId("movable-line__line");
+        expect(line).toBeInTheDocument();
+
+        // Map graph coordinates to SVG coordinates
+        const halfXBox = baseMafsGraphProps.box[0] / 2;
+        const halfYBox = baseMafsGraphProps.box[1] / 2;
+        const expectedX1 = map(-7, -10, 10, halfXBox * -1, halfXBox);
+        const expectedY1 = map(0, -10, 10, halfYBox * -1, halfYBox) * -1;
+        const expectedX2 = map(0, -10, 10, halfXBox * -1, halfXBox);
+        const expectedY2 = map(-0.5, -10, 10, halfYBox * -1, halfYBox) * -1;
+
+        expect(line.getAttribute("x1")).toBe(`${expectedX1}`);
+        expect(line.getAttribute("y1")).toBe(`${expectedY1}`);
+        expect(line.getAttribute("x2")).toBe(`${expectedX2}`);
+        expect(line.getAttribute("y2")).toBe(`${expectedY2}`);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -2,7 +2,7 @@ import {render} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import React from "react";
 
-import {MafsGraph} from "./mafs-graph";
+import {StatefulMafsGraph} from "./mafs-graph";
 
 import type {Props as MafsGraphProps} from "./mafs-graph";
 import type {UserEvent} from "@testing-library/user-event";
@@ -33,7 +33,9 @@ describe("MafsGraph", () => {
     });
 
     it("renders", () => {
-        const {container} = render(<MafsGraph {...getBaseMafsGraphProps()} />);
+        const {container} = render(
+            <StatefulMafsGraph {...getBaseMafsGraphProps()} />,
+        );
 
         // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
         const movablePoints = container.querySelectorAll(
@@ -47,7 +49,7 @@ describe("MafsGraph", () => {
         const mockChangeHandler = jest.fn();
 
         const {container} = render(
-            <MafsGraph
+            <StatefulMafsGraph
                 {...getBaseMafsGraphProps()}
                 onChange={mockChangeHandler}
             />,

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -68,24 +68,23 @@ const renderGraph = (props: {
     }
 };
 
-export const StatefulMafsGraph = React.forwardRef<
-    Partial<Widget>,
-    React.PropsWithChildren<Props>
->((props, ref) => {
-    const [state, dispatch] = React.useReducer(
-        interactiveGraphReducer,
-        props,
-        initializeGraphState,
-    );
+export const StatefulMafsGraph = React.forwardRef<Partial<Widget>, Props>(
+    (props, ref) => {
+        const [state, dispatch] = React.useReducer(
+            interactiveGraphReducer,
+            props,
+            initializeGraphState,
+        );
 
-    useImperativeHandle(ref, () => ({
-        getUserInput: () => getGradableGraph(state, props.graph),
-    }));
+        useImperativeHandle(ref, () => ({
+            getUserInput: () => getGradableGraph(state, props.graph),
+        }));
 
-    return <MafsGraph state={state} dispatch={dispatch} {...props} />;
-});
+        return <MafsGraph state={state} dispatch={dispatch} {...props} />;
+    },
+);
 
-type MafsGraphProps = React.PropsWithChildren<Props> & {
+type MafsGraphProps = Props & {
     state: InteractiveGraphState;
     dispatch: React.Dispatch<InteractiveGraphAction>;
 };

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -2,7 +2,7 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
 import {Mafs} from "mafs";
 import * as React from "react";
-import {useEffect, useRef} from "react";
+import {useEffect, useImperativeHandle, useRef} from "react";
 import _ from "underscore";
 
 import GraphLockedLayer from "./graph-locked-layer";
@@ -23,7 +23,7 @@ import {
 } from "./reducer/interactive-graph-state";
 import {GraphStateContext} from "./reducer/use-graph-state";
 
-import type {InteractiveGraphProps, InteractiveGraphState} from "./types";
+import type {InteractiveGraphState, InteractiveGraphProps} from "./types";
 import type {Widget} from "../../renderer";
 
 import "mafs/core.css";
@@ -68,16 +68,31 @@ const renderGraph = (props: {
     }
 };
 
-export const MafsGraph = React.forwardRef<
+export const StatefulMafsGraph = React.forwardRef<
     Partial<Widget>,
     React.PropsWithChildren<Props>
 >((props, ref) => {
-    const [width, height] = props.box;
     const [state, dispatch] = React.useReducer(
         interactiveGraphReducer,
         props,
         initializeGraphState,
     );
+
+    useImperativeHandle(ref, () => ({
+        getUserInput: () => getGradableGraph(state, props.graph),
+    }));
+
+    return <MafsGraph state={state} dispatch={dispatch} {...props} />;
+});
+
+type MafsGraphProps = React.PropsWithChildren<Props> & {
+    state: InteractiveGraphState;
+    dispatch: React.Dispatch<InteractiveGraphAction>;
+};
+
+export const MafsGraph = (props: MafsGraphProps) => {
+    const {state, dispatch} = props;
+    const [width, height] = props.box;
 
     const prevState = useRef<InteractiveGraphState>(state);
     useEffect(() => {
@@ -91,7 +106,7 @@ export const MafsGraph = React.forwardRef<
     const [xSnap, ySnap] = props.snapStep;
     useEffect(() => {
         dispatch(changeSnapStep([xSnap, ySnap]));
-    }, [xSnap, ySnap]);
+    }, [dispatch, xSnap, ySnap]);
 
     // Destructuring first to keep useEffect from making excess calls
     const [[xMinRange, xMaxRange], [yMinRange, yMaxRange]] = props.range;
@@ -102,11 +117,7 @@ export const MafsGraph = React.forwardRef<
                 [yMinRange, yMaxRange],
             ]),
         );
-    }, [xMinRange, xMaxRange, yMinRange, yMaxRange]);
-
-    React.useImperativeHandle(ref, () => ({
-        getUserInput: () => getGradableGraph(state, props.graph),
-    }));
+    }, [dispatch, xMinRange, xMaxRange, yMinRange, yMaxRange]);
 
     return (
         <GraphStateContext.Provider
@@ -174,4 +185,4 @@ export const MafsGraph = React.forwardRef<
             </View>
         </GraphStateContext.Provider>
     );
-});
+};


### PR DESCRIPTION
## Summary:
This is pretty simple PR conceptually, but I think it's going to be really helpful for actual DOM unit tests (vs reducer/logic unit test). In a perfect world, the reducer would be the single source of all logic and the UI would be the visual representation of the output of that logic (state). However Mafs _also_ has logic in it; while I could test what the reducer would do given a certain action, I was having trouble testing the result of a user interaction with Mafs.

So this PR splits MafsGraph into two pieces:
- StatefulMafsGraph: which holds the `useReducer`
- MafsGraph: which basically holds everything else

The benefits:
- I can pass MafsGraph an initial state, so bootstrapping a test is a breeze
- I can mock and spy on a `dispatch` function to assert that I'm getting the actions I want

I added two regression tests for bugs I was having trouble testing before.

I got Ben's blessing to explore this idea before I started.

Part of: [LEMS-1907](https://khanacademy.atlassian.net/browse/LEMS-1907)

## Test plan:
- Tests pass

[LEMS-1907]: https://khanacademy.atlassian.net/browse/LEMS-1907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ