### PR TITLE
Possible fix for Chrome repositioning bug

### DIFF
--- a/.changeset/orange-ways-whisper.md
+++ b/.changeset/orange-ways-whisper.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Bugfix for Mafs SVG positioning bug

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -29,6 +29,7 @@
 }
 
 .MafsView > svg {
+    /* Chrome/Safari bugfix for LEMS-1906 */
     display: block;
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -26,6 +26,7 @@
     --movable-line-stroke-color: var(--mafs-blue);
     --movable-line-stroke-weight: 2px;
     --movable-line-stroke-weight-active: 4px;
+    overflow: initial;
 }
 
 .MafsView .movable-line:hover,

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -26,7 +26,10 @@
     --movable-line-stroke-color: var(--mafs-blue);
     --movable-line-stroke-weight: 2px;
     --movable-line-stroke-weight-active: 4px;
-    overflow: initial;
+}
+
+.MafsView > svg {
+    display: block;
 }
 
 .MafsView .movable-line:hover,


### PR DESCRIPTION
## Summary:
This works, but I don't know why and I don't know what repercussions there will be. I wasn't able to repro in FF, but I was in Chrome/Safari (this fix works for both). It makes me wonder if this is a browser bug.

It's overriding [this CSS](https://github.com/stevenpetryk/mafs/blob/adc9122f102dc18128644d752d07390a27b92a64/core.css#L4) from Mafs' first commit.

Before
https://github.com/Khan/perseus/assets/16308368/fa2c76aa-c3ee-4672-92ef-e784857fe276

After
https://github.com/Khan/perseus/assets/16308368/145584fe-cc32-44bb-9be2-83c7b99cf792

Issue: [LEMS-1906](https://khanacademy.atlassian.net/browse/LEMS-1906)

## Alternative

An alternative that seems to work: `.MafsView > svg { display: block; }`. Given the amount of spacing at the bottom, it looks suspiciously like this is `inline` spacing accidentally surfacing.

I'm actually leaning towards this solution. Curious what others think.


[LEMS-1906]: https://khanacademy.atlassian.net/browse/LEMS-1906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ