### PR TITLE
Add Styling Specific to Dragging a Movable Point

### DIFF
--- a/.changeset/dry-carrots-relax.md
+++ b/.changeset/dry-carrots-relax.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Adjust movable point style while dragging

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
@@ -30,7 +30,7 @@ export const StyledMovablePoint = (props: Props) => {
         onMove,
         constrain: (p) => snap(state.snapStep, p),
     });
-    const pointClasses = "movable-point" + (dragging ? " dragging" : "");
+    const pointClasses = `movable-point ${dragging ? "dragging" : ""}`;
 
     const [[x, y]] = useTransform(point);
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
@@ -30,7 +30,7 @@ export const StyledMovablePoint = (props: Props) => {
         onMove,
         constrain: (p) => snap(state.snapStep, p),
     });
-    const pointClasses = `movable-point ${dragging ? "dragging" : ""}`;
+    const pointClasses = `movable-point ${dragging ? "movable-point--dragging" : ""}`;
 
     const [[x, y]] = useTransform(point);
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
@@ -30,22 +30,16 @@ export const StyledMovablePoint = (props: Props) => {
         onMove,
         constrain: (p) => snap(state.snapStep, p),
     });
+    const pointClasses = "movable-point" + (dragging ? " dragging" : "");
 
     const [[x, y]] = useTransform(point);
 
     return (
         <g
             ref={hitboxRef}
-            className="movable-point"
+            className={pointClasses}
             tabIndex={0}
-            style={
-                {
-                    cursor: dragging ? "grabbing" : "grab",
-                    touchAction: "none",
-                    outline: "none",
-                    "--movable-point-color": color,
-                } as any
-            }
+            style={{"--movable-point-color": color} as any}
             data-test-id="movable-point"
         >
             <circle

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -65,11 +65,11 @@
     outline: none;
 }
 
-.MafsView .movable-point.dragging {
+.MafsView .movable-point.movable-point--dragging {
     cursor: grabbing;
 }
 
-.MafsView .movable-point.dragging .movable-point-halo {
+.MafsView .movable-point.movable-point--dragging .movable-point-halo {
     opacity: 0;
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -54,6 +54,23 @@
     stroke-width: 6px;
 }
 
+.MafsView .movable-point {
+    cursor: grab;
+    touch-action: none;
+    outline: none;
+}
+
+.MafsView .movable-point.dragging {
+    cursor: grabbing;
+}
+
+.MafsView .movable-point.dragging :is(
+        .movable-point-ring,
+        .movable-point-halo
+) {
+    opacity: 0;
+}
+
 .MafsView .movable-point-hitbox {
     fill: transparent;
 }
@@ -65,7 +82,7 @@
         .movable-point-halo,
         .movable-point-focus-outline
     ) {
-    transition: r 0.15s ease-out;
+    transition: r 0.15s ease-out, opacity 0.15s ease-out;
 }
 
 .MafsView .movable-point-center {

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -64,10 +64,7 @@
     cursor: grabbing;
 }
 
-.MafsView .movable-point.dragging :is(
-        .movable-point-ring,
-        .movable-point-halo
-) {
+.MafsView .movable-point.dragging .movable-point-halo {
     opacity: 0;
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -84,7 +84,9 @@
         .movable-point-halo,
         .movable-point-focus-outline
     ) {
-    transition: r 0.15s ease-out, opacity 0.15s ease-out;
+    transition:
+        r 0.15s ease-out,
+        opacity 0.15s ease-out;
 }
 
 .MafsView .movable-point-center {


### PR DESCRIPTION
## Summary:
Adjust cursor and point visuals to better convey that the point is being dragged.

Issue: LEMS-1894

## Test plan:

1. Run `yarn dev` to start a local test server
1. View the page (`http://localhost:5173/`)
   * Ensure that at least one graph type is selected in the "Mafs Flags" dropdown
1. Move your mouse to one of the movable points
   * Notice the hover state of the point (larger dot, halo and white ring adjust accordingly)
1. Click onto and drag the movable point to a new location
   * Notice that the halo is not visible, though the point is still larger (same as hover)
1. Release the mouse (no longer dragging or holding it down)
   * Notice the halo has returned (if still hovering)

## Affected Behavior

### Before:

https://github.com/Khan/perseus/assets/13896410/e79f441a-7c58-46c1-8472-d57f02a41e67

### After:

https://github.com/Khan/perseus/assets/13896410/9bbe5b66-1de7-472e-9f73-5923869fe4c7
