### PR TITLE
Change APIOptions' 'flags' field to be strongly typed

### DIFF
--- a/.changeset/ninety-chairs-add.md
+++ b/.changeset/ninety-chairs-add.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-dev-ui": patch
+"@khanacademy/perseus": patch
+---
+
+Change APIOptions.flags to be strongly typed

--- a/dev/gallery.tsx
+++ b/dev/gallery.tsx
@@ -10,6 +10,7 @@ import * as React from "react";
 import {useEffect, useMemo, useState} from "react";
 
 import {Renderer} from "../packages/perseus/src";
+import {MafsFlags} from "../packages/perseus/src/types";
 import * as grapher from "../packages/perseus/src/widgets/__testdata__/grapher.testdata";
 import * as interactiveGraph from "../packages/perseus/src/widgets/__testdata__/interactive-graph.testdata";
 import * as numberLine from "../packages/perseus/src/widgets/__testdata__/number-line.testdata";
@@ -76,6 +77,16 @@ const styles = StyleSheet.create({
     },
 });
 
+function capitalize(key: string): string {
+    return key
+        .split("-")
+        .map(
+            (word) =>
+                `${word.slice(0, 1).toLocaleUpperCase()}${word.slice(1).toLocaleLowerCase()}`,
+        )
+        .join(" ");
+}
+
 export function Gallery() {
     const ids = useUniqueIdWithMock();
     const params = useMemo(
@@ -85,7 +96,12 @@ export function Gallery() {
 
     const [isMobile, setIsMobile] = useState(params.get("mobile") === "true");
     const [mafsFlags, setMafsFlags] = useState<Array<string>>(
-        params.get("flags")?.split(",") || [],
+        params
+            .get("flags")
+            ?.split(",")
+            // We filter through the MafsFlags array to ensure we don't retain
+            // flags from the query string that don't actually exist anymore.
+            .filter((flag) => MafsFlags.includes(flag as any)) || [],
     );
     const [search, setSearch] = useState<string>(params.get("search") || "");
 
@@ -141,15 +157,13 @@ export function Gallery() {
                         onChange={setMafsFlags}
                         selectedValues={mafsFlags}
                     >
-                        <OptionItem value="segment" label="Segment" />
-                        <OptionItem value="linear" label="Linear" />
-                        <OptionItem
-                            value="linear-system"
-                            label="Linear System"
-                        />
-                        <OptionItem value="point" label="Point" />
-                        <OptionItem value="ray" label="Ray" />
-                        <OptionItem value="polygon" label="Polygon" />
+                        {MafsFlags.map((flag) => (
+                            <OptionItem
+                                key={flag}
+                                value={flag}
+                                label={capitalize(flag)}
+                            />
+                        ))}
                     </MultiSelect>
                     <Strut size={spacing.xSmall_8} />
                     <label htmlFor={flagsId}>Mafs Flags</label>

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -127,6 +127,19 @@ type TrackInteractionArgs = {
 } & Partial<TrackingGradedGroupExtraArguments> &
     Partial<TrackingSequenceExtraArguments>;
 
+export const MafsFlags = [
+    /** Enables the `segment` interactive-graph type.  */
+    "segment",
+    /** Enables the `linear` interactive-graph type.  */
+    "linear",
+    /** Enables the `linear-system` interactive-graph type.  */
+    "linear-system",
+    /** Enables the `ray` interactive-graph type.  */
+    "ray",
+    /** Enables the `polygon` interactive-graph type.  */
+    "polygon",
+] as const;
+
 /**
  * APIOptions provides different ways to customize the behaviour of Perseus.
  *
@@ -255,7 +268,14 @@ export type APIOptions = Readonly<{
      */
     editorChangeDelay?: number;
     /** Feature flags that can be passed from consuming application. */
-    flags?: Record<string, boolean | Record<string, boolean>>;
+    flags?: {
+        /**
+         * Flags related to the interactive-graph Mafs migration.
+         *
+         * Add values to the `MafsFlags` array to create new flags.
+         */
+        mafs?: false | {[Key in (typeof MafsFlags)[number]]?: boolean};
+    };
     /**
      * This is a callback function that returns all of the Widget props
      * after they have been transformed by the widget's transform function.


### PR DESCRIPTION
## Summary:

We recently introduced feature flags into Perseus via `APIOptions`. These flags were originally loosely typed with the `Record<>` type, but this is problematic for a few reasons:

  1. The host application does not know what flags are supported (or that the structure is nested)
  2. The host has no way of knowing when a Perseus update drops support for a flag 
  3. Inside Pereus, there's no way of knowing what flags might be passed in, so typos can easily cause a flag not to be used. 

So, this PR changes the flags field to be strongly and explicitly typed. Adding flags should be relatively trivial (if it's a Mafs flag, just add the flag name to the `MafsFlags` array, otherwise add it as you would to any Typescript type)

Issue: "none"

## Test plan:

`yarn test`
`yarn tsc`