### PR TITLE
Bugfix: unable to select financial calculator in editor

### DIFF
--- a/.changeset/purple-sloths-occur.md
+++ b/.changeset/purple-sloths-occur.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Bugfix: allow selecting financial calculator options again

--- a/packages/perseus-editor/src/item-extras-editor.tsx
+++ b/packages/perseus-editor/src/item-extras-editor.tsx
@@ -9,11 +9,7 @@ type Props = PerseusAnswerArea & {
     onChange: (props: Partial<PerseusAnswerArea>) => void;
 };
 
-type State = {
-    financialCalculatorOptionsExpanded: boolean;
-};
-
-class ItemExtrasEditor extends React.Component<Props, State> {
+class ItemExtrasEditor extends React.Component<Props> {
     static defaultProps: PerseusAnswerArea = {
         calculator: false,
         chi2Table: false,
@@ -26,37 +22,12 @@ class ItemExtrasEditor extends React.Component<Props, State> {
         zTable: false,
     };
 
-    finCalcOptions: Array<boolean> = [];
-
-    state = {
-        financialCalculatorOptionsExpanded: false,
-    };
-
-    constructor(props: Props) {
-        super(props);
-
-        this.finCalcOptions = [
-            props.financialCalculatorMonthlyPayment,
-            props.financialCalculatorTotalAmount,
-            props.financialCalculatorTimeToPayOff,
-        ];
-
-        this.state = {
-            financialCalculatorOptionsExpanded: this.finCalcOptions.some(
-                (opt) => opt === true,
-            ),
-        };
-    }
-
-    componentDidUpdate(): void {
-        // If no financial calculator options are checked, uncheck the
-        // financial calculator option.
-        if (
-            this.state.financialCalculatorOptionsExpanded &&
-            !this.finCalcOptions.some((option) => option === true)
-        ) {
-            this.setState({financialCalculatorOptionsExpanded: false});
-        }
+    shouldShowFinancialCalculatorOptions() {
+        return (
+            this.props.financialCalculatorMonthlyPayment ||
+            this.props.financialCalculatorTotalAmount ||
+            this.props.financialCalculatorTimeToPayOff
+        );
     }
 
     serialize: () => PerseusAnswerArea = () => {
@@ -85,12 +56,8 @@ class ItemExtrasEditor extends React.Component<Props, State> {
                     <ItemExtraCheckbox
                         label="Show financial calculator:"
                         infoTip="This provides the student with the ability to view a financial calculator, e.g., for answering financial questions. Once checked, requires at least one of the three options below to be checked."
-                        checked={this.state.financialCalculatorOptionsExpanded}
+                        checked={this.shouldShowFinancialCalculatorOptions()}
                         onChange={(e) => {
-                            this.setState({
-                                financialCalculatorOptionsExpanded:
-                                    e.target.checked,
-                            });
                             // If the financial calculator is unchecked,
                             // these need to be reset. All checked by
                             // default.
@@ -105,7 +72,7 @@ class ItemExtrasEditor extends React.Component<Props, State> {
                         }}
                     />
 
-                    {this.state.financialCalculatorOptionsExpanded && (
+                    {this.shouldShowFinancialCalculatorOptions() && (
                         <>
                             <ItemExtraCheckbox
                                 label="Include monthly payment:"


### PR DESCRIPTION
## Summary:
This is mostly tests since it seems to have tripped us up a couple of times.

The core of the change is to remove component state and compute whether to show FinCalc options using props. That way state can't become stale (because it doesn't exist).

Issue: LEMS-1914

https://github.com/Khan/perseus/assets/16308368/0a1aa82b-bd45-4ca0-962c-ec3a4eeb1326

## Test plan:
- Go to the "Item Extras Editor" story: `/?path=/docs/perseus-editor-item-extras-editor--docs`
- Select "Show financial calculator"
  - Note the checkbox is checked
  - Note the child checkboxes are checked
- One-by-one deselect child checkboxes
  - Note "Show financial calculator" stays checked as long as a child is checked
  - Note "Show financial calculator" becomes unchecked when all children are unchecked