### PR TITLE
Update locked points in preparation for locked lines

### DIFF
--- a/.changeset/sweet-mugs-listen.md
+++ b/.changeset/sweet-mugs-listen.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+LockedPointSettings update: Allow toggleable points, refactor so that it's easy to add lines later

--- a/packages/perseus-editor/package.json
+++ b/packages/perseus-editor/package.json
@@ -32,6 +32,7 @@
         "@khanacademy/perseus-core": "1.4.2"
     },
     "devDependencies": {
+        "@khanacademy/wonder-blocks-accordion": "^1.2.16",
         "@khanacademy/wonder-blocks-button": "^6.2.8",
         "@khanacademy/wonder-blocks-clickable": "^4.1.0",
         "@khanacademy/wonder-blocks-core": "^6.3.1",
@@ -40,6 +41,7 @@
         "@khanacademy/wonder-blocks-i18n": "^2.0.2",
         "@khanacademy/wonder-blocks-icon": "4.0.1",
         "@khanacademy/wonder-blocks-icon-button": "^5.1.13",
+        "@khanacademy/wonder-blocks-switch": "^1.1.14",
         "@khanacademy/wonder-blocks-tokens": "^1.1.0",
         "@khanacademy/wonder-blocks-typography": "^2.1.10",
         "@khanacademy/wonder-stuff-core": "^1.5.1",
@@ -56,6 +58,7 @@
         "underscore": "^1.4.4"
     },
     "peerDependencies": {
+        "@khanacademy/wonder-blocks-accordion": "^1.2.16",
         "@khanacademy/wonder-blocks-button": "^6.2.8",
         "@khanacademy/wonder-blocks-clickable": "^4.1.0",
         "@khanacademy/wonder-blocks-core": "^6.3.1",
@@ -64,6 +67,7 @@
         "@khanacademy/wonder-blocks-i18n": "^2.0.2",
         "@khanacademy/wonder-blocks-icon": "4.0.1",
         "@khanacademy/wonder-blocks-icon-button": "^5.1.13",
+        "@khanacademy/wonder-blocks-switch": "^1.1.14",
         "@khanacademy/wonder-blocks-tokens": "^1.1.0",
         "@khanacademy/wonder-blocks-typography": "^2.1.10",
         "@khanacademy/wonder-stuff-core": "^1.5.1",

--- a/packages/perseus-editor/src/components/__stories__/color-circle.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/color-circle.stories.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+
+import ColorCircle from "../color-circle";
+
+import type {Meta} from "@storybook/react";
+
+export default {
+    title: "Perseus Editor/Components/Color Circle",
+    component: ColorCircle,
+} as Meta<typeof ColorCircle>;
+
+export const Default = (args): React.ReactElement => {
+    return <ColorCircle {...args} />;
+};
+
+// Set the default values in the control panel.
+Default.args = {
+    color: "blue",
+    filled: true,
+};

--- a/packages/perseus-editor/src/components/__stories__/color-select.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/color-select.stories.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+
+import ColorSelect from "../color-select";
+
+import type {Meta} from "@storybook/react";
+
+export default {
+    title: "Perseus Editor/Components/Color Select",
+    component: ColorSelect,
+} as Meta<typeof ColorSelect>;
+
+export const Default = (args): React.ReactElement => {
+    return <ColorSelect {...args} />;
+};
+
+// Set the default values in the control panel.
+Default.args = {
+    id: "color-select",
+    selectedValue: "blue",
+    onChange: () => {},
+};
+
+export const Controlled = {
+    render: function Render() {
+        const [selectedValue, setSelectedValue] = React.useState("blue");
+
+        return (
+            <ColorSelect
+                id="color-select"
+                selectedValue={selectedValue}
+                onChange={setSelectedValue}
+            />
+        );
+    },
+};

--- a/packages/perseus-editor/src/components/__stories__/color-select.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/color-select.stories.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import ColorSelect from "../color-select";
 
 import type {Meta} from "@storybook/react";
+import {LockedFigure, LockedFigureColor} from "@khanacademy/perseus";
 
 export default {
     title: "Perseus Editor/Components/Color Select",
@@ -17,18 +18,24 @@ export const Default = (args): React.ReactElement => {
 Default.args = {
     id: "color-select",
     selectedValue: "blue",
-    onChange: () => {},
+    onChange: (color: LockedFigureColor) => {},
 };
 
 export const Controlled = {
     render: function Render() {
-        const [selectedValue, setSelectedValue] = React.useState("blue");
+        const [selectedValue, setSelectedValue] = React.useState(
+            "blue" as LockedFigureColor,
+        );
+
+        const handleColorChange = (color: LockedFigureColor) => {
+            setSelectedValue(color);
+        }
 
         return (
             <ColorSelect
                 id="color-select"
                 selectedValue={selectedValue}
-                onChange={setSelectedValue}
+                onChange={handleColorChange}
             />
         );
     },

--- a/packages/perseus-editor/src/components/__stories__/color-select.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/color-select.stories.tsx
@@ -2,8 +2,8 @@ import * as React from "react";
 
 import ColorSelect from "../color-select";
 
+import type {LockedFigureColor} from "@khanacademy/perseus";
 import type {Meta} from "@storybook/react";
-import {LockedFigure, LockedFigureColor} from "@khanacademy/perseus";
 
 export default {
     title: "Perseus Editor/Components/Color Select",
@@ -29,7 +29,7 @@ export const Controlled = {
 
         const handleColorChange = (color: LockedFigureColor) => {
             setSelectedValue(color);
-        }
+        };
 
         return (
             <ColorSelect

--- a/packages/perseus-editor/src/components/__stories__/locked-point-settings.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/locked-point-settings.stories.tsx
@@ -1,0 +1,76 @@
+import * as React from "react";
+
+import LockedPointSettings from "../locked-point-settings";
+import {getDefaultFigureForType} from "../util";
+
+import type {Meta, StoryObj} from "@storybook/react";
+
+export default {
+    title: "Perseus Editor/Components/Locked Point Settings",
+    component: LockedPointSettings,
+} as Meta<typeof LockedPointSettings>;
+
+export const Default = (args): React.ReactElement => {
+    return <LockedPointSettings {...args} />;
+};
+
+type StoryComponentType = StoryObj<typeof LockedPointSettings>;
+
+// Set the default values in the control panel.
+Default.args = {
+    ...getDefaultFigureForType("point"),
+    onChangeProps: () => {},
+};
+
+export const Controlled: StoryComponentType = {
+    render: function Render() {
+        const [props, setProps] = React.useState(
+            getDefaultFigureForType("point"),
+        );
+
+        const handlePropsUpdate = (newProps) => {
+            setProps({
+                ...props,
+                ...newProps,
+            });
+        };
+
+        return (
+            <LockedPointSettings {...props} onChangeProps={handlePropsUpdate} />
+        );
+    },
+};
+
+/**
+ * In some cases, the locked point may be shown or hidden from the graph,
+ * such as when the point is used to define a locked line.
+ *
+ * Use `onToggle` and `toggled` to update the visibility of the locked point.
+ * When `onToggled` is passed in, a switch will be rendered to allow
+ * toggling the point, which will then show/hide the relevant properties
+ * for the locked point.
+ */
+export const Toggleable: StoryComponentType = {
+    render: function Render() {
+        const [toggled, setToggled] = React.useState(true);
+        const [props, setProps] = React.useState(
+            getDefaultFigureForType("point"),
+        );
+
+        const handlePropsUpdate = (newProps) => {
+            setProps({
+                ...props,
+                ...newProps,
+            });
+        };
+
+        return (
+            <LockedPointSettings
+                {...props}
+                onChangeProps={handlePropsUpdate}
+                toggled={toggled}
+                onToggle={setToggled}
+            />
+        );
+    },
+};

--- a/packages/perseus-editor/src/components/__tests__/locked-point-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-point-settings.test.tsx
@@ -1,0 +1,174 @@
+import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
+import {render, screen} from "@testing-library/react";
+import * as React from "react";
+
+import LockedPointSettings from "../locked-point-settings";
+import {getDefaultFigureForType} from "../util";
+
+describe("LockedPointSettings", () => {
+    test("Should show the point's coordinates and color by default", () => {
+        // Arrange
+
+        // Act
+        render(
+            <LockedPointSettings
+                {...getDefaultFigureForType("point")}
+                onChangeProps={() => {}}
+            />,
+            {wrapper: RenderStateRoot},
+        );
+
+        const titleText = screen.getByText("Point (0, 0)");
+        const colorCircle = screen.getByLabelText("Point color: blue, filled");
+
+        // Assert
+        expect(titleText).toBeInTheDocument();
+        expect(colorCircle).toBeInTheDocument();
+    });
+
+    test("Should not show the color in summary if toggled off", () => {
+        // Arrange
+
+        // Act
+        render(
+            <LockedPointSettings
+                {...getDefaultFigureForType("point")}
+                onChangeProps={() => {}}
+                toggled={false}
+                onToggle={() => {}}
+            />,
+            {wrapper: RenderStateRoot},
+        );
+
+        const titleText = screen.getByText("Point (0, 0)");
+        const colorCircle = screen.queryByLabelText(
+            "Point color: blue, filled",
+        );
+
+        // Assert
+        expect(titleText).toBeInTheDocument();
+        expect(colorCircle).not.toBeInTheDocument();
+    });
+
+    test("Should show toggle switch if onToggle is passed in", () => {
+        // Arrange
+
+        // Act
+        render(
+            <LockedPointSettings
+                {...getDefaultFigureForType("point")}
+                onChangeProps={() => {}}
+                onToggle={() => {}}
+            />,
+            {wrapper: RenderStateRoot},
+        );
+
+        const toggleSwitch = screen.getByLabelText("Show point on graph");
+
+        // Assert
+        expect(toggleSwitch).toBeInTheDocument();
+    });
+
+    test("Toggle switch should match toggled prop when true", () => {
+        // Arrange
+
+        // Act
+        render(
+            <LockedPointSettings
+                {...getDefaultFigureForType("point")}
+                onChangeProps={() => {}}
+                toggled={true}
+                onToggle={() => {}}
+            />,
+            {wrapper: RenderStateRoot},
+        );
+
+        const toggleSwitch = screen.getByLabelText("Show point on graph");
+
+        // Assert
+        expect(toggleSwitch).toBeChecked();
+    });
+
+    test("Toggle switch should match toggled prop when false", () => {
+        // Arrange
+
+        // Act
+        render(
+            <LockedPointSettings
+                {...getDefaultFigureForType("point")}
+                onChangeProps={() => {}}
+                toggled={false}
+                onToggle={() => {}}
+            />,
+            {wrapper: RenderStateRoot},
+        );
+
+        const toggleSwitch = screen.getByLabelText("Show point on graph");
+
+        // Assert
+        expect(toggleSwitch).not.toBeChecked();
+    });
+
+    test("Should show extra fields if toggled on", () => {
+        // Arrange
+
+        // Act
+        render(
+            <LockedPointSettings
+                {...getDefaultFigureForType("point")}
+                onChangeProps={() => {}}
+                toggled={true}
+                onToggle={() => {}}
+            />,
+            {wrapper: RenderStateRoot},
+        );
+
+        const colorSelect = screen.getByLabelText("Color");
+        const openCheckbox = screen.getByLabelText("Open point");
+
+        // Assert
+        expect(colorSelect).toBeInTheDocument();
+        expect(openCheckbox).toBeInTheDocument();
+    });
+
+    test("Should not show extra fields if toggled off", () => {
+        // Arrange
+
+        // Act
+        render(
+            <LockedPointSettings
+                {...getDefaultFigureForType("point")}
+                onChangeProps={() => {}}
+                toggled={false}
+                onToggle={() => {}}
+            />,
+            {wrapper: RenderStateRoot},
+        );
+
+        const colorSelect = screen.queryByLabelText("Color");
+        const openCheckbox = screen.queryByLabelText("Open point");
+
+        // Assert
+        expect(colorSelect).not.toBeInTheDocument();
+        expect(openCheckbox).not.toBeInTheDocument();
+    });
+
+    test("Summary should reflect the coordinates", () => {
+        // Arrange
+
+        // Act
+        render(
+            <LockedPointSettings
+                {...getDefaultFigureForType("point")}
+                coord={[23, 45]}
+                onChangeProps={() => {}}
+            />,
+            {wrapper: RenderStateRoot},
+        );
+
+        const titleText = screen.getByText("Point (23, 45)");
+
+        // Assert
+        expect(titleText).toBeInTheDocument();
+    });
+});

--- a/packages/perseus-editor/src/components/__tests__/locked-point-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-point-settings.test.tsx
@@ -19,7 +19,7 @@ describe("LockedPointSettings", () => {
         );
 
         const titleText = screen.getByText("Point (0, 0)");
-        const colorCircle = screen.getByLabelText("Point color: blue, filled");
+        const colorCircle = screen.getByLabelText("Color: blue, filled");
 
         // Assert
         expect(titleText).toBeInTheDocument();

--- a/packages/perseus-editor/src/components/__tests__/util.test.ts
+++ b/packages/perseus-editor/src/components/__tests__/util.test.ts
@@ -1,4 +1,4 @@
-import {getValidNumberFromString, getDefaultFigureForFigureType} from "../util";
+import {getValidNumberFromString, getDefaultFigureForType} from "../util";
 
 describe("getValidNumberFromString", () => {
     test("should return a number from a string", () => {
@@ -34,9 +34,14 @@ describe("getValidNumberFromString", () => {
     });
 });
 
-describe("getDefaultFigureForFigureType", () => {
+describe("getDefaultFigureForType", () => {
     test("should return a point with default coordinates", () => {
-        const figure = getDefaultFigureForFigureType("point");
-        expect(figure).toEqual({type: "point", coord: [0, 0]});
+        const figure = getDefaultFigureForType("point");
+        expect(figure).toEqual({
+            type: "point",
+            coord: [0, 0],
+            color: "blue",
+            filled: true,
+        });
     });
 });

--- a/packages/perseus-editor/src/components/color-circle.tsx
+++ b/packages/perseus-editor/src/components/color-circle.tsx
@@ -1,8 +1,7 @@
-import * as React from "react";
-import {StyleSheet} from "aphrodite";
-
 import {View} from "@khanacademy/wonder-blocks-core";
 import {color as wbColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {StyleSheet} from "aphrodite";
+import * as React from "react";
 
 type Props = {
     color: string;

--- a/packages/perseus-editor/src/components/color-circle.tsx
+++ b/packages/perseus-editor/src/components/color-circle.tsx
@@ -8,14 +8,20 @@ import type {LockedFigureColor} from "@khanacademy/perseus";
 type Props = {
     color: LockedFigureColor;
     filled?: boolean;
+    decorative?: boolean;
 };
 
 const ColorCircle = (props: Props) => {
-    const {color, filled = true} = props;
+    const {color, filled = true, decorative = false} = props;
 
     return (
         <View
-            aria-label={`Color: ${color}, ${filled ? "filled" : "open"}`}
+            aria-label={
+                // Don't include an aria label for decorative circles.
+                !decorative
+                    ? `Color: ${color}, ${filled ? "filled" : "open"}`
+                    : undefined
+            }
             style={[
                 styles.colorCircle,
                 {

--- a/packages/perseus-editor/src/components/color-circle.tsx
+++ b/packages/perseus-editor/src/components/color-circle.tsx
@@ -3,8 +3,10 @@ import {color as wbColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
+import type {LockedFigureColor} from "@khanacademy/perseus";
+
 type Props = {
-    color: string;
+    color: LockedFigureColor;
     filled?: boolean;
 };
 

--- a/packages/perseus-editor/src/components/color-circle.tsx
+++ b/packages/perseus-editor/src/components/color-circle.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import {StyleSheet} from "aphrodite";
+
+import {View} from "@khanacademy/wonder-blocks-core";
+import {color as wbColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+
+type Props = {
+    color: string;
+    filled?: boolean;
+};
+
+const ColorCircle = (props: Props) => {
+    const {color, filled = true} = props;
+
+    return (
+        <View
+            aria-label={`Color: ${color}, ${filled ? "filled" : "open"}`}
+            style={[
+                styles.colorCircle,
+                {
+                    border: `4px solid ${wbColor[color]}`,
+                    backgroundColor: filled ? wbColor[color] : wbColor.white,
+                },
+            ]}
+        />
+    );
+};
+
+const styles = StyleSheet.create({
+    colorCircle: {
+        // Add a white outline so that the color circle is visible when
+        // the dropdown option is highlighted with its blue background.
+        outline: `2px solid ${wbColor.offWhite}`,
+        borderRadius: "50%",
+        width: spacing.large_24,
+        height: spacing.large_24,
+    },
+});
+
+export default ColorCircle;

--- a/packages/perseus-editor/src/components/color-select.tsx
+++ b/packages/perseus-editor/src/components/color-select.tsx
@@ -1,11 +1,10 @@
-import * as React from "react";
-import {StyleSheet} from "aphrodite";
-
 import {lockedFigureColors} from "@khanacademy/perseus";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
-import {color as wbColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
+import {StyleSheet} from "aphrodite";
+import * as React from "react";
 
 import ColorCircle from "./color-circle";
 

--- a/packages/perseus-editor/src/components/color-select.tsx
+++ b/packages/perseus-editor/src/components/color-select.tsx
@@ -8,10 +8,12 @@ import * as React from "react";
 
 import ColorCircle from "./color-circle";
 
+import type {LockedFigureColor} from "@khanacademy/perseus";
+
 type Props = {
     // Required ID so that the label can be associated with the select.
     id: string;
-    selectedValue: string;
+    selectedValue: LockedFigureColor;
     onChange: (newValue: string) => void;
 };
 

--- a/packages/perseus-editor/src/components/color-select.tsx
+++ b/packages/perseus-editor/src/components/color-select.tsx
@@ -37,7 +37,9 @@ const ColorSelect = (props: Props) => {
                         key={colorName}
                         value={colorName}
                         label={colorName}
-                        leftAccessory={<ColorCircle color={colorName} />}
+                        leftAccessory={
+                            <ColorCircle color={colorName} decorative={true} />
+                        }
                     >
                         {colorName}
                     </OptionItem>

--- a/packages/perseus-editor/src/components/color-select.tsx
+++ b/packages/perseus-editor/src/components/color-select.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+import {StyleSheet} from "aphrodite";
+
+import {lockedFigureColors} from "@khanacademy/perseus";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
+import {color as wbColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
+
+import ColorCircle from "./color-circle";
+
+type Props = {
+    // Required ID so that the label can be associated with the select.
+    id: string;
+    selectedValue: string;
+    onChange: (newValue: string) => void;
+};
+
+const ColorSelect = (props: Props) => {
+    const {id, selectedValue, onChange} = props;
+
+    return (
+        <View style={styles.row}>
+            <LabelMedium htmlFor={id} style={styles.label} tag="label">
+                Color
+            </LabelMedium>
+            <SingleSelect
+                id={id}
+                selectedValue={selectedValue}
+                onChange={onChange}
+                // Placeholder is required, but never gets used.
+                placeholder=""
+            >
+                {lockedFigureColors.map((colorName) => (
+                    <OptionItem
+                        key={colorName}
+                        value={colorName}
+                        label={colorName}
+                        leftAccessory={<ColorCircle color={colorName} />}
+                    >
+                        {colorName}
+                    </OptionItem>
+                ))}
+            </SingleSelect>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    row: {
+        flexDirection: "row",
+        alignItems: "center",
+    },
+    label: {
+        marginInlineEnd: spacing.xSmall_8,
+    },
+});
+
+export default ColorSelect;

--- a/packages/perseus-editor/src/components/locked-figure-select.tsx
+++ b/packages/perseus-editor/src/components/locked-figure-select.tsx
@@ -21,7 +21,10 @@ const LockedFigureSelect = (props: Props) => {
 
     return (
         <View style={styles.container}>
-            <ActionMenu menuText="Add element" style={styles.addElementSelect}>
+            <ActionMenu
+                menuText="Add locked figure"
+                style={styles.addElementSelect}
+            >
                 {[
                     <ActionItem
                         key={`${id}-point`}

--- a/packages/perseus-editor/src/components/locked-figures-section.tsx
+++ b/packages/perseus-editor/src/components/locked-figures-section.tsx
@@ -10,7 +10,7 @@ import * as React from "react";
 
 import LockedFigureSelect from "./locked-figure-select";
 import LockedFigureSettings from "./locked-figure-settings";
-import {getDefaultFigureForFigureType} from "./util";
+import {getDefaultFigureForType} from "./util";
 
 import type {Props as InteractiveGraphEditorProps} from "../widgets/interactive-graph-editor";
 import type {LockedFigure, LockedFigureType} from "@khanacademy/perseus";
@@ -29,7 +29,7 @@ const LockedFiguresSection = (props: Props) => {
         const newProps = {
             lockedFigures: [
                 ...lockedFigures,
-                getDefaultFigureForFigureType(newFigure),
+                getDefaultFigureForType(newFigure),
             ],
         };
         onChange(newProps);
@@ -45,38 +45,19 @@ const LockedFiguresSection = (props: Props) => {
         });
     }
 
-    function changeCoord(index: number, coord: [number, number]) {
+    function changeProps(index: number, newProps: Partial<LockedFigure>) {
         const lockedFigures = figures || [];
-        const newProps = {
+        const newFigures = {
             lockedFigures: [
                 ...lockedFigures.slice(0, index),
                 {
                     ...lockedFigures[index],
-                    coord,
+                    ...newProps,
                 },
                 ...lockedFigures.slice(index + 1),
             ],
         };
-        onChange(newProps);
-    }
-
-    function changeColor(index: number, colorName: string) {
-        const lockedFigures = figures || [];
-        const newProps = {
-            lockedFigures: [
-                ...lockedFigures.slice(0, index),
-                {
-                    ...lockedFigures[index],
-                    style: {
-                        ...lockedFigures[index].style,
-                        fill: colorName,
-                        stroke: colorName,
-                    },
-                },
-                ...lockedFigures.slice(index + 1),
-            ],
-        };
-        onChange(newProps);
+        onChange(newFigures);
     }
 
     return (
@@ -85,8 +66,7 @@ const LockedFiguresSection = (props: Props) => {
                 <LockedFigureSettings
                     key={`${uniqueId}-locked-${figure}-${index}`}
                     {...figure}
-                    onChangeColor={(color) => changeColor(index, color)}
-                    onChangeCoord={(coord) => changeCoord(index, coord)}
+                    onChangeProps={(newProps) => changeProps(index, newProps)}
                     onRemove={() => removeLockedFigure(index)}
                 />
             ))}

--- a/packages/perseus-editor/src/components/locked-point-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-point-settings.tsx
@@ -4,10 +4,8 @@
  *
  * Used in the interactive graph editor's locked figures section.
  */
-import {lockedFigureColors} from "@khanacademy/perseus";
 import {AccordionSection} from "@khanacademy/wonder-blocks-accordion";
 import {View, useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
-import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
 import {Checkbox, TextField} from "@khanacademy/wonder-blocks-form";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
@@ -22,6 +20,8 @@ import {getValidNumberFromString} from "./util";
 
 import type {LockedPointType} from "@khanacademy/perseus";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
+import ColorCircle from "./color-circle";
+import ColorSelect from "./color-select";
 
 export type Props = LockedPointType & {
     label?: string;
@@ -36,7 +36,7 @@ const LockedPointSettings = (props: Props) => {
     const {
         coord,
         color: pointColor,
-        filled = "true",
+        filled = true,
         label,
         toggled = "true",
         style,
@@ -94,23 +94,12 @@ const LockedPointSettings = (props: Props) => {
                 style={[styles.container, style]}
                 headerStyle={styles.accordionHeader}
                 header={
+                    // Summary: Point, coords, color (filled/open)
                     <View style={styles.row}>
                         <LabelLarge>{`${label || "Point"} (${coord[0]}, ${coord[1]})`}</LabelLarge>
                         <Strut size={spacing.xSmall_8} />
                         {toggled && (
-                            <View
-                                aria-label={`Point color: ${pointColor}, ${filled ? "filled" : "open"}`}
-                                style={[
-                                    styles.colorCircle,
-                                    styles.spaceStart,
-                                    {
-                                        border: `4px solid ${wbColor[pointColor]}`,
-                                        backgroundColor: filled
-                                            ? wbColor[pointColor]
-                                            : wbColor.white,
-                                    },
-                                ]}
-                            />
+                            <ColorCircle color={pointColor} filled={filled} />
                         )}
                     </View>
                 }
@@ -137,9 +126,7 @@ const LockedPointSettings = (props: Props) => {
                                 style={styles.textField}
                             />
                         </View>
-
                         <Strut size={spacing.medium_16} />
-
                         <View style={[styles.row, styles.spaceUnder]}>
                             <LabelMedium
                                 htmlFor={yCoordId}
@@ -161,6 +148,7 @@ const LockedPointSettings = (props: Props) => {
                         </View>
                     </View>
 
+                    {/* Toggle switch */}
                     {onToggle && (
                         <View style={[styles.row, styles.spaceUnder]}>
                             <Switch
@@ -181,46 +169,12 @@ const LockedPointSettings = (props: Props) => {
                     {/* Toggleable section */}
                     {toggled && (
                         <>
-                            {/* Color */}
-                            <View style={[styles.row, styles.spaceUnder]}>
-                                <LabelMedium
-                                    htmlFor={colorSelectId}
-                                    style={styles.label}
-                                    tag="label"
-                                >
-                                    Color
-                                </LabelMedium>
-                                <SingleSelect
-                                    id={colorSelectId}
-                                    selectedValue={pointColor || "blue"}
-                                    onChange={handleColorChange}
-                                    // Placeholder is required, but never gets used.
-                                    placeholder=""
-                                >
-                                    {lockedFigureColors.map((colorName) => (
-                                        <OptionItem
-                                            key={colorName}
-                                            value={colorName}
-                                            label={colorName}
-                                            leftAccessory={
-                                                <View
-                                                    style={[
-                                                        styles.colorCircle,
-                                                        {
-                                                            backgroundColor:
-                                                                wbColor[
-                                                                    colorName
-                                                                ],
-                                                        },
-                                                    ]}
-                                                />
-                                            }
-                                        >
-                                            {colorName}
-                                        </OptionItem>
-                                    ))}
-                                </SingleSelect>
-                            </View>
+                            <ColorSelect
+                                id={colorSelectId}
+                                selectedValue={pointColor || "blue"}
+                                onChange={handleColorChange}
+                            />
+                            <Strut size={spacing.xSmall_8} />
                             <Checkbox
                                 label="Open point"
                                 checked={!filled}
@@ -232,6 +186,7 @@ const LockedPointSettings = (props: Props) => {
                         </>
                     )}
 
+                    {/* Delete icon */}
                     {onRemove && (
                         <IconButton
                             icon={trashIcon}

--- a/packages/perseus-editor/src/components/locked-point-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-point-settings.tsx
@@ -84,9 +84,10 @@ const LockedPointSettings = (props: Props) => {
 
     return (
         <View
-        // More specificity so that we can override the default
-        // universal styles from the .less file.
-        className="locked-figure-accordion">
+            // More specificity so that we can override the default
+            // universal styles from the .less file.
+            className="locked-figure-accordion"
+        >
             <AccordionSection
                 style={[styles.container, style]}
                 headerStyle={styles.accordionHeader}

--- a/packages/perseus-editor/src/components/locked-point-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-point-settings.tsx
@@ -16,12 +16,12 @@ import trashIcon from "@phosphor-icons/core/bold/trash-bold.svg";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
+import ColorCircle from "./color-circle";
+import ColorSelect from "./color-select";
 import {getValidNumberFromString} from "./util";
 
 import type {LockedPointType} from "@khanacademy/perseus";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
-import ColorCircle from "./color-circle";
-import ColorSelect from "./color-select";
 
 export type Props = LockedPointType & {
     label?: string;
@@ -230,14 +230,6 @@ const styles = StyleSheet.create({
     },
     textField: {
         width: spacing.xxxLarge_64,
-    },
-    colorCircle: {
-        // Add a white outline so that the color circle is visible when
-        // the dropdown option is highlighted with its blue background.
-        outline: `2px solid ${wbColor.offWhite}`,
-        borderRadius: "50%",
-        width: spacing.large_24,
-        height: spacing.large_24,
     },
     deleteButton: {
         position: "absolute",

--- a/packages/perseus-editor/src/components/locked-point-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-point-settings.tsx
@@ -4,6 +4,7 @@
  *
  * Used in the interactive graph editor's locked figures section.
  */
+import {lockedFigureColors} from "@khanacademy/perseus";
 import {AccordionSection} from "@khanacademy/wonder-blocks-accordion";
 import {View, useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
@@ -17,7 +18,7 @@ import trashIcon from "@phosphor-icons/core/bold/trash-bold.svg";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
-import {getValidNumberFromString, possibleColors} from "./util";
+import {getValidNumberFromString} from "./util";
 
 import type {LockedPointType} from "@khanacademy/perseus";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
@@ -85,7 +86,8 @@ const LockedPointSettings = (props: Props) => {
     return (
         <View
             // More specificity so that we can override the default
-            // universal styles from the .less file.
+            // .heading > h2 > .header styles from the articles.less
+            // file (which is imported in perseus-renderer.less).
             className="locked-figure-accordion"
         >
             <AccordionSection
@@ -195,7 +197,7 @@ const LockedPointSettings = (props: Props) => {
                                     // Placeholder is required, but never gets used.
                                     placeholder=""
                                 >
-                                    {possibleColors.map((colorName) => (
+                                    {lockedFigureColors.map((colorName) => (
                                         <OptionItem
                                             key={colorName}
                                             value={colorName}

--- a/packages/perseus-editor/src/components/locked-point-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-point-settings.tsx
@@ -83,153 +83,163 @@ const LockedPointSettings = (props: Props) => {
     }
 
     return (
-        <AccordionSection
-            style={[styles.container, style]}
-            headerStyle={styles.accordionHeader}
-            header={
-                <View style={styles.row}>
-                    <LabelLarge>{`${label || "Point"} (${coord[0]}, ${coord[1]})`}</LabelLarge>
-                    <Strut size={spacing.xSmall_8} />
-                    {toggled && (
-                        <View
-                            aria-label={`Point color: ${pointColor}, ${filled ? "filled" : "open"}`}
-                            style={[
-                                styles.colorCircle,
-                                styles.spaceStart,
-                                {
-                                    border: `4px solid ${wbColor[pointColor]}`,
-                                    backgroundColor: filled
-                                        ? wbColor[pointColor]
-                                        : wbColor.white,
-                                },
-                            ]}
-                        />
-                    )}
-                </View>
-            }
-        >
-            <View style={styles.accordionPanel}>
-                {/* Coordinates */}
-                <View style={styles.row}>
-                    <View style={[styles.row, styles.spaceUnder]}>
-                        <LabelMedium
-                            htmlFor={xCoordId}
-                            style={styles.label}
-                            tag="label"
-                        >
-                            x Coord
-                        </LabelMedium>
-                        <TextField
-                            id={xCoordId}
-                            type="number"
-                            value={coordState[0]}
-                            onChange={(newValue) =>
-                                handleCoordChange(newValue, 0)
-                            }
-                            onBlur={handleBlur}
-                            style={styles.textField}
-                        />
+        <View
+        // More specificity so that we can override the default
+        // universal styles from the .less file.
+        className="locked-figure-accordion">
+            <AccordionSection
+                style={[styles.container, style]}
+                headerStyle={styles.accordionHeader}
+                header={
+                    <View style={styles.row}>
+                        <LabelLarge>{`${label || "Point"} (${coord[0]}, ${coord[1]})`}</LabelLarge>
+                        <Strut size={spacing.xSmall_8} />
+                        {toggled && (
+                            <View
+                                aria-label={`Point color: ${pointColor}, ${filled ? "filled" : "open"}`}
+                                style={[
+                                    styles.colorCircle,
+                                    styles.spaceStart,
+                                    {
+                                        border: `4px solid ${wbColor[pointColor]}`,
+                                        backgroundColor: filled
+                                            ? wbColor[pointColor]
+                                            : wbColor.white,
+                                    },
+                                ]}
+                            />
+                        )}
                     </View>
-
-                    <Strut size={spacing.medium_16} />
-
-                    <View style={[styles.row, styles.spaceUnder]}>
-                        <LabelMedium
-                            htmlFor={yCoordId}
-                            style={styles.label}
-                            tag="label"
-                        >
-                            y Coord
-                        </LabelMedium>
-                        <TextField
-                            id={yCoordId}
-                            type="number"
-                            value={coordState[1]}
-                            onChange={(newValue) =>
-                                handleCoordChange(newValue, 1)
-                            }
-                            onBlur={handleBlur}
-                            style={styles.textField}
-                        />
-                    </View>
-                </View>
-
-                {onToggle && (
-                    <View style={[styles.row, styles.spaceUnder]}>
-                        <Switch
-                            id={showPointToggleId}
-                            checked={!!toggled}
-                            onChange={onToggle}
-                        />
-                        <Strut size={spacing.small_12} />
-                        <LabelMedium tag="label" htmlFor={showPointToggleId}>
-                            Show point on graph
-                        </LabelMedium>
-                    </View>
-                )}
-
-                {/* Toggleable section */}
-                {toggled && (
-                    <>
-                        {/* Color */}
+                }
+            >
+                <View style={styles.accordionPanel}>
+                    {/* Coordinates */}
+                    <View style={styles.row}>
                         <View style={[styles.row, styles.spaceUnder]}>
                             <LabelMedium
-                                htmlFor={colorSelectId}
+                                htmlFor={xCoordId}
                                 style={styles.label}
                                 tag="label"
                             >
-                                Color
+                                x Coord
                             </LabelMedium>
-                            <SingleSelect
-                                id={colorSelectId}
-                                selectedValue={pointColor || "blue"}
-                                onChange={handleColorChange}
-                                // Placeholder is required, but never gets used.
-                                placeholder=""
-                            >
-                                {possibleColors.map((colorName) => (
-                                    <OptionItem
-                                        key={colorName}
-                                        value={colorName}
-                                        label={colorName}
-                                        leftAccessory={
-                                            <View
-                                                style={[
-                                                    styles.colorCircle,
-                                                    {
-                                                        backgroundColor:
-                                                            wbColor[colorName],
-                                                    },
-                                                ]}
-                                            />
-                                        }
-                                    >
-                                        {colorName}
-                                    </OptionItem>
-                                ))}
-                            </SingleSelect>
+                            <TextField
+                                id={xCoordId}
+                                type="number"
+                                value={coordState[0]}
+                                onChange={(newValue) =>
+                                    handleCoordChange(newValue, 0)
+                                }
+                                onBlur={handleBlur}
+                                style={styles.textField}
+                            />
                         </View>
-                        <Checkbox
-                            label="Open point"
-                            checked={!filled}
-                            onChange={(newValue) => {
-                                onChangeProps({filled: !newValue});
-                            }}
-                            style={styles.spaceUnder}
-                        />
-                    </>
-                )}
 
-                {onRemove && (
-                    <IconButton
-                        icon={trashIcon}
-                        aria-label={`Delete locked point at ${coordState[0]}, ${coordState[1]}`}
-                        onClick={onRemove}
-                        style={styles.deleteButton}
-                    />
-                )}
-            </View>
-        </AccordionSection>
+                        <Strut size={spacing.medium_16} />
+
+                        <View style={[styles.row, styles.spaceUnder]}>
+                            <LabelMedium
+                                htmlFor={yCoordId}
+                                style={styles.label}
+                                tag="label"
+                            >
+                                y Coord
+                            </LabelMedium>
+                            <TextField
+                                id={yCoordId}
+                                type="number"
+                                value={coordState[1]}
+                                onChange={(newValue) =>
+                                    handleCoordChange(newValue, 1)
+                                }
+                                onBlur={handleBlur}
+                                style={styles.textField}
+                            />
+                        </View>
+                    </View>
+
+                    {onToggle && (
+                        <View style={[styles.row, styles.spaceUnder]}>
+                            <Switch
+                                id={showPointToggleId}
+                                checked={!!toggled}
+                                onChange={onToggle}
+                            />
+                            <Strut size={spacing.small_12} />
+                            <LabelMedium
+                                tag="label"
+                                htmlFor={showPointToggleId}
+                            >
+                                Show point on graph
+                            </LabelMedium>
+                        </View>
+                    )}
+
+                    {/* Toggleable section */}
+                    {toggled && (
+                        <>
+                            {/* Color */}
+                            <View style={[styles.row, styles.spaceUnder]}>
+                                <LabelMedium
+                                    htmlFor={colorSelectId}
+                                    style={styles.label}
+                                    tag="label"
+                                >
+                                    Color
+                                </LabelMedium>
+                                <SingleSelect
+                                    id={colorSelectId}
+                                    selectedValue={pointColor || "blue"}
+                                    onChange={handleColorChange}
+                                    // Placeholder is required, but never gets used.
+                                    placeholder=""
+                                >
+                                    {possibleColors.map((colorName) => (
+                                        <OptionItem
+                                            key={colorName}
+                                            value={colorName}
+                                            label={colorName}
+                                            leftAccessory={
+                                                <View
+                                                    style={[
+                                                        styles.colorCircle,
+                                                        {
+                                                            backgroundColor:
+                                                                wbColor[
+                                                                    colorName
+                                                                ],
+                                                        },
+                                                    ]}
+                                                />
+                                            }
+                                        >
+                                            {colorName}
+                                        </OptionItem>
+                                    ))}
+                                </SingleSelect>
+                            </View>
+                            <Checkbox
+                                label="Open point"
+                                checked={!filled}
+                                onChange={(newValue) => {
+                                    onChangeProps({filled: !newValue});
+                                }}
+                                style={styles.spaceUnder}
+                            />
+                        </>
+                    )}
+
+                    {onRemove && (
+                        <IconButton
+                            icon={trashIcon}
+                            aria-label={`Delete locked point at ${coordState[0]}, ${coordState[1]}`}
+                            onClick={onRemove}
+                            style={styles.deleteButton}
+                        />
+                    )}
+                </View>
+            </AccordionSection>
+        </View>
     );
 };
 

--- a/packages/perseus-editor/src/components/locked-point-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-point-settings.tsx
@@ -4,39 +4,48 @@
  *
  * Used in the interactive graph editor's locked figures section.
  */
+import {AccordionSection} from "@khanacademy/wonder-blocks-accordion";
 import {View, useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
-import {TextField} from "@khanacademy/wonder-blocks-form";
+import {Checkbox, TextField} from "@khanacademy/wonder-blocks-form";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
-import {Spring} from "@khanacademy/wonder-blocks-layout";
-import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import Switch from "@khanacademy/wonder-blocks-switch";
+import {color as wbColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium, LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import trashIcon from "@phosphor-icons/core/bold/trash-bold.svg";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
-import {getValidNumberFromString} from "./util";
+import {getValidNumberFromString, possibleColors} from "./util";
 
-import type {LockedPoint} from "@khanacademy/perseus";
+import type {LockedPointType} from "@khanacademy/perseus";
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
-const possibleColors = [
-    "purple",
-    "blue",
-    "teal",
-    "green",
-    "gold",
-    "red",
-    "pink",
-];
-
-export type Props = LockedPoint & {
-    onRemove: () => void;
-    onChangeCoord: (coord: [number, number]) => void;
-    onChangeColor: (color: string) => void;
+export type Props = LockedPointType & {
+    label?: string;
+    toggled?: boolean;
+    style?: StyleType;
+    onRemove?: () => void;
+    onToggle?: (newValue) => void;
+    onChangeProps: (newProps: Partial<LockedPointType>) => void;
 };
 
 const LockedPointSettings = (props: Props) => {
-    const {coord, style, onChangeColor, onChangeCoord, onRemove} = props;
+    const {
+        coord,
+        color: pointColor,
+        filled = "true",
+        label,
+        toggled = "true",
+        style,
+        onChangeProps,
+        onToggle,
+        onRemove,
+    } = props;
+
+    // Keep track of the coordinates via state as the user is editing them,
+    // before they are updated in the props on blur.
     const [coordState, setCoordState] = React.useState([
         // Using strings to make it easier to work with the text fields.
         coord[0].toString(),
@@ -48,7 +57,8 @@ const LockedPointSettings = (props: Props) => {
     const ids = useUniqueIdWithMock();
     const xCoordId = ids.get("x-coord");
     const yCoordId = ids.get("y-coord");
-    const colorSelectId = ids.get("color-select");
+    const colorSelectId = ids.get("point-color-select");
+    const showPointToggleId = ids.get("show-point-toggle");
 
     function handleBlur() {
         const validCoord = [
@@ -59,7 +69,7 @@ const LockedPointSettings = (props: Props) => {
         // Make the text field only show valid numbers after blur.
         setCoordState([validCoord[0].toString(), validCoord[1].toString()]);
         // Update the graph with the new coordinates.
-        onChangeCoord(validCoord);
+        onChangeProps({coord: validCoord});
     }
 
     function handleCoordChange(newValue, coordIndex) {
@@ -68,105 +78,183 @@ const LockedPointSettings = (props: Props) => {
         setCoordState(newCoord);
     }
 
+    function handleColorChange(newValue) {
+        onChangeProps({color: newValue});
+    }
+
     return (
-        <View style={styles.container}>
-            {/* Title row */}
-            <View style={styles.row}>
-                <LabelLarge>Point</LabelLarge>
-                <Spring />
-                <IconButton
-                    icon={trashIcon}
-                    aria-label={`Delete locked point at ${coordState[0]}, ${coordState[1]}`}
-                    onClick={onRemove}
-                />
-            </View>
-
-            {/* Coordinates */}
-            <View>
+        <AccordionSection
+            style={[styles.container, style]}
+            headerStyle={styles.accordionHeader}
+            header={
                 <View style={styles.row}>
-                    <LabelMedium
-                        htmlFor={xCoordId}
-                        style={styles.label}
-                        tag="label"
-                    >
-                        x Coordinate
-                    </LabelMedium>
-                    <TextField
-                        id={xCoordId}
-                        value={coordState[0]}
-                        onChange={(newValue) => handleCoordChange(newValue, 0)}
-                        onBlur={handleBlur}
-                        style={styles.textField}
-                    />
+                    <LabelLarge>{`${label || "Point"} (${coord[0]}, ${coord[1]})`}</LabelLarge>
+                    <Strut size={spacing.xSmall_8} />
+                    {toggled && (
+                        <View
+                            aria-label={`Point color: ${pointColor}, ${filled ? "filled" : "open"}`}
+                            style={[
+                                styles.colorCircle,
+                                styles.spaceStart,
+                                {
+                                    border: `4px solid ${wbColor[pointColor]}`,
+                                    backgroundColor: filled
+                                        ? wbColor[pointColor]
+                                        : wbColor.white,
+                                },
+                            ]}
+                        />
+                    )}
                 </View>
-
+            }
+        >
+            <View style={styles.accordionPanel}>
+                {/* Coordinates */}
                 <View style={styles.row}>
-                    <LabelMedium
-                        htmlFor={yCoordId}
-                        style={styles.label}
-                        tag="label"
-                    >
-                        y Coordinate
-                    </LabelMedium>
-                    <TextField
-                        id={yCoordId}
-                        value={coordState[1]}
-                        onChange={(newValue) => handleCoordChange(newValue, 1)}
-                        onBlur={handleBlur}
-                        style={styles.textField}
-                    />
-                </View>
-            </View>
-
-            {/* Color */}
-            <View style={styles.row}>
-                <LabelMedium
-                    htmlFor={colorSelectId}
-                    style={styles.label}
-                    tag="label"
-                >
-                    Color
-                </LabelMedium>
-                <SingleSelect
-                    id={colorSelectId}
-                    selectedValue={style?.fill || "blue"}
-                    onChange={onChangeColor}
-                    // Placeholder is required, but never gets used.
-                    placeholder=""
-                >
-                    {possibleColors.map((colorName) => (
-                        <OptionItem
-                            key={colorName}
-                            value={colorName}
-                            label={colorName}
-                            leftAccessory={
-                                <View
-                                    style={[
-                                        styles.colorCircle,
-                                        {backgroundColor: color[colorName]},
-                                    ]}
-                                />
-                            }
+                    <View style={[styles.row, styles.spaceUnder]}>
+                        <LabelMedium
+                            htmlFor={xCoordId}
+                            style={styles.label}
+                            tag="label"
                         >
-                            {colorName}
-                        </OptionItem>
-                    ))}
-                </SingleSelect>
+                            x Coord
+                        </LabelMedium>
+                        <TextField
+                            id={xCoordId}
+                            type="number"
+                            value={coordState[0]}
+                            onChange={(newValue) =>
+                                handleCoordChange(newValue, 0)
+                            }
+                            onBlur={handleBlur}
+                            style={styles.textField}
+                        />
+                    </View>
+
+                    <Strut size={spacing.medium_16} />
+
+                    <View style={[styles.row, styles.spaceUnder]}>
+                        <LabelMedium
+                            htmlFor={yCoordId}
+                            style={styles.label}
+                            tag="label"
+                        >
+                            y Coord
+                        </LabelMedium>
+                        <TextField
+                            id={yCoordId}
+                            type="number"
+                            value={coordState[1]}
+                            onChange={(newValue) =>
+                                handleCoordChange(newValue, 1)
+                            }
+                            onBlur={handleBlur}
+                            style={styles.textField}
+                        />
+                    </View>
+                </View>
+
+                {onToggle && (
+                    <View style={[styles.row, styles.spaceUnder]}>
+                        <Switch
+                            id={showPointToggleId}
+                            checked={!!toggled}
+                            onChange={onToggle}
+                        />
+                        <Strut size={spacing.small_12} />
+                        <LabelMedium tag="label" htmlFor={showPointToggleId}>
+                            Show point on graph
+                        </LabelMedium>
+                    </View>
+                )}
+
+                {/* Toggleable section */}
+                {toggled && (
+                    <>
+                        {/* Color */}
+                        <View style={[styles.row, styles.spaceUnder]}>
+                            <LabelMedium
+                                htmlFor={colorSelectId}
+                                style={styles.label}
+                                tag="label"
+                            >
+                                Color
+                            </LabelMedium>
+                            <SingleSelect
+                                id={colorSelectId}
+                                selectedValue={pointColor || "blue"}
+                                onChange={handleColorChange}
+                                // Placeholder is required, but never gets used.
+                                placeholder=""
+                            >
+                                {possibleColors.map((colorName) => (
+                                    <OptionItem
+                                        key={colorName}
+                                        value={colorName}
+                                        label={colorName}
+                                        leftAccessory={
+                                            <View
+                                                style={[
+                                                    styles.colorCircle,
+                                                    {
+                                                        backgroundColor:
+                                                            wbColor[colorName],
+                                                    },
+                                                ]}
+                                            />
+                                        }
+                                    >
+                                        {colorName}
+                                    </OptionItem>
+                                ))}
+                            </SingleSelect>
+                        </View>
+                        <Checkbox
+                            label="Open point"
+                            checked={!filled}
+                            onChange={(newValue) => {
+                                onChangeProps({filled: !newValue});
+                            }}
+                            style={styles.spaceUnder}
+                        />
+                    </>
+                )}
+
+                {onRemove && (
+                    <IconButton
+                        icon={trashIcon}
+                        aria-label={`Delete locked point at ${coordState[0]}, ${coordState[1]}`}
+                        onClick={onRemove}
+                        style={styles.deleteButton}
+                    />
+                )}
             </View>
-        </View>
+        </AccordionSection>
     );
 };
 
 const styles = StyleSheet.create({
     container: {
-        backgroundColor: color.fadedBlue8,
-        marginBottom: spacing.xSmall_8,
+        backgroundColor: wbColor.fadedBlue8,
+        marginBottom: spacing.small_12,
+    },
+    accordionHeader: {
+        paddingTop: spacing.small_12,
+        paddingBottom: spacing.small_12,
+        paddingInlineStart: spacing.medium_16,
+        // Fixed height so the addition of the color circle doesn't
+        // change the height of the header when toggling.
+        height: spacing.xxLarge_48,
+    },
+    accordionPanel: {
         padding: spacing.medium_16,
-        borderRadius: spacing.xSmall_8,
+        paddingBottom: spacing.xSmall_8,
     },
     row: {
         flexDirection: "row",
         alignItems: "center",
+    },
+    spaceUnder: {
         marginBottom: spacing.xSmall_8,
     },
     label: {
@@ -176,12 +264,17 @@ const styles = StyleSheet.create({
         width: spacing.xxxLarge_64,
     },
     colorCircle: {
-        // Add a white border so that the color circle is visible when
+        // Add a white outline so that the color circle is visible when
         // the dropdown option is highlighted with its blue background.
-        border: `2px solid ${color.offWhite}`,
+        outline: `2px solid ${wbColor.offWhite}`,
         borderRadius: "50%",
         width: spacing.large_24,
         height: spacing.large_24,
+    },
+    deleteButton: {
+        position: "absolute",
+        top: spacing.small_12,
+        right: spacing.small_12,
     },
 });
 

--- a/packages/perseus-editor/src/components/util.ts
+++ b/packages/perseus-editor/src/components/util.ts
@@ -1,7 +1,7 @@
 import type {
     LockedFigure,
     LockedFigureType,
-    LockedPoint,
+    LockedPointType,
 } from "@khanacademy/perseus";
 
 export function focusWithChromeStickyFocusBugWorkaround(element: Element) {
@@ -49,14 +49,24 @@ export function getValidNumberFromString(value: string) {
     return isNaN(parsed) ? 0 : parsed;
 }
 
-export function getDefaultFigureForFigureType(
-    type: LockedFigureType,
-): LockedFigure {
+export function getDefaultFigureForType(type: LockedFigureType): LockedFigure {
     switch (type) {
         case "point":
             return {
                 type: "point",
                 coord: [0, 0],
-            } as LockedPoint;
+                color: "blue",
+                filled: true,
+            } as LockedPointType;
     }
 }
+
+export const possibleColors = [
+    "purple",
+    "blue",
+    "teal",
+    "green",
+    "gold",
+    "red",
+    "pink",
+];

--- a/packages/perseus-editor/src/components/util.ts
+++ b/packages/perseus-editor/src/components/util.ts
@@ -60,13 +60,3 @@ export function getDefaultFigureForType(type: LockedFigureType): LockedFigure {
             } as LockedPointType;
     }
 }
-
-export const possibleColors = [
-    "purple",
-    "blue",
-    "teal",
-    "green",
-    "gold",
-    "red",
-    "pink",
-];

--- a/packages/perseus-editor/src/widgets/__stories__/interactive-graph-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/interactive-graph-editor.stories.tsx
@@ -89,14 +89,14 @@ export const WithLockedPoints: StoryComponentType = {
                 {
                     type: "point",
                     coord: [1, 1],
+                    color: "blue",
+                    filled: true,
                 },
                 {
                     type: "point",
                     coord: [-1, -1],
-                    style: {
-                        stroke: "gold",
-                        fill: "gold",
-                    },
+                    color: "purple",
+                    filled: false,
                 },
             ],
         });

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
@@ -508,7 +508,7 @@ describe("InteractiveGraphEditor", () => {
         );
     });
 
-    test("Calls onChange when a locked figure is added", async () => {
+    test("Calls onChange when a locked point is added", async () => {
         // Arrange
         const onChangeMock = jest.fn();
 
@@ -521,7 +521,7 @@ describe("InteractiveGraphEditor", () => {
 
         // Act
         const addLockedFigureButton = screen.getByRole("button", {
-            name: "Add element",
+            name: "Add locked figure",
         });
         await userEvent.click(addLockedFigureButton);
         const addPointButton = screen.getByText("Point");
@@ -540,7 +540,7 @@ describe("InteractiveGraphEditor", () => {
         );
     });
 
-    test("Calls onChange when a locked figure is removed", async () => {
+    test("Calls onChange when a locked point is removed", async () => {
         // Arrange
         const onChangeMock = jest.fn();
 
@@ -548,7 +548,9 @@ describe("InteractiveGraphEditor", () => {
             <InteractiveGraphEditor
                 {...mafsProps}
                 onChange={onChangeMock}
-                lockedFigures={[{type: "point", coord: [0, 0]}]}
+                lockedFigures={[
+                    {type: "point", coord: [0, 0], color: "blue", filled: true},
+                ]}
             />,
             {
                 wrapper: RenderStateRoot,
@@ -569,7 +571,7 @@ describe("InteractiveGraphEditor", () => {
         );
     });
 
-    test("Calls onChange when a locked figure's coordinates are changed", async () => {
+    test("Calls onChange when a locked point's coordinates are changed", async () => {
         // Arrange
         const onChangeMock = jest.fn();
 
@@ -577,7 +579,9 @@ describe("InteractiveGraphEditor", () => {
             <InteractiveGraphEditor
                 {...mafsProps}
                 onChange={onChangeMock}
-                lockedFigures={[{type: "point", coord: [0, 0]}]}
+                lockedFigures={[
+                    {type: "point", coord: [0, 0], color: "blue", filled: true},
+                ]}
             />,
             {
                 wrapper: RenderStateRoot,
@@ -585,7 +589,7 @@ describe("InteractiveGraphEditor", () => {
         );
 
         // Act
-        const xCoordInput = screen.getByLabelText("x Coordinate");
+        const xCoordInput = screen.getByLabelText("x Coord");
         await userEvent.clear(xCoordInput);
         await userEvent.type(xCoordInput, "1");
         await userEvent.tab();
@@ -603,7 +607,7 @@ describe("InteractiveGraphEditor", () => {
         );
     });
 
-    test("Shows the locked figure settings when a locked figure is passed in", async () => {
+    test("Shows the locked point settings when a locked point is passed in", async () => {
         // Arrange
 
         // Act
@@ -611,7 +615,9 @@ describe("InteractiveGraphEditor", () => {
             <InteractiveGraphEditor
                 {...mafsProps}
                 onChange={() => {}}
-                lockedFigures={[{type: "point", coord: [0, 0]}]}
+                lockedFigures={[
+                    {type: "point", coord: [0, 0], color: "blue", filled: true},
+                ]}
             />,
             {
                 wrapper: RenderStateRoot,
@@ -619,9 +625,9 @@ describe("InteractiveGraphEditor", () => {
         );
 
         // Assert
-        expect(screen.getByText("Point")).toBeInTheDocument();
-        expect(screen.getByText("x Coordinate")).toBeInTheDocument();
-        expect(screen.getByText("y Coordinate")).toBeInTheDocument();
+        expect(screen.getByText("Point (0, 0)")).toBeInTheDocument();
+        expect(screen.getByText("x Coord")).toBeInTheDocument();
+        expect(screen.getByText("y Coord")).toBeInTheDocument();
         expect(
             screen.getByRole("button", {
                 name: "Delete locked point at 0, 0",
@@ -630,7 +636,7 @@ describe("InteractiveGraphEditor", () => {
         expect(screen.getByText("Color")).toBeInTheDocument();
     });
 
-    test("Calls onChange when a locked figure's color is changed", async () => {
+    test("Calls onChange when a locked point's color is changed", async () => {
         // Arrange
         const onChangeMock = jest.fn();
 
@@ -638,7 +644,9 @@ describe("InteractiveGraphEditor", () => {
             <InteractiveGraphEditor
                 {...mafsProps}
                 onChange={onChangeMock}
-                lockedFigures={[{type: "point", coord: [0, 0]}]}
+                lockedFigures={[
+                    {type: "point", coord: [0, 0], color: "blue", filled: true},
+                ]}
             />,
             {
                 wrapper: RenderStateRoot,
@@ -660,10 +668,46 @@ describe("InteractiveGraphEditor", () => {
                     expect.objectContaining({
                         type: "point",
                         coord: [0, 0],
-                        style: {
-                            stroke: "purple",
-                            fill: "purple",
-                        },
+                        color: "purple",
+                        filled: true,
+                    }),
+                ],
+            }),
+        );
+    });
+
+    test("Calls onChange when a locked point's `filled` is changed", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+
+        render(
+            <InteractiveGraphEditor
+                {...mafsProps}
+                onChange={onChangeMock}
+                lockedFigures={[
+                    {type: "point", coord: [0, 0], color: "blue", filled: true},
+                ]}
+            />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
+
+        // Act
+        const fillInput = screen.getByRole("checkbox", {
+            name: "Open point",
+        });
+        await userEvent.click(fillInput);
+
+        // Assert
+        expect(onChangeMock).toBeCalledWith(
+            expect.objectContaining({
+                lockedFigures: [
+                    expect.objectContaining({
+                        type: "point",
+                        coord: [0, 0],
+                        color: "blue",
+                        filled: false,
                     }),
                 ],
             }),

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
@@ -571,7 +571,7 @@ describe("InteractiveGraphEditor", () => {
         );
     });
 
-    test("Calls onChange when a locked point's coordinates are changed", async () => {
+    test("Calls onChange when a locked point's x coordinate is changed", async () => {
         // Arrange
         const onChangeMock = jest.fn();
 
@@ -601,6 +601,42 @@ describe("InteractiveGraphEditor", () => {
                     expect.objectContaining({
                         type: "point",
                         coord: [1, 0],
+                    }),
+                ],
+            }),
+        );
+    });
+
+    test("Calls onChange when a locked point's y coordinate is changed", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+
+        render(
+            <InteractiveGraphEditor
+                {...mafsProps}
+                onChange={onChangeMock}
+                lockedFigures={[
+                    {type: "point", coord: [0, 0], color: "blue", filled: true},
+                ]}
+            />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
+
+        // Act
+        const xCoordInput = screen.getByLabelText("y Coord");
+        await userEvent.clear(xCoordInput);
+        await userEvent.type(xCoordInput, "1");
+        await userEvent.tab();
+
+        // Assert
+        expect(onChangeMock).toBeCalledWith(
+            expect.objectContaining({
+                lockedFigures: [
+                    expect.objectContaining({
+                        type: "point",
+                        coord: [0, 1],
                     }),
                 ],
             }),

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
@@ -577,7 +577,7 @@ class InteractiveGraphEditor extends React.Component<Props> {
                 </LabeledRow>
                 {graph}
                 {
-                    // Only show the "Add element" dropdown if the graph is
+                    // Only show the "Add locked figure" dropdown if the graph is
                     // using Mafs.
                     this.props.graph &&
                         this.props.apiOptions?.flags?.["mafs"]?.[

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -64,6 +64,7 @@ export {
     PerseusExpressionAnswerFormConsidered,
     plotterPlotTypes,
     ItemExtras,
+    lockedFigureColors,
 } from "./perseus-types";
 export {traverse} from "./traversal";
 export {isItemRenderableByVersion} from "./renderability";

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -151,6 +151,7 @@ export type {
 export type {ParsedValue} from "./util";
 export type {
     LockedFigure,
+    LockedFigureColor,
     LockedFigureType,
     LockedPointType,
     PerseusGraphType,

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -151,7 +151,7 @@ export type {ParsedValue} from "./util";
 export type {
     LockedFigure,
     LockedFigureType,
-    LockedPoint,
+    LockedPointType,
     PerseusGraphType,
     PerseusAnswerArea,
     PerseusExpressionWidgetOptions,

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -654,16 +654,7 @@ export type PerseusInteractiveGraphWidgetOptions = {
     lockedFigures?: ReadonlyArray<LockedFigure>;
 };
 
-export type LockedFigure = LockedPointType;
-export type LockedFigureType = "point";
-
-export type LockedPointType = {
-    type: "point";
-    coord: Coord;
-    color: string;
-    filled: boolean;
-};
-export const lockedFigureColors = [
+export const lockedFigureColors: ReadonlyArray<LockedFigureColor> = [
     "purple",
     "blue",
     "teal",
@@ -672,6 +663,26 @@ export const lockedFigureColors = [
     "red",
     "pink",
 ];
+
+// export type LockedFigureColor = typeof lockedFigureColors[number];
+export type LockedFigureColor =
+    | "purple"
+    | "blue"
+    | "teal"
+    | "green"
+    | "gold"
+    | "red"
+    | "pink";
+
+export type LockedFigure = LockedPointType;
+export type LockedFigureType = "point";
+
+export type LockedPointType = {
+    type: "point";
+    coord: Coord;
+    color: LockedFigureColor;
+    filled: boolean;
+};
 
 export type PerseusGraphType =
     | PerseusGraphTypeAngle

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -663,6 +663,15 @@ export type LockedPointType = {
     color: string;
     filled: boolean;
 };
+export const lockedFigureColors = [
+    "purple",
+    "blue",
+    "teal",
+    "green",
+    "gold",
+    "red",
+    "pink",
+];
 
 export type PerseusGraphType =
     | PerseusGraphTypeAngle

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -10,11 +10,6 @@ export type Range = Interval;
 export type Size = [number, number];
 export type CollinearTuple = readonly [vec.Vector2, vec.Vector2];
 
-export type StyleParams = {
-    fill?: string;
-    stroke?: string;
-};
-
 // TODO(FEI-5054): Figure out how to get global .d.ts files working with monorepos
 type Empty = Record<never, never>;
 
@@ -659,13 +654,14 @@ export type PerseusInteractiveGraphWidgetOptions = {
     lockedFigures?: ReadonlyArray<LockedFigure>;
 };
 
-export type LockedFigure = LockedPoint;
+export type LockedFigure = LockedPointType;
 export type LockedFigureType = "point";
 
-export type LockedPoint = {
+export type LockedPointType = {
     type: "point";
     coord: Coord;
-    style?: StyleParams;
+    color: string;
+    filled: boolean;
 };
 
 export type PerseusGraphType =

--- a/packages/perseus/src/styles/perseus-renderer.less
+++ b/packages/perseus/src/styles/perseus-renderer.less
@@ -727,4 +727,10 @@
     }
 }
 
+.perseus-widget-editor-content .locked-figure-accordion h2 {
+    // Reset the padding that's added to article h2
+    // for the accordion h2.
+    padding-top: 0;
+}
+
 @import "../../../math-input/less/main.less";

--- a/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
@@ -200,7 +200,6 @@ export const linearQuestionWithDefaultCorrect: PerseusRenderer = {
     },
 };
 
-const bluePointStyle = {stroke: "#6494ed", fill: "#6494ed"};
 export const linearQuestionWithLockedPoints: PerseusRenderer = {
     content:
         "**Draw the line of reflection that will map $\\triangle{SIM}$ onto the other triangle below.**\n\n\n[[☃ interactive-graph 1]]",
@@ -226,17 +225,20 @@ export const linearQuestionWithLockedPoints: PerseusRenderer = {
                     {
                         type: "point",
                         coord: [5, 3],
-                        style: bluePointStyle,
+                        color: "blue",
+                        filled: true,
                     },
                     {
                         type: "point",
                         coord: [4, -4],
-                        style: bluePointStyle,
+                        color: "blue",
+                        filled: true,
                     },
                     {
                         type: "point",
                         coord: [7, -3],
-                        style: bluePointStyle,
+                        color: "blue",
+                        filled: true,
                     },
                 ],
                 markings: "graph",
@@ -966,10 +968,14 @@ export const segmentWithLockedPointsQuestion: PerseusRenderer = {
                     {
                         type: "point",
                         coord: [-7, -7],
+                        color: "blue",
+                        filled: true,
                     },
                     {
                         type: "point",
                         coord: [2, -5],
+                        color: "blue",
+                        filled: true,
                     },
                 ],
             },
@@ -1019,12 +1025,14 @@ export const segmentWithLockedPointsWithColorQuestion: PerseusRenderer = {
                     {
                         type: "point",
                         coord: [-7, -7],
-                        style: {fill: "green", stroke: "green"},
+                        color: "green",
+                        filled: true,
                     },
                     {
                         type: "point",
                         coord: [2, -5],
-                        style: {fill: "green", stroke: "green"},
+                        color: "green",
+                        filled: true,
                     },
                 ],
             },

--- a/packages/perseus/src/widgets/interactive-graphs/graph-locked-layer.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graph-locked-layer.tsx
@@ -1,55 +1,35 @@
-import {color} from "@khanacademy/wonder-blocks-tokens";
 import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
-import {Point} from "mafs";
 import * as React from "react";
 
-import type {LockedFigure, StyleParams} from "../../perseus-types";
+import LockedPoint from "./locked-point";
+
+import type {LockedFigure} from "../../perseus-types";
 
 type Props = {
     lockedFigures: ReadonlyArray<LockedFigure>;
 };
-
-/**
- * Takes a style object with color names and converts them to actual
- * Wonder Blocks color values. This way, we can use colors and their
- * names in the editor UI without having to convert them back and forth.
- */
-function convertStyle(style?: StyleParams): StyleParams {
-    return {
-        ...style,
-        stroke: color[style?.stroke || "blue"],
-        fill: color[style?.fill || "blue"],
-    };
-}
 
 const GraphLockedLayer = (props: Props) => {
     const {lockedFigures} = props;
     return (
         <>
             {lockedFigures.map((figure, index) => {
+                let Figure;
                 switch (figure.type) {
                     case "point":
-                        const [x, y] = figure.coord;
-                        return (
-                            <Point
-                                key={`${figure.type}-${index}`}
-                                x={x}
-                                y={y}
-                                svgCircleProps={{
-                                    style: convertStyle(figure.style),
-                                }}
-                            />
-                        );
+                        Figure = LockedPoint;
+                        break;
+                    default:
+                        /**
+                         * Devlopment-time future-proofing: This should
+                         * fail during type-checking if we add a new locked
+                         * shape type and forget to handle it in any other
+                         * switch case here.
+                         */
+                        throw new UnreachableCaseError(figure.type);
                 }
 
-                /**
-                 * Devlopment-time future-proofing: This `never` should
-                 * fail during type-checking if we add a new locked
-                 * shape type and forget to handle it in any other
-                 * switch case here.
-                 */
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                throw new UnreachableCaseError(figure.type);
+                return <Figure key={`${figure.type}-${index}`} {...figure} />;
             })}
         </>
     );

--- a/packages/perseus/src/widgets/interactive-graphs/locked-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-point.tsx
@@ -1,0 +1,25 @@
+import {color as wbColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {Point} from "mafs";
+import * as React from "react";
+
+import type {LockedPointType} from "../../perseus-types";
+
+const LockedPoint = (props: LockedPointType) => {
+    const {color, coord, filled} = props;
+    const [x, y] = coord;
+    return (
+        <Point
+            x={x}
+            y={y}
+            svgCircleProps={{
+                style: {
+                    fill: filled ? wbColor[color] : wbColor.white,
+                    stroke: wbColor[color],
+                    strokeWidth: spacing.xxxxSmall_2,
+                },
+            }}
+        />
+    );
+};
+
+export default LockedPoint;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2441,6 +2441,17 @@
     mathjax-full "3.2.2"
     mu-lambda "^0.0.3"
 
+"@khanacademy/wonder-blocks-accordion@^1.2.16":
+  version "1.2.16"
+  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-accordion/-/wonder-blocks-accordion-1.2.16.tgz#ebbf90399b5a45f443f1b9a3c1d22d15548ff8fc"
+  integrity sha512-3jrHw/oRm1ri4YKWwGIFM49Avk2V1moVt40Z4ayKvuxQXW2IXd/ZBaQvs+qMAw/zWtGEnMoFGkrQdKIfh9rVyw==
+  dependencies:
+    "@khanacademy/wonder-blocks-clickable" "^4.1.3"
+    "@khanacademy/wonder-blocks-core" "^6.3.1"
+    "@khanacademy/wonder-blocks-icon" "^4.0.1"
+    "@khanacademy/wonder-blocks-tokens" "^1.2.0"
+    "@khanacademy/wonder-blocks-typography" "^2.1.10"
+
 "@khanacademy/wonder-blocks-banner@^3.0.33":
   version "3.0.34"
   resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-banner/-/wonder-blocks-banner-3.0.34.tgz#b19e7b6757d9ce94eb0882189a75f94d15b9aa16"
@@ -2552,6 +2563,15 @@
     "@babel/runtime" "^7.18.6"
     "@khanacademy/wonder-blocks-core" "^6.3.1"
     "@khanacademy/wonder-blocks-tokens" "^1.1.0"
+
+"@khanacademy/wonder-blocks-clickable@^4.1.3":
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-clickable/-/wonder-blocks-clickable-4.1.3.tgz#1238a7c76ebe87bece65968a586b92c00a6ff507"
+  integrity sha512-60YGSlVFtYJYyykrp6Y/hZZR+J5Kg1y9z3B1+bQlzdxw6DuXbjLirogkc+Ni8E4Hv7Dir4WON1qiuByJ7AqZLA==
+  dependencies:
+    "@babel/runtime" "^7.18.6"
+    "@khanacademy/wonder-blocks-core" "^6.3.1"
+    "@khanacademy/wonder-blocks-tokens" "^1.2.0"
 
 "@khanacademy/wonder-blocks-color@^3.0.0":
   version "3.0.0"
@@ -2844,6 +2864,17 @@
     "@khanacademy/wonder-blocks-theming" "^2.0.1"
     "@khanacademy/wonder-blocks-tokens" "^1.0.0"
 
+"@khanacademy/wonder-blocks-switch@^1.1.14":
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-switch/-/wonder-blocks-switch-1.1.14.tgz#e147033c48d7d0f6926d3ea5f497a8d8811a32f6"
+  integrity sha512-n/Qcu4Di/T02vJj8guQ9h2bBzVWgYV6nuelE64YvbsoduMY+iIz1dJIcIf6Ag+TJoSi5Y9BFUSAiSW2uDCSzTg==
+  dependencies:
+    "@babel/runtime" "^7.18.6"
+    "@khanacademy/wonder-blocks-core" "^6.3.1"
+    "@khanacademy/wonder-blocks-icon" "^4.0.1"
+    "@khanacademy/wonder-blocks-theming" "^2.0.2"
+    "@khanacademy/wonder-blocks-tokens" "^1.2.0"
+
 "@khanacademy/wonder-blocks-theming@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-theming/-/wonder-blocks-theming-1.3.0.tgz#33b252780957e96cebe623eb0e7ec56574362647"
@@ -2856,6 +2887,11 @@
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-theming/-/wonder-blocks-theming-2.0.1.tgz#0c586a215624e3c12714accf6865e26928b32cbc"
   integrity sha512-Xn9EBqDqElsT+2LUxOAtSHg6tTozSpYyTBM71Z1BdQEkmhC1PNs5wIE2yRZy8PbkZifd9JBWrw7DiM9JWH7SyQ==
+
+"@khanacademy/wonder-blocks-theming@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-theming/-/wonder-blocks-theming-2.0.2.tgz#b3175ad778db3a87272b2d64995617cf22a1e14b"
+  integrity sha512-o3EkwpK5H8NEjWt5nCelRdOl0zPJNyWLNoEWyWnourJtxUTwqzd98sxZMEbQhn2/4wlqVNrLEK8ZbypBSmm+ig==
 
 "@khanacademy/wonder-blocks-timing@^4.0.2":
   version "4.0.2"
@@ -2877,6 +2913,11 @@
   dependencies:
     "@khanacademy/wonder-blocks-color" "^3.0.0"
     "@khanacademy/wonder-blocks-spacing" "^4.0.1"
+
+"@khanacademy/wonder-blocks-tokens@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-tokens/-/wonder-blocks-tokens-1.2.0.tgz#b58611f8b4a58e0c6e7e4e505d5acdb2b475acf4"
+  integrity sha512-F24xzjFjpZFEGsuV7s8pBqeIVOY+NeIRVZU0BzTeMqRWvkaz9NzZbIcbYBxMnOvrw3Jk/xAPaSjcRukzbEbkdA==
 
 "@khanacademy/wonder-blocks-tooltip@^2.1.28":
   version "2.1.28"


### PR DESCRIPTION
## Summary:
Update to locked points in preparation for locked lines:
- Use Wonder Blocks Accordion's AccordionSection to make the points info collapsible. This will take up less vertical space when necessary.
- Add `toggleable` and `onToggle` props to LockedPointSettings. This should be allow the future LockedLineSettings component to make the points show/hide.
- Add a story to demonstrate said toggleable functionality
- Refactoring to make LockedFiguresSection more universal, not point-specific
- Add more info in the header so the point is easily identifiable (coords, color, filled)

Issue: none

## Test plan:
`yarn jest packages/perseus-editor/src/components/__tests__/locked-point-settings.test.tsx`
`yarn jest packages/perseus/src/widgets/__tests__/interactive-graph.test.ts`
`yarn jest packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx`

Storybook
http://localhost:6006/?path=/story/perseus-editor-widgets-interactive-graph-editor--with-locked-points

## Screenshots
![Screenshot 2024-04-16 at 6 28 30 PM](https://github.com/Khan/perseus/assets/13231763/0110d99b-4285-48ee-97d4-bdf41a51723f)

![Screenshot 2024-04-16 at 6 28 36 PM](https://github.com/Khan/perseus/assets/13231763/b6270294-1b43-411d-b492-9ae6cbdb7e6c)

![Screenshot 2024-04-16 at 6 28 43 PM](https://github.com/Khan/perseus/assets/13231763/35d6c625-42d6-429b-af5d-e197f9163e24)

<img width="631" alt="Screenshot 2024-04-16 at 6 52 13 PM" src="https://github.com/Khan/perseus/assets/13231763/7f734094-26d6-4ac5-8a6c-0887ca40cab2">

<img width="629" alt="Screenshot 2024-04-16 at 6 52 18 PM" src="https://github.com/Khan/perseus/assets/13231763/c2e1cc17-fea1-434e-8685-32441474e7f7">
