### PR TITLE
Add flag for M1 locked features

### DIFF
--- a/.changeset/clean-tips-reflect.md
+++ b/.changeset/clean-tips-reflect.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-dev-ui": patch
+"@khanacademy/perseus": patch
+---
+
+Rename internal type `MafsFlags` to `MafsGraphTypeFlags`

--- a/.changeset/wicked-poems-grin.md
+++ b/.changeset/wicked-poems-grin.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Move locked features for interactive-graph behind new flag named "interactive-graph-locked-features-m1"

--- a/dev/gallery.tsx
+++ b/dev/gallery.tsx
@@ -10,7 +10,7 @@ import * as React from "react";
 import {useEffect, useMemo, useState} from "react";
 
 import {Renderer} from "../packages/perseus/src";
-import {MafsFlags} from "../packages/perseus/src/types";
+import {MafsGraphTypeFlags} from "../packages/perseus/src/types";
 import * as grapher from "../packages/perseus/src/widgets/__testdata__/grapher.testdata";
 import * as interactiveGraph from "../packages/perseus/src/widgets/__testdata__/interactive-graph.testdata";
 import * as numberLine from "../packages/perseus/src/widgets/__testdata__/number-line.testdata";
@@ -101,7 +101,7 @@ export function Gallery() {
             ?.split(",")
             // We filter through the MafsFlags array to ensure we don't retain
             // flags from the query string that don't actually exist anymore.
-            .filter((flag) => MafsFlags.includes(flag as any)) || [],
+            .filter((flag) => MafsGraphTypeFlags.includes(flag as any)) || [],
     );
     const [search, setSearch] = useState<string>(params.get("search") || "");
 
@@ -157,7 +157,7 @@ export function Gallery() {
                         onChange={setMafsFlags}
                         selectedValues={mafsFlags}
                     >
-                        {MafsFlags.map((flag) => (
+                        {MafsGraphTypeFlags.map((flag) => (
                             <OptionItem
                                 key={flag}
                                 value={flag}

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
@@ -8,6 +8,7 @@ import {testDependencies} from "../../../../../testing/test-dependencies";
 import InteractiveGraphEditor from "../interactive-graph-editor";
 
 import type {PerseusGraphType} from "@khanacademy/perseus";
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
 const baseProps = {
     apiOptions: ApiOptions.defaults,
@@ -18,12 +19,13 @@ const baseProps = {
     graph: undefined,
 };
 
-const mafsProps = {
+const mafsProps: PropsFor<typeof InteractiveGraphEditor> = {
     ...baseProps,
     apiOptions: {
         ...ApiOptions.defaults,
         flags: {
             mafs: {
+                "interactive-graph-locked-features-m1": true,
                 segment: true,
             },
         },

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
@@ -587,7 +587,10 @@ class InteractiveGraphEditor extends React.Component<Props> {
                     // Only show the "Add locked figure" dropdown if the graph is
                     // using Mafs.
                     this.props.graph &&
-                        this.props.apiOptions?.flags?.["mafs"]?.[
+                        this.props.apiOptions?.flags?.mafs?.[
+                            "interactive-graph-locked-features-m1"
+                        ] &&
+                        this.props.apiOptions?.flags?.mafs?.[
                             this.props.graph.type
                         ] && (
                             <LockedFiguresSection

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -127,7 +127,7 @@ type TrackInteractionArgs = {
 } & Partial<TrackingGradedGroupExtraArguments> &
     Partial<TrackingSequenceExtraArguments>;
 
-export const MafsFlags = [
+export const MafsGraphTypeFlags = [
     /** Enables the `segment` interactive-graph type.  */
     "segment",
     /** Enables the `linear` interactive-graph type.  */
@@ -138,6 +138,14 @@ export const MafsFlags = [
     "ray",
     /** Enables the `polygon` interactive-graph type.  */
     "polygon",
+] as const;
+
+export const InteractiveGraphLockedFeaturesFlags = [
+    /**
+     * Enables/Disables Milestone 1 locked features in the new Mafs
+     * interactive-graph widget (points and lines).
+     */
+    "interactive-graph-locked-features-m1",
 ] as const;
 
 /**
@@ -272,9 +280,13 @@ export type APIOptions = Readonly<{
         /**
          * Flags related to the interactive-graph Mafs migration.
          *
-         * Add values to the `MafsFlags` array to create new flags.
+         * Add values to the relevant array to create new flags.
          */
-        mafs?: false | {[Key in (typeof MafsFlags)[number]]?: boolean};
+        mafs?:
+            | false
+            | ({[Key in (typeof MafsGraphTypeFlags)[number]]?: boolean} & {
+                  [Key in (typeof InteractiveGraphLockedFeaturesFlags)[number]]?: boolean;
+              });
     };
     /**
      * This is a callback function that returns all of the Widget props


### PR DESCRIPTION
## Summary:

This PR adds the feature flag `interactive-graph-locked-features-m1` which gates access to locked features being built in Milestone 1 (M1) of the interactive-graph rebuild. 

This flag will gate access to adding/editing locked points and locked lines. 

Issue: "none"

## Test plan: