### PR TITLE
New logic to handle bug regarding overlapping axis tick labels in Interactive Graph.

### DIFF
--- a/.changeset/old-hornets-laugh.md
+++ b/.changeset/old-hornets-laugh.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Added new logic for conditionally rendering initial negative axis tick labels.

--- a/packages/perseus/src/widgets/interactive-graphs/__tests__/axis-ticks.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/__tests__/axis-ticks.test.ts
@@ -21,10 +21,16 @@ describe("generateTickLocations", () => {
     });
 
     it("should hide the first negative axis tick label if the gridStep > tickStep", () => {
-        expect(showTickLabel(2, 1, -1)).toEqual(false);
+        const gridStep = 2;
+        const tickStep = 1;
+        const label = -1;
+        expect(showTickLabel(gridStep, tickStep, label)).toEqual(false);
     });
 
     it("should show the first negative axis tick label if the tickStep > gridStep", () => {
-        expect(showTickLabel(1, 2, -2)).toEqual(true);
+        const gridStep = 1;
+        const tickStep = 2;
+        const label = -2;
+        expect(showTickLabel(gridStep, tickStep, label)).toEqual(true);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/__tests__/axis-ticks.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/__tests__/axis-ticks.test.ts
@@ -1,4 +1,4 @@
-import {generateTickLocations} from "../axis-ticks";
+import {generateTickLocations, showTickLabel} from "../axis-ticks";
 
 describe("generateTickLocations", () => {
     it("should generate ticks from the origin", () => {
@@ -18,5 +18,13 @@ describe("generateTickLocations", () => {
         expect(generateTickLocations(3, -10, 10)).toEqual([
             3, 6, 9, -3, -6, -9,
         ]);
+    });
+
+    it("should hide the first negative axis tick label if the gridStep > tickStep", () => {
+        expect(showTickLabel(2, 1, -1)).toEqual(false);
+    });
+
+    it("should show the first negative axis tick label if the tickStep > gridStep", () => {
+        expect(showTickLabel(1, 2, -2)).toEqual(true);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
@@ -11,7 +11,24 @@ const tickStyle: React.CSSProperties = {
     strokeWidth: 1,
 };
 
-const YGridTick = ({y}: {y: number}) => {
+const showTickLabel = (
+    gridStep: number,
+    tickStep: number,
+    label: number,
+): boolean => {
+    const showLabel = gridStep > tickStep ? true : label !== -tickStep;
+    return showLabel;
+};
+
+const YGridTick = ({
+    y,
+    gridStep,
+    tickStep,
+}: {
+    y: number;
+    gridStep: number;
+    tickStep: number;
+}) => {
     const pointOnAxis: vec.Vector2 = [0, y];
     const [[xPosition, yPosition]] = useTransform(pointOnAxis);
 
@@ -28,21 +45,30 @@ const YGridTick = ({y}: {y: number}) => {
                 // TODO (LEMS-1891): Negative one is a special case as the labels can
                 // overlap with the axis line. We should handle this case more gracefully.
             }
-
-            <text
-                height={20}
-                width={50}
-                textAnchor="end"
-                x={xPosition - 10}
-                y={yPosition + 5}
-            >
-                {y.toString()}
-            </text>
+            {showTickLabel(gridStep, tickStep, y) && (
+                <text
+                    height={20}
+                    width={50}
+                    textAnchor="end"
+                    x={xPosition - 10}
+                    y={yPosition + 5}
+                >
+                    {y.toString()}
+                </text>
+            )}
         </g>
     );
 };
 
-const XGridTick = ({x}: {x: number}) => {
+const XGridTick = ({
+    x,
+    gridStep,
+    tickStep,
+}: {
+    x: number;
+    gridStep: number;
+    tickStep: number;
+}) => {
     const pointOnAxis: vec.Vector2 = [x, 0];
     const [[xPosition, yPosition]] = useTransform(pointOnAxis);
 
@@ -59,16 +85,17 @@ const XGridTick = ({x}: {x: number}) => {
                 // TODO (LEMS-1891): Negative one is a special case as the labels can
                 // overlap with the axis line. We should handle this case more gracefully.
             }
-
-            <text
-                height={20}
-                width={50}
-                textAnchor="middle"
-                x={xPosition}
-                y={yPosition + 25}
-            >
-                {x.toString()}
-            </text>
+            {showTickLabel(gridStep, tickStep, x) && (
+                <text
+                    height={20}
+                    width={50}
+                    textAnchor="middle"
+                    x={xPosition}
+                    y={yPosition + 25}
+                >
+                    {x.toString()}
+                </text>
+            )}
         </g>
     );
 };
@@ -85,9 +112,8 @@ export function generateTickLocations(
         ticks.push(i);
     }
 
-    // Add ticks in the negative direction, but skip the first tick
-    // as it will overlap with the label on the other axis line
-    for (let i = 0 - tickStep * 2; i > min; i -= tickStep) {
+    // Add ticks in the negative direction
+    for (let i = 0 - tickStep; i > min; i -= tickStep) {
         ticks.push(i);
     }
     return ticks;
@@ -96,6 +122,7 @@ export function generateTickLocations(
 type Props = {
     tickStep: [number, number];
     range: [[number, number], [number, number]];
+    gridStep: [number, number];
 };
 
 export const AxisTicks = (props: Props) => {
@@ -113,10 +140,24 @@ export const AxisTicks = (props: Props) => {
     return (
         <g className="axis-ticks">
             {yGridTicks.map((y) => {
-                return <YGridTick y={y} key={`y-grid-tick-${y}`} />;
+                return (
+                    <YGridTick
+                        y={y}
+                        key={`y-grid-tick-${y}`}
+                        gridStep={props.gridStep[0]}
+                        tickStep={yTickStep}
+                    />
+                );
             })}
             {xGridTicks.map((x) => {
-                return <XGridTick x={x} key={`x-grid-tick-${x}`} />;
+                return (
+                    <XGridTick
+                        x={x}
+                        key={`x-grid-tick-${x}`}
+                        gridStep={props.gridStep[1]}
+                        tickStep={xTickStep}
+                    />
+                );
             })}
         </g>
     );

--- a/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
@@ -11,15 +11,16 @@ const tickStyle: React.CSSProperties = {
     strokeWidth: 1,
 };
 
-// We only want to show the initial negative tick labels on each axis if the
-// gridStep is larger than the tickStep, which allows for enough space for
-// these labels to render without overlapping.
+// We only want to show the initial negative tick labels (e.g. -1) on each
+// axis if the tickStep > gridStep, to ensure that these labels do not overlap.
+// e.g. If gridStep = 1 and tickStep = 2, there are 2 grid lines for every 1 tick,
+// which allows enough room for both these tick labels to render.
 const showTickLabel = (
     gridStep: number,
     tickStep: number,
     label: number,
 ): boolean => {
-    const showLabel = gridStep > tickStep ? true : label !== -tickStep;
+    const showLabel = tickStep > gridStep ? true : label !== -tickStep;
     return showLabel;
 };
 

--- a/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
@@ -15,7 +15,7 @@ const tickStyle: React.CSSProperties = {
 // axis if the tickStep > gridStep, to ensure that these labels do not overlap.
 // e.g. If gridStep = 1 and tickStep = 2, there are 2 grid lines for every 1 tick,
 // which allows enough room for both these tick labels to render.
-const showTickLabel = (
+export const showTickLabel = (
     gridStep: number,
     tickStep: number,
     label: number,

--- a/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
@@ -28,17 +28,16 @@ const YGridTick = ({y}: {y: number}) => {
                 // TODO (LEMS-1891): Negative one is a special case as the labels can
                 // overlap with the axis line. We should handle this case more gracefully.
             }
-            {y !== -1 && (
-                <text
-                    height={20}
-                    width={50}
-                    textAnchor="end"
-                    x={xPosition - 10}
-                    y={yPosition + 5}
-                >
-                    {y.toString()}
-                </text>
-            )}
+
+            <text
+                height={20}
+                width={50}
+                textAnchor="end"
+                x={xPosition - 10}
+                y={yPosition + 5}
+            >
+                {y.toString()}
+            </text>
         </g>
     );
 };
@@ -60,17 +59,16 @@ const XGridTick = ({x}: {x: number}) => {
                 // TODO (LEMS-1891): Negative one is a special case as the labels can
                 // overlap with the axis line. We should handle this case more gracefully.
             }
-            {x !== -1 && (
-                <text
-                    height={20}
-                    width={50}
-                    textAnchor="middle"
-                    x={xPosition}
-                    y={yPosition + 25}
-                >
-                    {x.toString()}
-                </text>
-            )}
+
+            <text
+                height={20}
+                width={50}
+                textAnchor="middle"
+                x={xPosition}
+                y={yPosition + 25}
+            >
+                {x.toString()}
+            </text>
         </g>
     );
 };
@@ -87,8 +85,9 @@ export function generateTickLocations(
         ticks.push(i);
     }
 
-    // Add ticks in the negative direction
-    for (let i = 0 - tickStep; i > min; i -= tickStep) {
+    // Add ticks in the negative direction, but skip the first tick
+    // as it will overlap with the label on the other axis line
+    for (let i = 0 - tickStep * 2; i > min; i -= tickStep) {
         ticks.push(i);
     }
     return ticks;

--- a/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
@@ -11,6 +11,9 @@ const tickStyle: React.CSSProperties = {
     strokeWidth: 1,
 };
 
+// We only want to show the initial negative tick labels on each axis if the
+// gridStep is larger than the tickStep, which allows for enough space for
+// these labels to render without overlapping.
 const showTickLabel = (
     gridStep: number,
     tickStep: number,

--- a/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
@@ -45,10 +45,6 @@ const YGridTick = ({
                 y2={yPosition}
                 style={tickStyle}
             />
-            {
-                // TODO (LEMS-1891): Negative one is a special case as the labels can
-                // overlap with the axis line. We should handle this case more gracefully.
-            }
             {showTickLabel(gridStep, tickStep, y) && (
                 <text
                     height={20}
@@ -85,10 +81,6 @@ const XGridTick = ({
                 y2={yPosition - tickSize / 2}
                 style={tickStyle}
             />
-            {
-                // TODO (LEMS-1891): Negative one is a special case as the labels can
-                // overlap with the axis line. We should handle this case more gracefully.
-            }
             {showTickLabel(gridStep, tickStep, x) && (
                 <text
                     height={20}

--- a/packages/perseus/src/widgets/interactive-graphs/grid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/grid.tsx
@@ -66,7 +66,11 @@ export const Grid = (props: GridProps) => {
                 xAxis={axisOptions(props, 0)}
                 yAxis={axisOptions(props, 1)}
             />
-            <AxisTicks range={props.range} tickStep={props.tickStep} />
+            <AxisTicks
+                range={props.range}
+                tickStep={props.tickStep}
+                gridStep={props.gridStep}
+            />
             {props.markings === "graph" && <AxisArrows />}
         </>
     );


### PR DESCRIPTION
## Summary:
Sometimes our negative axis labels will overlap, which causes visual issues. 

The previous approach for this issue in graphie consisted of hardcoded logic that hid ALL instances of any axis labels for `-1`. Unfortunately, this logic only works properly if the tickStep is specially set to `1`.

This PR adds new logic that ensures that we **_only_** show the first negative axis tick label IF the gridStep is larger than the tick step. This should account for cases where there's clearly enough room to render the label, and alternative tickSteps such as 0.5. 

e.g. If our gridStep = 1 and our tickStep = 2, it means that there are 2 grid lines for every 1 tick. This allows enough room for both these tick labels to render. 

Issue: LEMS-1891

## Test plan:
- manual testing
- new tests 

## Screenshots:
![Screenshot 2024-04-17 at 11 09 40 AM](https://github.com/Khan/perseus/assets/12463099/7d6626c0-f429-404b-9ff6-c602c150b836)
![Screenshot 2024-04-17 at 11 09 25 AM](https://github.com/Khan/perseus/assets/12463099/095615fd-4ed1-4d16-8f26-c613dfc04438)
![Screenshot 2024-04-17 at 11 07 35 AM](https://github.com/Khan/perseus/assets/12463099/3b173e93-145b-46a2-b402-a9dba72912d6)
