### PR TITLE
Add `showSolutions`, implement for radio widget (others coming in following PRs)

### DIFF
--- a/.changeset/breezy-jeans-invent.md
+++ b/.changeset/breezy-jeans-invent.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Adds `showSolutions`, which adds the ability to show all rationales for the radio widget and will deprecate `showshowRationalesForCurrentlySelectedChoices`

--- a/packages/perseus-editor/src/widgets/__tests__/radio-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/radio-editor.test.tsx
@@ -1,4 +1,5 @@
 import {Dependencies, ApiOptions} from "@khanacademy/perseus";
+import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 import {render, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
@@ -24,6 +25,7 @@ describe("radio-editor", () => {
                 onChange={() => undefined}
                 apiOptions={ApiOptions.defaults}
             />,
+            {wrapper: RenderStateRoot},
         );
 
         expect(screen.getByText(/Multiple selections/)).toBeInTheDocument();
@@ -37,6 +39,7 @@ describe("radio-editor", () => {
                 onChange={onChangeMock}
                 apiOptions={ApiOptions.defaults}
             />,
+            {wrapper: RenderStateRoot},
         );
 
         await userEvent.click(
@@ -56,6 +59,7 @@ describe("radio-editor", () => {
                 onChange={onChangeMock}
                 apiOptions={ApiOptions.defaults}
             />,
+            {wrapper: RenderStateRoot},
         );
 
         await userEvent.click(
@@ -75,6 +79,7 @@ describe("radio-editor", () => {
                 onChange={onChangeMock}
                 apiOptions={ApiOptions.defaults}
             />,
+            {wrapper: RenderStateRoot},
         );
 
         await userEvent.click(
@@ -101,6 +106,7 @@ describe("radio-editor", () => {
                 onChange={onChangeMock}
                 apiOptions={ApiOptions.defaults}
             />,
+            {wrapper: RenderStateRoot},
         );
 
         await userEvent.click(

--- a/packages/perseus/src/multi-items/__tests__/__snapshots__/multi-renderer.test.tsx.snap
+++ b/packages/perseus/src/multi-items/__tests__/__snapshots__/multi-renderer.test.tsx.snap
@@ -140,12 +140,12 @@ exports[`multi-item renderer should snapshot: initial render 1`] = `
                           >
                             <input
                               class="perseus-radio-option-content"
-                              id="choice-0"
+                              id="uid-choice-0-a"
                               tabindex="-1"
                               type="radio"
                             />
                             <label
-                              for="choice-0"
+                              for="uid-choice-0-a"
                             >
                               (Choice A)
                                  
@@ -307,12 +307,12 @@ exports[`multi-item renderer should snapshot: initial render 1`] = `
                           >
                             <input
                               class="perseus-radio-option-content"
-                              id="choice-1"
+                              id="uid-choice-1-b"
                               tabindex="-1"
                               type="radio"
                             />
                             <label
-                              for="choice-1"
+                              for="uid-choice-1-b"
                             >
                               (Choice B)
                                  
@@ -474,12 +474,12 @@ exports[`multi-item renderer should snapshot: initial render 1`] = `
                           >
                             <input
                               class="perseus-radio-option-content"
-                              id="choice-2"
+                              id="uid-choice-2-c"
                               tabindex="-1"
                               type="radio"
                             />
                             <label
-                              for="choice-2"
+                              for="uid-choice-2-c"
                             >
                               (Choice C)
                                  
@@ -641,12 +641,12 @@ exports[`multi-item renderer should snapshot: initial render 1`] = `
                           >
                             <input
                               class="perseus-radio-option-content"
-                              id="choice-3"
+                              id="uid-choice-3-d"
                               tabindex="-1"
                               type="radio"
                             />
                             <label
-                              for="choice-3"
+                              for="uid-choice-3-d"
                             >
                               (Choice D)
                                  
@@ -808,12 +808,12 @@ exports[`multi-item renderer should snapshot: initial render 1`] = `
                           >
                             <input
                               class="perseus-radio-option-content"
-                              id="choice-4"
+                              id="uid-choice-4-e"
                               tabindex="-1"
                               type="radio"
                             />
                             <label
-                              for="choice-4"
+                              for="uid-choice-4-e"
                             >
                               (Choice E)
                                  

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -9,6 +9,7 @@ import type {Interval, vec} from "mafs";
 export type Range = Interval;
 export type Size = [number, number];
 export type CollinearTuple = readonly [vec.Vector2, vec.Vector2];
+export type ShowRationales = "all" | "selected" | "none";
 
 export type StyleParams = {
     fill?: string;

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -9,7 +9,7 @@ import type {Interval, vec} from "mafs";
 export type Range = Interval;
 export type Size = [number, number];
 export type CollinearTuple = readonly [vec.Vector2, vec.Vector2];
-export type ShowRationales = "all" | "selected" | "none";
+export type ShowSolutions = "all" | "selected" | "none";
 
 export type StyleParams = {
     fill?: string;

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -36,6 +36,7 @@ import type {
     PerseusWidget,
     PerseusWidgetOptions,
     PerseusWidgetsMap,
+    ShowRationales,
 } from "./perseus-types";
 import type {
     APIOptions,
@@ -157,6 +158,9 @@ export type Widget = {
             message?: string | null | undefined,
         ) => unknown | null | undefined,
     ) => PerseusScore;
+    /**
+     * @deprecated Use `showRationales` prop instead.
+     */
     showRationalesForCurrentlySelectedChoices?: (options?: any) => void;
     examples?: () => ReadonlyArray<string>;
 };
@@ -173,20 +177,31 @@ type Props = Partial<React.ContextType<typeof DependenciesContext>> & {
     problemNum?: number;
     questionCompleted?: boolean;
     reviewMode?: boolean | null | undefined;
+    /**
+     * If set to "all", all rationales will be shown. If set to "selected",
+     * rationales will only be shown for selected choices. If set to "none",
+     * rationales will not be shown-- equivalent to `undefined`.
+     */
+    showRationales?: ShowRationales;
     content: PerseusRenderer["content"];
     serializedState?: any;
-    // Callback which is called when serialized state changes with the new
-    // serialized state.
+    /**
+     * Callback which is called when serialized state changes with the new
+     * serialized state.
+     */
     onSerializedStateUpdated: (serializedState: {
         [key: string]: any;
     }) => unknown;
-    // If linterContext.highlightLint is true, then content will be passed
-    // to the linter and any warnings will be highlighted in the rendered
-    // output.
+    /**
+     * If linterContext.highlightLint is true, then content will be passed to
+     * the linter and any warnings will be highlighted in the rendered output.
+     */
     linterContext: LinterContextProps;
     legacyPerseusLint?: ReadonlyArray<string>;
     widgets: PerseusRenderer["widgets"];
-    // Skip adding paragraph class
+    /**
+     *  Skip adding paragraph class
+     */
     inline?: boolean;
 };
 
@@ -210,21 +225,25 @@ type Context = LinterContextProps & {
     // This is inexact because LinterContextProps is inexact
 };
 
-type DefaultProps = {
-    alwaysUpdate: Props["alwaysUpdate"];
-    content: Props["content"];
-    findExternalWidgets: Props["findExternalWidgets"];
-    highlightedWidgets: Props["highlightedWidgets"];
-    images: Props["images"];
-    linterContext: Props["linterContext"];
-    onInteractWithWidget: Props["onInteractWithWidget"];
-    onRender: Props["onRender"];
-    onSerializedStateUpdated: Props["onSerializedStateUpdated"];
-    questionCompleted: Props["questionCompleted"];
-    reviewMode: Props["reviewMode"];
-    serializedState: Props["serializedState"];
-    widgets: Props["widgets"];
-};
+type DefaultProps = Required<
+    Pick<
+        Props,
+        | "alwaysUpdate"
+        | "content"
+        | "findExternalWidgets"
+        | "highlightedWidgets"
+        | "images"
+        | "linterContext"
+        | "onInteractWithWidget"
+        | "onRender"
+        | "onSerializedStateUpdated"
+        | "questionCompleted"
+        | "showRationales"
+        | "reviewMode"
+        | "serializedState"
+        | "widgets"
+    >
+>;
 
 class Renderer extends React.Component<Props, State> {
     _currentFocus: FocusPath | null | undefined;
@@ -258,6 +277,7 @@ class Renderer extends React.Component<Props, State> {
         images: {},
         highlightedWidgets: [],
         questionCompleted: false,
+        showRationales: "none",
         // onRender may be called multiple times per render, for example
         // if there are multiple images or TeX pieces within `content`.
         // It is a good idea to debounce any functions passed here.
@@ -640,6 +660,7 @@ class Renderer extends React.Component<Props, State> {
             apiOptions: this.getApiOptions(),
             keypadElement: this.props.keypadElement,
             questionCompleted: this.props.questionCompleted,
+            showRationales: this.props.showRationales,
             onFocus: _.partial(this._onWidgetFocus, id),
             onBlur: _.partial(this._onWidgetBlur, id),
             findWidgets: this.findWidgets,

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -36,7 +36,7 @@ import type {
     PerseusWidget,
     PerseusWidgetOptions,
     PerseusWidgetsMap,
-    ShowRationales,
+    ShowSolutions,
 } from "./perseus-types";
 import type {
     APIOptions,
@@ -159,7 +159,7 @@ export type Widget = {
         ) => unknown | null | undefined,
     ) => PerseusScore;
     /**
-     * @deprecated Use `showRationales` prop instead.
+     * @deprecated Internal only. Use `showSolutions` prop instead.
      */
     showRationalesForCurrentlySelectedChoices?: (options?: any) => void;
     examples?: () => ReadonlyArray<string>;
@@ -178,11 +178,11 @@ type Props = Partial<React.ContextType<typeof DependenciesContext>> & {
     questionCompleted?: boolean;
     reviewMode?: boolean | null | undefined;
     /**
-     * If set to "all", all rationales will be shown. If set to "selected",
-     * rationales will only be shown for selected choices. If set to "none",
-     * rationales will not be shown-- equivalent to `undefined`.
+     * If set to "all", all rationales or solutions will be shown. If set to
+     * "selected", soltions will only be shown for selected choices. If set to
+     * "none", solutions will not be shown-- equivalent to `undefined`.
      */
-    showRationales?: ShowRationales;
+    showSolutions?: ShowSolutions;
     content: PerseusRenderer["content"];
     serializedState?: any;
     /**
@@ -238,7 +238,7 @@ type DefaultProps = Required<
         | "onRender"
         | "onSerializedStateUpdated"
         | "questionCompleted"
-        | "showRationales"
+        | "showSolutions"
         | "reviewMode"
         | "serializedState"
         | "widgets"
@@ -277,7 +277,7 @@ class Renderer extends React.Component<Props, State> {
         images: {},
         highlightedWidgets: [],
         questionCompleted: false,
-        showRationales: "none",
+        showSolutions: "none",
         // onRender may be called multiple times per render, for example
         // if there are multiple images or TeX pieces within `content`.
         // It is a good idea to debounce any functions passed here.
@@ -660,7 +660,7 @@ class Renderer extends React.Component<Props, State> {
             apiOptions: this.getApiOptions(),
             keypadElement: this.props.keypadElement,
             questionCompleted: this.props.questionCompleted,
-            showRationales: this.props.showRationales,
+            showSolutions: this.props.showSolutions,
             onFocus: _.partial(this._onWidgetFocus, id),
             onBlur: _.partial(this._onWidgetBlur, id),
             findWidgets: this.findWidgets,
@@ -784,6 +784,7 @@ class Renderer extends React.Component<Props, State> {
      * currently selected choices inside of them. If the widget is correct, it
      * shows rationales for all of the choices. This also disables interaction
      * with the choices that we show rationales for.
+     * @deprecated Internal only. Use `showSolutions` prop instead.
      */
     showRationalesForCurrentlySelectedChoices: () => void = () => {
         Object.keys(this.props.widgets).forEach((widgetId) => {

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -158,9 +158,6 @@ export type Widget = {
             message?: string | null | undefined,
         ) => unknown | null | undefined,
     ) => PerseusScore;
-    /**
-     * @deprecated Internal only. Use `showSolutions` prop instead.
-     */
     showRationalesForCurrentlySelectedChoices?: (options?: any) => void;
     examples?: () => ReadonlyArray<string>;
 };
@@ -784,7 +781,6 @@ class Renderer extends React.Component<Props, State> {
      * currently selected choices inside of them. If the widget is correct, it
      * shows rationales for all of the choices. This also disables interaction
      * with the choices that we show rationales for.
-     * @deprecated Internal only. Use `showSolutions` prop instead.
      */
     showRationalesForCurrentlySelectedChoices: () => void = () => {
         Object.keys(this.props.widgets).forEach((widgetId) => {

--- a/packages/perseus/src/widgets/__stories__/radio.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/radio.stories.tsx
@@ -9,20 +9,19 @@ import {
 
 import type {PerseusRenderer} from "../../perseus-types";
 import type {APIOptions} from "../../types";
+import type {Meta} from "@storybook/react";
 
-type StoryArgs = {
+interface StoryArgs {
+    // Story Option
+    question: PerseusRenderer;
     // Radio Options
     static: boolean;
     // API Options
     crossOutEnabled: boolean;
     // Renderer Options
     reviewMode: boolean;
-};
-
-type Story = {
-    title: string;
-    args: StoryArgs;
-};
+    showRationales: "none" | "all" | "selected";
+}
 
 export default {
     title: "Perseus/Widgets/Radio",
@@ -30,57 +29,58 @@ export default {
         static: false,
         crossOutEnabled: false,
         reviewMode: false,
+        showRationales: "none",
+        question: questionWithPassage,
+    } satisfies StoryArgs,
+    argTypes: {
+        showRationales: {
+            options: ["none", "all", "selected"],
+            control: {
+                type: "select",
+            },
+        },
     },
-} as Story;
+    render: (args: StoryArgs) => (
+        <RendererWithDebugUI
+            question={applyStoryArgs(args)}
+            apiOptions={buildApiOptions(args)}
+            reviewMode={args.reviewMode}
+            showRationales={args.showRationales}
+        />
+    ),
+} satisfies Meta;
 
-const applyStoryArgs = (
-    question: PerseusRenderer,
-    args: StoryArgs,
-): PerseusRenderer => {
+const applyStoryArgs = (args: StoryArgs): PerseusRenderer => {
     const q = {
-        ...question,
+        ...args.question,
         widgets: {},
     } as const;
 
-    for (const [widgetId, widget] of Object.entries(question.widgets)) {
+    for (const [widgetId, widget] of Object.entries(args.question.widgets)) {
         q.widgets[widgetId] = {...widget, static: args.static};
     }
 
     return q;
 };
 
-const buildApiOptions = (args: StoryArgs): APIOptions => {
-    return {
-        crossOutEnabled: args.crossOutEnabled,
-    };
+const buildApiOptions = (args: StoryArgs): APIOptions => ({
+    crossOutEnabled: args.crossOutEnabled,
+});
+
+export const SingleSelect = {
+    args: {
+        question: questionWithPassage,
+    },
 };
 
-export const SingleSelect = (args: StoryArgs): React.ReactElement => {
-    return (
-        <RendererWithDebugUI
-            question={applyStoryArgs(questionWithPassage, args)}
-            apiOptions={buildApiOptions(args)}
-            reviewMode={args.reviewMode}
-        />
-    );
+export const MultiSelectSimple = {
+    args: {
+        question: multiChoiceQuestionSimple,
+    },
 };
 
-export const MultiSelectSimple = (args: StoryArgs): React.ReactElement => {
-    return (
-        <RendererWithDebugUI
-            question={applyStoryArgs(multiChoiceQuestionSimple, args)}
-            apiOptions={buildApiOptions(args)}
-            reviewMode={args.reviewMode}
-        />
-    );
-};
-
-export const MultiSelect = (args: StoryArgs): React.ReactElement => {
-    return (
-        <RendererWithDebugUI
-            question={applyStoryArgs(multiChoiceQuestion, args)}
-            apiOptions={buildApiOptions(args)}
-            reviewMode={args.reviewMode}
-        />
-    );
+export const MultiSelect = {
+    args: {
+        question: multiChoiceQuestion,
+    },
 };

--- a/packages/perseus/src/widgets/__stories__/radio.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/radio.stories.tsx
@@ -11,17 +11,17 @@ import type {PerseusRenderer} from "../../perseus-types";
 import type {APIOptions} from "../../types";
 import type {Meta} from "@storybook/react";
 
-interface StoryArgs {
+type StoryArgs = {
     // Story Option
     question: PerseusRenderer;
     // Radio Options
     static: boolean;
     // API Options
     crossOutEnabled: boolean;
-    // Renderer Options
-    reviewMode: boolean;
-    showRationales: "none" | "all" | "selected";
-}
+} & Pick<
+    React.ComponentProps<typeof RendererWithDebugUI>,
+    "reviewMode" | "showSolutions"
+>;
 
 export default {
     title: "Perseus/Widgets/Radio",
@@ -29,11 +29,11 @@ export default {
         static: false,
         crossOutEnabled: false,
         reviewMode: false,
-        showRationales: "none",
+        showSolutions: "none",
         question: questionWithPassage,
     } satisfies StoryArgs,
     argTypes: {
-        showRationales: {
+        showSolutions: {
             options: ["none", "all", "selected"],
             control: {
                 type: "select",
@@ -45,7 +45,7 @@ export default {
             question={applyStoryArgs(args)}
             apiOptions={buildApiOptions(args)}
             reviewMode={args.reviewMode}
-            showRationales={args.showRationales}
+            showSolutions={args.showSolutions}
         />
     ),
 } satisfies Meta;

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/group.test.tsx.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/group.test.tsx.snap
@@ -140,12 +140,12 @@ exports[`group widget should snapshot: initial render 1`] = `
                                       >
                                         <input
                                           class="perseus-radio-option-content"
-                                          id="choice-5"
+                                          id="uid-choice-0-a"
                                           tabindex="-1"
                                           type="radio"
                                         />
                                         <label
-                                          for="choice-5"
+                                          for="uid-choice-0-a"
                                         >
                                           (Choice A)
                                              
@@ -255,12 +255,12 @@ exports[`group widget should snapshot: initial render 1`] = `
                                       >
                                         <input
                                           class="perseus-radio-option-content"
-                                          id="choice-6"
+                                          id="uid-choice-1-b"
                                           tabindex="-1"
                                           type="radio"
                                         />
                                         <label
-                                          for="choice-6"
+                                          for="uid-choice-1-b"
                                         >
                                           (Choice B)
                                              
@@ -370,12 +370,12 @@ exports[`group widget should snapshot: initial render 1`] = `
                                       >
                                         <input
                                           class="perseus-radio-option-content"
-                                          id="choice-7"
+                                          id="uid-choice-2-c"
                                           tabindex="-1"
                                           type="radio"
                                         />
                                         <label
-                                          for="choice-7"
+                                          for="uid-choice-2-c"
                                         >
                                           (Choice C)
                                              
@@ -485,12 +485,12 @@ exports[`group widget should snapshot: initial render 1`] = `
                                       >
                                         <input
                                           class="perseus-radio-option-content"
-                                          id="choice-8"
+                                          id="uid-choice-3-d"
                                           tabindex="-1"
                                           type="radio"
                                         />
                                         <label
-                                          for="choice-8"
+                                          for="uid-choice-3-d"
                                         >
                                           (Choice D)
                                              
@@ -600,12 +600,12 @@ exports[`group widget should snapshot: initial render 1`] = `
                                       >
                                         <input
                                           class="perseus-radio-option-content"
-                                          id="choice-9"
+                                          id="uid-choice-4-e"
                                           tabindex="-1"
                                           type="radio"
                                         />
                                         <label
-                                          for="choice-9"
+                                          for="uid-choice-4-e"
                                         >
                                           (Choice E)
                                              

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/radio.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/radio.test.ts.snap
@@ -75,12 +75,12 @@ exports[`multi-choice question should snapshot the same when invalid: invalid st
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-318"
+                          id="uid-choice-210-a"
                           tabindex="-1"
                           type="checkbox"
                         />
                         <label
-                          for="choice-318"
+                          for="uid-choice-210-a"
                         >
                           (Choice A, Checked)
                              
@@ -190,12 +190,12 @@ exports[`multi-choice question should snapshot the same when invalid: invalid st
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-319"
+                          id="uid-choice-211-b"
                           tabindex="-1"
                           type="checkbox"
                         />
                         <label
-                          for="choice-319"
+                          for="uid-choice-211-b"
                         >
                           (Choice B)
                              
@@ -305,12 +305,12 @@ exports[`multi-choice question should snapshot the same when invalid: invalid st
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-320"
+                          id="uid-choice-212-c"
                           tabindex="-1"
                           type="checkbox"
                         />
                         <label
-                          for="choice-320"
+                          for="uid-choice-212-c"
                         >
                           (Choice C)
                              
@@ -420,12 +420,12 @@ exports[`multi-choice question should snapshot the same when invalid: invalid st
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-321"
+                          id="uid-choice-213-d"
                           tabindex="-1"
                           type="checkbox"
                         />
                         <label
-                          for="choice-321"
+                          for="uid-choice-213-d"
                         >
                           (Choice D)
                              
@@ -635,12 +635,12 @@ exports[`single-choice question reviewMode: false should snapshot the same with 
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-88"
+                          id="uid-choice-48-a"
                           tabindex="-1"
                           type="radio"
                         />
                         <label
-                          for="choice-88"
+                          for="uid-choice-48-a"
                         >
                           (Choice A)
                              
@@ -776,12 +776,12 @@ exports[`single-choice question reviewMode: false should snapshot the same with 
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-89"
+                          id="uid-choice-49-b"
                           tabindex="-1"
                           type="radio"
                         />
                         <label
-                          for="choice-89"
+                          for="uid-choice-49-b"
                         >
                           (Choice B)
                              
@@ -891,12 +891,12 @@ exports[`single-choice question reviewMode: false should snapshot the same with 
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-90"
+                          id="uid-choice-50-c"
                           tabindex="-1"
                           type="radio"
                         />
                         <label
-                          for="choice-90"
+                          for="uid-choice-50-c"
                         >
                           (Choice C, Checked)
                              
@@ -1006,12 +1006,12 @@ exports[`single-choice question reviewMode: false should snapshot the same with 
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-91"
+                          id="uid-choice-51-d"
                           tabindex="-1"
                           type="radio"
                         />
                         <label
-                          for="choice-91"
+                          for="uid-choice-51-d"
                         >
                           (Choice D)
                              
@@ -1207,12 +1207,12 @@ exports[`single-choice question reviewMode: false should snapshot the same with 
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-96"
+                          id="uid-choice-52-a"
                           tabindex="-1"
                           type="radio"
                         />
                         <label
-                          for="choice-96"
+                          for="uid-choice-52-a"
                         >
                           (Choice A, Checked)
                              
@@ -1348,12 +1348,12 @@ exports[`single-choice question reviewMode: false should snapshot the same with 
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-97"
+                          id="uid-choice-53-b"
                           tabindex="-1"
                           type="radio"
                         />
                         <label
-                          for="choice-97"
+                          for="uid-choice-53-b"
                         >
                           (Choice B)
                              
@@ -1463,12 +1463,12 @@ exports[`single-choice question reviewMode: false should snapshot the same with 
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-98"
+                          id="uid-choice-54-c"
                           tabindex="-1"
                           type="radio"
                         />
                         <label
-                          for="choice-98"
+                          for="uid-choice-54-c"
                         >
                           (Choice C)
                              
@@ -1578,12 +1578,12 @@ exports[`single-choice question reviewMode: false should snapshot the same with 
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-99"
+                          id="uid-choice-55-d"
                           tabindex="-1"
                           type="radio"
                         />
                         <label
-                          for="choice-99"
+                          for="uid-choice-55-d"
                         >
                           (Choice D)
                              
@@ -1779,12 +1779,12 @@ exports[`single-choice question reviewMode: false should snapshot the same: firs
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-80"
+                          id="uid-choice-44-a"
                           tabindex="-1"
                           type="radio"
                         />
                         <label
-                          for="choice-80"
+                          for="uid-choice-44-a"
                         >
                           (Choice A)
                              
@@ -1920,12 +1920,12 @@ exports[`single-choice question reviewMode: false should snapshot the same: firs
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-81"
+                          id="uid-choice-45-b"
                           tabindex="-1"
                           type="radio"
                         />
                         <label
-                          for="choice-81"
+                          for="uid-choice-45-b"
                         >
                           (Choice B)
                              
@@ -2035,12 +2035,12 @@ exports[`single-choice question reviewMode: false should snapshot the same: firs
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-82"
+                          id="uid-choice-46-c"
                           tabindex="-1"
                           type="radio"
                         />
                         <label
-                          for="choice-82"
+                          for="uid-choice-46-c"
                         >
                           (Choice C)
                              
@@ -2150,12 +2150,12 @@ exports[`single-choice question reviewMode: false should snapshot the same: firs
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-83"
+                          id="uid-choice-47-d"
                           tabindex="-1"
                           type="radio"
                         />
                         <label
-                          for="choice-83"
+                          for="uid-choice-47-d"
                         >
                           (Choice D)
                              
@@ -2351,12 +2351,12 @@ exports[`single-choice question reviewMode: true should snapshot the same with c
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-8"
+                          id="uid-choice-4-a"
                           tabindex="-1"
                           type="radio"
                         />
                         <label
-                          for="choice-8"
+                          for="uid-choice-4-a"
                         >
                           (Choice A)
                              
@@ -2492,12 +2492,12 @@ exports[`single-choice question reviewMode: true should snapshot the same with c
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-9"
+                          id="uid-choice-5-b"
                           tabindex="-1"
                           type="radio"
                         />
                         <label
-                          for="choice-9"
+                          for="uid-choice-5-b"
                         >
                           (Choice B)
                              
@@ -2607,12 +2607,12 @@ exports[`single-choice question reviewMode: true should snapshot the same with c
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-10"
+                          id="uid-choice-6-c"
                           tabindex="-1"
                           type="radio"
                         />
                         <label
-                          for="choice-10"
+                          for="uid-choice-6-c"
                         >
                           (Choice C, Checked)
                              
@@ -2722,12 +2722,12 @@ exports[`single-choice question reviewMode: true should snapshot the same with c
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-11"
+                          id="uid-choice-7-d"
                           tabindex="-1"
                           type="radio"
                         />
                         <label
-                          for="choice-11"
+                          for="uid-choice-7-d"
                         >
                           (Choice D)
                              
@@ -2923,12 +2923,12 @@ exports[`single-choice question reviewMode: true should snapshot the same with i
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-16"
+                          id="uid-choice-8-a"
                           tabindex="-1"
                           type="radio"
                         />
                         <label
-                          for="choice-16"
+                          for="uid-choice-8-a"
                         >
                           (Choice A, Checked)
                              
@@ -3064,12 +3064,12 @@ exports[`single-choice question reviewMode: true should snapshot the same with i
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-17"
+                          id="uid-choice-9-b"
                           tabindex="-1"
                           type="radio"
                         />
                         <label
-                          for="choice-17"
+                          for="uid-choice-9-b"
                         >
                           (Choice B)
                              
@@ -3179,12 +3179,12 @@ exports[`single-choice question reviewMode: true should snapshot the same with i
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-18"
+                          id="uid-choice-10-c"
                           tabindex="-1"
                           type="radio"
                         />
                         <label
-                          for="choice-18"
+                          for="uid-choice-10-c"
                         >
                           (Choice C)
                              
@@ -3294,12 +3294,12 @@ exports[`single-choice question reviewMode: true should snapshot the same with i
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-19"
+                          id="uid-choice-11-d"
                           tabindex="-1"
                           type="radio"
                         />
                         <label
-                          for="choice-19"
+                          for="uid-choice-11-d"
                         >
                           (Choice D)
                              
@@ -3495,12 +3495,12 @@ exports[`single-choice question reviewMode: true should snapshot the same: first
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-0"
+                          id="uid-choice-0-a"
                           tabindex="-1"
                           type="radio"
                         />
                         <label
-                          for="choice-0"
+                          for="uid-choice-0-a"
                         >
                           (Choice A, Incorrect)
                              
@@ -3717,12 +3717,12 @@ exports[`single-choice question reviewMode: true should snapshot the same: first
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-1"
+                          id="uid-choice-1-b"
                           tabindex="-1"
                           type="radio"
                         />
                         <label
-                          for="choice-1"
+                          for="uid-choice-1-b"
                         >
                           (Choice B, Incorrect)
                              
@@ -3897,12 +3897,12 @@ exports[`single-choice question reviewMode: true should snapshot the same: first
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-2"
+                          id="uid-choice-2-c"
                           tabindex="-1"
                           type="radio"
                         />
                         <label
-                          for="choice-2"
+                          for="uid-choice-2-c"
                         >
                           (Choice C, Correct)
                              
@@ -4072,12 +4072,12 @@ exports[`single-choice question reviewMode: true should snapshot the same: first
                       >
                         <input
                           class="perseus-radio-option-content"
-                          id="choice-3"
+                          id="uid-choice-3-d"
                           tabindex="-1"
                           type="radio"
                         />
                         <label
-                          for="choice-3"
+                          for="uid-choice-3-d"
                         >
                           (Choice D, Incorrect)
                              

--- a/packages/perseus/src/widgets/__tests__/radio.test.ts
+++ b/packages/perseus/src/widgets/__tests__/radio.test.ts
@@ -15,7 +15,7 @@ import {
 
 import {renderQuestion} from "./renderQuestion";
 
-import type {PerseusRenderer, ShowSolutions} from "../../perseus-types";
+import type {PerseusRenderer} from "../../perseus-types";
 import type {APIOptions} from "../../types";
 
 const selectOption = async (

--- a/packages/perseus/src/widgets/__tests__/radio.test.ts
+++ b/packages/perseus/src/widgets/__tests__/radio.test.ts
@@ -3,7 +3,6 @@ import {act, screen, fireEvent} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import _ from "underscore";
 
-import {getMockUniqueId} from "../../../../../testing/mock-unique-id";
 import {clone} from "../../../../../testing/object-utils";
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
@@ -40,7 +39,6 @@ describe("single-choice question", () => {
             advanceTimers: jest.advanceTimersByTime,
         });
 
-        jest.spyOn(_, "uniqueId").mockImplementation(getMockUniqueId());
         jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
             testDependencies,
         );

--- a/packages/perseus/src/widgets/__tests__/radio.test.ts
+++ b/packages/perseus/src/widgets/__tests__/radio.test.ts
@@ -15,7 +15,7 @@ import {
 
 import {renderQuestion} from "./renderQuestion";
 
-import type {PerseusRenderer} from "../../perseus-types";
+import type {PerseusRenderer, ShowSolutions} from "../../perseus-types";
 import type {APIOptions} from "../../types";
 
 const selectOption = async (
@@ -330,7 +330,7 @@ describe("single-choice question", () => {
         expect(passageRefRadio).toHaveTextContent("lines NaN–NaN");
     });
 
-    it("should render rationales for selected choices", async () => {
+    it("should render rationales for selected choices using method", async () => {
         // Arrange
         const {renderer} = renderQuestion(question, apiOptions);
 
@@ -340,10 +340,47 @@ describe("single-choice question", () => {
 
         // Assert
         expect(
-            screen.queryAllByTestId(
-                `perseus-radio-rationale-content-${incorrect[0]}`,
-            ),
+            screen.queryAllByTestId(/perseus-radio-rationale-content/),
         ).toHaveLength(1);
+    });
+
+    it("should render rationales for selected choices using prop", async () => {
+        // Arrange
+        const {rerender} = renderQuestion(question, apiOptions);
+
+        // Act
+        await selectOption(userEvent, incorrect[0]);
+
+        rerender(question, {showSolutions: "selected"});
+
+        // Assert
+        expect(
+            screen.queryAllByTestId(/perseus-radio-rationale-content/),
+        ).toHaveLength(1);
+    });
+
+    it("should render all rationales when showSolutions is 'all'", async () => {
+        // Arrange
+        renderQuestion(question, apiOptions, {
+            showSolutions: "all",
+        });
+
+        // Assert
+        expect(
+            screen.queryAllByTestId(/perseus-radio-rationale-content/),
+        ).toHaveLength(4);
+    });
+
+    it("should render no rationales when showSolutions is 'none'", async () => {
+        // Arrange
+        renderQuestion(question, apiOptions, {
+            showSolutions: "none",
+        });
+
+        // Assert
+        expect(
+            screen.queryAllByTestId(/perseus-radio-rationale-content/),
+        ).toHaveLength(0);
     });
 
     describe("cross-out is enabled", () => {

--- a/packages/perseus/src/widgets/__tests__/radio/base-radio.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/radio/base-radio.test.tsx
@@ -1,3 +1,4 @@
+import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 import {render, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
@@ -9,7 +10,6 @@ import {generateChoice} from "../../__testdata__/base-radio.testdata";
 import BaseRadio from "../../radio/base-radio";
 
 import type {APIOptions} from "../../../types";
-import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 
 function renderBaseRadio(props) {
     const apiOptions: APIOptions = Object.freeze({});

--- a/packages/perseus/src/widgets/__tests__/radio/base-radio.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/radio/base-radio.test.tsx
@@ -9,6 +9,7 @@ import {generateChoice} from "../../__testdata__/base-radio.testdata";
 import BaseRadio from "../../radio/base-radio";
 
 import type {APIOptions} from "../../../types";
+import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 
 function renderBaseRadio(props) {
     const apiOptions: APIOptions = Object.freeze({});
@@ -37,7 +38,9 @@ function renderBaseRadio(props) {
 
     const overwrittenProps = {...baseProps, ...props} as const;
 
-    return render(<BaseRadio {...overwrittenProps} />);
+    return render(<BaseRadio {...overwrittenProps} />, {
+        wrapper: RenderStateRoot,
+    });
 }
 
 describe("base-radio", () => {

--- a/packages/perseus/src/widgets/__tests__/radio/choice.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/radio/choice.test.tsx
@@ -1,10 +1,10 @@
 import {describe, it} from "@jest/globals";
+import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 import {render, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
 import Choice from "../../radio/choice";
-import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 
 function renderChoice(options) {
     const defaultOptions = {

--- a/packages/perseus/src/widgets/__tests__/radio/choice.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/radio/choice.test.tsx
@@ -4,6 +4,7 @@ import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
 import Choice from "../../radio/choice";
+import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 
 function renderChoice(options) {
     const defaultOptions = {
@@ -24,7 +25,9 @@ function renderChoice(options) {
 
     const overwrittenOptions = {...defaultOptions, ...options} as const;
 
-    return render(<Choice {...overwrittenOptions} />);
+    return render(<Choice {...overwrittenOptions} />, {
+        wrapper: RenderStateRoot,
+    });
 }
 
 describe("all choice options", () => {

--- a/packages/perseus/src/widgets/radio/choice.tsx
+++ b/packages/perseus/src/widgets/radio/choice.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-unsafe */
 import Button from "@khanacademy/wonder-blocks-button";
 import Clickable from "@khanacademy/wonder-blocks-clickable";
-import {View} from "@khanacademy/wonder-blocks-core";
+import {View, useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
 import * as i18n from "@khanacademy/wonder-blocks-i18n";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {Popover, PopoverContent} from "@khanacademy/wonder-blocks-popover";
@@ -69,15 +69,6 @@ type WithForwardRef = {
 
 type ChoicePropsWithForwardRef = ChoiceProps & WithForwardRef;
 
-// Note(TB): Received errors when using useUniqueIdWithMock
-// so created this workaround function. Will update when
-// useUniqueIdWithMock is available.
-// https://khanacademy.atlassian.net/browse/FEI-4861?atlOrigin=eyJpIjoiNDJlZWMwNjM1NWJhNDBkMWFjY2FmN2I0ZjcxZmQxOGUiLCJwIjoiaiJ9
-let id = 0;
-function uniqueId() {
-    return `choice-${id++}`;
-}
-
 const Choice = function (props: ChoicePropsWithForwardRef): React.ReactElement {
     const {
         disabled = false,
@@ -143,7 +134,9 @@ const Choice = function (props: ChoicePropsWithForwardRef): React.ReactElement {
         crossedOut,
         showCorrectness,
     );
-    const choiceId = uniqueId();
+
+    const idFactory = useUniqueIdWithMock(`choice`);
+    const choiceId = idFactory.get(letter);
 
     return (
         <div

--- a/packages/perseus/src/widgets/radio/radio.tsx
+++ b/packages/perseus/src/widgets/radio/radio.tsx
@@ -12,7 +12,7 @@ import type {FocusFunction, ChoiceType} from "./base-radio";
 import type {
     PerseusRadioChoice,
     PerseusRadioWidgetOptions,
-    ShowRationales,
+    ShowSolutions,
 } from "../../perseus-types";
 import type {PerseusScore, WidgetProps, ChoiceState} from "../../types";
 
@@ -25,7 +25,7 @@ export type RenderProps = {
     deselectEnabled?: boolean;
     choices: ReadonlyArray<RadioChoiceWithMetadata>;
     selectedChoices: ReadonlyArray<PerseusRadioChoice["correct"]>;
-    showRationales?: ShowRationales;
+    showSolutions?: ShowSolutions;
     choiceStates?: ReadonlyArray<ChoiceState>;
     // Depreciated; support for legacy way of handling changes
     // Adds proptype for prop that is used but was lacking type
@@ -50,7 +50,7 @@ type DefaultProps = Required<
         | "countChoices"
         | "deselectEnabled"
         | "linterContext"
-        | "showRationales"
+        | "showSolutions"
     >
 >;
 
@@ -69,7 +69,7 @@ class Radio extends React.Component<Props> {
         countChoices: false,
         deselectEnabled: false,
         linterContext: linterContextDefault,
-        showRationales: "none",
+        showSolutions: "none",
     };
 
     static validate(userInput: UserInput, rubric: Rubric): PerseusScore {
@@ -202,10 +202,10 @@ class Radio extends React.Component<Props> {
         };
     }
 
-    componentDidUpdate(prevProps) {
+    componentDidUpdate(prevProps: Props) {
         if (
-            this.props.showRationales === "selected" &&
-            prevProps.showRationales !== "selected"
+            this.props.showSolutions === "selected" &&
+            prevProps.showSolutions !== "selected"
         ) {
             this.showRationalesForCurrentlySelectedChoices(this.props);
         }
@@ -350,7 +350,7 @@ class Radio extends React.Component<Props> {
      * Turn on rationale display for the currently selected choices. Note that
      * this leaves rationales on for choices that are already showing
      * rationales.
-     * @deprecated Internal only. Use `showRationales` prop instead.
+     * @deprecated Internal only. Use `showSolutions` prop instead.
      */
     showRationalesForCurrentlySelectedChoices: (
         arg1: PerseusRadioWidgetOptions,
@@ -380,7 +380,7 @@ class Radio extends React.Component<Props> {
                         state.selected ||
                         state.readOnly ||
                         widgetCorrect ||
-                        this.props.showRationales !== "none",
+                        this.props.showSolutions !== "none",
                     correctnessShown: state.selected || state.correctnessShown,
                     previouslyAnswered:
                         state.previouslyAnswered || state.selected,
@@ -437,7 +437,7 @@ class Radio extends React.Component<Props> {
                 correctnessShown: true,
                 previouslyAnswered: false,
             }));
-        } else if (this.props.showRationales === "all") {
+        } else if (this.props.showSolutions === "all") {
             choiceStates = choices.map(() => ({
                 selected: false,
                 crossedOut: false,

--- a/packages/perseus/src/widgets/radio/radio.tsx
+++ b/packages/perseus/src/widgets/radio/radio.tsx
@@ -438,11 +438,11 @@ class Radio extends React.Component<Props> {
                 previouslyAnswered: false,
             }));
         } else if (this.props.showSolutions === "all") {
-            choiceStates = choices.map(() => ({
-                selected: false,
+            choiceStates = choices.map(({correct}) => ({
+                selected: correct, // to draw the eye to the correct answer
                 crossedOut: false,
                 readOnly: true,
-                highlighted: false,
+                highlighted: false, // has no effect in this mode
                 rationaleShown: true,
                 correctnessShown: true,
                 previouslyAnswered: false,

--- a/testing/renderer-with-debug-ui.tsx
+++ b/testing/renderer-with-debug-ui.tsx
@@ -15,18 +15,22 @@ import {registerAllWidgetsForTesting} from "../packages/perseus/src/util/registe
 import SideBySide from "./side-by-side";
 
 import type {PerseusRenderer} from "../packages/perseus/src/perseus-types";
-import type {APIOptions} from "../packages/perseus/src/types";
+import type {ComponentProps} from "react";
 
 type Props = {
     question: PerseusRenderer;
-    apiOptions?: APIOptions;
-    reviewMode?: boolean;
-};
+} & Partial<
+    Omit<
+        ComponentProps<typeof Renderer>,
+        "content" | "images" | "widgets" | "problemNum"
+    >
+>;
 
 export const RendererWithDebugUI = ({
     question,
     apiOptions,
     reviewMode = false,
+    ...rest
 }: Props): React.ReactElement => {
     registerAllWidgetsForTesting();
     const ref = React.useRef<Renderer | null | undefined>(null);
@@ -65,6 +69,7 @@ export const RendererWithDebugUI = ({
                             problemNum={0}
                             apiOptions={{...apiOptions, isMobile}}
                             reviewMode={reviewMode}
+                            {...rest}
                         />
                     </View>
                     <View style={{flexDirection: "row", alignItems: "center"}}>


### PR DESCRIPTION
Summary
This is a completely backwards-compatible solution that provides an functional-React-friendly API alternative to `showRationalesForCurrentlySelectedChoices` while providing a way to reveal all rationales.

PRs will follow for `label-image`, `group`, and `graded-group`.

Naming it `showSolutions` instead of `showRationales` because for `label-image`, the method displays the correctness of each answer without rationales.


https://github.com/Khan/perseus/assets/23404711/67137a1c-1e3d-4632-9d24-524937c2b80c


Issue: TUT-425

Testing:
Unit tests added and storybook updated to reflect the changes!