### PR TITLE
Clarify the role of our graph context

### DIFF
--- a/.changeset/dirty-cobras-dance.md
+++ b/.changeset/dirty-cobras-dance.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: restructure the interactive graph React context to clarify its purpose

--- a/packages/perseus/src/widgets/interactive-graphs/axis-arrows.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-arrows.tsx
@@ -4,11 +4,7 @@ import {Arrowhead} from "./graphs/components/arrowhead";
 import useGraphModel from "./reducer/use-graph-model";
 
 export default function AxisArrows() {
-    const {state} = useGraphModel();
-
-    const range = state.range;
-    const [xMin, xMax] = range[0];
-    const [yMin, yMax] = range[1];
+    const {range: [[xMin, xMax], [yMin, yMax]]} = useGraphModel();
 
     return (
         <>

--- a/packages/perseus/src/widgets/interactive-graphs/axis-arrows.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-arrows.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 
 import {Arrowhead} from "./graphs/components/arrowhead";
-import useGraphState from "./reducer/use-graph-state";
+import useGraphModel from "./reducer/use-graph-model";
 
 export default function AxisArrows() {
-    const {state} = useGraphState();
+    const {state} = useGraphModel();
 
     const range = state.range;
     const [xMin, xMax] = range[0];

--- a/packages/perseus/src/widgets/interactive-graphs/axis-arrows.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-arrows.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 
 import {Arrowhead} from "./graphs/components/arrowhead";
-import useGraphModel from "./reducer/use-graph-model";
+import useGraphConfig from "./reducer/use-graph-config";
 
 export default function AxisArrows() {
-    const {range: [[xMin, xMax], [yMin, yMax]]} = useGraphModel();
+    const {range: [[xMin, xMax], [yMin, yMax]]} = useGraphConfig();
 
     return (
         <>

--- a/packages/perseus/src/widgets/interactive-graphs/axis-arrows.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-arrows.tsx
@@ -4,7 +4,9 @@ import {Arrowhead} from "./graphs/components/arrowhead";
 import useGraphConfig from "./reducer/use-graph-config";
 
 export default function AxisArrows() {
-    const {range: [[xMin, xMax], [yMin, yMax]]} = useGraphConfig();
+    const {
+        range: [[xMin, xMax], [yMin, yMax]],
+    } = useGraphConfig();
 
     return (
         <>

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
@@ -20,7 +20,7 @@ type Props = {
 const hitboxSizePx = 48;
 
 export const StyledMovablePoint = (props: Props) => {
-    const {state} = useGraphModel();
+    const {range, snapStep, markings} = useGraphModel();
     const hitboxRef = useRef<SVGCircleElement>(null);
     const {point, onMove, color = WBColor.blue} = props;
 
@@ -28,21 +28,21 @@ export const StyledMovablePoint = (props: Props) => {
         gestureTarget: hitboxRef,
         point,
         onMove,
-        constrain: (p) => snap(state.snapStep, p),
+        constrain: (p) => snap(snapStep, p),
     });
     const pointClasses = `movable-point ${dragging ? "movable-point--dragging" : ""}`;
 
     const [[x, y]] = useTransform(point);
 
-    const [xMin, xMax] = state.range[0];
-    const [yMin, yMax] = state.range[1];
+    const [xMin, xMax] = range[0];
+    const [yMin, yMax] = range[1];
 
     const [[verticalStartX]] = useTransform([xMin, 0]);
     const [[verticalEndX]] = useTransform([xMax, 0]);
     const [[_, horizontalStartY]] = useTransform([0, yMin]);
     const [[__, horizontalEndY]] = useTransform([0, yMax]);
 
-    const showHairlines = dragging && state.markings !== "none";
+    const showHairlines = dragging && markings !== "none";
 
     return (
         <>

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
@@ -3,7 +3,7 @@ import {useMovable} from "mafs";
 import * as React from "react";
 import {useRef} from "react";
 
-import useGraphModel from "../../reducer/use-graph-model";
+import useGraphConfig from "../../reducer/use-graph-config";
 import {snap} from "../../utils";
 import {useTransform} from "../use-transform";
 
@@ -20,7 +20,7 @@ type Props = {
 const hitboxSizePx = 48;
 
 export const StyledMovablePoint = (props: Props) => {
-    const {range, snapStep, markings} = useGraphModel();
+    const {range, snapStep, markings} = useGraphConfig();
     const hitboxRef = useRef<SVGCircleElement>(null);
     const {point, onMove, color = WBColor.blue} = props;
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
@@ -3,7 +3,7 @@ import {useMovable} from "mafs";
 import * as React from "react";
 import {useRef} from "react";
 
-import useGraphState from "../../reducer/use-graph-state";
+import useGraphModel from "../../reducer/use-graph-model";
 import {snap} from "../../utils";
 import {useTransform} from "../use-transform";
 
@@ -20,7 +20,7 @@ type Props = {
 const hitboxSizePx = 48;
 
 export const StyledMovablePoint = (props: Props) => {
-    const {state} = useGraphState();
+    const {state} = useGraphModel();
     const hitboxRef = useRef<SVGCircleElement>(null);
     const {point, onMove, color = WBColor.blue} = props;
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
@@ -44,7 +44,11 @@ export const LinearGraph = (props: LinearGraphProps) => {
     );
 };
 
-const LineView = (props: InteractiveLineProps & {stroke: string}) => {
+interface LineViewProps extends InteractiveLineProps {
+    stroke: string;
+}
+
+const LineView = (props: LineViewProps) => {
     const {
         onMoveLine,
         onMovePoint,

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
@@ -8,6 +8,7 @@ import {StyledMovablePoint} from "./components/movable-point";
 import type {InteractiveLineProps} from "./types";
 import type {MafsGraphProps, LinearGraphState} from "../types";
 import type {vec} from "mafs";
+import useGraphModel from "../reducer/use-graph-model";
 
 type LinearGraphProps = MafsGraphProps<LinearGraphState>;
 
@@ -23,7 +24,6 @@ export const LinearGraph = (props: LinearGraphProps) => {
                 <LineView
                     key={i}
                     collinearPair={line}
-                    range={range}
                     onMoveLine={(delta: vec.Vector2) => {
                         dispatch(moveLine(i, delta));
                     }}
@@ -49,9 +49,10 @@ const LineView = (props: InteractiveLineProps & {stroke: string}) => {
         onMoveLine,
         onMovePoint,
         collinearPair: [start, end],
-        range,
         stroke,
     } = props;
+
+    const {range} = useGraphModel();
 
     return (
         <>

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
@@ -23,7 +23,7 @@ export const LinearGraph = (props: LinearGraphProps) => {
             {lines?.map((line, i) => (
                 <LineView
                     key={i}
-                    collinearPair={line}
+                    points={line}
                     onMoveLine={(delta: vec.Vector2) => {
                         dispatch(moveLine(i, delta));
                     }}
@@ -48,7 +48,7 @@ const LineView = (props: InteractiveLineProps & {stroke: string}) => {
     const {
         onMoveLine,
         onMovePoint,
-        collinearPair: [start, end],
+        points: [start, end],
         stroke,
     } = props;
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
@@ -23,7 +23,6 @@ export const LinearGraph = (props: LinearGraphProps) => {
                 <LineView
                     key={i}
                     collinearPair={line}
-                    snaps={snapStep}
                     range={range}
                     onMoveLine={(delta: vec.Vector2) => {
                         dispatch(moveLine(i, delta));

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import {moveControlPoint, moveLine} from "../reducer/interactive-graph-action";
+import useGraphConfig from "../reducer/use-graph-config";
 
 import {MovableLine} from "./components/movable-line";
 import {StyledMovablePoint} from "./components/movable-point";
@@ -8,13 +9,12 @@ import {StyledMovablePoint} from "./components/movable-point";
 import type {InteractiveLineProps} from "./types";
 import type {MafsGraphProps, LinearGraphState} from "../types";
 import type {vec} from "mafs";
-import useGraphConfig from "../reducer/use-graph-config";
 
 type LinearGraphProps = MafsGraphProps<LinearGraphState>;
 
 export const LinearGraph = (props: LinearGraphProps) => {
     const {dispatch} = props;
-    const {coords: lines, snapStep, range, type} = props.graphState;
+    const {coords: lines, type} = props.graphState;
 
     const colors = ["var(--movable-line-stroke-color)", "var(--mafs-violet)"];
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
@@ -8,7 +8,7 @@ import {StyledMovablePoint} from "./components/movable-point";
 import type {InteractiveLineProps} from "./types";
 import type {MafsGraphProps, LinearGraphState} from "../types";
 import type {vec} from "mafs";
-import useGraphModel from "../reducer/use-graph-model";
+import useGraphConfig from "../reducer/use-graph-config";
 
 type LinearGraphProps = MafsGraphProps<LinearGraphState>;
 
@@ -56,7 +56,7 @@ const LineView = (props: LineViewProps) => {
         stroke,
     } = props;
 
-    const {range} = useGraphModel();
+    const {range} = useGraphConfig();
 
     return (
         <>

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
@@ -13,7 +13,7 @@ type SegmentProps = MafsGraphProps<SegmentGraphState>;
 
 export const SegmentGraph = (props: SegmentProps) => {
     const {dispatch} = props;
-    const {coords: segments, snapStep, range} = props.graphState;
+    const {coords: segments} = props.graphState;
 
     return (
         <>

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
@@ -20,7 +20,7 @@ export const SegmentGraph = (props: SegmentProps) => {
             {segments?.map((segment, i) => (
                 <SegmentView
                     key={i}
-                    collinearPair={segment}
+                    points={segment}
                     onMoveLine={(delta: vec.Vector2) => {
                         dispatch(moveLine(i, delta));
                     }}
@@ -42,7 +42,7 @@ export const SegmentGraph = (props: SegmentProps) => {
 const SegmentView = (props: InteractiveLineProps) => {
     const {
         onMoveLine: onMoveSegment,
-        collinearPair: [start, end],
+        points: [start, end],
     } = props;
 
     return (

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
@@ -21,7 +21,6 @@ export const SegmentGraph = (props: SegmentProps) => {
                 <SegmentView
                     key={i}
                     collinearPair={segment}
-                    range={range}
                     onMoveLine={(delta: vec.Vector2) => {
                         dispatch(moveLine(i, delta));
                     }}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
@@ -21,7 +21,6 @@ export const SegmentGraph = (props: SegmentProps) => {
                 <SegmentView
                     key={i}
                     collinearPair={segment}
-                    snaps={snapStep}
                     range={range}
                     onMoveLine={(delta: vec.Vector2) => {
                         dispatch(moveLine(i, delta));

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/types.ts
@@ -3,7 +3,6 @@ import type {Interval, vec} from "mafs";
 
 export interface InteractiveLineProps {
     collinearPair: Readonly<CollinearTuple>;
-    snaps: [number, number];
     range: [x: Interval, y: Interval];
     onMovePoint: (endpointIndex: number, destination: vec.Vector2) => unknown;
     onMoveLine: (delta: vec.Vector2) => unknown;

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/types.ts
@@ -2,7 +2,7 @@ import type {CollinearTuple} from "../../../perseus-types";
 import type {Interval, vec} from "mafs";
 
 export interface InteractiveLineProps {
-    collinearPair: Readonly<CollinearTuple>;
+    points: Readonly<[vec.Vector2, vec.Vector2]>;
     onMovePoint: (endpointIndex: number, destination: vec.Vector2) => unknown;
     onMoveLine: (delta: vec.Vector2) => unknown;
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/types.ts
@@ -3,7 +3,6 @@ import type {Interval, vec} from "mafs";
 
 export interface InteractiveLineProps {
     collinearPair: Readonly<CollinearTuple>;
-    range: [x: Interval, y: Interval];
     onMovePoint: (endpointIndex: number, destination: vec.Vector2) => unknown;
     onMoveLine: (delta: vec.Vector2) => unknown;
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/types.ts
@@ -1,5 +1,4 @@
-import type {CollinearTuple} from "../../../perseus-types";
-import type {Interval, vec} from "mafs";
+import type {vec} from "mafs";
 
 export interface InteractiveLineProps {
     points: Readonly<[vec.Vector2, vec.Vector2]>;

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -170,11 +170,7 @@ describe("MafsGraph", () => {
         };
 
         const {rerender} = render(
-            <MafsGraph
-                state={state}
-                dispatch={mockDispatch}
-                {...props}
-            />,
+            <MafsGraph state={state} dispatch={mockDispatch} {...props} />,
         );
 
         const group = screen.getByTestId("movable-point");

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -163,14 +163,14 @@ describe("MafsGraph", () => {
             coords: [[2, 2]],
         };
 
-        const props = {
-            ...getBaseMafsGraphProps(),
-            range: state.range,
-            snapStep: state.snapStep,
-        };
+        const baseMafsGraphProps = getBaseMafsGraphProps();
 
         const {rerender} = render(
-            <MafsGraph state={state} dispatch={mockDispatch} {...props} />,
+            <MafsGraph
+                state={state}
+                dispatch={mockDispatch}
+                {...baseMafsGraphProps}
+            />,
         );
 
         const group = screen.getByTestId("movable-point");
@@ -185,7 +185,7 @@ describe("MafsGraph", () => {
             <MafsGraph
                 state={updatedState}
                 dispatch={mockDispatch}
-                {...props}
+                {...baseMafsGraphProps}
             />,
         );
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -163,13 +163,17 @@ describe("MafsGraph", () => {
             coords: [[2, 2]],
         };
 
-        const baseMafsGraphProps = getBaseMafsGraphProps();
+        const props = {
+            ...getBaseMafsGraphProps(),
+            range: state.range,
+            snapStep: state.snapStep,
+        };
 
         const {rerender} = render(
             <MafsGraph
                 state={state}
                 dispatch={mockDispatch}
-                {...baseMafsGraphProps}
+                {...props}
             />,
         );
 
@@ -185,7 +189,7 @@ describe("MafsGraph", () => {
             <MafsGraph
                 state={updatedState}
                 dispatch={mockDispatch}
-                {...baseMafsGraphProps}
+                {...props}
             />,
         );
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -122,7 +122,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
         <GraphConfigContext.Provider
             value={{
                 range: state.range,
-                snapStep: props.snapStep,
+                snapStep: state.snapStep,
                 markings: props.markings,
             }}
         >

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -21,7 +21,7 @@ import {
     getGradableGraph,
     initializeGraphState,
 } from "./reducer/interactive-graph-state";
-import {GraphModelContext} from "./reducer/use-graph-model";
+import {GraphConfigContext} from "./reducer/use-graph-config";
 
 import type {InteractiveGraphState, InteractiveGraphProps} from "./types";
 import type {Widget} from "../../renderer";
@@ -119,7 +119,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
     }, [dispatch, xMinRange, xMaxRange, yMinRange, yMaxRange]);
 
     return (
-        <GraphModelContext.Provider
+        <GraphConfigContext.Provider
             value={{
                 range: state.range,
                 snapStep: props.snapStep,
@@ -185,6 +185,6 @@ export const MafsGraph = (props: MafsGraphProps) => {
                     </Mafs>
                 </View>
             </View>
-        </GraphModelContext.Provider>
+        </GraphConfigContext.Provider>
     );
 };

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -121,7 +121,9 @@ export const MafsGraph = (props: MafsGraphProps) => {
     return (
         <GraphModelContext.Provider
             value={{
-                state,
+                range: state.range,
+                snapStep: props.snapStep,
+                markings: props.markings,
             }}
         >
             <View

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -122,7 +122,6 @@ export const MafsGraph = (props: MafsGraphProps) => {
         <GraphModelContext.Provider
             value={{
                 state,
-                dispatch,
             }}
         >
             <View

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -21,7 +21,7 @@ import {
     getGradableGraph,
     initializeGraphState,
 } from "./reducer/interactive-graph-state";
-import {GraphStateContext} from "./reducer/use-graph-state";
+import {GraphModelContext} from "./reducer/use-graph-model";
 
 import type {InteractiveGraphState, InteractiveGraphProps} from "./types";
 import type {Widget} from "../../renderer";
@@ -119,7 +119,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
     }, [dispatch, xMinRange, xMaxRange, yMinRange, yMaxRange]);
 
     return (
-        <GraphStateContext.Provider
+        <GraphModelContext.Provider
             value={{
                 state,
                 dispatch,
@@ -184,6 +184,6 @@ export const MafsGraph = (props: MafsGraphProps) => {
                     </Mafs>
                 </View>
             </View>
-        </GraphStateContext.Provider>
+        </GraphModelContext.Provider>
     );
 };

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/use-graph-config.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/use-graph-config.ts
@@ -2,20 +2,20 @@ import React, {createContext} from "react";
 
 import {Interval, vec} from "mafs";
 
-type GraphModel = {
+type GraphConfig = {
     range: [Interval, Interval];
     snapStep: vec.Vector2;
     markings: "graph" | "grid" | "none";
 };
 
-const defaultGraphModel: GraphModel = {
+const defaultGraphConfig: GraphConfig = {
     range: [[0, 1], [0, 1]],
     snapStep: [1, 1],
     markings: "none",
 };
 
-export const GraphModelContext = createContext<GraphModel>(defaultGraphModel);
+export const GraphConfigContext = createContext<GraphConfig>(defaultGraphConfig);
 
-export default function useGraphModel(): GraphModel {
-    return React.useContext(GraphModelContext);
+export default function useGraphConfig(): GraphConfig {
+    return React.useContext(GraphConfigContext);
 }

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/use-graph-config.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/use-graph-config.ts
@@ -1,6 +1,6 @@
 import React, {createContext} from "react";
 
-import {Interval, vec} from "mafs";
+import type {Interval, vec} from "mafs";
 
 type GraphConfig = {
     range: [Interval, Interval];
@@ -9,12 +9,16 @@ type GraphConfig = {
 };
 
 const defaultGraphConfig: GraphConfig = {
-    range: [[0, 1], [0, 1]],
+    range: [
+        [0, 1],
+        [0, 1],
+    ],
     snapStep: [1, 1],
     markings: "none",
 };
 
-export const GraphConfigContext = createContext<GraphConfig>(defaultGraphConfig);
+export const GraphConfigContext =
+    createContext<GraphConfig>(defaultGraphConfig);
 
 export default function useGraphConfig(): GraphConfig {
     return React.useContext(GraphConfigContext);

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/use-graph-model.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/use-graph-model.ts
@@ -3,14 +3,18 @@ import React, {createContext} from "react";
 import type {InteractiveGraphAction} from "./interactive-graph-action";
 import type {InteractiveGraphState} from "../types";
 
-export const GraphStateContext = createContext<{
+type GraphModel = {
     state: InteractiveGraphState;
     dispatch: React.Dispatch<InteractiveGraphAction>;
-}>({
+};
+
+const defaultGraphModel = {
     state: {} as any,
     dispatch: () => {},
-});
+};
 
-export default function useGraphState() {
-    return React.useContext(GraphStateContext);
+export const GraphModelContext = createContext<GraphModel>(defaultGraphModel);
+
+export default function useGraphModel() {
+    return React.useContext(GraphModelContext);
 }

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/use-graph-model.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/use-graph-model.ts
@@ -1,16 +1,13 @@
 import React, {createContext} from "react";
 
-import type {InteractiveGraphAction} from "./interactive-graph-action";
 import type {InteractiveGraphState} from "../types";
 
 type GraphModel = {
     state: InteractiveGraphState;
-    dispatch: React.Dispatch<InteractiveGraphAction>;
 };
 
 const defaultGraphModel = {
     state: {} as any,
-    dispatch: () => {},
 };
 
 export const GraphModelContext = createContext<GraphModel>(defaultGraphModel);

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/use-graph-model.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/use-graph-model.ts
@@ -1,17 +1,21 @@
 import React, {createContext} from "react";
 
-import type {InteractiveGraphState} from "../types";
+import {Interval, vec} from "mafs";
 
 type GraphModel = {
-    state: InteractiveGraphState;
+    range: [Interval, Interval];
+    snapStep: vec.Vector2;
+    markings: "graph" | "grid" | "none";
 };
 
-const defaultGraphModel = {
-    state: {} as any,
+const defaultGraphModel: GraphModel = {
+    range: [[0, 1], [0, 1]],
+    snapStep: [1, 1],
+    markings: "none",
 };
 
 export const GraphModelContext = createContext<GraphModel>(defaultGraphModel);
 
-export default function useGraphModel() {
+export default function useGraphModel(): GraphModel {
     return React.useContext(GraphModelContext);
 }


### PR DESCRIPTION
## Summary:
We use a React context to convey contextual information about an
interactive graph down the component tree. I think when this context was
introduced, we envisioned it being the one-stop shop for all information
about a graph, but it turns out that doesn't work well. The different
graph types have different state shapes, so getting state from the
context in the individual graph components would force us to add a bunch
of redundant conditionals to narrow the types.

As a result of this limitation, the context was only used in practice
for information that doesn't vary between the graph types.

This PR renames and restructures the context to clarify its role.

Issue: none

Test plan:

`yarn test`