### PR TITLE
Don't extend graphed lines all the way to the graph bounds

### DIFF
--- a/.changeset/afraid-moons-live.md
+++ b/.changeset/afraid-moons-live.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix a visual bug where the arrowheads of graphed lines were sometimes clipped off at the edge of the graph.

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle.tsx
@@ -2,7 +2,7 @@ import {vec} from "mafs";
 import * as React from "react";
 
 import {clockwise} from "../../../../util/geometry";
-import {getRayIntersectionCoords as getRangeIntersectionVertex} from "../utils";
+import {getIntersectionOfRayWithBox as getRangeIntersectionVertex} from "../utils";
 
 import {MafsCssTransformWrapper} from "./css-transform-wrapper";
 import {TextLabel} from "./text-label";
@@ -166,11 +166,7 @@ export const shouldDrawArcOutside = (
     polygonLines: readonly CollinearTuple[],
 ) => {
     // Create a ray from the midpoint (inside angle) to the edge of the range
-    const rangeIntersectionPoint = getRangeIntersectionVertex(
-        midpoint,
-        vertex,
-        range,
-    );
+    const rangeIntersectionPoint = getRangeIntersectionVertex(vertex, midpoint, range);
 
     let lineIntersectionCount = 0;
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle.tsx
@@ -166,7 +166,11 @@ export const shouldDrawArcOutside = (
     polygonLines: readonly CollinearTuple[],
 ) => {
     // Create a ray from the midpoint (inside angle) to the edge of the range
-    const rangeIntersectionPoint = getRangeIntersectionVertex(vertex, midpoint, range);
+    const rangeIntersectionPoint = getRangeIntersectionVertex(
+        vertex,
+        midpoint,
+        range,
+    );
 
     let lineIntersectionCount = 0;
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.test.ts
@@ -3,38 +3,62 @@ import {type Interval, vec} from "mafs";
 
 describe("trimRange", () => {
     it("does not trim smaller than [[0, 0], [0, 0]]", () => {
-        const range: [Interval, Interval] = [[0, 1], [0, 1]];
-        const graphDimensionsInPixels: vec.Vector2 = [1, 1]
+        const range: [Interval, Interval] = [
+            [0, 1],
+            [0, 1],
+        ];
+        const graphDimensionsInPixels: vec.Vector2 = [1, 1];
 
         const trimmed = trimRange(range, graphDimensionsInPixels);
 
-        expect(trimmed).toEqual([[0, 0], [0, 0]])
+        expect(trimmed).toEqual([
+            [0, 0],
+            [0, 0],
+        ]);
     });
 
     it("trims 4 units from each edge when a unit is one pixel", () => {
-        const range: [Interval, Interval] = [[-10, 10], [-10, 10]];
-        const graphDimensionsInPixels: vec.Vector2 = [20, 20]
+        const range: [Interval, Interval] = [
+            [-10, 10],
+            [-10, 10],
+        ];
+        const graphDimensionsInPixels: vec.Vector2 = [20, 20];
 
         const trimmed = trimRange(range, graphDimensionsInPixels);
 
-        expect(trimmed).toEqual([[-6, 6], [-6, 6]])
+        expect(trimmed).toEqual([
+            [-6, 6],
+            [-6, 6],
+        ]);
     });
 
     it("trims 0.4 units from each edge when a unit is ten pixels", () => {
-        const range: [Interval, Interval] = [[-10, 10], [-10, 10]];
-        const graphDimensionsInPixels: vec.Vector2 = [200, 200]
+        const range: [Interval, Interval] = [
+            [-10, 10],
+            [-10, 10],
+        ];
+        const graphDimensionsInPixels: vec.Vector2 = [200, 200];
 
         const trimmed = trimRange(range, graphDimensionsInPixels);
 
-        expect(trimmed).toEqual([[-9.6, 9.6], [-9.6, 9.6]])
+        expect(trimmed).toEqual([
+            [-9.6, 9.6],
+            [-9.6, 9.6],
+        ]);
     });
 
     it("doesn't mix up x and y", () => {
-        const range: [Interval, Interval] = [[-10, 10], [-1, 1]];
-        const graphDimensionsInPixels: vec.Vector2 = [200, 400]
+        const range: [Interval, Interval] = [
+            [-10, 10],
+            [-1, 1],
+        ];
+        const graphDimensionsInPixels: vec.Vector2 = [200, 400];
 
         const trimmed = trimRange(range, graphDimensionsInPixels);
 
-        expect(trimmed).toEqual([[-9.6, 9.6], [-0.98, 0.98]])
+        expect(trimmed).toEqual([
+            [-9.6, 9.6],
+            [-0.98, 0.98],
+        ]);
     });
-})
+});

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.test.ts
@@ -1,0 +1,40 @@
+import {trimRange} from "./movable-line";
+import {type Interval, vec} from "mafs";
+
+describe("trimRange", () => {
+    it("does not trim smaller than [[0, 0], [0, 0]]", () => {
+        const range: [Interval, Interval] = [[0, 1], [0, 1]];
+        const graphDimensionsInPixels: vec.Vector2 = [1, 1]
+
+        const trimmed = trimRange(range, graphDimensionsInPixels);
+
+        expect(trimmed).toEqual([[0, 0], [0, 0]])
+    });
+
+    it("trims 4 units from each edge when a unit is one pixel", () => {
+        const range: [Interval, Interval] = [[-10, 10], [-10, 10]];
+        const graphDimensionsInPixels: vec.Vector2 = [20, 20]
+
+        const trimmed = trimRange(range, graphDimensionsInPixels);
+
+        expect(trimmed).toEqual([[-6, 6], [-6, 6]])
+    });
+
+    it("trims 0.4 units from each edge when a unit is ten pixels", () => {
+        const range: [Interval, Interval] = [[-10, 10], [-10, 10]];
+        const graphDimensionsInPixels: vec.Vector2 = [200, 200]
+
+        const trimmed = trimRange(range, graphDimensionsInPixels);
+
+        expect(trimmed).toEqual([[-9.6, 9.6], [-9.6, 9.6]])
+    });
+
+    it("doesn't mix up x and y", () => {
+        const range: [Interval, Interval] = [[-10, 10], [-1, 1]];
+        const graphDimensionsInPixels: vec.Vector2 = [200, 400]
+
+        const trimmed = trimRange(range, graphDimensionsInPixels);
+
+        expect(trimmed).toEqual([[-9.6, 9.6], [-0.98, 0.98]])
+    });
+})

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.test.ts
@@ -1,5 +1,6 @@
+import type {Interval, vec} from "mafs";
+
 import {trimRange} from "./movable-line";
-import {type Interval, vec} from "mafs";
 
 describe("trimRange", () => {
     it("does not trim smaller than [[0, 0], [0, 0]]", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.test.ts
@@ -1,6 +1,6 @@
-import type {Interval, vec} from "mafs";
-
 import {trimRange} from "./movable-line";
+
+import type {Interval, vec} from "mafs";
 
 describe("trimRange", () => {
     it("does not trim smaller than [[0, 0], [0, 0]]", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.test.ts
@@ -3,11 +3,11 @@ import {type Interval, vec} from "mafs";
 
 describe("trimRange", () => {
     it("does not trim smaller than [[0, 0], [0, 0]]", () => {
+        const graphDimensionsInPixels: vec.Vector2 = [1, 1];
         const range: [Interval, Interval] = [
             [0, 1],
             [0, 1],
         ];
-        const graphDimensionsInPixels: vec.Vector2 = [1, 1];
 
         const trimmed = trimRange(range, graphDimensionsInPixels);
 
@@ -18,11 +18,11 @@ describe("trimRange", () => {
     });
 
     it("trims 4 units from each edge when a unit is one pixel", () => {
+        const graphDimensionsInPixels: vec.Vector2 = [20, 20];
         const range: [Interval, Interval] = [
             [-10, 10],
             [-10, 10],
         ];
-        const graphDimensionsInPixels: vec.Vector2 = [20, 20];
 
         const trimmed = trimRange(range, graphDimensionsInPixels);
 
@@ -33,11 +33,11 @@ describe("trimRange", () => {
     });
 
     it("trims 0.4 units from each edge when a unit is ten pixels", () => {
+        const graphDimensionsInPixels: vec.Vector2 = [200, 200];
         const range: [Interval, Interval] = [
             [-10, 10],
             [-10, 10],
         ];
-        const graphDimensionsInPixels: vec.Vector2 = [200, 200];
 
         const trimmed = trimRange(range, graphDimensionsInPixels);
 
@@ -48,11 +48,11 @@ describe("trimRange", () => {
     });
 
     it("doesn't mix up x and y", () => {
+        const graphDimensionsInPixels: vec.Vector2 = [200, 400];
         const range: [Interval, Interval] = [
             [-10, 10],
             [-1, 1],
         ];
-        const graphDimensionsInPixels: vec.Vector2 = [200, 400];
 
         const trimmed = trimRange(range, graphDimensionsInPixels);
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -2,6 +2,7 @@ import {vec, useMovable} from "mafs";
 import {useRef} from "react";
 import * as React from "react";
 
+import useGraphConfig from "../../reducer/use-graph-config";
 import {TARGET_SIZE} from "../../utils";
 import {useTransform} from "../use-transform";
 import {getIntersectionOfRayWithBox} from "../utils";
@@ -10,7 +11,6 @@ import {SVGLine} from "./svg-line";
 import {Vector} from "./vector";
 
 import type {Interval} from "mafs";
-import useGraphConfig from "../../reducer/use-graph-config";
 
 const defaultStroke = "var(--movable-line-stroke-color)";
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -4,12 +4,13 @@ import * as React from "react";
 
 import {TARGET_SIZE} from "../../utils";
 import {useTransform} from "../use-transform";
-import {getRayIntersectionCoords} from "../utils";
+import {getIntersectionOfRayWithBox} from "../utils";
 
 import {SVGLine} from "./svg-line";
 import {Vector} from "./vector";
 
 import type {Interval} from "mafs";
+import useGraphConfig from "../../reducer/use-graph-config";
 
 const defaultStroke = "var(--movable-line-stroke-color)";
 
@@ -31,16 +32,18 @@ export const MovableLine = (props: Props) => {
     const midpoint = vec.midpoint(start, end);
 
     const [startPtPx, endPtPx] = useTransform(start, end);
+    const {graphDimensionsInPixels} = useGraphConfig();
 
     let startExtend: vec.Vector2 | undefined = undefined;
     let endExtend: vec.Vector2 | undefined = undefined;
 
     if (extend) {
+        const trimmedRange = trimRange(extend.range, graphDimensionsInPixels)
         startExtend = extend.start
-            ? getRayIntersectionCoords(end, start, extend.range)
+            ? getIntersectionOfRayWithBox(start, end, trimmedRange)
             : undefined;
         endExtend = extend.end
-            ? getRayIntersectionCoords(start, end, extend.range)
+            ? getIntersectionOfRayWithBox(end, start, trimmedRange)
             : undefined;
     }
 
@@ -103,3 +106,25 @@ export const MovableLine = (props: Props) => {
         </>
     );
 };
+
+export function trimRange(range: [Interval, Interval], graphDimensionsInPixels: vec.Vector2): [Interval, Interval] {
+    const pixelsToTrim = 4;
+    const [xRange, yRange] = range;
+    const [pixelsWide, pixelsTall] = graphDimensionsInPixels;
+    const graphUnitsPerPixelX = size(xRange) / pixelsWide
+    const graphUnitsPerPixelY = size(yRange) / pixelsTall
+    const graphUnitsToTrimX = pixelsToTrim * graphUnitsPerPixelX
+    const graphUnitsToTrimY = pixelsToTrim * graphUnitsPerPixelY
+    return [trim(xRange, graphUnitsToTrimX), trim(yRange, graphUnitsToTrimY)]
+}
+
+function trim(interval: Interval, amount: number): Interval {
+    if (size(interval) < amount * 2) {
+        return [0, 0];
+    }
+    return [interval[0] + amount, interval[1] - amount]
+}
+
+function size(interval: Interval): number {
+    return interval[1] - interval[0]
+}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -38,7 +38,7 @@ export const MovableLine = (props: Props) => {
     let endExtend: vec.Vector2 | undefined = undefined;
 
     if (extend) {
-        const trimmedRange = trimRange(extend.range, graphDimensionsInPixels)
+        const trimmedRange = trimRange(extend.range, graphDimensionsInPixels);
         startExtend = extend.start
             ? getIntersectionOfRayWithBox(start, end, trimmedRange)
             : undefined;
@@ -107,24 +107,27 @@ export const MovableLine = (props: Props) => {
     );
 };
 
-export function trimRange(range: [Interval, Interval], graphDimensionsInPixels: vec.Vector2): [Interval, Interval] {
+export function trimRange(
+    range: [Interval, Interval],
+    graphDimensionsInPixels: vec.Vector2,
+): [Interval, Interval] {
     const pixelsToTrim = 4;
     const [xRange, yRange] = range;
     const [pixelsWide, pixelsTall] = graphDimensionsInPixels;
-    const graphUnitsPerPixelX = size(xRange) / pixelsWide
-    const graphUnitsPerPixelY = size(yRange) / pixelsTall
-    const graphUnitsToTrimX = pixelsToTrim * graphUnitsPerPixelX
-    const graphUnitsToTrimY = pixelsToTrim * graphUnitsPerPixelY
-    return [trim(xRange, graphUnitsToTrimX), trim(yRange, graphUnitsToTrimY)]
+    const graphUnitsPerPixelX = size(xRange) / pixelsWide;
+    const graphUnitsPerPixelY = size(yRange) / pixelsTall;
+    const graphUnitsToTrimX = pixelsToTrim * graphUnitsPerPixelX;
+    const graphUnitsToTrimY = pixelsToTrim * graphUnitsPerPixelY;
+    return [trim(xRange, graphUnitsToTrimX), trim(yRange, graphUnitsToTrimY)];
 }
 
 function trim(interval: Interval, amount: number): Interval {
     if (size(interval) < amount * 2) {
         return [0, 0];
     }
-    return [interval[0] + amount, interval[1] - amount]
+    return [interval[0] + amount, interval[1] - amount];
 }
 
 function size(interval: Interval): number {
-    return interval[1] - interval[0]
+    return interval[1] - interval[0];
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
@@ -2,19 +2,20 @@ import type {CollinearTuple} from "../../../perseus-types";
 import type {Interval, vec} from "mafs";
 
 /**
- * Given two points, find the tips that extends through the points to the edge of the range.
- * @param collinearPoint - The point that the line passes through. Needed to establish slope.
- * @param extendFrom - The point that the line extends from to the edge of the graph.
+ * Given a ray and a rectangular box, find the point where the ray intersects
+ * the edge of the box. Assumes the `initialPoint` is inside the box.
+ * @param initialPoint - The starting point of the ray.
+ * @param throughPoint - A point that the ray passes through. Must be different from initialPoint.
+ * @param box - The box with which to intersect the ray, in the form [[xMin, xMax], [yMin, yMax]]
  */
-export const getRayIntersectionCoords = (
-    collinearPoint: vec.Vector2,
-    extendFrom: vec.Vector2,
-    range: [Interval, Interval],
+export const getIntersectionOfRayWithBox = (
+    initialPoint: vec.Vector2,
+    throughPoint: vec.Vector2,
+    box: [x: Interval, y: Interval],
 ): [number, number] => {
-    // edges of the graph
-    const [[xMin, xMax], [yMin, yMax]] = range;
-    const [aX, aY] = collinearPoint;
-    const [bX, bY] = extendFrom;
+    const [[xMin, xMax], [yMin, yMax]] = box;
+    const [aX, aY] = throughPoint;
+    const [bX, bY] = initialPoint;
 
     const yDiff = bY - aY;
     const xDiff = bX - aX;

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -127,6 +127,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                 snapStep: state.snapStep,
                 markings: props.markings,
                 showTooltips: !!props.showTooltips,
+                graphDimensionsInPixels: props.box,
             }}
         >
             <View

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/use-graph-config.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/use-graph-config.ts
@@ -7,6 +7,7 @@ type GraphConfig = {
     snapStep: vec.Vector2;
     markings: "graph" | "grid" | "none";
     showTooltips: boolean;
+    graphDimensionsInPixels: vec.Vector2;
 };
 
 const defaultGraphConfig: GraphConfig = {
@@ -17,6 +18,7 @@ const defaultGraphConfig: GraphConfig = {
     snapStep: [1, 1],
     markings: "none",
     showTooltips: false,
+    graphDimensionsInPixels: [1, 1],
 };
 
 export const GraphConfigContext =


### PR DESCRIPTION
## Summary:
Our SVG drawings get clipped off at the bounds of the Mafs SVG
container. This was causing the arrowheads at the end of lines to get
clipped in certain circumstances, e.g. when a line intersects the edge
of the graph at a small acute angle.

The solution implemented in this commit is to draw the arrowheads a few
pixels inside the graph bounds. Note that the legacy interactive graph
takes a similar approach to solving this problem.

Issue: LEMS-1893

Test plan:

- `yarn dev`
- View the Mafs linear graphs at `http://localhost:5173`. Drag the lines
  around. The arrowheads should remain visible.
<img width="440" alt="Screen Shot 2024-04-18 at 10 10 50 AM" src="https://github.com/Khan/perseus/assets/693920/ae86aa05-eae0-4348-ad01-c8c24cef3f7d">

