### PR TITLE
Centralize where we control feature flags in perseus-editor for Storybook

### DIFF
--- a/.changeset/twelve-llamas-tap.md
+++ b/.changeset/twelve-llamas-tap.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Enable M1 locked features in Perseus Editor storybook stories

--- a/packages/perseus-editor/src/__stories__/editor-page.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/editor-page.stories.tsx
@@ -4,6 +4,8 @@ import * as React from "react";
 import {EditorPage} from "..";
 import {registerAllWidgetsAndEditorsForTesting} from "../util/register-all-widgets-and-editors-for-testing";
 
+import {flags} from "./flags-for-api-options";
+
 import type {
     DeviceType,
     Hint,
@@ -35,11 +37,7 @@ export const Demo = (): React.ReactElement => {
         <EditorPage
             apiOptions={{
                 isMobile: false,
-                flags: {
-                    mafs: {
-                        segment: true,
-                    },
-                },
+                flags,
             }}
             previewDevice={previewDevice}
             onPreviewDeviceChange={(newDevice) => setPreviewDevice(newDevice)}

--- a/packages/perseus-editor/src/__stories__/editor.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/editor.stories.tsx
@@ -9,6 +9,8 @@ import SideBySide from "../../../../testing/side-by-side";
 import {question1} from "../__testdata__/input-number.testdata";
 import {registerAllWidgetsAndEditorsForTesting} from "../util/register-all-widgets-and-editors-for-testing";
 
+import {apiOptionsWithDefaults} from "./flags-for-api-options";
+
 import type {PerseusRenderer} from "@khanacademy/perseus";
 
 registerAllWidgetsAndEditorsForTesting(); // SIDE_EFFECTY!!!! :cry:
@@ -20,7 +22,7 @@ export default {
 export const Demo = (): React.ReactElement => {
     return (
         <Editor
-            apiOptions={ApiOptions.defaults}
+            apiOptions={apiOptionsWithDefaults}
             content={question1.content}
             placeholder=""
             widgets={question1.widgets}
@@ -93,7 +95,7 @@ export const DemoInteractiveGraph = (): React.ReactElement => {
                     <View style={{width: "360px", margin: "20px"}}>
                         <Editor
                             ref={editorRef}
-                            apiOptions={ApiOptions.defaults}
+                            apiOptions={apiOptionsWithDefaults}
                             content={content}
                             placeholder=""
                             widgets={widgets}

--- a/packages/perseus-editor/src/__stories__/editor.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/editor.stories.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/prop-types */
-import {ApiOptions} from "@khanacademy/perseus";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {action} from "@storybook/addon-actions";
 import * as React from "react";

--- a/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
+++ b/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
@@ -1,0 +1,16 @@
+import {ApiOptions, type APIOptions} from "@khanacademy/perseus";
+
+export const flags = {
+    mafs: {
+        segment: true,
+        "interactive-graph-locked-features-m1": true,
+    },
+} satisfies APIOptions["flags"];
+
+export const apiOptionsWithDefaults = {
+    ...ApiOptions.defaults,
+    flags: {
+        ...ApiOptions.defaults.flags,
+        ...flags,
+    },
+};

--- a/packages/perseus-editor/src/widgets/__stories__/interactive-graph-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/interactive-graph-editor.stories.tsx
@@ -1,7 +1,9 @@
 import * as React from "react";
 
+import {flags} from "../../__stories__/flags-for-api-options";
 import InteractiveGraphEditor from "../interactive-graph-editor";
 
+import {apiOptionsWithDefaults} from "./flags-for-api-options";
 import InteractiveGraphEditorArgTypes from "./interactive-graph-editor.argtypes";
 
 import type {Meta, StoryObj} from "@storybook/react";
@@ -72,13 +74,7 @@ export const WithLockedPoints: StoryComponentType = {
 
         const [state, dispatch] = React.useReducer(reducer, {
             // Use locked figures with mafs only.
-            apiOptions: {
-                flags: {
-                    mafs: {
-                        segment: true,
-                    },
-                },
-            },
+            apiOptions: {flags},
             graph: {
                 type: "segment",
             },
@@ -119,13 +115,7 @@ export const WithMafs: StoryComponentType = {
         };
 
         const [state, dispatch] = React.useReducer(reducer, {
-            apiOptions: {
-                flags: {
-                    mafs: {
-                        segment: true,
-                    },
-                },
-            },
+            apiOptions: {flags},
             graph: {
                 type: "segment",
             },

--- a/packages/perseus-editor/src/widgets/__stories__/interactive-graph-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/interactive-graph-editor.stories.tsx
@@ -3,7 +3,6 @@ import * as React from "react";
 import {flags} from "../../__stories__/flags-for-api-options";
 import InteractiveGraphEditor from "../interactive-graph-editor";
 
-import {apiOptionsWithDefaults} from "./flags-for-api-options";
 import InteractiveGraphEditorArgTypes from "./interactive-graph-editor.argtypes";
 
 import type {Meta, StoryObj} from "@storybook/react";


### PR DESCRIPTION
## Summary:

This PR enables the new `interactive-graph-locked-features-m1` feature flag for all `interactive-graph` editor stories (so that you can actually see the locked features as we build them). 

I also centralized our feature flags for `Perseus-editor` stories so it'll be just a bit easier as we start doing more graph types and M2 locked features. 

Issue: "none"

## Test plan:

`yarn start`
Navigate to the [With Mafs](http://localhost:6006/?path=/story/perseus-editor-widgets-interactive-graph-editor--with-mafs) sory
Note that the locked figures editing tools appear below the graph

It should also be available in the [With Locked Points](http://localhost:6006/?path=/story/perseus-editor-widgets-interactive-graph-editor--with-locked-points) story.