### PR TITLE
[🔥AUDIT🔥] Fix up stale usage of wonder-blocks-color to use wonder-blocks-tokens

### DIFF
--- a/.changeset/witty-readers-shout.md
+++ b/.changeset/witty-readers-shout.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-dev-ui": patch
+---
+
+Fix up stale usage of wonder-blocks-color to use wonder-blocks-tokens

--- a/dev/flipbook.tsx
+++ b/dev/flipbook.tsx
@@ -1,9 +1,8 @@
 /* eslint monorepo/no-internal-import: "off", monorepo/no-relative-import: "off", import/no-relative-packages: "off" */
 import Button from "@khanacademy/wonder-blocks-button";
-import Color from "@khanacademy/wonder-blocks-color";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import * as React from "react";
 import {useEffect, useReducer, useRef} from "react";
 
@@ -207,7 +206,7 @@ function GradableRenderer(props: QuestionRendererProps) {
             style={{
                 alignItems: "flex-start",
                 overflow: "hidden",
-                background: Color.white,
+                background: color.white,
                 padding: spacing.medium_16,
             }}
         >


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:

There was a reference to `wonder-blocks-color` in `dev/flipboox.tsx` that got back into `main`. WB Color is deprecated and we should use the `@khanacademy/wonder-blocks-tokens` going forward for color definitions. 

Issue: "none"

## Test plan:

`yarn tsc` is happy