### PR TITLE
Add Storybook stories for Mafs visual regression testing

### DIFF
--- a/.changeset/chilly-shoes-sniff.md
+++ b/.changeset/chilly-shoes-sniff.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Add Storybook stories for visual regression testing of Mafs interactive graphs

--- a/packages/perseus/src/widgets/__stories__/interactive-graph-regression.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/interactive-graph-regression.stories.tsx
@@ -1,0 +1,159 @@
+import * as React from "react";
+
+import Renderer from "../../renderer";
+import {interactiveGraphQuestionBuilder} from "../interactive-graphs/interactive-graph-question-builder";
+
+import type {PerseusRenderer} from "@khanacademy/perseus";
+
+type StoryArgs = Record<any, any>;
+
+export default {
+    title: "Perseus/Widgets/Interactive Graph Visual Regression Tests",
+};
+
+export const MafsWithCustomAxisLabels = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder()
+            .withAxisLabels(
+                "\\text{Custom $x$ label}",
+                "\\text{Custom $y$ label}",
+            )
+            .build()}
+    />
+);
+
+export const MafsWithFractionalGridStep = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder()
+            .withGridStep(2.571, 3.123)
+            .build()}
+    />
+);
+
+export const MafsWithFractionalAxisTicks = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder()
+            .withTickStep(1.5, 1.5)
+            .build()}
+    />
+);
+
+export const MafsWithGridMarkings = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder()
+            .withMarkings("grid")
+            .build()}
+    />
+);
+
+export const MafsWithNoMarkings = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder()
+            .withMarkings("none")
+            .build()}
+    />
+);
+
+export const MafsWithSmallRange = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder()
+            .withXRange(-2, 2)
+            .withYRange(-2, 2)
+            .build()}
+    />
+);
+
+export const MafsWithLargeRange = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder()
+            .withXRange(-50, 50)
+            .withYRange(-50, 50)
+            .build()}
+    />
+);
+
+export const MafsWithYAxisAtLeft = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder().withXRange(0, 20).build()}
+    />
+);
+
+export const MafsWithYAxisNearLeft = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder().withXRange(-1, 20).build()}
+    />
+);
+
+export const MafsWithYAxisOffLeft = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder().withXRange(1, 20).build()}
+    />
+);
+
+export const MafsWithYAxisAtRight = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder().withXRange(-20, 0).build()}
+    />
+);
+
+export const MafsWithYAxisOffRight = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder().withXRange(-20, -1).build()}
+    />
+);
+
+export const MafsWithXAxisAtBottom = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder().withYRange(0, 20).build()}
+    />
+);
+
+export const MafsWithXAxisNearBottom = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder().withYRange(-1, 20).build()}
+    />
+);
+
+export const MafsWithXAxisOffBottom = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder().withYRange(1, 20).build()}
+    />
+);
+
+export const MafsWithXAxisAtTop = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder().withYRange(-20, 0).build()}
+    />
+);
+
+export const MafsWithXAxisOffTop = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder().withYRange(-20, -1).build()}
+    />
+);
+
+function MafsQuestionRenderer(props: {question: PerseusRenderer}) {
+    const {question} = props;
+    return (
+        <Renderer
+            content={question.content}
+            widgets={question.widgets}
+            images={question.images}
+            apiOptions={{
+                flags: {
+                    mafs: {
+                        segment: true,
+                    },
+                },
+            }}
+        />
+    );
+}

--- a/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
@@ -61,6 +61,134 @@ export const MafsWithFractionalAxisTicks = (
             .build()} />
 );
 
+export const MafsWithGridMarkings = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <MafsQuestionRenderer question={
+        interactiveGraphQuestionBuilder()
+            .withMarkings("grid")
+            .build()} />
+);
+
+export const MafsWithNoMarkings = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <MafsQuestionRenderer question={
+        interactiveGraphQuestionBuilder()
+            .withMarkings("none")
+            .build()} />
+);
+
+export const MafsWithSmallRange = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <MafsQuestionRenderer question={
+        interactiveGraphQuestionBuilder()
+            .withXRange(-2, 2)
+            .withYRange(-2, 2)
+            .build()} />
+);
+
+export const MafsWithLargeRange = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <MafsQuestionRenderer question={
+        interactiveGraphQuestionBuilder()
+            .withXRange(-50, 50)
+            .withYRange(-50, 50)
+            .build()} />
+);
+
+export const MafsWithYAxisAtLeft = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <MafsQuestionRenderer question={
+        interactiveGraphQuestionBuilder()
+            .withXRange(0, 20)
+            .build()} />
+);
+
+export const MafsWithYAxisNearLeft = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <MafsQuestionRenderer question={
+        interactiveGraphQuestionBuilder()
+            .withXRange(-1, 20)
+            .build()} />
+);
+
+export const MafsWithYAxisOffLeft = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <MafsQuestionRenderer question={
+        interactiveGraphQuestionBuilder()
+            .withXRange(1, 20)
+            .build()} />
+);
+
+export const MafsWithYAxisAtRight = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <MafsQuestionRenderer question={
+        interactiveGraphQuestionBuilder()
+            .withXRange(-20, 0)
+            .build()} />
+);
+
+export const MafsWithYAxisOffRight = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <MafsQuestionRenderer question={
+        interactiveGraphQuestionBuilder()
+            .withXRange(-20, -1)
+            .build()} />
+);
+
+export const MafsWithXAxisAtBottom = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <MafsQuestionRenderer question={
+        interactiveGraphQuestionBuilder()
+            .withYRange(0, 20)
+            .build()} />
+);
+
+export const MafsWithXAxisNearBottom = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <MafsQuestionRenderer question={
+        interactiveGraphQuestionBuilder()
+            .withYRange(-1, 20)
+            .build()} />
+);
+
+export const MafsWithXAxisOffBottom = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <MafsQuestionRenderer question={
+        interactiveGraphQuestionBuilder()
+            .withYRange(1, 20)
+            .build()} />
+);
+
+export const MafsWithXAxisAtTop = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <MafsQuestionRenderer question={
+        interactiveGraphQuestionBuilder()
+            .withYRange(-20, 0)
+            .build()} />
+);
+
+export const MafsWithXAxisOffTop = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <MafsQuestionRenderer question={
+        interactiveGraphQuestionBuilder()
+            .withYRange(-20, -1)
+            .build()} />
+);
+
 
 export const Angle = (args: StoryArgs): React.ReactElement => (
     <RendererWithDebugUI question={angleQuestion} />

--- a/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
@@ -37,7 +37,28 @@ export const SideBySideFlipbook = (args: StoryArgs): React.ReactElement => (
 export const MafsWithCustomAxisLabels = (
     args: StoryArgs,
 ): React.ReactElement => (
-    <MafsQuestionRenderer question={interactiveGraphQuestionBuilder().build()} />
+    <MafsQuestionRenderer question={
+        interactiveGraphQuestionBuilder()
+            .withAxisLabels("\\text{Custom $x$ label}", "\\text{Custom $y$ label}")
+            .build()} />
+);
+
+export const MafsWithFractionalGridStep = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <MafsQuestionRenderer question={
+        interactiveGraphQuestionBuilder()
+            .withGridStep(2.571, 3.123)
+            .build()} />
+);
+
+export const MafsWithFractionalAxisTicks = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <MafsQuestionRenderer question={
+        interactiveGraphQuestionBuilder()
+            .withTickStep(1.5, 1.5)
+            .build()} />
 );
 
 

--- a/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 
 import {Flipbook} from "../../../../../dev/flipbook";
 import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui";
-import Renderer from "../../renderer";
 import {
     angleQuestion,
     circleQuestion,
@@ -19,9 +18,6 @@ import {
     sinusoidQuestion,
     segmentWithAllLockedLineVariations,
 } from "../__testdata__/interactive-graph.testdata";
-import {interactiveGraphQuestionBuilder} from "../interactive-graphs/interactive-graph-question-builder";
-
-import type {PerseusRenderer} from "@khanacademy/perseus";
 
 export default {
     title: "Perseus/Widgets/Interactive Graph",
@@ -31,135 +27,6 @@ type StoryArgs = Record<any, any>;
 
 export const SideBySideFlipbook = (args: StoryArgs): React.ReactElement => (
     <Flipbook />
-);
-
-export const MafsWithCustomAxisLabels = (
-    args: StoryArgs,
-): React.ReactElement => (
-    <MafsQuestionRenderer
-        question={interactiveGraphQuestionBuilder()
-            .withAxisLabels(
-                "\\text{Custom $x$ label}",
-                "\\text{Custom $y$ label}",
-            )
-            .build()}
-    />
-);
-
-export const MafsWithFractionalGridStep = (
-    args: StoryArgs,
-): React.ReactElement => (
-    <MafsQuestionRenderer
-        question={interactiveGraphQuestionBuilder()
-            .withGridStep(2.571, 3.123)
-            .build()}
-    />
-);
-
-export const MafsWithFractionalAxisTicks = (
-    args: StoryArgs,
-): React.ReactElement => (
-    <MafsQuestionRenderer
-        question={interactiveGraphQuestionBuilder()
-            .withTickStep(1.5, 1.5)
-            .build()}
-    />
-);
-
-export const MafsWithGridMarkings = (args: StoryArgs): React.ReactElement => (
-    <MafsQuestionRenderer
-        question={interactiveGraphQuestionBuilder()
-            .withMarkings("grid")
-            .build()}
-    />
-);
-
-export const MafsWithNoMarkings = (args: StoryArgs): React.ReactElement => (
-    <MafsQuestionRenderer
-        question={interactiveGraphQuestionBuilder()
-            .withMarkings("none")
-            .build()}
-    />
-);
-
-export const MafsWithSmallRange = (args: StoryArgs): React.ReactElement => (
-    <MafsQuestionRenderer
-        question={interactiveGraphQuestionBuilder()
-            .withXRange(-2, 2)
-            .withYRange(-2, 2)
-            .build()}
-    />
-);
-
-export const MafsWithLargeRange = (args: StoryArgs): React.ReactElement => (
-    <MafsQuestionRenderer
-        question={interactiveGraphQuestionBuilder()
-            .withXRange(-50, 50)
-            .withYRange(-50, 50)
-            .build()}
-    />
-);
-
-export const MafsWithYAxisAtLeft = (args: StoryArgs): React.ReactElement => (
-    <MafsQuestionRenderer
-        question={interactiveGraphQuestionBuilder().withXRange(0, 20).build()}
-    />
-);
-
-export const MafsWithYAxisNearLeft = (args: StoryArgs): React.ReactElement => (
-    <MafsQuestionRenderer
-        question={interactiveGraphQuestionBuilder().withXRange(-1, 20).build()}
-    />
-);
-
-export const MafsWithYAxisOffLeft = (args: StoryArgs): React.ReactElement => (
-    <MafsQuestionRenderer
-        question={interactiveGraphQuestionBuilder().withXRange(1, 20).build()}
-    />
-);
-
-export const MafsWithYAxisAtRight = (args: StoryArgs): React.ReactElement => (
-    <MafsQuestionRenderer
-        question={interactiveGraphQuestionBuilder().withXRange(-20, 0).build()}
-    />
-);
-
-export const MafsWithYAxisOffRight = (args: StoryArgs): React.ReactElement => (
-    <MafsQuestionRenderer
-        question={interactiveGraphQuestionBuilder().withXRange(-20, -1).build()}
-    />
-);
-
-export const MafsWithXAxisAtBottom = (args: StoryArgs): React.ReactElement => (
-    <MafsQuestionRenderer
-        question={interactiveGraphQuestionBuilder().withYRange(0, 20).build()}
-    />
-);
-
-export const MafsWithXAxisNearBottom = (
-    args: StoryArgs,
-): React.ReactElement => (
-    <MafsQuestionRenderer
-        question={interactiveGraphQuestionBuilder().withYRange(-1, 20).build()}
-    />
-);
-
-export const MafsWithXAxisOffBottom = (args: StoryArgs): React.ReactElement => (
-    <MafsQuestionRenderer
-        question={interactiveGraphQuestionBuilder().withYRange(1, 20).build()}
-    />
-);
-
-export const MafsWithXAxisAtTop = (args: StoryArgs): React.ReactElement => (
-    <MafsQuestionRenderer
-        question={interactiveGraphQuestionBuilder().withYRange(-20, 0).build()}
-    />
-);
-
-export const MafsWithXAxisOffTop = (args: StoryArgs): React.ReactElement => (
-    <MafsQuestionRenderer
-        question={interactiveGraphQuestionBuilder().withYRange(-20, -1).build()}
-    />
 );
 
 export const Angle = (args: StoryArgs): React.ReactElement => (
@@ -257,24 +124,6 @@ export const AllLockedLines = (args: StoryArgs): React.ReactElement => (
 export const Sinusoid = (args: StoryArgs): React.ReactElement => (
     <RendererWithDebugUI question={sinusoidQuestion} />
 );
-
-function MafsQuestionRenderer(props: {question: PerseusRenderer}) {
-    const {question} = props;
-    return (
-        <Renderer
-            content={question.content}
-            widgets={question.widgets}
-            images={question.images}
-            apiOptions={{
-                flags: {
-                    mafs: {
-                        segment: true,
-                    },
-                },
-            }}
-        />
-    );
-}
 
 // TODO(jeremy): As of Jan 2022 there are no peresus items in production that
 // use the "quadratic" graph type.

--- a/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import {Flipbook} from "../../../../../dev/flipbook";
 import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui";
+import Renderer from "../../renderer";
 import {
     angleQuestion,
     circleQuestion,
@@ -18,11 +19,9 @@ import {
     sinusoidQuestion,
     segmentWithAllLockedLineVariations,
 } from "../__testdata__/interactive-graph.testdata";
-import {
-    interactiveGraphQuestionBuilder
-} from "../interactive-graphs/interactive-graph-question-builder";
-import Renderer from "../../renderer";
-import {PerseusRenderer} from "@khanacademy/perseus";
+import {interactiveGraphQuestionBuilder} from "../interactive-graphs/interactive-graph-question-builder";
+
+import type {PerseusRenderer} from "@khanacademy/perseus";
 
 export default {
     title: "Perseus/Widgets/Interactive Graph",
@@ -37,158 +36,131 @@ export const SideBySideFlipbook = (args: StoryArgs): React.ReactElement => (
 export const MafsWithCustomAxisLabels = (
     args: StoryArgs,
 ): React.ReactElement => (
-    <MafsQuestionRenderer question={
-        interactiveGraphQuestionBuilder()
-            .withAxisLabels("\\text{Custom $x$ label}", "\\text{Custom $y$ label}")
-            .build()} />
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder()
+            .withAxisLabels(
+                "\\text{Custom $x$ label}",
+                "\\text{Custom $y$ label}",
+            )
+            .build()}
+    />
 );
 
 export const MafsWithFractionalGridStep = (
     args: StoryArgs,
 ): React.ReactElement => (
-    <MafsQuestionRenderer question={
-        interactiveGraphQuestionBuilder()
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder()
             .withGridStep(2.571, 3.123)
-            .build()} />
+            .build()}
+    />
 );
 
 export const MafsWithFractionalAxisTicks = (
     args: StoryArgs,
 ): React.ReactElement => (
-    <MafsQuestionRenderer question={
-        interactiveGraphQuestionBuilder()
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder()
             .withTickStep(1.5, 1.5)
-            .build()} />
+            .build()}
+    />
 );
 
-export const MafsWithGridMarkings = (
-    args: StoryArgs,
-): React.ReactElement => (
-    <MafsQuestionRenderer question={
-        interactiveGraphQuestionBuilder()
+export const MafsWithGridMarkings = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder()
             .withMarkings("grid")
-            .build()} />
+            .build()}
+    />
 );
 
-export const MafsWithNoMarkings = (
-    args: StoryArgs,
-): React.ReactElement => (
-    <MafsQuestionRenderer question={
-        interactiveGraphQuestionBuilder()
+export const MafsWithNoMarkings = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder()
             .withMarkings("none")
-            .build()} />
+            .build()}
+    />
 );
 
-export const MafsWithSmallRange = (
-    args: StoryArgs,
-): React.ReactElement => (
-    <MafsQuestionRenderer question={
-        interactiveGraphQuestionBuilder()
+export const MafsWithSmallRange = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder()
             .withXRange(-2, 2)
             .withYRange(-2, 2)
-            .build()} />
+            .build()}
+    />
 );
 
-export const MafsWithLargeRange = (
-    args: StoryArgs,
-): React.ReactElement => (
-    <MafsQuestionRenderer question={
-        interactiveGraphQuestionBuilder()
+export const MafsWithLargeRange = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder()
             .withXRange(-50, 50)
             .withYRange(-50, 50)
-            .build()} />
+            .build()}
+    />
 );
 
-export const MafsWithYAxisAtLeft = (
-    args: StoryArgs,
-): React.ReactElement => (
-    <MafsQuestionRenderer question={
-        interactiveGraphQuestionBuilder()
-            .withXRange(0, 20)
-            .build()} />
+export const MafsWithYAxisAtLeft = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder().withXRange(0, 20).build()}
+    />
 );
 
-export const MafsWithYAxisNearLeft = (
-    args: StoryArgs,
-): React.ReactElement => (
-    <MafsQuestionRenderer question={
-        interactiveGraphQuestionBuilder()
-            .withXRange(-1, 20)
-            .build()} />
+export const MafsWithYAxisNearLeft = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder().withXRange(-1, 20).build()}
+    />
 );
 
-export const MafsWithYAxisOffLeft = (
-    args: StoryArgs,
-): React.ReactElement => (
-    <MafsQuestionRenderer question={
-        interactiveGraphQuestionBuilder()
-            .withXRange(1, 20)
-            .build()} />
+export const MafsWithYAxisOffLeft = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder().withXRange(1, 20).build()}
+    />
 );
 
-export const MafsWithYAxisAtRight = (
-    args: StoryArgs,
-): React.ReactElement => (
-    <MafsQuestionRenderer question={
-        interactiveGraphQuestionBuilder()
-            .withXRange(-20, 0)
-            .build()} />
+export const MafsWithYAxisAtRight = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder().withXRange(-20, 0).build()}
+    />
 );
 
-export const MafsWithYAxisOffRight = (
-    args: StoryArgs,
-): React.ReactElement => (
-    <MafsQuestionRenderer question={
-        interactiveGraphQuestionBuilder()
-            .withXRange(-20, -1)
-            .build()} />
+export const MafsWithYAxisOffRight = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder().withXRange(-20, -1).build()}
+    />
 );
 
-export const MafsWithXAxisAtBottom = (
-    args: StoryArgs,
-): React.ReactElement => (
-    <MafsQuestionRenderer question={
-        interactiveGraphQuestionBuilder()
-            .withYRange(0, 20)
-            .build()} />
+export const MafsWithXAxisAtBottom = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder().withYRange(0, 20).build()}
+    />
 );
 
 export const MafsWithXAxisNearBottom = (
     args: StoryArgs,
 ): React.ReactElement => (
-    <MafsQuestionRenderer question={
-        interactiveGraphQuestionBuilder()
-            .withYRange(-1, 20)
-            .build()} />
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder().withYRange(-1, 20).build()}
+    />
 );
 
-export const MafsWithXAxisOffBottom = (
-    args: StoryArgs,
-): React.ReactElement => (
-    <MafsQuestionRenderer question={
-        interactiveGraphQuestionBuilder()
-            .withYRange(1, 20)
-            .build()} />
+export const MafsWithXAxisOffBottom = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder().withYRange(1, 20).build()}
+    />
 );
 
-export const MafsWithXAxisAtTop = (
-    args: StoryArgs,
-): React.ReactElement => (
-    <MafsQuestionRenderer question={
-        interactiveGraphQuestionBuilder()
-            .withYRange(-20, 0)
-            .build()} />
+export const MafsWithXAxisAtTop = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder().withYRange(-20, 0).build()}
+    />
 );
 
-export const MafsWithXAxisOffTop = (
-    args: StoryArgs,
-): React.ReactElement => (
-    <MafsQuestionRenderer question={
-        interactiveGraphQuestionBuilder()
-            .withYRange(-20, -1)
-            .build()} />
+export const MafsWithXAxisOffTop = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder().withYRange(-20, -1).build()}
+    />
 );
-
 
 export const Angle = (args: StoryArgs): React.ReactElement => (
     <RendererWithDebugUI question={angleQuestion} />
@@ -288,18 +260,20 @@ export const Sinusoid = (args: StoryArgs): React.ReactElement => (
 
 function MafsQuestionRenderer(props: {question: PerseusRenderer}) {
     const {question} = props;
-    return <Renderer
-        content={question.content}
-        widgets={question.widgets}
-        images={question.images}
-        apiOptions={{
-            flags: {
-                mafs: {
-                    segment: true,
+    return (
+        <Renderer
+            content={question.content}
+            widgets={question.widgets}
+            images={question.images}
+            apiOptions={{
+                flags: {
+                    mafs: {
+                        segment: true,
+                    },
                 },
-            },
-        }}
-    />
+            }}
+        />
+    );
 }
 
 // TODO(jeremy): As of Jan 2022 there are no peresus items in production that

--- a/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
@@ -18,6 +18,11 @@ import {
     sinusoidQuestion,
     segmentWithAllLockedLineVariations,
 } from "../__testdata__/interactive-graph.testdata";
+import {
+    interactiveGraphQuestionBuilder
+} from "../interactive-graphs/interactive-graph-question-builder";
+import Renderer from "../../renderer";
+import {PerseusRenderer} from "@khanacademy/perseus";
 
 export default {
     title: "Perseus/Widgets/Interactive Graph",
@@ -28,6 +33,13 @@ type StoryArgs = Record<any, any>;
 export const SideBySideFlipbook = (args: StoryArgs): React.ReactElement => (
     <Flipbook />
 );
+
+export const MafsWithCustomAxisLabels = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <MafsQuestionRenderer question={interactiveGraphQuestionBuilder().build()} />
+);
+
 
 export const Angle = (args: StoryArgs): React.ReactElement => (
     <RendererWithDebugUI question={angleQuestion} />
@@ -124,6 +136,22 @@ export const AllLockedLines = (args: StoryArgs): React.ReactElement => (
 export const Sinusoid = (args: StoryArgs): React.ReactElement => (
     <RendererWithDebugUI question={sinusoidQuestion} />
 );
+
+function MafsQuestionRenderer(props: {question: PerseusRenderer}) {
+    const {question} = props;
+    return <Renderer
+        content={question.content}
+        widgets={question.widgets}
+        images={question.images}
+        apiOptions={{
+            flags: {
+                mafs: {
+                    segment: true,
+                },
+            },
+        }}
+    />
+}
 
 // TODO(jeremy): As of Jan 2022 there are no peresus items in production that
 // use the "quadratic" graph type.

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
@@ -56,4 +56,13 @@ describe("InteractiveGraphQuestionBuilder", () => {
 
         expect(graph.options.snapStep).toEqual([5, 6])
     });
+
+    it("sets the axis tick step", () => {
+        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withTickStep(7, 8)
+            .build();
+        const graph = question.widgets["interactive-graph 1"];
+
+        expect(graph.options.step).toEqual([7, 8])
+    })
 })

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
@@ -1,0 +1,59 @@
+import {
+    interactiveGraphQuestionBuilder
+} from "./interactive-graph-question-builder";
+import {PerseusRenderer} from "../../perseus-types";
+
+describe("InteractiveGraphQuestionBuilder", () => {
+    it("builds a default graph question", () => {
+        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .build()
+
+        expect(question.content).toBe("[[☃ interactive-graph 1]]")
+    });
+
+    it("sets the grid step", () => {
+        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withGridStep(7, 8)
+            .build();
+        const graph = question.widgets["interactive-graph 1"];
+
+        expect(graph.options.gridStep).toEqual([7, 8]);
+    });
+
+    it("sets the axis labels", () => {
+        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withAxisLabels("the x label", "the y label")
+            .build();
+        const graph = question.widgets["interactive-graph 1"];
+
+        expect(graph.options.labels).toEqual(["the x label", "the y label"]);
+    });
+
+    it("sets the background markings", () => {
+        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withMarkings("grid")
+            .build();
+        const graph = question.widgets["interactive-graph 1"];
+
+        expect(graph.options.markings).toBe("grid");
+    });
+
+    it("sets the ranges", () => {
+        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withXRange(-1, 2)
+            .withYRange(3, 4)
+            .build();
+        const graph = question.widgets["interactive-graph 1"];
+
+        expect(graph.options.range).toEqual([[-1, 2], [3, 4]]);
+    });
+
+    it("sets the snap step", () => {
+        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withSnapStep(5, 6)
+            .build();
+        const graph = question.widgets["interactive-graph 1"];
+
+        expect(graph.options.snapStep).toEqual([5, 6])
+    });
+})

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
@@ -1,14 +1,13 @@
-import {
-    interactiveGraphQuestionBuilder
-} from "./interactive-graph-question-builder";
-import {PerseusRenderer} from "../../perseus-types";
+import {interactiveGraphQuestionBuilder} from "./interactive-graph-question-builder";
+
+import type {PerseusRenderer} from "../../perseus-types";
 
 describe("InteractiveGraphQuestionBuilder", () => {
     it("builds a default graph question", () => {
-        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
-            .build()
+        const question: PerseusRenderer =
+            interactiveGraphQuestionBuilder().build();
 
-        expect(question.content).toBe("[[☃ interactive-graph 1]]")
+        expect(question.content).toBe("[[☃ interactive-graph 1]]");
     });
 
     it("sets the grid step", () => {
@@ -45,7 +44,10 @@ describe("InteractiveGraphQuestionBuilder", () => {
             .build();
         const graph = question.widgets["interactive-graph 1"];
 
-        expect(graph.options.range).toEqual([[-1, 2], [3, 4]]);
+        expect(graph.options.range).toEqual([
+            [-1, 2],
+            [3, 4],
+        ]);
     });
 
     it("sets the snap step", () => {
@@ -54,7 +56,7 @@ describe("InteractiveGraphQuestionBuilder", () => {
             .build();
         const graph = question.widgets["interactive-graph 1"];
 
-        expect(graph.options.snapStep).toEqual([5, 6])
+        expect(graph.options.snapStep).toEqual([5, 6]);
     });
 
     it("sets the axis tick step", () => {
@@ -63,6 +65,6 @@ describe("InteractiveGraphQuestionBuilder", () => {
             .build();
         const graph = question.widgets["interactive-graph 1"];
 
-        expect(graph.options.step).toEqual([7, 8])
-    })
-})
+        expect(graph.options.step).toEqual([7, 8]);
+    });
+});

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -1,23 +1,22 @@
-import {PerseusRenderer} from "../../perseus-types";
-import {Interval, vec} from "mafs";
+import type {PerseusRenderer} from "../../perseus-types";
+import type {Interval, vec} from "mafs";
 
 export function interactiveGraphQuestionBuilder(): InteractiveGraphQuestionBuilder {
     return new InteractiveGraphQuestionBuilder();
 }
 
 class InteractiveGraphQuestionBuilder {
-    gridStep: vec.Vector2 = [1, 1]
-    labels: [string, string] = ["x", "y"]
-    markings: "graph" | "grid" | "none" = "graph"
-    xRange: Interval = [-10, 10]
-    yRange: Interval = [-10, 10]
-    snapStep: vec.Vector2 = [0.5, 0.5]
-    tickStep: vec.Vector2 = [1, 1]
+    gridStep: vec.Vector2 = [1, 1];
+    labels: [string, string] = ["x", "y"];
+    markings: "graph" | "grid" | "none" = "graph";
+    xRange: Interval = [-10, 10];
+    yRange: Interval = [-10, 10];
+    snapStep: vec.Vector2 = [0.5, 0.5];
+    tickStep: vec.Vector2 = [1, 1];
 
     build(): PerseusRenderer {
         return {
-            content:
-                "[[☃ interactive-graph 1]]",
+            content: "[[☃ interactive-graph 1]]",
             images: {},
             widgets: {
                 "interactive-graph 1": {
@@ -38,10 +37,7 @@ class InteractiveGraphQuestionBuilder {
                         gridStep: this.gridStep,
                         labels: this.labels,
                         markings: this.markings,
-                        range: [
-                            this.xRange,
-                            this.yRange,
-                        ],
+                        range: [this.xRange, this.yRange],
                         rulerLabel: "",
                         rulerTicks: 10,
                         showProtractor: false,
@@ -56,7 +52,7 @@ class InteractiveGraphQuestionBuilder {
                     },
                 },
             },
-        }
+        };
     }
 
     withGridStep(x: number, y: number): InteractiveGraphQuestionBuilder {
@@ -69,30 +65,30 @@ class InteractiveGraphQuestionBuilder {
         return this;
     }
 
-    withMarkings(markings: "graph" | "grid" | "none"): InteractiveGraphQuestionBuilder {
+    withMarkings(
+        markings: "graph" | "grid" | "none",
+    ): InteractiveGraphQuestionBuilder {
         this.markings = markings;
         return this;
     }
 
     withXRange(min: number, max: number): InteractiveGraphQuestionBuilder {
-        this.xRange = [min, max]
+        this.xRange = [min, max];
         return this;
     }
 
     withYRange(min: number, max: number): InteractiveGraphQuestionBuilder {
-        this.yRange = [min, max]
+        this.yRange = [min, max];
         return this;
     }
 
     withSnapStep(x: number, y: number): InteractiveGraphQuestionBuilder {
-        this.snapStep = [x, y]
+        this.snapStep = [x, y];
         return this;
     }
 
     withTickStep(x: number, y: number): InteractiveGraphQuestionBuilder {
-        this.tickStep = [x, y]
+        this.tickStep = [x, y];
         return this;
     }
 }
-
-

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -12,6 +12,7 @@ class InteractiveGraphQuestionBuilder {
     xRange: Interval = [-10, 10]
     yRange: Interval = [-10, 10]
     snapStep: vec.Vector2 = [0.5, 0.5]
+    tickStep: vec.Vector2 = [1, 1]
 
     build(): PerseusRenderer {
         return {
@@ -46,7 +47,7 @@ class InteractiveGraphQuestionBuilder {
                         showProtractor: false,
                         showRuler: false,
                         snapStep: this.snapStep,
-                        step: [1, 1],
+                        step: this.tickStep,
                     },
                     type: "interactive-graph",
                     version: {
@@ -85,6 +86,11 @@ class InteractiveGraphQuestionBuilder {
 
     withSnapStep(x: number, y: number): InteractiveGraphQuestionBuilder {
         this.snapStep = [x, y]
+        return this;
+    }
+
+    withTickStep(x: number, y: number): InteractiveGraphQuestionBuilder {
+        this.tickStep = [x, y]
         return this;
     }
 }

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -1,0 +1,92 @@
+import {PerseusRenderer} from "../../perseus-types";
+import {Interval, vec} from "mafs";
+
+export function interactiveGraphQuestionBuilder(): InteractiveGraphQuestionBuilder {
+    return new InteractiveGraphQuestionBuilder();
+}
+
+class InteractiveGraphQuestionBuilder {
+    gridStep: vec.Vector2 = [1, 1]
+    labels: [string, string] = ["x", "y"]
+    markings: "graph" | "grid" | "none" = "graph"
+    xRange: Interval = [-10, 10]
+    yRange: Interval = [-10, 10]
+    snapStep: vec.Vector2 = [0.5, 0.5]
+
+    build(): PerseusRenderer {
+        return {
+            content:
+                "[[☃ interactive-graph 1]]",
+            images: {},
+            widgets: {
+                "interactive-graph 1": {
+                    graded: true,
+                    options: {
+                        correct: {
+                            coords: [
+                                [
+                                    [-7, 7],
+                                    [2, 5],
+                                ],
+                            ],
+                            type: "segment",
+                        },
+                        graph: {
+                            type: "segment",
+                        },
+                        gridStep: this.gridStep,
+                        labels: this.labels,
+                        markings: this.markings,
+                        range: [
+                            this.xRange,
+                            this.yRange,
+                        ],
+                        rulerLabel: "",
+                        rulerTicks: 10,
+                        showProtractor: false,
+                        showRuler: false,
+                        snapStep: this.snapStep,
+                        step: [1, 1],
+                    },
+                    type: "interactive-graph",
+                    version: {
+                        major: 0,
+                        minor: 0,
+                    },
+                },
+            },
+        }
+    }
+
+    withGridStep(x: number, y: number): InteractiveGraphQuestionBuilder {
+        this.gridStep = [x, y];
+        return this;
+    }
+
+    withAxisLabels(x: string, y: string): InteractiveGraphQuestionBuilder {
+        this.labels = [x, y];
+        return this;
+    }
+
+    withMarkings(markings: "graph" | "grid" | "none"): InteractiveGraphQuestionBuilder {
+        this.markings = markings;
+        return this;
+    }
+
+    withXRange(min: number, max: number): InteractiveGraphQuestionBuilder {
+        this.xRange = [min, max]
+        return this;
+    }
+
+    withYRange(min: number, max: number): InteractiveGraphQuestionBuilder {
+        this.yRange = [min, max]
+        return this;
+    }
+
+    withSnapStep(x: number, y: number): InteractiveGraphQuestionBuilder {
+        this.snapStep = [x, y]
+        return this;
+    }
+}
+
+


### PR DESCRIPTION
In a future PR, we'll configure Storybook to run snapshot tests on these
stories, which should help us catch visual regressions in Mafs graphs.

Issue: https://khanacademy.atlassian.net/browse/LEMS-1926

## Test plan:

- `yarn storybook`
- `open http://localhost:6006/?path=/story/perseus-widgets-interactive-graph--mafs-with-custom-axis-labels`