### PR TITLE
Ensure there's enough contrast on the grid axis lines 

### DIFF
--- a/.changeset/happy-months-agree.md
+++ b/.changeset/happy-months-agree.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix for new interactive grid lines not having enough contrast with the background

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/interactive-graph.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/interactive-graph.test.ts.snap
@@ -3439,7 +3439,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="-15"
                       >
                         1
@@ -3459,7 +3459,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="-35"
                       >
                         2
@@ -3479,7 +3479,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="-55"
                       >
                         3
@@ -3499,7 +3499,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="-75"
                       >
                         4
@@ -3519,7 +3519,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="-95"
                       >
                         5
@@ -3539,7 +3539,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="-115"
                       >
                         6
@@ -3559,7 +3559,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="-135"
                       >
                         7
@@ -3579,7 +3579,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="-155"
                       >
                         8
@@ -3599,7 +3599,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="-175"
                       >
                         9
@@ -3630,7 +3630,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="45"
                       >
                         -2
@@ -3650,7 +3650,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="65"
                       >
                         -3
@@ -3670,7 +3670,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="85"
                       >
                         -4
@@ -3690,7 +3690,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="105"
                       >
                         -5
@@ -3710,7 +3710,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="125"
                       >
                         -6
@@ -3730,7 +3730,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="145"
                       >
                         -7
@@ -3750,7 +3750,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="165"
                       >
                         -8
@@ -3770,7 +3770,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="185"
                       >
                         -9
@@ -3791,7 +3791,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="20"
-                        y="25"
+                        y="20"
                       >
                         1
                       </text>
@@ -3811,7 +3811,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="40"
-                        y="25"
+                        y="20"
                       >
                         2
                       </text>
@@ -3831,7 +3831,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="60"
-                        y="25"
+                        y="20"
                       >
                         3
                       </text>
@@ -3851,7 +3851,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="80"
-                        y="25"
+                        y="20"
                       >
                         4
                       </text>
@@ -3871,7 +3871,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="100"
-                        y="25"
+                        y="20"
                       >
                         5
                       </text>
@@ -3891,7 +3891,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="120"
-                        y="25"
+                        y="20"
                       >
                         6
                       </text>
@@ -3911,7 +3911,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="140"
-                        y="25"
+                        y="20"
                       >
                         7
                       </text>
@@ -3931,7 +3931,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="160"
-                        y="25"
+                        y="20"
                       >
                         8
                       </text>
@@ -3951,7 +3951,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="180"
-                        y="25"
+                        y="20"
                       >
                         9
                       </text>
@@ -3982,7 +3982,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="-40"
-                        y="25"
+                        y="20"
                       >
                         -2
                       </text>
@@ -4002,7 +4002,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="-60"
-                        y="25"
+                        y="20"
                       >
                         -3
                       </text>
@@ -4022,7 +4022,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="-80"
-                        y="25"
+                        y="20"
                       >
                         -4
                       </text>
@@ -4042,7 +4042,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="-100"
-                        y="25"
+                        y="20"
                       >
                         -5
                       </text>
@@ -4062,7 +4062,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="-120"
-                        y="25"
+                        y="20"
                       >
                         -6
                       </text>
@@ -4082,7 +4082,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="-140"
-                        y="25"
+                        y="20"
                       >
                         -7
                       </text>
@@ -4102,7 +4102,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="-160"
-                        y="25"
+                        y="20"
                       >
                         -8
                       </text>
@@ -4122,7 +4122,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="-180"
-                        y="25"
+                        y="20"
                       >
                         -9
                       </text>
@@ -4638,7 +4638,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="-15"
                       >
                         1
@@ -4658,7 +4658,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="-35"
                       >
                         2
@@ -4678,7 +4678,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="-55"
                       >
                         3
@@ -4698,7 +4698,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="-75"
                       >
                         4
@@ -4718,7 +4718,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="-95"
                       >
                         5
@@ -4738,7 +4738,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="-115"
                       >
                         6
@@ -4758,7 +4758,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="-135"
                       >
                         7
@@ -4778,7 +4778,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="-155"
                       >
                         8
@@ -4798,7 +4798,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="-175"
                       >
                         9
@@ -4829,7 +4829,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="45"
                       >
                         -2
@@ -4849,7 +4849,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="65"
                       >
                         -3
@@ -4869,7 +4869,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="85"
                       >
                         -4
@@ -4889,7 +4889,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="105"
                       >
                         -5
@@ -4909,7 +4909,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="125"
                       >
                         -6
@@ -4929,7 +4929,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="145"
                       >
                         -7
@@ -4949,7 +4949,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="165"
                       >
                         -8
@@ -4969,7 +4969,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         height="20"
                         text-anchor="end"
                         width="50"
-                        x="-10"
+                        x="-8"
                         y="185"
                       >
                         -9
@@ -4990,7 +4990,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="20"
-                        y="25"
+                        y="20"
                       >
                         1
                       </text>
@@ -5010,7 +5010,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="40"
-                        y="25"
+                        y="20"
                       >
                         2
                       </text>
@@ -5030,7 +5030,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="60"
-                        y="25"
+                        y="20"
                       >
                         3
                       </text>
@@ -5050,7 +5050,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="80"
-                        y="25"
+                        y="20"
                       >
                         4
                       </text>
@@ -5070,7 +5070,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="100"
-                        y="25"
+                        y="20"
                       >
                         5
                       </text>
@@ -5090,7 +5090,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="120"
-                        y="25"
+                        y="20"
                       >
                         6
                       </text>
@@ -5110,7 +5110,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="140"
-                        y="25"
+                        y="20"
                       >
                         7
                       </text>
@@ -5130,7 +5130,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="160"
-                        y="25"
+                        y="20"
                       >
                         8
                       </text>
@@ -5150,7 +5150,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="180"
-                        y="25"
+                        y="20"
                       >
                         9
                       </text>
@@ -5181,7 +5181,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="-40"
-                        y="25"
+                        y="20"
                       >
                         -2
                       </text>
@@ -5201,7 +5201,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="-60"
-                        y="25"
+                        y="20"
                       >
                         -3
                       </text>
@@ -5221,7 +5221,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="-80"
-                        y="25"
+                        y="20"
                       >
                         -4
                       </text>
@@ -5241,7 +5241,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="-100"
-                        y="25"
+                        y="20"
                       >
                         -5
                       </text>
@@ -5261,7 +5261,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="-120"
-                        y="25"
+                        y="20"
                       >
                         -6
                       </text>
@@ -5281,7 +5281,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="-140"
-                        y="25"
+                        y="20"
                       >
                         -7
                       </text>
@@ -5301,7 +5301,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="-160"
-                        y="25"
+                        y="20"
                       >
                         -8
                       </text>
@@ -5321,7 +5321,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         text-anchor="middle"
                         width="50"
                         x="-180"
-                        y="25"
+                        y="20"
                       >
                         -9
                       </text>

--- a/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
@@ -50,7 +50,7 @@ const YGridTick = ({
                     height={20}
                     width={50}
                     textAnchor="end"
-                    x={xPosition - 10}
+                    x={xPosition - 8}
                     y={yPosition + 5}
                 >
                     {y.toString()}
@@ -87,7 +87,7 @@ const XGridTick = ({
                     width={50}
                     textAnchor="middle"
                     x={xPosition}
-                    y={yPosition + 25}
+                    y={yPosition + 20}
                 >
                     {x.toString()}
                 </text>

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -155,4 +155,10 @@
 .MafsView .axis-ticks text {
     font-size: 14px;
     font-family: "Mafs-MJXTEX";
+    stroke: white;
+    stroke-width: 8px;
+    paint-order: stroke fill;
+}
+.MafsView pattern g {
+    stroke: #bfbfc1;
 }


### PR DESCRIPTION
## Summary:
During the playtest we discovered that the axis tick grid lines are far too light on several different devices. This PR updates the gridlines to use a close approximation to OffBlack32.

As a result of increasing the contrast of these grid lines, I felt the axis tick labels were getting a little harder to read. After checking with design, I've added a white stroke to these labels. This greatly increases readability of our graphs.

Example of old graph contrast:
![Screenshot 2024-04-23 at 11 07 03 AM](https://github.com/Khan/perseus/assets/12463099/4c6a1c00-8582-4faa-afd0-cca4d7b943c7)

Issue: LEMS-1925

## Test plan:
- manual testing 

## Screenshots:
![Screenshot 2024-04-23 at 11 02 05 AM](https://github.com/Khan/perseus/assets/12463099/fbfb21e5-9abb-4723-a077-61114287d1c0)

![Screenshot 2024-04-23 at 11 04 25 AM](https://github.com/Khan/perseus/assets/12463099/67fc1cc7-2517-4932-9230-41696550df5f)

## Contrast Comparison:
We don't pass the WCAG rules for text, but I don't think we actually have to for the grid lines. I will confirm with design that the new contrast level is sufficient. The previous grid line color is above with a ratio of 1.12. The contrast ratio after the changes is 1.84, and appears far more legible. 
![Screenshot 2024-04-23 at 11 17 47 AM](https://github.com/Khan/perseus/assets/12463099/c617af66-6197-41e7-82bd-1f4684c8d87e)


