### PR TITLE
Explicitly set the color of the axis arrows on Mafs graphs

### DIFF
--- a/.changeset/tender-socks-live.md
+++ b/.changeset/tender-socks-live.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix bug where arrowheads on Mafs graph axes weren't visible

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/interactive-graph.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/interactive-graph.test.ts.snap
@@ -3363,66 +3363,6 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                     />
                   </g>
                   <g
-                    transform="translate(200 0) rotate(0)"
-                  >
-                    <g
-                      transform="translate(-1.5)"
-                    >
-                      <path
-                        d="M-4.199999999999999 5.6C-3.8499999999999996 3.5 0 0.35 1.0499999999999998 0C0 -0.35 -3.8499999999999996 -3.5 -4.199999999999999 -5.6"
-                        fill="none"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        style="stroke: inherit;"
-                      />
-                    </g>
-                  </g>
-                  <g
-                    transform="translate(0 200) rotate(-90)"
-                  >
-                    <g
-                      transform="translate(-1.5)"
-                    >
-                      <path
-                        d="M-4.199999999999999 5.6C-3.8499999999999996 3.5 0 0.35 1.0499999999999998 0C0 -0.35 -3.8499999999999996 -3.5 -4.199999999999999 -5.6"
-                        fill="none"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        style="stroke: inherit;"
-                      />
-                    </g>
-                  </g>
-                  <g
-                    transform="translate(-200 0) rotate(-180)"
-                  >
-                    <g
-                      transform="translate(-1.5)"
-                    >
-                      <path
-                        d="M-4.199999999999999 5.6C-3.8499999999999996 3.5 0 0.35 1.0499999999999998 0C0 -0.35 -3.8499999999999996 -3.5 -4.199999999999999 -5.6"
-                        fill="none"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        style="stroke: inherit;"
-                      />
-                    </g>
-                  </g>
-                  <g
-                    transform="translate(0 -200) rotate(-270)"
-                  >
-                    <g
-                      transform="translate(-1.5)"
-                    >
-                      <path
-                        d="M-4.199999999999999 5.6C-3.8499999999999996 3.5 0 0.35 1.0499999999999998 0C0 -0.35 -3.8499999999999996 -3.5 -4.199999999999999 -5.6"
-                        fill="none"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        style="stroke: inherit;"
-                      />
-                    </g>
-                  </g>
-                  <g
                     class="axis-ticks"
                   >
                     <g
@@ -4129,36 +4069,6 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                     </g>
                   </g>
                   <g
-                    transform="translate(200 0) rotate(0)"
-                  >
-                    <g
-                      transform="translate(-1.5)"
-                    >
-                      <path
-                        d="M-4.199999999999999 5.6C-3.8499999999999996 3.5 0 0.35 1.0499999999999998 0C0 -0.35 -3.8499999999999996 -3.5 -4.199999999999999 -5.6"
-                        fill="none"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        style="stroke: inherit;"
-                      />
-                    </g>
-                  </g>
-                  <g
-                    transform="translate(0 200) rotate(-90)"
-                  >
-                    <g
-                      transform="translate(-1.5)"
-                    >
-                      <path
-                        d="M-4.199999999999999 5.6C-3.8499999999999996 3.5 0 0.35 1.0499999999999998 0C0 -0.35 -3.8499999999999996 -3.5 -4.199999999999999 -5.6"
-                        fill="none"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        style="stroke: inherit;"
-                      />
-                    </g>
-                  </g>
-                  <g
                     transform="translate(-200 0) rotate(-180)"
                   >
                     <g
@@ -4169,12 +4079,12 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         fill="none"
                         stroke-linecap="round"
                         stroke-linejoin="round"
-                        style="stroke: inherit;"
+                        style="stroke: var(--mafs-fg);"
                       />
                     </g>
                   </g>
                   <g
-                    transform="translate(0 -200) rotate(-270)"
+                    transform="translate(200 0) rotate(0)"
                   >
                     <g
                       transform="translate(-1.5)"
@@ -4184,7 +4094,37 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                         fill="none"
                         stroke-linecap="round"
                         stroke-linejoin="round"
-                        style="stroke: inherit;"
+                        style="stroke: var(--mafs-fg);"
+                      />
+                    </g>
+                  </g>
+                  <g
+                    transform="translate(0 200) rotate(-270)"
+                  >
+                    <g
+                      transform="translate(-1.5)"
+                    >
+                      <path
+                        d="M-4.199999999999999 5.6C-3.8499999999999996 3.5 0 0.35 1.0499999999999998 0C0 -0.35 -3.8499999999999996 -3.5 -4.199999999999999 -5.6"
+                        fill="none"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        style="stroke: var(--mafs-fg);"
+                      />
+                    </g>
+                  </g>
+                  <g
+                    transform="translate(0 -200) rotate(-90)"
+                  >
+                    <g
+                      transform="translate(-1.5)"
+                    >
+                      <path
+                        d="M-4.199999999999999 5.6C-3.8499999999999996 3.5 0 0.35 1.0499999999999998 0C0 -0.35 -3.8499999999999996 -3.5 -4.199999999999999 -5.6"
+                        fill="none"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        style="stroke: var(--mafs-fg);"
                       />
                     </g>
                   </g>
@@ -4562,66 +4502,6 @@ exports[`snapshots should render correctly with locked points 1`] = `
                     />
                   </g>
                   <g
-                    transform="translate(200 0) rotate(0)"
-                  >
-                    <g
-                      transform="translate(-1.5)"
-                    >
-                      <path
-                        d="M-4.199999999999999 5.6C-3.8499999999999996 3.5 0 0.35 1.0499999999999998 0C0 -0.35 -3.8499999999999996 -3.5 -4.199999999999999 -5.6"
-                        fill="none"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        style="stroke: inherit;"
-                      />
-                    </g>
-                  </g>
-                  <g
-                    transform="translate(0 200) rotate(-90)"
-                  >
-                    <g
-                      transform="translate(-1.5)"
-                    >
-                      <path
-                        d="M-4.199999999999999 5.6C-3.8499999999999996 3.5 0 0.35 1.0499999999999998 0C0 -0.35 -3.8499999999999996 -3.5 -4.199999999999999 -5.6"
-                        fill="none"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        style="stroke: inherit;"
-                      />
-                    </g>
-                  </g>
-                  <g
-                    transform="translate(-200 0) rotate(-180)"
-                  >
-                    <g
-                      transform="translate(-1.5)"
-                    >
-                      <path
-                        d="M-4.199999999999999 5.6C-3.8499999999999996 3.5 0 0.35 1.0499999999999998 0C0 -0.35 -3.8499999999999996 -3.5 -4.199999999999999 -5.6"
-                        fill="none"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        style="stroke: inherit;"
-                      />
-                    </g>
-                  </g>
-                  <g
-                    transform="translate(0 -200) rotate(-270)"
-                  >
-                    <g
-                      transform="translate(-1.5)"
-                    >
-                      <path
-                        d="M-4.199999999999999 5.6C-3.8499999999999996 3.5 0 0.35 1.0499999999999998 0C0 -0.35 -3.8499999999999996 -3.5 -4.199999999999999 -5.6"
-                        fill="none"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        style="stroke: inherit;"
-                      />
-                    </g>
-                  </g>
-                  <g
                     class="axis-ticks"
                   >
                     <g
@@ -5328,36 +5208,6 @@ exports[`snapshots should render correctly with locked points 1`] = `
                     </g>
                   </g>
                   <g
-                    transform="translate(200 0) rotate(0)"
-                  >
-                    <g
-                      transform="translate(-1.5)"
-                    >
-                      <path
-                        d="M-4.199999999999999 5.6C-3.8499999999999996 3.5 0 0.35 1.0499999999999998 0C0 -0.35 -3.8499999999999996 -3.5 -4.199999999999999 -5.6"
-                        fill="none"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        style="stroke: inherit;"
-                      />
-                    </g>
-                  </g>
-                  <g
-                    transform="translate(0 200) rotate(-90)"
-                  >
-                    <g
-                      transform="translate(-1.5)"
-                    >
-                      <path
-                        d="M-4.199999999999999 5.6C-3.8499999999999996 3.5 0 0.35 1.0499999999999998 0C0 -0.35 -3.8499999999999996 -3.5 -4.199999999999999 -5.6"
-                        fill="none"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        style="stroke: inherit;"
-                      />
-                    </g>
-                  </g>
-                  <g
                     transform="translate(-200 0) rotate(-180)"
                   >
                     <g
@@ -5368,12 +5218,12 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         fill="none"
                         stroke-linecap="round"
                         stroke-linejoin="round"
-                        style="stroke: inherit;"
+                        style="stroke: var(--mafs-fg);"
                       />
                     </g>
                   </g>
                   <g
-                    transform="translate(0 -200) rotate(-270)"
+                    transform="translate(200 0) rotate(0)"
                   >
                     <g
                       transform="translate(-1.5)"
@@ -5383,7 +5233,37 @@ exports[`snapshots should render correctly with locked points 1`] = `
                         fill="none"
                         stroke-linecap="round"
                         stroke-linejoin="round"
-                        style="stroke: inherit;"
+                        style="stroke: var(--mafs-fg);"
+                      />
+                    </g>
+                  </g>
+                  <g
+                    transform="translate(0 200) rotate(-270)"
+                  >
+                    <g
+                      transform="translate(-1.5)"
+                    >
+                      <path
+                        d="M-4.199999999999999 5.6C-3.8499999999999996 3.5 0 0.35 1.0499999999999998 0C0 -0.35 -3.8499999999999996 -3.5 -4.199999999999999 -5.6"
+                        fill="none"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        style="stroke: var(--mafs-fg);"
+                      />
+                    </g>
+                  </g>
+                  <g
+                    transform="translate(0 -200) rotate(-90)"
+                  >
+                    <g
+                      transform="translate(-1.5)"
+                    >
+                      <path
+                        d="M-4.199999999999999 5.6C-3.8499999999999996 3.5 0 0.35 1.0499999999999998 0C0 -0.35 -3.8499999999999996 -3.5 -4.199999999999999 -5.6"
+                        fill="none"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        style="stroke: var(--mafs-fg);"
                       />
                     </g>
                   </g>

--- a/packages/perseus/src/widgets/interactive-graphs/axis-arrows.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-arrows.tsx
@@ -8,12 +8,14 @@ export default function AxisArrows() {
         range: [[xMin, xMax], [yMin, yMax]],
     } = useGraphConfig();
 
+    const axisColor = "var(--mafs-fg)";
+
     return (
         <>
-            <Arrowhead x={xMax} y={0} angle={0} />
-            <Arrowhead x={0} y={yMin} angle={90} />
-            <Arrowhead x={xMin} y={0} angle={180} />
-            <Arrowhead x={0} y={yMax} angle={270} />
+            <Arrowhead color={axisColor} x={xMax} y={0} angle={0} />
+            <Arrowhead color={axisColor} x={0} y={yMin} angle={270} />
+            <Arrowhead color={axisColor} x={xMin} y={0} angle={180} />
+            <Arrowhead color={axisColor} x={0} y={yMax} angle={90} />
         </>
     );
 }

--- a/packages/perseus/src/widgets/interactive-graphs/axis-arrows.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-arrows.tsx
@@ -12,9 +12,9 @@ export default function AxisArrows() {
 
     return (
         <>
+            <Arrowhead color={axisColor} x={xMin} y={0} angle={180} />
             <Arrowhead color={axisColor} x={xMax} y={0} angle={0} />
             <Arrowhead color={axisColor} x={0} y={yMin} angle={270} />
-            <Arrowhead color={axisColor} x={xMin} y={0} angle={180} />
             <Arrowhead color={axisColor} x={0} y={yMax} angle={90} />
         </>
     );

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/arrowhead.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/arrowhead.tsx
@@ -7,6 +7,7 @@ type Props = {
     x: number;
     y: number;
     angle: number; // degrees counterclockwise from the positive x-axis
+    color?: string;
 };
 
 // We use the pathBuilder here to scale up the SVG path coordinates used
@@ -31,7 +32,7 @@ export function Arrowhead(props: Props) {
                 <path
                     d={arrowPath}
                     fill="none"
-                    style={{stroke: "inherit"}}
+                    style={{stroke: props.color ?? "inherit"}}
                     strokeLinejoin="round"
                     strokeLinecap="round"
                 />

--- a/packages/perseus/src/widgets/interactive-graphs/grid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/grid.tsx
@@ -66,7 +66,6 @@ export const Grid = (props: GridProps) => {
                 xAxis={axisOptions(props, 0)}
                 yAxis={axisOptions(props, 1)}
             />
-            {props.markings === "graph" && <AxisArrows />}
             {
                 // Only render the axis ticks and arrows if the markings are set to a full "graph"
                 props.markings === "graph" && (


### PR DESCRIPTION
## Summary:
The arrowheads had `stroke: inherit` set in their styles, but their
parent element had no stroke set, so the arrowheads weren't showing up.

This commit fixes that, and also fixes some other issues related to
arrowheads:

- The positions of the y-axis arrowheads were swapped
- The axis arrows were getting rendered twice.

Issue: LEMS-1893

Test plan:

- `yarn dev`
- visit http://localhost:5173/#flipbook
- Paste this data into the box:

```json
{"content":"आलेख पर रेखा खींचे जो संपत्ति के साथ $d$ और $t$ में आनुपातिक संबंध दर्शाती हैI इस कारण $t$ की $3$ इकाई में वृद्धि $d$ की  $8$ इकाई में हुई वृद्धि के समान है\n\n\n** $t$ के संबंध में $d$ की परिवर्तन की इकाई दर क्या है?** (यह है कि,$t$ में परिवर्तन की $1$ इकाई $d$ में परिवर्तन की कितनी इकाई के समान होगी?)\n\n परिवर्तन की इकाई दर [[☃ input-number 1]] हैI \n\n**संबंधों का आलेख बनाएं I**\n\n\n[[☃ interactive-graph 1]]\n\n\n","images":{},"widgets":{"input-number 1":{"alignment":"default","graded":true,"options":{"answerType":"number","inexact":false,"maxError":0.1,"simplify":"required","size":"small","value":"2.6666666666666665"},"type":"input-number","version":{"major":0,"minor":0}},"interactive-graph 1":{"alignment":"default","graded":true,"options":{"backgroundImage":{"bottom":0,"height":0,"left":0,"scale":1,"url":null,"width":0},"correct":{"coords":[[0,0],[3,8]],"type":"linear"},"graph":{"type":"linear"},"gridStep":[1,1],"labels":["t","d"],"markings":"graph","range":[[-10,10],[-10,10]],"rulerLabel":"","rulerTicks":10,"showProtractor":false,"showRuler":false,"snapStep":[0.5,0.5],"step":[1,1]},"type":"interactive-graph","version":{"major":0,"minor":0}}}}
```

You should see arrowheads on the ends of the graph axes.