### PR TITLE
[🔥AUDIT🔥] Fix `yarn dev`

### DIFF
--- a/.changeset/tasty-bananas-pump.md
+++ b/.changeset/tasty-bananas-pump.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-dev-ui": patch
+---
+
+Fix 'process.env' replacement in dev UI

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -41,11 +41,6 @@ const config: StorybookConfig = {
     viteFinal: async (config, {configType}) => {
         return mergeConfig(config, {
             ...viteConfig,
-            define: {
-                // This is used to determine if we are running in a
-                // Storybook environment.
-                "process.env.STORYBOOK": JSON.stringify(true),
-            },
             build: {
                 // Vite 5 has a bug with how it builds `url(data: )` urls when
                 // it inlines SVGs. Given this is mostly used for static

--- a/dev/vite.config.ts
+++ b/dev/vite.config.ts
@@ -15,6 +15,11 @@ glob.sync(resolve(__dirname, "../packages/*/package.json")).forEach(
 );
 
 export default defineConfig({
+    define: {
+        // This is used to determine if we are running in a
+        // Storybook environment.
+        "process.env.STORYBOOK": JSON.stringify(true),
+    },
     resolve: {
         alias: {
             hubble: resolve(__dirname, "../vendor/hubble/hubble.js"),

--- a/dev/vite.config.ts
+++ b/dev/vite.config.ts
@@ -17,7 +17,7 @@ glob.sync(resolve(__dirname, "../packages/*/package.json")).forEach(
 export default defineConfig({
     define: {
         // This is used to determine if we are running in a
-        // Storybook environment.
+        // Dev/Storybook environment.
         "process.env.STORYBOOK": JSON.stringify(true),
     },
     resolve: {


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:

As part of the move away from `@khanacademy/wonder-blocks-i18n` we added some Storybook config to check if we're in a dev/storybook env and just use hard-coded (mock) strings. 

This config was applied in `.storybook/main.ts` but not to our custom dev server (in `/dev`). 

This PR moves the Vite config into `dev/vite.config.ts` so it works for both (we "inherit" the dev vite config in Storybook - maybe that's confusing and we should move it)

Issue: "none"

## Test plan:

`yarn dev` - dev UI works