### PR TITLE
[🔥AUDIT🔥] Ensure that we don't error on blur.

### DIFF
--- a/.changeset/mighty-rules-turn.md
+++ b/.changeset/mighty-rules-turn.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fixes an error when accessing the blur method.

--- a/packages/perseus/src/components/simple-keypad-input.tsx
+++ b/packages/perseus/src/components/simple-keypad-input.tsx
@@ -36,7 +36,7 @@ export default class SimpleKeypadInput extends React.Component<any> {
 
     blur() {
         // @ts-expect-error - TS2339 - Property 'blur' does not exist on type 'ReactInstance'.
-        this.refs.input.blur(); // eslint-disable-line react/no-string-refs
+        this.refs.input?.blur(); // eslint-disable-line react/no-string-refs
     }
 
     getValue(): string | number {

--- a/packages/perseus/src/widgets/expression.tsx
+++ b/packages/perseus/src/widgets/expression.tsx
@@ -494,7 +494,7 @@ export class Expression extends React.Component<Props, ExpressionState> {
     blurInputPath: (inputPath: InputPath) => void = (inputPath: InputPath) => {
         // eslint-disable-next-line react/no-string-refs
         // @ts-expect-error - TS2339 - Property 'blur' does not exist on type 'ReactInstance'.
-        this.refs.input.blur();
+        this.refs.input?.blur();
     };
 
     // HACK(joel)

--- a/packages/perseus/src/widgets/input-number.tsx
+++ b/packages/perseus/src/widgets/input-number.tsx
@@ -225,7 +225,7 @@ class InputNumber extends React.Component<Props> {
     blurInputPath: (arg1: Path) => void = (inputPath) => {
         // eslint-disable-next-line react/no-string-refs
         // @ts-expect-error - TS2339 - Property 'blur' does not exist on type 'ReactInstance'.
-        this.refs.input.blur();
+        this.refs.input?.blur();
     };
 
     getInputPaths: () => ReadonlyArray<Path> = () => {


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
Ran across this error when going into production. Unfortunately, I'm not able to replicate it!

Issue: FEI-5550

## Test plan:
I used an expression widget at:
/math/cc-fifth-grade-math/powers-of-ten/imp-comparing-decimal-place-values/quiz/powers-of-ten-quiz-2

And no matter what I could do (both desktop and mobile) I couldn't get the error to display. This at least makes sure that the error is handled if it does come up. It wasn't exactly clear to me which `.input.blur()` was undefined, so I tried to handle a few of them.