### PR TITLE
Bugfix: changing graph markings resetting number of segments

### DIFF
--- a/.changeset/lazy-poems-fix.md
+++ b/.changeset/lazy-poems-fix.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/math-input": patch
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Bugfix: interactive graph editor kept resetting state

--- a/packages/math-input/src/components/keypad/__tests__/keypad-v2-mathquill.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/keypad-v2-mathquill.test.tsx
@@ -228,7 +228,7 @@ describe("Keypad v2 with MathQuill", () => {
         );
     });
 
-    it.skip("deletes from the input using the backspace button", async () => {
+    it("deletes from the input using the backspace button", async () => {
         // Arrange
         const mockMathInputCallback = jest.fn();
         render(
@@ -275,7 +275,7 @@ describe("Keypad v2 with MathQuill", () => {
         }
 
         expect(mockMathInputCallback).toHaveBeenLastCalledWith("");
-    });
+    }, 10000);
 
     // Keypad event tests
     it("fires the keypad open event on open", async () => {

--- a/packages/math-input/src/components/keypad/__tests__/keypad-v2-mathquill.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/keypad-v2-mathquill.test.tsx
@@ -228,7 +228,7 @@ describe("Keypad v2 with MathQuill", () => {
         );
     });
 
-    it("deletes from the input using the backspace button", async () => {
+    it.skip("deletes from the input using the backspace button", async () => {
         // Arrange
         const mockMathInputCallback = jest.fn();
         render(

--- a/packages/perseus-editor/src/components/widget-editor.tsx
+++ b/packages/perseus-editor/src/components/widget-editor.tsx
@@ -11,7 +11,7 @@ import _ from "underscore";
 import SectionControlButton from "./section-control-button";
 
 import type Editor from "../editor";
-import type {Alignment, PerseusWidget} from "@khanacademy/perseus";
+import type {APIOptions, Alignment, PerseusWidget} from "@khanacademy/perseus";
 
 const {InlineIcon} = components;
 const {iconChevronDown, iconChevronRight, iconTrash} = icons;
@@ -25,7 +25,7 @@ type WidgetEditorProps = {
         silent?: boolean,
     ) => unknown;
     onRemove: () => unknown;
-    apiOptions: any;
+    apiOptions: APIOptions;
 } & Omit<PerseusWidget, "key">;
 
 type WidgetEditorState = {

--- a/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
+++ b/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
@@ -154,6 +154,17 @@ describe("mafs graphs", () => {
                 renderQuestion(question, apiOptions);
             });
 
+            it("should reject when has not been interacted with", () => {
+                // Arrange
+                const {renderer} = renderQuestion(question, apiOptions);
+
+                // Act
+                // no action
+
+                // Assert
+                expect(renderer).toHaveInvalidInput();
+            });
+
             it("rejects incorrect answer", async () => {
                 // Arrange
                 const {renderer, container} = renderQuestion(

--- a/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
+++ b/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
@@ -154,17 +154,6 @@ describe("mafs graphs", () => {
                 renderQuestion(question, apiOptions);
             });
 
-            it("should reject when has not been interacted with", () => {
-                // Arrange
-                const {renderer} = renderQuestion(question, apiOptions);
-
-                // Act
-                // no action
-
-                // Assert
-                expect(renderer).toHaveInvalidInput();
-            });
-
             it("rejects incorrect answer", async () => {
                 // Arrange
                 const {renderer, container} = renderQuestion(

--- a/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
+++ b/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
@@ -19,6 +19,12 @@ import {
     polygonQuestionDefaultCorrect,
     pointQuestionWithDefaultCorrect,
     segmentWithLockedLineQuestion,
+    segmentQuestion,
+    linearQuestion,
+    linearSystemQuestion,
+    rayQuestion,
+    polygonQuestion,
+    pointQuestion,
 } from "../__testdata__/interactive-graph.testdata";
 import {trueForAllMafsSupportedGraphTypes} from "../interactive-graphs/mafs-supported-graph-types";
 
@@ -139,6 +145,17 @@ describe("mafs graphs", () => {
     const graphQuestionRenderers: {
         [K in (typeof mafsSupportedGraphTypes)[number]]: PerseusRenderer;
     } = {
+        segment: segmentQuestion,
+        linear: linearQuestion,
+        "linear-system": linearSystemQuestion,
+        ray: rayQuestion,
+        polygon: polygonQuestion,
+        point: pointQuestion,
+    };
+
+    const graphQuestionRenderersCorrect: {
+        [K in (typeof mafsSupportedGraphTypes)[number]]: PerseusRenderer;
+    } = {
         segment: segmentQuestionDefaultCorrect,
         linear: linearQuestionWithDefaultCorrect,
         "linear-system": linearSystemQuestionWithDefaultCorrect,
@@ -163,6 +180,15 @@ describe("mafs graphs", () => {
 
                 // Assert
                 expect(renderer).toHaveInvalidInput();
+            });
+        },
+    );
+
+    describe.each(Object.entries(graphQuestionRenderersCorrect))(
+        "graph type %s: default correct",
+        (_type, question) => {
+            it("should render", () => {
+                renderQuestion(question, apiOptions);
             });
 
             it("rejects incorrect answer", async () => {

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -1689,8 +1689,9 @@ class LegacyInteractiveGraph extends React.Component<Props, State> {
         this.onChange({graph: graph});
     };
 
-    getUserInput: () => PerseusGraphType = () =>
-        InteractiveGraph.getUserInputFromProps(this.props);
+    getUserInput() {
+        return InteractiveGraph.getUserInputFromProps(this.props);
+    }
 
     simpleValidate: (rubric: Rubric) => PerseusScore = (rubric) =>
         InteractiveGraph.validate(this.getUserInput(), rubric, this);

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -1809,8 +1809,9 @@ class InteractiveGraph extends React.Component<Props, State> {
         );
     };
 
-    simpleValidate: (rubric: Rubric) => PerseusScore = (rubric) =>
-        InteractiveGraph.validate(this.getUserInput?.(), rubric, this);
+    simpleValidate(rubric: Rubric) {
+        return InteractiveGraph.validate(this.getUserInput?.(), rubric, this);
+    }
 
     render() {
         // Mafs shim

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -1693,8 +1693,9 @@ class LegacyInteractiveGraph extends React.Component<Props, State> {
         return InteractiveGraph.getUserInputFromProps(this.props);
     }
 
-    simpleValidate: (rubric: Rubric) => PerseusScore = (rubric) =>
-        InteractiveGraph.validate(this.getUserInput(), rubric, this);
+    simpleValidate(rubric: Rubric) {
+        return InteractiveGraph.validate(this.getUserInput(), rubric, this);
+    }
 
     focus: () => void = $.noop;
 

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
@@ -1,8 +1,12 @@
 import invariant from "tiny-invariant";
 
-import {initializeGraphState} from "./interactive-graph-state";
+import {
+    getGradableGraph,
+    initializeGraphState,
+} from "./interactive-graph-state";
 
-import type {InteractiveGraphProps} from "../types";
+import type {PerseusGraphType} from "../../../perseus-types";
+import type {InteractiveGraphProps, InteractiveGraphState} from "../types";
 
 type BaseGraphData = {
     range: InteractiveGraphProps["range"];
@@ -192,4 +196,32 @@ describe("initializeGraphState for point graphs", () => {
             expect(graph.coords).toHaveLength(n);
         },
     );
+});
+
+describe("getGradableGraph", () => {
+    /**
+     * Originally `getGradableGraph` was returning a PerseusGraphType with just a
+     * `type` property, stripping everything else off of `initialGraph`.
+     * This caused the editor to keep resetting certain properties (ie `numSegments`).
+     */
+    it("regression LEMS-1935: false hasBeenInteractedWith returns full initial graph", () => {
+        const state: InteractiveGraphState = {
+            type: "segment",
+            coords: [],
+            hasBeenInteractedWith: false,
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            snapStep: [1, 1],
+            markings: "graph",
+        };
+        const initialGraph: PerseusGraphType = {
+            type: "segment",
+            numSegments: 4,
+        };
+        const result = getGradableGraph(state, initialGraph);
+
+        expect(result).toEqual(initialGraph);
+    });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -161,7 +161,7 @@ export function getGradableGraph(
     initialGraph: PerseusGraphType,
 ): PerseusGraphType {
     if (!state.hasBeenInteractedWith) {
-        return {type: initialGraph.type};
+        return {...initialGraph};
     }
 
     if (


### PR DESCRIPTION
## Summary:
When `hasBeenInteractedWith` was false and `getGradableGraph` was called, `getGradableGraph` would strip everything but `type` off of `initialGraph`. When this happened in the editor, it meant that certain properties were getting reset to their defaults.

https://github.com/Khan/perseus/assets/16308368/6bbba3de-7dae-4e01-bed6-c586747a3b15

Issue: [LEMS-1935](https://khanacademy.atlassian.net/browse/LEMS-1935)

## Test plan:
- Go to the `Interactive Graph Edior > With Mafs` story
- Change type to "Line Segment(s)"
- Change "Number of segments" to 4
- Change "Marking" from "Graph" to "Grid"
- Note "Number of segments" stays on 4 (before it would reset to 1)

[LEMS-1935]: https://khanacademy.atlassian.net/browse/LEMS-1935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ