### PR TITLE
Move delete button in locked figure settings

### DIFF
--- a/.changeset/calm-icons-change.md
+++ b/.changeset/calm-icons-change.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Move the delete button in locked figure settings

--- a/packages/perseus-editor/src/components/__stories__/locked-point-settings.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/locked-point-settings.stories.tsx
@@ -20,13 +20,15 @@ type StoryComponentType = StoryObj<typeof LockedPointSettings>;
 Default.args = {
     ...getDefaultFigureForType("point"),
     onChangeProps: () => {},
+    onRemove: () => {},
 };
 
 export const Controlled: StoryComponentType = {
     render: function Render() {
-        const [props, setProps] = React.useState(
-            getDefaultFigureForType("point"),
-        );
+        const [props, setProps] = React.useState({
+            ...getDefaultFigureForType("point"),
+            onRemove: () => {},
+        });
 
         const handlePropsUpdate = (newProps) => {
             setProps({

--- a/packages/perseus-editor/src/components/locked-figure-settings-actions.tsx
+++ b/packages/perseus-editor/src/components/locked-figure-settings-actions.tsx
@@ -1,0 +1,47 @@
+/**
+ * The part of a locked figure settings panel that contains actions
+ * for this panel and its associated locked figure, including
+ * the delete button.
+ */
+import Button from "@khanacademy/wonder-blocks-button";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import trashIcon from "@phosphor-icons/core/bold/trash-bold.svg";
+import {StyleSheet} from "aphrodite";
+import * as React from "react";
+
+type Props = {
+    onRemove: () => void;
+    figureAriaLabel: string;
+};
+
+const LockedFigureSettingsActions = (props: Props) => {
+    const {onRemove, figureAriaLabel} = props;
+    return (
+        <View style={styles.container}>
+            <Button
+                startIcon={trashIcon}
+                aria-label={`Delete ${figureAriaLabel}`}
+                onClick={onRemove}
+                kind="tertiary"
+                style={styles.deleteButton}
+            >
+                Delete
+            </Button>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        width: "100%",
+        flexDirection: "row",
+        alignItems: "center",
+    },
+    deleteButton: {
+        // Line up the delete icon with the rest of the content.
+        marginInlineStart: -spacing.xxxSmall_4,
+    },
+});
+
+export default LockedFigureSettingsActions;

--- a/packages/perseus-editor/src/components/locked-figures-section.tsx
+++ b/packages/perseus-editor/src/components/locked-figures-section.tsx
@@ -36,13 +36,16 @@ const LockedFiguresSection = (props: Props) => {
     }
 
     function removeLockedFigure(index: number) {
-        const lockedFigures = figures || [];
-        onChange({
-            lockedFigures: [
-                ...lockedFigures.slice(0, index),
-                ...lockedFigures.slice(index + 1),
-            ],
-        });
+        // eslint-disable-next-line no-alert
+        if (window.confirm("Are you sure you want to delete this figure?")) {
+            const lockedFigures = figures || [];
+            onChange({
+                lockedFigures: [
+                    ...lockedFigures.slice(0, index),
+                    ...lockedFigures.slice(index + 1),
+                ],
+            });
+        }
     }
 
     function changeProps(

--- a/packages/perseus-editor/src/components/locked-line-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-line-settings.tsx
@@ -8,16 +8,15 @@ import {AccordionSection} from "@khanacademy/wonder-blocks-accordion";
 import {View, useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
-import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {color as wbColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium, LabelLarge} from "@khanacademy/wonder-blocks-typography";
-import trashIcon from "@phosphor-icons/core/bold/trash-bold.svg";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 import ColorSelect from "./color-select";
 import ColorSwatch from "./color-swatch";
+import LockedFigureSettingsActions from "./locked-figure-settings-actions";
 import LockedPointSettings from "./locked-point-settings";
 
 import type {
@@ -199,14 +198,12 @@ const LockedLineSettings = (props: Props) => {
                         style={styles.lockedPointSettingsContainer}
                     />
 
-                    {/* Delete button */}
-                    <IconButton
-                        icon={trashIcon}
-                        aria-label={`Delete locked line defined by
-            ${startPoint.coord[0]}, ${startPoint.coord[1]} and
-            ${endPoint.coord[0]}, ${endPoint.coord[1]}.`}
-                        onClick={onRemove}
-                        style={styles.deleteButton}
+                    {/* Actions */}
+                    <LockedFigureSettingsActions
+                        onRemove={onRemove}
+                        figureAriaLabel={`locked line defined by
+                    ${startPoint.coord[0]}, ${startPoint.coord[1]} and
+                    ${endPoint.coord[0]}, ${endPoint.coord[1]}.`}
                     />
                 </View>
             </AccordionSection>
@@ -244,11 +241,6 @@ const styles = StyleSheet.create({
     },
     label: {
         marginInlineEnd: spacing.xSmall_8,
-    },
-    deleteButton: {
-        position: "absolute",
-        top: spacing.small_12,
-        right: spacing.small_12,
     },
 });
 

--- a/packages/perseus-editor/src/components/locked-point-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-point-settings.tsx
@@ -7,17 +7,16 @@
 import {AccordionSection} from "@khanacademy/wonder-blocks-accordion";
 import {View, useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
 import {Checkbox, TextField} from "@khanacademy/wonder-blocks-form";
-import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Switch from "@khanacademy/wonder-blocks-switch";
 import {color as wbColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium, LabelLarge} from "@khanacademy/wonder-blocks-typography";
-import trashIcon from "@phosphor-icons/core/bold/trash-bold.svg";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 import ColorSelect from "./color-select";
 import ColorSwatch from "./color-swatch";
+import LockedFigureSettingsActions from "./locked-figure-settings-actions";
 import {getValidNumberFromString} from "./util";
 
 import type {LockedPointType} from "@khanacademy/perseus";
@@ -186,13 +185,11 @@ const LockedPointSettings = (props: Props) => {
                         </>
                     )}
 
-                    {/* Delete icon */}
+                    {/* Actions */}
                     {onRemove && (
-                        <IconButton
-                            icon={trashIcon}
-                            aria-label={`Delete locked point at ${coordState[0]}, ${coordState[1]}`}
-                            onClick={onRemove}
-                            style={styles.deleteButton}
+                        <LockedFigureSettingsActions
+                            onRemove={onRemove}
+                            figureAriaLabel={`locked point at ${coordState[0]}, ${coordState[1]}`}
                         />
                     )}
                 </View>
@@ -230,11 +227,6 @@ const styles = StyleSheet.create({
     },
     textField: {
         width: spacing.xxxLarge_64,
-    },
-    deleteButton: {
-        position: "absolute",
-        top: spacing.small_12,
-        right: spacing.small_12,
     },
 });
 

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
@@ -77,6 +77,7 @@ describe("InteractiveGraphEditor locked figures", () => {
         test("Calls onChange when a locked point is removed", async () => {
             // Arrange
             const onChangeMock = jest.fn();
+            window.confirm = jest.fn(() => true); // always click yes
 
             render(
                 <InteractiveGraphEditor
@@ -96,6 +97,7 @@ describe("InteractiveGraphEditor locked figures", () => {
             await userEvent.click(deleteButton);
 
             // Assert
+            expect(window.confirm).toBeCalled();
             expect(onChangeMock).toBeCalledWith(
                 expect.objectContaining({
                     lockedFigures: [],
@@ -303,6 +305,7 @@ describe("InteractiveGraphEditor locked figures", () => {
         test("Calls onChange when a locked line is removed", async () => {
             // Arrange
             const onChangeMock = jest.fn();
+            window.confirm = jest.fn(() => true); // always click yes
 
             render(
                 <InteractiveGraphEditor
@@ -322,6 +325,7 @@ describe("InteractiveGraphEditor locked figures", () => {
             await userEvent.click(deleteButton);
 
             // Assert
+            expect(window.confirm).toBeCalled();
             expect(onChangeMock).toBeCalledWith(
                 expect.objectContaining({
                     lockedFigures: [],

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
@@ -77,7 +77,10 @@ describe("InteractiveGraphEditor locked figures", () => {
         test("Calls onChange when a locked point is removed", async () => {
             // Arrange
             const onChangeMock = jest.fn();
-            window.confirm = jest.fn(() => true); // always click yes
+            const confirmSpy = jest.spyOn(window, "confirm").mockImplementation(
+                // Confirm button clicked
+                () => true,
+            );
 
             render(
                 <InteractiveGraphEditor
@@ -97,12 +100,42 @@ describe("InteractiveGraphEditor locked figures", () => {
             await userEvent.click(deleteButton);
 
             // Assert
-            expect(window.confirm).toBeCalled();
+            expect(confirmSpy).toBeCalled();
             expect(onChangeMock).toBeCalledWith(
                 expect.objectContaining({
                     lockedFigures: [],
                 }),
             );
+        });
+
+        test("Does not call onChange when the delete is canceled", async () => {
+            // Arrange
+            const onChangeMock = jest.fn();
+            const confirmSpy = jest.spyOn(window, "confirm").mockImplementation(
+                // Cancel button clicked
+                () => false,
+            );
+
+            render(
+                <InteractiveGraphEditor
+                    {...mafsProps}
+                    onChange={onChangeMock}
+                    lockedFigures={[defaultPoint]}
+                />,
+                {
+                    wrapper: RenderStateRoot,
+                },
+            );
+
+            // Act
+            const deleteButton = screen.getByRole("button", {
+                name: "Delete locked point at 0, 0",
+            });
+            await userEvent.click(deleteButton);
+
+            // Assert
+            expect(confirmSpy).toBeCalled();
+            expect(onChangeMock).not.toBeCalled();
         });
 
         test("Calls onChange when a locked point's x coordinate is changed", async () => {
@@ -305,7 +338,10 @@ describe("InteractiveGraphEditor locked figures", () => {
         test("Calls onChange when a locked line is removed", async () => {
             // Arrange
             const onChangeMock = jest.fn();
-            window.confirm = jest.fn(() => true); // always click yes
+            const confirmSpy = jest.spyOn(window, "confirm").mockImplementation(
+                // Confirm button clicked
+                () => true,
+            );
 
             render(
                 <InteractiveGraphEditor
@@ -325,12 +361,42 @@ describe("InteractiveGraphEditor locked figures", () => {
             await userEvent.click(deleteButton);
 
             // Assert
-            expect(window.confirm).toBeCalled();
+            expect(confirmSpy).toBeCalled();
             expect(onChangeMock).toBeCalledWith(
                 expect.objectContaining({
                     lockedFigures: [],
                 }),
             );
+        });
+
+        test("Does not call onChange when the delete is canceled", async () => {
+            // Arrange
+            const onChangeMock = jest.fn();
+            const confirmSpy = jest.spyOn(window, "confirm").mockImplementation(
+                // Cancel button clicked
+                () => false,
+            );
+
+            render(
+                <InteractiveGraphEditor
+                    {...mafsProps}
+                    onChange={onChangeMock}
+                    lockedFigures={[defaultLine]}
+                />,
+                {
+                    wrapper: RenderStateRoot,
+                },
+            );
+
+            // Act
+            const deleteButton = screen.getByRole("button", {
+                name: "Delete locked line defined by 0, 0 and 2, 2.",
+            });
+            await userEvent.click(deleteButton);
+
+            // Assert
+            expect(confirmSpy).toBeCalled();
+            expect(onChangeMock).not.toBeCalled();
         });
 
         test("Shows the locked line settings when a locked line is passed in", async () => {


### PR DESCRIPTION
## Summary:
Right now, the delete button ovelaps with other inputs
on prod. Moved the button to the bottom to give it
more space.

Added a window confirm to the delete button.

[Tentative design inspiration](https://khanacademy.slack.com/archives/C067UM1QAR4/p1714014186088429?thread_ts=1713986944.666589&cid=C067UM1QAR4)

Issue: none

## Test plan:
`yarn jest packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx`

Storybook
http://localhost:6006/?path=/story/perseus-editor-widgets-interactive-graph-editor--with-locked-points
http://localhost:6006/?path=/story/perseus-editor-widgets-interactive-graph-editor--with-locked-lines

## Screenshots

### Before
![image](https://github.com/Khan/perseus/assets/13231763/0c97cd9d-a6a7-414e-8a32-d13c78a925e7)

### After
<img width="402" alt="Screenshot 2024-04-25 at 10 46 58 AM" src="https://github.com/Khan/perseus/assets/13231763/dbc4cd67-5675-4626-aaad-c8f80396c853">

<img width="1014" alt="Screenshot 2024-04-25 at 10 48 00 AM" src="https://github.com/Khan/perseus/assets/13231763/e63f42ee-8a8b-46ca-8d69-12df1778ac75">
