### PR TITLE
[Dev UI] Wrap flipbook navigation controls in Toolbar

### DIFF
--- a/.changeset/empty-yaks-hope.md
+++ b/.changeset/empty-yaks-hope.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-dev-ui": patch
+---
+
+✨ Wrap the navigation controls of the Flipbook inside of a WB Toolbar

--- a/dev/flipbook.tsx
+++ b/dev/flipbook.tsx
@@ -3,6 +3,7 @@ import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import Toolbar from "@khanacademy/wonder-blocks-toolbar";
 import * as React from "react";
 import {useEffect, useReducer, useRef} from "react";
 
@@ -92,14 +93,22 @@ export function Flipbook() {
                     value={state.questions}
                     onChange={(e) => dispatch(setQuestions(e.target.value))}
                 />
-                <View style={{flexDirection: "row", alignItems: "baseline"}}>
-                    <Button kind="secondary" onClick={() => dispatch(previous)}>
-                        Previous
-                    </Button>
-                    <Strut size={spacing.xxSmall_6} />
-                    <Button kind="secondary" onClick={() => dispatch(next)}>
-                        Next
-                    </Button>
+                <Toolbar
+                    leftContent={
+                        <>
+                            <Button
+                                kind="secondary"
+                                onClick={() => dispatch(previous)}
+                            >
+                                Previous
+                            </Button>
+                            <Strut size={spacing.xxSmall_6} />
+                            <Button
+                                kind="secondary"
+                                onClick={() => dispatch(next)}
+                            >
+                                Next
+                            </Button>
                     <Strut size={spacing.medium_16} />
                     <Progress
                         zeroBasedIndex={index}
@@ -114,8 +123,11 @@ export function Flipbook() {
                         onClick={() => dispatch(removeCurrentQuestion)}
                     >
                         Discard question
-                    </Button>
-                </View>
+                            </Button>
+                        </>
+                    }
+                />
+
                 <Strut size={spacing.small_12} />
                 <div style={{display: noTextEntered ? "block" : "none"}}>
                     <h2>Instructions</h2>

--- a/dev/flipbook.tsx
+++ b/dev/flipbook.tsx
@@ -109,20 +109,20 @@ export function Flipbook() {
                             >
                                 Next
                             </Button>
-                    <Strut size={spacing.medium_16} />
-                    <Progress
-                        zeroBasedIndex={index}
-                        total={numQuestions}
-                        onIndexChanged={(input) =>
-                            dispatch(jumpToQuestion(input))
-                        }
-                    />
-                    <Strut size={spacing.medium_16} />
-                    <Button
-                        kind="tertiary"
-                        onClick={() => dispatch(removeCurrentQuestion)}
-                    >
-                        Discard question
+                            <Strut size={spacing.medium_16} />
+                            <Progress
+                                zeroBasedIndex={index}
+                                total={numQuestions}
+                                onIndexChanged={(input) =>
+                                    dispatch(jumpToQuestion(input))
+                                }
+                            />
+                            <Strut size={spacing.medium_16} />
+                            <Button
+                                kind="tertiary"
+                                onClick={() => dispatch(removeCurrentQuestion)}
+                            >
+                                Discard question
                             </Button>
                         </>
                     }

--- a/dev/package.json
+++ b/dev/package.json
@@ -25,7 +25,8 @@
         "@khanacademy/simple-markdown": "^0.11.4",
         "@khanacademy/wonder-blocks-banner": "^3.0.41",
         "@khanacademy/wonder-blocks-search-field": "^2.2.9",
-        "@khanacademy/wonder-blocks-tokens": "^1.0.0"
+        "@khanacademy/wonder-blocks-tokens": "^1.0.0",
+        "@khanacademy/wonder-blocks-toolbar": "^3.0.30"
     },
     "devDependencies": {
         "vite": "^5.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2694,6 +2694,16 @@
   resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-tokens/-/wonder-blocks-tokens-1.2.0.tgz#b58611f8b4a58e0c6e7e4e505d5acdb2b475acf4"
   integrity sha512-F24xzjFjpZFEGsuV7s8pBqeIVOY+NeIRVZU0BzTeMqRWvkaz9NzZbIcbYBxMnOvrw3Jk/xAPaSjcRukzbEbkdA==
 
+"@khanacademy/wonder-blocks-toolbar@^3.0.30":
+  version "3.0.30"
+  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-toolbar/-/wonder-blocks-toolbar-3.0.30.tgz#30054636e5af57b963d4c376610c3aac4de70fc9"
+  integrity sha512-On31nldxQnD8ssuS+0GzMDhHCj/WrThP+v7HyyeAGGCEe8ciG4mOeNk78uLHvCXvRmOvfrHyf1wunpTpv9Ouaw==
+  dependencies:
+    "@babel/runtime" "^7.18.6"
+    "@khanacademy/wonder-blocks-core" "^6.4.0"
+    "@khanacademy/wonder-blocks-tokens" "^1.2.0"
+    "@khanacademy/wonder-blocks-typography" "^2.1.11"
+
 "@khanacademy/wonder-blocks-tooltip@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-tooltip/-/wonder-blocks-tooltip-2.2.1.tgz#16b406577822c9605d39d59c50d4bcf804efa2a2"


### PR DESCRIPTION
## Summary:

This little PR wraps the controls below the "Perseus JSON content" field of the Flipbook inside of a Toolbar. Subjective improvement? Maybe. :) 

<img width="659" alt="image" src="https://github.com/Khan/perseus/assets/77138/b9a2d5ad-81c7-4f2a-b596-b35ede7704c9">


Issue: "none"

## Test plan:

Run `yarn dev` and flip to the Flipbook :eyes: