### PR TITLE
Upgrade to Mafs 0.18.5 (includes consistent dash styles for lines)

### DIFF
--- a/.changeset/many-cougars-drop.md
+++ b/.changeset/many-cougars-drop.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Upgrade Mafs to v0.18.5 - includes fix to make dashed lines use a consistent dash style

--- a/packages/perseus/package.json
+++ b/packages/perseus/package.json
@@ -46,7 +46,7 @@
         "@khanacademy/perseus-linter": "^0.3.12",
         "@khanacademy/pure-markdown": "^0.3.2",
         "@khanacademy/simple-markdown": "^0.11.4",
-        "mafs": "https://github.com/Khan/mafs/releases/download/v0.18.1%2Bbuild-cd8b2467893342ba0b02100073fe21f93f8b1125/mafs-0.18.1.tgz"
+        "mafs": "0.18.5"
     },
     "devDependencies": {
         "@khanacademy/wonder-blocks-banner": "^3.0.41",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11536,9 +11536,10 @@ lz-string@^1.4.4:
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
   integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
 
-"mafs@https://github.com/Khan/mafs/releases/download/v0.18.1%2Bbuild-cd8b2467893342ba0b02100073fe21f93f8b1125/mafs-0.18.1.tgz":
-  version "0.18.1"
-  resolved "https://github.com/Khan/mafs/releases/download/v0.18.1%2Bbuild-cd8b2467893342ba0b02100073fe21f93f8b1125/mafs-0.18.1.tgz#986a72d339ac62dec18492684cf76d3bacf311bc"
+mafs@0.18.5:
+  version "0.18.5"
+  resolved "https://registry.yarnpkg.com/mafs/-/mafs-0.18.5.tgz#f9edc05cefa0643bee57903b2cce55409f347ff3"
+  integrity sha512-QhipU2UfH3x/b07VRhSFTJJ+jA8fEgaIOhuIx6tgGkVmWK3awK7tGL49jeRx9sTYAQjbezdfKNoZS4+OBEvO1w==
   dependencies:
     "@use-gesture/react" "^10.2.27"
     computer-modern "^0.1.2"


### PR DESCRIPTION
## Summary:

Nisha noticed that some Mafs line types used different dash styles. We fixed this upstream in Mafs. Upgrading to Mafs v0.18.5 includes this fix.


| Line | Segment |
| --- | --- | 
| <img width="350" alt="image" src="https://github.com/Khan/perseus/assets/77138/b6c7f0c4-c01d-4776-973e-5be7c733867d"> |  <img width="350" alt="image" src="https://github.com/Khan/perseus/assets/77138/cc7f7836-eb71-4be6-86a4-f06e063be5a2"> |

Issue: LEMS-1930

## Test plan:

`yarn start`
Navigate to [All Locked Line Segments](http://localhost:6006/?path=/story/perseus-widgets-interactive-graph--all-locked-line-segments)
Navigate to [All Locked Lines](http://localhost:6006/?path=/story/perseus-widgets-interactive-graph--all-locked-lines)

Note that the dash styles are the same.