### PR TITLE
Fix Storybook sorting

### DIFF
--- a/.changeset/dirty-snails-run.md
+++ b/.changeset/dirty-snails-run.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Update all story names to avoid spaces

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -33,7 +33,8 @@ const preview: Preview = {
     parameters: {
         options: {
             storySort: {
-                order: ["Perseus", "Perseus Editor", "Math-Input", "*"],
+                order: ["Perseus", "PerseusEditor", "Math-Input", "*"],
+                includeNames: true,
             },
         },
         // TODO(somewhatabstract): This actions configuration does not appear to be

--- a/packages/perseus-editor/src/__stories__/editor-page.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/editor-page.stories.tsx
@@ -16,7 +16,7 @@ import type {
 registerAllWidgetsAndEditorsForTesting(); // SIDE_EFFECTY!!!! :cry:
 
 export default {
-    title: "Perseus Editor/EditorPage",
+    title: "PerseusEditor/EditorPage",
 };
 
 const onChangeAction = action("onChange");

--- a/packages/perseus-editor/src/__stories__/editor.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/editor.stories.tsx
@@ -15,7 +15,7 @@ import type {PerseusRenderer} from "@khanacademy/perseus";
 registerAllWidgetsAndEditorsForTesting(); // SIDE_EFFECTY!!!! :cry:
 
 export default {
-    title: "Perseus Editor/Editor",
+    title: "PerseusEditor/Editor",
 };
 
 export const Demo = (): React.ReactElement => {

--- a/packages/perseus-editor/src/__stories__/item-editor.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/item-editor.stories.tsx
@@ -27,7 +27,7 @@ const Wrapper = (props: Props) => {
 };
 
 const story: Meta<Props> = {
-    title: "Perseus Editor/Item Extras Editor",
+    title: "PerseusEditor/Item Extras Editor",
     component: ItemExtrasEditor,
     render: (args) => <Wrapper {...args} />,
     argTypes: {onChange: {action: "changed"}},

--- a/packages/perseus-editor/src/__stories__/tex-error-view.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/tex-error-view.stories.tsx
@@ -4,7 +4,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 
 const meta: Meta<typeof TexErrorView> = {
     component: TexErrorView,
-    title: "Perseus Editor/TexErrorView",
+    title: "PerseusEditor/TexErrorView",
 };
 
 export default meta;

--- a/packages/perseus-editor/src/components/__stories__/blur-input.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/blur-input.stories.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import BlurInput from "../blur-input";
 
 export default {
-    title: "Perseus Editor/Components/Blur Input",
+    title: "PerseusEditor/Components/Blur Input",
 };
 
 export const Default = (): React.ReactElement => {

--- a/packages/perseus-editor/src/components/__stories__/color-select.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/color-select.stories.tsx
@@ -6,7 +6,7 @@ import type {LockedFigureColor} from "@khanacademy/perseus";
 import type {Meta} from "@storybook/react";
 
 export default {
-    title: "Perseus Editor/Components/Color Select",
+    title: "PerseusEditor/Components/Color Select",
     component: ColorSelect,
 } as Meta<typeof ColorSelect>;
 

--- a/packages/perseus-editor/src/components/__stories__/color-swatch.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/color-swatch.stories.tsx
@@ -5,7 +5,7 @@ import ColorSwatch from "../color-swatch";
 import type {Meta} from "@storybook/react";
 
 export default {
-    title: "Perseus Editor/Components/Color Swatch",
+    title: "PerseusEditor/Components/Color Swatch",
     component: ColorSwatch,
 } as Meta<typeof ColorSwatch>;
 

--- a/packages/perseus-editor/src/components/__stories__/graph-settings.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/graph-settings.stories.tsx
@@ -5,7 +5,7 @@ import GraphSettings from "../graph-settings";
 import GraphSettingsArgTypes from "./graph-settings.argtypes";
 
 export default {
-    title: "Perseus Editor/Components/Graph Settings",
+    title: "PerseusEditor/Components/Graph Settings",
     component: GraphSettings,
     argTypes: GraphSettingsArgTypes,
 };

--- a/packages/perseus-editor/src/components/__stories__/interactive-graph-settings.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/interactive-graph-settings.stories.tsx
@@ -7,7 +7,7 @@ import InteractiveGraphSettingsArgTypes from "./interactive-graph-settings.argty
 import type {StoryObj} from "@storybook/react";
 
 export default {
-    title: "Perseus Editor/Components/Interactive Graph Settings",
+    title: "PerseusEditor/Components/Interactive Graph Settings",
     component: InteractiveGraphSettings,
     argTypes: InteractiveGraphSettingsArgTypes,
 };

--- a/packages/perseus-editor/src/components/__stories__/locked-point-settings.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/locked-point-settings.stories.tsx
@@ -6,7 +6,7 @@ import {getDefaultFigureForType} from "../util";
 import type {Meta, StoryObj} from "@storybook/react";
 
 export default {
-    title: "Perseus Editor/Components/Locked Point Settings",
+    title: "PerseusEditor/Components/Locked Point Settings",
     component: LockedPointSettings,
 } as Meta<typeof LockedPointSettings>;
 

--- a/packages/perseus-editor/src/components/__stories__/section-control-button.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/section-control-button.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus Editor/Components/Section Control Button",
+    title: "PerseusEditor/Components/Section Control Button",
 } as Story;
 
 export const ButtonForEditingSectionsOfContentWithInArticleEditor = (

--- a/packages/perseus-editor/src/diffs/__stories__/structured-item-diff.stories.tsx
+++ b/packages/perseus-editor/src/diffs/__stories__/structured-item-diff.stories.tsx
@@ -16,7 +16,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus Editor/Diffs/Structured Item Diff",
+    title: "PerseusEditor/Diffs/Structured Item Diff",
     decorators: [
         (StoryComponent) => (
             <Wrapper>

--- a/packages/perseus-editor/src/diffs/__stories__/tags-diff.stories.tsx
+++ b/packages/perseus-editor/src/diffs/__stories__/tags-diff.stories.tsx
@@ -14,7 +14,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus Editor/Diffs/Tags Diff",
+    title: "PerseusEditor/Diffs/Tags Diff",
     decorators: [
         (StoryComponent) => (
             <Wrapper>

--- a/packages/perseus-editor/src/diffs/__stories__/text-diff.stories.tsx
+++ b/packages/perseus-editor/src/diffs/__stories__/text-diff.stories.tsx
@@ -14,7 +14,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus Editor/Diffs/Text Diff",
+    title: "PerseusEditor/Diffs/Text Diff",
     decorators: [
         (StoryComponent) => (
             <Wrapper>

--- a/packages/perseus-editor/src/widgets/__stories__/categorizer-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/categorizer-editor.stories.tsx
@@ -11,7 +11,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus Editor/Widgets/Categorizer Editor",
+    title: "PerseusEditor/Widgets/Categorizer Editor",
 } as Story;
 
 export const Default = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus-editor/src/widgets/__stories__/definition-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/definition-editor.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus Editor/Widgets/Definition Editor",
+    title: "PerseusEditor/Widgets/Definition Editor",
 } as Story;
 
 export const Default = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus-editor/src/widgets/__stories__/dropdown-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/dropdown-editor.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus Editor/Widgets/Dropdown Editor",
+    title: "PerseusEditor/Widgets/Dropdown Editor",
 } as Story;
 
 export const Default = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus-editor/src/widgets/__stories__/explanation-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/explanation-editor.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus Editor/Widgets/Explanation Editor",
+    title: "PerseusEditor/Widgets/Explanation Editor",
 } as Story;
 
 export const Default = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus-editor/src/widgets/__stories__/expression-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/expression-editor.stories.tsx
@@ -17,7 +17,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus Editor/Widgets/Expression Editor",
+    title: "PerseusEditor/Widgets/Expression Editor",
 } as Story;
 
 // TODO(FEI-5054): Figure out how to get global .d.ts files working with monorepos

--- a/packages/perseus-editor/src/widgets/__stories__/image-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/image-editor.stories.tsx
@@ -17,7 +17,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus Editor/Widgets/Image Editor",
+    title: "PerseusEditor/Widgets/Image Editor",
 } as Story;
 
 const styles = StyleSheet.create({

--- a/packages/perseus-editor/src/widgets/__stories__/input-number-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/input-number-editor.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus Editor/Widgets/InputNumber Editor",
+    title: "PerseusEditor/Widgets/InputNumber Editor",
 } as Story;
 
 export const Default = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus-editor/src/widgets/__stories__/interaction-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/interaction-editor.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus Editor/Widgets/Interaction Editor",
+    title: "PerseusEditor/Widgets/Interaction Editor",
 } as Story;
 
 export const Default = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus-editor/src/widgets/__stories__/interactive-graph-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/interactive-graph-editor.stories.tsx
@@ -26,7 +26,7 @@ const defaultPointProps = {
 };
 
 export default {
-    title: "Perseus Editor/Widgets/Interactive Graph Editor",
+    title: "PerseusEditor/Widgets/Interactive Graph Editor",
     component: InteractiveGraphEditor,
     argTypes: InteractiveGraphEditorArgTypes,
 } as Meta<typeof InteractiveGraphEditor>;

--- a/packages/perseus-editor/src/widgets/__stories__/label-image-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/label-image-editor.stories.tsx
@@ -16,7 +16,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus Editor/Widgets/Label Image Editor",
+    title: "PerseusEditor/Widgets/Label Image Editor",
 } as Story;
 
 const styles = StyleSheet.create({

--- a/packages/perseus-editor/src/widgets/__stories__/matcher-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/matcher-editor.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus Editor/Widgets/Matcher Editor",
+    title: "PerseusEditor/Widgets/Matcher Editor",
 } as Story;
 
 export const Default = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus-editor/src/widgets/__stories__/number-line-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/number-line-editor.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus Editor/Widgets/Number Line Editor",
+    title: "PerseusEditor/Widgets/Number Line Editor",
 } as Story;
 
 export const Default = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus-editor/src/widgets/__stories__/numeric-input-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/numeric-input-editor.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus Editor/Widgets/NumericInput Editor",
+    title: "PerseusEditor/Widgets/NumericInput Editor",
 } as Story;
 
 export const Default = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus-editor/src/widgets/__stories__/python-program-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/python-program-editor.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus Editor/Widgets/Python Program Editor",
+    title: "PerseusEditor/Widgets/Python Program Editor",
 } as Story;
 
 export const Default = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus-editor/src/widgets/__stories__/radio-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/radio-editor.stories.tsx
@@ -20,7 +20,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus Editor/Widgets/Radio Editor",
+    title: "PerseusEditor/Widgets/Radio Editor",
 } as Story;
 
 const styles = StyleSheet.create({

--- a/packages/perseus-editor/src/widgets/__stories__/sorter-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/sorter-editor.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus Editor/Widgets/Sorter Editor",
+    title: "PerseusEditor/Widgets/Sorter Editor",
 } as Story;
 
 export const Default = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus-editor/src/widgets/label-image/__stories__/answer-choices.stories.tsx
+++ b/packages/perseus-editor/src/widgets/label-image/__stories__/answer-choices.stories.tsx
@@ -11,7 +11,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus Editor/Widgets/Label Image/Answer Choices",
+    title: "PerseusEditor/Widgets/Label Image/Answer Choices",
 } as Story;
 
 const styles = StyleSheet.create({

--- a/packages/perseus-editor/src/widgets/label-image/__stories__/behavior.stories.tsx
+++ b/packages/perseus-editor/src/widgets/label-image/__stories__/behavior.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus Editor/Widgets/Label Image/Behavior",
+    title: "PerseusEditor/Widgets/Label Image/Behavior",
 } as Story;
 
 export const Default = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus-editor/src/widgets/label-image/__stories__/marker.stories.tsx
+++ b/packages/perseus-editor/src/widgets/label-image/__stories__/marker.stories.tsx
@@ -11,7 +11,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus Editor/Widgets/Label Image/Marker",
+    title: "PerseusEditor/Widgets/Label Image/Marker",
 } as Story;
 
 const styles = StyleSheet.create({

--- a/packages/perseus-editor/src/widgets/label-image/__stories__/question-markers.stories.tsx
+++ b/packages/perseus-editor/src/widgets/label-image/__stories__/question-markers.stories.tsx
@@ -12,7 +12,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus Editor/Widgets/Label Image/Question Markers",
+    title: "PerseusEditor/Widgets/Label Image/Question Markers",
 } as Story;
 
 const styles = StyleSheet.create({

--- a/packages/perseus-editor/src/widgets/label-image/__stories__/select-image.stories.tsx
+++ b/packages/perseus-editor/src/widgets/label-image/__stories__/select-image.stories.tsx
@@ -10,7 +10,7 @@ type Story = {
 };
 
 export default {
-    title: "Perseus Editor/Widgets/Label Image/Select Image",
+    title: "PerseusEditor/Widgets/Label Image/Select Image",
 } as Story;
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
## Summary:

It was noted that the Storybook navigation panel was not properly nesting stories under the "Perseus" node. This PR fixes this by removing spaces from the "Perseus Editor" stories. It appears that Storybook splits names on spaces and so I suspect that's why the Perseus and Perseus Editor stories were intermingled.

Issue: "none"

https://github.com/Khan/perseus/assets/77138/2e41965c-de81-451d-958d-8b5946201dd8

## Test plan: