### PR TITLE
Fix build warnings related to phosphor icons

### DIFF
--- a/.changeset/hungry-kangaroos-sell.md
+++ b/.changeset/hungry-kangaroos-sell.md
@@ -1,0 +1,5 @@
+---
+"perseus-build-settings": patch
+---
+
+Mark @phosphor-icons/core as external so they aren't bundled into Perseus

--- a/config/build/rollup.config.js
+++ b/config/build/rollup.config.js
@@ -186,6 +186,7 @@ const createConfig = (
     const config = {
         output: createOutputConfig(name, format, file),
         input: makePackageBasedPath(name, inputFile),
+        external: [/@phosphor-icons\/core\/.*/],
         plugins: [
             // We don't want to do process.env.NODE_ENV checks in our main
             // builds. Our consumers should handle that. However, if we


### PR DESCRIPTION
## Summary:

For a while I've noticed warnings slide by in the console when running `yarn build`. I didn't take much notice of them as everything seems to work. 

The errors have to do with imports of the Phosphor icons.

Today, however, I dug in and the fix is quite simple. We have `@phosphor-icons/core` set as a `peerDependency` so we don't have to bundle them in our packages (webapp already does). As a result, we want to mark any imports from that package as external so the don't get inlined into our Perseus bundles. 

The fix was quite easy (just mark it as external 🙄).

Issue: "none"

## Test plan:

`yarn build` -> watch for `.svg` warnings