### PR TITLE
Get `@khanacademy/mathjax-renderer` from NPM

### DIFF
--- a/.changeset/strange-crabs-bake.md
+++ b/.changeset/strange-crabs-bake.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": minor
+---
+
+Get `@khanacademy/mathjax-renderer` from NPM, to allow third-party clients of Perseus to install it

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@jest/globals": "^29.7.0",
     "@khanacademy/eslint-config": "^4.0.0",
     "@khanacademy/eslint-plugin": "^3.0.0",
-    "@khanacademy/mathjax-renderer": "^1.7.1",
+    "@khanacademy/mathjax-renderer": "^1.7.2",
     "@khanacademy/wonder-blocks-button": "6.3.0",
     "@khanacademy/wonder-blocks-i18n": "^2.0.2",
     "@khanacademy/wonder-blocks-layout": "^2.0.31",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@jest/globals": "^29.7.0",
     "@khanacademy/eslint-config": "^4.0.0",
     "@khanacademy/eslint-plugin": "^3.0.0",
-    "@khanacademy/mathjax-renderer": "git+ssh://git@github.com:Khan/mathjax-renderer.git#v1.6.2",
+    "@khanacademy/mathjax-renderer": "^1.7.1",
     "@khanacademy/wonder-blocks-button": "6.3.0",
     "@khanacademy/wonder-blocks-i18n": "^2.0.2",
     "@khanacademy/wonder-blocks-layout": "^2.0.31",

--- a/packages/math-input/package.json
+++ b/packages/math-input/package.json
@@ -41,7 +41,7 @@
         "mathquill": "https://github.com/Khan/mathquill/releases/download/v1.0.0/mathquill-v1.0.0.tgz"
     },
     "devDependencies": {
-        "@khanacademy/mathjax-renderer": "^1.7.1",
+        "@khanacademy/mathjax-renderer": "^1.7.2",
         "@khanacademy/wonder-blocks-clickable": "^4.1.0",
         "@khanacademy/wonder-blocks-core": "^6.3.1",
         "@khanacademy/wonder-blocks-popover": "^3.1.3",
@@ -61,7 +61,7 @@
         "react-transition-group": "^4.4.1"
     },
     "peerDependencies": {
-        "@khanacademy/mathjax-renderer": "^1.7.1",
+        "@khanacademy/mathjax-renderer": "^1.7.2",
         "@khanacademy/wonder-blocks-clickable": "^4.2.0",
         "@khanacademy/wonder-blocks-core": "^6.4.0",
         "@khanacademy/wonder-blocks-popover": "^3.2.0",

--- a/packages/math-input/package.json
+++ b/packages/math-input/package.json
@@ -41,7 +41,7 @@
         "mathquill": "https://github.com/Khan/mathquill/releases/download/v1.0.0/mathquill-v1.0.0.tgz"
     },
     "devDependencies": {
-        "@khanacademy/mathjax-renderer": "git+ssh://git@github.com:Khan/mathjax-renderer.git#v1.6.2",
+        "@khanacademy/mathjax-renderer": "^1.7.1",
         "@khanacademy/wonder-blocks-clickable": "^4.1.0",
         "@khanacademy/wonder-blocks-core": "^6.3.1",
         "@khanacademy/wonder-blocks-popover": "^3.1.3",
@@ -61,7 +61,7 @@
         "react-transition-group": "^4.4.1"
     },
     "peerDependencies": {
-        "@khanacademy/mathjax-renderer": "git+ssh://git@github.com:Khan/mathjax-renderer.git#v1.6.2",
+        "@khanacademy/mathjax-renderer": "^1.7.1",
         "@khanacademy/wonder-blocks-clickable": "^4.2.0",
         "@khanacademy/wonder-blocks-core": "^6.4.0",
         "@khanacademy/wonder-blocks-popover": "^3.2.0",

--- a/utils/publish-snapshot.sh
+++ b/utils/publish-snapshot.sh
@@ -111,7 +111,6 @@ create_npmrc
 
 yarn build
 yarn build:types
-yarn extract-strings
 
 # Now version the packages and publish a snapshot
 # By using the `--snapshot` option we are asking Changeset to version the

--- a/yarn.lock
+++ b/yarn.lock
@@ -2434,10 +2434,10 @@
     "@typescript-eslint/utils" "^5.60.1"
     checksync "^5.0.5"
 
-"@khanacademy/mathjax-renderer@^1.7.1":
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/@khanacademy/mathjax-renderer/-/mathjax-renderer-1.7.1.tgz#590bb7b3c046308c5379d4b391497d74290ba4f9"
-  integrity sha512-SQJlgPYTQ7ei+oGZB7Un1AFvHfFqMbd5KRCs5/bDUXcBVottG1Nm/+zjHzk7pzq0a0OgVitaQ+LniA0nIvLxjQ==
+"@khanacademy/mathjax-renderer@^1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@khanacademy/mathjax-renderer/-/mathjax-renderer-1.7.2.tgz#18127f24a9ae2c77424ee4cce52e62d558258e25"
+  integrity sha512-p4mYMrgX7CdgtPR3zAeThh3ZkteaxlB1PLIY4CcHVeKYmVXklWPh57tpj6gt3eHycEZqX4LpHYp69Z466rdApA==
   dependencies:
     mathjax-full "3.2.2"
     mu-lambda "^0.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2434,9 +2434,10 @@
     "@typescript-eslint/utils" "^5.60.1"
     checksync "^5.0.5"
 
-"@khanacademy/mathjax-renderer@git+ssh://git@github.com:Khan/mathjax-renderer.git#v1.6.2":
-  version "1.6.2"
-  resolved "git+ssh://git@github.com:Khan/mathjax-renderer.git#8bc76941309e4083a5207447c97eaf17fda15e65"
+"@khanacademy/mathjax-renderer@^1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@khanacademy/mathjax-renderer/-/mathjax-renderer-1.7.1.tgz#590bb7b3c046308c5379d4b391497d74290ba4f9"
+  integrity sha512-SQJlgPYTQ7ei+oGZB7Un1AFvHfFqMbd5KRCs5/bDUXcBVottG1Nm/+zjHzk7pzq0a0OgVitaQ+LniA0nIvLxjQ==
   dependencies:
     mathjax-full "3.2.2"
     mu-lambda "^0.0.3"


### PR DESCRIPTION
## Summary:
Previously, we were installing mathjax-renderer directly from a private
GitHub repository. This caused third-party clients of Perseus to be unable
to use Perseus, since they don't have access to that repository.

This commit fixes that by installing `@khanacademy/mathjax-renderer`
from NPM.

Issue: LEMS-1818

Test plan:

- Install the test build of Perseus in webapp.
- Update the version of `@khanacademy/mathjax-renderer` used in webapp to 1.7.2.
- Verify that TeX rendering works.
- Verify that `yarn.lock` lists no GitHub URLs for `@khanacademy/mathjax-renderer`.