### PR TITLE
Update spacing in locked figure settings

### DIFF
--- a/.changeset/honest-pens-count.md
+++ b/.changeset/honest-pens-count.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Adjust spacing in locked point and locked line settings

--- a/packages/perseus-editor/src/__stories__/editor-page.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/editor-page.stories.tsx
@@ -2,6 +2,7 @@ import {action} from "@storybook/addon-actions";
 import * as React from "react";
 
 import {EditorPage} from "..";
+import {segmentWithLockedFigures} from "../../../perseus/src/widgets/__testdata__/interactive-graph.testdata";
 import {registerAllWidgetsAndEditorsForTesting} from "../util/register-all-widgets-and-editors-for-testing";
 
 import {flags} from "./flags-for-api-options";
@@ -31,6 +32,54 @@ export const Demo = (): React.ReactElement => {
     const [question, setQuestion] = React.useState<
         PerseusRenderer | undefined
     >();
+    const [hints, setHints] = React.useState<ReadonlyArray<Hint> | undefined>();
+
+    return (
+        <EditorPage
+            apiOptions={{
+                isMobile: false,
+                flags,
+            }}
+            previewDevice={previewDevice}
+            onPreviewDeviceChange={(newDevice) => setPreviewDevice(newDevice)}
+            developerMode={true}
+            jsonMode={jsonMode}
+            answerArea={answerArea}
+            question={question}
+            hints={hints}
+            frameSource="about:blank"
+            previewURL="about:blank"
+            itemId="1"
+            onChange={(props) => {
+                onChangeAction(props);
+
+                if ("jsonMode" in props) {
+                    setJsonMode(props.jsonMode);
+                }
+                if ("answerArea" in props) {
+                    setAnswerArea(props.answerArea);
+                }
+                if ("question" in props) {
+                    setQuestion(props.question);
+                }
+                if ("hints" in props) {
+                    setHints(props.hints);
+                }
+            }}
+        />
+    );
+};
+
+export const MafsWithLockedFigures = (): React.ReactElement => {
+    const [previewDevice, setPreviewDevice] =
+        React.useState<DeviceType>("phone");
+    const [jsonMode, setJsonMode] = React.useState<boolean | undefined>(false);
+    const [answerArea, setAnswerArea] = React.useState<
+        PerseusAnswerArea | undefined | null
+    >();
+    const [question, setQuestion] = React.useState<PerseusRenderer | undefined>(
+        segmentWithLockedFigures,
+    );
     const [hints, setHints] = React.useState<ReadonlyArray<Hint> | undefined>();
 
     return (

--- a/packages/perseus-editor/src/components/__stories__/locked-figures-section.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/locked-figures-section.stories.tsx
@@ -1,0 +1,77 @@
+import {View} from "@khanacademy/wonder-blocks-core";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {StyleSheet} from "aphrodite";
+import * as React from "react";
+
+import LockedFiguresSection from "../locked-figures-section";
+import {getDefaultFigureForType} from "../util";
+
+import type {Meta, StoryObj} from "@storybook/react";
+
+export default {
+    title: "Perseus Editor/Components/Locked Figures Section",
+    component: LockedFiguresSection,
+} as Meta<typeof LockedFiguresSection>;
+
+export const Default = (args): React.ReactElement => {
+    return <LockedFiguresSection {...args} />;
+};
+
+type StoryComponentType = StoryObj<typeof LockedFiguresSection>;
+
+// Set the default values in the control panel.
+Default.args = {};
+
+export const Controlled: StoryComponentType = {
+    render: function Render() {
+        const [figures, setFigures] = React.useState([]);
+
+        const handlePropsUpdate = (newProps) => {
+            setFigures(newProps.lockedFigures);
+        };
+
+        return (
+            <LockedFiguresSection
+                figures={figures}
+                onChange={handlePropsUpdate}
+            />
+        );
+    },
+};
+
+export const WithProdWidth: StoryComponentType = {
+    render: function Render() {
+        const [figures, setFigures] = React.useState([
+            getDefaultFigureForType("point"),
+            getDefaultFigureForType("line"),
+        ]);
+
+        const handlePropsUpdate = (newProps) => {
+            setFigures(newProps.lockedFigures);
+        };
+
+        return (
+            <View style={styles.prodSizeContainer}>
+                <LockedFiguresSection
+                    figures={figures}
+                    onChange={handlePropsUpdate}
+                />
+            </View>
+        );
+    },
+};
+
+const contentSize = 310;
+const padding = 10;
+// Padding on each side
+const containerSize = contentSize + 2 * padding;
+
+const styles = StyleSheet.create({
+    prodSizeContainer: {
+        width: containerSize,
+        padding: padding,
+        marginInlineStart: spacing.medium_16,
+        border: `1px solid ${color.offBlack32}`,
+        borderRadius: spacing.xxxSmall_4,
+    },
+});

--- a/packages/perseus-editor/src/components/__stories__/locked-figures-section.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/locked-figures-section.stories.tsx
@@ -9,7 +9,7 @@ import {getDefaultFigureForType} from "../util";
 import type {Meta, StoryObj} from "@storybook/react";
 
 export default {
-    title: "Perseus Editor/Components/Locked Figures Section",
+    title: "PerseusEditor/Components/Locked Figures Section",
     component: LockedFiguresSection,
 } as Meta<typeof LockedFiguresSection>;
 

--- a/packages/perseus-editor/src/components/__tests__/locked-point-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-point-settings.test.tsx
@@ -62,7 +62,7 @@ describe("LockedPointSettings", () => {
             {wrapper: RenderStateRoot},
         );
 
-        const toggleSwitch = screen.getByLabelText("Show point on graph");
+        const toggleSwitch = screen.getByLabelText("show point on graph");
 
         // Assert
         expect(toggleSwitch).toBeInTheDocument();
@@ -82,7 +82,7 @@ describe("LockedPointSettings", () => {
             {wrapper: RenderStateRoot},
         );
 
-        const toggleSwitch = screen.getByLabelText("Show point on graph");
+        const toggleSwitch = screen.getByLabelText("show point on graph");
 
         // Assert
         expect(toggleSwitch).toBeChecked();
@@ -102,7 +102,7 @@ describe("LockedPointSettings", () => {
             {wrapper: RenderStateRoot},
         );
 
-        const toggleSwitch = screen.getByLabelText("Show point on graph");
+        const toggleSwitch = screen.getByLabelText("show point on graph");
 
         // Assert
         expect(toggleSwitch).not.toBeChecked();
@@ -122,8 +122,8 @@ describe("LockedPointSettings", () => {
             {wrapper: RenderStateRoot},
         );
 
-        const colorSelect = screen.getByLabelText("Color");
-        const openCheckbox = screen.getByLabelText("Open point");
+        const colorSelect = screen.getByLabelText("color");
+        const openCheckbox = screen.getByLabelText("open point");
 
         // Assert
         expect(colorSelect).toBeInTheDocument();

--- a/packages/perseus-editor/src/components/color-select.tsx
+++ b/packages/perseus-editor/src/components/color-select.tsx
@@ -9,6 +9,7 @@ import * as React from "react";
 import ColorSwatch from "./color-swatch";
 
 import type {LockedFigureColor} from "@khanacademy/perseus";
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 const possibleColors = Object.keys(lockedFigureColors) as LockedFigureColor[];
 
@@ -16,16 +17,17 @@ type Props = {
     // Required ID so that the label can be associated with the select.
     id: string;
     selectedValue: LockedFigureColor;
+    style?: StyleType;
     onChange: (newValue: string) => void;
 };
 
 const ColorSelect = (props: Props) => {
-    const {id, selectedValue, onChange} = props;
+    const {id, selectedValue, style, onChange} = props;
 
     return (
-        <View style={styles.row}>
+        <View style={[styles.row, style]}>
             <LabelMedium htmlFor={id} style={styles.label} tag="label">
-                Color
+                color
             </LabelMedium>
             <SingleSelect
                 id={id}
@@ -57,7 +59,7 @@ const styles = StyleSheet.create({
         alignItems: "center",
     },
     label: {
-        marginInlineEnd: spacing.xSmall_8,
+        marginInlineEnd: spacing.xxxSmall_4,
     },
 });
 

--- a/packages/perseus-editor/src/components/labeled-switch.tsx
+++ b/packages/perseus-editor/src/components/labeled-switch.tsx
@@ -1,0 +1,42 @@
+import {View, useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import Switch from "@khanacademy/wonder-blocks-switch";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
+import {StyleSheet} from "aphrodite";
+import * as React from "react";
+
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
+
+type Props = {
+    label: string;
+    checked: boolean;
+    style?: StyleType;
+    onChange: (newValue: boolean) => void;
+};
+
+const LabeledSwitch = (props: Props) => {
+    const {checked, label, style, onChange} = props;
+
+    const ids = useUniqueIdWithMock();
+    const switchId = ids.get("switch");
+
+    return (
+        <View style={[styles.row, style]}>
+            <Switch id={switchId} checked={checked} onChange={onChange} />
+            <Strut size={spacing.xSmall_8} />
+            <LabelMedium tag="label" htmlFor={switchId}>
+                {label}
+            </LabelMedium>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    row: {
+        flexDirection: "row",
+        alignItems: "center",
+    },
+});
+
+export default LabeledSwitch;

--- a/packages/perseus-editor/src/components/locked-figure-select.tsx
+++ b/packages/perseus-editor/src/components/locked-figure-select.tsx
@@ -48,7 +48,7 @@ const LockedFigureSelect = (props: Props) => {
 
 const styles = StyleSheet.create({
     container: {
-        marginTop: spacing.xxxSmall_4,
+        marginTop: spacing.xSmall_8,
     },
     addElementSelect: {
         backgroundColor: color.fadedBlue8,

--- a/packages/perseus-editor/src/components/locked-figure-settings-actions.tsx
+++ b/packages/perseus-editor/src/components/locked-figure-settings-actions.tsx
@@ -37,6 +37,7 @@ const styles = StyleSheet.create({
         width: "100%",
         flexDirection: "row",
         alignItems: "center",
+        marginTop: spacing.xxxSmall_4,
     },
     deleteButton: {
         // Line up the delete icon with the rest of the content.

--- a/packages/perseus-editor/src/components/locked-figures-section.tsx
+++ b/packages/perseus-editor/src/components/locked-figures-section.tsx
@@ -4,8 +4,6 @@
  * the dropdown for adding figures as well as the settings for each figure.
  */
 import {View, useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
-import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 import LockedFigureSelect from "./locked-figure-select";
@@ -69,7 +67,7 @@ const LockedFiguresSection = (props: Props) => {
     }
 
     return (
-        <View style={styles.container}>
+        <View>
             {figures?.map((figure, index) => (
                 <LockedFigureSettings
                     key={`${uniqueId}-locked-${figure}-${index}`}
@@ -85,11 +83,5 @@ const LockedFiguresSection = (props: Props) => {
         </View>
     );
 };
-
-const styles = StyleSheet.create({
-    container: {
-        paddingTop: spacing.large_24,
-    },
-});
 
 export default LockedFiguresSection;

--- a/packages/perseus-editor/src/components/locked-line-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-line-settings.tsx
@@ -7,7 +7,6 @@
 import {AccordionSection} from "@khanacademy/wonder-blocks-accordion";
 import {View, useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
-import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {color as wbColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium, LabelLarge} from "@khanacademy/wonder-blocks-typography";
@@ -16,6 +15,7 @@ import * as React from "react";
 
 import ColorSelect from "./color-select";
 import ColorSwatch from "./color-swatch";
+import LabeledSwitch from "./labeled-switch";
 import LockedFigureSettingsActions from "./locked-figure-settings-actions";
 import LockedPointSettings from "./locked-point-settings";
 
@@ -93,6 +93,9 @@ const LockedLineSettings = (props: Props) => {
             // file (which is imported in perseus-renderer.less).
             className="locked-figure-accordion"
         >
+            {/* TODO(LEMS-1966): Break out AccordionSection + its styles
+                into its own component to remove redundancy across
+                locked figure settings. */}
             <AccordionSection
                 style={styles.container}
                 headerStyle={styles.accordionHeader}
@@ -112,7 +115,7 @@ const LockedLineSettings = (props: Props) => {
                             style={styles.label}
                             tag="label"
                         >
-                            Kind
+                            kind
                         </LabelMedium>
                         <SingleSelect
                             id={kindSelectId}
@@ -136,7 +139,7 @@ const LockedLineSettings = (props: Props) => {
                             selectedValue={lineColor}
                             onChange={handleColorChange}
                         />
-                        <Strut size={spacing.medium_16} />
+                        <Strut size={spacing.small_12} />
 
                         {/* Line style settings */}
                         <View style={styles.row}>
@@ -145,7 +148,7 @@ const LockedLineSettings = (props: Props) => {
                                 style={styles.label}
                                 tag="label"
                             >
-                                Style
+                                style
                             </LabelMedium>
                             <SingleSelect
                                 id={styleSelectId}
@@ -155,6 +158,7 @@ const LockedLineSettings = (props: Props) => {
                                 }
                                 // Placeholder is required, but never gets used.
                                 placeholder=""
+                                style={styles.selectMarginOffset}
                             >
                                 <OptionItem value="solid" label="solid" />
                                 <OptionItem value="dashed" label="dashed" />
@@ -163,13 +167,12 @@ const LockedLineSettings = (props: Props) => {
                     </View>
 
                     {/* Show arrows setting */}
-                    <Checkbox
-                        label="Show arrows"
+                    <LabeledSwitch
+                        label="show arrows"
                         checked={showArrows}
                         onChange={(newValue) =>
                             onChangeProps({showArrows: newValue})
                         }
-                        style={styles.spaceUnder}
                     />
 
                     {/* Defining points settings */}
@@ -214,20 +217,22 @@ const LockedLineSettings = (props: Props) => {
 const styles = StyleSheet.create({
     container: {
         backgroundColor: wbColor.fadedBlue8,
-        marginBottom: spacing.xSmall_8,
+        marginTop: spacing.xSmall_8,
     },
     accordionHeader: {
-        paddingTop: spacing.small_12,
-        paddingBottom: spacing.small_12,
-        paddingInlineStart: spacing.medium_16,
+        padding: spacing.small_12,
+        // Don't move the dropdown caret.
+        paddingInlineEnd: 0,
     },
     accordionPanel: {
-        padding: spacing.medium_16,
-        paddingBottom: spacing.xSmall_8,
+        paddingTop: spacing.xxSmall_6,
+        paddingBottom: spacing.xxxSmall_4,
+        paddingLeft: spacing.small_12,
+        paddingRight: spacing.small_12,
     },
     lockedPointSettingsContainer: {
         marginTop: spacing.xSmall_8,
-        marginBottom: spacing.xSmall_8,
+        marginBottom: 0,
         marginLeft: -spacing.xxxSmall_4,
         marginRight: -spacing.xxxSmall_4,
         backgroundColor: wbColor.white,
@@ -240,7 +245,11 @@ const styles = StyleSheet.create({
         marginBottom: spacing.xSmall_8,
     },
     label: {
-        marginInlineEnd: spacing.xSmall_8,
+        marginInlineEnd: spacing.xxxSmall_4,
+    },
+    selectMarginOffset: {
+        // Align with the point settings accordions.
+        marginInlineEnd: -spacing.xxxSmall_4,
     },
 });
 

--- a/packages/perseus-editor/src/components/locked-point-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-point-settings.tsx
@@ -6,9 +6,8 @@
  */
 import {AccordionSection} from "@khanacademy/wonder-blocks-accordion";
 import {View, useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
-import {Checkbox, TextField} from "@khanacademy/wonder-blocks-form";
+import {TextField} from "@khanacademy/wonder-blocks-form";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Switch from "@khanacademy/wonder-blocks-switch";
 import {color as wbColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium, LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import {StyleSheet} from "aphrodite";
@@ -16,6 +15,7 @@ import * as React from "react";
 
 import ColorSelect from "./color-select";
 import ColorSwatch from "./color-swatch";
+import LabeledSwitch from "./labeled-switch";
 import LockedFigureSettingsActions from "./locked-figure-settings-actions";
 import {getValidNumberFromString} from "./util";
 
@@ -58,7 +58,6 @@ const LockedPointSettings = (props: Props) => {
     const xCoordId = ids.get("x-coord");
     const yCoordId = ids.get("y-coord");
     const colorSelectId = ids.get("point-color-select");
-    const showPointToggleId = ids.get("show-point-toggle");
 
     function handleBlur() {
         const validCoord = [
@@ -89,6 +88,9 @@ const LockedPointSettings = (props: Props) => {
             // file (which is imported in perseus-renderer.less).
             className="locked-figure-accordion"
         >
+            {/* TODO(LEMS-1966): Break out AccordionSection + its styles
+                into its own component to remove redundancy across
+                locked figure settings. */}
             <AccordionSection
                 style={[styles.container, style]}
                 headerStyle={styles.accordionHeader}
@@ -103,66 +105,59 @@ const LockedPointSettings = (props: Props) => {
                     </View>
                 }
             >
-                <View style={styles.accordionPanel}>
+                <View
+                    style={[
+                        styles.accordionPanel,
+                        !onRemove && styles.accordionPanelWithoutActions,
+                    ]}
+                >
                     {/* Coordinates */}
-                    <View style={styles.row}>
-                        <View style={[styles.row, styles.spaceUnder]}>
-                            <LabelMedium
-                                htmlFor={xCoordId}
-                                style={styles.label}
-                                tag="label"
-                            >
-                                x Coord
-                            </LabelMedium>
-                            <TextField
-                                id={xCoordId}
-                                type="number"
-                                value={coordState[0]}
-                                onChange={(newValue) =>
-                                    handleCoordChange(newValue, 0)
-                                }
-                                onBlur={handleBlur}
-                                style={styles.textField}
-                            />
-                        </View>
+                    <View style={[styles.row, styles.spaceUnder]}>
+                        <LabelMedium
+                            htmlFor={xCoordId}
+                            style={styles.label}
+                            tag="label"
+                        >
+                            x coord
+                        </LabelMedium>
+                        <TextField
+                            id={xCoordId}
+                            type="number"
+                            value={coordState[0]}
+                            onChange={(newValue) =>
+                                handleCoordChange(newValue, 0)
+                            }
+                            onBlur={handleBlur}
+                            style={styles.textField}
+                        />
                         <Strut size={spacing.medium_16} />
-                        <View style={[styles.row, styles.spaceUnder]}>
-                            <LabelMedium
-                                htmlFor={yCoordId}
-                                style={styles.label}
-                                tag="label"
-                            >
-                                y Coord
-                            </LabelMedium>
-                            <TextField
-                                id={yCoordId}
-                                type="number"
-                                value={coordState[1]}
-                                onChange={(newValue) =>
-                                    handleCoordChange(newValue, 1)
-                                }
-                                onBlur={handleBlur}
-                                style={styles.textField}
-                            />
-                        </View>
+                        <LabelMedium
+                            htmlFor={yCoordId}
+                            style={styles.label}
+                            tag="label"
+                        >
+                            y coord
+                        </LabelMedium>
+                        <TextField
+                            id={yCoordId}
+                            type="number"
+                            value={coordState[1]}
+                            onChange={(newValue) =>
+                                handleCoordChange(newValue, 1)
+                            }
+                            onBlur={handleBlur}
+                            style={styles.textField}
+                        />
                     </View>
 
                     {/* Toggle switch */}
                     {onToggle && (
-                        <View style={[styles.row, styles.spaceUnder]}>
-                            <Switch
-                                id={showPointToggleId}
-                                checked={!!toggled}
-                                onChange={onToggle}
-                            />
-                            <Strut size={spacing.small_12} />
-                            <LabelMedium
-                                tag="label"
-                                htmlFor={showPointToggleId}
-                            >
-                                Show point on graph
-                            </LabelMedium>
-                        </View>
+                        <LabeledSwitch
+                            label="show point on graph"
+                            checked={!!toggled}
+                            style={toggled && styles.spaceUnder}
+                            onChange={onToggle}
+                        />
                     )}
 
                     {/* Toggleable section */}
@@ -172,15 +167,14 @@ const LockedPointSettings = (props: Props) => {
                                 id={colorSelectId}
                                 selectedValue={pointColor}
                                 onChange={handleColorChange}
+                                style={styles.spaceUnder}
                             />
-                            <Strut size={spacing.xSmall_8} />
-                            <Checkbox
-                                label="Open point"
+                            <LabeledSwitch
+                                label="open point"
                                 checked={!filled}
                                 onChange={(newValue) => {
                                     onChangeProps({filled: !newValue});
                                 }}
-                                style={styles.spaceUnder}
                             />
                         </>
                     )}
@@ -201,19 +195,25 @@ const LockedPointSettings = (props: Props) => {
 const styles = StyleSheet.create({
     container: {
         backgroundColor: wbColor.fadedBlue8,
-        marginBottom: spacing.small_12,
+        marginTop: spacing.xSmall_8,
     },
     accordionHeader: {
-        paddingTop: spacing.small_12,
-        paddingBottom: spacing.small_12,
-        paddingInlineStart: spacing.medium_16,
+        padding: spacing.small_12,
+        // Don't move the dropdown caret.
+        paddingInlineEnd: 0,
         // Fixed height so the addition of the color swatch doesn't
         // change the height of the header when toggling.
         height: spacing.xxLarge_48,
     },
     accordionPanel: {
-        padding: spacing.medium_16,
-        paddingBottom: spacing.xSmall_8,
+        paddingTop: spacing.xxSmall_6,
+        paddingBottom: spacing.xxxSmall_4,
+        paddingLeft: spacing.small_12,
+        paddingRight: spacing.small_12,
+    },
+    accordionPanelWithoutActions: {
+        // Need more space since we don't have the actions' margins.
+        paddingBottom: spacing.medium_16,
     },
     row: {
         flexDirection: "row",
@@ -223,7 +223,7 @@ const styles = StyleSheet.create({
         marginBottom: spacing.xSmall_8,
     },
     label: {
-        marginInlineEnd: spacing.xSmall_8,
+        marginInlineEnd: spacing.xxSmall_6,
     },
     textField: {
         width: spacing.xxxLarge_64,

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
@@ -154,7 +154,7 @@ describe("InteractiveGraphEditor locked figures", () => {
             );
 
             // Act
-            const xCoordInput = screen.getByLabelText("x Coord");
+            const xCoordInput = screen.getByLabelText("x coord");
             await userEvent.clear(xCoordInput);
             await userEvent.type(xCoordInput, "1");
             await userEvent.tab();
@@ -187,7 +187,7 @@ describe("InteractiveGraphEditor locked figures", () => {
             );
 
             // Act
-            const xCoordInput = screen.getByLabelText("y Coord");
+            const xCoordInput = screen.getByLabelText("y coord");
             await userEvent.clear(xCoordInput);
             await userEvent.type(xCoordInput, "1");
             await userEvent.tab();
@@ -221,14 +221,14 @@ describe("InteractiveGraphEditor locked figures", () => {
 
             // Assert
             expect(screen.getByText("Point (0, 0)")).toBeInTheDocument();
-            expect(screen.getByText("x Coord")).toBeInTheDocument();
-            expect(screen.getByText("y Coord")).toBeInTheDocument();
+            expect(screen.getByText("x coord")).toBeInTheDocument();
+            expect(screen.getByText("y coord")).toBeInTheDocument();
             expect(
                 screen.getByRole("button", {
                     name: "Delete locked point at 0, 0",
                 }),
             ).toBeInTheDocument();
-            expect(screen.getByText("Color")).toBeInTheDocument();
+            expect(screen.getByText("color")).toBeInTheDocument();
         });
 
         test("Calls onChange when a locked point's color is changed", async () => {
@@ -248,7 +248,7 @@ describe("InteractiveGraphEditor locked figures", () => {
 
             // Act
             const colorInput = screen.getByRole("button", {
-                name: "Color",
+                name: "color",
             });
             await userEvent.click(colorInput);
             const colorSelection = screen.getByText("purple");
@@ -282,8 +282,8 @@ describe("InteractiveGraphEditor locked figures", () => {
             );
 
             // Act
-            const fillInput = screen.getByRole("checkbox", {
-                name: "Open point",
+            const fillInput = screen.getByRole("switch", {
+                name: "open point",
             });
             await userEvent.click(fillInput);
 
@@ -416,9 +416,9 @@ describe("InteractiveGraphEditor locked figures", () => {
 
             // Assert
             expect(screen.getByText("Line (0, 0), (2, 2)")).toBeInTheDocument();
-            expect(screen.getByText("Kind")).toBeInTheDocument();
-            expect(screen.getByText("Color")).toBeInTheDocument();
-            expect(screen.getByText("Style")).toBeInTheDocument();
+            expect(screen.getByText("kind")).toBeInTheDocument();
+            expect(screen.getByText("color")).toBeInTheDocument();
+            expect(screen.getByText("style")).toBeInTheDocument();
             expect(screen.getByText("Start point (0, 0)")).toBeInTheDocument();
             expect(screen.getByText("End point (2, 2)")).toBeInTheDocument();
         });
@@ -440,7 +440,7 @@ describe("InteractiveGraphEditor locked figures", () => {
 
             // Act
             const colorInput = screen.getByRole("button", {
-                name: "Color",
+                name: "color",
             });
             await userEvent.click(colorInput);
             const colorSelection = screen.getByText("purple");
@@ -480,7 +480,7 @@ describe("InteractiveGraphEditor locked figures", () => {
 
             // Act
             const styleInput = screen.getByRole("button", {
-                name: "Style",
+                name: "style",
             });
             await userEvent.click(styleInput);
             const styleSelection = screen.getByText("dashed");
@@ -515,8 +515,8 @@ describe("InteractiveGraphEditor locked figures", () => {
             );
 
             // Act
-            const showArrowsInput = screen.getByRole("checkbox", {
-                name: "Show arrows",
+            const showArrowsInput = screen.getByRole("switch", {
+                name: "show arrows",
             });
             await userEvent.click(showArrowsInput);
 
@@ -549,13 +549,13 @@ describe("InteractiveGraphEditor locked figures", () => {
             );
 
             // Act
-            const startPointInput = screen.getAllByLabelText("x Coord")[0];
+            const startPointInput = screen.getAllByLabelText("x coord")[0];
             await userEvent.click(startPointInput);
             await userEvent.clear(startPointInput);
             await userEvent.type(startPointInput, "1");
             await userEvent.tab();
 
-            const endPointInput = screen.getAllByLabelText("y Coord")[0];
+            const endPointInput = screen.getAllByLabelText("y coord")[0];
             await userEvent.click(endPointInput);
             await userEvent.clear(endPointInput);
             await userEvent.type(endPointInput, "5");
@@ -593,13 +593,13 @@ describe("InteractiveGraphEditor locked figures", () => {
             );
 
             // Act
-            const startPointInput = screen.getAllByLabelText("x Coord")[1];
+            const startPointInput = screen.getAllByLabelText("x coord")[1];
             await userEvent.click(startPointInput);
             await userEvent.clear(startPointInput);
             await userEvent.type(startPointInput, "1");
             await userEvent.tab();
 
-            const endPointInput = screen.getAllByLabelText("y Coord")[1];
+            const endPointInput = screen.getAllByLabelText("y coord")[1];
             await userEvent.click(endPointInput);
             await userEvent.clear(endPointInput);
             await userEvent.type(endPointInput, "5");
@@ -638,7 +638,7 @@ describe("InteractiveGraphEditor locked figures", () => {
 
             // Act
             const kindInput = screen.getByRole("button", {
-                name: "Kind",
+                name: "kind",
             });
             await userEvent.click(kindInput);
             const kindSelection = screen.getByText("segment");
@@ -673,7 +673,7 @@ describe("InteractiveGraphEditor locked figures", () => {
             );
 
             // Act
-            const toggle = screen.getAllByRole("switch")[0];
+            const toggle = screen.getAllByLabelText("show point on graph")[0];
             await userEvent.click(toggle);
 
             // Assert
@@ -705,7 +705,7 @@ describe("InteractiveGraphEditor locked figures", () => {
             );
 
             // Act
-            const toggle = screen.getAllByRole("switch")[1];
+            const toggle = screen.getAllByLabelText("show point on graph")[1];
             await userEvent.click(toggle);
 
             // Assert

--- a/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
@@ -1777,3 +1777,78 @@ export const segmentWithAllLockedRayVariations: PerseusRenderer = {
         },
     },
 };
+
+export const segmentWithLockedFigures: PerseusRenderer = {
+    content: "All locked lines\n\n[[☃ interactive-graph 1]]",
+    images: {},
+    widgets: {
+        "interactive-graph 1": {
+            graded: true,
+            options: {
+                correct: {
+                    coords: [
+                        [
+                            [-7, -7],
+                            [2, -5],
+                        ],
+                    ],
+                    type: "segment",
+                },
+                graph: {
+                    type: "segment",
+                },
+                gridStep: [1, 1],
+                labels: ["x", "y"],
+                markings: "graph",
+                range: [
+                    [-10, 10],
+                    [-10, 10],
+                ],
+                rulerLabel: "",
+                rulerTicks: 10,
+                showProtractor: false,
+                showRuler: false,
+                snapStep: [0.5, 0.5],
+                step: [1, 1],
+                lockedFigures: [
+                    // Just a point
+                    {
+                        type: "point",
+                        coord: [-7, -7],
+                        color: "green",
+                        filled: true,
+                    },
+                    // Point shown, one filled, one open
+                    {
+                        type: "line",
+                        kind: "line",
+                        points: [
+                            {
+                                type: "point",
+                                coord: [-7, -5],
+                                color: "green",
+                                filled: true,
+                            },
+                            {
+                                type: "point",
+                                coord: [2, -3],
+                                color: "green",
+                                filled: false,
+                            },
+                        ],
+                        color: "green",
+                        lineStyle: "solid",
+                        showArrows: false,
+                        showStartPoint: true,
+                        showEndPoint: true,
+                    },
+                ],
+            },
+            type: "interactive-graph",
+            version: {
+                major: 0,
+                minor: 0,
+            },
+        },
+    },
+};


### PR DESCRIPTION
## Summary:
Update spacing in the Locked Point Settings and Locked Line Settings
accordions so that the settings fit better.

PR includes
- spacing updates
- lowercase letters to save space
- checkboxes changed to switches (based on this [UX guidance](https://blog.uxtweak.com/checkbox-vs-toggle-switch/))
- LabeledSwitch component to remove redundancy
- LockedFiguresSection stories

Issue: https://khanacademy.atlassian.net/browse/LEMS-1965

## Test plan:
`yarn jest`

http://localhost:6006/?path=/story/perseus-editor-components-locked-figures-section--with-prod-width

### Screenshots

Note: the font styles are ever so slightly off, probably because of global styles in prod vs dev

| Before | After ("solid") | After ("dashed") |
| --- | --- | --- |
| ![Screenshot 2024-04-26 at 4 54 42 PM](https://github.com/Khan/perseus/assets/13231763/21403be0-dc63-426d-96b6-a70f56dbf13e) | ![Screenshot 2024-04-26 at 4 53 35 PM](https://github.com/Khan/perseus/assets/13231763/cc1ac547-4546-4af9-9004-3ac619f676c6) | ![Screenshot 2024-04-26 at 5 06 21 PM](https://github.com/Khan/perseus/assets/13231763/83b8875f-930e-4b1a-aed2-58d6036dcb8e) |