### PR TITLE
Update line segment tab order

### DIFF
--- a/.changeset/tricky-goats-beg.md
+++ b/.changeset/tricky-goats-beg.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fixed tab order for movable segments to be more intuitive. Previously, the tab order was (whole segment, point 1, point2). Now it's (point 1, whole segment, point 2).

--- a/packages/perseus/src/widgets/__stories__/interactive-graph-regression.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/interactive-graph-regression.stories.tsx
@@ -141,6 +141,12 @@ export const MafsWithXAxisOffTop = (args: StoryArgs): React.ReactElement => (
     />
 );
 
+export const MafsWithMultipleSegments = (args: StoryArgs): React.ReactElement => (
+    <MafsQuestionRenderer
+        question={interactiveGraphQuestionBuilder().withSegments(3).build()}
+    />
+)
+
 function MafsQuestionRenderer(props: {question: PerseusRenderer}) {
     const {question} = props;
     return (

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/interactive-graph.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/interactive-graph.test.ts.snap
@@ -3040,6 +3040,41 @@ exports[`snapshots should render correctly 1`] = `
                     </filter>
                   </defs>
                   <g
+                    class="movable-point "
+                    data-testid="movable-point"
+                    style="--movable-point-color: #1865f2;"
+                    tabindex="0"
+                  >
+                    <circle
+                      class="movable-point-hitbox"
+                      cx="-100"
+                      cy="-100"
+                      r="24"
+                    />
+                    <circle
+                      class="movable-point-halo"
+                      cx="-100"
+                      cy="-100"
+                    />
+                    <circle
+                      class="movable-point-ring"
+                      cx="-100"
+                      cy="-100"
+                    />
+                    <circle
+                      class="movable-point-focus-outline"
+                      cx="-100"
+                      cy="-100"
+                    />
+                    <circle
+                      class="movable-point-center"
+                      cx="-100"
+                      cy="-100"
+                      data-testid="movable-point__center"
+                      style="fill: #1865f2;"
+                    />
+                  </g>
+                  <g
                     class="movable-line"
                     data-testid="movable-line"
                     style="cursor: grab;"
@@ -3074,41 +3109,6 @@ exports[`snapshots should render correctly 1`] = `
                       x2="100"
                       y1="-100"
                       y2="-100"
-                    />
-                  </g>
-                  <g
-                    class="movable-point "
-                    data-testid="movable-point"
-                    style="--movable-point-color: #1865f2;"
-                    tabindex="0"
-                  >
-                    <circle
-                      class="movable-point-hitbox"
-                      cx="-100"
-                      cy="-100"
-                      r="24"
-                    />
-                    <circle
-                      class="movable-point-halo"
-                      cx="-100"
-                      cy="-100"
-                    />
-                    <circle
-                      class="movable-point-ring"
-                      cx="-100"
-                      cy="-100"
-                    />
-                    <circle
-                      class="movable-point-focus-outline"
-                      cx="-100"
-                      cy="-100"
-                    />
-                    <circle
-                      class="movable-point-center"
-                      cx="-100"
-                      cy="-100"
-                      data-testid="movable-point__center"
-                      style="fill: #1865f2;"
                     />
                   </g>
                   <g
@@ -4231,6 +4231,41 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                     />
                   </g>
                   <g
+                    class="movable-point "
+                    data-testid="movable-point"
+                    style="--movable-point-color: #1865f2;"
+                    tabindex="0"
+                  >
+                    <circle
+                      class="movable-point-hitbox"
+                      cx="-100"
+                      cy="-100"
+                      r="24"
+                    />
+                    <circle
+                      class="movable-point-halo"
+                      cx="-100"
+                      cy="-100"
+                    />
+                    <circle
+                      class="movable-point-ring"
+                      cx="-100"
+                      cy="-100"
+                    />
+                    <circle
+                      class="movable-point-focus-outline"
+                      cx="-100"
+                      cy="-100"
+                    />
+                    <circle
+                      class="movable-point-center"
+                      cx="-100"
+                      cy="-100"
+                      data-testid="movable-point__center"
+                      style="fill: #1865f2;"
+                    />
+                  </g>
+                  <g
                     class="movable-line"
                     data-testid="movable-line"
                     style="cursor: grab;"
@@ -4265,41 +4300,6 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                       x2="100"
                       y1="-100"
                       y2="-100"
-                    />
-                  </g>
-                  <g
-                    class="movable-point "
-                    data-testid="movable-point"
-                    style="--movable-point-color: #1865f2;"
-                    tabindex="0"
-                  >
-                    <circle
-                      class="movable-point-hitbox"
-                      cx="-100"
-                      cy="-100"
-                      r="24"
-                    />
-                    <circle
-                      class="movable-point-halo"
-                      cx="-100"
-                      cy="-100"
-                    />
-                    <circle
-                      class="movable-point-ring"
-                      cx="-100"
-                      cy="-100"
-                    />
-                    <circle
-                      class="movable-point-focus-outline"
-                      cx="-100"
-                      cy="-100"
-                    />
-                    <circle
-                      class="movable-point-center"
-                      cx="-100"
-                      cy="-100"
-                      data-testid="movable-point__center"
-                      style="fill: #1865f2;"
                     />
                   </g>
                   <g
@@ -5349,6 +5349,41 @@ exports[`snapshots should render correctly with locked points 1`] = `
                     style="fill: #ffffff; opacity: 1; stroke: #447A53; stroke-width: 2;"
                   />
                   <g
+                    class="movable-point "
+                    data-testid="movable-point"
+                    style="--movable-point-color: #1865f2;"
+                    tabindex="0"
+                  >
+                    <circle
+                      class="movable-point-hitbox"
+                      cx="-100"
+                      cy="-100"
+                      r="24"
+                    />
+                    <circle
+                      class="movable-point-halo"
+                      cx="-100"
+                      cy="-100"
+                    />
+                    <circle
+                      class="movable-point-ring"
+                      cx="-100"
+                      cy="-100"
+                    />
+                    <circle
+                      class="movable-point-focus-outline"
+                      cx="-100"
+                      cy="-100"
+                    />
+                    <circle
+                      class="movable-point-center"
+                      cx="-100"
+                      cy="-100"
+                      data-testid="movable-point__center"
+                      style="fill: #1865f2;"
+                    />
+                  </g>
+                  <g
                     class="movable-line"
                     data-testid="movable-line"
                     style="cursor: grab;"
@@ -5383,41 +5418,6 @@ exports[`snapshots should render correctly with locked points 1`] = `
                       x2="100"
                       y1="-100"
                       y2="-100"
-                    />
-                  </g>
-                  <g
-                    class="movable-point "
-                    data-testid="movable-point"
-                    style="--movable-point-color: #1865f2;"
-                    tabindex="0"
-                  >
-                    <circle
-                      class="movable-point-hitbox"
-                      cx="-100"
-                      cy="-100"
-                      r="24"
-                    />
-                    <circle
-                      class="movable-point-halo"
-                      cx="-100"
-                      cy="-100"
-                    />
-                    <circle
-                      class="movable-point-ring"
-                      cx="-100"
-                      cy="-100"
-                    />
-                    <circle
-                      class="movable-point-focus-outline"
-                      cx="-100"
-                      cy="-100"
-                    />
-                    <circle
-                      class="movable-point-center"
-                      cx="-100"
-                      cy="-100"
-                      data-testid="movable-point__center"
-                      style="fill: #1865f2;"
                     />
                   </g>
                   <g

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/interactive-graph.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/interactive-graph.test.ts.snap
@@ -3040,39 +3040,44 @@ exports[`snapshots should render correctly 1`] = `
                     </filter>
                   </defs>
                   <g
-                    class="movable-point "
-                    data-testid="movable-point"
-                    style="--movable-point-color: #1865f2;"
-                    tabindex="0"
+                    style="opacity: 0;"
                   >
-                    <circle
-                      class="movable-point-hitbox"
-                      cx="-100"
-                      cy="-100"
-                      r="24"
-                    />
-                    <circle
-                      class="movable-point-halo"
-                      cx="-100"
-                      cy="-100"
-                    />
-                    <circle
-                      class="movable-point-ring"
-                      cx="-100"
-                      cy="-100"
-                    />
-                    <circle
-                      class="movable-point-focus-outline"
-                      cx="-100"
-                      cy="-100"
-                    />
-                    <circle
-                      class="movable-point-center"
-                      cx="-100"
-                      cy="-100"
-                      data-testid="movable-point__center"
-                      style="fill: #1865f2;"
-                    />
+                    <g
+                      class="movable-point "
+                      data-testid="movable-point"
+                      id="point1"
+                      style="--movable-point-color: #1865f2;"
+                      tabindex="0"
+                    >
+                      <circle
+                        class="movable-point-hitbox"
+                        cx="-100"
+                        cy="-100"
+                        r="24"
+                      />
+                      <circle
+                        class="movable-point-halo"
+                        cx="-100"
+                        cy="-100"
+                      />
+                      <circle
+                        class="movable-point-ring"
+                        cx="-100"
+                        cy="-100"
+                      />
+                      <circle
+                        class="movable-point-focus-outline"
+                        cx="-100"
+                        cy="-100"
+                      />
+                      <circle
+                        class="movable-point-center"
+                        cx="-100"
+                        cy="-100"
+                        data-testid="movable-point__center"
+                        style="fill: #1865f2;"
+                      />
+                    </g>
                   </g>
                   <g
                     class="movable-line"
@@ -3114,6 +3119,7 @@ exports[`snapshots should render correctly 1`] = `
                   <g
                     class="movable-point "
                     data-testid="movable-point"
+                    id="point2"
                     style="--movable-point-color: #1865f2;"
                     tabindex="0"
                   >
@@ -3146,6 +3152,10 @@ exports[`snapshots should render correctly 1`] = `
                       style="fill: #1865f2;"
                     />
                   </g>
+                  <use
+                    href="#point1"
+                    tabindex="-1"
+                  />
                 </svg>
               </div>
             </div>
@@ -4231,39 +4241,44 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                     />
                   </g>
                   <g
-                    class="movable-point "
-                    data-testid="movable-point"
-                    style="--movable-point-color: #1865f2;"
-                    tabindex="0"
+                    style="opacity: 0;"
                   >
-                    <circle
-                      class="movable-point-hitbox"
-                      cx="-100"
-                      cy="-100"
-                      r="24"
-                    />
-                    <circle
-                      class="movable-point-halo"
-                      cx="-100"
-                      cy="-100"
-                    />
-                    <circle
-                      class="movable-point-ring"
-                      cx="-100"
-                      cy="-100"
-                    />
-                    <circle
-                      class="movable-point-focus-outline"
-                      cx="-100"
-                      cy="-100"
-                    />
-                    <circle
-                      class="movable-point-center"
-                      cx="-100"
-                      cy="-100"
-                      data-testid="movable-point__center"
-                      style="fill: #1865f2;"
-                    />
+                    <g
+                      class="movable-point "
+                      data-testid="movable-point"
+                      id="point1"
+                      style="--movable-point-color: #1865f2;"
+                      tabindex="0"
+                    >
+                      <circle
+                        class="movable-point-hitbox"
+                        cx="-100"
+                        cy="-100"
+                        r="24"
+                      />
+                      <circle
+                        class="movable-point-halo"
+                        cx="-100"
+                        cy="-100"
+                      />
+                      <circle
+                        class="movable-point-ring"
+                        cx="-100"
+                        cy="-100"
+                      />
+                      <circle
+                        class="movable-point-focus-outline"
+                        cx="-100"
+                        cy="-100"
+                      />
+                      <circle
+                        class="movable-point-center"
+                        cx="-100"
+                        cy="-100"
+                        data-testid="movable-point__center"
+                        style="fill: #1865f2;"
+                      />
+                    </g>
                   </g>
                   <g
                     class="movable-line"
@@ -4305,6 +4320,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                   <g
                     class="movable-point "
                     data-testid="movable-point"
+                    id="point2"
                     style="--movable-point-color: #1865f2;"
                     tabindex="0"
                   >
@@ -4337,6 +4353,10 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                       style="fill: #1865f2;"
                     />
                   </g>
+                  <use
+                    href="#point1"
+                    tabindex="-1"
+                  />
                 </svg>
               </div>
             </div>
@@ -5349,39 +5369,44 @@ exports[`snapshots should render correctly with locked points 1`] = `
                     style="fill: #ffffff; opacity: 1; stroke: #447A53; stroke-width: 2;"
                   />
                   <g
-                    class="movable-point "
-                    data-testid="movable-point"
-                    style="--movable-point-color: #1865f2;"
-                    tabindex="0"
+                    style="opacity: 0;"
                   >
-                    <circle
-                      class="movable-point-hitbox"
-                      cx="-100"
-                      cy="-100"
-                      r="24"
-                    />
-                    <circle
-                      class="movable-point-halo"
-                      cx="-100"
-                      cy="-100"
-                    />
-                    <circle
-                      class="movable-point-ring"
-                      cx="-100"
-                      cy="-100"
-                    />
-                    <circle
-                      class="movable-point-focus-outline"
-                      cx="-100"
-                      cy="-100"
-                    />
-                    <circle
-                      class="movable-point-center"
-                      cx="-100"
-                      cy="-100"
-                      data-testid="movable-point__center"
-                      style="fill: #1865f2;"
-                    />
+                    <g
+                      class="movable-point "
+                      data-testid="movable-point"
+                      id="point1"
+                      style="--movable-point-color: #1865f2;"
+                      tabindex="0"
+                    >
+                      <circle
+                        class="movable-point-hitbox"
+                        cx="-100"
+                        cy="-100"
+                        r="24"
+                      />
+                      <circle
+                        class="movable-point-halo"
+                        cx="-100"
+                        cy="-100"
+                      />
+                      <circle
+                        class="movable-point-ring"
+                        cx="-100"
+                        cy="-100"
+                      />
+                      <circle
+                        class="movable-point-focus-outline"
+                        cx="-100"
+                        cy="-100"
+                      />
+                      <circle
+                        class="movable-point-center"
+                        cx="-100"
+                        cy="-100"
+                        data-testid="movable-point__center"
+                        style="fill: #1865f2;"
+                      />
+                    </g>
                   </g>
                   <g
                     class="movable-line"
@@ -5423,6 +5448,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                   <g
                     class="movable-point "
                     data-testid="movable-point"
+                    id="point2"
                     style="--movable-point-color: #1865f2;"
                     tabindex="0"
                   >
@@ -5455,6 +5481,10 @@ exports[`snapshots should render correctly with locked points 1`] = `
                       style="fill: #1865f2;"
                     />
                   </g>
+                  <use
+                    href="#point1"
+                    tabindex="-1"
+                  />
                 </svg>
               </div>
             </div>

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/interactive-graph.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/interactive-graph.test.ts.snap
@@ -3045,7 +3045,7 @@ exports[`snapshots should render correctly 1`] = `
                     <g
                       class="movable-point "
                       data-testid="movable-point"
-                      id="point1"
+                      id="uid--18-point"
                       style="--movable-point-color: #1865f2;"
                       tabindex="0"
                     >
@@ -3119,7 +3119,6 @@ exports[`snapshots should render correctly 1`] = `
                   <g
                     class="movable-point "
                     data-testid="movable-point"
-                    id="point2"
                     style="--movable-point-color: #1865f2;"
                     tabindex="0"
                   >
@@ -3153,7 +3152,7 @@ exports[`snapshots should render correctly 1`] = `
                     />
                   </g>
                   <use
-                    href="#point1"
+                    href="#uid--18-point"
                     tabindex="-1"
                   />
                 </svg>
@@ -4246,7 +4245,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                     <g
                       class="movable-point "
                       data-testid="movable-point"
-                      id="point1"
+                      id="uid--20-point"
                       style="--movable-point-color: #1865f2;"
                       tabindex="0"
                     >
@@ -4320,7 +4319,6 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                   <g
                     class="movable-point "
                     data-testid="movable-point"
-                    id="point2"
                     style="--movable-point-color: #1865f2;"
                     tabindex="0"
                   >
@@ -4354,7 +4352,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
                     />
                   </g>
                   <use
-                    href="#point1"
+                    href="#uid--20-point"
                     tabindex="-1"
                   />
                 </svg>
@@ -5374,7 +5372,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                     <g
                       class="movable-point "
                       data-testid="movable-point"
-                      id="point1"
+                      id="uid--19-point"
                       style="--movable-point-color: #1865f2;"
                       tabindex="0"
                     >
@@ -5448,7 +5446,6 @@ exports[`snapshots should render correctly with locked points 1`] = `
                   <g
                     class="movable-point "
                     data-testid="movable-point"
-                    id="point2"
                     style="--movable-point-color: #1865f2;"
                     tabindex="0"
                   >
@@ -5482,7 +5479,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
                     />
                   </g>
                   <use
-                    href="#point1"
+                    href="#uid--19-point"
                     tabindex="-1"
                   />
                 </svg>

--- a/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
+++ b/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
@@ -1,41 +1,45 @@
-import {describe, beforeEach, it} from "@jest/globals";
+import {beforeEach, describe, it} from "@jest/globals";
 import {color as wbColor} from "@khanacademy/wonder-blocks-tokens";
 import {waitFor} from "@testing-library/react";
+import type {UserEvent} from "@testing-library/user-event";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 
 import {clone} from "../../../../../testing/object-utils";
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
 import {ApiOptions} from "../../perseus-api";
+import type {PerseusRenderer} from "../../perseus-types";
 import {lockedFigureColors} from "../../perseus-types";
 import {
+    linearQuestion,
+    linearQuestionWithDefaultCorrect,
+    linearSystemQuestion,
+    linearSystemQuestionWithDefaultCorrect,
+    pointQuestion,
+    pointQuestionWithDefaultCorrect,
+    polygonQuestion,
+    polygonQuestionDefaultCorrect,
     questionsAndAnswers,
+    rayQuestion,
+    rayQuestionWithDefaultCorrect,
+    segmentQuestion,
+    segmentQuestionDefaultCorrect,
+    segmentWithLockedLineQuestion,
     segmentWithLockedPointsQuestion,
     segmentWithLockedPointsWithColorQuestion,
-    segmentQuestionDefaultCorrect,
-    linearQuestionWithDefaultCorrect,
-    linearSystemQuestionWithDefaultCorrect,
-    rayQuestionWithDefaultCorrect,
-    polygonQuestionDefaultCorrect,
-    pointQuestionWithDefaultCorrect,
-    segmentWithLockedLineQuestion,
-    segmentQuestion,
-    linearQuestion,
-    linearSystemQuestion,
-    rayQuestion,
-    polygonQuestion,
-    pointQuestion,
 } from "../__testdata__/interactive-graph.testdata";
-import {trueForAllMafsSupportedGraphTypes} from "../interactive-graphs/mafs-supported-graph-types";
+import type {
+    mafsSupportedGraphTypes
+} from "../interactive-graphs/mafs-supported-graph-types";
+import {
+    trueForAllMafsSupportedGraphTypes
+} from "../interactive-graphs/mafs-supported-graph-types";
 
 import {renderQuestion} from "./renderQuestion";
 
 import type {Coord} from "../../interactive2/types";
-import type {PerseusRenderer} from "../../perseus-types";
 import type Renderer from "../../renderer";
 import type {APIOptions} from "../../types";
-import type {mafsSupportedGraphTypes} from "../interactive-graphs/mafs-supported-graph-types";
-import type {UserEvent} from "@testing-library/user-event";
 
 const updateWidgetState = (renderer: Renderer, widgetId: string, update) => {
     const state = clone(renderer.getSerializedState());
@@ -129,7 +133,7 @@ describe("interactive-graph widget", function () {
     );
 });
 
-describe("mafs graphs", () => {
+describe("a mafs graph", () => {
     let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
@@ -277,6 +281,77 @@ describe("mafs graphs", () => {
                 stroke: lockedFigureColors.green,
             });
         });
+    });
+});
+
+describe("tabbing forward on a Mafs segment graph", () => {
+    let userEvent: UserEvent;
+    beforeEach(() => {
+        userEvent = userEventLib.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+    });
+
+    it("focuses the first endpoint of a segment first", async () => {
+        const {container} = renderQuestion(segmentQuestion, {flags: {mafs: {segment: true}}});
+
+        await userEvent.tab();
+
+        const movablePoints = container.querySelectorAll("[data-testid=movable-point]");
+        expect(movablePoints[0]).toHaveFocus();
+    });
+
+    it("focuses the whole segment second", async () => {
+        const {container} = renderQuestion(segmentQuestion, {flags: {mafs: {segment: true}}});
+
+        await userEvent.tab();
+        await userEvent.tab();
+
+        const movableLine = container.querySelector("[data-testid=movable-line]");
+        expect(movableLine).toHaveFocus();
+    });
+
+    it("focuses the second point third", async () => {
+        const {container} = renderQuestion(segmentQuestion, {flags: {mafs: {segment: true}}});
+
+        await userEvent.tab();
+        await userEvent.tab();
+        await userEvent.tab();
+
+        const movablePoints = container.querySelectorAll("[data-testid=movable-point]");
+        expect(movablePoints[1]).toHaveFocus();
+    });
+});
+
+describe("tabbing backward on a Mafs segment graph", () => {
+    let userEvent: UserEvent;
+    beforeEach(() => {
+        userEvent = userEventLib.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+    });
+
+    it("moves focus from the last point to the whole segment", async () => {
+        const {container} = renderQuestion(segmentQuestion, {flags: {mafs: {segment: true}}});
+
+        await userEvent.tab();
+        await userEvent.tab();
+        await userEvent.tab();
+        await userEvent.tab({shift: true})
+
+        const movableLine = container.querySelector("[data-testid=movable-line]");
+        expect(movableLine).toHaveFocus();
+    });
+
+    it("moves focus from the whole segment to the first point", async () => {
+        const {container} = renderQuestion(segmentQuestion, {flags: {mafs: {segment: true}}});
+
+        await userEvent.tab();
+        await userEvent.tab();
+        await userEvent.tab({shift: true})
+
+        const movablePoints = container.querySelectorAll("[data-testid=movable-point]");
+        expect(movablePoints[0]).toHaveFocus();
     });
 });
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
@@ -9,11 +9,13 @@ import {snap} from "../../utils";
 import {useTransformVectorsToPixels} from "../use-transform";
 
 import type {vec} from "mafs";
+import {CSSProperties} from "aphrodite";
 
 type Props = {
     point: vec.Vector2;
     onMove: (newPoint: vec.Vector2) => unknown;
     color?: string;
+    id?: string;
 };
 
 // The hitbox size of 48px by 48px is preserved from the legacy interactive
@@ -23,7 +25,7 @@ const hitboxSizePx = 48;
 export const StyledMovablePoint = (props: Props) => {
     const {range, snapStep, markings, showTooltips} = useGraphConfig();
     const hitboxRef = useRef<SVGCircleElement>(null);
-    const {point, onMove, color = WBColor.blue} = props;
+    const {point, onMove, color = WBColor.blue, id} = props;
 
     // WB Tooltip requires a color name for the background color.
     // Since the color in props is a hex value, a reverse lookup is needed.
@@ -71,6 +73,7 @@ export const StyledMovablePoint = (props: Props) => {
 
     const svgForPoint = (
         <g
+            id={id}
             ref={hitboxRef}
             className={pointClasses}
             tabIndex={0}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
@@ -9,7 +9,6 @@ import {snap} from "../../utils";
 import {useTransformVectorsToPixels} from "../use-transform";
 
 import type {vec} from "mafs";
-import {CSSProperties} from "aphrodite";
 
 type Props = {
     point: vec.Vector2;

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
@@ -46,13 +46,13 @@ const SegmentView = (props: InteractiveLineProps) => {
 
     return (
         <>
-            <MovableLine start={start} end={end} onMove={onMoveSegment} />
             <StyledMovablePoint
                 point={start}
                 onMove={(newPoint) => {
                     props.onMovePoint(0, newPoint);
                 }}
             />
+            <MovableLine start={start} end={end} onMove={onMoveSegment} />
             <StyledMovablePoint
                 point={end}
                 onMove={(newPoint) => {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
@@ -46,19 +46,24 @@ const SegmentView = (props: InteractiveLineProps) => {
 
     return (
         <>
-            <StyledMovablePoint
-                point={start}
-                onMove={(newPoint) => {
-                    props.onMovePoint(0, newPoint);
-                }}
-            />
+            <g style={{opacity: 0}}>
+                <StyledMovablePoint
+                    id={"point1"}
+                    point={start}
+                    onMove={(newPoint) => {
+                        props.onMovePoint(0, newPoint);
+                    }}
+                />
+            </g>
             <MovableLine start={start} end={end} onMove={onMoveSegment} />
             <StyledMovablePoint
+                id={"point2"}
                 point={end}
                 onMove={(newPoint) => {
                     props.onMovePoint(1, newPoint);
                 }}
             />
+            <use href="#point1" tabIndex={-1} />
         </>
     );
 };

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -1,20 +1,23 @@
 import type {PerseusRenderer} from "../../perseus-types";
 import type {Interval, vec} from "mafs";
+import {PerseusGraphType} from "../../perseus-types";
 
 export function interactiveGraphQuestionBuilder(): InteractiveGraphQuestionBuilder {
     return new InteractiveGraphQuestionBuilder();
 }
 
 class InteractiveGraphQuestionBuilder {
-    gridStep: vec.Vector2 = [1, 1];
-    labels: [string, string] = ["x", "y"];
-    markings: "graph" | "grid" | "none" = "graph";
-    xRange: Interval = [-10, 10];
-    yRange: Interval = [-10, 10];
-    snapStep: vec.Vector2 = [0.5, 0.5];
-    tickStep: vec.Vector2 = [1, 1];
+    private gridStep: vec.Vector2 = [1, 1];
+    private labels: [string, string] = ["x", "y"];
+    private markings: "graph" | "grid" | "none" = "graph";
+    private xRange: Interval = [-10, 10];
+    private yRange: Interval = [-10, 10];
+    private snapStep: vec.Vector2 = [0.5, 0.5];
+    private tickStep: vec.Vector2 = [1, 1];
+    private interactiveFigureConfig: InteractiveFigureConfig = new SegmentGraphConfig(1);
 
     build(): PerseusRenderer {
+        console.log("config", this.interactiveFigureConfig.correct())
         return {
             content: "[[☃ interactive-graph 1]]",
             images: {},
@@ -22,18 +25,8 @@ class InteractiveGraphQuestionBuilder {
                 "interactive-graph 1": {
                     graded: true,
                     options: {
-                        correct: {
-                            coords: [
-                                [
-                                    [-7, 7],
-                                    [2, 5],
-                                ],
-                            ],
-                            type: "segment",
-                        },
-                        graph: {
-                            type: "segment",
-                        },
+                        correct: this.interactiveFigureConfig.correct(),
+                        graph: this.interactiveFigureConfig.graph(),
                         gridStep: this.gridStep,
                         labels: this.labels,
                         markings: this.markings,
@@ -91,4 +84,42 @@ class InteractiveGraphQuestionBuilder {
         this.tickStep = [x, y];
         return this;
     }
+
+    withSegments(numSegments: number): InteractiveGraphQuestionBuilder {
+        this.interactiveFigureConfig = new SegmentGraphConfig(numSegments)
+        return this;
+    }
+}
+
+interface InteractiveFigureConfig {
+    graph(): PerseusGraphType
+    correct(): PerseusGraphType
+}
+
+class SegmentGraphConfig implements InteractiveFigureConfig {
+    private numSegments: number;
+    constructor(numSegments: number) {
+        this.numSegments = numSegments;
+    }
+    
+    correct(): PerseusGraphType {
+        return {
+            type: "segment",
+            numSegments: this.numSegments,
+            coords: repeat(this.numSegments,
+                [
+                    [-7, 7],
+                    [2, 5],
+                ],
+            ),
+        };
+    }
+
+    graph(): PerseusGraphType {
+        return {type: "segment", numSegments: this.numSegments};
+    }
+}
+
+function repeat<T>(n: number, item: T): T[] {
+    return new Array(n).fill(null).map(() => item);
 }


### PR DESCRIPTION
During playtesting, Sarah B pointed out that the tab order for segment graphs
was not very intuitive. Tabbing to a segment first selects the whole segment.
Tabbing further selects each endpoint.

This PR updates the tab order so the first endpoint is selected first, then the
segment, then the second endpoint.

Issue: LEMS-1936

## Test plan:

View a Mafs segment graph in the dev ui (`yarn dev`). Tabbing between UI
elements should feel intuitive.