### PR TITLE
Prevent mobile styling from overriding graph axis label size

### DIFF
--- a/.changeset/tame-days-worry.md
+++ b/.changeset/tame-days-worry.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix sizing of interactive graph axis labels on mobile

--- a/packages/perseus/src/styles/articles.less
+++ b/packages/perseus/src/styles/articles.less
@@ -421,8 +421,7 @@
 
     .math(@blockMathTextSize; @blockMathLineHeight;
           @inlineMathTextSize; @inlineMathLineHeight) {
-        .katex,
-        mjx-container {
+        :is(.katex, mjx-container):not(.mafs-graph *) {
             font-size: @inlineMathTextSize;
             line-height: @inlineMathLineHeight;
             color: @gray17;

--- a/packages/perseus/src/widgets/__stories__/interactive-graph-regression.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/interactive-graph-regression.stories.tsx
@@ -141,6 +141,14 @@ export const MafsWithXAxisOffTop = (args: StoryArgs): React.ReactElement => (
     />
 );
 
+export const MafsInMobileContainer = (args: StoryArgs): React.ReactElement => (
+    <div className="framework-perseus perseus-mobile">
+        <MafsQuestionRenderer
+            question={interactiveGraphQuestionBuilder().build()}
+        />
+    </div>
+);
+
 function MafsQuestionRenderer(props: {question: PerseusRenderer}) {
     const {question} = props;
     return (

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/interactive-graph.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/interactive-graph.test.ts.snap
@@ -2975,7 +2975,7 @@ exports[`snapshots should render correctly 1`] = `
           class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="default_xu2jcg-o_O-inlineStyles_5seapk"
+            class="default_xu2jcg-o_O-inlineStyles_5seapk mafs-graph"
           >
             <div
               class="default_xu2jcg-o_O-inlineStyles_16155wj"
@@ -3244,7 +3244,7 @@ exports[`snapshots should render correctly with locked lines 1`] = `
           class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="default_xu2jcg-o_O-inlineStyles_5seapk"
+            class="default_xu2jcg-o_O-inlineStyles_5seapk mafs-graph"
           >
             <div
               class="default_xu2jcg-o_O-inlineStyles_16155wj"
@@ -4435,7 +4435,7 @@ exports[`snapshots should render correctly with locked points 1`] = `
           class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="default_xu2jcg-o_O-inlineStyles_5seapk"
+            class="default_xu2jcg-o_O-inlineStyles_5seapk mafs-graph"
           >
             <div
               class="default_xu2jcg-o_O-inlineStyles_16155wj"

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -135,6 +135,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
             }}
         >
             <View
+                className="mafs-graph"
                 style={{
                     width,
                     height,


### PR DESCRIPTION
There was a bug in the exercise editor where the axis labels on Mafs interactive
graphs were too big.  The cause was the small-screen-specific styling changed
in this commit.

Issue: LEMS-1964

## Test plan:

- View the visual regression test added in this commit.
- The axis labels should not overlap with the graph grid.