### PR TITLE
Fix dash style for 'ray' line types that I missed

### DIFF
--- a/.changeset/green-ladybugs-design.md
+++ b/.changeset/green-ladybugs-design.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix dash style for locked lines when kind is 'ray'

--- a/packages/perseus/src/widgets/interactive-graphs/locked-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-line.tsx
@@ -43,10 +43,7 @@ const LockedLine = (props: Props) => {
                 style={{
                     strokeDasharray:
                         lineStyle === "dashed"
-                            ? // TODO(lems-1930): Uncomment this line when the
-                              // dashed style is updated in Mafs.
-                              // ? "var(--mafs-line-stroke-dash-style)"
-                              "4, 3"
+                            ? "var(--mafs-line-stroke-dash-style)"
                             : undefined,
                 }}
             />


### PR DESCRIPTION
## Summary:

After the initial fix for our dashed line styles being inconsistent, I missed fixing it for our `ray` line type. This PR fixes the ray so that it uses the MAFS-provided CSS variable for the dash style.

<img width="372" alt="Comparing dash styles of locked ray and locked line - they're the same!" src="https://github.com/Khan/perseus/assets/77138/352db7b9-ba4c-4915-b7d1-ff10d6cc5df0">


Issue: LEMS-1930

## Test plan:

  * `yarn start`
  * Navigate to: http://localhost:6006/?path=/story/perseuseditor-editorpage--mafs-with-locked-figures
  * Change the "Line" locked figure to be a "ray" and have a "style: dashed"

Note that the dash style looks correct. Switch the line "kind" to be a "line" and compare the dash style (it shouldn't change)