### PR TITLE
[🔥AUDIT🔥] Fix stories that had a separator in the top-level name

### DIFF
--- a/.changeset/violet-peaches-tie.md
+++ b/.changeset/violet-peaches-tie.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Fix location of DeviceFramer and ViewportResizer in Storybook

--- a/packages/perseus-editor/src/components/__stories__/device-framer.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/device-framer.stories.tsx
@@ -7,7 +7,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 
 const meta: Meta<typeof DeviceFramer> = {
     component: DeviceFramer,
-    title: "Perseus/Editor/Components/Device Framer",
+    title: "PerseusEditor/Components/Device Framer",
 };
 
 export default meta;

--- a/packages/perseus-editor/src/components/__stories__/viewport-resizer.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/viewport-resizer.stories.tsx
@@ -8,7 +8,7 @@ import type {Meta, StoryFn} from "@storybook/react";
 
 const meta: Meta<typeof ViewportResizer> = {
     component: ViewportResizer,
-    title: "Perseus/Editor/Components/Viewport Resizer",
+    title: "PerseusEditor/Components/Viewport Resizer",
 };
 
 export default meta;


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:

I noticed that there were two components from the editor package that kept bubbling up to the top of the story listing in the "Perseus" area. 

<img width="221" alt="image" src="https://github.com/Khan/perseus/assets/77138/884bb2cc-ad9d-45cd-8024-a39e0c985808">


This was caused by having a `/` (separator) character in the name. Removing that moves the `DeviceFramer` and `ViewportResizer` stories down into the PerseusEditor area. 


Issue: "none"

## Test plan: