### PR TITLE
Changed locked figures default color to gray

### DIFF
--- a/.changeset/small-donuts-applaud.md
+++ b/.changeset/small-donuts-applaud.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Change locked figures' initial color to grayH (previusly green)

--- a/packages/perseus-editor/src/components/__tests__/locked-point-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-point-settings.test.tsx
@@ -18,7 +18,7 @@ describe("LockedPointSettings", () => {
         );
 
         const titleText = screen.getByText("Point (0, 0)");
-        const colorSwatch = screen.getByLabelText("Color: green, filled");
+        const colorSwatch = screen.getByLabelText("Color: grayH, filled");
 
         // Assert
         expect(titleText).toBeInTheDocument();

--- a/packages/perseus-editor/src/components/__tests__/util.test.ts
+++ b/packages/perseus-editor/src/components/__tests__/util.test.ts
@@ -39,12 +39,12 @@ describe("getValidNumberFromString", () => {
 });
 
 describe("getDefaultFigureForType", () => {
-    test("should return a point with default coordinates", () => {
+    test("should return a point with default values", () => {
         const figure = getDefaultFigureForType("point");
         expect(figure).toEqual({
             type: "point",
             coord: [0, 0],
-            color: "green",
+            color: "grayH",
             filled: true,
         });
     });
@@ -58,17 +58,17 @@ describe("getDefaultFigureForType", () => {
                 {
                     type: "point",
                     coord: [0, 0],
-                    color: "green",
+                    color: "grayH",
                     filled: true,
                 },
                 {
                     type: "point",
                     coord: [2, 2],
-                    color: "green",
+                    color: "grayH",
                     filled: true,
                 },
             ],
-            color: "green",
+            color: "grayH",
             lineStyle: "solid",
             showArrows: false,
             showStartPoint: false,

--- a/packages/perseus-editor/src/components/util.ts
+++ b/packages/perseus-editor/src/components/util.ts
@@ -52,7 +52,7 @@ export function getValidNumberFromString(value: string) {
     return isNaN(parsed) ? 0 : parsed;
 }
 
-const DEFAULT_COLOR = "green";
+const DEFAULT_COLOR = "grayH";
 
 export function getDefaultFigureForType(type: "point"): LockedPointType;
 export function getDefaultFigureForType(type: "line"): LockedLineType;


### PR DESCRIPTION
## Summary:
SarahB suggested that the default color for locked figures
should be gray so that they don't look more interactive than
they need to.

Updating that here.

https://khanacademy.slack.com/archives/C067UM1QAR4/p1714408357638599?thread_ts=1714070893.730669&cid=C067UM1QAR4

Issue: none

## Test plan:
`yarn jest`

Storybook
- http://localhost:6006/?path=/story/perseuseditor-editorpage--mafs-with-locked-figures
- Add a new line and confirm it's gray, and its points are gray
- Add a new point and confirm it's gray


![image](https://github.com/Khan/perseus/assets/13231763/631ce9f9-8518-467a-bbe8-0801f92570ec)
