### PR TITLE
Only show ruler/protractor warning when either is enabled

### DIFF
--- a/.changeset/curvy-falcons-crash.md
+++ b/.changeset/curvy-falcons-crash.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Only show a11y banner for ruler and protractor when either or both is enabled

--- a/packages/perseus-editor/src/components/__tests__/interactive-graph-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/interactive-graph-settings.test.tsx
@@ -61,6 +61,35 @@ describe("InteractiveGraphSettings", () => {
         );
     });
 
+    test("displays a11y warning banner when ruler enabled", () => {
+        // Arrange
+        render(
+            <InteractiveGraphSettings showRuler onChange={() => undefined} />,
+        );
+
+        // Act
+        const banner = screen.getByRole("alert");
+
+        // Assert
+        expect(banner).toHaveTextContent(
+            /The ruler and protractor are not accessible/,
+        );
+    });
+
+    test("hides a11y warning banner when ruler and protractor disabled", () => {
+        // Arrange
+        const {rerender} = render(
+            <InteractiveGraphSettings showRuler onChange={() => undefined} />,
+        );
+
+        // Act
+        rerender(<InteractiveGraphSettings onChange={() => undefined} />);
+
+        // Assert
+        const banner = screen.queryByRole("alert");
+        expect(banner).not.toBeInTheDocument();
+    });
+
     test("calls onChange when ruler label is changed", async () => {
         // Arrange
         const onChange = jest.fn();
@@ -217,6 +246,41 @@ describe("InteractiveGraphSettings", () => {
         expect(onChange).not.toHaveBeenCalled();
     });
 
+    test("displays a11y warning banner when ruler enabled", () => {
+        // Arrange
+        render(
+            <InteractiveGraphSettings
+                showProtractor
+                onChange={() => undefined}
+            />,
+        );
+
+        // Act
+        const banner = screen.getByRole("alert");
+
+        // Assert
+        expect(banner).toHaveTextContent(
+            /The ruler and protractor are not accessible/,
+        );
+    });
+
+    test("hides a11y warning banner when ruler and protractor disabled", () => {
+        // Arrange
+        const {rerender} = render(
+            <InteractiveGraphSettings
+                showProtractor
+                onChange={() => undefined}
+            />,
+        );
+
+        // Act
+        rerender(<InteractiveGraphSettings onChange={() => undefined} />);
+
+        // Assert
+        const banner = screen.queryByRole("alert");
+        expect(banner).not.toBeInTheDocument();
+    });
+
     test("calls onChange when protractor label is changed", async () => {
         // Arrange
         const onChange = jest.fn();
@@ -237,6 +301,25 @@ describe("InteractiveGraphSettings", () => {
         expect(onChange).toHaveBeenCalledWith(
             expect.objectContaining({showProtractor: false}),
             undefined,
+        );
+    });
+
+    test("shows a11y warning banner when both ruler and protractor enabled", () => {
+        // Arrange
+        render(
+            <InteractiveGraphSettings
+                showRuler
+                showProtractor
+                onChange={() => undefined}
+            />,
+        );
+
+        // Act
+        const banner = screen.getByRole("alert");
+
+        // Assert
+        expect(banner).toHaveTextContent(
+            /The ruler and protractor are not accessible/,
         );
     });
 

--- a/packages/perseus-editor/src/components/interactive-graph-settings.tsx
+++ b/packages/perseus-editor/src/components/interactive-graph-settings.tsx
@@ -583,11 +583,13 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
                 </LabeledRow>
 
                 <View style={styles.rulerSection}>
-                    <Banner
-                        layout="floating"
-                        text="The ruler and protractor are not accessible. Please consider an alternate approach."
-                        kind="warning"
-                    />
+                    {(this.props.showRuler || this.props.showProtractor) && (
+                        <Banner
+                            layout="floating"
+                            text="The ruler and protractor are not accessible. Please consider an alternate approach."
+                            kind="warning"
+                        />
+                    )}
                     <View style={styles.checkboxRow}>
                         <PropCheckBox
                             label="Show ruler"

--- a/packages/perseus-editor/src/components/interactive-graph-settings.tsx
+++ b/packages/perseus-editor/src/components/interactive-graph-settings.tsx
@@ -583,13 +583,6 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
                 </LabeledRow>
 
                 <View style={styles.rulerSection}>
-                    {(this.props.showRuler || this.props.showProtractor) && (
-                        <Banner
-                            layout="floating"
-                            text="The ruler and protractor are not accessible. Please consider an alternate approach."
-                            kind="warning"
-                        />
-                    )}
                     <View style={styles.checkboxRow}>
                         <PropCheckBox
                             label="Show ruler"
@@ -604,6 +597,13 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
                             style={styles.resetSpaceTop}
                         />
                     </View>
+                    {(this.props.showRuler || this.props.showProtractor) && (
+                        <Banner
+                            layout="floating"
+                            text="The ruler and protractor are not accessible. Please consider an alternate approach."
+                            kind="warning"
+                        />
+                    )}
                     {this.props.showRuler && (
                         <View style={styles.spaceTop}>
                             <LabeledRow
@@ -689,7 +689,7 @@ const styles = StyleSheet.create({
         flexDirection: "row",
         alignItems: "center",
         justifyContent: "space-between",
-        marginTop: spacing.xSmall_8,
+        marginBottom: spacing.xSmall_8,
     },
     rulerSection: {
         marginTop: spacing.xSmall_8,


### PR DESCRIPTION
## Summary:

This PR updates the banner warning content authors against using the ruler or protractor so that its only shown if one (or both) are enabled. This will cut down on visual clutter when neither are selected (which is most common).

Issue: LEMS-1963

## Test plan:

`yarn start`
Navigate to the EditorPage story
Add an `interactive-graph` widget
Enable the ruler - note that the banner appears
Disable the ruler and enable the protractor - note that the banner appears
Enable both ruler and protractor - note that the banner appears