### PR TITLE
Suppress spurious errors logged by tests

### DIFF
--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/arrowhead.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/arrowhead.test.tsx
@@ -6,7 +6,9 @@ import {Arrowhead} from "./arrowhead";
 describe("Arrowhead", () => {
     it("Uses provided color to fill the arrow", () => {
         const {container} = render(
-            <Arrowhead tip={[0, 0]} angle={0} color="green" />,
+            <svg>
+                <Arrowhead tip={[0, 0]} angle={0} color="green" />
+            </svg>,
         );
         // eslint-disable-next-line testing-library/no-container,testing-library/no-node-access
         const svgArrow = container.querySelector("path");
@@ -14,7 +16,11 @@ describe("Arrowhead", () => {
     });
 
     it("Inherits the color of the parent element when no color is specified", () => {
-        const {container} = render(<Arrowhead tip={[0, 0]} angle={0} />);
+        const {container} = render(
+            <svg>
+                <Arrowhead tip={[0, 0]} angle={0} />
+            </svg>,
+        );
         // eslint-disable-next-line testing-library/no-container,testing-library/no-node-access
         const svgArrow = container.querySelector("path");
         expect(svgArrow?.getAttribute("style")).toContain("stroke: inherit");


### PR DESCRIPTION
## Summary:
Our Jest tests were logging that `<g>` is not a recognized HTML element.
That's because it's not HTML; it's only valid in SVGs.

The noisy errors made it harder to spot actual test failures in the
output. This commit wraps the rendered elements in an `<svg>` tag to
prevent the errors.

Issue: none

Test plan:

`yarn test`