### PR TITLE
Update LockedLineSettings to reflect line kind in the summary

### DIFF
--- a/.changeset/shy-pugs-shave.md
+++ b/.changeset/shy-pugs-shave.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Locked line summary reflects line kind

--- a/packages/perseus-editor/src/components/__tests__/locked-line-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-line-settings.test.tsx
@@ -1,0 +1,53 @@
+import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
+import {render, screen} from "@testing-library/react";
+import * as React from "react";
+
+import LockedLineSettings from "../locked-line-settings";
+import {getDefaultFigureForType} from "../util";
+
+const defaultProps = {
+    ...getDefaultFigureForType("line"),
+    onChangeProps: () => {},
+    onRemove: () => {},
+};
+
+describe("LockedPointSettings", () => {
+    test("renders", () => {
+        // Arrange
+
+        // Act
+        render(<LockedLineSettings {...defaultProps} />, {
+            wrapper: RenderStateRoot,
+        });
+
+        // Assert
+        const titleText = screen.getByText("Line (0, 0), (2, 2)");
+        expect(titleText).toBeInTheDocument();
+    });
+
+    test("summary reflects kind (segment)", () => {
+        // Arrange
+
+        // Act
+        render(<LockedLineSettings {...defaultProps} kind="segment" />, {
+            wrapper: RenderStateRoot,
+        });
+
+        // Assert
+        const titleText = screen.getByText("Segment (0, 0), (2, 2)");
+        expect(titleText).toBeInTheDocument();
+    });
+
+    test("summary reflects kind (ray)", () => {
+        // Arrange
+
+        // Act
+        render(<LockedLineSettings {...defaultProps} kind="ray" />, {
+            wrapper: RenderStateRoot,
+        });
+
+        // Assert
+        const titleText = screen.getByText("Ray (0, 0), (2, 2)");
+        expect(titleText).toBeInTheDocument();
+    });
+});

--- a/packages/perseus-editor/src/components/locked-line-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-line-settings.tsx
@@ -50,8 +50,9 @@ const LockedLineSettings = (props: Props) => {
     const colorSelectId = ids.get("line-color-select");
     const styleSelectId = ids.get("line-style-select");
 
-    const lineLabel = `Line (${startPoint.coord[0]}, ${startPoint.coord[1]}),
-        (${endPoint.coord[0]}, ${endPoint.coord[1]})`;
+    const capitalizeKind = kind.charAt(0).toUpperCase() + kind.slice(1);
+    const lineLabel = `${capitalizeKind} (${startPoint.coord[0]},
+        ${startPoint.coord[1]}), (${endPoint.coord[0]}, ${endPoint.coord[1]})`;
 
     function handleChangePoint(
         newPointProps: Partial<LockedPointType>,


### PR DESCRIPTION
## Summary:
It would be nice if the summary at the top of the locked line settings
accordion also showed what its kind is (line, segment, ray).

Adding that functionality here.

Issue: https://khanacademy.atlassian.net/browse/LEMS-1993

## Test plan:
`yarn jest packages/perseus-editor/src/components/__tests__/locked-line-settings.test.tsx`

Storybook
- http://localhost:6006/?path=/story/perseuseditor-editorpage--mafs-with-locked-figures
- change the kind
- confirm that the summary updates

| Line | Ray | Segment |
| --- | --- | --- |
| <img width="376" alt="Screenshot 2024-05-09 at 11 39 53 AM" src="https://github.com/Khan/perseus/assets/13231763/737f259e-dde6-4180-9085-c8ae14a06aa8"> | <img width="368" alt="Screenshot 2024-05-09 at 11 40 10 AM" src="https://github.com/Khan/perseus/assets/13231763/e0e56f83-958d-4a20-9f50-62b690500717"> | <img width="366" alt="Screenshot 2024-05-09 at 11 40 02 AM" src="https://github.com/Khan/perseus/assets/13231763/dea87959-2dd3-4976-853a-1cbc40d3f13d"> |
