### PR TITLE
Add a "drag handle" to the center of graphed circles

### DIFF
--- a/.changeset/flat-feet-leave.md
+++ b/.changeset/flat-feet-leave.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Update the styling of interactive circle graphs rendered with Mafs

--- a/packages/perseus/src/widgets/__stories__/interactive-graph-regression.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/interactive-graph-regression.stories.tsx
@@ -157,10 +157,16 @@ export const MafsWithMultipleSegments = (
     />
 );
 
-export const MafsCircleGraphWithNonsquareRange = (args: StoryArgs): React.ReactElement => (
+export const MafsCircleGraphWithNonsquareRange = (
+    args: StoryArgs,
+): React.ReactElement => (
     <div className="framework-perseus perseus-mobile">
         <MafsQuestionRenderer
-            question={interactiveGraphQuestionBuilder().withCircle().withYRange(-5, 5).withXRange(-10, 10).build()}
+            question={interactiveGraphQuestionBuilder()
+                .withCircle()
+                .withXRange(-10, 10)
+                .withYRange(-5, 5)
+                .build()}
         />
     </div>
 );

--- a/packages/perseus/src/widgets/__stories__/interactive-graph-regression.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/interactive-graph-regression.stories.tsx
@@ -157,6 +157,14 @@ export const MafsWithMultipleSegments = (
     />
 );
 
+export const MafsCircleGraphWithNonsquareRange = (args: StoryArgs): React.ReactElement => (
+    <div className="framework-perseus perseus-mobile">
+        <MafsQuestionRenderer
+            question={interactiveGraphQuestionBuilder().withCircle().withYRange(-5, 5).withXRange(-10, 10).build()}
+        />
+    </div>
+);
+
 function MafsQuestionRenderer(props: {question: PerseusRenderer}) {
     const {question} = props;
     return (
@@ -169,6 +177,7 @@ function MafsQuestionRenderer(props: {question: PerseusRenderer}) {
                 flags: {
                     mafs: {
                         segment: true,
+                        circle: true,
                     },
                 },
             }}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -11,6 +11,7 @@ import type {CircleGraphState, MafsGraphProps} from "../types";
 import {useRef} from "react";
 import {snap} from "../utils";
 import useGraphConfig from "../reducer/use-graph-config";
+import {useTransformVectorsToPixels} from "./use-transform";
 
 type CircleGraphProps = MafsGraphProps<CircleGraphState>;
 
@@ -56,6 +57,35 @@ function MovableCircle(props: {center: vec.Vector2, radius: number, onMove: (new
                 fillOpacity={0}
                 color={color.blue}
             />
+            <DragHandle center={center}/>
         </g>
     )
+}
+
+const dragHandleDimensions: vec.Vector2 = [24, 14];
+const dragHandlePointPositions = crossProduct([-4.4, 0, 4.4], [-2.1, 2.1])
+function DragHandle(props: { center: [x: number, y: number] }) {
+    const {center} = props;
+    const cornerRadius = Math.min(...dragHandleDimensions) / 2;
+    const [centerPx] = useTransformVectorsToPixels(center);
+    const topLeft = vec.sub(centerPx, vec.scale(dragHandleDimensions, 0.5));
+
+    // FIXME make fill color a WB color
+    return <>
+        <rect x={topLeft[0]} y={topLeft[1]} width={dragHandleDimensions[0]} height={dragHandleDimensions[1]} rx={cornerRadius} ry={cornerRadius} fill="#777" stroke="#fff" strokeWidth={2}/>
+        {dragHandlePointPositions.map((offsetPx) => {
+            const [xPx, yPx] = vec.add(offsetPx, centerPx)
+            return <circle cx={xPx} cy={yPx} r={1.25} fill="#fff" />
+        })}
+    </>;
+}
+
+function crossProduct<A, B>(as: A[], bs: B[]): [A, B][] {
+    const result: [A, B][] = [];
+    for (const a of as) {
+        for (const b of bs) {
+            result.push([a, b]);
+        }
+    }
+    return result;
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -72,9 +72,6 @@ function MovableCircle(props: {
                 cy={centerPx[1]}
                 rx={radiiPx[0] + 3}
                 ry={radiiPx[1] + 3}
-                stroke="var(--mafs-blue)"
-                strokeWidth={2}
-                fill="transparent"
             />
             <Circle
                 center={center}
@@ -95,23 +92,20 @@ function DragHandle(props: {center: [x: number, y: number]}) {
     const [centerPx] = useTransformVectorsToPixels(center);
     const topLeft = vec.sub(centerPx, vec.scale(dragHandleDimensions, 0.5));
 
-    // FIXME make fill color a WB color
     return (
         <>
             <rect
+                className="movable-circle-handle"
                 x={topLeft[0]}
                 y={topLeft[1]}
                 width={dragHandleDimensions[0]}
                 height={dragHandleDimensions[1]}
                 rx={cornerRadius}
                 ry={cornerRadius}
-                fill="#777"
-                stroke="#fff"
-                strokeWidth={2}
             />
             {dragHandlePointPositions.map((offsetPx) => {
                 const [xPx, yPx] = vec.add(offsetPx, centerPx);
-                return <circle cx={xPx} cy={yPx} r={1.25} fill="#fff" />;
+                return <circle className="movable-circle-handle-dot" cx={xPx} cy={yPx} />;
             })}
         </>
     );

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -9,7 +9,10 @@ import useGraphConfig from "../reducer/use-graph-config";
 import {snap} from "../utils";
 
 import {StyledMovablePoint} from "./components/movable-point";
-import {useTransformVectorsToPixels} from "./use-transform";
+import {
+    useTransformDimensionsToPixels,
+    useTransformVectorsToPixels
+} from "./use-transform";
 
 import type {CircleGraphState, MafsGraphProps} from "../types";
 
@@ -53,10 +56,8 @@ function MovableCircle(props: {
         constrain: (p) => snap(snapStep, p),
     });
 
-    const [centerPx, [radiusPx]] = useTransformVectorsToPixels(center, [
-        radius,
-        0,
-    ]);
+    const [centerPx] = useTransformVectorsToPixels(center);
+    const [radiiPx] = useTransformDimensionsToPixels([radius, radius]);
 
     return (
         <g
@@ -69,8 +70,8 @@ function MovableCircle(props: {
                 className="focus-ring"
                 cx={centerPx[0]}
                 cy={centerPx[1]}
-                rx={radiusPx + 3}
-                ry={radiusPx + 3}
+                rx={radiiPx[0] + 3}
+                ry={radiiPx[1] + 3}
                 stroke="var(--mafs-blue)"
                 strokeWidth={2}
                 fill="transparent"

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -1,5 +1,5 @@
 import {color} from "@khanacademy/wonder-blocks-tokens";
-import {Circle} from "mafs";
+import {Circle, vec} from "mafs";
 import * as React from "react";
 
 import {moveCenter, moveRadiusPoint} from "../reducer/interactive-graph-action";
@@ -17,17 +17,10 @@ export function CircleGraph(props: CircleGraphProps) {
 
     return (
         <>
-            <Circle
+            <MovableCircle
                 center={center}
                 radius={getRadius(graphState)}
-                fillOpacity={0}
-                color={color.blue}
-            />
-            <StyledMovablePoint
-                point={center}
-                onMove={(newCenter) => {
-                    dispatch(moveCenter(newCenter));
-                }}
+                onMove={(newCenter) => dispatch(moveCenter(newCenter))}
             />
             <StyledMovablePoint
                 point={radiusPoint}
@@ -37,4 +30,22 @@ export function CircleGraph(props: CircleGraphProps) {
             />
         </>
     );
+}
+
+function MovableCircle(props: {center: vec.Vector2, radius: number, onMove: (newCenter: vec.Vector2) => unknown}) {
+    const {center, radius, onMove} = props;
+    return (
+        <>
+            <Circle
+                center={center}
+                radius={radius}
+                fillOpacity={0}
+                color={color.blue}
+            />
+            <StyledMovablePoint
+                point={center}
+                onMove={onMove}
+            />
+        </>
+    )
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -49,8 +49,12 @@ function MovableCircle(props: {center: vec.Vector2, radius: number, onMove: (new
         constrain: (p) => snap(snapStep, p),
     })
 
+    const [centerPx, [radiusPx]] = useTransformVectorsToPixels(center, [radius, 0]);
+
     return (
-        <g ref={draggableRef} className={`movable-circle ${dragging ? "movable-circle--dragging" : ""}`}>
+        <g ref={draggableRef} tabIndex={0} className={`movable-circle ${dragging ? "movable-circle--dragging" : ""}`}>
+            {/* focus ring */}
+            <ellipse className="focus-ring" cx={centerPx[0]} cy={centerPx[1]} rx={radiusPx + 3} ry={radiusPx + 3} stroke="var(--mafs-blue)" strokeWidth={2} fill="transparent" />
             <Circle
                 center={center}
                 radius={radius}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -11,7 +11,7 @@ import {snap} from "../utils";
 import {StyledMovablePoint} from "./components/movable-point";
 import {
     useTransformDimensionsToPixels,
-    useTransformVectorsToPixels
+    useTransformVectorsToPixels,
 } from "./use-transform";
 
 import type {CircleGraphState, MafsGraphProps} from "../types";
@@ -105,7 +105,13 @@ function DragHandle(props: {center: [x: number, y: number]}) {
             />
             {dragHandlePointPositions.map((offsetPx) => {
                 const [xPx, yPx] = vec.add(offsetPx, centerPx);
-                return <circle className="movable-circle-handle-dot" cx={xPx} cy={yPx} />;
+                return (
+                    <circle
+                        className="movable-circle-handle-dot"
+                        cx={xPx}
+                        cy={yPx}
+                    />
+                );
             })}
         </>
     );

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -65,7 +65,6 @@ function MovableCircle(props: {
             tabIndex={0}
             className={`movable-circle ${dragging ? "movable-circle--dragging" : ""}`}
         >
-            {/* focus ring */}
             <ellipse
                 className="focus-ring"
                 cx={centerPx[0]}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -1,5 +1,5 @@
 import {color} from "@khanacademy/wonder-blocks-tokens";
-import {Circle, vec} from "mafs";
+import {Circle, useMovable, vec} from "mafs";
 import * as React from "react";
 
 import {moveCenter, moveRadiusPoint} from "../reducer/interactive-graph-action";
@@ -8,6 +8,9 @@ import {getRadius} from "../reducer/interactive-graph-state";
 import {StyledMovablePoint} from "./components/movable-point";
 
 import type {CircleGraphState, MafsGraphProps} from "../types";
+import {useRef} from "react";
+import {snap} from "../utils";
+import useGraphConfig from "../reducer/use-graph-config";
 
 type CircleGraphProps = MafsGraphProps<CircleGraphState>;
 
@@ -34,18 +37,25 @@ export function CircleGraph(props: CircleGraphProps) {
 
 function MovableCircle(props: {center: vec.Vector2, radius: number, onMove: (newCenter: vec.Vector2) => unknown}) {
     const {center, radius, onMove} = props;
+    const {snapStep} = useGraphConfig();
+
+    const draggableRef = useRef<SVGGElement>(null);
+
+    const {dragging} = useMovable({
+        gestureTarget: draggableRef,
+        point: center,
+        onMove,
+        constrain: (p) => snap(snapStep, p),
+    })
+
     return (
-        <>
+        <g ref={draggableRef} className={`movable-circle ${dragging ? "movable-circle--dragging" : ""}`}>
             <Circle
                 center={center}
                 radius={radius}
                 fillOpacity={0}
                 color={color.blue}
             />
-            <StyledMovablePoint
-                point={center}
-                onMove={onMove}
-            />
-        </>
+        </g>
     )
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -84,7 +84,7 @@ function MovableCircle(props: {
 }
 
 const dragHandleDimensions: vec.Vector2 = [24, 14];
-const dragHandlePointPositions = crossProduct([-4.4, 0, 4.4], [-2.1, 2.1]);
+const dragHandleDotPositions = crossProduct([-4.4, 0, 4.4], [-2.1, 2.1]);
 function DragHandle(props: {center: [x: number, y: number]}) {
     const {center} = props;
     const cornerRadius = Math.min(...dragHandleDimensions) / 2;
@@ -102,7 +102,7 @@ function DragHandle(props: {center: [x: number, y: number]}) {
                 rx={cornerRadius}
                 ry={cornerRadius}
             />
-            {dragHandlePointPositions.map((offsetPx) => {
+            {dragHandleDotPositions.map((offsetPx) => {
                 const [xPx, yPx] = vec.add(offsetPx, centerPx);
                 return (
                     <circle

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/use-transform.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/use-transform.test.tsx
@@ -1,10 +1,11 @@
 import {
+    dimensionsToPixels,
     type GraphDimensions,
     pointToPixel,
     vectorsToPixels,
 } from "./use-transform";
 
-describe("vectorToPixel", () => {
+describe("vectorsToPixels", () => {
     it("should correctly transform the origin", () => {
         const testContext: GraphDimensions = {
             range: [
@@ -39,6 +40,32 @@ describe("vectorToPixel", () => {
             height: 400,
         };
         expect(vectorsToPixels([[2, -2]], testContext)).toEqual([[40, 40]]);
+    });
+});
+
+describe("dimensionsToPixels", () => {
+    it("transforms (0, 0) to (0, 0)", () => {
+        const testContext: GraphDimensions = {
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            width: 400,
+            height: 400,
+        }
+        expect(dimensionsToPixels([[0, 0]], testContext)).toEqual([[0, 0]])
+    });
+
+    it("scales the x and y dimensions", () => {
+        const testContext: GraphDimensions = {
+            range: [
+                [-5, 5],
+                [-10, 10],
+            ],
+            width: 100, // 10 px per graph unit in the x dimension
+            height: 100, // 5 px per graph unit in the y dimension
+        }
+        expect(dimensionsToPixels([[3, 7]], testContext)).toEqual([[30, 35]])
     });
 });
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/use-transform.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/use-transform.test.tsx
@@ -52,8 +52,8 @@ describe("dimensionsToPixels", () => {
             ],
             width: 400,
             height: 400,
-        }
-        expect(dimensionsToPixels([[0, 0]], testContext)).toEqual([[0, 0]])
+        };
+        expect(dimensionsToPixels([[0, 0]], testContext)).toEqual([[0, 0]]);
     });
 
     it("scales the x and y dimensions", () => {
@@ -64,8 +64,8 @@ describe("dimensionsToPixels", () => {
             ],
             width: 100, // 10 px per graph unit in the x dimension
             height: 100, // 5 px per graph unit in the y dimension
-        }
-        expect(dimensionsToPixels([[3, 7]], testContext)).toEqual([[30, 35]])
+        };
+        expect(dimensionsToPixels([[3, 7]], testContext)).toEqual([[30, 35]]);
     });
 });
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/use-transform.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/use-transform.ts
@@ -54,4 +54,4 @@ export const useTransformVectorsToPixels = (...vectors: vec.Vector2[]) => {
 export const useTransformDimensionsToPixels = (...dimens: vec.Vector2[]) => {
     const graphState = useGraphConfig();
     return dimensionsToPixels(dimens, graphState);
-}
+};

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/use-transform.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/use-transform.ts
@@ -26,6 +26,18 @@ export function vectorsToPixels(
     return vectors.map((p) => vec.transform(p, transformToPx));
 }
 
+export function dimensionsToPixels(
+    dimens: vec.Vector2[],
+    graphState: GraphDimensions,
+): vec.Vector2[] {
+    const {range, width, height} = graphState;
+    const [[xMin, xMax], [yMin, yMax]] = range;
+    const transformToPx = matrixBuilder()
+        .scale(width / (xMax - xMin), height / (yMax - yMin))
+        .get();
+    return dimens.map((d) => vec.transform(d, transformToPx));
+}
+
 // When converting points, we translate so the pixel point ends up in the right location.
 // This is because points are specific locations on graphs, unlike vectors.
 export function pointToPixel(point: vec.Vector2, graphState: GraphDimensions) {
@@ -38,3 +50,8 @@ export const useTransformVectorsToPixels = (...vectors: vec.Vector2[]) => {
     const graphState = useGraphConfig();
     return vectorsToPixels(vectors, graphState);
 };
+
+export const useTransformDimensionsToPixels = (...dimens: vec.Vector2[]) => {
+    const graphState = useGraphConfig();
+    return dimensionsToPixels(dimens, graphState);
+}

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
@@ -92,4 +92,17 @@ describe("InteractiveGraphQuestionBuilder", () => {
             }),
         );
     });
+
+    it("creates a circle graph", () => {
+        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withCircle()
+            .build();
+        const graph = question.widgets["interactive-graph 1"]
+        expect(graph.options).toEqual(
+            expect.objectContaining({
+                graph: {type: "circle"},
+                correct: {type: "circle", radius: 5, center: [0, 0]},
+            })
+        )
+    });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
@@ -97,12 +97,12 @@ describe("InteractiveGraphQuestionBuilder", () => {
         const question: PerseusRenderer = interactiveGraphQuestionBuilder()
             .withCircle()
             .build();
-        const graph = question.widgets["interactive-graph 1"]
+        const graph = question.widgets["interactive-graph 1"];
         expect(graph.options).toEqual(
             expect.objectContaining({
                 graph: {type: "circle"},
                 correct: {type: "circle", radius: 5, center: [0, 0]},
-            })
-        )
+            }),
+        );
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -88,6 +88,11 @@ class InteractiveGraphQuestionBuilder {
         this.interactiveFigureConfig = new SegmentGraphConfig(numSegments);
         return this;
     }
+
+    withCircle(): InteractiveGraphQuestionBuilder {
+        this.interactiveFigureConfig = new CircleGraphConfig();
+        return this;
+    }
 }
 
 interface InteractiveFigureConfig {
@@ -114,6 +119,16 @@ class SegmentGraphConfig implements InteractiveFigureConfig {
 
     graph(): PerseusGraphType {
         return {type: "segment", numSegments: this.numSegments};
+    }
+}
+
+class CircleGraphConfig implements InteractiveFigureConfig {
+    correct(): PerseusGraphType {
+        return {type: "circle", radius: 5, center: [0, 0]};
+    }
+
+    graph(): PerseusGraphType {
+        return {type: "circle"};
     }
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -156,6 +156,18 @@
     cursor: grabbing;
 }
 
+.MafsView .movable-circle .focus-ring {
+    visibility: hidden;
+}
+
+.MafsView .movable-circle:focus-visible {
+    outline: none;
+}
+
+.MafsView .movable-circle:focus-visible .focus-ring {
+    visibility: visible;
+}
+
 @font-face {
     font-family: Mafs-MJXTEX;
     src: url("https://cdn.kastatic.org/fonts/mathjax/MathJax_Main-Regular.woff")

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -148,6 +148,14 @@
     visibility: visible;
 }
 
+.MafsView .movable-circle {
+    cursor: grab;
+}
+
+.MafsView .movable-circle.movable-circle--dragging {
+    cursor: grabbing;
+}
+
 @font-face {
     font-family: Mafs-MJXTEX;
     src: url("https://cdn.kastatic.org/fonts/mathjax/MathJax_Main-Regular.woff")

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -173,7 +173,7 @@
 }
 
 .MafsView .movable-circle .movable-circle-handle {
-    fill: #717378; /* WB fadedOffBlack64 */
+    fill: var(--mafs-blue); /* WB fadedOffBlack64 */
     stroke: #fff;
     stroke-width: 2px;
 }

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -154,18 +154,33 @@
 
 .MafsView .movable-circle.movable-circle--dragging {
     cursor: grabbing;
+    outline: none;
 }
 
 .MafsView .movable-circle .focus-ring {
-    visibility: hidden;
+    visibility: hidden; /* overridden when the circle is focused */
+    stroke: var(--mafs-blue);
+    stroke-width: 2px;
+    fill: transparent;
 }
 
-.MafsView .movable-circle:focus-visible {
+.MafsView .movable-circle:focus {
     outline: none;
 }
 
 .MafsView .movable-circle:focus-visible .focus-ring {
     visibility: visible;
+}
+
+.MafsView .movable-circle .movable-circle-handle {
+    fill: #717378; /* WB fadedOffBlack64 */
+    stroke: #fff;
+    stroke-width: 2px;
+}
+
+.MafsView .movable-circle .movable-circle-handle-dot {
+    fill: #fff;
+    r: 1.25px;
 }
 
 @font-face {


### PR DESCRIPTION
This brings the circle graph more in line with Sarah B's [Figma
designs](https://www.figma.com/file/JroPokeCLBv2VRIw3GPvY5/LC---Interactive-graph-widget?type=design&node-id=1150-51899&mode=design&t=rLzMLVWek25t36gx-0)

Issue: LEMS-1976, LEMS-1977

## Test plan:

Play around with the circle graphs in the `yarn dev` UI.

Video:

https://github.com/Khan/perseus/assets/693920/ebcb0e39-1418-480e-8169-4b0b043d2e42