### PR TITLE
Introduce EditorWithLayout

### DIFF
--- a/packages/perseus-editor/src/__stories__/editor-with-layout.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/editor-with-layout.stories.tsx
@@ -1,5 +1,12 @@
-import EditorWithLayout from "../editor-with-layout";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {HeadingSmall} from "@khanacademy/wonder-blocks-typography";
+import {action} from "@storybook/addon-actions";
+import * as React from "react";
 
+import {EditorWithLayout} from "..";
+
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
 import type {Meta, StoryObj} from "@storybook/react";
 
 type Story = StoryObj<typeof EditorWithLayout>;
@@ -9,8 +16,78 @@ const meta: Meta<typeof EditorWithLayout> = {
     component: EditorWithLayout,
 };
 
+function Section(
+    props: React.PropsWithChildren<{title: string; style?: StyleType}>,
+) {
+    return (
+        <View
+            style={{
+                borderWidth: "1px",
+                borderRadius: spacing.xxxSmall_4,
+                ...props.style,
+            }}
+        >
+            <HeadingSmall
+                style={{
+                    backgroundColor: color.darkBlue,
+                    color: color.offWhite,
+                    padding: spacing.xxSmall_6,
+                    marginBottom: spacing.xxSmall_6,
+                }}
+            >
+                {props.title}
+            </HeadingSmall>
+            <View style={{padding: spacing.xxxSmall_4}}>{props.children}</View>
+        </View>
+    );
+}
+
 export const Default: Story = {
-    args: {},
+    render(props, context) {
+        return (
+            <EditorWithLayout {...props}>
+                {(items) => <View>{items.jsonModeEditor}</View>}
+            </EditorWithLayout>
+        );
+    },
+};
+
+export const Controlled: Story = {
+    args: {
+        onChange: action("onChange"),
+    },
+    render(props, context) {
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        const [state, setState] = React.useState(props);
+
+        return (
+            <EditorWithLayout
+                {...state}
+                onChange={(updatedProps) =>
+                    setState({...state, ...updatedProps})
+                }
+            >
+                {(items) => (
+                    <View style={{gap: spacing.xSmall_8}}>
+                        <Section title="JSON Mode Editor">
+                            {items.jsonModeEditor}
+                        </Section>
+
+                        <Section
+                            title="JSON Editor"
+                            style={{width: 50, height: 300}}
+                        >
+                            <items.JsonEditor style={{height: 100}} />
+                        </Section>
+
+                        <Section title="Heads-up Display (HUD)">
+                            {items.hudElement}
+                        </Section>
+                    </View>
+                )}
+            </EditorWithLayout>
+        );
+    },
 };
 
 export default meta;

--- a/packages/perseus-editor/src/__stories__/editor-with-layout.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/editor-with-layout.stories.tsx
@@ -86,6 +86,10 @@ export const Controlled: Story = {
                             <Section title="JSON Mode Editor">
                                 {items.jsonModeEditor}
                             </Section>
+
+                            <Section title="Question Extras">
+                                {items.questionExtras}
+                            </Section>
                         </View>
 
                         <Section title="Item Editor">
@@ -101,10 +105,6 @@ export const Controlled: Story = {
 
                         <Section title="Hints Editor">
                             {items.hintsEditor}
-                        </Section>
-
-                        <Section title="Question Extras">
-                            {items.questionExtras}
                         </Section>
                     </View>
                 )}

--- a/packages/perseus-editor/src/__stories__/editor-with-layout.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/editor-with-layout.stories.tsx
@@ -102,6 +102,10 @@ export const Controlled: Story = {
                         <Section title="Hints Editor">
                             {items.hintsEditor}
                         </Section>
+
+                        <Section title="Question Extras">
+                            {items.questionExtras}
+                        </Section>
                     </View>
                 )}
             </EditorWithLayout>

--- a/packages/perseus-editor/src/__stories__/editor-with-layout.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/editor-with-layout.stories.tsx
@@ -69,19 +69,38 @@ export const Controlled: Story = {
             >
                 {(items) => (
                     <View style={{gap: spacing.xSmall_8}}>
-                        <Section title="JSON Mode Editor">
-                            {items.jsonModeEditor}
+                        <View
+                            style={{
+                                flexDirection: "row",
+                                gap: spacing.xSmall_8,
+                            }}
+                        >
+                            <Section title="Viewport Resizer">
+                                {items.viewportResizerElement}
+                            </Section>
+
+                            <Section title="Heads-up Display (HUD)">
+                                {items.hudElement}
+                            </Section>
+
+                            <Section title="JSON Mode Editor">
+                                {items.jsonModeEditor}
+                            </Section>
+                        </View>
+
+                        <Section title="Item Editor">
+                            {items.itemEditor}
                         </Section>
 
                         <Section
                             title="JSON Editor"
-                            style={{width: 50, height: 300}}
+                            style={{width: "100%", height: 300}}
                         >
                             <items.JsonEditor style={{height: 100}} />
                         </Section>
 
-                        <Section title="Heads-up Display (HUD)">
-                            {items.hudElement}
+                        <Section title="Hints Editor">
+                            {items.hintsEditor}
                         </Section>
                     </View>
                 )}

--- a/packages/perseus-editor/src/__stories__/editor-with-layout.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/editor-with-layout.stories.tsx
@@ -1,0 +1,16 @@
+import EditorWithLayout from "../editor-with-layout";
+
+import type {Meta, StoryObj} from "@storybook/react";
+
+type Story = StoryObj<typeof EditorWithLayout>;
+
+const meta: Meta<typeof EditorWithLayout> = {
+    title: "PerseusEditor/EditorWithLayout",
+    component: EditorWithLayout,
+};
+
+export const Default: Story = {
+    args: {},
+};
+
+export default meta;

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -7,6 +7,7 @@ import ViewportResizer from "./components/viewport-resizer";
 import CombinedHintsEditor from "./hint-editor";
 import ItemEditor from "./item-editor";
 
+import type {SerializeOptions} from "./types";
 import type {
     APIOptions,
     APIOptionsWithDefaults,
@@ -193,7 +194,7 @@ class EditorPage extends React.Component<Props, State> {
         return issues1.concat(issues2);
     }
 
-    serialize(options?: {keepDeletedWidgets?: boolean}): any | PerseusItem {
+    serialize(options?: SerializeOptions): PerseusItem {
         if (this.props.jsonMode) {
             return this.state.json;
         }

--- a/packages/perseus-editor/src/editor-with-layout.tsx
+++ b/packages/perseus-editor/src/editor-with-layout.tsx
@@ -1,13 +1,353 @@
+import {components, ApiOptions, ClassNames} from "@khanacademy/perseus";
+import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import * as React from "react";
+import _ from "underscore";
 
-import type {APIOptions} from "@khanacademy/perseus";
+import JsonEditor from "./components/json-editor";
+import ViewportResizer from "./components/viewport-resizer";
+
+import type CombinedHintsEditor from "./hint-editor";
+import type ItemEditor from "./item-editor";
+import type {
+    APIOptions,
+    APIOptionsWithDefaults,
+    ChangeHandler,
+    DeviceType,
+    Hint,
+    ImageUploader,
+    Version,
+    PerseusItem,
+} from "@khanacademy/perseus";
+import type {KEScore} from "@khanacademy/perseus-core";
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
+
+const {HUD} = components;
 
 type Props = {
-    apiOptions: APIOptions;
+    apiOptions?: APIOptions;
+    answerArea?: any; // related to the question,
+    // TODO(CP-4838): Should this be a required prop?
+    contentPaths?: ReadonlyArray<string>;
+    // Source HTML for the iframe to render
+    frameSource: string;
+    hints?: ReadonlyArray<Hint>; // related to the question,
+    // A function which takes a file object (guaranteed to be an image) and
+    // a callback, then calls the callback with the url where the image
+    // will be hosted. Image drag and drop is disabled when imageUploader
+    // is null.
+    imageUploader?: ImageUploader;
+    // Part of the question
+    itemDataVersion?: Version;
+    // The content ID of the AssessmentItem being edited.
+    itemId: string;
+    // Whether the question is displaying as JSON or if it is
+    // showing the editor itself with the rendering
+    // Only used in the perseus demos. Consider removing.
+    jsonMode: boolean;
+    // A function which is called with the new JSON blob of content
+    onChange: ChangeHandler;
+    onPreviewDeviceChange: (arg1: DeviceType) => unknown;
+    previewDevice: DeviceType;
+    // Initial value of the question being edited
+    question?: any;
+    // URL of the route to show on initial load of the preview frames.
+    previewURL: string;
+
+    children: (components: {
+        /**
+         * Provides a rendered component that allows users to flip between the
+         * standard content editors or the raw JSON view. This view should be
+         * gated behind a permission check and only "Developer" level folks
+         * should be able to access this mode.
+         */
+        jsonModeEditor: React.ReactNode;
+
+        /**
+         * Provides a React Component that renders the JSON view of the current
+         * item being edited. Note that this is a "Power User" editor and can
+         * easily break an item if not used carefully.
+         */
+        JsonEditor: React.ComponentType<{style: StyleType}>;
+
+        /**
+         * Provides a rendered component that flips the preview component
+         * between different viewport sizes (ie. phone, tablet, desktop).
+         */
+        viewportResizerElement: React.ReactNode;
+
+        /**
+         * Provides a rendered component that provides a button to toggle lint
+         * warnings on and off in the other editors.
+         */
+        hudElement: React.ReactNode;
+    }) => React.ReactNode;
 };
 
-function EditorWithLayout(props: Props) {
-    return <div>A very nice editor, indeed!</div>;
-}
+type State = {
+    json?: PerseusItem;
+    question?: any;
+    answerArea: any;
+    hints: any;
+    itemDataVersion?: Version;
 
+    gradeMessage: string;
+    wasAnswered: boolean;
+    highlightLint: boolean;
+};
+
+class EditorWithLayout extends React.Component<Props, State> {
+    _isMounted: boolean;
+    renderer: any;
+
+    itemEditor = React.createRef<ItemEditor>();
+    hintsEditor = React.createRef<CombinedHintsEditor>();
+
+    static defaultProps: {
+        developerMode: boolean;
+        jsonMode: boolean;
+        onChange: () => void;
+    } = {
+        developerMode: false,
+        jsonMode: false,
+        onChange: () => {},
+    };
+
+    constructor(props: Props) {
+        super(props);
+
+        this.state = {
+            question: this.props.question,
+            answerArea: this.props.answerArea,
+            hints: this.props.hints,
+            itemDataVersion: this.props.itemDataVersion,
+
+            gradeMessage: "",
+            wasAnswered: false,
+            highlightLint: true,
+        };
+
+        this._isMounted = false;
+    }
+
+    componentDidMount() {
+        // TODO(scottgrant): This is a hack to remove the deprecated call to
+        // this.isMounted() but is still considered an anti-pattern.
+        this._isMounted = true;
+
+        this.updateRenderer();
+    }
+
+    componentDidUpdate() {
+        // NOTE: It is required to delay the preview update until after the
+        // current frame, to allow for ItemEditor to render its widgets.
+        // This then enables to serialize the widgets properties correctly,
+        // in order to send data to the preview iframe (IframeContentRenderer).
+        // Otherwise, widgets will render in an "empty" state in the preview.
+        // TODO(jeff, CP-3128): Use Wonder Blocks Timing API
+        // eslint-disable-next-line no-restricted-syntax
+        setTimeout(() => {
+            this.updateRenderer();
+        });
+    }
+
+    componentWillUnmount() {
+        this._isMounted = false;
+    }
+
+    toggleJsonMode: () => void = () => {
+        this.setState(
+            {
+                json: this.serialize({keepDeletedWidgets: true}),
+            },
+            () => {
+                this.props.onChange({
+                    jsonMode: !this.props.jsonMode,
+                });
+            },
+        );
+    };
+
+    updateRenderer() {
+        // Some widgets (namely the image widget) like to call onChange before
+        // anything has actually been mounted, which causes problems here. We
+        // just ensure don't update until we've mounted
+        const hasEditor = !this.props.jsonMode;
+        if (!this._isMounted || !hasEditor) {
+            return;
+        }
+
+        const touch =
+            this.props.previewDevice === "phone" ||
+            this.props.previewDevice === "tablet";
+        const deviceBasedApiOptions: APIOptionsWithDefaults = {
+            ...this.getApiOptions(),
+            customKeypad: touch,
+            isMobile: touch,
+        };
+
+        this.itemEditor.current?.triggerPreviewUpdate({
+            type: "question",
+            data: _({
+                item: this.serialize(),
+                apiOptions: deviceBasedApiOptions,
+                initialHintsVisible: 0,
+                device: this.props.previewDevice,
+                linterContext: {
+                    contentType: "exercise",
+                    highlightLint: this.state.highlightLint,
+                    // TODO(CP-4838): is it okay to use [] as a default?
+                    paths: this.props.contentPaths || [],
+                },
+                reviewMode: true,
+                legacyPerseusLint: this.itemEditor.current?.getSaveWarnings(),
+            }).extend(
+                _(this.props).pick(
+                    "workAreaSelector",
+                    "solutionAreaSelector",
+                    "hintsAreaSelector",
+                    "problemNum",
+                ),
+            ),
+        });
+    }
+
+    getApiOptions(): APIOptionsWithDefaults {
+        return {
+            ...ApiOptions.defaults,
+            ...this.props.apiOptions,
+        };
+    }
+
+    getSaveWarnings(): any {
+        const issues1 = this.itemEditor.current?.getSaveWarnings();
+        const issues2 = this.hintsEditor.current?.getSaveWarnings();
+        return issues1.concat(issues2);
+    }
+
+    serialize(options?: {
+        keepDeletedWidgets?: boolean;
+    }): PerseusItem | undefined {
+        if (this.props.jsonMode) {
+            return this.state.json;
+        }
+        return _.extend(this.itemEditor.current?.serialize(options), {
+            hints: this.hintsEditor.current?.serialize(options),
+        });
+    }
+
+    handleChange: ChangeHandler = (toChange, cb, silent) => {
+        const newProps = _(this.props).pick("question", "hints", "answerArea");
+        _(newProps).extend(toChange);
+        this.props.onChange(newProps, cb, silent);
+    };
+
+    changeJSON: (newJson: PerseusItem) => void = (newJson: PerseusItem) => {
+        this.setState({
+            json: newJson,
+        });
+        this.props.onChange(newJson);
+    };
+
+    scorePreview(): KEScore | null | undefined {
+        // Do we actually ever set this.renderer anywhere in the codebase?
+        if (this.renderer) {
+            return this.renderer.scoreInput();
+        }
+        return null;
+    }
+
+    render(): React.ReactNode {
+        let className = "framework-perseus";
+
+        const touch =
+            this.props.previewDevice === "phone" ||
+            this.props.previewDevice === "tablet";
+        const deviceBasedApiOptions: APIOptionsWithDefaults = {
+            ...this.getApiOptions(),
+            customKeypad: touch,
+            isMobile: touch,
+        };
+
+        if (deviceBasedApiOptions.isMobile) {
+            className += " " + ClassNames.MOBILE;
+        }
+
+        const jsonModeEditor = (
+            <Checkbox
+                label="Developer JSON Mode"
+                checked={this.props.jsonMode}
+                onChange={this.toggleJsonMode}
+            />
+        );
+
+        return (
+            <div id="perseus" className={className}>
+                {this.props.children({
+                    jsonModeEditor: jsonModeEditor,
+                    JsonEditor: ({style}: {style: StyleType}) => (
+                        // I suspect this will need some way to pass styles in
+                        // so the host can define its size.
+                        <JsonEditor
+                            value={this.state.json}
+                            onChange={this.changeJSON}
+                            style={style}
+                        />
+                    ),
+                    viewportResizerElement: (
+                        <ViewportResizer
+                            deviceType={this.props.previewDevice}
+                            onViewportSizeChanged={
+                                this.props.onPreviewDeviceChange
+                            }
+                        />
+                    ),
+                    hudElement: (
+                        <HUD
+                            message="Style warnings"
+                            enabled={this.state.highlightLint}
+                            fixedPosition={false}
+                            onClick={() => {
+                                this.setState({
+                                    highlightLint: !this.state.highlightLint,
+                                });
+                            }}
+                        />
+                    ),
+                })}
+            </div>
+        );
+    }
+}
+/*
+
+{(!this.props.developerMode || !this.props.jsonMode) && (
+<ItemEditor
+    ref={this.itemEditor}
+    itemId={this.props.itemId}
+    question={this.props.question}
+    answerArea={this.props.answerArea}
+    imageUploader={this.props.imageUploader}
+    onChange={this.handleChange}
+    wasAnswered={this.state.wasAnswered}
+    gradeMessage={this.state.gradeMessage}
+    deviceType={this.props.previewDevice}
+    apiOptions={deviceBasedApiOptions}
+    previewURL={this.props.previewURL}
+/>
+)}
+
+{(!this.props.developerMode || !this.props.jsonMode) && (
+<CombinedHintsEditor
+    ref={this.hintsEditor}
+    itemId={this.props.itemId}
+    hints={this.props.hints}
+    imageUploader={this.props.imageUploader}
+    onChange={this.handleChange}
+    deviceType={this.props.previewDevice}
+    apiOptions={deviceBasedApiOptions}
+    previewURL={this.props.previewURL}
+    highlightLint={this.state.highlightLint}
+/>
+)}
+*/
 export default EditorWithLayout;

--- a/packages/perseus-editor/src/editor-with-layout.tsx
+++ b/packages/perseus-editor/src/editor-with-layout.tsx
@@ -5,9 +5,9 @@ import _ from "underscore";
 
 import JsonEditor from "./components/json-editor";
 import ViewportResizer from "./components/viewport-resizer";
+import CombinedHintsEditor from "./hint-editor";
+import ItemEditor from "./item-editor";
 
-import type CombinedHintsEditor from "./hint-editor";
-import type ItemEditor from "./item-editor";
 import type {
     APIOptions,
     APIOptionsWithDefaults,
@@ -55,7 +55,7 @@ type Props = {
 
     children: (components: {
         /**
-         * Provides a rendered component that allows users to flip between the
+         * A rendered component that allows users to flip between the
          * standard content editors or the raw JSON view. This view should be
          * gated behind a permission check and only "Developer" level folks
          * should be able to access this mode.
@@ -63,23 +63,37 @@ type Props = {
         jsonModeEditor: React.ReactNode;
 
         /**
-         * Provides a React Component that renders the JSON view of the current
+         * A React Component that renders the JSON view of the current
          * item being edited. Note that this is a "Power User" editor and can
          * easily break an item if not used carefully.
          */
         JsonEditor: React.ComponentType<{style: StyleType}>;
 
         /**
-         * Provides a rendered component that flips the preview component
+         * A rendered component that flips the preview component
          * between different viewport sizes (ie. phone, tablet, desktop).
          */
         viewportResizerElement: React.ReactNode;
 
         /**
-         * Provides a rendered component that provides a button to toggle lint
+         * A rendered component of a button to toggle lint
          * warnings on and off in the other editors.
          */
         hudElement: React.ReactNode;
+
+        /**
+         * A rendered component that provides the item editing experience.
+         * TODO: Inline this component into EditorWithLayout for more layout
+         * control.
+         */
+        itemEditor: React.ReactNode;
+
+        /**
+         * A rendered component that provides the hints editing experience.
+         * TODO: Inline this component into EditorWithLayout for more layout
+         * control.
+         */
+        hintsEditor: React.ReactNode;
     }) => React.ReactNode;
 };
 
@@ -285,8 +299,6 @@ class EditorWithLayout extends React.Component<Props, State> {
                 {this.props.children({
                     jsonModeEditor: jsonModeEditor,
                     JsonEditor: ({style}: {style: StyleType}) => (
-                        // I suspect this will need some way to pass styles in
-                        // so the host can define its size.
                         <JsonEditor
                             value={this.state.json}
                             onChange={this.changeJSON}
@@ -313,41 +325,38 @@ class EditorWithLayout extends React.Component<Props, State> {
                             }}
                         />
                     ),
+                    itemEditor: !this.props.jsonMode && (
+                        <ItemEditor
+                            ref={this.itemEditor}
+                            itemId={this.props.itemId}
+                            question={this.props.question}
+                            answerArea={this.props.answerArea}
+                            imageUploader={this.props.imageUploader}
+                            onChange={this.handleChange}
+                            wasAnswered={this.state.wasAnswered}
+                            gradeMessage={this.state.gradeMessage}
+                            deviceType={this.props.previewDevice}
+                            apiOptions={deviceBasedApiOptions}
+                            previewURL={this.props.previewURL}
+                        />
+                    ),
+                    hintsEditor: !this.props.jsonMode && (
+                        <CombinedHintsEditor
+                            ref={this.hintsEditor}
+                            itemId={this.props.itemId}
+                            hints={this.props.hints}
+                            imageUploader={this.props.imageUploader}
+                            onChange={this.handleChange}
+                            deviceType={this.props.previewDevice}
+                            apiOptions={deviceBasedApiOptions}
+                            previewURL={this.props.previewURL}
+                            highlightLint={this.state.highlightLint}
+                        />
+                    ),
                 })}
             </div>
         );
     }
 }
-/*
 
-{(!this.props.developerMode || !this.props.jsonMode) && (
-<ItemEditor
-    ref={this.itemEditor}
-    itemId={this.props.itemId}
-    question={this.props.question}
-    answerArea={this.props.answerArea}
-    imageUploader={this.props.imageUploader}
-    onChange={this.handleChange}
-    wasAnswered={this.state.wasAnswered}
-    gradeMessage={this.state.gradeMessage}
-    deviceType={this.props.previewDevice}
-    apiOptions={deviceBasedApiOptions}
-    previewURL={this.props.previewURL}
-/>
-)}
-
-{(!this.props.developerMode || !this.props.jsonMode) && (
-<CombinedHintsEditor
-    ref={this.hintsEditor}
-    itemId={this.props.itemId}
-    hints={this.props.hints}
-    imageUploader={this.props.imageUploader}
-    onChange={this.handleChange}
-    deviceType={this.props.previewDevice}
-    apiOptions={deviceBasedApiOptions}
-    previewURL={this.props.previewURL}
-    highlightLint={this.state.highlightLint}
-/>
-)}
-*/
 export default EditorWithLayout;

--- a/packages/perseus-editor/src/editor-with-layout.tsx
+++ b/packages/perseus-editor/src/editor-with-layout.tsx
@@ -1,0 +1,13 @@
+import * as React from "react";
+
+import type {APIOptions} from "@khanacademy/perseus";
+
+type Props = {
+    apiOptions: APIOptions;
+};
+
+function EditorWithLayout(props: Props) {
+    return <div>A very nice editor, indeed!</div>;
+}
+
+export default EditorWithLayout;

--- a/packages/perseus-editor/src/editor-with-layout.tsx
+++ b/packages/perseus-editor/src/editor-with-layout.tsx
@@ -6,7 +6,6 @@ import _ from "underscore";
 import DeviceFramer from "./components/device-framer";
 import JsonEditor from "./components/json-editor";
 import ViewportResizer from "./components/viewport-resizer";
-import ContentPreview from "./content-preview";
 import CombinedHintsEditor from "./hint-editor";
 import IframeContentRenderer from "./iframe-content-renderer";
 import ItemEditor from "./item-editor";
@@ -393,7 +392,6 @@ class EditorWithLayout extends React.Component<Props, State> {
                             ref={this.itemExtrasEditor}
                             onChange={(answerArea) =>
                                 this.handleChange({
-                                    // @ts-expect-error - TS2322 - Types of property 'calculator' are incompatible.
                                     answerArea: {
                                         ...this.props.answerArea,
                                         ...answerArea,

--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -25,6 +25,7 @@ import WidgetEditor from "./components/widget-editor";
 import WidgetSelect from "./components/widget-select";
 import TexErrorView from "./tex-error-view";
 
+import type {SerializeOptions} from "./types";
 import type {ChangeHandler, PerseusWidget} from "@khanacademy/perseus";
 
 // like [[snowman input-number 1]]
@@ -830,12 +831,12 @@ class Editor extends React.Component<Props, State> {
         }
     };
 
-    serialize: (options?: any) => {
+    serialize: (options?: SerializeOptions) => {
         content: string;
         images: any;
         replace: any | undefined;
         widgets: Record<any, any>;
-    } = (options: any) => {
+    } = (options) => {
         // need to serialize the widgets since the state might not be
         // completely represented in props. ahem //transformer// (and
         // interactive-graph and plotter).

--- a/packages/perseus-editor/src/hint-editor.tsx
+++ b/packages/perseus-editor/src/hint-editor.tsx
@@ -12,6 +12,7 @@ import DeviceFramer from "./components/device-framer";
 import Editor from "./editor";
 import IframeContentRenderer from "./iframe-content-renderer";
 
+import type {SerializeOptions} from "./types";
 import type {
     APIOptions,
     WidgetDict,
@@ -90,7 +91,7 @@ export class HintEditor extends React.Component<HintEditorProps> {
         return this.editor.current?.getSaveWarnings();
     };
 
-    serialize: (options?: any) => any = (options: any) => {
+    serialize: (options?: SerializeOptions) => any = (options) => {
         return this.editor.current?.serialize(options);
     };
 
@@ -222,7 +223,7 @@ class CombinedHintEditor extends React.Component<CombinedHintEditorProps> {
         return this.editor.current?.getSaveWarnings();
     };
 
-    serialize = (options: any) => {
+    serialize = (options: SerializeOptions) => {
         return this.editor.current?.serialize(options);
     };
 
@@ -390,7 +391,9 @@ class CombinedHintsEditor extends React.Component<CombinedHintsEditorProps> {
             .value();
     };
 
-    serialize: (options?: any) => ReadonlyArray<string> = (options: any) => {
+    serialize: (options?: SerializeOptions) => ReadonlyArray<string> = (
+        options,
+    ) => {
         return this.props.hints.map((hint, i) => {
             return this.serializeHint(i, options);
         });

--- a/packages/perseus-editor/src/hint-editor.tsx
+++ b/packages/perseus-editor/src/hint-editor.tsx
@@ -414,9 +414,9 @@ class CombinedHintsEditor extends React.Component<CombinedHintsEditorProps> {
             return (
                 <CombinedHintEditor
                     ref={"hintEditor" + i}
-                        key={"hintEditor" + i}
-                        isFirst={i === 0}
-                        isLast={i + 1 === hints.length}
+                    key={"hintEditor" + i}
+                    isFirst={i === 0}
+                    isLast={i + 1 === hints.length}
                     itemId={itemId}
                     hint={hint}
                     pos={i}
@@ -430,6 +430,7 @@ class CombinedHintsEditor extends React.Component<CombinedHintsEditorProps> {
                     deviceType={this.props.deviceType}
                     apiOptions={this.props.apiOptions}
                     highlightLint={this.props.highlightLint}
+                    previewURL={this.props.previewURL}
                     // TODO(CP-4838): what should be passed here?
                     contentPaths={[]}
                 />

--- a/packages/perseus-editor/src/hint-editor.tsx
+++ b/packages/perseus-editor/src/hint-editor.tsx
@@ -410,44 +410,31 @@ class CombinedHintsEditor extends React.Component<CombinedHintsEditorProps> {
 
     render(): React.ReactNode {
         const {itemId, hints} = this.props;
-        const hintElems = _.map(
-            hints,
-            function (hint, i) {
-                return (
-                    <CombinedHintEditor
-                        ref={"hintEditor" + i}
+        const hintElems = hints.map((hint, i) => {
+            return (
+                <CombinedHintEditor
+                    ref={"hintEditor" + i}
                         key={"hintEditor" + i}
                         isFirst={i === 0}
                         isLast={i + 1 === hints.length}
-                        itemId={itemId}
-                        hint={hint}
-                        pos={i}
-                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                        imageUploader={this.props.imageUploader}
-                        // eslint-disable-next-line react/jsx-no-bind
-                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                        onChange={this.handleHintChange.bind(this, i)}
-                        // eslint-disable-next-line react/jsx-no-bind
-                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                        onRemove={this.handleHintRemove.bind(this, i)}
-                        // eslint-disable-next-line react/jsx-no-bind
-                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                        onMove={this.handleHintMove.bind(this, i)}
-                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                        deviceType={this.props.deviceType}
-                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                        apiOptions={this.props.apiOptions}
-                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                        highlightLint={this.props.highlightLint}
-                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                        previewURL={this.props.previewURL}
-                        // TODO(CP-4838): what should be passed here?
-                        contentPaths={[]}
-                    />
-                );
-            },
-            this,
-        );
+                    itemId={itemId}
+                    hint={hint}
+                    pos={i}
+                    imageUploader={this.props.imageUploader}
+                    // eslint-disable-next-line react/jsx-no-bind
+                    onChange={this.handleHintChange.bind(this, i)}
+                    // eslint-disable-next-line react/jsx-no-bind
+                    onRemove={this.handleHintRemove.bind(this, i)}
+                    // eslint-disable-next-line react/jsx-no-bind
+                    onMove={this.handleHintMove.bind(this, i)}
+                    deviceType={this.props.deviceType}
+                    apiOptions={this.props.apiOptions}
+                    highlightLint={this.props.highlightLint}
+                    // TODO(CP-4838): what should be passed here?
+                    contentPaths={[]}
+                />
+            );
+        });
 
         return (
             <div className="perseus-hints-editor perseus-editor-table">

--- a/packages/perseus-editor/src/index.ts
+++ b/packages/perseus-editor/src/index.ts
@@ -8,6 +8,7 @@ export {default as ItemDiff} from "./diffs/item-diff";
 export {default as StructuredItemDiff} from "./diffs/structured-item-diff";
 export {default as EditorPage} from "./editor-page";
 export {default as Editor} from "./editor";
+export {default as EditorWithLayout} from "./editor-with-layout";
 export {default as i18n} from "./i18n";
 export {default as IframeContentRenderer} from "./iframe-content-renderer";
 export {default as MultiRendererEditor} from "./multirenderer-editor";

--- a/packages/perseus-editor/src/item-editor.tsx
+++ b/packages/perseus-editor/src/item-editor.tsx
@@ -7,6 +7,7 @@ import Editor from "./editor";
 import IframeContentRenderer from "./iframe-content-renderer";
 import ItemExtrasEditor from "./item-extras-editor";
 
+import type {SerializeOptions} from "./types";
 import type {
     APIOptions,
     ImageUploader,
@@ -72,7 +73,7 @@ class ItemEditor extends React.Component<Props> {
         return this.questionEditor.current?.getSaveWarnings();
     };
 
-    serialize: (options?: any) => {
+    serialize: (options?: SerializeOptions) => {
         answerArea: any;
         itemDataVersion: {
             major: number;

--- a/packages/perseus-editor/src/types.ts
+++ b/packages/perseus-editor/src/types.ts
@@ -1,0 +1,1 @@
+export type SerializeOptions = {keepDeletedWidgets?: boolean};

--- a/packages/perseus/src/components/hud.tsx
+++ b/packages/perseus/src/components/hud.tsx
@@ -1,81 +1,10 @@
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
+import eyeIcon from "@phosphor-icons/core/bold/eye-bold.svg";
+import eyeSlashIcon from "@phosphor-icons/core/bold/eye-slash-bold.svg";
 import {StyleSheet, css} from "aphrodite";
 import * as React from "react";
 
 import * as constants from "../styles/constants";
-
-// Displays a stylized open eye: lint warnings are visible
-const VisibleIcon = () => (
-    <svg
-        width="24"
-        height="24"
-        viewBox="0 0 24 24"
-        className={css(styles.icon)}
-    >
-        <defs>
-            <path
-                id="a"
-                d={
-                    "M7.401 10.035c-1.424.748-2.599 1.905-3.544 " +
-                    "3.48a1 1 0 0 1-1.714-1.03C4.325 8.849 7.652 7 " +
-                    "12 7c4.348 0 7.675 1.848 9.857 5.486a1 1 0 0 " +
-                    "1-1.714 1.028c-.945-1.574-2.12-2.73-3.544-" +
-                    "3.48a5 5 0 1 1-9.198 0zM12 15a3 3 0 1 0 0-6 3 3 " +
-                    "0 0 0 0 6z"
-                }
-            />
-        </defs>
-        <g fill="none" fillRule="evenodd">
-            <path fill="none" d="M0 0h24v24H0z" />
-            <mask id="b" fill="#fff">
-                <use href="#a" />
-            </mask>
-            <use fill="#fff" fillRule="nonzero" href="#a" />
-            <g fill="#fff" mask="url(#b)">
-                <path d="M0 0h24v24H0z" />
-            </g>
-        </g>
-    </svg>
-);
-
-// Displays a stylized eye with a line through it: I don't want to see lint
-const HiddenIcon = () => (
-    <svg
-        width="24"
-        height="24"
-        viewBox="0 0 24 24"
-        className={css(styles.icon)}
-    >
-        <defs>
-            <path
-                id="a"
-                d={
-                    "M8.794 7.38C9.791 7.127 10.86 7 12 7c4.348 0 " +
-                    "7.675 1.848 9.857 5.486a1 1 0 0 1-1.714 " +
-                    "1.028c-.945-1.574-2.12-2.73-3.544-3.48.258." +
-                    "604.401 1.268.401 1.966 0 1.02-.305 " +
-                    "1.967-.828 2.757l2.535 2.536a1 1 0 0 " +
-                    "1-1.414 1.414l-12-12a1 1 0 0 1 " +
-                    "1.414-1.414L8.794 7.38zm5.914 5.913a3 3 0 0 " +
-                    "0-4.001-4.001l4 4.001zM6.072 8.486l2.976 " +
-                    "2.976a3 3 0 0 0 3.49 3.49l1.579 1.58A5 5 0 " +
-                    "0 1 7.4 10.035c-1.424.747-2.599 1.904-3.544 " +
-                    "3.478a1 1 0 0 1-1.714-1.028c1.049-1.75 " +
-                    "2.363-3.085 3.929-4z"
-                }
-            />
-        </defs>
-        <g fill="none" fillRule="evenodd">
-            <path fill="none" d="M0 0h24v24H0z" />
-            <mask id="b" fill="#fff">
-                <use href="#a" />
-            </mask>
-            <use fill="#fff" fillRule="nonzero" href="#a" />
-            <g fill="#fff" mask="url(#b)">
-                <path d="M0 0h24v24H0z" />
-            </g>
-        </g>
-    </svg>
-);
 
 type Props = {
     message: string;
@@ -85,15 +14,9 @@ type Props = {
 };
 
 const HUD = ({message, enabled, onClick, fixedPosition = true}: Props) => {
-    let state;
-    let icon;
-    if (enabled) {
-        state = styles.enabled;
-        icon = <VisibleIcon />;
-    } else {
-        state = styles.disabled;
-        icon = <HiddenIcon />;
-    }
+    const [state, icon] = enabled
+        ? [styles.enabled, eyeIcon]
+        : [styles.disabled, eyeSlashIcon];
 
     return (
         <button
@@ -106,7 +29,7 @@ const HUD = ({message, enabled, onClick, fixedPosition = true}: Props) => {
                 onClick();
             }}
         >
-            {icon}
+            <PhosphorIcon icon={icon} style={styles.icon} />
             {message}
         </button>
     );


### PR DESCRIPTION
## Summary:

This PR introduces a new Perseus Editor component that allows the host to control layout of individual editor pieces. It does this by using a callback function for the `children` prop. This is a similar approach to how the `MultiRenderer` works today. 

The associated Story for the `EditrorWithLayout` component provides an example of placing each piece of the editor wherever is needed. 

## What's next?

This PR can be thought of as a proof-of-concept for how this could be built. There are components that are nested inside other, high-level components (such as inside the `Editor`) that would need to be raised up to the `EditorWithLayout` so that they can be exposed individually.

The preview component `IframeContentRenderer` is also likely to be problematic as it uses an iframe that is typically pointed at production webapp. The LEMS team has ticket https://khanacademy.atlassian.net/browse/LEMS-1809 to fix this, but it is not on our near-term roadmap. We could adjust that if necessary. 

Issue: LEMS-1972

## Test plan:

`yarn`
`yarn start`
Navigate to http://localhost:6006/?path=/story/perseuseditor-editorwithlayout--controlled and test things out. 

Open `packages/perseus-editor/src/__stories__/editor-with-layout.stories.tsx` and move things around and note that the layout can be adjusted without making any changes to the `EditorWithLayout` component.