### PR TITLE
Remove unused wonder-blocks-i18n

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@khanacademy/eslint-plugin": "^3.0.0",
     "@khanacademy/mathjax-renderer": "^2.0.0",
     "@khanacademy/wonder-blocks-button": "6.3.0",
-    "@khanacademy/wonder-blocks-i18n": "^2.0.2",
     "@khanacademy/wonder-blocks-layout": "^2.0.31",
     "@khanacademy/wonder-blocks-spacing": "^4.0.1",
     "@popperjs/core": "^2.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2602,13 +2602,6 @@
     "@khanacademy/wonder-blocks-tokens" "^1.2.0"
     "@khanacademy/wonder-blocks-typography" "^2.1.11"
 
-"@khanacademy/wonder-blocks-i18n@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-i18n/-/wonder-blocks-i18n-2.0.2.tgz#c44cf2d1cd6bc35ffab74448f5a515d169fd8735"
-  integrity sha512-0eqlleTbNDWGZiJuisVxI9UbIk5mcXxAA8mT9Sus6VE/3gkBbNtUaAfA5muuF2Hlu5K2Jzsz8/TEOXmGQ+HR1Q==
-  dependencies:
-    "@babel/runtime" "^7.18.6"
-
 "@khanacademy/wonder-blocks-icon-button@^5.2.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-icon-button/-/wonder-blocks-icon-button-5.2.0.tgz#44942a79a44bc0f36bf220d64ca33bb253a189d8"


### PR DESCRIPTION
## Summary:

John migrated Perseus to use the new Khan Academy localization system where translated strings are passed in. This removed the need/use for wonder-blocks-i18n.  This PR removes a dangling dependency that we no longer need. 

Issue: "none"

## Test plan:

`yarn`
`yarn test`
`yarn tsc`