### PR TITLE
Update locked points onChange instead of onBlur

### DIFF
--- a/.changeset/new-rings-boil.md
+++ b/.changeset/new-rings-boil.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Locked line coordinates update on input change instead of on input blur

--- a/packages/perseus-editor/src/components/__tests__/locked-point-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-point-settings.test.tsx
@@ -226,6 +226,8 @@ describe("LockedPointSettings", () => {
         ${"x"}     | ${".2"}    | ${0.2}
         ${"x"}     | ${"0.2"}   | ${0.2}
         ${"x"}     | ${"-1"}    | ${-1}
+        ${"x"}     | ${"-1.2"}  | ${-1.2}
+        ${"x"}     | ${"-.2"}   | ${-0.2}
         ${"y"}     | ${"-"}     | ${null}
         ${"y"}     | ${"."}     | ${null}
         ${"y"}     | ${"0"}     | ${0}
@@ -234,6 +236,8 @@ describe("LockedPointSettings", () => {
         ${"y"}     | ${".2"}    | ${0.2}
         ${"y"}     | ${"0.2"}   | ${0.2}
         ${"y"}     | ${"-1"}    | ${-1}
+        ${"y"}     | ${"-1.2"}  | ${-1.2}
+        ${"y"}     | ${"-.2"}   | ${-0.2}
     `(
         "Typing in the $Coordinate coordinate field should update the field ($inputValue)",
         async ({Coordinate, inputValue, expectedValue}) => {

--- a/packages/perseus-editor/src/components/__tests__/locked-point-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-point-settings.test.tsx
@@ -182,13 +182,12 @@ describe("LockedPointSettings", () => {
 
     test("Clear the x coordinate field should update the field", async () => {
         // Arrange
-
-        // Act
         render(
             <LockedPointSettings {...defaultProps} onChangeProps={() => {}} />,
             {wrapper: RenderStateRoot},
         );
 
+        // Act
         const xCoordField = screen.getByLabelText("x coord");
         await userEvent.clear(xCoordField);
 
@@ -198,13 +197,12 @@ describe("LockedPointSettings", () => {
 
     test("Clear the y coordinate field should update the field", async () => {
         // Arrange
-
-        // Act
         render(
             <LockedPointSettings {...defaultProps} onChangeProps={() => {}} />,
             {wrapper: RenderStateRoot},
         );
 
+        // Act
         const yCoordField = screen.getByLabelText("y coord");
         await userEvent.clear(yCoordField);
 
@@ -216,49 +214,44 @@ describe("LockedPointSettings", () => {
     // (and it does, visually), the actual value on the HTML element is null
     // unless the input is a valid number. This is because the input has
     // type="number".
-    test.each`
-        Coordinate | inputValue | expectedValue
-        ${"x"}     | ${"-"}     | ${null}
-        ${"x"}     | ${"."}     | ${null}
-        ${"x"}     | ${"0"}     | ${0}
-        ${"x"}     | ${"1"}     | ${1}
-        ${"x"}     | ${"1.2"}   | ${1.2}
-        ${"x"}     | ${".2"}    | ${0.2}
-        ${"x"}     | ${"0.2"}   | ${0.2}
-        ${"x"}     | ${"-1"}    | ${-1}
-        ${"x"}     | ${"-1.2"}  | ${-1.2}
-        ${"x"}     | ${"-.2"}   | ${-0.2}
-        ${"y"}     | ${"-"}     | ${null}
-        ${"y"}     | ${"."}     | ${null}
-        ${"y"}     | ${"0"}     | ${0}
-        ${"y"}     | ${"1"}     | ${1}
-        ${"y"}     | ${"1.2"}   | ${1.2}
-        ${"y"}     | ${".2"}    | ${0.2}
-        ${"y"}     | ${"0.2"}   | ${0.2}
-        ${"y"}     | ${"-1"}    | ${-1}
-        ${"y"}     | ${"-1.2"}  | ${-1.2}
-        ${"y"}     | ${"-.2"}   | ${-0.2}
-    `(
-        "Typing in the $Coordinate coordinate field should update the field ($inputValue)",
-        async ({Coordinate, inputValue, expectedValue}) => {
-            // Arrange
+    describe.each`
+        Coordinate
+        ${"x"}
+        ${"y"}
+    `("Coordinate $Coordinate", ({Coordinate}) => {
+        test.each`
+            inputValue | expectedValue
+            ${"-"}     | ${null}
+            ${"."}     | ${null}
+            ${"0"}     | ${0}
+            ${"1"}     | ${1}
+            ${"1.2"}   | ${1.2}
+            ${".2"}    | ${0.2}
+            ${"0.2"}   | ${0.2}
+            ${"-1"}    | ${-1}
+            ${"-1.2"}  | ${-1.2}
+            ${"-.2"}   | ${-0.2}
+        `(
+            "Typing in the coord field should update the numeric field value ($inputValue)",
+            async ({inputValue, expectedValue}) => {
+                // Arrange
+                render(
+                    <LockedPointSettings
+                        {...defaultProps}
+                        onChangeProps={() => {}}
+                    />,
+                    {wrapper: RenderStateRoot},
+                );
 
-            // Act
-            render(
-                <LockedPointSettings
-                    {...defaultProps}
-                    onChangeProps={() => {}}
-                />,
-                {wrapper: RenderStateRoot},
-            );
+                // Act
+                const coordField = screen.getByLabelText(`${Coordinate} coord`);
+                await userEvent.clear(coordField);
+                await userEvent.type(coordField, inputValue);
+                await userEvent.tab();
 
-            const coordField = screen.getByLabelText(`${Coordinate} coord`);
-            await userEvent.clear(coordField);
-            await userEvent.type(coordField, inputValue);
-            await userEvent.tab();
-
-            // Assert
-            expect(coordField).toHaveValue(expectedValue);
-        },
-    );
+                // Assert
+                expect(coordField).toHaveValue(expectedValue);
+            },
+        );
+    });
 });

--- a/packages/perseus-editor/src/components/__tests__/util.test.ts
+++ b/packages/perseus-editor/src/components/__tests__/util.test.ts
@@ -1,42 +1,4 @@
-import {getValidNumberFromString, getDefaultFigureForType} from "../util";
-
-describe("getValidNumberFromString", () => {
-    test("should return a number from a string", () => {
-        expect(getValidNumberFromString("123")).toBe(123);
-    });
-
-    test("should return a negative number from a string", () => {
-        expect(getValidNumberFromString("-123")).toBe(-123);
-    });
-
-    test("should return 0 from an invalid string", () => {
-        expect(getValidNumberFromString("abc")).toBe(0);
-    });
-
-    test("should return 0 from an empty string", () => {
-        expect(getValidNumberFromString("")).toBe(0);
-    });
-
-    test("should return 0 from a string with spaces", () => {
-        expect(getValidNumberFromString("  ")).toBe(0);
-    });
-
-    test("should return the number from a combo of numbers followed by letters", () => {
-        expect(getValidNumberFromString("123abc")).toBe(123);
-    });
-
-    test("should return 0 from a combo of letters followed by numbers", () => {
-        expect(getValidNumberFromString("abc123")).toBe(0);
-    });
-
-    test("should return the first number from a mixed combo of numbers and letters", () => {
-        expect(getValidNumberFromString("123abc123")).toBe(123);
-    });
-
-    test("should work with decimal numbers", () => {
-        expect(getValidNumberFromString("123.456")).toBe(123.456);
-    });
-});
+import {getDefaultFigureForType} from "../util";
 
 describe("getDefaultFigureForType", () => {
     test("should return a point with default values", () => {

--- a/packages/perseus-editor/src/components/util.ts
+++ b/packages/perseus-editor/src/components/util.ts
@@ -46,12 +46,6 @@ export function focusWithChromeStickyFocusBugWorkaround(element: Element) {
     element.focus({preventScroll: true});
 }
 
-export function getValidNumberFromString(value: string) {
-    const parsed = parseFloat(value);
-    // If the value is not a number, return 0.
-    return isNaN(parsed) ? 0 : parsed;
-}
-
 const DEFAULT_COLOR = "grayH";
 
 export function getDefaultFigureForType(type: "point"): LockedPointType;

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
@@ -298,6 +298,88 @@ describe("InteractiveGraphEditor locked figures", () => {
                 }),
             );
         });
+
+        test("Does not call onChange when x coord is cleared", async () => {
+            // Arrange
+            const onChangeMock = jest.fn();
+
+            render(
+                <InteractiveGraphEditor
+                    {...mafsProps}
+                    onChange={onChangeMock}
+                    lockedFigures={[defaultPoint]}
+                />,
+                {
+                    wrapper: RenderStateRoot,
+                },
+            );
+
+            // Act
+            const xCoordInput = screen.getByLabelText("x coord");
+            await userEvent.clear(xCoordInput);
+            await userEvent.tab();
+
+            // Assert
+            expect(onChangeMock).not.toBeCalled();
+        });
+
+        test("Does not call onChange when y coord is cleared", async () => {
+            // Arrange
+            const onChangeMock = jest.fn();
+
+            render(
+                <InteractiveGraphEditor
+                    {...mafsProps}
+                    onChange={onChangeMock}
+                    lockedFigures={[defaultPoint]}
+                />,
+                {
+                    wrapper: RenderStateRoot,
+                },
+            );
+
+            // Act
+            const yCoordInput = screen.getByLabelText("y coord");
+            await userEvent.clear(yCoordInput);
+            await userEvent.tab();
+
+            // Assert
+            expect(onChangeMock).not.toBeCalled();
+        });
+
+        test.each`
+            coord  | value
+            ${"x"} | ${"."}
+            ${"x"} | ${"-"}
+            ${"y"} | ${"."}
+            ${"y"} | ${"-"}
+        `(
+            "Does not call onChange when $coord coord is set to $value",
+            async ({coord, value}) => {
+                // Arrange
+                const onChangeMock = jest.fn();
+
+                render(
+                    <InteractiveGraphEditor
+                        {...mafsProps}
+                        onChange={onChangeMock}
+                        lockedFigures={[defaultPoint]}
+                    />,
+                    {
+                        wrapper: RenderStateRoot,
+                    },
+                );
+
+                // Act
+                const coordInput = screen.getByLabelText(`${coord} coord`);
+                await userEvent.clear(coordInput);
+                await userEvent.type(coordInput, value);
+                await userEvent.tab();
+
+                // Assert
+                expect(onChangeMock).not.toBeCalled();
+            },
+        );
     });
 
     describe("lines", () => {
@@ -499,7 +581,7 @@ describe("InteractiveGraphEditor locked figures", () => {
             );
         });
 
-        test("Calls onChange when a locked line's point1 is changed", async () => {
+        test("Calls onChange when a locked line's point1 x is changed", async () => {
             // Arrange
             const onChangeMock = jest.fn();
 
@@ -521,10 +603,42 @@ describe("InteractiveGraphEditor locked figures", () => {
             await userEvent.type(point1Input, "1");
             await userEvent.tab();
 
+            // Assert
+            expect(onChangeMock).toBeCalledWith(
+                expect.objectContaining({
+                    lockedFigures: [
+                        expect.objectContaining({
+                            ...defaultLine,
+                            points: [
+                                expect.objectContaining({coord: [1, 0]}),
+                                expect.objectContaining({coord: [2, 2]}),
+                            ],
+                        }),
+                    ],
+                }),
+            );
+        });
+
+        test("Calls onChange when a locked line's point1 y is changed", async () => {
+            // Arrange
+            const onChangeMock = jest.fn();
+
+            render(
+                <InteractiveGraphEditor
+                    {...mafsProps}
+                    onChange={onChangeMock}
+                    lockedFigures={[defaultLine]}
+                />,
+                {
+                    wrapper: RenderStateRoot,
+                },
+            );
+
+            // Act
             const point2Input = screen.getAllByLabelText("y coord")[0];
             await userEvent.click(point2Input);
             await userEvent.clear(point2Input);
-            await userEvent.type(point2Input, "5");
+            await userEvent.type(point2Input, "1");
             await userEvent.tab();
 
             // Assert
@@ -534,7 +648,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                         expect.objectContaining({
                             ...defaultLine,
                             points: [
-                                expect.objectContaining({coord: [1, 5]}),
+                                expect.objectContaining({coord: [0, 1]}),
                                 expect.objectContaining({coord: [2, 2]}),
                             ],
                         }),
@@ -543,7 +657,7 @@ describe("InteractiveGraphEditor locked figures", () => {
             );
         });
 
-        test("Calls onChange when a locked line's point2 is changed", async () => {
+        test("Calls onChange when a locked line's point2 x is changed", async () => {
             // Arrange
             const onChangeMock = jest.fn();
 
@@ -565,10 +679,42 @@ describe("InteractiveGraphEditor locked figures", () => {
             await userEvent.type(point1Input, "1");
             await userEvent.tab();
 
-            const point2Input = screen.getAllByLabelText("y coord")[1];
-            await userEvent.click(point2Input);
-            await userEvent.clear(point2Input);
-            await userEvent.type(point2Input, "5");
+            // Assert
+            expect(onChangeMock).toBeCalledWith(
+                expect.objectContaining({
+                    lockedFigures: [
+                        expect.objectContaining({
+                            ...defaultLine,
+                            points: [
+                                expect.objectContaining({coord: [0, 0]}),
+                                expect.objectContaining({coord: [1, 2]}),
+                            ],
+                        }),
+                    ],
+                }),
+            );
+        });
+
+        test("Calls onChange when a locked line's point2 y is changed", async () => {
+            // Arrange
+            const onChangeMock = jest.fn();
+
+            render(
+                <InteractiveGraphEditor
+                    {...mafsProps}
+                    onChange={onChangeMock}
+                    lockedFigures={[defaultLine]}
+                />,
+                {
+                    wrapper: RenderStateRoot,
+                },
+            );
+
+            // Act
+            const point1Input = screen.getAllByLabelText("y coord")[1];
+            await userEvent.click(point1Input);
+            await userEvent.clear(point1Input);
+            await userEvent.type(point1Input, "1");
             await userEvent.tab();
 
             // Assert
@@ -579,7 +725,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                             ...defaultLine,
                             points: [
                                 expect.objectContaining({coord: [0, 0]}),
-                                expect.objectContaining({coord: [1, 5]}),
+                                expect.objectContaining({coord: [2, 1]}),
                             ],
                         }),
                     ],


### PR DESCRIPTION
## Summary:
People would prefer for the locked figures to update on every change
instead of waiting until the input fields are blurred.

This should also resolve the firefox where the figures were not update on blur
after using the arrow buttons.

Implementing that in this PR.

Issue: https://khanacademy.atlassian.net/browse/LEMS-1986

## Test plan:
`yarn jest`

Storybook
- http://localhost:6006/?path=/story/perseuseditor-editorpage--mafs-with-locked-figures
- Change the coordinates for locked points and locked lines
- Try typing all sorts of weird numbers and other characters
- negative numbers and decimal numbers are supported

## Demo:


https://github.com/Khan/perseus/assets/13231763/0e9b32d3-8807-4d45-901d-ab5e6c1beaf4


