### PR TITLE
Fix a bug where line-ending arrows would flip around or vanish

### DIFF
--- a/.changeset/giant-seals-camp.md
+++ b/.changeset/giant-seals-camp.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix a bug in Mafs linear graphs where the arrows on the ends of the lines would sometimes disappear or flip around

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle.tsx
@@ -166,11 +166,7 @@ export const shouldDrawArcOutside = (
     polygonLines: readonly CollinearTuple[],
 ) => {
     // Create a ray from the midpoint (inside angle) to the edge of the range
-    const rangeIntersectionPoint = getRangeIntersectionVertex(
-        vertex,
-        midpoint,
-        range,
-    );
+    const rangeIntersectionPoint = getRangeIntersectionVertex(midpoint, vertex, range);
 
     let lineIntersectionCount = 0;
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle.tsx
@@ -166,7 +166,11 @@ export const shouldDrawArcOutside = (
     polygonLines: readonly CollinearTuple[],
 ) => {
     // Create a ray from the midpoint (inside angle) to the edge of the range
-    const rangeIntersectionPoint = getRangeIntersectionVertex(midpoint, vertex, range);
+    const rangeIntersectionPoint = getRangeIntersectionVertex(
+        midpoint,
+        vertex,
+        range,
+    );
 
     let lineIntersectionCount = 0;
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -148,10 +148,10 @@ const Line = (props: LineProps) => {
     if (extend) {
         const trimmedRange = trimRange(range, graphDimensionsInPixels);
         startExtend = extend.start
-            ? getIntersectionOfRayWithBox(start, end, trimmedRange)
+            ? getIntersectionOfRayWithBox(end, start, trimmedRange)
             : undefined;
         endExtend = extend.end
-            ? getIntersectionOfRayWithBox(end, start, trimmedRange)
+            ? getIntersectionOfRayWithBox(start, end, trimmedRange)
             : undefined;
     }
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.test.ts
@@ -18,6 +18,22 @@ describe("getIntersectionOfRayWithBox", () => {
         expect(intersection).toEqual([7, 0]);
     });
 
+    test("given a vertical ray passing through the origin upward", () => {
+        const box: [Interval, Interval] = [[-7, 7], [-11, 11]];
+        const initialPoint: vec.Vector2 = [0, -1];
+        const throughPoint: vec.Vector2 = [0, 1];
+        const intersection = getIntersectionOfRayWithBox(initialPoint, throughPoint, box);
+        expect(intersection).toEqual([0, 11]);
+    });
+
+    test("given a vertical ray passing through the origin downward", () => {
+        const box: [Interval, Interval] = [[-7, 7], [-11, 11]];
+        const initialPoint: vec.Vector2 = [0, 1];
+        const throughPoint: vec.Vector2 = [0, -1];
+        const intersection = getIntersectionOfRayWithBox(initialPoint, throughPoint, box);
+        expect(intersection).toEqual([0, -11]);
+    });
+
     test("given a y coordinate of -0 for the initialPoint when the ray points right", () => {
         const box: [Interval, Interval] = [[-7, 7], [-11, 11]];
         const initialPoint: vec.Vector2 = [-1, -0];

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.test.ts
@@ -3,6 +3,21 @@ import {getIntersectionOfRayWithBox} from "./utils";
 import type {Interval, vec} from "mafs";
 
 describe("getIntersectionOfRayWithBox", () => {
+    it("returns [0, 0] when the given points are the same", () => {
+        const box: [Interval, Interval] = [
+            [-7, 7],
+            [-11, 11],
+        ];
+        const initialPoint: vec.Vector2 = [3, 5];
+        const throughPoint: vec.Vector2 = [3, 5];
+        const intersection = getIntersectionOfRayWithBox(
+            initialPoint,
+            throughPoint,
+            box,
+        );
+        expect(intersection).toEqual([0, 0]);
+    });
+
     test("given a horizontal ray passing through the origin to the left", () => {
         const box: [Interval, Interval] = [
             [-7, 7],

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.test.ts
@@ -1,68 +1,125 @@
 import {getIntersectionOfRayWithBox} from "./utils";
-import {Interval, vec} from "mafs";
+
+import type {Interval, vec} from "mafs";
 
 describe("getIntersectionOfRayWithBox", () => {
     test("given a horizontal ray passing through the origin to the left", () => {
-        const box: [Interval, Interval] = [[-7, 7], [-11, 11]];
+        const box: [Interval, Interval] = [
+            [-7, 7],
+            [-11, 11],
+        ];
         const initialPoint: vec.Vector2 = [1, 0];
         const throughPoint: vec.Vector2 = [-1, 0];
-        const intersection = getIntersectionOfRayWithBox(initialPoint, throughPoint, box);
+        const intersection = getIntersectionOfRayWithBox(
+            initialPoint,
+            throughPoint,
+            box,
+        );
         expect(intersection).toEqual([-7, 0]);
     });
 
     test("given a horizontal ray passing through the origin to the right", () => {
-        const box: [Interval, Interval] = [[-7, 7], [-11, 11]];
+        const box: [Interval, Interval] = [
+            [-7, 7],
+            [-11, 11],
+        ];
         const initialPoint: vec.Vector2 = [-1, 0];
         const throughPoint: vec.Vector2 = [1, 0];
-        const intersection = getIntersectionOfRayWithBox(initialPoint, throughPoint, box);
+        const intersection = getIntersectionOfRayWithBox(
+            initialPoint,
+            throughPoint,
+            box,
+        );
         expect(intersection).toEqual([7, 0]);
     });
 
     test("given a vertical ray passing through the origin upward", () => {
-        const box: [Interval, Interval] = [[-7, 7], [-11, 11]];
+        const box: [Interval, Interval] = [
+            [-7, 7],
+            [-11, 11],
+        ];
         const initialPoint: vec.Vector2 = [0, -1];
         const throughPoint: vec.Vector2 = [0, 1];
-        const intersection = getIntersectionOfRayWithBox(initialPoint, throughPoint, box);
+        const intersection = getIntersectionOfRayWithBox(
+            initialPoint,
+            throughPoint,
+            box,
+        );
         expect(intersection).toEqual([0, 11]);
     });
 
     test("given a vertical ray passing through the origin downward", () => {
-        const box: [Interval, Interval] = [[-7, 7], [-11, 11]];
+        const box: [Interval, Interval] = [
+            [-7, 7],
+            [-11, 11],
+        ];
         const initialPoint: vec.Vector2 = [0, 1];
         const throughPoint: vec.Vector2 = [0, -1];
-        const intersection = getIntersectionOfRayWithBox(initialPoint, throughPoint, box);
+        const intersection = getIntersectionOfRayWithBox(
+            initialPoint,
+            throughPoint,
+            box,
+        );
         expect(intersection).toEqual([0, -11]);
     });
 
     test("given a y coordinate of -0 for the initialPoint when the ray points right", () => {
-        const box: [Interval, Interval] = [[-7, 7], [-11, 11]];
+        const box: [Interval, Interval] = [
+            [-7, 7],
+            [-11, 11],
+        ];
         const initialPoint: vec.Vector2 = [-1, -0];
         const throughPoint: vec.Vector2 = [1, 0];
-        const intersection = getIntersectionOfRayWithBox(initialPoint, throughPoint, box);
+        const intersection = getIntersectionOfRayWithBox(
+            initialPoint,
+            throughPoint,
+            box,
+        );
         expect(intersection).toEqual([7, 0]);
     });
 
     test("given a y coordinate of -0 for the throughPoint when the ray points right", () => {
-        const box: [Interval, Interval] = [[-7, 7], [-11, 11]];
+        const box: [Interval, Interval] = [
+            [-7, 7],
+            [-11, 11],
+        ];
         const initialPoint: vec.Vector2 = [-1, 0];
         const throughPoint: vec.Vector2 = [1, -0];
-        const intersection = getIntersectionOfRayWithBox(initialPoint, throughPoint, box);
+        const intersection = getIntersectionOfRayWithBox(
+            initialPoint,
+            throughPoint,
+            box,
+        );
         expect(intersection).toEqual([7, 0]);
     });
 
     test("given a y coordinate of -0 for the initialPoint when the ray points left", () => {
-        const box: [Interval, Interval] = [[-7, 7], [-11, 11]];
+        const box: [Interval, Interval] = [
+            [-7, 7],
+            [-11, 11],
+        ];
         const initialPoint: vec.Vector2 = [1, -0];
         const throughPoint: vec.Vector2 = [-1, 0];
-        const intersection = getIntersectionOfRayWithBox(initialPoint, throughPoint, box);
+        const intersection = getIntersectionOfRayWithBox(
+            initialPoint,
+            throughPoint,
+            box,
+        );
         expect(intersection).toEqual([-7, 0]);
     });
 
     test("given a y coordinate of -0 for the throughPoint when the ray points left", () => {
-        const box: [Interval, Interval] = [[-7, 7], [-11, 11]];
+        const box: [Interval, Interval] = [
+            [-7, 7],
+            [-11, 11],
+        ];
         const initialPoint: vec.Vector2 = [1, 0];
         const throughPoint: vec.Vector2 = [-1, -0];
-        const intersection = getIntersectionOfRayWithBox(initialPoint, throughPoint, box);
+        const intersection = getIntersectionOfRayWithBox(
+            initialPoint,
+            throughPoint,
+            box,
+        );
         expect(intersection).toEqual([-7, 0]);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.test.ts
@@ -1,0 +1,52 @@
+import {getIntersectionOfRayWithBox} from "./utils";
+import {Interval, vec} from "mafs";
+
+describe("getIntersectionOfRayWithBox", () => {
+    test("given a horizontal ray passing through the origin to the left", () => {
+        const box: [Interval, Interval] = [[-7, 7], [-11, 11]];
+        const initialPoint: vec.Vector2 = [1, 0];
+        const throughPoint: vec.Vector2 = [-1, 0];
+        const intersection = getIntersectionOfRayWithBox(initialPoint, throughPoint, box);
+        expect(intersection).toEqual([-7, 0]);
+    });
+
+    test("given a horizontal ray passing through the origin to the right", () => {
+        const box: [Interval, Interval] = [[-7, 7], [-11, 11]];
+        const initialPoint: vec.Vector2 = [-1, 0];
+        const throughPoint: vec.Vector2 = [1, 0];
+        const intersection = getIntersectionOfRayWithBox(initialPoint, throughPoint, box);
+        expect(intersection).toEqual([7, 0]);
+    });
+
+    test("given a y coordinate of -0 for the initialPoint when the ray points right", () => {
+        const box: [Interval, Interval] = [[-7, 7], [-11, 11]];
+        const initialPoint: vec.Vector2 = [-1, -0];
+        const throughPoint: vec.Vector2 = [1, 0];
+        const intersection = getIntersectionOfRayWithBox(initialPoint, throughPoint, box);
+        expect(intersection).toEqual([7, 0]);
+    });
+
+    test("given a y coordinate of -0 for the throughPoint when the ray points right", () => {
+        const box: [Interval, Interval] = [[-7, 7], [-11, 11]];
+        const initialPoint: vec.Vector2 = [-1, 0];
+        const throughPoint: vec.Vector2 = [1, -0];
+        const intersection = getIntersectionOfRayWithBox(initialPoint, throughPoint, box);
+        expect(intersection).toEqual([7, 0]);
+    });
+
+    test("given a y coordinate of -0 for the initialPoint when the ray points left", () => {
+        const box: [Interval, Interval] = [[-7, 7], [-11, 11]];
+        const initialPoint: vec.Vector2 = [1, -0];
+        const throughPoint: vec.Vector2 = [-1, 0];
+        const intersection = getIntersectionOfRayWithBox(initialPoint, throughPoint, box);
+        expect(intersection).toEqual([-7, 0]);
+    });
+
+    test("given a y coordinate of -0 for the throughPoint when the ray points left", () => {
+        const box: [Interval, Interval] = [[-7, 7], [-11, 11]];
+        const initialPoint: vec.Vector2 = [1, 0];
+        const throughPoint: vec.Vector2 = [-1, -0];
+        const intersection = getIntersectionOfRayWithBox(initialPoint, throughPoint, box);
+        expect(intersection).toEqual([-7, 0]);
+    });
+});

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
@@ -24,11 +24,12 @@ export const getIntersectionOfRayWithBox = (
     const yDiff = bY - aY;
     const xDiff = bX - aX;
     const slope = yDiff / xDiff;
+    const inverseSlope = 1 / slope
 
-    const yAtXMin = slope * (xMin - aX) + aY;
-    const yAtXMax = slope * (xMax - aX) + aY;
-    const xAtYMin = (yMin - aY) / slope + aX;
-    const xAtYMax = (yMax - aY) / slope + aX;
+    const yAtXMin = aY + (xMin - aX) * slope;
+    const yAtXMax = aY + (xMax - aX) * slope;
+    const xAtYMin = aX + (yMin - aY) * inverseSlope;
+    const xAtYMax = aX + (yMax - aY) * inverseSlope;
 
     // clock analogy to describe quadrants
     switch (true) {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
@@ -38,11 +38,13 @@ export const getIntersectionOfRayWithBox = (
             return [xMax, yAtXMax]
         case yDiff > 0 && xDiff >= 0:
             return [xAtYMax, yMax];
+
         // 3 o'clock to 5:59
         case yDiff < 0 && xDiff >= 0 && xAtYMin > xMax:
             return [xMax, yAtXMax]
         case yDiff < 0 && xDiff >= 0:
             return [xAtYMin, yMin];
+
         // 9 o'clock to 11:59
         case yDiff === 0 && xDiff < 0:
             return [xMin, aY]
@@ -50,6 +52,7 @@ export const getIntersectionOfRayWithBox = (
             return [xMin, yAtXMin]
         case yDiff >= 0 && xDiff < 0:
             return [xAtYMax, yMax]
+
         // 6 o'clock to 8:59
         case yDiff < 0 && xDiff < 0 && xAtYMin < xMin:
             return [xMin, yAtXMin]

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
@@ -26,30 +26,23 @@ export const getIntersectionOfRayWithBox = (
     const slope = yDiff / xDiff;
     const inverseSlope = 1 / slope
 
-    const yAtXMin = aY + (xMin - aX) * slope;
-    const yAtXMax = aY + (xMax - aX) * slope;
-    const xAtYMin = aX + (yMin - aY) * inverseSlope;
-    const xAtYMax = aX + (yMax - aY) * inverseSlope;
+    const xExtreme = xDiff < 0 ? xMin : xMax;
+    const yExtreme = yDiff < 0 ? yMin : yMax;
+
+    const yAtXExtreme = aY + (xExtreme - aX) * slope;
+    const xAtYExtreme = aX + (yExtreme - aY) * inverseSlope;
 
     switch (true) {
-        // check if the ray intersects the left edge of the graph
-        case xDiff < 0 && isBetween(yAtXMin, yMin, yMax):
-            return [xMin, yAtXMin]
+        // does the ray intersect the left or right edge?
+        case isBetween(yAtXExtreme, yMin, yMax):
+            return [xExtreme, yAtXExtreme];
 
-        // right edge
-        case xDiff > 0 && isBetween(yAtXMax, yMin, yMax):
-            return [xMax, yAtXMax]
-
-        // bottom edge
-        case yDiff < 0 && isBetween(xAtYMin, xMin, xMax):
-            return [xAtYMin, yMin]
-
-        // top edge
-        case yDiff > 0 && isBetween(xAtYMax, xMin, xMax):
-            return [xAtYMax, yMax]
+        // does the ray intersect the top or bottom edge?
+        case isBetween(xAtYExtreme, xMin, xMax):
+            return [xAtYExtreme, yExtreme];
 
         default:
-            return [xMax, yAtXMax];
+            return [0, 0];
     }
 };
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
@@ -31,36 +31,22 @@ export const getIntersectionOfRayWithBox = (
     const xAtYMin = aX + (yMin - aY) * inverseSlope;
     const xAtYMax = aX + (yMax - aY) * inverseSlope;
 
-    // clock analogy to describe quadrants
     switch (true) {
-        // 6 o'clock
-        case yDiff < 0 && xDiff === 0:
-            return [aX + 0, yMin]
-        // 12 o'clock
-        case yDiff > 0 && xDiff === 0:
-            return [aX + 0, yMax]
-        // 9 o'clock
-        case yDiff === 0 && xDiff < 0:
-            return [xMin, aY + 0]
-        // 3 o'clock
-        case yDiff === 0 && xDiff > 0:
-            return [xMax, aY + 0]
+        // check if the ray intersects the left edge of the graph
+        case xDiff < 0 && isBetween(yAtXMin, yMin, yMax):
+            return [xMin, yAtXMin]
 
-        case yDiff > 0 && xDiff > 0 && xAtYMax > xMax:
-        case yDiff < 0 && xDiff > 0 && xAtYMin > xMax:
+        // right edge
+        case xDiff > 0 && isBetween(yAtXMax, yMin, yMax):
             return [xMax, yAtXMax]
 
-        case yDiff < 0 && xDiff > 0 && xAtYMin >= xMin:
-        case yDiff < 0 && xDiff < 0 && xAtYMin >= xMin:
-            return [xAtYMin, yMin];
+        // bottom edge
+        case yDiff < 0 && isBetween(xAtYMin, xMin, xMax):
+            return [xAtYMin, yMin]
 
-        case yDiff < 0 && xDiff < 0 && xAtYMin < xMin:
-        case yDiff > 0 && xDiff < 0 && xAtYMax < xMin:
-            return [xMin, yAtXMin];
-
-        case yDiff > 0 && xDiff > 0 && xAtYMax <= xMax:
-        case yDiff > 0 && xDiff < 0 && xAtYMax <= xMax:
-            return [xAtYMax, yMax];
+        // top edge
+        case yDiff > 0 && isBetween(xAtYMax, xMin, xMax):
+            return [xAtYMax, yMax]
 
         default:
             return [xMax, yAtXMax];
@@ -73,3 +59,7 @@ export const getLines = (points: readonly vec.Vector2[]): CollinearTuple[] => {
         return [point, next];
     });
 };
+
+function isBetween(x: number, low: number, high: number) {
+    return x >= low && x <= high
+}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
@@ -33,31 +33,43 @@ export const getIntersectionOfRayWithBox = (
 
     // clock analogy to describe quadrants
     switch (true) {
-        // 12 o'clock to 2:59
-        case yDiff > 0 && xDiff >= 0 && xAtYMax > xMax:
+        // 6 o'clock
+        case yDiff < 0 && xDiff === 0:
+            return [aX + 0, yMin]
+        // 12 o'clock
+        case yDiff > 0 && xDiff === 0:
+            return [aX + 0, yMax]
+        // 9 o'clock
+        case yDiff === 0 && xDiff < 0:
+            return [xMin, aY + 0]
+        // 3 o'clock
+        case yDiff === 0 && xDiff > 0:
+            return [xMax, aY + 0]
+
+        // 12:00 to 3:00
+        case yDiff > 0 && xDiff > 0 && xAtYMax > xMax:
             return [xMax, yAtXMax]
-        case yDiff > 0 && xDiff >= 0:
+        case yDiff > 0 && xDiff > 0:
             return [xAtYMax, yMax];
 
-        // 3 o'clock to 5:59
-        case yDiff < 0 && xDiff >= 0 && xAtYMin > xMax:
+        // 3:00 to 6:00
+        case yDiff < 0 && xDiff > 0 && xAtYMin > xMax:
             return [xMax, yAtXMax]
-        case yDiff < 0 && xDiff >= 0:
+        case yDiff < 0 && xDiff > 0:
             return [xAtYMin, yMin];
 
-        // 9 o'clock to 11:59
-        case yDiff === 0 && xDiff < 0:
-            return [xMin, aY]
-        case yDiff >= 0 && xDiff < 0 && xAtYMax < xMin:
-            return [xMin, yAtXMin]
-        case yDiff >= 0 && xDiff < 0:
-            return [xAtYMax, yMax]
+        // 9:00 to 12:00
+        case yDiff > 0 && xDiff < 0 && xAtYMax < xMin:
+            return [xMin, yAtXMin];
+        case yDiff > 0 && xDiff < 0:
+            return [xAtYMax, yMax];
 
-        // 6 o'clock to 8:59
+        // 6:00 to 9:00
         case yDiff < 0 && xDiff < 0 && xAtYMin < xMin:
             return [xMin, yAtXMin]
         case yDiff < 0 && xDiff < 0:
             return [xAtYMin, yMin];
+
         default:
             return [xMax, yAtXMax];
     }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
@@ -8,8 +8,8 @@ export function calculateAngleInDegrees([x, y]: vec.Vector2) {
 /**
  * Given a ray and a rectangular box, find the point where the ray intersects
  * the edge of the box. Assumes the `initialPoint` is inside the box.
- * @param initialPoint - A point that the ray passes through. Must be different from initialPoint.
- * @param throughPoint - The starting point of the ray.
+ * @param initialPoint - The starting point of the ray.
+ * @param throughPoint - A point that the ray passes through. Must be different from initialPoint.
  * @param box - The box with which to intersect the ray, in the form [[xMin, xMax], [yMin, yMax]]
  */
 export const getIntersectionOfRayWithBox = (
@@ -33,15 +33,18 @@ export const getIntersectionOfRayWithBox = (
     const xAtYExtreme = aX + (yExtreme - aY) * inverseSlope;
 
     switch (true) {
-        // does the ray intersect the left or right edge?
+        // does the ray exit the graph bounding box via the left or right edge?
         case isBetween(yAtXExtreme, yMin, yMax):
             return [xExtreme, yAtXExtreme];
 
-        // does the ray intersect the top or bottom edge?
+        // does the ray exit the graph bounding box via the top or bottom edge?
         case isBetween(xAtYExtreme, xMin, xMax):
             return [xAtYExtreme, yExtreme];
 
         default:
+            // This default case is only reachable if the input is invalid
+            // (initialPoint is outside the graph bounds, or initialPoint and
+            // throughPoint are the same).
             return [0, 0];
     }
 };

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
@@ -38,10 +38,9 @@ export const getIntersectionOfRayWithBox = (
         case yDiff > 0 && xDiff >= 0:
             return [xAtYMax, yMax];
         // 3 o'clock to 5:59
-        // xAtYMin evaluates to -Infinity here, so we use absolute value
-        case yDiff <= 0 && xDiff > 0 && Math.abs(xAtYMin) > xMax:
+        case yDiff < 0 && xDiff >= 0 && xAtYMin > xMax:
             return [xMax, yAtXMax]
-        case yDiff <= 0 && xDiff > 0:
+        case yDiff < 0 && xDiff >= 0:
             return [xAtYMin, yMin];
         // 9 o'clock to 11:59
         case yDiff >= 0 && xDiff < 0 && xAtYMax < xMin:
@@ -49,9 +48,9 @@ export const getIntersectionOfRayWithBox = (
         case yDiff >= 0 && xDiff < 0:
             return [xAtYMax, yMax]
         // 6 o'clock to 8:59
-        case yDiff < 0 && xDiff <= 0 && xAtYMin < xMin:
+        case yDiff < 0 && xDiff < 0 && xAtYMin < xMin:
             return [xMin, yAtXMin]
-        case yDiff < 0 && xDiff <= 0:
+        case yDiff < 0 && xDiff < 0:
             return [xAtYMin, yMin];
         default:
             return [xMax, yAtXMax];

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
@@ -33,18 +33,26 @@ export const getIntersectionOfRayWithBox = (
     // clock analogy to describe quadrants
     switch (true) {
         // 12 o'clock to 2:59
+        case yDiff > 0 && xDiff >= 0 && xAtYMax > xMax:
+            return [xMax, yAtXMax]
         case yDiff > 0 && xDiff >= 0:
-            return xAtYMax > xMax ? [xMax, yAtXMax] : [xAtYMax, yMax];
+            return [xAtYMax, yMax];
         // 3 o'clock to 5:59
+        // xAtYMin evaluates to -Infinity here, so we use absolute value
+        case yDiff <= 0 && xDiff > 0 && Math.abs(xAtYMin) > xMax:
+            return [xMax, yAtXMax]
         case yDiff <= 0 && xDiff > 0:
-            // xAtYMin evaluates to -Infinity here, so we use absolute value
-            return Math.abs(xAtYMin) > xMax ? [xMax, yAtXMax] : [xAtYMin, yMin];
+            return [xAtYMin, yMin];
         // 9 o'clock to 11:59
+        case yDiff >= 0 && xDiff < 0 && xAtYMax < xMin:
+            return [xMin, yAtXMin]
         case yDiff >= 0 && xDiff < 0:
-            return xAtYMax < xMin ? [xMin, yAtXMin] : [xAtYMax, yMax];
+            return [xAtYMax, yMax]
         // 6 o'clock to 8:59
+        case yDiff < 0 && xDiff <= 0 && xAtYMin < xMin:
+            return [xMin, yAtXMin]
         case yDiff < 0 && xDiff <= 0:
-            return xAtYMin < xMin ? [xMin, yAtXMin] : [xAtYMin, yMin];
+            return [xAtYMin, yMin];
         default:
             return [xMax, yAtXMax];
     }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
@@ -8,8 +8,8 @@ export function calculateAngleInDegrees([x, y]: vec.Vector2) {
 /**
  * Given a ray and a rectangular box, find the point where the ray intersects
  * the edge of the box. Assumes the `initialPoint` is inside the box.
- * @param initialPoint - The starting point of the ray.
- * @param throughPoint - A point that the ray passes through. Must be different from initialPoint.
+ * @param initialPoint - A point that the ray passes through. Must be different from initialPoint.
+ * @param throughPoint - The starting point of the ray.
  * @param box - The box with which to intersect the ray, in the form [[xMin, xMax], [yMin, yMax]]
  */
 export const getIntersectionOfRayWithBox = (
@@ -18,8 +18,8 @@ export const getIntersectionOfRayWithBox = (
     box: [x: Interval, y: Interval],
 ): [number, number] => {
     const [[xMin, xMax], [yMin, yMax]] = box;
-    const [aX, aY] = throughPoint;
-    const [bX, bY] = initialPoint;
+    const [aX, aY] = initialPoint;
+    const [bX, bY] = throughPoint;
 
     const yDiff = bY - aY;
     const xDiff = bX - aX;

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
@@ -24,7 +24,7 @@ export const getIntersectionOfRayWithBox = (
     const yDiff = bY - aY;
     const xDiff = bX - aX;
     const slope = yDiff / xDiff;
-    const inverseSlope = 1 / slope
+    const inverseSlope = 1 / slope;
 
     const xExtreme = xDiff < 0 ? xMin : xMax;
     const yExtreme = yDiff < 0 ? yMin : yMax;
@@ -54,5 +54,5 @@ export const getLines = (points: readonly vec.Vector2[]): CollinearTuple[] => {
 };
 
 function isBetween(x: number, low: number, high: number) {
-    return x >= low && x <= high
+    return x >= low && x <= high;
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
@@ -46,29 +46,21 @@ export const getIntersectionOfRayWithBox = (
         case yDiff === 0 && xDiff > 0:
             return [xMax, aY + 0]
 
-        // 12:00 to 3:00
         case yDiff > 0 && xDiff > 0 && xAtYMax > xMax:
-            return [xMax, yAtXMax]
-        case yDiff > 0 && xDiff > 0:
-            return [xAtYMax, yMax];
-
-        // 3:00 to 6:00
         case yDiff < 0 && xDiff > 0 && xAtYMin > xMax:
             return [xMax, yAtXMax]
+
         case yDiff < 0 && xDiff > 0:
+        case yDiff < 0 && xDiff < 0 && xAtYMin >= xMin:
             return [xAtYMin, yMin];
 
-        // 9:00 to 12:00
+        case yDiff < 0 && xDiff < 0 && xAtYMin < xMin:
         case yDiff > 0 && xDiff < 0 && xAtYMax < xMin:
             return [xMin, yAtXMin];
+
+        case yDiff > 0 && xDiff > 0 && xAtYMax <= xMax:
         case yDiff > 0 && xDiff < 0:
             return [xAtYMax, yMax];
-
-        // 6:00 to 9:00
-        case yDiff < 0 && xDiff < 0 && xAtYMin < xMin:
-            return [xMin, yAtXMin]
-        case yDiff < 0 && xDiff < 0:
-            return [xAtYMin, yMin];
 
         default:
             return [xMax, yAtXMax];

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
@@ -50,7 +50,7 @@ export const getIntersectionOfRayWithBox = (
         case yDiff < 0 && xDiff > 0 && xAtYMin > xMax:
             return [xMax, yAtXMax]
 
-        case yDiff < 0 && xDiff > 0:
+        case yDiff < 0 && xDiff > 0 && xAtYMin >= xMin:
         case yDiff < 0 && xDiff < 0 && xAtYMin >= xMin:
             return [xAtYMin, yMin];
 
@@ -59,7 +59,7 @@ export const getIntersectionOfRayWithBox = (
             return [xMin, yAtXMin];
 
         case yDiff > 0 && xDiff > 0 && xAtYMax <= xMax:
-        case yDiff > 0 && xDiff < 0:
+        case yDiff > 0 && xDiff < 0 && xAtYMax <= xMax:
             return [xAtYMax, yMax];
 
         default:

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
@@ -43,6 +43,8 @@ export const getIntersectionOfRayWithBox = (
         case yDiff < 0 && xDiff >= 0:
             return [xAtYMin, yMin];
         // 9 o'clock to 11:59
+        case yDiff === 0 && xDiff < 0:
+            return [xMin, aY]
         case yDiff >= 0 && xDiff < 0 && xAtYMax < xMin:
             return [xMin, yAtXMin]
         case yDiff >= 0 && xDiff < 0:

--- a/packages/perseus/src/widgets/interactive-graphs/locked-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-line.tsx
@@ -27,11 +27,7 @@ const LockedLine = (props: Props) => {
 
     if (kind === "ray") {
         // Rays extend to the end of the graph in one direction.
-        const extendedPoint = getIntersectionOfRayWithBox(
-            point2.coord,
-            point1.coord,
-            range,
-        );
+        const extendedPoint = getIntersectionOfRayWithBox(point1.coord, point2.coord, range);
         line = (
             <Vector
                 tail={point1.coord}
@@ -51,11 +47,7 @@ const LockedLine = (props: Props) => {
         let arrowTip =
             kind === "segment"
                 ? point2.coord
-                : getIntersectionOfRayWithBox(
-                      point2.coord,
-                      point1.coord,
-                      range,
-                  );
+                : getIntersectionOfRayWithBox(point1.coord, point2.coord, range);
         const direction = vec.sub(point2.coord, point1.coord);
         let angle = calculateAngleInDegrees(direction);
         const startArrowHead = kind !== "segment" && (
@@ -69,11 +61,7 @@ const LockedLine = (props: Props) => {
         arrowTip =
             kind === "segment"
                 ? point1.coord
-                : getIntersectionOfRayWithBox(
-                      point1.coord,
-                      point2.coord,
-                      range,
-                  );
+                : getIntersectionOfRayWithBox(point2.coord, point1.coord, range);
         angle = angle > 180 ? angle - 180 : angle + 180;
         const endArrowHead = kind !== "segment" && (
             <Arrowhead

--- a/packages/perseus/src/widgets/interactive-graphs/locked-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-line.tsx
@@ -27,7 +27,11 @@ const LockedLine = (props: Props) => {
 
     if (kind === "ray") {
         // Rays extend to the end of the graph in one direction.
-        const extendedPoint = getIntersectionOfRayWithBox(point1.coord, point2.coord, range);
+        const extendedPoint = getIntersectionOfRayWithBox(
+            point1.coord,
+            point2.coord,
+            range,
+        );
         line = (
             <Vector
                 tail={point1.coord}
@@ -47,7 +51,11 @@ const LockedLine = (props: Props) => {
         let arrowTip =
             kind === "segment"
                 ? point2.coord
-                : getIntersectionOfRayWithBox(point1.coord, point2.coord, range);
+                : getIntersectionOfRayWithBox(
+                      point1.coord,
+                      point2.coord,
+                      range,
+                  );
         const direction = vec.sub(point2.coord, point1.coord);
         let angle = calculateAngleInDegrees(direction);
         const startArrowHead = kind !== "segment" && (
@@ -61,7 +69,11 @@ const LockedLine = (props: Props) => {
         arrowTip =
             kind === "segment"
                 ? point1.coord
-                : getIntersectionOfRayWithBox(point2.coord, point1.coord, range);
+                : getIntersectionOfRayWithBox(
+                      point2.coord,
+                      point1.coord,
+                      range,
+                  );
         angle = angle > 180 ? angle - 180 : angle + 180;
         const endArrowHead = kind !== "segment" && (
             <Arrowhead


### PR DESCRIPTION
The bug happened when `-0` was passed as a coordinate (yes, `-0` is a distinct
value in floating point, because the sign bit is stored separately from the
mantissa).

This PR patches the bug by handling horizontal and vertical lines as a special
case, and then refactors to a design where the special-casing is no longer
necessary. It's probably easiest to read the PR one commit at a time.

Issue: LEMS-1955

## Test plan:

- `yarn dev`
- Play around with the linear graphs at `localhost:5173`