### PR TITLE
Remove range and snapStep from MafsGraph props

### DIFF
--- a/.changeset/beige-dolphins-promise.md
+++ b/.changeset/beige-dolphins-promise.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Refactor the MafsGraph components to deduplicate data across props and state

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -7,15 +7,11 @@ import invariant from "tiny-invariant";
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import {setDependencies} from "../../dependencies";
 
-import {
-    MafsGraph,
-    StatefulMafsGraph,
-    StatefulMafsGraphProps,
-} from "./mafs-graph";
+import {MafsGraph, StatefulMafsGraph} from "./mafs-graph";
 import {movePoint} from "./reducer/interactive-graph-action";
 import {interactiveGraphReducer} from "./reducer/interactive-graph-reducer";
 
-import type {MafsGraphProps} from "./mafs-graph";
+import type {MafsGraphProps, StatefulMafsGraphProps} from "./mafs-graph";
 import type {InteractiveGraphState} from "./types";
 import type {GraphRange} from "../../perseus-types";
 import type {UserEvent} from "@testing-library/user-event";

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -23,7 +23,6 @@ function getBaseMafsGraphProps(): MafsGraphProps {
         gridStep: [1, 1],
         markings: "graph",
         containerSizeClass: "small",
-        onChange: () => {},
         showTooltips: false,
         labels: ["x", "y"],
         dispatch: () => {},

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -11,7 +11,7 @@ import {MafsGraph, StatefulMafsGraph} from "./mafs-graph";
 import {movePoint} from "./reducer/interactive-graph-action";
 import {interactiveGraphReducer} from "./reducer/interactive-graph-reducer";
 
-import type {Props as MafsGraphProps} from "./mafs-graph";
+import type {MafsGraphProps} from "./mafs-graph";
 import type {InteractiveGraphState} from "./types";
 import type {GraphRange} from "../../perseus-types";
 import type {UserEvent} from "@testing-library/user-event";
@@ -21,18 +21,37 @@ function getBaseMafsGraphProps(): MafsGraphProps {
         box: [400, 400],
         step: [1, 1],
         gridStep: [1, 1],
-        snapStep: [1, 1],
         markings: "graph",
-        range: [
-            [-10, 10],
-            [-10, 10],
-        ],
-        graph: {type: "segment"},
         containerSizeClass: "small",
         onChange: () => {},
         showTooltips: false,
         labels: ["x", "y"],
+        dispatch: () => {},
+        state: {
+            type: "segment",
+            hasBeenInteractedWith: false,
+            coords: [],
+            markings: "none",
+            snapStep: [1, 1],
+            range: [[-10, 10], [-10, 10]],
+        }
     };
+}
+
+function getBaseStatefulMafsGraphProps(): StatefulMafsGraphProps {
+    return {
+        box: [400, 400],
+        step: [1, 1],
+        snapStep: [1, 1],
+        gridStep: [1, 1],
+        range: [[-10, 10], [-10, 10]],
+        markings: "graph",
+        containerSizeClass: "small",
+        onChange: () => {},
+        showTooltips: false,
+        labels: ["x", "y"],
+        graph: {type: "segment"},
+    }
 }
 
 function createFakeStore<S, A>(reducer: (state: S, action: A) => S, state: S) {
@@ -58,7 +77,7 @@ describe("StatefulMafsGraph", () => {
 
     it("renders", () => {
         const {container} = render(
-            <StatefulMafsGraph {...getBaseMafsGraphProps()} />,
+            <StatefulMafsGraph {...getBaseStatefulMafsGraphProps()} />,
         );
 
         // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
@@ -74,7 +93,7 @@ describe("StatefulMafsGraph", () => {
 
         render(
             <StatefulMafsGraph
-                {...getBaseMafsGraphProps()}
+                {...getBaseStatefulMafsGraphProps()}
                 onChange={mockChangeHandler}
             />,
         );
@@ -140,9 +159,9 @@ describe("MafsGraph", () => {
 
         render(
             <MafsGraph
+                {...baseMafsGraphProps}
                 state={state}
                 dispatch={mockDispatch}
-                {...baseMafsGraphProps}
             />,
         );
 
@@ -184,9 +203,9 @@ describe("MafsGraph", () => {
         // Act
         render(
             <MafsGraph
+                {...baseMafsGraphProps}
                 state={state}
                 dispatch={mockDispatch}
-                {...baseMafsGraphProps}
             />,
         );
 
@@ -223,9 +242,9 @@ describe("MafsGraph", () => {
         // Act
         render(
             <MafsGraph
+                {...baseMafsGraphProps}
                 state={state}
                 dispatch={mockDispatch}
-                {...baseMafsGraphProps}
                 markings="none"
             />,
         );
@@ -259,9 +278,9 @@ describe("MafsGraph", () => {
 
         const {rerender} = render(
             <MafsGraph
+                {...baseMafsGraphProps}
                 state={state}
                 dispatch={mockDispatch}
-                {...baseMafsGraphProps}
             />,
         );
 
@@ -275,9 +294,9 @@ describe("MafsGraph", () => {
 
         rerender(
             <MafsGraph
+                {...baseMafsGraphProps}
                 state={updatedState}
                 dispatch={mockDispatch}
-                {...baseMafsGraphProps}
             />,
         );
 
@@ -427,9 +446,9 @@ describe("MafsGraph", () => {
 
         render(
             <MafsGraph
+                {...baseMafsGraphProps}
                 state={getState()}
                 dispatch={dispatch}
-                {...baseMafsGraphProps}
             />,
         );
 
@@ -479,9 +498,9 @@ describe("MafsGraph", () => {
 
         render(
             <MafsGraph
+                {...baseMafsGraphProps}
                 state={getState()}
                 dispatch={dispatch}
-                {...baseMafsGraphProps}
             />,
         );
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -7,7 +7,11 @@ import invariant from "tiny-invariant";
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import {setDependencies} from "../../dependencies";
 
-import {MafsGraph, StatefulMafsGraph} from "./mafs-graph";
+import {
+    MafsGraph,
+    StatefulMafsGraph,
+    StatefulMafsGraphProps
+} from "./mafs-graph";
 import {movePoint} from "./reducer/interactive-graph-action";
 import {interactiveGraphReducer} from "./reducer/interactive-graph-reducer";
 
@@ -341,9 +345,9 @@ describe("MafsGraph", () => {
 
         render(
             <MafsGraph
+                {...baseMafsGraphProps}
                 state={getState()}
                 dispatch={dispatch}
-                {...baseMafsGraphProps}
             />,
         );
 
@@ -393,9 +397,9 @@ describe("MafsGraph", () => {
 
         render(
             <MafsGraph
+                {...baseMafsGraphProps}
                 state={getState()}
                 dispatch={dispatch}
-                {...baseMafsGraphProps}
             />,
         );
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -10,7 +10,7 @@ import {setDependencies} from "../../dependencies";
 import {
     MafsGraph,
     StatefulMafsGraph,
-    StatefulMafsGraphProps
+    StatefulMafsGraphProps,
 } from "./mafs-graph";
 import {movePoint} from "./reducer/interactive-graph-action";
 import {interactiveGraphReducer} from "./reducer/interactive-graph-reducer";
@@ -36,8 +36,11 @@ function getBaseMafsGraphProps(): MafsGraphProps {
             coords: [],
             markings: "none",
             snapStep: [1, 1],
-            range: [[-10, 10], [-10, 10]],
-        }
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+        },
     };
 }
 
@@ -47,14 +50,17 @@ function getBaseStatefulMafsGraphProps(): StatefulMafsGraphProps {
         step: [1, 1],
         snapStep: [1, 1],
         gridStep: [1, 1],
-        range: [[-10, 10], [-10, 10]],
+        range: [
+            [-10, 10],
+            [-10, 10],
+        ],
         markings: "graph",
         containerSizeClass: "small",
         onChange: () => {},
         showTooltips: false,
         labels: ["x", "y"],
         graph: {type: "segment"},
-    }
+    };
 }
 
 function createFakeStore<S, A>(reducer: (state: S, action: A) => S, state: S) {

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -116,6 +116,15 @@ export const StatefulMafsGraph = React.forwardRef<Partial<Widget>, StatefulMafsG
             props.onChange(mafsStateToInteractiveGraph(next));
         }
 
+        const prevState = useRef<InteractiveGraphState>(state);
+
+        useEffect(() => {
+            if (prevState.current !== state) {
+                onChange({graph: state});
+            }
+            prevState.current = state;
+        }, [props, state]);
+
         // Destructuring first to keep useEffect from making excess calls
         const [xSnap, ySnap] = props.snapStep;
         useEffect(() => {
@@ -138,7 +147,6 @@ export const StatefulMafsGraph = React.forwardRef<Partial<Widget>, StatefulMafsG
                 {...props}
                 state={state}
                 dispatch={dispatch}
-                onChange={onChange}
             />
         );
     },
@@ -152,7 +160,6 @@ export interface MafsGraphProps {
     gridStep: InteractiveGraphProps["gridStep"];
     containerSizeClass: InteractiveGraphProps["containerSizeClass"];
     markings: InteractiveGraphProps["markings"];
-    onChange: InteractiveGraphProps["onChange"];
     showTooltips: Required<InteractiveGraphProps["showTooltips"]>;
     labels: InteractiveGraphProps["labels"];
     state: InteractiveGraphState;
@@ -162,15 +169,6 @@ export interface MafsGraphProps {
 export const MafsGraph = (props: MafsGraphProps) => {
     const {state, dispatch, labels} = props;
     const [width, height] = props.box;
-
-    const prevState = useRef<InteractiveGraphState>(state);
-
-    useEffect(() => {
-        if (prevState.current !== state) {
-            props.onChange({graph: state});
-        }
-        prevState.current = state;
-    }, [props, state]);
 
     return (
         <GraphConfigContext.Provider

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -127,10 +127,10 @@ export const StatefulMafsGraph = React.forwardRef<Partial<Widget>, Props>(
     },
 );
 
-type MafsGraphProps = Props & {
+interface MafsGraphProps extends Props {
     state: InteractiveGraphState;
     dispatch: React.Dispatch<InteractiveGraphAction>;
-};
+}
 
 export const MafsGraph = (props: MafsGraphProps) => {
     const {state, dispatch, labels} = props;

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -127,7 +127,20 @@ export const StatefulMafsGraph = React.forwardRef<Partial<Widget>, Props>(
     },
 );
 
-interface MafsGraphProps extends Props {
+interface MafsGraphProps {
+    box: [number, number];
+    backgroundImage?: InteractiveGraphProps["backgroundImage"];
+    graph: InteractiveGraphProps["graph"];
+    lockedFigures?: InteractiveGraphProps["lockedFigures"];
+    range: InteractiveGraphProps["range"];
+    snapStep: InteractiveGraphProps["snapStep"];
+    step: InteractiveGraphProps["step"];
+    gridStep: InteractiveGraphProps["gridStep"];
+    containerSizeClass: InteractiveGraphProps["containerSizeClass"];
+    markings: InteractiveGraphProps["markings"];
+    onChange: InteractiveGraphProps["onChange"];
+    showTooltips: Required<InteractiveGraphProps["showTooltips"]>;
+    labels: InteractiveGraphProps["labels"];
     state: InteractiveGraphState;
     dispatch: React.Dispatch<InteractiveGraphAction>;
 }

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -131,7 +131,6 @@ interface MafsGraphProps {
     box: [number, number];
     backgroundImage?: InteractiveGraphProps["backgroundImage"];
     lockedFigures?: InteractiveGraphProps["lockedFigures"];
-    snapStep: InteractiveGraphProps["snapStep"]; // FIXME: snapStep is duplicated in state; remove it
     step: InteractiveGraphProps["step"];
     gridStep: InteractiveGraphProps["gridStep"];
     containerSizeClass: InteractiveGraphProps["containerSizeClass"];
@@ -157,7 +156,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
     }, [props, state]);
 
     // Destructuring first to keep useEffect from making excess calls
-    const [xSnap, ySnap] = props.snapStep;
+    const [xSnap, ySnap] = state.snapStep;
     useEffect(() => {
         dispatch(changeSnapStep([xSnap, ySnap]));
     }, [dispatch, xSnap, ySnap]);

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -130,7 +130,6 @@ export const StatefulMafsGraph = React.forwardRef<Partial<Widget>, Props>(
 interface MafsGraphProps {
     box: [number, number];
     backgroundImage?: InteractiveGraphProps["backgroundImage"];
-    graph: InteractiveGraphProps["graph"];
     lockedFigures?: InteractiveGraphProps["lockedFigures"];
     range: InteractiveGraphProps["range"];
     snapStep: InteractiveGraphProps["snapStep"];

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -36,7 +36,7 @@ import type {Widget} from "../../renderer";
 import "mafs/core.css";
 import "./mafs-styles.css";
 
-export type Props = {
+export interface Props {
     box: [number, number];
     backgroundImage?: InteractiveGraphProps["backgroundImage"];
     graph: InteractiveGraphProps["graph"];
@@ -50,7 +50,7 @@ export type Props = {
     onChange: InteractiveGraphProps["onChange"];
     showTooltips: Required<InteractiveGraphProps["showTooltips"]>;
     labels: InteractiveGraphProps["labels"];
-};
+}
 
 type MafsChange = {
     graph: InteractiveGraphState;

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -50,7 +50,7 @@ export type StatefulMafsGraphProps = {
     onChange: InteractiveGraphProps["onChange"];
     showTooltips: Required<InteractiveGraphProps["showTooltips"]>;
     labels: InteractiveGraphProps["labels"];
-}
+};
 
 type MafsChange = {
     graph: InteractiveGraphState;
@@ -157,7 +157,7 @@ export type MafsGraphProps = {
     labels: InteractiveGraphProps["labels"];
     state: InteractiveGraphState;
     dispatch: React.Dispatch<InteractiveGraphAction>;
-}
+};
 
 export const MafsGraph = (props: MafsGraphProps) => {
     const {state, dispatch, labels} = props;

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -116,6 +116,23 @@ export const StatefulMafsGraph = React.forwardRef<Partial<Widget>, StatefulMafsG
             props.onChange(mafsStateToInteractiveGraph(next));
         }
 
+        // Destructuring first to keep useEffect from making excess calls
+        const [xSnap, ySnap] = props.snapStep;
+        useEffect(() => {
+            dispatch(changeSnapStep([xSnap, ySnap]));
+        }, [dispatch, xSnap, ySnap]);
+
+        // Destructuring first to keep useEffect from making excess calls
+        const [[xMinRange, xMaxRange], [yMinRange, yMaxRange]] = props.range;
+        useEffect(() => {
+            dispatch(
+                changeRange([
+                    [xMinRange, xMaxRange],
+                    [yMinRange, yMaxRange],
+                ]),
+            );
+        }, [dispatch, xMinRange, xMaxRange, yMinRange, yMaxRange]);
+
         return (
             <MafsGraph
                 {...props}
@@ -154,23 +171,6 @@ export const MafsGraph = (props: MafsGraphProps) => {
         }
         prevState.current = state;
     }, [props, state]);
-
-    // Destructuring first to keep useEffect from making excess calls
-    const [xSnap, ySnap] = state.snapStep;
-    useEffect(() => {
-        dispatch(changeSnapStep([xSnap, ySnap]));
-    }, [dispatch, xSnap, ySnap]);
-
-    // Destructuring first to keep useEffect from making excess calls
-    const [[xMinRange, xMaxRange], [yMinRange, yMaxRange]] = state.range;
-    useEffect(() => {
-        dispatch(
-            changeRange([
-                [xMinRange, xMaxRange],
-                [yMinRange, yMaxRange],
-            ]),
-        );
-    }, [dispatch, xMinRange, xMaxRange, yMinRange, yMaxRange]);
 
     return (
         <GraphConfigContext.Provider

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -131,8 +131,8 @@ interface MafsGraphProps {
     box: [number, number];
     backgroundImage?: InteractiveGraphProps["backgroundImage"];
     lockedFigures?: InteractiveGraphProps["lockedFigures"];
-    range: InteractiveGraphProps["range"];
-    snapStep: InteractiveGraphProps["snapStep"];
+    range: InteractiveGraphProps["range"]; // FIXME: range is duplicated in state; remove it
+    snapStep: InteractiveGraphProps["snapStep"]; // FIXME: snapStep is duplicated in state; remove it
     step: InteractiveGraphProps["step"];
     gridStep: InteractiveGraphProps["gridStep"];
     containerSizeClass: InteractiveGraphProps["containerSizeClass"];

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -104,6 +104,8 @@ export const StatefulMafsGraph = React.forwardRef<
     Partial<Widget>,
     StatefulMafsGraphProps
 >((props, ref) => {
+    const {onChange} = props;
+
     const [state, dispatch] = React.useReducer(
         interactiveGraphReducer,
         props,
@@ -114,18 +116,14 @@ export const StatefulMafsGraph = React.forwardRef<
         getUserInput: () => getGradableGraph(state, props.graph),
     }));
 
-    function onChange(next: MafsChange) {
-        props.onChange(mafsStateToInteractiveGraph(next));
-    }
-
     const prevState = useRef<InteractiveGraphState>(state);
 
     useEffect(() => {
         if (prevState.current !== state) {
-            onChange({graph: state});
+            onChange(mafsStateToInteractiveGraph({graph: state}));
         }
         prevState.current = state;
-    }, [props, state]);
+    }, [onChange, state]);
 
     // Destructuring first to keep useEffect from making excess calls
     const [xSnap, ySnap] = props.snapStep;

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -36,7 +36,7 @@ import type {Widget} from "../../renderer";
 import "mafs/core.css";
 import "./mafs-styles.css";
 
-export interface StatefulMafsGraphProps {
+export type StatefulMafsGraphProps = {
     box: [number, number];
     backgroundImage?: InteractiveGraphProps["backgroundImage"];
     graph: InteractiveGraphProps["graph"];
@@ -145,7 +145,7 @@ export const StatefulMafsGraph = React.forwardRef<
     return <MafsGraph {...props} state={state} dispatch={dispatch} />;
 });
 
-export interface MafsGraphProps {
+export type MafsGraphProps = {
     box: [number, number];
     backgroundImage?: InteractiveGraphProps["backgroundImage"];
     lockedFigures?: InteractiveGraphProps["lockedFigures"];

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -131,7 +131,6 @@ interface MafsGraphProps {
     box: [number, number];
     backgroundImage?: InteractiveGraphProps["backgroundImage"];
     lockedFigures?: InteractiveGraphProps["lockedFigures"];
-    range: InteractiveGraphProps["range"]; // FIXME: range is duplicated in state; remove it
     snapStep: InteractiveGraphProps["snapStep"]; // FIXME: snapStep is duplicated in state; remove it
     step: InteractiveGraphProps["step"];
     gridStep: InteractiveGraphProps["gridStep"];
@@ -164,7 +163,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
     }, [dispatch, xSnap, ySnap]);
 
     // Destructuring first to keep useEffect from making excess calls
-    const [[xMinRange, xMaxRange], [yMinRange, yMaxRange]] = props.range;
+    const [[xMinRange, xMaxRange], [yMinRange, yMaxRange]] = state.range;
     useEffect(() => {
         dispatch(
             changeRange([
@@ -212,8 +211,8 @@ export const MafsGraph = (props: MafsGraphProps) => {
                     <Mafs
                         preserveAspectRatio={false}
                         viewBox={{
-                            x: props.range[0],
-                            y: props.range[1],
+                            x: state.range[0],
+                            y: state.range[1],
                             padding: 0,
                         }}
                         pan={false}
@@ -228,7 +227,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                         <Grid
                             tickStep={props.step}
                             gridStep={props.gridStep}
-                            range={props.range}
+                            range={state.range}
                             containerSizeClass={props.containerSizeClass}
                             markings={props.markings}
                         />
@@ -237,7 +236,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                         {props.lockedFigures && (
                             <GraphLockedLayer
                                 lockedFigures={props.lockedFigures}
-                                range={props.range}
+                                range={state.range}
                             />
                         )}
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -100,57 +100,52 @@ function mafsStateToInteractiveGraph(state: MafsChange) {
     };
 }
 
-export const StatefulMafsGraph = React.forwardRef<Partial<Widget>, StatefulMafsGraphProps>(
-    (props, ref) => {
-        const [state, dispatch] = React.useReducer(
-            interactiveGraphReducer,
-            props,
-            initializeGraphState,
-        );
+export const StatefulMafsGraph = React.forwardRef<
+    Partial<Widget>,
+    StatefulMafsGraphProps
+>((props, ref) => {
+    const [state, dispatch] = React.useReducer(
+        interactiveGraphReducer,
+        props,
+        initializeGraphState,
+    );
 
-        useImperativeHandle(ref, () => ({
-            getUserInput: () => getGradableGraph(state, props.graph),
-        }));
+    useImperativeHandle(ref, () => ({
+        getUserInput: () => getGradableGraph(state, props.graph),
+    }));
 
-        function onChange(next: MafsChange) {
-            props.onChange(mafsStateToInteractiveGraph(next));
+    function onChange(next: MafsChange) {
+        props.onChange(mafsStateToInteractiveGraph(next));
+    }
+
+    const prevState = useRef<InteractiveGraphState>(state);
+
+    useEffect(() => {
+        if (prevState.current !== state) {
+            onChange({graph: state});
         }
+        prevState.current = state;
+    }, [props, state]);
 
-        const prevState = useRef<InteractiveGraphState>(state);
+    // Destructuring first to keep useEffect from making excess calls
+    const [xSnap, ySnap] = props.snapStep;
+    useEffect(() => {
+        dispatch(changeSnapStep([xSnap, ySnap]));
+    }, [dispatch, xSnap, ySnap]);
 
-        useEffect(() => {
-            if (prevState.current !== state) {
-                onChange({graph: state});
-            }
-            prevState.current = state;
-        }, [props, state]);
-
-        // Destructuring first to keep useEffect from making excess calls
-        const [xSnap, ySnap] = props.snapStep;
-        useEffect(() => {
-            dispatch(changeSnapStep([xSnap, ySnap]));
-        }, [dispatch, xSnap, ySnap]);
-
-        // Destructuring first to keep useEffect from making excess calls
-        const [[xMinRange, xMaxRange], [yMinRange, yMaxRange]] = props.range;
-        useEffect(() => {
-            dispatch(
-                changeRange([
-                    [xMinRange, xMaxRange],
-                    [yMinRange, yMaxRange],
-                ]),
-            );
-        }, [dispatch, xMinRange, xMaxRange, yMinRange, yMaxRange]);
-
-        return (
-            <MafsGraph
-                {...props}
-                state={state}
-                dispatch={dispatch}
-            />
+    // Destructuring first to keep useEffect from making excess calls
+    const [[xMinRange, xMaxRange], [yMinRange, yMaxRange]] = props.range;
+    useEffect(() => {
+        dispatch(
+            changeRange([
+                [xMinRange, xMaxRange],
+                [yMinRange, yMaxRange],
+            ]),
         );
-    },
-);
+    }, [dispatch, xMinRange, xMaxRange, yMinRange, yMaxRange]);
+
+    return <MafsGraph {...props} state={state} dispatch={dispatch} />;
+});
 
 export interface MafsGraphProps {
     box: [number, number];

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -36,7 +36,7 @@ import type {Widget} from "../../renderer";
 import "mafs/core.css";
 import "./mafs-styles.css";
 
-export interface Props {
+export interface StatefulMafsGraphProps {
     box: [number, number];
     backgroundImage?: InteractiveGraphProps["backgroundImage"];
     graph: InteractiveGraphProps["graph"];
@@ -100,7 +100,7 @@ function mafsStateToInteractiveGraph(state: MafsChange) {
     };
 }
 
-export const StatefulMafsGraph = React.forwardRef<Partial<Widget>, Props>(
+export const StatefulMafsGraph = React.forwardRef<Partial<Widget>, StatefulMafsGraphProps>(
     (props, ref) => {
         const [state, dispatch] = React.useReducer(
             interactiveGraphReducer,
@@ -127,7 +127,7 @@ export const StatefulMafsGraph = React.forwardRef<Partial<Widget>, Props>(
     },
 );
 
-interface MafsGraphProps {
+export interface MafsGraphProps {
     box: [number, number];
     backgroundImage?: InteractiveGraphProps["backgroundImage"];
     lockedFigures?: InteractiveGraphProps["lockedFigures"];

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
@@ -1,5 +1,4 @@
-import type {Props as MafsGraphProps} from "../mafs-graph";
-import type {vec} from "mafs";
+import type {Interval, vec} from "mafs";
 
 export type InteractiveGraphAction =
     | MoveControlPoint
@@ -98,10 +97,10 @@ export function moveRadiusPoint(destination: vec.Vector2): MoveRadiusPoint {
 export const CHANGE_SNAP_STEP = "change-snap-step";
 export interface ChangeSnapStep {
     type: typeof CHANGE_SNAP_STEP;
-    snapStep: MafsGraphProps["snapStep"];
+    snapStep: [x: number, y: number];
 }
 export function changeSnapStep(
-    snapStep: MafsGraphProps["snapStep"],
+    snapStep: [x: number, y: number],
 ): ChangeSnapStep {
     return {
         type: CHANGE_SNAP_STEP,
@@ -112,9 +111,9 @@ export function changeSnapStep(
 export const CHANGE_RANGE = "change-range";
 export interface ChangeRange {
     type: typeof CHANGE_RANGE;
-    range: MafsGraphProps["range"];
+    range: [x: Interval, y: Interval];
 }
-export function changeRange(range: MafsGraphProps["range"]): ChangeRange {
+export function changeRange(range: [x: Interval, y: Interval]): ChangeRange {
     return {
         type: CHANGE_RANGE,
         range,

--- a/packages/perseus/src/widgets/interactive-graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/types.ts
@@ -37,6 +37,7 @@ export interface InteractiveGraphStateCommon {
     range: [xRange: Interval, yRange: Interval];
     // snapStep = [xStep, yStep] in Cartesian units
     snapStep: vec.Vector2;
+    // TODO(benchristel): markings doesn't seem to be used. Remove it?
     markings: InteractiveGraphProps["markings"];
 }
 


### PR DESCRIPTION
The `range` and `snapStep` are available on the `state`. When pairing, Tamara
and I saw some surprising test failures that were caused by this duplication.
Our props and state got out of sync, and since some parts of the graph code
were getting snapStep from props, and other parts were getting it from state,
the resulting behavior was inconsistent.

This commit removes the duplication, ensuring that `range` and `snapStep` are
only passed to each component once.

Issue: none

## Test plan:

- `yarn storybook`
- Visit http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph-editor--with-mafs
- Change the range of the graph and observe that the line segment is
  constrained to the new range when you drag it around.