### PR TITLE
Remove markings from interactive graph state

### DIFF
--- a/.changeset/angry-islands-cough.md
+++ b/.changeset/angry-islands-cough.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Internal: remove the `markings` property from the interactive graph state

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -30,7 +30,6 @@ function getBaseMafsGraphProps(): MafsGraphProps {
             type: "segment",
             hasBeenInteractedWith: false,
             coords: [],
-            markings: "none",
             snapStep: [1, 1],
             range: [
                 [-10, 10],
@@ -145,7 +144,6 @@ describe("MafsGraph", () => {
         const mockDispatch = jest.fn();
         const state: InteractiveGraphState = {
             type: "segment",
-            markings: "graph",
             hasBeenInteractedWith: true,
             range: [
                 [-10, 10],
@@ -188,7 +186,6 @@ describe("MafsGraph", () => {
         const mockDispatch = jest.fn();
         const state: InteractiveGraphState = {
             type: "segment",
-            markings: "graph",
             hasBeenInteractedWith: true,
             range: [
                 [-10, 10],
@@ -227,7 +224,6 @@ describe("MafsGraph", () => {
         const mockDispatch = jest.fn();
         const state: InteractiveGraphState = {
             type: "segment",
-            markings: "none",
             hasBeenInteractedWith: true,
             range: [
                 [-10, 10],
@@ -269,7 +265,6 @@ describe("MafsGraph", () => {
         const mockDispatch = jest.fn();
         const state: InteractiveGraphState = {
             type: "point",
-            markings: "graph",
             hasBeenInteractedWith: true,
             range: [
                 [-10, 10],
@@ -316,7 +311,6 @@ describe("MafsGraph", () => {
     it("MovableLine moves down based on down keystroke ", async () => {
         const initialState: InteractiveGraphState = {
             type: "segment",
-            markings: "graph",
             hasBeenInteractedWith: true,
             range: [
                 [-10, 10],

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -362,7 +362,6 @@ describe("MafsGraph", () => {
     it("MovableLine moves up based on up keystroke ", async () => {
         const initialState: InteractiveGraphState = {
             type: "segment",
-            markings: "graph",
             hasBeenInteractedWith: true,
             range: [
                 [-10, 10],
@@ -414,7 +413,6 @@ describe("MafsGraph", () => {
     it("MovableLine moves right based on right keystroke ", async () => {
         const initialState: InteractiveGraphState = {
             type: "segment",
-            markings: "graph",
             hasBeenInteractedWith: true,
             range: [
                 [-10, 10],
@@ -466,7 +464,6 @@ describe("MafsGraph", () => {
     it("MovableLine moves left based on left keystroke ", async () => {
         const initialState: InteractiveGraphState = {
             type: "segment",
-            markings: "graph",
             hasBeenInteractedWith: true,
             range: [
                 [-10, 10],

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -17,7 +17,6 @@ import type {CircleGraphState, InteractiveGraphState} from "../types";
 const baseSegmentGraphState: InteractiveGraphState = {
     hasBeenInteractedWith: false,
     type: "segment",
-    markings: "graph",
     range: [
         [-10, 10],
         [-10, 10],
@@ -29,7 +28,6 @@ const baseSegmentGraphState: InteractiveGraphState = {
 const basePointGraphState: InteractiveGraphState = {
     hasBeenInteractedWith: false,
     type: "point",
-    markings: "graph",
     range: [
         [-10, 10],
         [-10, 10],
@@ -41,7 +39,6 @@ const basePointGraphState: InteractiveGraphState = {
 const baseCircleGraphState: InteractiveGraphState = {
     hasBeenInteractedWith: false,
     type: "circle",
-    markings: "graph",
     range: [
         [-10, 10],
         [-10, 10],

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
@@ -35,7 +35,6 @@ describe("initializeGraphState for segment graphs", () => {
             step: [1, 1],
             snapStep: [2, 3],
             graph: {type: "segment"},
-            markings: "graph",
         });
         expect(state.range).toEqual([
             [0, 10],
@@ -214,7 +213,6 @@ describe("getGradableGraph", () => {
                 [-10, 10],
             ],
             snapStep: [1, 1],
-            markings: "graph",
         };
         const initialGraph: PerseusGraphType = {
             type: "segment",

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -25,18 +25,16 @@ export type InitializeGraphStateParam = {
     step: InteractiveGraphProps["step"];
     snapStep: InteractiveGraphProps["snapStep"];
     graph: InteractiveGraphProps["graph"];
-    markings: InteractiveGraphProps["markings"];
 };
 
 export function initializeGraphState(
     params: InitializeGraphStateParam,
 ): InteractiveGraphState {
-    const {graph, step, snapStep, range, markings} = params;
+    const {graph, step, snapStep, range} = params;
     const shared = {
         hasBeenInteractedWith: false,
         range,
         snapStep,
-        markings,
     };
     switch (graph.type) {
         case "segment":

--- a/packages/perseus/src/widgets/interactive-graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/types.ts
@@ -37,8 +37,6 @@ export interface InteractiveGraphStateCommon {
     range: [xRange: Interval, yRange: Interval];
     // snapStep = [xStep, yStep] in Cartesian units
     snapStep: vec.Vector2;
-    // TODO(benchristel): markings doesn't seem to be used. Remove it?
-    markings: InteractiveGraphProps["markings"];
 }
 
 export interface SegmentGraphState extends InteractiveGraphStateCommon {


### PR DESCRIPTION
It seems to be unused. `markings` is still available via the MafsGraph props.
It doesn't need to be part of the state because nothing you can do to the graph
can change it, and it's not needed to compute state updates.

Issue: none

## Test plan:

`yarn typecheck`