### PR TITLE
Split out DefiningPointSettings from LockedPointSettings

### DIFF
--- a/.changeset/nice-bears-tickle.md
+++ b/.changeset/nice-bears-tickle.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Refactor: Split LockedPointSettings out into LockedPointSettings (for a regular standalone locked point) and DefiningPointSettings (for points that define other locked figures such as lines)

--- a/packages/perseus-editor/src/components/__stories__/color-select.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/color-select.stories.tsx
@@ -35,7 +35,6 @@ export const Controlled = {
 
         return (
             <ColorSelect
-                id="color-select"
                 selectedValue={selectedValue}
                 onChange={handleColorChange}
             />

--- a/packages/perseus-editor/src/components/__stories__/locked-point-settings.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/locked-point-settings.stories.tsx
@@ -50,47 +50,6 @@ Controlled.parameters = {
     },
 };
 
-/**
- * In some cases, the locked point may be shown or hidden from the graph,
- * such as when the point is used to define a locked line.
- *
- * Use `onExtrasToggle` and `extrasToggled` to update the visibility of the locked point.
- * When `onextrasToggled` is passed in, a switch will be rendered to allow
- * toggling the point, which will then show/hide the relevant properties
- * for the locked point.
- */
-export const ExtrasToggleable: StoryComponentType = {
-    render: function Render() {
-        const [extrasToggled, setExtrasToggled] = React.useState(true);
-        const [props, setProps] = React.useState(
-            getDefaultFigureForType("point"),
-        );
-
-        const handlePropsUpdate = (newProps) => {
-            setProps({
-                ...props,
-                ...newProps,
-            });
-        };
-
-        return (
-            <LockedPointSettings
-                {...props}
-                onChangeProps={handlePropsUpdate}
-                extrasToggled={extrasToggled}
-                onToggle={setExtrasToggled}
-            />
-        );
-    },
-};
-
-ExtrasToggleable.parameters = {
-    chromatic: {
-        // Disabling because this doesn't test anything visual, just behavior.
-        disableSnapshot: true,
-    },
-};
-
 // Fully expanded view of the locked point settings to allow snapshot testing.
 export const Expanded: StoryComponentType = {
     render: function Render() {

--- a/packages/perseus-editor/src/components/__tests__/locked-line-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-line-settings.test.tsx
@@ -11,7 +11,7 @@ const defaultProps = {
     onRemove: () => {},
 };
 
-describe("DefiningPointSettings", () => {
+describe("LockedLineSettings", () => {
     test("renders", () => {
         // Arrange
 
@@ -107,26 +107,7 @@ describe("DefiningPointSettings", () => {
         expect(onToggle).toHaveBeenCalled();
     });
 
-    test("Should show toggle switch if onExtrasToggle is passed in", () => {
-        // Arrange
-
-        // Act
-        render(
-            <LockedLineSettings
-                {...defaultProps}
-                onChangeProps={() => {}}
-                expanded={true}
-            />,
-            {wrapper: RenderStateRoot},
-        );
-
-        const toggleSwitches = screen.getAllByLabelText("show point on graph");
-
-        // Assert
-        expect(toggleSwitches).toHaveLength(2);
-    });
-
-    test("Toggle switch should match extrasToggled prop when true", () => {
+    test("Toggle switch should match showPoint prop when true", () => {
         // Arrange
 
         // Act
@@ -145,7 +126,7 @@ describe("DefiningPointSettings", () => {
         expect(toggleSwitch).toBeChecked();
     });
 
-    test("Toggle switch should match extrasToggled prop when false", () => {
+    test("Toggle switch should match showPoint prop when false", () => {
         // Arrange
 
         // Act

--- a/packages/perseus-editor/src/components/__tests__/locked-line-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-line-settings.test.tsx
@@ -11,7 +11,7 @@ const defaultProps = {
     onRemove: () => {},
 };
 
-describe("LockedPointSettings", () => {
+describe("DefiningPointSettings", () => {
     test("renders", () => {
         // Arrange
 
@@ -105,5 +105,62 @@ describe("LockedPointSettings", () => {
 
         // Assert
         expect(onToggle).toHaveBeenCalled();
+    });
+
+    test("Should show toggle switch if onExtrasToggle is passed in", () => {
+        // Arrange
+
+        // Act
+        render(
+            <LockedLineSettings
+                {...defaultProps}
+                onChangeProps={() => {}}
+                expanded={true}
+            />,
+            {wrapper: RenderStateRoot},
+        );
+
+        const toggleSwitches = screen.getAllByLabelText("show point on graph");
+
+        // Assert
+        expect(toggleSwitches).toHaveLength(2);
+    });
+
+    test("Toggle switch should match extrasToggled prop when true", () => {
+        // Arrange
+
+        // Act
+        render(
+            <LockedLineSettings
+                {...defaultProps}
+                showPoint1={true}
+                onChangeProps={() => {}}
+            />,
+            {wrapper: RenderStateRoot},
+        );
+
+        const toggleSwitch = screen.getAllByLabelText("show point on graph")[0];
+
+        // Assert
+        expect(toggleSwitch).toBeChecked();
+    });
+
+    test("Toggle switch should match extrasToggled prop when false", () => {
+        // Arrange
+
+        // Act
+        render(
+            <LockedLineSettings
+                {...defaultProps}
+                showPoint1={false}
+                onChangeProps={() => {}}
+            />,
+            {wrapper: RenderStateRoot},
+        );
+
+        const toggleSwitch = screen.getAllByLabelText("show point on graph")[0];
+
+        // Assert
+        expect(toggleSwitch).not.toBeChecked();
     });
 });

--- a/packages/perseus-editor/src/components/__tests__/locked-point-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-point-settings.test.tsx
@@ -38,59 +38,6 @@ describe("LockedPointSettings", () => {
         expect(colorSwatch).toBeInTheDocument();
     });
 
-    test("Should not show the color in summary if extrasToggled off", () => {
-        // Arrange
-
-        // Act
-        render(
-            <LockedPointSettings {...defaultProps} onChangeProps={() => {}} />,
-            {wrapper: RenderStateRoot},
-        );
-
-        const titleText = screen.getByText("Point (0, 0)");
-        const colorSwatch = screen.queryByLabelText(
-            "Point color: blue, filled",
-        );
-
-        // Assert
-        expect(titleText).toBeInTheDocument();
-        expect(colorSwatch).not.toBeInTheDocument();
-    });
-
-    test("Should show extra fields if extrasToggled on", () => {
-        // Arrange
-
-        // Act
-        render(
-            <LockedPointSettings {...defaultProps} onChangeProps={() => {}} />,
-            {wrapper: RenderStateRoot},
-        );
-
-        const colorSelect = screen.getByLabelText("color");
-        const openCheckbox = screen.getByLabelText("open point");
-
-        // Assert
-        expect(colorSelect).toBeInTheDocument();
-        expect(openCheckbox).toBeInTheDocument();
-    });
-
-    test("Should not show extra fields if extrasToggled off", () => {
-        // Arrange
-
-        // Act
-        render(
-            <LockedPointSettings {...defaultProps} onChangeProps={() => {}} />,
-            {wrapper: RenderStateRoot},
-        );
-
-        const colorSelect = screen.queryByLabelText("Color");
-        const openCheckbox = screen.queryByLabelText("Open point");
-
-        // Assert
-        expect(colorSelect).not.toBeInTheDocument();
-        expect(openCheckbox).not.toBeInTheDocument();
-    });
-
     test("Summary should reflect the coordinates", () => {
         // Arrange
 

--- a/packages/perseus-editor/src/components/__tests__/locked-point-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-point-settings.test.tsx
@@ -8,7 +8,11 @@ import {getDefaultFigureForType} from "../util";
 
 import type {UserEvent} from "@testing-library/user-event";
 
-const defaultProps = getDefaultFigureForType("point");
+const defaultProps = {
+    ...getDefaultFigureForType("point"),
+    onRemove: () => {},
+    onChangeProps: () => {},
+};
 
 describe("LockedPointSettings", () => {
     let userEvent: UserEvent;
@@ -39,12 +43,7 @@ describe("LockedPointSettings", () => {
 
         // Act
         render(
-            <LockedPointSettings
-                {...defaultProps}
-                onChangeProps={() => {}}
-                extrasToggled={false}
-                onExtrasToggle={() => {}}
-            />,
+            <LockedPointSettings {...defaultProps} onChangeProps={() => {}} />,
             {wrapper: RenderStateRoot},
         );
 
@@ -58,76 +57,12 @@ describe("LockedPointSettings", () => {
         expect(colorSwatch).not.toBeInTheDocument();
     });
 
-    test("Should show toggle switch if onExtrasToggle is passed in", () => {
-        // Arrange
-
-        // Act
-        render(
-            <LockedPointSettings
-                {...defaultProps}
-                onChangeProps={() => {}}
-                onExtrasToggle={() => {}}
-            />,
-            {wrapper: RenderStateRoot},
-        );
-
-        const toggleSwitch = screen.getByLabelText("show point on graph");
-
-        // Assert
-        expect(toggleSwitch).toBeInTheDocument();
-    });
-
-    test("Toggle switch should match extrasToggled prop when true", () => {
-        // Arrange
-
-        // Act
-        render(
-            <LockedPointSettings
-                {...defaultProps}
-                onChangeProps={() => {}}
-                extrasToggled={true}
-                onExtrasToggle={() => {}}
-            />,
-            {wrapper: RenderStateRoot},
-        );
-
-        const toggleSwitch = screen.getByLabelText("show point on graph");
-
-        // Assert
-        expect(toggleSwitch).toBeChecked();
-    });
-
-    test("Toggle switch should match extrasToggled prop when false", () => {
-        // Arrange
-
-        // Act
-        render(
-            <LockedPointSettings
-                {...defaultProps}
-                onChangeProps={() => {}}
-                extrasToggled={false}
-                onExtrasToggle={() => {}}
-            />,
-            {wrapper: RenderStateRoot},
-        );
-
-        const toggleSwitch = screen.getByLabelText("show point on graph");
-
-        // Assert
-        expect(toggleSwitch).not.toBeChecked();
-    });
-
     test("Should show extra fields if extrasToggled on", () => {
         // Arrange
 
         // Act
         render(
-            <LockedPointSettings
-                {...defaultProps}
-                onChangeProps={() => {}}
-                extrasToggled={true}
-                onExtrasToggle={() => {}}
-            />,
+            <LockedPointSettings {...defaultProps} onChangeProps={() => {}} />,
             {wrapper: RenderStateRoot},
         );
 
@@ -144,12 +79,7 @@ describe("LockedPointSettings", () => {
 
         // Act
         render(
-            <LockedPointSettings
-                {...defaultProps}
-                onChangeProps={() => {}}
-                extrasToggled={false}
-                onExtrasToggle={() => {}}
-            />,
+            <LockedPointSettings {...defaultProps} onChangeProps={() => {}} />,
             {wrapper: RenderStateRoot},
         );
 

--- a/packages/perseus-editor/src/components/color-select.tsx
+++ b/packages/perseus-editor/src/components/color-select.tsx
@@ -1,5 +1,5 @@
 import {lockedFigureColors} from "@khanacademy/perseus";
-import {View} from "@khanacademy/wonder-blocks-core";
+import {View, useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
@@ -14,15 +14,16 @@ import type {StyleType} from "@khanacademy/wonder-blocks-core";
 const possibleColors = Object.keys(lockedFigureColors) as LockedFigureColor[];
 
 type Props = {
-    // Required ID so that the label can be associated with the select.
-    id: string;
     selectedValue: LockedFigureColor;
     style?: StyleType;
     onChange: (newValue: string) => void;
 };
 
 const ColorSelect = (props: Props) => {
-    const {id, selectedValue, style, onChange} = props;
+    const {selectedValue, style, onChange} = props;
+
+    const ids = useUniqueIdWithMock();
+    const id = ids.get("color-select");
 
     return (
         <View style={[styles.row, style]}>

--- a/packages/perseus-editor/src/components/coordinate-pair-input.tsx
+++ b/packages/perseus-editor/src/components/coordinate-pair-input.tsx
@@ -1,0 +1,94 @@
+import {View, useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
+import {TextField} from "@khanacademy/wonder-blocks-form";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
+import {StyleSheet} from "aphrodite";
+import * as React from "react";
+
+import type {LockedPointType} from "@khanacademy/perseus";
+
+type Props = {
+    coord: [number, number];
+    onChangeProps: (newProps: Partial<LockedPointType>) => void;
+};
+
+const CoordinatePairInput = (props: Props) => {
+    const {coord, onChangeProps} = props;
+
+    // Keep track of the coordinates via state as the user is editing them,
+    // before they are updated in the props as a valid number.
+    const [coordState, setCoordState] = React.useState([
+        // Using strings to make it easier to work with the text fields.
+        coord[0].toString(),
+        coord[1].toString(),
+    ]);
+
+    // Generate unique IDs so that the programmatic labels can be associated
+    // with their respective text fields.
+    const ids = useUniqueIdWithMock();
+    const xCoordId = ids.get("x-coord");
+    const yCoordId = ids.get("y-coord");
+
+    function handleCoordChange(newValue, coordIndex) {
+        // Update the local state (update the input field value).
+        const newCoordState = [...coordState];
+        newCoordState[coordIndex] = newValue;
+        setCoordState(newCoordState);
+
+        // If the new value is not a number, don't update the props.
+        // If it's empty, keep the props the same value instead of setting to 0.
+        if (isNaN(+newValue) || newValue === "") {
+            return;
+        }
+
+        // Update the props (update the graph).
+        const newCoords = [...coord] satisfies [number, number];
+        newCoords[coordIndex] = +newValue;
+        onChangeProps({coord: newCoords});
+    }
+
+    return (
+        <View style={[styles.row, styles.spaceUnder]}>
+            <LabelMedium htmlFor={xCoordId} style={styles.label} tag="label">
+                x coord
+            </LabelMedium>
+            <TextField
+                id={xCoordId}
+                type="number"
+                value={coordState[0]}
+                onChange={(newValue) => handleCoordChange(newValue, 0)}
+                style={styles.textField}
+            />
+            <Strut size={spacing.medium_16} />
+            <LabelMedium htmlFor={yCoordId} style={styles.label} tag="label">
+                y coord
+            </LabelMedium>
+            <TextField
+                id={yCoordId}
+                type="number"
+                value={coordState[1]}
+                onChange={(newValue) => handleCoordChange(newValue, 1)}
+                style={styles.textField}
+            />
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    row: {
+        flexDirection: "row",
+        alignItems: "center",
+    },
+    spaceUnder: {
+        marginBottom: spacing.xSmall_8,
+    },
+    label: {
+        marginInlineEnd: spacing.xxSmall_6,
+    },
+    textField: {
+        width: spacing.xxxLarge_64,
+    },
+});
+
+export default CoordinatePairInput;

--- a/packages/perseus-editor/src/components/defining-point-settings.tsx
+++ b/packages/perseus-editor/src/components/defining-point-settings.tsx
@@ -30,11 +30,11 @@ export type Props = AccordionProps &
         /**
          * Whether the extra point settings are toggled open.
          */
-        extrasToggled?: boolean;
+        showPoint?: boolean;
         /**
          * Called when the extra settings toggle switch is changed.
          */
-        onExtrasToggle?: (newValue) => void;
+        onTogglePoint?: (newValue) => void;
         /**
          * Called when the props (coords, color, etc.) are updated.
          */
@@ -47,9 +47,9 @@ const DefiningPointSettings = (props: Props) => {
         color: pointColor,
         filled = true,
         label,
-        extrasToggled = "false",
+        showPoint = "false",
         onChangeProps,
-        onExtrasToggle,
+        onTogglePoint,
     } = props;
 
     function handleColorChange(newValue) {
@@ -67,7 +67,7 @@ const DefiningPointSettings = (props: Props) => {
                 <View style={styles.row}>
                     <LabelLarge>{`${label || "Point"} (${coord[0]}, ${coord[1]})`}</LabelLarge>
                     <Strut size={spacing.xSmall_8} />
-                    {extrasToggled && (
+                    {showPoint && (
                         <ColorSwatch color={pointColor} filled={filled} />
                     )}
                 </View>
@@ -77,17 +77,17 @@ const DefiningPointSettings = (props: Props) => {
             <CoordinatePairInput coord={coord} onChangeProps={onChangeProps} />
 
             {/* Toggle switch */}
-            {onExtrasToggle && (
+            {onTogglePoint && (
                 <LabeledSwitch
                     label="show point on graph"
-                    checked={!!extrasToggled}
-                    style={extrasToggled && styles.spaceUnder}
-                    onChange={onExtrasToggle}
+                    checked={!!showPoint}
+                    style={showPoint && styles.spaceUnder}
+                    onChange={onTogglePoint}
                 />
             )}
 
             {/* Toggleable section */}
-            {extrasToggled && (
+            {showPoint && (
                 <>
                     <ColorSelect
                         selectedValue={pointColor}

--- a/packages/perseus-editor/src/components/defining-point-settings.tsx
+++ b/packages/perseus-editor/src/components/defining-point-settings.tsx
@@ -1,0 +1,131 @@
+/**
+ * DefiningPointSettings is a component that allows the user to edit the
+ * settings of a point that defines a locked figure (ex. line) on the graph.
+ *
+ * Used in the interactive graph editor's locked figures section.
+ */
+import {View} from "@khanacademy/wonder-blocks-core";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import {spacing, color as wbColor} from "@khanacademy/wonder-blocks-tokens";
+import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
+import {StyleSheet} from "aphrodite";
+import * as React from "react";
+
+import ColorSelect from "./color-select";
+import ColorSwatch from "./color-swatch";
+import CoordinatePairInput from "./coordinate-pair-input";
+import LabeledSwitch from "./labeled-switch";
+import LockedFigureSettingsAccordion from "./locked-figure-settings-accordion";
+
+import type {AccordionProps} from "./locked-figure-settings";
+import type {LockedPointType} from "@khanacademy/perseus";
+
+export type Props = AccordionProps &
+    LockedPointType & {
+        /**
+         * Optional label for the point to display in the header summary.
+         * Defaults to "Point".
+         */
+        label: string;
+        /**
+         * Whether the extra point settings are toggled open.
+         */
+        extrasToggled?: boolean;
+        /**
+         * Called when the extra settings toggle switch is changed.
+         */
+        onExtrasToggle?: (newValue) => void;
+        /**
+         * Called when the props (coords, color, etc.) are updated.
+         */
+        onChangeProps: (newProps: Partial<LockedPointType>) => void;
+    };
+
+const DefiningPointSettings = (props: Props) => {
+    const {
+        coord,
+        color: pointColor,
+        filled = true,
+        label,
+        extrasToggled = "false",
+        onChangeProps,
+        onExtrasToggle,
+    } = props;
+
+    function handleColorChange(newValue) {
+        onChangeProps({color: newValue});
+    }
+
+    return (
+        <LockedFigureSettingsAccordion
+            expanded={props.expanded}
+            onToggle={props.onToggle}
+            containerStyle={styles.container}
+            panelStyle={styles.accordionPanel}
+            header={
+                // Summary: Point, coords, color (filled/open)
+                <View style={styles.row}>
+                    <LabelLarge>{`${label || "Point"} (${coord[0]}, ${coord[1]})`}</LabelLarge>
+                    <Strut size={spacing.xSmall_8} />
+                    {extrasToggled && (
+                        <ColorSwatch color={pointColor} filled={filled} />
+                    )}
+                </View>
+            }
+        >
+            {/* Coordinates */}
+            <CoordinatePairInput coord={coord} onChangeProps={onChangeProps} />
+
+            {/* Toggle switch */}
+            {onExtrasToggle && (
+                <LabeledSwitch
+                    label="show point on graph"
+                    checked={!!extrasToggled}
+                    style={extrasToggled && styles.spaceUnder}
+                    onChange={onExtrasToggle}
+                />
+            )}
+
+            {/* Toggleable section */}
+            {extrasToggled && (
+                <>
+                    <ColorSelect
+                        selectedValue={pointColor}
+                        onChange={handleColorChange}
+                        style={styles.spaceUnder}
+                    />
+                    <LabeledSwitch
+                        label="open point"
+                        checked={!filled}
+                        onChange={(newValue) => {
+                            onChangeProps({filled: !newValue});
+                        }}
+                    />
+                </>
+            )}
+        </LockedFigureSettingsAccordion>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        marginTop: spacing.xSmall_8,
+        marginBottom: 0,
+        marginLeft: -spacing.xxxSmall_4,
+        marginRight: -spacing.xxxSmall_4,
+        backgroundColor: wbColor.white,
+    },
+    accordionPanel: {
+        // Need more space since we don't have the actions' margins.
+        paddingBottom: spacing.medium_16,
+    },
+    row: {
+        flexDirection: "row",
+        alignItems: "center",
+    },
+    spaceUnder: {
+        marginBottom: spacing.xSmall_8,
+    },
+});
+
+export default DefiningPointSettings;

--- a/packages/perseus-editor/src/components/locked-line-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-line-settings.tsx
@@ -164,18 +164,18 @@ const LockedLineSettings = (props: Props) => {
             {/* Defining points settings */}
             <DefiningPointSettings
                 label="Point 1"
-                extrasToggled={showPoint1}
+                showPoint={showPoint1}
                 {...point1}
-                onExtrasToggle={(newValue) =>
+                onTogglePoint={(newValue) =>
                     onChangeProps({showPoint1: newValue})
                 }
                 onChangeProps={(newProps) => handleChangePoint(newProps, 0)}
             />
             <DefiningPointSettings
                 label="Point 2"
-                extrasToggled={showPoint2}
+                showPoint={showPoint2}
                 {...point2}
-                onExtrasToggle={(newValue) =>
+                onTogglePoint={(newValue) =>
                     onChangeProps({showPoint2: newValue})
                 }
                 onChangeProps={(newProps) => handleChangePoint(newProps, 1)}

--- a/packages/perseus-editor/src/components/locked-line-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-line-settings.tsx
@@ -7,16 +7,16 @@
 import {View, useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {color as wbColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium, LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 import ColorSelect from "./color-select";
+import DefiningPointSettings from "./defining-point-settings";
 import LineSwatch from "./line-swatch";
 import LockedFigureSettingsAccordion from "./locked-figure-settings-accordion";
 import LockedFigureSettingsActions from "./locked-figure-settings-actions";
-import LockedPointSettings from "./locked-point-settings";
 
 import type {AccordionProps} from "./locked-figure-settings";
 import type {
@@ -55,7 +55,6 @@ const LockedLineSettings = (props: Props) => {
     // with their respective text fields.
     const ids = useUniqueIdWithMock();
     const kindSelectId = ids.get("line-kind-select");
-    const colorSelectId = ids.get("line-color-select");
     const styleSelectId = ids.get("line-style-select");
 
     const capitalizeKind = kind.charAt(0).toUpperCase() + kind.slice(1);
@@ -132,7 +131,6 @@ const LockedLineSettings = (props: Props) => {
             <View style={[styles.row, styles.spaceUnder]}>
                 {/* Line color settings */}
                 <ColorSelect
-                    id={colorSelectId}
                     selectedValue={lineColor}
                     onChange={handleColorChange}
                 />
@@ -164,7 +162,7 @@ const LockedLineSettings = (props: Props) => {
             </View>
 
             {/* Defining points settings */}
-            <LockedPointSettings
+            <DefiningPointSettings
                 label="Point 1"
                 extrasToggled={showPoint1}
                 {...point1}
@@ -172,9 +170,8 @@ const LockedLineSettings = (props: Props) => {
                     onChangeProps({showPoint1: newValue})
                 }
                 onChangeProps={(newProps) => handleChangePoint(newProps, 0)}
-                style={styles.lockedPointSettingsContainer}
             />
-            <LockedPointSettings
+            <DefiningPointSettings
                 label="Point 2"
                 extrasToggled={showPoint2}
                 {...point2}
@@ -182,7 +179,6 @@ const LockedLineSettings = (props: Props) => {
                     onChangeProps({showPoint2: newValue})
                 }
                 onChangeProps={(newProps) => handleChangePoint(newProps, 1)}
-                style={styles.lockedPointSettingsContainer}
             />
 
             {/* Actions */}
@@ -197,13 +193,6 @@ const LockedLineSettings = (props: Props) => {
 };
 
 const styles = StyleSheet.create({
-    lockedPointSettingsContainer: {
-        marginTop: spacing.xSmall_8,
-        marginBottom: 0,
-        marginLeft: -spacing.xxxSmall_4,
-        marginRight: -spacing.xxxSmall_4,
-        backgroundColor: wbColor.white,
-    },
     row: {
         flexDirection: "row",
         alignItems: "center",

--- a/packages/perseus-editor/src/components/locked-point-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-point-settings.tsx
@@ -4,47 +4,29 @@
  *
  * Used in the interactive graph editor's locked figures section.
  */
-import {View, useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
-import {TextField} from "@khanacademy/wonder-blocks-form";
+import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
-import {LabelMedium, LabelLarge} from "@khanacademy/wonder-blocks-typography";
+import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 import ColorSelect from "./color-select";
 import ColorSwatch from "./color-swatch";
+import CoordinatePairInput from "./coordinate-pair-input";
 import LabeledSwitch from "./labeled-switch";
 import LockedFigureSettingsAccordion from "./locked-figure-settings-accordion";
 import LockedFigureSettingsActions from "./locked-figure-settings-actions";
 
 import type {AccordionProps} from "./locked-figure-settings";
 import type {LockedPointType} from "@khanacademy/perseus";
-import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 export type Props = AccordionProps &
     LockedPointType & {
         /**
-         * Optional label for the point to display in the header summary.
-         * Defaults to "Point".
-         */
-        label?: string;
-        /**
-         * Whether the extra point settings are toggled open.
-         */
-        extrasToggled?: boolean;
-        /**
-         * Optional style to apply to the container of the settings.
-         */
-        style?: StyleType;
-        /**
          * Called when the delete button is pressed.
          */
-        onRemove?: () => void;
-        /**
-         * Called when the extra settings toggle switch is changed.
-         */
-        onExtrasToggle?: (newValue) => void;
+        onRemove: () => void;
         /**
          * Called when the props (coords, color, etc.) are updated.
          */
@@ -56,46 +38,9 @@ const LockedPointSettings = (props: Props) => {
         coord,
         color: pointColor,
         filled = true,
-        label,
-        extrasToggled = "true",
-        style,
         onChangeProps,
-        onExtrasToggle,
         onRemove,
     } = props;
-
-    // Keep track of the coordinates via state as the user is editing them,
-    // before they are updated in the props as a valid number.
-    const [coordState, setCoordState] = React.useState([
-        // Using strings to make it easier to work with the text fields.
-        coord[0].toString(),
-        coord[1].toString(),
-    ]);
-
-    // Generate unique IDs so that the programmatic labels can be associated
-    // with their respective text fields.
-    const ids = useUniqueIdWithMock();
-    const xCoordId = ids.get("x-coord");
-    const yCoordId = ids.get("y-coord");
-    const colorSelectId = ids.get("point-color-select");
-
-    function handleCoordChange(newValue, coordIndex) {
-        // Update the local state (update the input field value).
-        const newCoordState = [...coordState];
-        newCoordState[coordIndex] = newValue;
-        setCoordState(newCoordState);
-
-        // If the new value is not a number, don't update the props.
-        // If it's empty, keep the props the same value instead of setting to 0.
-        if (isNaN(+newValue) || newValue === "") {
-            return;
-        }
-
-        // Update the props (update the graph).
-        const newCoords = [...coord] satisfies [number, number];
-        newCoords[coordIndex] = +newValue;
-        onChangeProps({coord: newCoords});
-    }
 
     function handleColorChange(newValue) {
         onChangeProps({color: newValue});
@@ -105,109 +50,46 @@ const LockedPointSettings = (props: Props) => {
         <LockedFigureSettingsAccordion
             expanded={props.expanded}
             onToggle={props.onToggle}
-            containerStyle={style}
-            panelStyle={!onRemove && styles.accordionPanelWithoutActions}
             header={
                 // Summary: Point, coords, color (filled/open)
                 <View style={styles.row}>
-                    <LabelLarge>{`${label || "Point"} (${coord[0]}, ${coord[1]})`}</LabelLarge>
+                    <LabelLarge>{`Point (${coord[0]}, ${coord[1]})`}</LabelLarge>
                     <Strut size={spacing.xSmall_8} />
-                    {extrasToggled && (
-                        <ColorSwatch color={pointColor} filled={filled} />
-                    )}
+                    <ColorSwatch color={pointColor} filled={filled} />
                 </View>
             }
         >
-            {/* Coordinates */}
-            <View style={[styles.row, styles.spaceUnder]}>
-                <LabelMedium
-                    htmlFor={xCoordId}
-                    style={styles.label}
-                    tag="label"
-                >
-                    x coord
-                </LabelMedium>
-                <TextField
-                    id={xCoordId}
-                    type="number"
-                    value={coordState[0]}
-                    onChange={(newValue) => handleCoordChange(newValue, 0)}
-                    style={styles.textField}
-                />
-                <Strut size={spacing.medium_16} />
-                <LabelMedium
-                    htmlFor={yCoordId}
-                    style={styles.label}
-                    tag="label"
-                >
-                    y coord
-                </LabelMedium>
-                <TextField
-                    id={yCoordId}
-                    type="number"
-                    value={coordState[1]}
-                    onChange={(newValue) => handleCoordChange(newValue, 1)}
-                    style={styles.textField}
-                />
-            </View>
+            <CoordinatePairInput coord={coord} onChangeProps={onChangeProps} />
 
-            {/* Toggle switch */}
-            {onExtrasToggle && (
-                <LabeledSwitch
-                    label="show point on graph"
-                    checked={!!extrasToggled}
-                    style={extrasToggled && styles.spaceUnder}
-                    onChange={onExtrasToggle}
-                />
-            )}
+            <ColorSelect
+                selectedValue={pointColor}
+                onChange={handleColorChange}
+                style={styles.spaceUnder}
+            />
 
-            {/* Toggleable section */}
-            {extrasToggled && (
-                <>
-                    <ColorSelect
-                        id={colorSelectId}
-                        selectedValue={pointColor}
-                        onChange={handleColorChange}
-                        style={styles.spaceUnder}
-                    />
-                    <LabeledSwitch
-                        label="open point"
-                        checked={!filled}
-                        onChange={(newValue) => {
-                            onChangeProps({filled: !newValue});
-                        }}
-                    />
-                </>
-            )}
+            <LabeledSwitch
+                label="open point"
+                checked={!filled}
+                onChange={(newValue) => {
+                    onChangeProps({filled: !newValue});
+                }}
+            />
 
-            {/* Actions */}
-            {onRemove && (
-                <LockedFigureSettingsActions
-                    onRemove={onRemove}
-                    figureAriaLabel={`locked point at ${coord[0]}, ${coord[1]}`}
-                />
-            )}
+            <LockedFigureSettingsActions
+                onRemove={onRemove}
+                figureAriaLabel={`locked point at ${coord[0]}, ${coord[1]}`}
+            />
         </LockedFigureSettingsAccordion>
     );
 };
 
 const styles = StyleSheet.create({
-    accordionPanelWithoutActions: {
-        // Need more space since we don't have the actions' margins.
-        paddingBottom: spacing.medium_16,
-    },
     row: {
         flexDirection: "row",
         alignItems: "center",
     },
     spaceUnder: {
         marginBottom: spacing.xSmall_8,
-    },
-    label: {
-        marginInlineEnd: spacing.xxSmall_6,
-    },
-    textField: {
-        width: spacing.xxxLarge_64,
     },
 });
 


### PR DESCRIPTION
## Summary:
The more functionality we add, the more the inner "defining point" settings diverge
from the standalone locked point settings.

To make things easier for future additions (such as the upcoming validation work
disallowing length 0 lines), I think these should be two separate components
altogether.

This PR includes a bunch of refactoring, including
- The creation of DefiningPointSettings
- Removing props from LockedPointSettings that are no longer needed
- Breakout out the CoordinatePairInput into a new component since
  it's the same between the two components. easier to reuse this way
- Moving the unique ID management into the inner components so the
  parents don't have to manage them
- Stories updates

Issue: none

## Test plan:
`yarn jest`
`yarn typecheck`

Confirm that everything behaves the same in the editor.
http://localhost:6006/?path=/story/perseuseditor-editorpage--mafs-with-locked-figures