### PR TITLE
Stub getDependencies instead of calling setDependencies in tests

### DIFF
--- a/packages/perseus/src/__tests__/widgets.test.ts
+++ b/packages/perseus/src/__tests__/widgets.test.ts
@@ -1,5 +1,5 @@
 import {testDependencies} from "../../../../testing/test-dependencies";
-import {setDependencies} from "../dependencies";
+import * as dependencies from "../dependencies";
 import {registerAllWidgetsForTesting} from "../util/register-all-widgets-for-testing";
 import * as Widgets from "../widgets";
 
@@ -75,7 +75,9 @@ describe("Widget API support", () => {
 
 describe("replaceWidget", () => {
     beforeEach(() => {
-        setDependencies(testDependencies);
+        jest.spyOn(dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
         registerAllWidgetsForTesting();
     });
 

--- a/packages/perseus/src/__tests__/widgets.test.ts
+++ b/packages/perseus/src/__tests__/widgets.test.ts
@@ -1,5 +1,5 @@
 import {testDependencies} from "../../../../testing/test-dependencies";
-import * as dependencies from "../dependencies";
+import * as Dependencies from "../dependencies";
 import {registerAllWidgetsForTesting} from "../util/register-all-widgets-for-testing";
 import * as Widgets from "../widgets";
 
@@ -75,7 +75,7 @@ describe("Widget API support", () => {
 
 describe("replaceWidget", () => {
     beforeEach(() => {
-        jest.spyOn(dependencies, "getDependencies").mockReturnValue(
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
             testDependencies,
         );
         registerAllWidgetsForTesting();

--- a/packages/perseus/src/logging/log.test.ts
+++ b/packages/perseus/src/logging/log.test.ts
@@ -1,13 +1,16 @@
 import {testDependencies} from "../../../../testing/test-dependencies";
-import {setDependencies} from "../dependencies";
+import * as dependencies from "../dependencies";
 
 import {Errors, Log} from "./log";
 
 describe("Perseus logging", () => {
-    it("should proxy log() calls to the logger provided through setDependencies", () => {
+    it("should proxy log() calls to the logger obtained from getDependencies", () => {
         // Arrange
-        const logSpy = jest.spyOn(testDependencies.Log, "log");
-        setDependencies(testDependencies);
+        const logSpy = jest.fn();
+        jest.spyOn(dependencies, "getDependencies").mockReturnValue({
+            ...testDependencies,
+            Log: {...testDependencies.Log, log: logSpy},
+        });
 
         // Act
         Log.log("test message", {a: 1, b: "two"});
@@ -16,10 +19,13 @@ describe("Perseus logging", () => {
         expect(logSpy).toHaveBeenCalledWith("test message", {a: 1, b: "two"});
     });
 
-    it("should proxy error() calls to the logger provided through setDependencies", () => {
+    it("should proxy error() calls to the logger obtained from getDependencies", () => {
         // Arrange
-        const errorSpy = jest.spyOn(testDependencies.Log, "error");
-        setDependencies(testDependencies);
+        const errorSpy = jest.fn();
+        jest.spyOn(dependencies, "getDependencies").mockReturnValue({
+            ...testDependencies,
+            Log: {...testDependencies.Log, error: errorSpy},
+        });
 
         // Act
         Log.error("test error", Errors.NotAllowed, {

--- a/packages/perseus/src/logging/log.test.ts
+++ b/packages/perseus/src/logging/log.test.ts
@@ -1,5 +1,5 @@
 import {testDependencies} from "../../../../testing/test-dependencies";
-import * as dependencies from "../dependencies";
+import * as Dependencies from "../dependencies";
 
 import {Errors, Log} from "./log";
 
@@ -7,7 +7,7 @@ describe("Perseus logging", () => {
     it("should proxy log() calls to the logger obtained from getDependencies", () => {
         // Arrange
         const logSpy = jest.fn();
-        jest.spyOn(dependencies, "getDependencies").mockReturnValue({
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue({
             ...testDependencies,
             Log: {...testDependencies.Log, log: logSpy},
         });
@@ -22,7 +22,7 @@ describe("Perseus logging", () => {
     it("should proxy error() calls to the logger obtained from getDependencies", () => {
         // Arrange
         const errorSpy = jest.fn();
-        jest.spyOn(dependencies, "getDependencies").mockReturnValue({
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue({
             ...testDependencies,
             Log: {...testDependencies.Log, error: errorSpy},
         });

--- a/packages/perseus/src/widgets/__tests__/grapher.test.ts
+++ b/packages/perseus/src/widgets/__tests__/grapher.test.ts
@@ -1,5 +1,5 @@
 import {testDependencies} from "../../../../../testing/test-dependencies";
-import * as dependencies from "../../dependencies";
+import * as Dependencies from "../../dependencies";
 import {
     linearQuestion,
     multipleAvailableTypesQuestion,
@@ -9,7 +9,7 @@ import {renderQuestion} from "./renderQuestion";
 
 describe("grapher widget", () => {
     beforeEach(() => {
-        jest.spyOn(dependencies, "getDependencies").mockReturnValue(
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
             testDependencies,
         );
     });

--- a/packages/perseus/src/widgets/__tests__/grapher.test.ts
+++ b/packages/perseus/src/widgets/__tests__/grapher.test.ts
@@ -1,5 +1,5 @@
 import {testDependencies} from "../../../../../testing/test-dependencies";
-import {setDependencies} from "../../dependencies";
+import * as dependencies from "../../dependencies";
 import {
     linearQuestion,
     multipleAvailableTypesQuestion,
@@ -9,7 +9,9 @@ import {renderQuestion} from "./renderQuestion";
 
 describe("grapher widget", () => {
     beforeEach(() => {
-        setDependencies(testDependencies);
+        jest.spyOn(dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
     });
 
     it("should snapshot linear graph question", () => {

--- a/packages/perseus/src/widgets/__tests__/plotter.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/plotter.test.tsx
@@ -2,13 +2,13 @@ import {screen, render} from "@testing-library/react";
 import React from "react";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
-import * as dependencies from "../../dependencies";
+import * as Dependencies from "../../dependencies";
 import {ApiOptions} from "../../perseus-api";
 import {Plotter} from "../plotter";
 
 describe("plotter widget", () => {
     beforeEach(() => {
-        jest.spyOn(dependencies, "getDependencies").mockReturnValue(
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
             testDependencies,
         );
     });

--- a/packages/perseus/src/widgets/__tests__/plotter.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/plotter.test.tsx
@@ -2,13 +2,15 @@ import {screen, render} from "@testing-library/react";
 import React from "react";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
-import {setDependencies} from "../../dependencies";
+import * as dependencies from "../../dependencies";
 import {ApiOptions} from "../../perseus-api";
 import {Plotter} from "../plotter";
 
 describe("plotter widget", () => {
     beforeEach(() => {
-        setDependencies(testDependencies);
+        jest.spyOn(dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
     });
 
     it("should show drag text when not static", () => {

--- a/packages/perseus/src/widgets/__tests__/radio/base-radio.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/radio/base-radio.test.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 
 // eslint-disable-next-line import/no-relative-packages
 import {testDependencies} from "../../../../../../testing/test-dependencies";
-import {setDependencies} from "../../../dependencies";
+import * as dependencies from "../../../dependencies";
 import {generateChoice} from "../../__testdata__/base-radio.testdata";
 import BaseRadio from "../../radio/base-radio";
 
@@ -52,9 +52,11 @@ describe("base-radio", () => {
         });
 
         // because choice-none-above uses a Renderer
-        // we need to set dependencies when it's rendered
+        // we need to stub dependencies when it's rendered
         // (this probably needs to be fixed)
-        setDependencies(testDependencies);
+        jest.spyOn(dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
     });
 
     it("renders a none of the above choice", () => {

--- a/packages/perseus/src/widgets/__tests__/radio/base-radio.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/radio/base-radio.test.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 
 // eslint-disable-next-line import/no-relative-packages
 import {testDependencies} from "../../../../../../testing/test-dependencies";
-import * as dependencies from "../../../dependencies";
+import * as Dependencies from "../../../dependencies";
 import {generateChoice} from "../../__testdata__/base-radio.testdata";
 import BaseRadio from "../../radio/base-radio";
 
@@ -54,7 +54,7 @@ describe("base-radio", () => {
         // because choice-none-above uses a Renderer
         // we need to stub dependencies when it's rendered
         // (this probably needs to be fixed)
-        jest.spyOn(dependencies, "getDependencies").mockReturnValue(
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
             testDependencies,
         );
     });

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import invariant from "tiny-invariant";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
-import * as dependencies from "../../dependencies";
+import * as Dependencies from "../../dependencies";
 
 import {MafsGraph, StatefulMafsGraph} from "./mafs-graph";
 import {movePoint} from "./reducer/interactive-graph-action";
@@ -73,7 +73,7 @@ function createFakeStore<S, A>(reducer: (state: S, action: A) => S, state: S) {
 describe("StatefulMafsGraph", () => {
     let userEvent: UserEvent;
     beforeEach(() => {
-        jest.spyOn(dependencies, "getDependencies").mockReturnValue(
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
             testDependencies,
         );
         userEvent = userEventLib.setup({
@@ -139,7 +139,7 @@ describe("MafsGraph", () => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,
         });
-        jest.spyOn(dependencies, "getDependencies").mockReturnValue(
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
             testDependencies,
         );
     });

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import invariant from "tiny-invariant";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
-import {setDependencies} from "../../dependencies";
+import * as dependencies from "../../dependencies";
 
 import {MafsGraph, StatefulMafsGraph} from "./mafs-graph";
 import {movePoint} from "./reducer/interactive-graph-action";
@@ -73,7 +73,9 @@ function createFakeStore<S, A>(reducer: (state: S, action: A) => S, state: S) {
 describe("StatefulMafsGraph", () => {
     let userEvent: UserEvent;
     beforeEach(() => {
-        setDependencies(testDependencies);
+        jest.spyOn(dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,
         });
@@ -137,7 +139,9 @@ describe("MafsGraph", () => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,
         });
-        setDependencies(testDependencies);
+        jest.spyOn(dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
     });
 
     it("renders", () => {


### PR DESCRIPTION
We had several tests that were calling setDependencies, which has the
possibility of contaminating tests that run afterward, since the dependencies
are not reset after every test.

This PR changes the tests to always stub getDependencies instead of calling
setDependencies. Jest automatically removes the stubs after every test.

Issue: https://khanacademy.atlassian.net/browse/LEMS-1997

## Test plan:

`yarn test`