### PR TITLE
Alphabetically order locked line kind dropdown options

### DIFF
--- a/.changeset/rare-oranges-count.md
+++ b/.changeset/rare-oranges-count.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Nit: put the line kind dropdown options in alphabetical order

--- a/packages/perseus-editor/src/components/locked-line-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-line-settings.tsx
@@ -123,8 +123,8 @@ const LockedLineSettings = (props: Props) => {
                     placeholder=""
                 >
                     <OptionItem value="line" label="line" />
-                    <OptionItem value="segment" label="segment" />
                     <OptionItem value="ray" label="ray" />
+                    <OptionItem value="segment" label="segment" />
                 </SingleSelect>
             </View>
 


### PR DESCRIPTION
## Summary:
This is just a nit. Putting Ray before Segment makes it so that
1. The options are in alpahbetical order
2. The options are in length order

Issue: none

## Test plan:
Storybook
http://localhost:6006/?path=/story/perseuseditor-editorpage--mafs-with-locked-figures

<img width="402" alt="Screenshot 2024-05-16 at 10 29 42 AM" src="https://github.com/Khan/perseus/assets/13231763/ccbb134e-abb3-4d7d-b91f-39275923e20d">
