### PR TITLE
FOCUSED: Fix low-contrast of line and dot in number-line component

### DIFF
--- a/.changeset/fast-roses-wave.md
+++ b/.changeset/fast-roses-wave.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Change colors to WB colors for number-line widget only

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/number-line.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/number-line.test.ts.snap
@@ -217,14 +217,14 @@ exports[`number-line widget should snapshot on mobile: first mobile render 1`] =
                   <path
                     d="M29.999999999999993,48L29.999999999999993,32"
                     fill="none"
-                    stroke="#11accd"
+                    stroke="#1865f2"
                     stroke-width="3.5"
                     style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 3.5;"
                   />
                   <path
                     d="M258,48L258,32"
                     fill="none"
-                    stroke="#11accd"
+                    stroke="#1865f2"
                     stroke-width="3.5"
                     style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 3.5;"
                   />
@@ -384,7 +384,7 @@ exports[`number-line widget should snapshot on mobile: first mobile render 1`] =
                 <span
                   class="graphie-label"
                   data-math-formula="-4"
-                  style="position: absolute; padding: 7px; color: rgb(17, 172, 205); left: 29.999999999999993px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; color: rgb(24, 101, 242); left: 29.999999999999993px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -393,7 +393,7 @@ exports[`number-line widget should snapshot on mobile: first mobile render 1`] =
                 <span
                   class="graphie-label"
                   data-math-formula="4"
-                  style="position: absolute; padding: 7px; color: rgb(17, 172, 205); left: 258px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; color: rgb(24, 101, 242); left: 258px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -621,14 +621,14 @@ exports[`number-line widget should snapshot: first render 1`] = `
                   <path
                     d="M29.999999999999982,48L29.999999999999982,32"
                     fill="none"
-                    stroke="#6495ed"
+                    stroke="#1865f2"
                     stroke-width="3.5"
                     style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 3.5;"
                   />
                   <path
                     d="M430,48L430,32"
                     fill="none"
-                    stroke="#6495ed"
+                    stroke="#1865f2"
                     stroke-width="3.5"
                     style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 3.5;"
                   />
@@ -657,11 +657,11 @@ exports[`number-line widget should snapshot: first render 1`] = `
                       <ellipse
                         cx="NaN"
                         cy="NaN"
-                        fill="#71b307"
+                        fill="#00a60e"
                         r="NaN"
                         rx="6"
                         ry="6"
-                        stroke="#71b307"
+                        stroke="#00a60e"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
                         transform=""

--- a/packages/perseus/src/widgets/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line.tsx
@@ -1,4 +1,5 @@
 import {number as knumber} from "@khanacademy/kmath";
+import {color} from "@khanacademy/wonder-blocks-tokens";
 import * as React from "react";
 import ReactDOM from "react-dom";
 import _ from "underscore";
@@ -10,7 +11,6 @@ import SimpleKeypadInput from "../components/simple-keypad-input";
 import InteractiveUtil from "../interactive2/interactive-util";
 import * as Changeable from "../mixins/changeable";
 import {ApiOptions} from "../perseus-api";
-import KhanColors from "../util/colors";
 import KhanMath from "../util/math";
 
 import type {ChangeableProps} from "../mixins/changeable";
@@ -157,7 +157,7 @@ const TickMarks: any = Graphie.createSimpleClass((graphie, props) => {
         graphie.style(
             props.isMobile
                 ? {
-                      color: KhanColors.BLUE_D,
+                      color: color.blue,
                   }
                 : {},
             () => _label(graphie, props.labelStyle, leftLabel, leftLabel, base),
@@ -168,7 +168,7 @@ const TickMarks: any = Graphie.createSimpleClass((graphie, props) => {
         graphie.style(
             props.isMobile
                 ? {
-                      color: KhanColors.BLUE_D,
+                      color: color.blue,
                   }
                 : {},
             () =>
@@ -179,7 +179,7 @@ const TickMarks: any = Graphie.createSimpleClass((graphie, props) => {
     // Render the labels' lines
     graphie.style(
         {
-            stroke: props.isMobile ? KhanColors.BLUE_D : KhanColors.DYNAMIC,
+            stroke: color.blue,
             strokeWidth: 3.5,
         },
         () => {
@@ -472,25 +472,25 @@ class NumberLine extends React.Component<Props, State> {
         // it can't be interacted with.
         let fill;
         if (isOpen) {
-            fill = KhanColors._BACKGROUND;
+            fill = "transparent";
         } else if (props.static) {
-            fill = KhanColors.DYNAMIC;
+            fill = color.blue;
         } else {
-            fill = KhanColors.INTERACTIVE;
+            fill = color.green;
         }
         const normalStyle = {
             fill: fill,
-            stroke: props.static ? KhanColors.DYNAMIC : KhanColors.INTERACTIVE,
+            stroke: props.static ? color.blue : color.green,
             "stroke-width": isOpen ? 3 : 1,
         } as const;
         const highlightStyle = {
-            fill: isOpen ? KhanColors._BACKGROUND : KhanColors.INTERACTING,
+            fill: isOpen ? "transparent" : color.green,
             "stroke-width": isOpen ? 3 : 1,
         } as const;
 
         const mobileDotStyle = props.isInequality
             ? {
-                  stroke: KhanColors.INTERACTIVE,
+                  stroke: color.green,
                   "fill-opacity": isOpen ? 0 : 1,
               }
             : {};
@@ -555,8 +555,8 @@ class NumberLine extends React.Component<Props, State> {
             const style = {
                 arrows: "->",
                 stroke: this.props.apiOptions.isMobile
-                    ? KhanColors.INTERACTIVE
-                    : KhanColors.DYNAMIC,
+                    ? color.green
+                    : color.blue,
                 strokeWidth: 3.5,
             } as const;
 


### PR DESCRIPTION
## Summary:
This fixes an issue where the line and point in the number-line widget were not meeting the WCAG standards for color contrast. The contrast should be at least 3:1, which is implemented here using [WB color tokens](https://khan.github.io/wonder-blocks/?path=/docs/packages-tokens-color--docs).

Before fix:
<img width="482" alt="image" src="https://github.com/Khan/perseus/assets/60857422/2141fda2-bbea-44c6-b3e6-99110f438263">
<img width="203" alt="image" src="https://github.com/Khan/perseus/assets/60857422/e93e0a32-3512-4129-b444-85252a880951">
<img width="194" alt="image" src="https://github.com/Khan/perseus/assets/60857422/68b06686-075d-4ee8-9c6f-2b55942fe8bc">


After fix:
<img width="485" alt="image" src="https://github.com/Khan/perseus/assets/60857422/26ab986c-e729-4585-8e54-b23cebbac08f">
<img width="208" alt="image" src="https://github.com/Khan/perseus/assets/60857422/585cdcec-fe3e-4888-8942-f24120684372">
<img width="206" alt="image" src="https://github.com/Khan/perseus/assets/60857422/618b48ad-a1a9-4937-b670-bd18f8c8c641">


Issue: LEMS-252

## Test plan:
- Run `yarn storybook`
- Open any of the number-line stories
- Confirm the contrast between the white background and the dot and line is above 3:1
- Confirm all checks pass