### PR TITLE
[a11y] Hide horizontal divider from screen reader

### DIFF
--- a/.changeset/chilled-moose-walk.md
+++ b/.changeset/chilled-moose-walk.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/simple-markdown": minor
+---
+
+Make horizontal divider invisible to screen reader

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/graded-group.test.ts.snap
@@ -9,7 +9,9 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
       class="paragraph perseus-paragraph-centered"
       data-perseus-paragraph-index="0"
     >
-      <hr />
+      <hr
+        aria-hidden="true"
+      />
     </div>
     <div
       class="paragraph"
@@ -447,7 +449,9 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
       class="paragraph perseus-paragraph-centered"
       data-perseus-paragraph-index="0"
     >
-      <hr />
+      <hr
+        aria-hidden="true"
+      />
     </div>
     <div
       class="paragraph"

--- a/packages/simple-markdown/src/__tests__/simple-markdown.test.ts
+++ b/packages/simple-markdown/src/__tests__/simple-markdown.test.ts
@@ -4187,9 +4187,9 @@ describe("simple markdown", function () {
         });
 
         it("should output hrs", function () {
-            assertParsesToReact("-----\n\n", "<hr/>");
-            assertParsesToReact(" * * * \n\n", "<hr/>");
-            assertParsesToReact("___\n\n", "<hr/>");
+            assertParsesToReact("-----\n\n", '<hr aria-hidden="true"/>');
+            assertParsesToReact(" * * * \n\n", '<hr aria-hidden="true"/>');
+            assertParsesToReact("___\n\n", '<hr aria-hidden="true"/>');
         });
 
         it("should output codeblocks", function () {
@@ -4516,9 +4516,9 @@ describe("simple markdown", function () {
         });
 
         it("should output hrs", function () {
-            assertParsesToHtml("-----\n\n", "<hr>");
-            assertParsesToHtml(" * * * \n\n", "<hr>");
-            assertParsesToHtml("___\n\n", "<hr>");
+            assertParsesToHtml("-----\n\n", '<hr aria-hidden="true">');
+            assertParsesToHtml(" * * * \n\n", '<hr aria-hidden="true">');
+            assertParsesToHtml("___\n\n", '<hr aria-hidden="true">');
         });
 
         it("should output codeblocks", function () {

--- a/packages/simple-markdown/src/index.ts
+++ b/packages/simple-markdown/src/index.ts
@@ -992,10 +992,10 @@ var defaultRules: DefaultRules = {
         match: blockRegex(/^( *[-*_]){3,} *(?:\n *)+\n/),
         parse: ignoreCapture,
         react: function (node, output, state) {
-            return reactElement("hr", state.key, EMPTY_PROPS);
+            return reactElement("hr", state.key, {"aria-hidden": true});
         },
         html: function (node, output, state) {
-            return "<hr>";
+            return '<hr aria-hidden="true">';
         },
     },
     codeBlock: {


### PR DESCRIPTION
## Summary:
When navigating through an exercise with a SR, it sometimes notices the horizontal divider as shown in the video below. This is most noticeable in long passage practice where the horizontal line is used to format the passage. 

https://github.com/Khan/perseus/assets/30729058/5b1671a4-7911-4c23-aff2-9e4f856b6031

This PR adds `aria-hidden` to the horizontal line, so the screen reader will skip over it.

Issue: [LIT-754](https://khanacademy.atlassian.net/browse/LIT-754)

## Test plan:

- Tests pass
- Here is how things would look in webapp:

https://github.com/Khan/perseus/assets/30729058/c28f02b1-f49c-4c8b-8183-147980b994fa


[LIT-754]: https://khanacademy.atlassian.net/browse/LIT-754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ