### PR TITLE
Clarify the code for initializing linear graphs

### DIFF
--- a/.changeset/wet-months-collect.md
+++ b/.changeset/wet-months-collect.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: refactor the code for initializing linear graph states

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
@@ -117,13 +117,27 @@ describe("initializeGraphState for linear-system graphs", () => {
             ...baseGraphData,
             graph: {
                 type: "linear-system",
-                coords: [[[1, 2], [3, 4]]],
+                coords: [
+                    [
+                        [1, 2],
+                        [3, 4],
+                    ],
+                ],
             },
         });
 
         invariant(state.type === "linear-system");
-        expect(state.coords).toEqual([[[-5, 5], [5, 5]], [[-5, -5], [5, -5]]])
-    })
+        expect(state.coords).toEqual([
+            [
+                [-5, 5],
+                [5, 5],
+            ],
+            [
+                [-5, -5],
+                [5, -5],
+            ],
+        ]);
+    });
 });
 
 describe("initializeGraphState for polygon graphs", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
@@ -89,8 +89,8 @@ describe("initializeGraphState for segment graphs", () => {
     });
 });
 
-describe("initializeGraphState for line graphs", () => {
-    it("adds a default line", () => {
+describe("initializeGraphState for linear-system graphs", () => {
+    it("adds default lines if no coords are provided", () => {
         const state = initializeGraphState({
             ...baseGraphData,
             graph: {type: "linear-system"},
@@ -109,6 +109,21 @@ describe("initializeGraphState for line graphs", () => {
             ],
         ]);
     });
+
+    it("ignores any provided coords", () => {
+        // This is a characterization test. I don't know if it's desired
+        // behavior, but it's the existing behavior.
+        const state = initializeGraphState({
+            ...baseGraphData,
+            graph: {
+                type: "linear-system",
+                coords: [[[1, 2], [3, 4]]],
+            },
+        });
+
+        invariant(state.type === "linear-system");
+        expect(state.coords).toEqual([[[-5, 5], [5, 5]], [[-5, -5], [5, -5]]])
+    })
 });
 
 describe("initializeGraphState for polygon graphs", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -301,12 +301,12 @@ const getLineCoords = ({
         case "linear-system":
             return defaultLinearCoords.map((points) =>
                 normalizePoints(range, step, points),
-            )
+            );
         case "linear":
         case "ray":
-            return [normalizePoints(range, step, defaultLinearCoords[0])]
+            return [normalizePoints(range, step, defaultLinearCoords[0])];
         default:
-            throw new UnreachableCaseError(graph)
+            throw new UnreachableCaseError(graph);
     }
 };
 

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -295,13 +295,20 @@ const getLineCoords = ({
     graph,
     range,
     step,
-}: getLineCoordsArg): PairOfPoints[] =>
-    // Return two lines for a linear system, one for a ray or linear
-    graph.coords ?? graph.type === "linear-system"
-        ? defaultLinearCoords.map((collinear) =>
-              normalizePoints(range, step, collinear),
-          )
-        : [normalizePoints(range, step, defaultLinearCoords[0])];
+}: getLineCoordsArg): PairOfPoints[] => {
+    //  Return two lines for a linear system, one for a ray or linear
+    switch (graph.type) {
+        case "linear-system":
+            return defaultLinearCoords.map((points) =>
+                normalizePoints(range, step, points),
+            )
+        case "linear":
+        case "ray":
+            return [normalizePoints(range, step, defaultLinearCoords[0])]
+        default:
+            throw new UnreachableCaseError(graph)
+    }
+};
 
 type getPolygonCoordsArg = {
     graph: PerseusGraphTypePolygon;


### PR DESCRIPTION
## Summary:
Previously, the code for initializing movable lines looked like it would
use `graph.coords` if that was provided, and fall back to default values
if not. That's not what it did, because the `??` operator has higher
precedence than the ternary operator. If any coords were passed, we'd
treat the graph as a linear-system graph.

I suspect the reason we didn't notice this bug is that `coords` is never
provided for `linear` or `ray` graphs. Linear and ray graphs always have
one line, and linear-system graphs always have two lines.

Issue: none

Test plan:

- `yarn dev`
- Go to `http://localhost:5173#flipbook`
- View the examples obtained by running each of:
  ```
  ag -l '"type":"linear"' data/questions/ | xargs cat | grep -v 'grapher 1' | pbcopy
  ag -l '"type":"ray"' data/questions/ | xargs cat | pbcopy
  ag -l '"type":"linear-system"' data/questions/ | xargs cat | pbcopy
  ```
  (run these one at a time; each one overwrites your clipboard)
- Verify that none of the Mafs graphs differ from the legacy version.