### PR TITLE
Github Actions: Provide matrix for upload_coverage job

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -195,7 +195,11 @@ jobs:
 
     upload_coverage:
         name: Upload Coverage
-        runs-on: ubuntu-latest
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                os: [ubuntu-latest]
+                node-version: [20.x]
         needs: [cypress, coverage]
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary:

While investigating a problem where the Github Action cache is broken (we get type check failures in the action runs that don't occur locally), I noticed that some cache keys were missing the node version in them (see screenshot). 

I think I've traced it down to a missing `strategy` key in one of the jobs that uses our shared `shared-node-cache` action. 

Issue: "none"

## Test plan:

There's no way to test this until it's landed. 

Once it's landed, I'll clear the caches once more and then monitor as PRs check/set the cache. Hopefully we won't see any more cache keys that are missing a node version (ie. ones that start with `Linux--v1-...` (note the double dash, the node version should be between those dashes!)