### PR TITLE
Fill interactive circles with blue on hover

### DIFF
--- a/.changeset/good-beers-tan.md
+++ b/.changeset/good-beers-tan.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Fill Mafs interactive circles with blue on hover

--- a/.changeset/tender-rules-juggle.md
+++ b/.changeset/tender-rules-juggle.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Add fill to Mafs interactive circles on hover

--- a/.changeset/tender-rules-juggle.md
+++ b/.changeset/tender-rules-juggle.md
@@ -1,5 +1,0 @@
----
-"@khanacademy/perseus": patch
----
-
-Add fill to Mafs interactive circles on hover

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -1,5 +1,4 @@
-import {color} from "@khanacademy/wonder-blocks-tokens";
-import {Circle, useMovable, vec} from "mafs";
+import {useMovable, vec} from "mafs";
 import * as React from "react";
 import {useRef} from "react";
 
@@ -72,11 +71,12 @@ function MovableCircle(props: {
                 rx={radiiPx[0] + 3}
                 ry={radiiPx[1] + 3}
             />
-            <Circle
-                center={center}
-                radius={radius}
-                fillOpacity={0}
-                color={color.blue}
+            <ellipse
+                className="circle"
+                cx={centerPx[0]}
+                cy={centerPx[1]}
+                rx={radiiPx[0]}
+                ry={radiiPx[1]}
             />
             <DragHandle center={center} />
         </g>

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -152,6 +152,17 @@
     cursor: grab;
 }
 
+.MafsView .movable-circle .circle {
+    stroke: var(--mafs-blue);
+    stroke-width: 2px;
+    fill: transparent;
+}
+
+.MafsView .movable-circle:hover .circle {
+    fill: var(--mafs-blue);
+    fill-opacity: 0.16;
+}
+
 .MafsView .movable-circle.movable-circle--dragging {
     cursor: grabbing;
     outline: none;


### PR DESCRIPTION
## Summary:
Designs: https://www.figma.com/design/JroPokeCLBv2VRIw3GPvY5/LC---Interactive-graph-widget?node-id=1150-51899&t=kJh1CRKGniWKyer1-0

Issue: LEMS-1978

Test plan:

Visit http://localhost:5173 and turn on Mafs for the circle graph.

The circle should light up blue when hovered.

Note that there is currently an issue where axis numbers intercept the
hover gesture, so the circle will not be blue if your cursor is over an
axis number. This will be fixed in LEMS-2003.

<img width="461" alt="Screen Shot 2024-05-17 at 1 10 41 PM" src="https://github.com/Khan/perseus/assets/693920/9652351f-1b5c-4dd0-a79b-5408eaa0a3a6">
