### PR TITLE
Prevent axis tick labels from being selected or clicked

### DIFF
--- a/.changeset/olive-ligers-sniff.md
+++ b/.changeset/olive-ligers-sniff.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix a bug where axis tick labels on Mafs interactive graphs could be selected and interfere with drag interactions

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -207,6 +207,10 @@
     font-size: 14px;
     font-family: "Mafs-MJXTEX";
     line-height: 1.5em;
+    /* Prevent labels from being selected, and from interfering with click and
+     * drag interactions on the graph. */
+    user-select: none;
+    pointer-events: none;
 }
 
 .y-axis-tick-labels {


### PR DESCRIPTION
## Summary:
Previously, axis tick labels could intercept mouse events, leading to a
few problems:

- It was hard to drag an interactive point that was under one of the
  labels.
- Hovering over a graphed circle wouldn't highlight the circle if your
  cursor was also over a label.
- The cursor changed to a text cursor when you hovered over a label,
  which was confusing/unexpected.
- The labels could be selected by dragging over them, which was
  unexpected and not useful.

This commit fixes those issues by making axis tick labels unselectable
and invisible to mouse events.

Issue: LEMS-2003

Test plan:

View the Mafs circle graph on `localhost:5173`. Confirm that the issues
described above no longer occur.