### PR TITLE
Fix a literal corner case in intersecting a ray with a box

### DIFF
--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.test.ts
@@ -18,7 +18,7 @@ describe("getIntersectionOfRayWithBox", () => {
         expect(intersection).toEqual([0, 0]);
     });
 
-    test("given a horizontal ray passing through the origin to the left", () => {
+    test("a horizontal ray passing through the origin to the left", () => {
         const box: [Interval, Interval] = [
             [-7, 7],
             [-11, 11],
@@ -33,7 +33,7 @@ describe("getIntersectionOfRayWithBox", () => {
         expect(intersection).toEqual([-7, 0]);
     });
 
-    test("given a horizontal ray passing through the origin to the right", () => {
+    test("a horizontal ray passing through the origin to the right", () => {
         const box: [Interval, Interval] = [
             [-7, 7],
             [-11, 11],
@@ -48,7 +48,7 @@ describe("getIntersectionOfRayWithBox", () => {
         expect(intersection).toEqual([7, 0]);
     });
 
-    test("given a vertical ray passing through the origin upward", () => {
+    test("a vertical ray passing through the origin upward", () => {
         const box: [Interval, Interval] = [
             [-7, 7],
             [-11, 11],
@@ -63,7 +63,7 @@ describe("getIntersectionOfRayWithBox", () => {
         expect(intersection).toEqual([0, 11]);
     });
 
-    test("given a vertical ray passing through the origin downward", () => {
+    test("a vertical ray passing through the origin downward", () => {
         const box: [Interval, Interval] = [
             [-7, 7],
             [-11, 11],
@@ -78,7 +78,7 @@ describe("getIntersectionOfRayWithBox", () => {
         expect(intersection).toEqual([0, -11]);
     });
 
-    test("given a y coordinate of -0 for the initialPoint when the ray points right", () => {
+    test("a y coordinate of -0 for the initialPoint when the ray points right", () => {
         const box: [Interval, Interval] = [
             [-7, 7],
             [-11, 11],
@@ -93,7 +93,7 @@ describe("getIntersectionOfRayWithBox", () => {
         expect(intersection).toEqual([7, 0]);
     });
 
-    test("given a y coordinate of -0 for the throughPoint when the ray points right", () => {
+    test("a y coordinate of -0 for the throughPoint when the ray points right", () => {
         const box: [Interval, Interval] = [
             [-7, 7],
             [-11, 11],
@@ -108,7 +108,7 @@ describe("getIntersectionOfRayWithBox", () => {
         expect(intersection).toEqual([7, 0]);
     });
 
-    test("given a y coordinate of -0 for the initialPoint when the ray points left", () => {
+    test("a y coordinate of -0 for the initialPoint when the ray points left", () => {
         const box: [Interval, Interval] = [
             [-7, 7],
             [-11, 11],
@@ -123,7 +123,7 @@ describe("getIntersectionOfRayWithBox", () => {
         expect(intersection).toEqual([-7, 0]);
     });
 
-    test("given a y coordinate of -0 for the throughPoint when the ray points left", () => {
+    test("a y coordinate of -0 for the throughPoint when the ray points left", () => {
         const box: [Interval, Interval] = [
             [-7, 7],
             [-11, 11],

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.test.ts
@@ -3,21 +3,6 @@ import {getIntersectionOfRayWithBox} from "./utils";
 import type {Interval, vec} from "mafs";
 
 describe("getIntersectionOfRayWithBox", () => {
-    it("returns [0, 0] when the given points are the same", () => {
-        const box: [Interval, Interval] = [
-            [-7, 7],
-            [-11, 11],
-        ];
-        const initialPoint: vec.Vector2 = [3, 5];
-        const throughPoint: vec.Vector2 = [3, 5];
-        const intersection = getIntersectionOfRayWithBox(
-            initialPoint,
-            throughPoint,
-            box,
-        );
-        expect(intersection).toEqual([0, 0]);
-    });
-
     test("a horizontal ray passing through the origin to the left", () => {
         const box: [Interval, Interval] = [
             [-7, 7],
@@ -136,5 +121,21 @@ describe("getIntersectionOfRayWithBox", () => {
             box,
         );
         expect(intersection).toEqual([-7, 0]);
+    });
+
+    test("a diagonal ray from top right to bottom left, when floating point gets imprecise", () => {
+        // This is a regression test for https://khanacademy.atlassian.net/browse/LEMS-2004
+        const box: [Interval, Interval] = [
+            [-1.11, 7.89],
+            [-1.11, 7.89],
+        ];
+        const initialPoint: vec.Vector2 = [6, 6];
+        const throughPoint: vec.Vector2 = [1, 1];
+        const intersection = getIntersectionOfRayWithBox(
+            initialPoint,
+            throughPoint,
+            box,
+        );
+        expect(intersection).toEqual([-1.11, -1.11]);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
@@ -42,10 +42,7 @@ export const getIntersectionOfRayWithBox = (
             return [xAtYExtreme, yExtreme];
 
         default:
-            // This default case is only reachable if the input is invalid
-            // (initialPoint is outside the graph bounds, or initialPoint and
-            // throughPoint are the same).
-            return [0, 0];
+            return [xExtreme, yExtreme];
     }
 };
 


### PR DESCRIPTION
## Summary:
The bug: the arrowhead of a drawn ray would always be at the origin when
floating-point imprecision caused the computed intersection with the
graph bounds to be just outside the actual bounds in both dimensions.
This happened when the ray was pointed directly at one of the corners.

Issue: LEMS-2004

Test plan:

Follow the repro steps in the linked issue. The bug should not repro.