### PR TITLE
Try to force Node v20

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -30,7 +30,7 @@ jobs:
                   fetch-depth: 0
 
             - name: Force Node version
-              uses: actions/setup-node
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: yarn

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -29,6 +29,12 @@ jobs:
               with:
                   fetch-depth: 0
 
+            - name: Force Node version
+              uses: actions/setup-node
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  cache: yarn
+
             - name: Get changed files
               uses: Khan/actions@get-changed-files-v2
               id: changed


### PR DESCRIPTION
## Summary:

We recently moved to Node v20. In doing so, we added an `engines` key to our root `package.json`. This file is only used for local dev and controlling tooling versions and has nothing to do with the packages we publish. 

An example of a failed run looks like this: 

<img width="903" alt="image" src="https://github.com/Khan/perseus/assets/77138/a34ac1a8-9c68-4bea-8de1-fe3d3e7b187a">

My working theory is that this job is getting the default Node version for the `ubuntu-latest` image (full list of installed software is [here](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#language-and-runtime)).  

In this PR I've added an explicit step that uses the `actions/setup-node` action and forces it to Node v20.  This seems to fix the situation (and align with my working theory of why it was broken). 

Issue: n/a

## Test plan: