### PR TITLE
Remove unused APIOptions and types

### DIFF
--- a/.changeset/brave-lions-melt.md
+++ b/.changeset/brave-lions-melt.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": major
+---
+
+Remove unused/deprecated APIOptions: useDraftEditor and inModal

--- a/.changeset/wild-cobras-applaud.md
+++ b/.changeset/wild-cobras-applaud.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Remove duplicate `Empty` type

--- a/packages/perseus-editor/src/widgets/__stories__/expression-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/expression-editor.stories.tsx
@@ -20,9 +20,6 @@ export default {
     title: "PerseusEditor/Widgets/Expression Editor",
 } as Story;
 
-// TODO(FEI-5054): Figure out how to get global .d.ts files working with monorepos
-type Empty = Record<string, never>;
-
 type State = PerseusExpressionWidgetOptions;
 
 class WithDebug extends React.Component<Empty, State> {

--- a/packages/perseus-editor/src/widgets/__stories__/label-image-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/label-image-editor.stories.tsx
@@ -6,9 +6,6 @@ import LabelImageEditor from "../label-image-editor";
 
 import type {MarkerType} from "@khanacademy/perseus";
 
-// TODO(FEI-5054): Figure out how to get global .d.ts files working with monorepos
-type Empty = Record<string, never>;
-
 type StoryArgs = Record<any, any>;
 
 type Story = {

--- a/packages/perseus-editor/src/widgets/__stories__/radio-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/radio-editor.stories.tsx
@@ -10,8 +10,6 @@ import type {
     APIOptions,
 } from "@khanacademy/perseus";
 
-// TODO(FEI-5054): Figure out how to get global .d.ts files working with monorepos
-type Empty = Record<string, never>;
 
 type StoryArgs = Record<any, any>;
 

--- a/packages/perseus-editor/src/widgets/__stories__/radio-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/radio-editor.stories.tsx
@@ -10,7 +10,6 @@ import type {
     APIOptions,
 } from "@khanacademy/perseus";
 
-
 type StoryArgs = Record<any, any>;
 
 type Story = {

--- a/packages/perseus/src/perseus-api.tsx
+++ b/packages/perseus/src/perseus-api.tsx
@@ -119,9 +119,6 @@ export const ApiOptions = {
         // Defaults to `false`.
         canScrollPage: PropTypes.bool,
 
-        // Whether or not we are rendering content inside of a modal.
-        inModal: PropTypes.bool,
-
         // Whether to enable the cross-out feature on multiple-choice radio
         // widgets. This allows users to note which answers they believe to
         // be incorrect, to find the answer by process of elimination.
@@ -163,7 +160,6 @@ export const ApiOptions = {
         setDrawingAreaAvailable: function () {},
         useDraftEditor: false,
         canScrollPage: false,
-        inModal: false,
         crossOutEnabled: false,
         editorChangeDelay: 0,
     } as APIOptionsWithDefaults,

--- a/packages/perseus/src/perseus-api.tsx
+++ b/packages/perseus/src/perseus-api.tsx
@@ -105,9 +105,6 @@ export const ApiOptions = {
         // Previously handled by `Khan.scratchpad.enable/disable`
         setDrawingAreaAvailable: PropTypes.func,
 
-        // Whether to use the Draft.js editor or the legacy textarea
-        useDraftEditor: PropTypes.bool,
-
         // The color used for the hint progress indicator (eg. 1 / 3)
         hintProgressColor: PropTypes.string,
 
@@ -158,7 +155,6 @@ export const ApiOptions = {
             },
         },
         setDrawingAreaAvailable: function () {},
-        useDraftEditor: false,
         canScrollPage: false,
         crossOutEnabled: false,
         editorChangeDelay: 0,

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -11,9 +11,6 @@ export type Size = [number, number];
 export type CollinearTuple = readonly [vec.Vector2, vec.Vector2];
 export type ShowSolutions = "all" | "selected" | "none";
 
-// TODO(FEI-5054): Figure out how to get global .d.ts files working with monorepos
-type Empty = Record<never, never>;
-
 export type PerseusWidgetsMap = {
     [key in `categorizer ${number}`]: CategorizerWidget;
 } & {

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -255,8 +255,6 @@ export type APIOptions = Readonly<{
      * Defaults to `false`.
      */
     canScrollPage?: boolean;
-    /** Whether or not we are rendering content inside of a modal. */
-    inModal?: boolean;
     /**
      * Whether to enable the cross-out feature on multiple-choice radio
      * widgets. This allows users to note which answers they believe to
@@ -429,7 +427,6 @@ export type APIOptionsWithDefaults = Readonly<
         crossOutEnabled: NonNullable<APIOptions["crossOutEnabled"]>;
         editorChangeDelay: NonNullable<APIOptions["editorChangeDelay"]>;
         groupAnnotator: NonNullable<APIOptions["groupAnnotator"]>;
-        inModal: NonNullable<APIOptions["inModal"]>;
         isArticle: NonNullable<APIOptions["isArticle"]>;
         isMobile: NonNullable<APIOptions["isMobile"]>;
         onFocusChange: NonNullable<APIOptions["onFocusChange"]>;

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -242,8 +242,6 @@ export type APIOptions = Readonly<{
      * Previously handled by `Khan.scratchpad.enable/disable`
      */
     setDrawingAreaAvailable?: (arg1: boolean) => unknown;
-    /** Whether to use the Draft.js editor or the legacy textarea */
-    useDraftEditor?: boolean;
     /** The color used for the hint progress indicator (eg. 1 / 3) */
     hintProgressColor?: string;
     /**
@@ -436,7 +434,6 @@ export type APIOptionsWithDefaults = Readonly<
             APIOptions["setDrawingAreaAvailable"]
         >;
         showAlignmentOptions: NonNullable<APIOptions["showAlignmentOptions"]>;
-        useDraftEditor: NonNullable<APIOptions["useDraftEditor"]>;
     }
 >;
 

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -17,9 +17,6 @@ import type * as React from "react";
 
 export type FocusPath = ReadonlyArray<string> | null | undefined;
 
-// TODO(FEI-5054): Figure out how to get global .d.ts files working with monorepos
-type Empty = Record<never, never>;
-
 export type Dimensions = {
     width?: number;
     height?: number;

--- a/packages/perseus/src/widgets/definition.tsx
+++ b/packages/perseus/src/widgets/definition.tsx
@@ -13,9 +13,6 @@ import type {
 } from "../perseus-types";
 import type {PerseusScore, WidgetExports, WidgetProps} from "../types";
 
-// TODO(FEI-5054): Figure out how to get global .d.ts files working with monorepos
-type Empty = Record<never, never>;
-
 type RenderProps = PerseusDefinitionWidgetOptions;
 
 type Rubric = PerseusDefinitionWidgetOptions;

--- a/packages/perseus/src/widgets/explanation.tsx
+++ b/packages/perseus/src/widgets/explanation.tsx
@@ -15,9 +15,6 @@ import Renderer from "../renderer";
 import type {PerseusExplanationWidgetOptions} from "../perseus-types";
 import type {PerseusScore, WidgetExports, WidgetProps} from "../types";
 
-// TODO(FEI-5054): Figure out how to get global .d.ts files working with monorepos
-type Empty = Record<never, never>;
-
 type RenderProps = PerseusExplanationWidgetOptions; // transform = _.identity
 
 type Rubric = PerseusExplanationWidgetOptions;


### PR DESCRIPTION
## Summary:

This PR removes some code/APIOptions that are completely unused today. To verify, I checked the webapp and mobile source code. I also checked and these options are not used in Perseus so even if they were set by calling applications, they do nothing. 

It's time to go!

  * Remove Empty type as its now centrally defined in `utility.d.ts` which is symlinked into each package src
  * Remove unused and deprecated `inModal` APIOption
  * Remove unused and deprecated `useDraftEditor` APIOption

Issue: "none"

## Test plan: