### PR TITLE
Ensure there's enough contrast on the grid lines by switching to offBlack50

### DIFF
--- a/.changeset/new-mirrors-shave.md
+++ b/.changeset/new-mirrors-shave.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Ensure there's enough contrast on the grid lines by switching to offBlack50

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -203,6 +203,9 @@
         format("woff");
 }
 
+.MafsView pattern g {
+    stroke: #909296;
+}
 .axis-tick-labels {
     font-size: 14px;
     font-family: "Mafs-MJXTEX";
@@ -239,10 +242,14 @@
 
 .x-axis-tick-labels span,
 .y-axis-tick-labels span {
+    /* The negative sign is rendered as a pseudo-element to
+        ensure that we are positioning all labels correctly */
     &::before {
         content: attr(data-content);
         position: absolute;
-        transform: translate(-100%);
+        /* We're translating the symbol up by 1px to ensure it's legible around gridlines. */
+        transform: translate(-100%, -1px);
+        font-weight: 600; /* This helps get the symbol to render crisply */
     }
 }
 


### PR DESCRIPTION
## Summary:
During the playtest we discovered that the axis tick grid lines are far too light on several different devices. This PR updates the gridlines to use a close approximation to OffBlack32.

As a result of increasing the contrast of these grid lines, I felt the axis tick labels were getting a little harder to read. After checking with design, I've added a white stroke to these labels. This greatly increases readability of our graphs.

Example of old graph contrast:
![Screenshot 2024-04-23 at 11 07 03 AM](https://github.com/Khan/perseus/assets/12463099/4c6a1c00-8582-4faa-afd0-cca4d7b943c7)

NOTE: There IS an issue with the contrast between our axis tick labels and the new gridlines.[ See the slack discussion here for more information](https://khanacademy.slack.com/archives/C067UM1QAR4/p1716408416655179). Currently, we have opted to keep the labels as-is until we can check in with design to take a more holistic look at our graphing colour palette. 

Issue: LEMS-1925

## Test plan:
- manual testing 

## Screenshots:
![Screenshot 2024-05-22 at 2 25 27 PM](https://github.com/Khan/perseus/assets/12463099/536d37fa-671d-4c87-854f-492d323b2f20)
