### PR TITLE
Add the `quadratic` question type for the new Mafs-based Interactive Graph

### DIFF
--- a/.changeset/lucky-cups-learn.md
+++ b/.changeset/lucky-cups-learn.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-editor": minor
+---
+
+Creation of the new Mafs-based Quadratic Graph for the Interactive Graph Widget

--- a/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
+++ b/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
@@ -4,6 +4,7 @@ export const flags = {
     mafs: {
         segment: true,
         circle: true,
+        quadratic: true,
         "interactive-graph-locked-features-m1": true,
     },
 } satisfies APIOptions["flags"];

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -770,7 +770,7 @@ export type PerseusGraphTypePolygon = {
 export type PerseusGraphTypeQuadratic = {
     type: "quadratic";
     // expects a list of 3 coords
-    readonly coords: [Coord, Coord, Coord];
+    coords?: [Coord, Coord, Coord];
 } & PerseusGraphTypeCommon;
 
 export type PerseusGraphTypeSegment = {

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -770,7 +770,7 @@ export type PerseusGraphTypePolygon = {
 export type PerseusGraphTypeQuadratic = {
     type: "quadratic";
     // expects a list of 3 coords
-    coords?: ReadonlyArray<Coord>;
+    readonly coords: [Coord, Coord, Coord];
 } & PerseusGraphTypeCommon;
 
 export type PerseusGraphTypeSegment = {

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -141,6 +141,8 @@ export const MafsGraphTypeFlags = [
     "polygon",
     /** Enables the `circle` interactive-graph type.  */
     "circle",
+    /** Enables the `quadratic` interactive-graph type.  */
+    "quadratic",
 ] as const;
 
 export const InteractiveGraphLockedFeaturesFlags = [

--- a/packages/perseus/src/widgets/__testdata__/interactive-graph-random.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/interactive-graph-random.testdata.ts
@@ -100,7 +100,9 @@ const randomGraphTypePolygon = (): PerseusGraphTypePolygon => {
 const randomGraphTypeQuadratic = (): PerseusGraphTypeQuadratic => {
     return {
         type: "quadratic",
-        coords: arrayOfLength(3).map(randomCoord),
+        coords: arrayOfLength(3).map(
+            randomCoord,
+        ) as PerseusGraphTypeQuadratic["coords"],
     };
 };
 

--- a/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
@@ -2002,6 +2002,7 @@ export const quadraticQuestion: PerseusRenderer = {
                     coords: [
                         [0, 0],
                         [3, 8],
+                        [6, 0],
                     ],
                     type: "quadratic",
                 },
@@ -2040,9 +2041,9 @@ export const quadraticQuestionWithDefaultCorrect: PerseusRenderer = {
             options: {
                 correct: {
                     coords: [
-                        [-1, 0],
-                        [1, 0],
-                        [0, -1],
+                        [-5, 5],
+                        [0, -5],
+                        [5, 5],
                     ],
                     type: "quadratic",
                 },
@@ -2060,7 +2061,7 @@ export const quadraticQuestionWithDefaultCorrect: PerseusRenderer = {
                 rulerTicks: 10,
                 showProtractor: false,
                 showRuler: false,
-                snapStep: [0.5, 0.5],
+                snapStep: [1, 1],
                 step: [1, 1],
             },
             type: "interactive-graph",

--- a/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
@@ -1990,3 +1990,84 @@ export const segmentWithLockedFigures: PerseusRenderer = {
         },
     },
 };
+
+export const quadraticQuestion: PerseusRenderer = {
+    content: "All locked lines\n\n[[☃ interactive-graph 1]]",
+    images: {},
+    widgets: {
+        "interactive-graph 1": {
+            graded: true,
+            options: {
+                correct: {
+                    coords: [
+                        [0, 0],
+                        [3, 8],
+                    ],
+                    type: "quadratic",
+                },
+                graph: {
+                    type: "quadratic",
+                },
+                gridStep: [1, 1],
+                labels: ["t", "d"],
+                markings: "graph",
+                range: [
+                    [-10, 10],
+                    [-10, 10],
+                ],
+                rulerLabel: "",
+                rulerTicks: 10,
+                showProtractor: false,
+                showRuler: false,
+                snapStep: [0.5, 0.5],
+                step: [1, 1],
+            },
+            type: "interactive-graph",
+            version: {
+                major: 0,
+                minor: 0,
+            },
+        },
+    },
+};
+
+export const quadraticQuestionWithDefaultCorrect: PerseusRenderer = {
+    content: "All locked lines\n\n[[☃ interactive-graph 1]]",
+    images: {},
+    widgets: {
+        "interactive-graph 1": {
+            graded: true,
+            options: {
+                correct: {
+                    coords: [
+                        [-1, 0],
+                        [1, 0],
+                        [0, -1],
+                    ],
+                    type: "quadratic",
+                },
+                graph: {
+                    type: "quadratic",
+                },
+                gridStep: [1, 1],
+                labels: ["t", "d"],
+                markings: "graph",
+                range: [
+                    [-10, 10],
+                    [-10, 10],
+                ],
+                rulerLabel: "",
+                rulerTicks: 10,
+                showProtractor: false,
+                showRuler: false,
+                snapStep: [0.5, 0.5],
+                step: [1, 1],
+            },
+            type: "interactive-graph",
+            version: {
+                major: 0,
+                minor: 0,
+            },
+        },
+    },
+};

--- a/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
@@ -2008,6 +2008,11 @@ export const quadraticQuestion: PerseusRenderer = {
                 },
                 graph: {
                     type: "quadratic",
+                    coords: [
+                        [-5, 5],
+                        [0, -5],
+                        [5, 5],
+                    ],
                 },
                 gridStep: [1, 1],
                 labels: ["t", "d"],
@@ -2049,6 +2054,11 @@ export const quadraticQuestionWithDefaultCorrect: PerseusRenderer = {
                 },
                 graph: {
                     type: "quadratic",
+                    coords: [
+                        [-5, 5],
+                        [0, -5],
+                        [5, 5],
+                    ],
                 },
                 gridStep: [1, 1],
                 labels: ["t", "d"],

--- a/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
+++ b/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
@@ -19,6 +19,8 @@ import {
     pointQuestionWithDefaultCorrect,
     polygonQuestion,
     polygonQuestionDefaultCorrect,
+    quadraticQuestion,
+    quadraticQuestionWithDefaultCorrect,
     questionsAndAnswers,
     rayQuestion,
     rayQuestionWithDefaultCorrect,
@@ -154,6 +156,7 @@ describe("a mafs graph", () => {
         polygon: polygonQuestion,
         point: pointQuestion,
         circle: circleQuestion,
+        quadratic: quadraticQuestion,
     };
 
     const graphQuestionRenderersCorrect: {
@@ -166,6 +169,7 @@ describe("a mafs graph", () => {
         polygon: polygonQuestionDefaultCorrect,
         point: pointQuestionWithDefaultCorrect,
         circle: circleQuestionWithDefaultCorrect,
+        quadratic: quadraticQuestionWithDefaultCorrect,
     };
 
     describe.each(Object.entries(graphQuestionRenderers))(

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -34,6 +34,7 @@ import {getInteractiveBoxFromSizeClass} from "../util/sizing-utils";
 
 import {StatefulMafsGraph} from "./interactive-graphs";
 
+import type {QuadraticGraphState} from "./interactive-graphs/types";
 import type {Coord} from "../interactive2/types";
 import type {
     PerseusGraphType,
@@ -2216,7 +2217,7 @@ class InteractiveGraph extends React.Component<Props, State> {
         return InteractiveGraph.getQuadraticCoefficients(coords);
     }
 
-    static defaultQuadraticCoords(props: Props): ReadonlyArray<Coord> {
+    static defaultQuadraticCoords(props: Props): QuadraticGraphState["coords"] {
         const coords = [
             [0.25, 0.75],
             [0.5, 0.25],

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/index.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/index.ts
@@ -3,3 +3,4 @@ export {LinearGraph} from "./linear";
 export {RayGraph} from "./ray";
 export {PolygonGraph} from "./polygon";
 export {CircleGraph} from "./circle";
+export {QuadraticGraph} from "./quadratic";

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.test.ts
@@ -14,6 +14,16 @@ describe("QuadraticGraph", () => {
         expect(getQuadraticCoefficients(coords)).toEqual(expected);
     });
 
+    it("should accurately calculate coefficients regardless of the provided order", () => {
+        const coords: QuadraticGraphState["coords"] = [
+            [-5, 5],
+            [4, 5],
+            [0, -5],
+        ];
+        const expected: [number, number, number] = [0.5, 0.5, -5];
+        expect(getQuadraticCoefficients(coords)).toEqual(expected);
+    });
+
     it("should return undefined when the coefficients are invalid", () => {
         const coords: QuadraticGraphState["coords"] = [
             [0, 0],

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.test.ts
@@ -1,0 +1,37 @@
+import {isValidDestination, getQuadraticCoefficients} from "./quadratic";
+
+import type {QuadraticGraphState} from "../types";
+import type {vec} from "mafs";
+
+describe("QuadraticGraph", () => {
+    it("should accurately calculate coefficients", () => {
+        const coords: QuadraticGraphState["coords"] = [
+            [-5, 5],
+            [0, -5],
+            [4, 5],
+        ];
+        const expected: [number, number, number] = [0.5, 0.5, -5];
+        expect(getQuadraticCoefficients(coords)).toEqual(expected);
+    });
+
+    it("should return undefined when the coefficients are invalid", () => {
+        const coords: QuadraticGraphState["coords"] = [
+            [0, 0],
+            [0, 0],
+            [0, 0],
+        ];
+        expect(getQuadraticCoefficients(coords)).toBe(undefined);
+    });
+
+    it("should indicate when new coordinates would invalidate the graph", () => {
+        const coords: QuadraticGraphState["coords"] = [
+            [-5, 5],
+            [0, -5],
+            [5, 5],
+        ];
+        const destination: vec.Vector2 = [0, 0];
+        const elementId = 0;
+        const isValid = isValidDestination(destination, elementId, coords);
+        expect(isValid).toBe(false);
+    });
+});

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
@@ -33,12 +33,6 @@ export function QuadraticGraph(props: QuadraticGraphProps) {
     // Calculate the y value based on the current x value
     const y = (x) => (a * x + b) * x + c;
 
-    // Set the xy values for the Parametric plot
-    const xy = (x: number) => [x, y(x)] as vec.Vector2;
-
-    // Determine the range / domain of the graph
-    const t: vec.Vector2 = [range[0][0], range[0][1]] as vec.Vector2;
-
     const handleOnMove = (destination: vec.Vector2, elementId: number) => {
         // If the destination is invalid, we want do not want to move the point
         const validDestination = isValidDestination(
@@ -55,7 +49,7 @@ export function QuadraticGraph(props: QuadraticGraphProps) {
 
     return (
         <>
-            <Plot.Parametric xy={xy} t={t} color={color.blue} />
+            <Plot.OfX y={y} color={color.blue} />
             {coords.map((coord, i) => (
                 <StyledMovablePoint
                     key={"point-" + i}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
@@ -1,0 +1,229 @@
+import {color} from "@khanacademy/wonder-blocks-tokens";
+import {Plot} from "mafs";
+import * as React from "react";
+
+import {movePoint} from "../reducer/interactive-graph-action";
+
+import {StyledMovablePoint} from "./components/movable-point";
+
+import type {QuadraticGraphState, MafsGraphProps} from "../types";
+import type {vec} from "mafs";
+
+type QuadraticGraphProps = MafsGraphProps<QuadraticGraphState>;
+
+export function QuadraticGraph(props: QuadraticGraphProps) {
+    // This is an example of the output from the editor for the correct equation
+    // correct y = 0.200x^2 + 0.000x + 0.000
+    const {dispatch, graphState} = props;
+
+    // expects a list of 3 coordinates
+    // [0] = start point
+    // [1] = mid point
+    // [2] = end point
+    const {coords, range, snapStep} = graphState;
+    const coeffRef = React.useRef<QuadraticCoefficient>([0.4, -0, -5]);
+
+    const coeff = getQuadraticCoefficients(coords);
+    const validCoeff = coeff !== undefined;
+    if (validCoeff) {
+        // If the coeff is not defined, it means we were hitting infinity
+        // STOPSHIP: we should probably use memo the prior value here until
+        // the user has entered a valid equation. This might be that
+        // line fallback I saw somewhere in the graphie code.
+
+        // OKAY so what the legacy graph does here is it simply does not allow you to
+        // plot / snap at all to a point where the equation is infinity.
+        // I will need to create a custom movePoint function that will not allow
+        // the user to move the point to a place where the equation is infinity.
+        // coeff = [0, 0, 0];
+        coeffRef.current = coeff;
+    }
+    const [a, b, c] = coeffRef.current;
+
+    // Get the coordinates of the 3 points
+    const [pointA, centerPoint, pointB] = coords;
+
+    const mid = centerPoint[0];
+    // This is the ENTIRE equation for Y so that I can grep it
+    // y = centerPoint.y *
+    // ((x - pointA.x) * (x - pointB.x) / (mid - pointA.x) * (mid - pointB.x)) /
+    // (mid - pointA.x) * (mid - pointB.x)
+
+    // This approach was taken from the mafs samples
+    // const fn = (x: number) => (x - pointA[0]) * (x - pointB[0]) - mid;
+
+    // This is a backup equation to try to figure out how to have x affect things
+    // const xFactor = (y: number) => (centerPoint[0] * fn(y)) / fn(mid);
+    const xFactor = (y: number) => y;
+
+    // Calculate the y value based on the x value
+    // const y = (x) => (centerPoint[1] * fn(x)) / fn(mid);
+    const y = (x) => (a * x + b) * x + c;
+    // y = ax^2 + bx + c <--- this is the original equation from graphie
+
+    // This is where we actually set the xy values for the plot
+    const xy = (x: number) => [xFactor(x), y(x)] as vec.Vector2;
+
+    // This is the range/domain of the plot
+    const t: vec.Vector2 = [range[0][0], range[0][1]] as vec.Vector2;
+
+    const handleOnMove = (destination: vec.Vector2, elementId: number) => {
+        const validDestination = getValidDestination(destination);
+        dispatch(movePoint(elementId, validDestination));
+    };
+
+    const getValidDestination = (destination: vec.Vector2): vec.Vector2 => {
+        const validDestination = validCoeff
+            ? destination
+            : ([destination[0] + snapStep[0], destination[1]] as vec.Vector2);
+        return validDestination;
+    };
+
+    return (
+        <>
+            <Plot.Parametric xy={xy} t={t} color={color.blue} />
+
+            <StyledMovablePoint
+                key={"pointA"}
+                point={[pointA[0], pointA[1]]}
+                onMove={(destination) => handleOnMove(destination, 0)}
+            />
+            <StyledMovablePoint
+                key={"centerPoint"}
+                point={centerPoint}
+                onMove={(destination) => handleOnMove(destination, 1)}
+            />
+
+            <StyledMovablePoint
+                key={"pointB"}
+                point={pointB}
+                onMove={(destination) => handleOnMove(destination, 2)}
+            />
+
+            <text x={-120} y={190} fill="black">
+                CURRENT COORDINATES:
+                {JSON.stringify(coords)}
+            </text>
+        </>
+    );
+}
+
+// If our QuadraticCoefficients are undefined, it means we have hit infinity
+export type QuadraticCoefficient = [number, number, number];
+
+// Get the quadratic coefficients from the 3 points
+const getQuadraticCoefficients = (
+    coords: ReadonlyArray<Coord>,
+): QuadraticCoefficient | undefined => {
+    const p1 = coords[0];
+    const p2 = coords[1];
+    const p3 = coords[2];
+
+    const denom = (p1[0] - p2[0]) * (p1[0] - p3[0]) * (p2[0] - p3[0]);
+    if (denom === 0) {
+        return;
+    }
+    const a =
+        (p3[0] * (p2[1] - p1[1]) +
+            p2[0] * (p1[1] - p3[1]) +
+            p1[0] * (p3[1] - p2[1])) /
+        denom;
+    const b =
+        (p3[0] * p3[0] * (p1[1] - p2[1]) +
+            p2[0] * p2[0] * (p3[1] - p1[1]) +
+            p1[0] * p1[0] * (p2[1] - p3[1])) /
+        denom;
+    const c =
+        (p2[0] * p3[0] * (p2[0] - p3[0]) * p1[1] +
+            p3[0] * p1[0] * (p3[0] - p1[0]) * p2[1] +
+            p1[0] * p2[0] * (p1[0] - p2[0]) * p3[1]) /
+        denom;
+    return [a, b, c];
+};
+
+const temporaryMovePoint = (
+    pointIndex: number,
+    newPoint: vec.Vector2,
+    coeffs: QuadraticCoefficient | undefined,
+    dispatch: any,
+) => {
+    console.log(coeffs);
+    if (!coeffs) {
+        return;
+    }
+
+    dispatch(movePoint(pointIndex, newPoint));
+};
+
+// This is the original code from our graphie library
+// let's step through this step by step to try to figure out the right calculation
+// I'll fake a bunch of the values here as I want to keep the syntax highlighting
+// while I work on the equations in the actual component above.
+type Coord = [number, number];
+const bounds = () => {
+    return {xMin: 0, xMax: 0, yMin: 0, yMax: 0};
+};
+const bound: any = [];
+const scalePoint = (point: Coord) => {
+    return point;
+};
+const svgPath = (points: Coord[]) => {
+    return "";
+};
+const svgParabolaPath = (a: number, b: number, c: number) => {
+    console.log("svgParabolaPath", a, b, c);
+    const computeParabola = function (x) {
+        return (a * x + b) * x + c; // THIS SEEMS TO BE A KEY CALCULATION TO UNDERSTAND
+        // y = ax^2 + bx + c <-- NEAT I never thought I'd get to do proofs again.
+    };
+
+    // If points are collinear, plot a line instead
+    if (a === 0) {
+        const points: Coord[] = [
+            [bounds().xMin, computeParabola(bounds().xMin)],
+            [bounds().xMax, computeParabola(bounds().xMax)],
+        ];
+        return svgPath(points);
+    }
+
+    // Calculate x coordinates of points on parabola
+    const xVertex = -b / (7 * a);
+    const distToEdge = Math.max(
+        Math.abs(xVertex - bounds().xMin),
+        Math.abs(xVertex - bounds().xMax),
+    );
+
+    // To guarantee that drawn parabola to spans the viewport, use a point
+    // on the edge of the graph furtherest from the vertex
+    const xPoint = xVertex + distToEdge;
+
+    // Compute parabola and other point on the curve
+    const vertex = [xVertex, computeParabola(xVertex)];
+    const point = [xPoint, computeParabola(xPoint)];
+
+    // Calculate SVG 'control' point, defined by spec
+    const control: Coord = [vertex[0], vertex[1] - (point[1] - vertex[1])];
+
+    // Calculate mirror points across parabola's axis of symmetry
+    const dx = Math.abs(vertex[0] - point[0]);
+    const left: Coord = [vertex[0] - dx, point[1]];
+    const right: Coord = [vertex[0] + dx, point[1]];
+
+    // Scale and bound
+    const points = [left, control, right].map(scalePoint);
+    const values = points.flat().map(bound);
+    return (
+        "M" +
+        values[0] +
+        "," +
+        values[1] +
+        " Q" +
+        values[2] +
+        "," +
+        values[3] +
+        " " +
+        values[4] +
+        "," +
+        values[5]
+    );
+};

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
@@ -47,9 +47,6 @@ export function QuadraticGraph(props: QuadraticGraphProps) {
     // We are going to destructure the coefficients here
     const [a, b, c] = coeffRef.current;
 
-    // Get the coordinates of the 3 points
-    const [pointA, centerPoint, pointB] = coordsRef.current;
-
     // Calculate the y value based on the x value
     const y = (x) => (a * x + b) * x + c;
 
@@ -92,22 +89,13 @@ export function QuadraticGraph(props: QuadraticGraphProps) {
     return (
         <>
             <Plot.Parametric xy={xy} t={t} color={color.blue} />
-            <StyledMovablePoint
-                key={"pointA"}
-                point={pointA}
-                onMove={(destination) => handleOnMove(destination, 0)}
-            />
-            <StyledMovablePoint
-                key={"centerPoint"}
-                point={centerPoint}
-                onMove={(destination) => handleOnMove(destination, 1)}
-            />
-
-            <StyledMovablePoint
-                key={"pointB"}
-                point={pointB}
-                onMove={(destination) => handleOnMove(destination, 2)}
-            />
+            {coordsRef.current.map((coord, i) => (
+                <StyledMovablePoint
+                    key={"point-" + i}
+                    point={coord}
+                    onMove={(destination) => handleOnMove(destination, i)}
+                />
+            ))}
         </>
     );
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
@@ -7,71 +7,55 @@ import {movePoint} from "../reducer/interactive-graph-action";
 import {StyledMovablePoint} from "./components/movable-point";
 
 import type {QuadraticGraphState, MafsGraphProps} from "../types";
+import type {Coord} from "@khanacademy/perseus";
 import type {vec} from "mafs";
 
 type QuadraticGraphProps = MafsGraphProps<QuadraticGraphState>;
+type QuadraticCoefficient = [number, number, number];
 
 export function QuadraticGraph(props: QuadraticGraphProps) {
-    // This is an example of the output from the editor for the correct equation
-    // correct y = 0.200x^2 + 0.000x + 0.000
     const {dispatch, graphState} = props;
 
-    // expects a list of 3 coordinates
+    // The quadratic graph expects a list of 3 coordinates
     // [0] = start point
     // [1] = mid point
     // [2] = end point
     const {coords, range, snapStep} = graphState;
-    const coeffRef = React.useRef<QuadraticCoefficient>([0.4, -0, -5]);
 
+    // The coefficients are used to calculate the quadratic equation, plot the graph, and
+    // to indicate to content creators the currently selected "correct answer". This is being
+    // stored as a ref as we may need to use the prior value if the current value is invalid.
+    const coeffRef = React.useRef<QuadraticCoefficient>([0, 0, 0]);
     const coeff = getQuadraticCoefficients(coords);
     const validCoeff = coeff !== undefined;
     if (validCoeff) {
         // If the coeff is not defined, it means we were hitting infinity
-        // STOPSHIP: we should probably use memo the prior value here until
-        // the user has entered a valid equation. This might be that
-        // line fallback I saw somewhere in the graphie code.
-
-        // OKAY so what the legacy graph does here is it simply does not allow you to
-        // plot / snap at all to a point where the equation is infinity.
-        // I will need to create a custom movePoint function that will not allow
-        // the user to move the point to a place where the equation is infinity.
-        // coeff = [0, 0, 0];
+        // and are unable to calculate the quadratic coefficients
         coeffRef.current = coeff;
     }
+
+    // We are going to destructure the coefficients here
     const [a, b, c] = coeffRef.current;
 
     // Get the coordinates of the 3 points
     const [pointA, centerPoint, pointB] = coords;
 
-    const mid = centerPoint[0];
-    // This is the ENTIRE equation for Y so that I can grep it
-    // y = centerPoint.y *
-    // ((x - pointA.x) * (x - pointB.x) / (mid - pointA.x) * (mid - pointB.x)) /
-    // (mid - pointA.x) * (mid - pointB.x)
-
-    // This approach was taken from the mafs samples
-    // const fn = (x: number) => (x - pointA[0]) * (x - pointB[0]) - mid;
-
-    // This is a backup equation to try to figure out how to have x affect things
-    // const xFactor = (y: number) => (centerPoint[0] * fn(y)) / fn(mid);
-    const xFactor = (y: number) => y;
-
     // Calculate the y value based on the x value
-    // const y = (x) => (centerPoint[1] * fn(x)) / fn(mid);
     const y = (x) => (a * x + b) * x + c;
-    // y = ax^2 + bx + c <--- this is the original equation from graphie
 
     // This is where we actually set the xy values for the plot
-    const xy = (x: number) => [xFactor(x), y(x)] as vec.Vector2;
+    const xy = (x: number) => [x, y(x)] as vec.Vector2;
 
     // This is the range/domain of the plot
     const t: vec.Vector2 = [range[0][0], range[0][1]] as vec.Vector2;
 
+    // We want to ensure that we are only moving the point to a valid destination
     const handleOnMove = (destination: vec.Vector2, elementId: number) => {
         const validDestination = getValidDestination(destination);
         dispatch(movePoint(elementId, validDestination));
     };
 
+    // This is the function that will snap the point to the nearest VALID grid line
     const getValidDestination = (destination: vec.Vector2): vec.Vector2 => {
         const validDestination = validCoeff
             ? destination
@@ -82,7 +66,6 @@ export function QuadraticGraph(props: QuadraticGraphProps) {
     return (
         <>
             <Plot.Parametric xy={xy} t={t} color={color.blue} />
-
             <StyledMovablePoint
                 key={"pointA"}
                 point={[pointA[0], pointA[1]]}
@@ -99,17 +82,15 @@ export function QuadraticGraph(props: QuadraticGraphProps) {
                 point={pointB}
                 onMove={(destination) => handleOnMove(destination, 2)}
             />
-
-            <text x={-120} y={190} fill="black">
-                CURRENT COORDINATES:
-                {JSON.stringify(coords)}
+            <text x={-170} y={195} style={{fill: "blue"}}>
+                COORDINATES: ----------{JSON.stringify(coords)}
+            </text>
+            <text x={-112} y={175} style={{fill: "blue"}}>
+                COEFFS: ----------[{JSON.stringify(coeff)}]
             </text>
         </>
     );
 }
-
-// If our QuadraticCoefficients are undefined, it means we have hit infinity
-export type QuadraticCoefficient = [number, number, number];
 
 // Get the quadratic coefficients from the 3 points
 const getQuadraticCoefficients = (
@@ -119,10 +100,13 @@ const getQuadraticCoefficients = (
     const p2 = coords[1];
     const p3 = coords[2];
 
+    // If the denominator is 0, we are going to return undefined as we are
+    // unable to calculate the quadratic coefficients as they hit infinity
     const denom = (p1[0] - p2[0]) * (p1[0] - p3[0]) * (p2[0] - p3[0]);
     if (denom === 0) {
         return;
     }
+
     const a =
         (p3[0] * (p2[1] - p1[1]) +
             p2[0] * (p1[1] - p3[1]) +
@@ -139,91 +123,4 @@ const getQuadraticCoefficients = (
             p1[0] * p2[0] * (p1[0] - p2[0]) * p3[1]) /
         denom;
     return [a, b, c];
-};
-
-const temporaryMovePoint = (
-    pointIndex: number,
-    newPoint: vec.Vector2,
-    coeffs: QuadraticCoefficient | undefined,
-    dispatch: any,
-) => {
-    console.log(coeffs);
-    if (!coeffs) {
-        return;
-    }
-
-    dispatch(movePoint(pointIndex, newPoint));
-};
-
-// This is the original code from our graphie library
-// let's step through this step by step to try to figure out the right calculation
-// I'll fake a bunch of the values here as I want to keep the syntax highlighting
-// while I work on the equations in the actual component above.
-type Coord = [number, number];
-const bounds = () => {
-    return {xMin: 0, xMax: 0, yMin: 0, yMax: 0};
-};
-const bound: any = [];
-const scalePoint = (point: Coord) => {
-    return point;
-};
-const svgPath = (points: Coord[]) => {
-    return "";
-};
-const svgParabolaPath = (a: number, b: number, c: number) => {
-    console.log("svgParabolaPath", a, b, c);
-    const computeParabola = function (x) {
-        return (a * x + b) * x + c; // THIS SEEMS TO BE A KEY CALCULATION TO UNDERSTAND
-        // y = ax^2 + bx + c <-- NEAT I never thought I'd get to do proofs again.
-    };
-
-    // If points are collinear, plot a line instead
-    if (a === 0) {
-        const points: Coord[] = [
-            [bounds().xMin, computeParabola(bounds().xMin)],
-            [bounds().xMax, computeParabola(bounds().xMax)],
-        ];
-        return svgPath(points);
-    }
-
-    // Calculate x coordinates of points on parabola
-    const xVertex = -b / (7 * a);
-    const distToEdge = Math.max(
-        Math.abs(xVertex - bounds().xMin),
-        Math.abs(xVertex - bounds().xMax),
-    );
-
-    // To guarantee that drawn parabola to spans the viewport, use a point
-    // on the edge of the graph furtherest from the vertex
-    const xPoint = xVertex + distToEdge;
-
-    // Compute parabola and other point on the curve
-    const vertex = [xVertex, computeParabola(xVertex)];
-    const point = [xPoint, computeParabola(xPoint)];
-
-    // Calculate SVG 'control' point, defined by spec
-    const control: Coord = [vertex[0], vertex[1] - (point[1] - vertex[1])];
-
-    // Calculate mirror points across parabola's axis of symmetry
-    const dx = Math.abs(vertex[0] - point[0]);
-    const left: Coord = [vertex[0] - dx, point[1]];
-    const right: Coord = [vertex[0] + dx, point[1]];
-
-    // Scale and bound
-    const points = [left, control, right].map(scalePoint);
-    const values = points.flat().map(bound);
-    return (
-        "M" +
-        values[0] +
-        "," +
-        values[1] +
-        " Q" +
-        values[2] +
-        "," +
-        values[3] +
-        " " +
-        values[4] +
-        "," +
-        values[5]
-    );
 };

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
@@ -6,11 +6,11 @@ import {movePoint} from "../reducer/interactive-graph-action";
 
 import {StyledMovablePoint} from "./components/movable-point";
 
-import type {Coord} from "../../../interactive2/types";
 import type {QuadraticGraphState, MafsGraphProps} from "../types";
 import type {vec} from "mafs";
 
 type QuadraticGraphProps = MafsGraphProps<QuadraticGraphState>;
+type QuadraticCoords = QuadraticGraphState["coords"];
 type QuadraticCoefficient = [number, number, number];
 
 export function QuadraticGraph(props: QuadraticGraphProps) {
@@ -46,7 +46,7 @@ export function QuadraticGraph(props: QuadraticGraphProps) {
     ): boolean => {
         // Set up the new coords to reflect the new destination so that
         // we can check if the new destination is valid
-        const newCoords = [...coords];
+        const newCoords: QuadraticCoords = [...coords];
         newCoords[elementId] = destination;
         const QuadraticCoefficients = getQuadraticCoefficients(newCoords);
 
@@ -84,7 +84,7 @@ export function QuadraticGraph(props: QuadraticGraphProps) {
 
 // Get the quadratic coefficients from the 3 control points
 const getQuadraticCoefficients = (
-    coords: ReadonlyArray<Coord>,
+    coords: QuadraticCoords,
 ): QuadraticCoefficient | undefined => {
     const p1 = coords[0];
     const p2 = coords[1];

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
@@ -61,7 +61,6 @@ export function QuadraticGraph(props: QuadraticGraphProps) {
 
     // We want to ensure that we are only moving the point to a valid destination
     const handleOnMove = (destination: vec.Vector2, elementId: number) => {
-        console.log("handleOnMove", destination, elementId);
         const validDestination = getValidDestination(destination, elementId);
         dispatch(movePoint(elementId, validDestination));
     };

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
@@ -39,27 +39,13 @@ export function QuadraticGraph(props: QuadraticGraphProps) {
     // Determine the range / domain of the graph
     const t: vec.Vector2 = [range[0][0], range[0][1]] as vec.Vector2;
 
-    // Ensure that we are only snapping to coordinates that result in a valid quadratic equation
-    const isValidDestination = (
-        destination: vec.Vector2,
-        elementId: number,
-    ): boolean => {
-        // Set up the new coords and check if the quadratic coefficients are valid
-        const newCoords: QuadraticCoords = [...coords];
-        newCoords[elementId] = destination;
-        const QuadraticCoefficients = getQuadraticCoefficients(newCoords);
-
-        // If the new destination results in an invalid quadratic equation, we don't want to move the point
-        if (QuadraticCoefficients === undefined) {
-            return false;
-        }
-
-        return true;
-    };
-
     const handleOnMove = (destination: vec.Vector2, elementId: number) => {
         // If the destination is invalid, we want do not want to move the point
-        const validDestination = isValidDestination(destination, elementId);
+        const validDestination = isValidDestination(
+            destination,
+            elementId,
+            coords,
+        );
         if (validDestination === false) {
             return;
         }
@@ -81,8 +67,27 @@ export function QuadraticGraph(props: QuadraticGraphProps) {
     );
 }
 
+// Ensure that we are only snapping to coordinates that result in a valid quadratic equation
+export const isValidDestination = (
+    destination: vec.Vector2,
+    elementId: number,
+    coords: QuadraticCoords,
+): boolean => {
+    // Set up the new coords and check if the quadratic coefficients are valid
+    const newCoords: QuadraticCoords = [...coords];
+    newCoords[elementId] = destination;
+    const QuadraticCoefficients = getQuadraticCoefficients(newCoords);
+
+    // If the new destination results in an invalid quadratic equation, we don't want to move the point
+    if (QuadraticCoefficients === undefined) {
+        return false;
+    }
+
+    return true;
+};
+
 // Get the quadratic coefficients from the 3 control points
-const getQuadraticCoefficients = (
+export const getQuadraticCoefficients = (
     coords: QuadraticCoords,
 ): QuadraticCoefficient | undefined => {
     const p1 = coords[0];

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
@@ -44,8 +44,7 @@ export function QuadraticGraph(props: QuadraticGraphProps) {
         destination: vec.Vector2,
         elementId: number,
     ): boolean => {
-        // Set up the new coords to reflect the new destination so that
-        // we can check if the new destination is valid
+        // Set up the new coords and check if the quadratic coefficients are valid
         const newCoords: QuadraticCoords = [...coords];
         newCoords[elementId] = destination;
         const QuadraticCoefficients = getQuadraticCoefficients(newCoords);

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
@@ -16,7 +16,7 @@ type QuadraticCoefficient = [number, number, number];
 export function QuadraticGraph(props: QuadraticGraphProps) {
     const {dispatch, graphState} = props;
 
-    const {coords, range} = graphState;
+    const {coords} = graphState;
 
     // The coefficients are used to calculate the quadratic equation, plot the graph, and to indicate
     // to content creators the currently selected "correct answer". ex: y = 0.200x^2 + 0.000x + 0.000
@@ -81,6 +81,9 @@ export const isValidDestination = (
 };
 
 // Get the quadratic coefficients from the 3 control points
+// These equations were originally set up in 2013 and may require some
+// additional comments to help clarify the quadratic formula manipulations
+// Origin: https://phabricator.khanacademy.org/D2413
 export const getQuadraticCoefficients = (
     coords: QuadraticCoords,
 ): QuadraticCoefficient | undefined => {

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -12,6 +12,7 @@ import {
     RayGraph,
     SegmentGraph,
     CircleGraph,
+    QuadraticGraph,
 } from "./graphs";
 import {AxisTickLabels} from "./graphs/components/axis-tick-labels";
 import {SvgDefs} from "./graphs/components/text-label";
@@ -78,6 +79,8 @@ const renderGraph = (props: {
             return <PointGraph graphState={state} dispatch={dispatch} />;
         case "circle":
             return <CircleGraph graphState={state} dispatch={dispatch} />;
+        case "quadratic":
+            return <QuadraticGraph graphState={state} dispatch={dispatch} />;
         default:
             return new UnreachableCaseError(type);
     }

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-supported-graph-types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-supported-graph-types.ts
@@ -6,6 +6,7 @@ export const mafsSupportedGraphTypes = [
     "polygon",
     "point",
     "circle",
+    "quadratic",
 ] as const;
 
 export type MafsSupportedGraphType = (typeof mafsSupportedGraphTypes)[number];

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -187,9 +187,26 @@ function doMovePoint(
     action: MovePoint,
 ): InteractiveGraphState {
     switch (state.type) {
-        case "quadratic":
-        case "point":
-        case "polygon": {
+        case "polygon":
+        case "point": {
+            return {
+                ...state,
+                hasBeenInteractedWith: true,
+                coords: setAtIndex({
+                    array: state.coords,
+                    index: action.index,
+                    newValue: snap(
+                        state.snapStep,
+                        bound({
+                            snapStep: state.snapStep,
+                            range: state.range,
+                            point: action.destination,
+                        }),
+                    ),
+                }),
+            };
+        }
+        case "quadratic": {
             return {
                 ...state,
                 hasBeenInteractedWith: true,

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -92,13 +92,11 @@ function doMoveControlPoint(
                 coords: newCoords,
             };
         }
-        case "quadratic": {
-            throw new Error("FIXME implement quadratic reducer");
-        }
         case "circle":
             throw new Error("FIXME implement circle reducer");
         case "point":
         case "polygon":
+        case "quadratic":
             throw new Error(
                 `Don't use moveControlPoint for ${state.type} graphs. Use movePoint instead!`,
             );

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -92,6 +92,9 @@ function doMoveControlPoint(
                 coords: newCoords,
             };
         }
+        case "quadratic": {
+            throw new Error("FIXME implement quadratic reducer");
+        }
         case "circle":
             throw new Error("FIXME implement circle reducer");
         case "point":
@@ -184,6 +187,7 @@ function doMovePoint(
     action: MovePoint,
 ): InteractiveGraphState {
     switch (state.type) {
+        case "quadratic":
         case "point":
         case "polygon": {
             return {
@@ -205,7 +209,7 @@ function doMovePoint(
         }
         default:
             throw new Error(
-                "The movePoint action is only for point and polygon graphs",
+                "The movePoint action is only for point, quadratic, and polygon graphs",
             );
     }
 }

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -76,19 +76,10 @@ export function initializeGraphState(
                 radiusPoint: [1, 0],
             };
         case "quadratic":
-            const rangeCenterPoint = range.map(([min, max]) =>
-                Math.round((min + max) / 2),
-            );
-            const defaultQuadraticCoords: PerseusGraphTypeQuadratic["coords"] =
-                [
-                    [rangeCenterPoint[0] - 5, rangeCenterPoint[1] + 5],
-                    [rangeCenterPoint[0], rangeCenterPoint[1] - 5],
-                    [rangeCenterPoint[0] + 5, rangeCenterPoint[1] + 5],
-                ];
             return {
                 ...shared,
                 type: graph.type,
-                coords: defaultQuadraticCoords,
+                coords: getQuadraticCoords(graph, range, step),
             };
         case "angle":
         case "sinusoid":
@@ -374,6 +365,22 @@ const getPolygonCoords = ({
 
     const snapToGrid = !["angles", "sides"].includes(graph.snapTo || "");
     coords = normalizePoints(range, step, coords, /* noSnap */ !snapToGrid);
+
+    return coords;
+};
+
+const getQuadraticCoords = (
+    graph: PerseusGraphTypeQuadratic,
+    range: InitializeGraphStateParam["range"],
+    step: InitializeGraphStateParam["step"],
+): [Coord, Coord, Coord] => {
+    let coords: [Coord, Coord, Coord] = [
+        [0.25, 0.75],
+        [0.5, 0.25],
+        [0.75, 0.75],
+    ];
+
+    coords = normalizePoints(range, step, coords, true);
 
     return coords;
 };

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -10,6 +10,7 @@ import type {
     PerseusGraphTypeLinear,
     PerseusGraphTypeLinearSystem,
     PerseusGraphTypePolygon,
+    PerseusGraphTypeQuadratic,
 } from "../../../perseus-types";
 import type {
     CircleGraphState,
@@ -78,11 +79,12 @@ export function initializeGraphState(
             const rangeCenterPoint = range.map(([min, max]) =>
                 Math.round((min + max) / 2),
             );
-            const defaultQuadraticCoords: Coord[] = [
-                [rangeCenterPoint[0] - 5, rangeCenterPoint[1] + 5],
-                [rangeCenterPoint[0], rangeCenterPoint[1] - 5],
-                [rangeCenterPoint[0] + 5, rangeCenterPoint[1] + 5],
-            ];
+            const defaultQuadraticCoords: PerseusGraphTypeQuadratic["coords"] =
+                [
+                    [rangeCenterPoint[0] - 5, rangeCenterPoint[1] + 5],
+                    [rangeCenterPoint[0], rangeCenterPoint[1] - 5],
+                    [rangeCenterPoint[0] + 5, rangeCenterPoint[1] + 5],
+                ];
             return {
                 ...shared,
                 type: graph.type,

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -74,9 +74,22 @@ export function initializeGraphState(
                 center: [0, 0],
                 radiusPoint: [1, 0],
             };
+        case "quadratic":
+            const rangeCenterPoint = range.map(([min, max]) =>
+                Math.round((min + max) / 2),
+            );
+            const defaultQuadraticCoords: Coord[] = [
+                [rangeCenterPoint[0] - 4, rangeCenterPoint[1] + 5],
+                [rangeCenterPoint[0], rangeCenterPoint[1] - 5],
+                [rangeCenterPoint[0] + 3, rangeCenterPoint[1] + 5],
+            ];
+            return {
+                ...shared,
+                type: graph.type,
+                coords: defaultQuadraticCoords,
+            };
         case "angle":
         case "sinusoid":
-        case "quadratic":
             throw new Error(
                 "Mafs not yet implemented for graph type: " + graph.type,
             );

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -235,6 +235,13 @@ export function getGradableGraph(
         };
     }
 
+    if (state.type === "quadratic" && initialGraph.type === "quadratic") {
+        return {
+            ...initialGraph,
+            coords: state.coords,
+        };
+    }
+
     throw new Error(
         "Mafs is not yet implemented for graph type: " + initialGraph.type,
     );

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -79,9 +79,9 @@ export function initializeGraphState(
                 Math.round((min + max) / 2),
             );
             const defaultQuadraticCoords: Coord[] = [
-                [rangeCenterPoint[0] - 4, rangeCenterPoint[1] + 5],
+                [rangeCenterPoint[0] - 5, rangeCenterPoint[1] + 5],
                 [rangeCenterPoint[0], rangeCenterPoint[1] - 5],
-                [rangeCenterPoint[0] + 3, rangeCenterPoint[1] + 5],
+                [rangeCenterPoint[0] + 5, rangeCenterPoint[1] + 5],
             ];
             return {
                 ...shared,

--- a/packages/perseus/src/widgets/interactive-graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/types.ts
@@ -29,7 +29,8 @@ export type InteractiveGraphState =
     | RayGraphState
     | PolygonGraphState
     | PointGraphState
-    | CircleGraphState;
+    | CircleGraphState
+    | QuadraticGraphState;
 
 export interface InteractiveGraphStateCommon {
     hasBeenInteractedWith: boolean;
@@ -70,6 +71,11 @@ export interface CircleGraphState extends InteractiveGraphStateCommon {
     type: "circle";
     center: Coord;
     radiusPoint: Coord;
+}
+
+export interface QuadraticGraphState extends InteractiveGraphStateCommon {
+    type: "quadratic";
+    coords: Coord[];
 }
 
 export type PairOfPoints = [Coord, Coord];

--- a/packages/perseus/src/widgets/interactive-graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/types.ts
@@ -75,7 +75,7 @@ export interface CircleGraphState extends InteractiveGraphStateCommon {
 
 export interface QuadraticGraphState extends InteractiveGraphStateCommon {
     type: "quadratic";
-    coords: Coord[];
+    coords: [Coord, Coord, Coord];
 }
 
 export type PairOfPoints = [Coord, Coord];


### PR DESCRIPTION
## Summary:
This PR adds the quadratic question type to the new Mafs-based Interactive Graph widget. It should function identically to the original implementation within Interactive Graph (with 3 control points). 

**Note:** [There is a bug](https://khanacademy.atlassian.net/browse/LEMS-2014) related to the "getValidDestination" method that is incompatible with the innate keyboard support of Mafs. If a user tries to use the keyboard to move the control point to an invalid location, the control point will simply refuse to move further in that direction. As keyboard support is part of an upcoming stage of work on Interactive Graph, I have opted to leave this bug for now. I believe that we will need to find some way to differentiate between a mouse event and a keyboard event to solve this issue.

## Video:
### User View: 
https://github.com/Khan/perseus/assets/12463099/bab8ef09-6bfb-4e96-89c4-ef8f3542fd32

### Content Creator View:
https://github.com/Khan/perseus/assets/12463099/ef74ccf7-e0a7-440f-a1cc-42eb77665045

Issue: LEMS-1831

## Test plan:
make tesc / yarn jest