### PR TITLE
Remove :before pseudo-element to fix axis tick labels in Safari 15.6

### DIFF
--- a/.changeset/rich-spoons-deliver.md
+++ b/.changeset/rich-spoons-deliver.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix Safari-specific bug where axis tick numbers did not appear

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/axis-tick-labels.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/axis-tick-labels.tsx
@@ -210,9 +210,6 @@ const AxisTickLabel = ({
     const pointOnAxis: vec.Vector2 = axis === "x" ? [label, 0] : [0, label];
     const pixelPoint = pointToPixel(pointOnAxis, graphConfig);
 
-    // Remove the negative sign from the label string as it is handled in the data-content attribute
-    const labelString = Math.abs(label).toString();
-
     // Determine the relevant edge of the graph based on the axis type
     const graphEdge = axis === "x" ? graphConfig.width : graphConfig.height;
 
@@ -229,14 +226,9 @@ const AxisTickLabel = ({
         tickStep: tickStep[vectorIndex],
     });
 
-    // Determine whether or not to render a negative symbol for the tick label
-    // as the negative sign is handled in the data-content attribute in order to
-    // maintain the correct spacing between the labels
-    const dataContent = label < 0 && shouldShowLabel ? "−" : null;
-
     return (
-        <span className={`${axis}-axis-tick-label`} data-content={dataContent}>
-            {shouldShowLabel && labelString}
+        <span className={`${axis}-axis-tick-label`}>
+            {shouldShowLabel && label}
         </span>
     );
 };

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -204,7 +204,7 @@
 }
 
 .MafsView pattern g {
-    stroke: #909296;
+    stroke: rgba(33, 36, 44, 0.32);
 }
 .axis-tick-labels {
     font-size: 14px;
@@ -238,19 +238,6 @@
 }
 .x-axis-top-of-grid {
     transform: translateY(calc(-100% + 0.25em));
-}
-
-.x-axis-tick-labels span,
-.y-axis-tick-labels span {
-    /* The negative sign is rendered as a pseudo-element to
-        ensure that we are positioning all labels correctly */
-    &::before {
-        content: attr(data-content);
-        position: absolute;
-        /* We're translating the symbol up by 1px to ensure it's legible around gridlines. */
-        transform: translate(-100%, -1px);
-        font-weight: 600; /* This helps get the symbol to render crisply */
-    }
 }
 
 .y-axis-tick-labels span {


### PR DESCRIPTION
## Summary:

There was a bug where the axis tick numbers did not render in older versions of Safari
(Ben repro'd the issue on Safari 15.6). Third tracked it down to the `:before` pseudo-element that we were using to display the negative sign without affecting the alignment of the numbers below the tick marks. By removing the `:before`, we sacrifice the nice alignment,
but fix the Safari bug. In the future, we can consider other ways of achieving the alignment,
e.g. absolute positioning.

## Test plan:

- Review Storybook on Safari 15.6