### PR TITLE
Rapid prototype of layered graph + new svg axis-tick labels

### DIFF
--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/axis-tick-labels.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/axis-tick-labels.tsx
@@ -26,6 +26,7 @@ type GridLabel = {
     graphConfig: GraphConfig;
     axisOutOfBounds: boolean;
     axis: "x" | "y";
+    xLabelWidth?: number;
 };
 
 type GridAxisProps = {
@@ -191,6 +192,7 @@ const XGridAxis = (props: GridAxisProps): React.ReactElement => {
                         key={`x-grid-tick-${label}`}
                         graphConfig={graphConfig}
                         axisOutOfBounds={xAxisOutOfBounds}
+                        xLabelWidth={xLabelWidth}
                     />
                 );
             })}
@@ -204,6 +206,7 @@ const AxisTickLabel = ({
     graphConfig,
     axisOutOfBounds,
     axis,
+    xLabelWidth,
 }: GridLabel) => {
     const {gridStep, tickStep} = graphConfig;
     // Determine the point on the axis based on the axis type
@@ -228,8 +231,18 @@ const AxisTickLabel = ({
 
     return (
         <span className={`${axis}-axis-tick-label`}>
-            {shouldShowLabel && label}
+            {shouldShowLabel && labelSVG(label, xLabelWidth || 20)}
         </span>
+    );
+};
+
+const labelSVG = (label: number, xLabelWidth: number) => {
+    return (
+        <svg height={"25px"} width={xLabelWidth}>
+            <text x={xLabelWidth / 2 + "px"} y={10} textAnchor="middle">
+                {label}
+            </text>
+        </svg>
     );
 };
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -200,18 +200,50 @@ export const MafsGraph = (props: MafsGraphProps) => {
                     backgroundImage={props.backgroundImage}
                 />
                 <View
+                    className="mafs-grid"
                     style={{
                         position: "absolute",
                         bottom: 0,
                         left: 0,
                     }}
                 >
+                    <Mafs
+                        preserveAspectRatio={false}
+                        viewBox={{
+                            x: state.range[0],
+                            y: state.range[1],
+                            padding: 0,
+                        }}
+                        pan={false}
+                        zoom={false}
+                        width={width}
+                        height={height}
+                    >
+                        {/* Background layer */}
+                        <Grid
+                            tickStep={props.step}
+                            gridStep={props.gridStep}
+                            range={state.range}
+                            containerSizeClass={props.containerSizeClass}
+                            markings={props.markings}
+                        />
+                    </Mafs>
+
                     {props.markings === "graph" && (
                         <>
                             <AxisLabels />
                             <AxisTickLabels />
                         </>
                     )}
+                </View>
+                <View
+                    className="actual-graph"
+                    style={{
+                        position: "absolute",
+                        bottom: 0,
+                        left: 0,
+                    }}
+                >
                     <Mafs
                         preserveAspectRatio={false}
                         viewBox={{
@@ -226,15 +258,6 @@ export const MafsGraph = (props: MafsGraphProps) => {
                     >
                         {/* Svg definitions to render only once */}
                         <SvgDefs />
-
-                        {/* Background layer */}
-                        <Grid
-                            tickStep={props.step}
-                            gridStep={props.gridStep}
-                            range={state.range}
-                            containerSizeClass={props.containerSizeClass}
-                            markings={props.markings}
-                        />
 
                         {/* Locked layer */}
                         {props.lockedFigures && (

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -214,15 +214,13 @@
      * drag interactions on the graph. */
     user-select: none;
     pointer-events: none;
-    /* Prevent labels from covering up interaction points. */
-    z-index: -1;
 }
 
 .y-axis-tick-labels {
     width: 1.75em;
     display: flex;
     flex-flow: column;
-    transform: translateX(calc(-100% - 0.5em));
+    transform: translateX(calc(-100%));
     position: absolute;
     text-align: right;
 }
@@ -248,4 +246,19 @@
 .x-axis-tick-labels span {
     text-align: center;
     width: var(--x-axis-label-width, 20px);
+}
+.axis-tick-labels svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+    font-size: 14px;
+}
+.axis-tick-labels svg text {
+    /* we want to add a white stroke to the text */
+    stroke: white;
+    stroke-width: 8px;
+    stroke-linecap: round;
+    fill: black;
+    /* we want to make sure the stroke  is rendered before the fill */
+    paint-order: stroke fill;
 }


### PR DESCRIPTION
## Summary:
DO NOT APPROVE. 
THIS PR IS JUST TO TEST A PROOF OF CONCEPT IN LAMBDA TO VERIFY THINGS WORK PROPERLY IN SAFARI. 

We've been facing a lot of issues with the gridlines and interactive elements needing to sandwich the axis tick labels. This is a rapid proof of concept prototype that switches the axis tick labels to individual svgs (so that we can use a nice text stroke, which should be more performant than text-shadows) + the breaking out of the graph layers. 

This PR has not spent any time worrying about making things DRY or clean. It's purpose is simply to see what is possible to help frame upcoming decisions. 