### PR TITLE
[Interactive graph editor] Streamline locked figure tests

### DIFF
--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
@@ -93,7 +93,7 @@ describe("InteractiveGraphEditor locked figures", () => {
 
             // Act
             const deleteButton = screen.getByRole("button", {
-                name: /Delete*/,
+                name: /Delete/,
             });
             await userEvent.click(deleteButton);
 
@@ -121,7 +121,7 @@ describe("InteractiveGraphEditor locked figures", () => {
 
             // Act
             const deleteButton = screen.getByRole("button", {
-                name: /Delete*/,
+                name: /Delete/,
             });
             await userEvent.click(deleteButton);
 
@@ -142,12 +142,10 @@ describe("InteractiveGraphEditor locked figures", () => {
             const accordionHeading = screen.getAllByRole("heading", {
                 level: 2,
             })[0];
-            const capitalizedFigureType =
-                figureType.charAt(0).toUpperCase() + figureType.slice(1);
 
             // Assert
             expect(accordionHeading).toBeInTheDocument();
-            expect(accordionHeading).toHaveTextContent(capitalizedFigureType);
+            expect(accordionHeading).toHaveTextContent(figureName);
         });
 
         test("Calls onChange when a locked $figureType's color is changed", async () => {


### PR DESCRIPTION
## Summary:
The `interactive-graph-locked-figures.test.tsx` file was getting really long,
so I thought I would take a pass at streamlining it.

There are a bunch of things that are common amongst the different locked figures,
so I batched them into a `test.each` at the top. This should also help when adding
more features in the future (soon).

I also created a `renderEditor()` function that makes it so that all the tests
don't have to specify the `RenderStateRoot` wrapper, which was also needlessly
taking up space.

This only took it down from ~870 lines to ~600 lines If anyone has ideas for how to streamline it more, I'm all ears.

Issue: none

## Test plan:
`yarn jest packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx`