### PR TITLE
[Accessibility Bug] Fixing alt and aria-hidden issues with image widgets.

### DIFF
--- a/.changeset/eleven-carrots-relate.md
+++ b/.changeset/eleven-carrots-relate.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fixing accessibility bug in image widget.

--- a/packages/perseus/src/components/svg-image.tsx
+++ b/packages/perseus/src/components/svg-image.tsx
@@ -594,15 +594,7 @@ class SvgImage extends React.Component<Props, State> {
         const imageProps: ImageProps = {
             alt: this.props.alt,
             title: this.props.title,
-            tabIndex: "0",
         };
-        // If alt text is present, AND overrideAriaHidden is true,
-        // include aria-hidden to avoid screen reader from crawling texts
-        // both from the div meant for screen readers (see svg-image.jsx)
-        // and alt attribute.
-        if (this.props.alt && this.props.overrideAriaHidden) {
-            imageProps["aria-hidden"] = true;
-        }
 
         const width = this.props.width && this.props.width * this.props.scale;
         const height =

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/group.test.tsx.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/group.test.tsx.snap
@@ -1163,24 +1163,6 @@ exports[`group widget should snapshot: initial render 1`] = `
                                 </div>
                               </span>
                             </div>
-                            <span
-                              class="perseus-sr-only"
-                            >
-                              <div
-                                class="perseus-renderer perseus-renderer-responsive"
-                              >
-                                <div
-                                  class="paragraph"
-                                  data-perseus-paragraph-index="0"
-                                >
-                                  <div
-                                    class="paragraph"
-                                  >
-                                    A number line labeled 200 to 300 with tick marks at every 5 units. The tick marks at 200, 210, 220, 230, 240, 250, 260, 270, 280, 290, and 300 are labeled. A red circle labeled A is between 220 tick mark and 230 tick mark.
-                                  </div>
-                                </div>
-                              </div>
-                            </span>
                           </figure>
                         </div>
                       </div>

--- a/packages/perseus/src/widgets/__tests__/__snapshots__/image.test.ts.snap
+++ b/packages/perseus/src/widgets/__tests__/__snapshots__/image.test.ts.snap
@@ -56,24 +56,6 @@ exports[`image widget - isMobile %b should snapshot: first render 1`] = `
                       </div>
                     </span>
                   </div>
-                  <span
-                    class="perseus-sr-only"
-                  >
-                    <div
-                      class="perseus-renderer perseus-renderer-responsive"
-                    >
-                      <div
-                        class="paragraph"
-                        data-perseus-paragraph-index="0"
-                      >
-                        <div
-                          class="paragraph"
-                        >
-                          An array of isosceles triangles. A triangle has height A. Two smaller triangle, one with height B and one with height C, have approximately the same combined height as A.
-                        </div>
-                      </div>
-                    </div>
-                  </span>
                   <figcaption
                     class="perseus-image-caption has-title"
                     style="max-width: 420px;"
@@ -256,24 +238,6 @@ exports[`image widget - isMobile %b should snapshot: first render 2`] = `
                       </div>
                     </span>
                   </div>
-                  <span
-                    class="perseus-sr-only"
-                  >
-                    <div
-                      class="perseus-renderer perseus-renderer-responsive"
-                    >
-                      <div
-                        class="paragraph"
-                        data-perseus-paragraph-index="0"
-                      >
-                        <div
-                          class="paragraph"
-                        >
-                          An array of isosceles triangles. A triangle has height A. Two smaller triangle, one with height B and one with height C, have approximately the same combined height as A.
-                        </div>
-                      </div>
-                    </div>
-                  </span>
                   <figcaption
                     class="perseus-image-caption"
                     style="max-width: 420px;"

--- a/packages/perseus/src/widgets/image.tsx
+++ b/packages/perseus/src/widgets/image.tsx
@@ -110,9 +110,7 @@ class ImageWidget extends React.Component<Props> {
                     {({setAssetStatus}) => (
                         <SvgImage
                             src={url}
-                            alt={
-                                alt
-                            }
+                            alt={alt}
                             width={backgroundImage.width}
                             height={backgroundImage.height}
                             preloader={apiOptions.imagePreloader}

--- a/packages/perseus/src/widgets/image.tsx
+++ b/packages/perseus/src/widgets/image.tsx
@@ -92,7 +92,7 @@ class ImageWidget extends React.Component<Props> {
 
     render(): React.ReactNode {
         let image;
-        let alt = this.props.caption === this.props.alt ? "" : this.props.alt;
+        const alt = this.props.caption === this.props.alt ? "" : this.props.alt;
         const {apiOptions} = this.props;
 
         const backgroundImage = this.props.backgroundImage;

--- a/packages/perseus/src/widgets/image.tsx
+++ b/packages/perseus/src/widgets/image.tsx
@@ -92,16 +92,10 @@ class ImageWidget extends React.Component<Props> {
 
     render(): React.ReactNode {
         let image;
-        let alt;
+        let alt = this.props.caption === this.props.alt ? "" : this.props.alt;
         const {apiOptions} = this.props;
 
         const backgroundImage = this.props.backgroundImage;
-
-        if (this.props.caption === this.props.alt) {
-            alt = "";
-        } else {
-            alt = this.props.alt;
-        }
 
         if (backgroundImage.url) {
             const url = backgroundImage.url;

--- a/packages/perseus/src/widgets/image.tsx
+++ b/packages/perseus/src/widgets/image.tsx
@@ -97,6 +97,12 @@ class ImageWidget extends React.Component<Props> {
 
         const backgroundImage = this.props.backgroundImage;
 
+        if (this.props.alt && this.props.caption && this.props.caption == this.props.alt) {
+            alt = "";
+        } else {
+            alt = this.props.alt;
+        }
+
         if (backgroundImage.url) {
             const url = backgroundImage.url;
             image = (
@@ -105,29 +111,8 @@ class ImageWidget extends React.Component<Props> {
                         <SvgImage
                             src={url}
                             alt={
-                                /* alt text is formatted in a sr-only
-                               div next to the image in addition to
-                               the alt attribute.
-                               If there is no alt text at all,
-                               we don't put an alt attribute on
-                               the image, so that screen readers
-                               know there's something they can't
-                               read there :(.
-                               NOTE: React <=0.13 (maybe later)
-                               has a bug where it won't ever
-                               remove an attribute, so if this
-                               alt node is ever defined it's
-                               not removed. This is sort of
-                               dangerous, but we usually re-key
-                               new renderers so that they're
-                               rendered from scratch anyways,
-                               so this shouldn't be a problem
-                               in practice right now, although
-                               it will exhibit weird behaviour
-                               while editing. */
-                                this.props.alt
+                                alt
                             }
-                            overrideAriaHidden={true}
                             width={backgroundImage.width}
                             height={backgroundImage.height}
                             preloader={apiOptions.imagePreloader}
@@ -144,19 +129,6 @@ class ImageWidget extends React.Component<Props> {
                         />
                     )}
                 </AssetContext.Consumer>
-            );
-        }
-
-        if (this.props.alt) {
-            alt = (
-                <span className="perseus-sr-only">
-                    <Renderer
-                        content={this.props.alt}
-                        apiOptions={apiOptions}
-                        linterContext={this.props.linterContext}
-                        strings={this.context.strings}
-                    />
-                </span>
             );
         }
 
@@ -240,7 +212,6 @@ class ImageWidget extends React.Component<Props> {
                     }}
                 >
                     {image}
-                    {alt}
                     {titleAndCaption}
                 </figure>
             );
@@ -288,7 +259,6 @@ class ImageWidget extends React.Component<Props> {
             >
                 {title}
                 {image}
-                {alt}
                 {caption}
             </figure>
         );

--- a/packages/perseus/src/widgets/image.tsx
+++ b/packages/perseus/src/widgets/image.tsx
@@ -97,7 +97,7 @@ class ImageWidget extends React.Component<Props> {
 
         const backgroundImage = this.props.backgroundImage;
 
-        if (this.props.caption == this.props.alt) {
+        if (this.props.caption === this.props.alt) {
             alt = "";
         } else {
             alt = this.props.alt;

--- a/packages/perseus/src/widgets/image.tsx
+++ b/packages/perseus/src/widgets/image.tsx
@@ -97,7 +97,7 @@ class ImageWidget extends React.Component<Props> {
 
         const backgroundImage = this.props.backgroundImage;
 
-        if (this.props.alt && this.props.caption && this.props.caption == this.props.alt) {
+        if (this.props.caption == this.props.alt) {
             alt = "";
         } else {
             alt = this.props.alt;


### PR DESCRIPTION
Fixing some issues around the accessibility of the image widget as it relates to alt text and aria-hidden usage. The fix is as follows:

- If the alt text and the caption are the same, set the alt text to "". This will ensure the image is still accessibility compliant, while avoiding reading out duplicate information. This is similar to a pattern that WCAG recommends for decorative images, https://www.w3.org/WAI/tutorials/images/decorative/.
- Remove hidden screen reader text blocks. This is unnecessary HTML content as we should make use of the alt text in images instead of re-creating it.
- Removing tabindex=0 and aria-hidden attribute on svg images. Non-interactive content should not be tabbable and like wise we shouldn't be aria-hiding images. If the images add no additional information for users we should simply set alt="".