### PR TITLE
Make the cursor for the circle edge point a left-right arrow

### DIFF
--- a/.changeset/beige-yaks-sin.md
+++ b/.changeset/beige-yaks-sin.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Change the cursor to a left-right arrow when the user hovers over the resize point of a circle on a Mafs interactive graph

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -30,6 +30,7 @@ export function CircleGraph(props: CircleGraphProps) {
             />
             <StyledMovablePoint
                 point={radiusPoint}
+                cursor="ew-resize"
                 onMove={(newRadiusPoint) => {
                     dispatch(moveRadiusPoint(newRadiusPoint));
                 }}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/css-cursor.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/css-cursor.ts
@@ -1,3 +1,3 @@
 // TODO(benchristel): add more possibilities for `cursor` if we need them
 // in the future.
-export type CSSCursor = "move" | "ew-resize"
+export type CSSCursor = "move" | "ew-resize";

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/css-cursor.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/css-cursor.ts
@@ -1,0 +1,3 @@
+// TODO(benchristel): add more possibilities for `cursor` if we need them
+// in the future.
+export type CSSCursor = "move" | "ew-resize"

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/css-cursor.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/css-cursor.ts
@@ -1,3 +1,6 @@
+// A type representing the values of the CSS `cursor` property that we use in
+// interactive graphs. For documentation on `cursor` see:
+// https://developer.mozilla.org/en-US/docs/Web/CSS/cursor
 // TODO(benchristel): add more possibilities for `cursor` if we need them
 // in the future.
 export type CSSCursor = "move" | "ew-resize";

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
@@ -6,9 +6,9 @@ import {forwardRef} from "react";
 import useGraphConfig from "../../reducer/use-graph-config";
 import {useTransformVectorsToPixels} from "../use-transform";
 
+import type {CSSCursor} from "./css-cursor";
 import type {vec} from "mafs";
 import type {ForwardedRef} from "react";
-import {CSSCursor} from "./css-cursor";
 
 type Props = {
     point: vec.Vector2;
@@ -38,7 +38,13 @@ const hitboxSizePx = 48;
 export const MovablePointView = forwardRef(
     (props: Props, hitboxRef: ForwardedRef<SVGGElement>) => {
         const {range, markings, showTooltips} = useGraphConfig();
-        const {point, color = WBColor.blue, dragging, focusBehavior, cursor} = props;
+        const {
+            point,
+            color = WBColor.blue,
+            dragging,
+            focusBehavior,
+            cursor,
+        } = props;
 
         // WB Tooltip requires a color name for the background color.
         // Since the color in props is a hex value, a reverse lookup is needed.

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
@@ -8,12 +8,14 @@ import {useTransformVectorsToPixels} from "../use-transform";
 
 import type {vec} from "mafs";
 import type {ForwardedRef} from "react";
+import {CSSCursor} from "./css-cursor";
 
 type Props = {
     point: vec.Vector2;
     color?: string | undefined;
     dragging: boolean;
     focusBehavior: FocusBehaviorConfig;
+    cursor?: CSSCursor | undefined;
 };
 
 type FocusBehaviorConfig =
@@ -36,7 +38,7 @@ const hitboxSizePx = 48;
 export const MovablePointView = forwardRef(
     (props: Props, hitboxRef: ForwardedRef<SVGGElement>) => {
         const {range, markings, showTooltips} = useGraphConfig();
-        const {point, color = WBColor.blue, dragging, focusBehavior} = props;
+        const {point, color = WBColor.blue, dragging, focusBehavior, cursor} = props;
 
         // WB Tooltip requires a color name for the background color.
         // Since the color in props is a hex value, a reverse lookup is needed.
@@ -80,7 +82,7 @@ export const MovablePointView = forwardRef(
             <g
                 ref={hitboxRef}
                 className={pointClasses}
-                style={{"--movable-point-color": color} as any}
+                style={{"--movable-point-color": color, cursor} as any}
                 data-testid="movable-point"
                 tabIndex={tabIndex(focusBehavior)}
             >

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
@@ -8,8 +8,8 @@ import {snap} from "../../utils";
 
 import {MovablePointView} from "./movable-point-view";
 
+import type {CSSCursor} from "./css-cursor";
 import type {vec} from "mafs";
-import {CSSCursor} from "./css-cursor";
 
 type Props = {
     point: vec.Vector2;

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
@@ -9,17 +9,19 @@ import {snap} from "../../utils";
 import {MovablePointView} from "./movable-point-view";
 
 import type {vec} from "mafs";
+import {CSSCursor} from "./css-cursor";
 
 type Props = {
     point: vec.Vector2;
     onMove: (newPoint: vec.Vector2) => unknown;
     color?: string;
+    cursor?: CSSCursor | undefined;
 };
 
 export const StyledMovablePoint = (props: Props) => {
     const {snapStep} = useGraphConfig();
     const elementRef = useRef<SVGGElement>(null);
-    const {point, onMove, color = WBColor.blue} = props;
+    const {point, onMove, cursor, color = WBColor.blue} = props;
 
     const {dragging} = useMovable({
         gestureTarget: elementRef,
@@ -35,6 +37,7 @@ export const StyledMovablePoint = (props: Props) => {
             color={color}
             dragging={dragging}
             focusBehavior={{type: "uncontrolled", tabIndex: 0}}
+            cursor={cursor}
         />
     );
 };


### PR DESCRIPTION
## Summary:
You can only drag this particular point to the left and right. The new
cursor makes that apparent.

Issue: LEMS-1979

Test plan:

Paste this data into the flipbook:

```
{"content":"**Graph the circle $(x+2)^2+(y+1)^2=49$.**\n\n[[☃ interactive-graph 1]]","images":{},"widgets":{"interactive-graph 1":{"alignment":"default","graded":true,"options":{"backgroundImage":{"url":null},"correct":{"center":[-2,-1],"radius":7,"type":"circle"},"graph":{"type":"circle"},"gridStep":[1,1],"labels":["x","y"],"markings":"graph","range":[[-10,10],[-10,10]],"rulerLabel":"","rulerTicks":10,"showProtractor":false,"showRuler":false,"snapStep":[1,1],"step":[1,1]},"static":false,"type":"interactive-graph","version":{"major":0,"minor":0}}}}
```

The cursor should change to a left-right arrow when you hover over the
movable point that changes the size of the circle.

https://github.com/Khan/perseus/assets/693920/036bf0ed-aae0-40f3-8e4b-3599a3f4b9ca


