### PR TITLE
Prevent the sides of a Mafs polygon from crossing

### DIFF
--- a/.changeset/eleven-ligers-accept.md
+++ b/.changeset/eleven-ligers-accept.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Prevent the sides of polygons on Mafs interactive graphs from crossing

--- a/packages/perseus/src/util/geometry.test.ts
+++ b/packages/perseus/src/util/geometry.test.ts
@@ -76,18 +76,44 @@ describe("clockwise", () => {
 
 describe("polygonSidesIntersect", () => {
     it("is false given an ordinary triangle", () => {
-        expect(polygonSidesIntersect([[0, 0], [1, 0], [0, 1]])).toBe(false)
-    })
+        expect(
+            polygonSidesIntersect([
+                [0, 0],
+                [1, 0],
+                [0, 1],
+            ]),
+        ).toBe(false);
+    });
 
     it("is true given a 'triangle' with two vertices the same", () => {
-        expect(polygonSidesIntersect([[0, 0], [1, 0], [1, 0]])).toBe(true)
-    })
+        expect(
+            polygonSidesIntersect([
+                [0, 0],
+                [1, 0],
+                [1, 0],
+            ]),
+        ).toBe(true);
+    });
 
     it("is true given a quadrilateral with intersecting sides", () => {
-        expect(polygonSidesIntersect([[0, 0], [2, 2], [0, 2], [2, 0]])).toBe(true)
-    })
+        expect(
+            polygonSidesIntersect([
+                [0, 0],
+                [2, 2],
+                [0, 2],
+                [2, 0],
+            ]),
+        ).toBe(true);
+    });
 
     it("is false given a quadrilateral with non-intersecting sides", () => {
-        expect(polygonSidesIntersect([[0, 0], [2, 0], [2, 2], [0, 2]])).toBe(false)
-    })
-})
+        expect(
+            polygonSidesIntersect([
+                [0, 0],
+                [2, 0],
+                [2, 2],
+                [0, 2],
+            ]),
+        ).toBe(false);
+    });
+});

--- a/packages/perseus/src/util/geometry.test.ts
+++ b/packages/perseus/src/util/geometry.test.ts
@@ -1,4 +1,4 @@
-import {clockwise, reverseVector} from "./geometry";
+import {clockwise, polygonSidesIntersect, reverseVector} from "./geometry";
 
 describe("reverseVector", () => {
     it("flips the sign of zero", () => {
@@ -73,3 +73,21 @@ describe("clockwise", () => {
         ).toBe(true);
     });
 });
+
+describe("polygonSidesIntersect", () => {
+    it("is false given an ordinary triangle", () => {
+        expect(polygonSidesIntersect([[0, 0], [1, 0], [0, 1]])).toBe(false)
+    })
+
+    it("is true given a 'triangle' with two vertices the same", () => {
+        expect(polygonSidesIntersect([[0, 0], [1, 0], [1, 0]])).toBe(true)
+    })
+
+    it("is true given a quadrilateral with intersecting sides", () => {
+        expect(polygonSidesIntersect([[0, 0], [2, 2], [0, 2], [2, 0]])).toBe(true)
+    })
+
+    it("is false given a quadrilateral with non-intersecting sides", () => {
+        expect(polygonSidesIntersect([[0, 0], [2, 0], [2, 2], [0, 2]])).toBe(false)
+    })
+})

--- a/packages/perseus/src/util/geometry.ts
+++ b/packages/perseus/src/util/geometry.ts
@@ -95,10 +95,10 @@ export function polygonSidesIntersect(vertices: Coord[]): boolean {
 
             const side1: Line = [vertices[i], vertices[iNext]];
             const side2: Line = [vertices[k], vertices[kNext]];
-            if (intersects(side1, side2)) return true
+            if (intersects(side1, side2)) return true;
         }
     }
-    return false
+    return false;
 }
 
 export function vector(a, b) {

--- a/packages/perseus/src/util/geometry.ts
+++ b/packages/perseus/src/util/geometry.ts
@@ -84,18 +84,24 @@ export function polygonSidesIntersect(vertices: Coord[]): boolean {
     for (let i = 0; i < vertices.length; i++) {
         for (let k = i + 1; k < vertices.length; k++) {
             // If any two vertices are the same point, sides overlap
-            if (kpoint.equal(vertices[i], vertices[k])) return true;
+            if (kpoint.equal(vertices[i], vertices[k])) {
+                return true;
+            }
 
             // Find the other end of the sides starting at vertices i and k
             const iNext = (i + 1) % vertices.length;
             const kNext = (k + 1) % vertices.length;
 
             // Adjacent sides always intersect (at the vertex); skip those
-            if (iNext === k || kNext === i) continue;
+            if (iNext === k || kNext === i) {
+                continue;
+            }
 
             const side1: Line = [vertices[i], vertices[iNext]];
             const side2: Line = [vertices[k], vertices[kNext]];
-            if (intersects(side1, side2)) return true;
+            if (intersects(side1, side2)) {
+                return true;
+            }
         }
     }
     return false;

--- a/packages/perseus/src/util/geometry.ts
+++ b/packages/perseus/src/util/geometry.ts
@@ -2,7 +2,7 @@
  * A collection of geomtry-related utility functions
  */
 
-import {number as knumber} from "@khanacademy/kmath";
+import {number as knumber, point as kpoint} from "@khanacademy/kmath";
 import _ from "underscore";
 
 import Util from "../util";
@@ -77,6 +77,28 @@ export function intersects(ab: Line, cd: Line): boolean {
     }
 
     return false;
+}
+
+// Whether any two sides of a polygon intersect each other
+export function polygonSidesIntersect(vertices: Coord[]): boolean {
+    for (let i = 0; i < vertices.length; i++) {
+        for (let k = i + 1; k < vertices.length; k++) {
+            // If any two vertices are the same point, sides overlap
+            if (kpoint.equal(vertices[i], vertices[k])) return true;
+
+            // Find the other end of the sides starting at vertices i and k
+            const iNext = (i + 1) % vertices.length;
+            const kNext = (k + 1) % vertices.length;
+
+            // Adjacent sides always intersect (at the vertex); skip those
+            if (iNext === k || kNext === i) continue;
+
+            const side1: Line = [vertices[i], vertices[iNext]];
+            const side2: Line = [vertices[k], vertices[kNext]];
+            if (intersects(side1, side2)) return true
+        }
+    }
+    return false
 }
 
 export function vector(a, b) {

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -62,6 +62,23 @@ const baseSinusoidGraphState: InteractiveGraphState = {
     ],
 };
 
+const basePolygonGraphState: InteractiveGraphState = {
+    hasBeenInteractedWith: false,
+    type: "polygon",
+    showAngles: false,
+    showSides: false,
+    range: [
+        [-10, 10],
+        [-10, 10],
+    ],
+    snapStep: [1, 1],
+    coords: [
+        [0, 0],
+        [0, 1],
+        [1, 0],
+    ],
+};
+
 describe("moveControlPoint", () => {
     it("moves the given point", () => {
         const state: InteractiveGraphState = {
@@ -276,7 +293,7 @@ describe("moveSegment", () => {
     });
 });
 
-describe("movePoint", () => {
+describe("movePoint on a point graph", () => {
     it("moves the point with the given index", () => {
         const state: InteractiveGraphState = {
             ...basePointGraphState,
@@ -329,6 +346,42 @@ describe("movePoint", () => {
         const updated = interactiveGraphReducer(state, movePoint(0, [1, 1]));
 
         expect(updated.hasBeenInteractedWith).toBe(true);
+    });
+});
+
+describe("movePoint on a polygon graph", () => {
+    it("moves a point", () => {
+        const state: InteractiveGraphState = {
+            ...basePolygonGraphState,
+            coords: [
+                [0, 0],
+                [0, 2],
+                [2, 2],
+                [2, 0],
+            ],
+        };
+
+        const updated = interactiveGraphReducer(state, movePoint(0, [0, 1]));
+
+        invariant(updated.type === "polygon");
+        expect(updated.coords[0]).toEqual([0, 1]);
+    });
+
+    it("rejects the move if it would cause sides of the polygon to intersect", () => {
+        const state: InteractiveGraphState = {
+            ...basePolygonGraphState,
+            coords: [
+                [0, 0],
+                [0, 2],
+                [2, 2],
+                [2, 0],
+            ],
+        };
+
+        const updated = interactiveGraphReducer(state, movePoint(0, [1, 3]));
+
+        invariant(updated.type === "polygon");
+        expect(updated.coords[0]).toEqual([0, 0]);
     });
 });
 

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -27,6 +27,7 @@ import {
 
 import type {InteractiveGraphState, PairOfPoints} from "../types";
 import type {Interval} from "mafs";
+import {polygonSidesIntersect} from "../../../util/geometry";
 
 export function interactiveGraphReducer(
     state: InteractiveGraphState,
@@ -179,6 +180,22 @@ function doMovePoint(
 ): InteractiveGraphState {
     switch (state.type) {
         case "polygon":
+            const newCoords = setAtIndex({
+                array: state.coords,
+                index: action.index,
+                newValue: boundAndSnapToGrid(action.destination, state),
+            });
+
+            // Reject the move if it would cause the sides of the polygon to cross
+            if (polygonSidesIntersect(newCoords)) {
+                return state;
+            }
+
+            return {
+                ...state,
+                hasBeenInteractedWith: true,
+                coords: newCoords,
+            };
         case "point": {
             return {
                 ...state,

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -58,7 +58,6 @@ function doMoveControlPoint(
     state: InteractiveGraphState,
     action: MoveControlPoint,
 ): InteractiveGraphState {
-    const {snapStep, range} = state;
     switch (state.type) {
         case "segment":
         case "linear":
@@ -71,11 +70,7 @@ function doMoveControlPoint(
                     setAtIndex({
                         array: tuple,
                         index: action.pointIndex,
-                        newValue: boundAndSnapToGrid({
-                            snapStep,
-                            range,
-                            point: action.destination,
-                        }),
+                        newValue: boundAndSnapToGrid(action.destination, state),
                     }),
             });
 
@@ -191,11 +186,7 @@ function doMovePoint(
                 coords: setAtIndex({
                     array: state.coords,
                     index: action.index,
-                    newValue: boundAndSnapToGrid({
-                        snapStep: state.snapStep,
-                        range: state.range,
-                        point: action.destination,
-                    }),
+                    newValue: boundAndSnapToGrid(action.destination, state),
                 }),
             };
         }
@@ -214,11 +205,7 @@ function doMovePoint(
                 coords: setAtIndex({
                     array: state.coords,
                     index: action.index,
-                    newValue: boundAndSnapToGrid({
-                        snapStep: state.snapStep,
-                        range: state.range,
-                        point: destination,
-                    }),
+                    newValue: boundAndSnapToGrid(destination, state),
                 }),
             };
         }
@@ -229,11 +216,7 @@ function doMovePoint(
                 coords: setAtIndex({
                     array: state.coords,
                     index: action.index,
-                    newValue: boundAndSnapToGrid({
-                        snapStep: state.snapStep,
-                        range: state.range,
-                        point: action.destination,
-                    }),
+                    newValue: boundAndSnapToGrid(action.destination, state),
                 }),
             };
         }
@@ -386,7 +369,10 @@ interface ConstraintArgs {
     point: vec.Vector2;
 }
 
-function boundAndSnapToGrid({snapStep, range, point}: ConstraintArgs) {
+function boundAndSnapToGrid(
+    point: vec.Vector2,
+    {snapStep, range}: {snapStep: vec.Vector2; range: [Interval, Interval]},
+) {
     return snap(snapStep, bound({snapStep, range, point}));
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -71,14 +71,11 @@ function doMoveControlPoint(
                     setAtIndex({
                         array: tuple,
                         index: action.pointIndex,
-                        newValue: snap(
+                        newValue: boundAndSnapToGrid({
                             snapStep,
-                            bound({
-                                snapStep,
-                                range,
-                                point: action.destination,
-                            }),
-                        ),
+                            range,
+                            point: action.destination,
+                        }),
                     }),
             });
 
@@ -194,14 +191,11 @@ function doMovePoint(
                 coords: setAtIndex({
                     array: state.coords,
                     index: action.index,
-                    newValue: snap(
-                        state.snapStep,
-                        bound({
-                            snapStep: state.snapStep,
-                            range: state.range,
-                            point: action.destination,
-                        }),
-                    ),
+                    newValue: boundAndSnapToGrid({
+                        snapStep: state.snapStep,
+                        range: state.range,
+                        point: action.destination,
+                    }),
                 }),
             };
         }
@@ -220,14 +214,11 @@ function doMovePoint(
                 coords: setAtIndex({
                     array: state.coords,
                     index: action.index,
-                    newValue: snap(
-                        state.snapStep,
-                        bound({
-                            snapStep: state.snapStep,
-                            range: state.range,
-                            point: destination,
-                        }),
-                    ),
+                    newValue: boundAndSnapToGrid({
+                        snapStep: state.snapStep,
+                        range: state.range,
+                        point: destination,
+                    }),
                 }),
             };
         }
@@ -238,14 +229,11 @@ function doMovePoint(
                 coords: setAtIndex({
                     array: state.coords,
                     index: action.index,
-                    newValue: snap(
-                        state.snapStep,
-                        bound({
-                            snapStep: state.snapStep,
-                            range: state.range,
-                            point: action.destination,
-                        }),
-                    ),
+                    newValue: boundAndSnapToGrid({
+                        snapStep: state.snapStep,
+                        range: state.range,
+                        point: action.destination,
+                    }),
                 }),
             };
         }
@@ -396,6 +384,10 @@ interface ConstraintArgs {
     snapStep: vec.Vector2;
     range: [Interval, Interval];
     point: vec.Vector2;
+}
+
+function boundAndSnapToGrid({snapStep, range, point}: ConstraintArgs) {
+    return snap(snapStep, bound({snapStep, range, point}));
 }
 
 // Returns the closest point to the given `point` that is within the graph

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -3,6 +3,7 @@ import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
 import {vec} from "mafs";
 import _ from "underscore";
 
+import {polygonSidesIntersect} from "../../../util/geometry";
 import {snap} from "../utils";
 
 import {
@@ -27,7 +28,6 @@ import {
 
 import type {InteractiveGraphState, PairOfPoints} from "../types";
 import type {Interval} from "mafs";
-import {polygonSidesIntersect} from "../../../util/geometry";
 
 export function interactiveGraphReducer(
     state: InteractiveGraphState,


### PR DESCRIPTION
## Summary:
The legacy interactive graph constrained vertex movement on polygon
graphs to prevent sides from crossing. As of this commit, we now do the
same for Mafs interactive graphs.

Issue: LEMS-1896

Test plan:

Run:

```
grep -rl '"type":"polygon"' data/questions/ | xargs cat | pbcopy
```

Paste the data into `http://localhost:5173#flipbook`.

Play around with the polygons and verify that you can't make their lines
cross.