### PR TITLE
Use coords from props to initialize Mafs graph state

### DIFF
--- a/.changeset/pink-weeks-cheer.md
+++ b/.changeset/pink-weeks-cheer.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix a bug where, after a page refresh, the interactive graph widget editor displayed the default interactive elements instead of the correct answer to the graph.

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -8,7 +8,7 @@ import type {Interval, vec} from "mafs";
 // and exported from the package, so we need to keep it around.
 export type Range = Interval;
 export type Size = [number, number];
-export type CollinearTuple = readonly [vec.Vector2, vec.Vector2];
+export type CollinearTuple = [vec.Vector2, vec.Vector2];
 export type ShowSolutions = "all" | "selected" | "none";
 
 export type PerseusWidgetsMap = {
@@ -758,7 +758,7 @@ export type PerseusGraphTypeLinear = {
 export type PerseusGraphTypeLinearSystem = {
     type: "linear-system";
     // expects 2 sets of 2 coords
-    coords?: ReadonlyArray<CollinearTuple>;
+    coords?: CollinearTuple[];
 } & PerseusGraphTypeCommon;
 
 export type PerseusGraphTypePoint = {
@@ -794,7 +794,7 @@ export type PerseusGraphTypeSegment = {
     // The number of segments if a "segment" type. default: 1.  Max: 6
     numSegments?: number;
     // Expects a list of Coord tuples. Length should match the `numSegments` value.
-    coords?: ReadonlyArray<CollinearTuple>;
+    coords?: CollinearTuple[];
 } & PerseusGraphTypeCommon;
 
 export type PerseusGraphTypeSinusoid = {

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
@@ -289,6 +289,30 @@ describe("initializeGraphState for point graphs", () => {
     );
 });
 
+describe("initializeGraphState for circle graphs", () => {
+    it("uses the given circle specs, if present", () => {
+        const graph = initializeGraphState({
+            ...baseGraphData,
+            graph: {type: "circle", center: [1, 2], radius: 5},
+        });
+
+        invariant(graph.type === "circle");
+        expect(graph.center).toEqual([1, 2]);
+        expect(graph.radiusPoint).toEqual([6, 2]);
+    });
+
+    it("uses defaults if no circle is given", () => {
+        const graph = initializeGraphState({
+            ...baseGraphData,
+            graph: {type: "circle"},
+        });
+
+        invariant(graph.type === "circle");
+        expect(graph.center).toEqual([0, 0]);
+        expect(graph.radiusPoint).toEqual([1, 0]);
+    });
+});
+
 describe("getGradableGraph", () => {
     /**
      * Originally `getGradableGraph` was returning a PerseusGraphType with just a

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
@@ -313,6 +313,33 @@ describe("initializeGraphState for circle graphs", () => {
     });
 });
 
+describe("initializeGraphState for quadratic graphs", () => {
+    it("uses the given coords, if present", () => {
+        const graph = initializeGraphState({
+            ...baseGraphData,
+            graph: {type: "quadratic", coords: [[0, 1], [2, 3], [4, 5]]},
+        });
+
+        invariant(graph.type === "quadratic");
+        expect(graph.coords).toEqual([[0, 1], [2, 3], [4, 5]]);
+    });
+
+    it("uses default coords if none are given, and does NOT snap", () => {
+        const graph = initializeGraphState({
+            ...baseGraphData,
+            snapStep: [10, 10],
+            graph: {type: "quadratic"},
+        });
+
+        invariant(graph.type === "quadratic");
+        expect(graph.coords).toEqual([
+            [-5, 5],
+            [0, -5],
+            [5, 5],
+        ]);
+    })
+});
+
 describe("getGradableGraph", () => {
     /**
      * Originally `getGradableGraph` was returning a PerseusGraphType with just a

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
@@ -340,6 +340,28 @@ describe("initializeGraphState for quadratic graphs", () => {
     })
 });
 
+describe("initializeGraphState for sinusoid graphs", () => {
+    it("uses the given coords, if present", () => {
+        const graph = initializeGraphState({
+            ...baseGraphData,
+            graph: {type: "sinusoid", coords: [[0, 1], [2, 3]]},
+        });
+
+        invariant(graph.type === "sinusoid");
+        expect(graph.coords).toEqual([[0, 1], [2, 3]]);
+    });
+
+    it("uses default coords if none are given", () => {
+        const graph = initializeGraphState({
+            ...baseGraphData,
+            graph: {type: "sinusoid"},
+        });
+
+        invariant(graph.type === "sinusoid");
+        expect(graph.coords).toEqual([[0, 0], [3, 2]]);
+    })
+});
+
 describe("getGradableGraph", () => {
     /**
      * Originally `getGradableGraph` was returning a PerseusGraphType with just a

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
@@ -42,13 +42,26 @@ describe("initializeGraphState for segment graphs", () => {
     });
 
     it("uses the given segment coordinates, if present", () => {
-        const state = initializeGraphState(({
+        const state = initializeGraphState({
             ...baseGraphData,
-            graph: {type: "segment", coords: [[[0, 1], [2, 3]]]}
-        }))
+            graph: {
+                type: "segment",
+                coords: [
+                    [
+                        [0, 1],
+                        [2, 3],
+                    ],
+                ],
+            },
+        });
 
-        invariant(state.type === "segment")
-        expect(state.coords).toEqual([[[0,1], [2,3]]])
+        invariant(state.type === "segment");
+        expect(state.coords).toEqual([
+            [
+                [0, 1],
+                [2, 3],
+            ],
+        ]);
     });
 
     it("adds a default segment", () => {
@@ -99,23 +112,39 @@ describe("initializeGraphState for segment graphs", () => {
 
 describe("initializeGraphState for linear graphs", () => {
     it("uses the given coordinates, if present", () => {
-        const state = initializeGraphState(({
+        const state = initializeGraphState({
             ...baseGraphData,
-            graph: {type: "linear", coords: [[0, 1], [2, 3]]}
-        }))
+            graph: {
+                type: "linear",
+                coords: [
+                    [0, 1],
+                    [2, 3],
+                ],
+            },
+        });
 
-        invariant(state.type === "linear")
-        expect(state.coords).toEqual([[[0,1], [2,3]]])
+        invariant(state.type === "linear");
+        expect(state.coords).toEqual([
+            [
+                [0, 1],
+                [2, 3],
+            ],
+        ]);
     });
 
     it("uses default coordinates if none are given", () => {
-        const state = initializeGraphState(({
+        const state = initializeGraphState({
             ...baseGraphData,
-            graph: {type: "linear"}
-        }))
+            graph: {type: "linear"},
+        });
 
-        invariant(state.type === "linear")
-        expect(state.coords).toEqual([[[-5,5], [5,5]]])
+        invariant(state.type === "linear");
+        expect(state.coords).toEqual([
+            [
+                [-5, 5],
+                [5, 5],
+            ],
+        ]);
     });
 
     it("puts the segments in the same place regardless of graph scale", () => {
@@ -317,11 +346,22 @@ describe("initializeGraphState for quadratic graphs", () => {
     it("uses the given coords, if present", () => {
         const graph = initializeGraphState({
             ...baseGraphData,
-            graph: {type: "quadratic", coords: [[0, 1], [2, 3], [4, 5]]},
+            graph: {
+                type: "quadratic",
+                coords: [
+                    [0, 1],
+                    [2, 3],
+                    [4, 5],
+                ],
+            },
         });
 
         invariant(graph.type === "quadratic");
-        expect(graph.coords).toEqual([[0, 1], [2, 3], [4, 5]]);
+        expect(graph.coords).toEqual([
+            [0, 1],
+            [2, 3],
+            [4, 5],
+        ]);
     });
 
     it("uses default coords if none are given, and does NOT snap", () => {
@@ -337,18 +377,27 @@ describe("initializeGraphState for quadratic graphs", () => {
             [0, -5],
             [5, 5],
         ]);
-    })
+    });
 });
 
 describe("initializeGraphState for sinusoid graphs", () => {
     it("uses the given coords, if present", () => {
         const graph = initializeGraphState({
             ...baseGraphData,
-            graph: {type: "sinusoid", coords: [[0, 1], [2, 3]]},
+            graph: {
+                type: "sinusoid",
+                coords: [
+                    [0, 1],
+                    [2, 3],
+                ],
+            },
         });
 
         invariant(graph.type === "sinusoid");
-        expect(graph.coords).toEqual([[0, 1], [2, 3]]);
+        expect(graph.coords).toEqual([
+            [0, 1],
+            [2, 3],
+        ]);
     });
 
     it("uses default coords if none are given", () => {
@@ -358,8 +407,11 @@ describe("initializeGraphState for sinusoid graphs", () => {
         });
 
         invariant(graph.type === "sinusoid");
-        expect(graph.coords).toEqual([[0, 0], [3, 2]]);
-    })
+        expect(graph.coords).toEqual([
+            [0, 0],
+            [3, 2],
+        ]);
+    });
 });
 
 describe("getGradableGraph", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
@@ -12,7 +12,6 @@ type BaseGraphData = {
     range: InteractiveGraphProps["range"];
     step: InteractiveGraphProps["step"];
     snapStep: InteractiveGraphProps["snapStep"];
-    markings: InteractiveGraphProps["markings"];
 };
 
 const baseGraphData: BaseGraphData = {
@@ -22,7 +21,6 @@ const baseGraphData: BaseGraphData = {
     ],
     step: [1, 1],
     snapStep: [1, 1],
-    markings: "graph",
 };
 
 describe("initializeGraphState for segment graphs", () => {
@@ -41,6 +39,16 @@ describe("initializeGraphState for segment graphs", () => {
             [1, 20],
         ]);
         expect(state.snapStep).toEqual([2, 3]);
+    });
+
+    it("uses the given segment coordinates, if present", () => {
+        const state = initializeGraphState(({
+            ...baseGraphData,
+            graph: {type: "segment", coords: [[[0, 1], [2, 3]]]}
+        }))
+
+        invariant(state.type === "segment")
+        expect(state.coords).toEqual([[[0,1], [2,3]]])
     });
 
     it("adds a default segment", () => {
@@ -89,6 +97,57 @@ describe("initializeGraphState for segment graphs", () => {
     });
 });
 
+describe("initializeGraphState for linear graphs", () => {
+    it("uses the given coordinates, if present", () => {
+        const state = initializeGraphState(({
+            ...baseGraphData,
+            graph: {type: "linear", coords: [[0, 1], [2, 3]]}
+        }))
+
+        invariant(state.type === "linear")
+        expect(state.coords).toEqual([[[0,1], [2,3]]])
+    });
+
+    it("uses default coordinates if none are given", () => {
+        const state = initializeGraphState(({
+            ...baseGraphData,
+            graph: {type: "linear"}
+        }))
+
+        invariant(state.type === "linear")
+        expect(state.coords).toEqual([[[-5,5], [5,5]]])
+    });
+
+    it("puts the segments in the same place regardless of graph scale", () => {
+        // When the graph bounds are the default of x: (-10, 10), y: (-10, 10),
+        // points get drawn at (-5, 5) and (5, 5). If the graph scale were
+        // (-1000, 1000), (-1000, 1000), though, we wouldn't want to keep the
+        // same point position; the points would be unclickably close together.
+        // So instead, we position the points in approximately the same
+        // *visual* position as (-5, 5), (5, 5), whatever that maps to in graph
+        // coordinates.
+        const state = initializeGraphState({
+            ...baseGraphData,
+            range: [
+                [-1000, 1000],
+                [-1000, 1000],
+            ],
+            step: [1, 1],
+            snapStep: [1, 1],
+            graph: {type: "linear"},
+        });
+
+        // Narrow the type of `graph` so TS knows it will have `coords`.
+        invariant(state.type === "linear");
+        expect(state.coords).toEqual([
+            [
+                [-500, 500],
+                [500, 500],
+            ],
+        ]);
+    });
+});
+
 describe("initializeGraphState for linear-system graphs", () => {
     it("adds default lines if no coords are provided", () => {
         const state = initializeGraphState({
@@ -110,7 +169,7 @@ describe("initializeGraphState for linear-system graphs", () => {
         ]);
     });
 
-    it("ignores any provided coords", () => {
+    it("uses the given line coordinates, if present", () => {
         // This is a characterization test. I don't know if it's desired
         // behavior, but it's the existing behavior.
         const state = initializeGraphState({
@@ -122,6 +181,10 @@ describe("initializeGraphState for linear-system graphs", () => {
                         [1, 2],
                         [3, 4],
                     ],
+                    [
+                        [5, 6],
+                        [7, 8],
+                    ],
                 ],
             },
         });
@@ -129,12 +192,12 @@ describe("initializeGraphState for linear-system graphs", () => {
         invariant(state.type === "linear-system");
         expect(state.coords).toEqual([
             [
-                [-5, 5],
-                [5, 5],
+                [1, 2],
+                [3, 4],
             ],
             [
-                [-5, -5],
-                [5, -5],
+                [5, 6],
+                [7, 8],
             ],
         ]);
     });

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -411,7 +411,7 @@ const getSinusoidCoords = (
     step: InitializeGraphStateParam["step"],
 ): [Coord, Coord] => {
     if (graph.coords) {
-        return graph.coords;
+        return [graph.coords[0], graph.coords[1]];
     }
 
     let coords: [Coord, Coord] = [

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -411,6 +411,10 @@ const getSinusoidCoords = (
     range: InitializeGraphStateParam["range"],
     step: InitializeGraphStateParam["step"],
 ): [Coord, Coord] => {
+    if (graph.coords) {
+        return graph.coords;
+    }
+
     let coords: [Coord, Coord] = [
         [0.5, 0.5],
         [0.65, 0.6],

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -1,4 +1,5 @@
 import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
+import {vec} from "mafs";
 
 import {normalizeCoords, normalizePoints} from "../utils";
 
@@ -11,7 +12,8 @@ import type {
     PerseusGraphTypeLinearSystem,
     PerseusGraphTypePolygon,
     PerseusGraphTypeQuadratic,
-    PerseusGraphTypeSinusoid, PerseusGraphTypeCircle,
+    PerseusGraphTypeSinusoid,
+    PerseusGraphTypeCircle,
 } from "../../../perseus-types";
 import type {
     CircleGraphState,
@@ -21,7 +23,6 @@ import type {
 } from "../types";
 import type {Coord} from "@khanacademy/perseus";
 import type {Interval} from "mafs";
-import {vec} from "mafs";
 
 export type InitializeGraphStateParam = {
     range: InteractiveGraphProps["range"];
@@ -321,9 +322,7 @@ const defaultLinearCoords: [Coord, Coord][] = [
 ];
 
 type getLineCoordsArg = {
-    graph:
-        | PerseusGraphTypeRay
-        | PerseusGraphTypeLinear
+    graph: PerseusGraphTypeRay | PerseusGraphTypeLinear;
     range: InitializeGraphStateParam["range"];
     step: InitializeGraphStateParam["step"];
 };
@@ -334,7 +333,7 @@ const getLineCoords = ({
     step,
 }: getLineCoordsArg): PairOfPoints[] => {
     if (graph.coords) {
-        return [graph.coords]
+        return [graph.coords];
     }
 
     return [normalizePoints(range, step, defaultLinearCoords[0])];
@@ -447,18 +446,18 @@ const getCircleCoords = (
     graph: PerseusGraphTypeCircle,
     range: InitializeGraphStateParam["range"],
     step: InitializeGraphStateParam["step"],
-): {center: Coord, radiusPoint: Coord} => {
+): {center: Coord; radiusPoint: Coord} => {
     if (graph.center != null && graph.radius != null) {
         return {
             center: graph.center,
-            radiusPoint: vec.add(graph.center,[graph.radius, 0])
-        }
+            radiusPoint: vec.add(graph.center, [graph.radius, 0]),
+        };
     }
     return {
         center: [0, 0],
         radiusPoint: [1, 0],
-    }
-}
+    };
+};
 
 /**
  * determine radius of a circle graph

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -11,7 +11,7 @@ import type {
     PerseusGraphTypeLinearSystem,
     PerseusGraphTypePolygon,
     PerseusGraphTypeQuadratic,
-    PerseusGraphTypeSinusoid,
+    PerseusGraphTypeSinusoid, PerseusGraphTypeCircle,
 } from "../../../perseus-types";
 import type {
     CircleGraphState,
@@ -21,6 +21,7 @@ import type {
 } from "../types";
 import type {Coord} from "@khanacademy/perseus";
 import type {Interval} from "mafs";
+import {vec} from "mafs";
 
 export type InitializeGraphStateParam = {
     range: InteractiveGraphProps["range"];
@@ -81,8 +82,7 @@ export function initializeGraphState(
             return {
                 ...shared,
                 type: graph.type,
-                center: [0, 0],
-                radiusPoint: [1, 0],
+                ...getCircleCoords(graph, range, step),
             };
         case "quadratic":
             return {
@@ -436,6 +436,23 @@ const getQuadraticCoords = (
 
     return coords;
 };
+
+const getCircleCoords = (
+    graph: PerseusGraphTypeCircle,
+    range: InitializeGraphStateParam["range"],
+    step: InitializeGraphStateParam["step"],
+): {center: Coord, radiusPoint: Coord} => {
+    if (graph.center != null && graph.radius != null) {
+        return {
+            center: graph.center,
+            radiusPoint: vec.add(graph.center,[graph.radius, 0])
+        }
+    }
+    return {
+        center: [0, 0],
+        radiusPoint: [1, 0],
+    }
+}
 
 /**
  * determine radius of a circle graph

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -426,15 +426,17 @@ const getQuadraticCoords = (
     range: InitializeGraphStateParam["range"],
     step: InitializeGraphStateParam["step"],
 ): [Coord, Coord, Coord] => {
-    let coords: [Coord, Coord, Coord] = [
+    if (graph.coords) {
+        return graph.coords;
+    }
+
+    const defaultCoords: [Coord, Coord, Coord] = [
         [0.25, 0.75],
         [0.5, 0.25],
         [0.75, 0.75],
     ];
 
-    coords = normalizePoints(range, step, coords, true);
-
-    return coords;
+    return normalizePoints(range, step, defaultCoords, true);
 };
 
 const getCircleCoords = (

--- a/packages/perseus/src/widgets/interactive-graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/types.ts
@@ -1,8 +1,5 @@
 import type {InteractiveGraphAction} from "./reducer/interactive-graph-action";
-import type {
-    PerseusGraphType,
-    PerseusInteractiveGraphWidgetOptions,
-} from "../../perseus-types";
+import type {PerseusInteractiveGraphWidgetOptions} from "../../perseus-types";
 import type {WidgetProps} from "../../types";
 import type {Coord} from "@khanacademy/perseus";
 import type {Interval, vec} from "mafs";
@@ -16,12 +13,6 @@ export type MafsGraphProps<T extends InteractiveGraphState> = {
     graphState: T;
     dispatch: (action: InteractiveGraphAction) => unknown;
 };
-
-export interface InitializeGraphStateParams<T extends PerseusGraphType> {
-    graph: T;
-    range: [Interval, Interval];
-    step: vec.Vector2;
-}
 
 export type InteractiveGraphState =
     | SegmentGraphState


### PR DESCRIPTION
This fixes an bug in the exercise editor. Previously, if you loaded an
existing exercise with an interactive graph and opened the interactive graph
widget editor, the graph displayed in the widget editor would *not* reflect the
correct answer.  This was inconsistent/misleading, because content creators
specify the correct answer for graphing questions by moving the elements on the
graph to the correct position.

The way this was implemented for the legacy interactive graph widget was pretty
straightforward: when initializing graph state, we used any coordinates for
interactive elements that were provided in the props. This commit makes Mafs
graphs do the same.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2021

## Test plan:

- Deploy the dev build of Perseus into a webapp ZND.
- Visit
  `https://www.khanacademy.org/devadmin/content/exercises/interactive-graph-exercise/x1454c1ae30522aff/x692a1df2f20f9a4a`
- Expand the interactive graph widget editor
- You should see a visualization of the correct answer for the graph (compare
  to the equations shown in the correct answer field).