### PR TITLE
Add locked circle UI

### DIFF
--- a/.changeset/poor-teachers-allow.md
+++ b/.changeset/poor-teachers-allow.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-editor": minor
+---
+
+[Interactive Graph Editor] Implement "Add locked circle" UI

--- a/packages/perseus-editor/src/components/__stories__/locked-circle-settings.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/locked-circle-settings.stories.tsx
@@ -1,0 +1,81 @@
+import * as React from "react";
+
+import LockedCircleSettings from "../locked-circle-settings";
+import {getDefaultFigureForType} from "../util";
+
+import type {Meta, StoryObj} from "@storybook/react";
+
+export default {
+    title: "PerseusEditor/Components/Locked Circle Settings",
+    component: LockedCircleSettings,
+} as Meta<typeof LockedCircleSettings>;
+
+export const Default = (args): React.ReactElement => {
+    return <LockedCircleSettings {...args} />;
+};
+
+type StoryComponentType = StoryObj<typeof LockedCircleSettings>;
+
+// Set the default values in the control panel.
+Default.args = {
+    ...getDefaultFigureForType("circle"),
+    onChangeProps: () => {},
+    onRemove: () => {},
+};
+
+export const Controlled: StoryComponentType = {
+    render: function Render() {
+        const [props, setProps] = React.useState({
+            ...getDefaultFigureForType("circle"),
+            onRemove: () => {},
+        });
+
+        const handlePropsUpdate = (newProps) => {
+            setProps({
+                ...props,
+                ...newProps,
+            });
+        };
+
+        return (
+            <LockedCircleSettings
+                {...props}
+                onChangeProps={handlePropsUpdate}
+            />
+        );
+    },
+};
+
+Controlled.parameters = {
+    chromatic: {
+        // Disabling because this is testing behavior, not visuals.
+        disableSnapshot: true,
+    },
+};
+
+// Fully expanded view of the locked circle settings to allow snapshot testing.
+export const Expanded: StoryComponentType = {
+    render: function Render() {
+        const [expanded, setExpanded] = React.useState(true);
+        const [props, setProps] = React.useState({
+            ...getDefaultFigureForType("circle"),
+            onRemove: () => {},
+        });
+
+        const handlePropsUpdate = (newProps) => {
+            setProps({
+                ...props,
+                ...newProps,
+            });
+        };
+
+        return (
+            <LockedCircleSettings
+                {...props}
+                expanded={expanded}
+                onToggle={setExpanded}
+                onChangeProps={handlePropsUpdate}
+            />
+        );
+    },
+};

--- a/packages/perseus-editor/src/components/__tests__/locked-circle-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-circle-settings.test.tsx
@@ -1,0 +1,144 @@
+import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
+import {render, screen} from "@testing-library/react";
+import {userEvent as userEventLib} from "@testing-library/user-event";
+import * as React from "react";
+
+import LockedCircleSettings from "../locked-circle-settings";
+import {getDefaultFigureForType} from "../util";
+
+import type {UserEvent} from "@testing-library/user-event";
+
+const defaultProps = {
+    ...getDefaultFigureForType("circle"),
+    onChangeProps: () => {},
+    onRemove: () => {},
+};
+
+describe("LockedCircleSettings", () => {
+    let userEvent: UserEvent;
+    beforeEach(() => {
+        userEvent = userEventLib.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+    });
+    test("renders", () => {
+        // Arrange
+
+        // Act
+        render(<LockedCircleSettings {...defaultProps} />, {
+            wrapper: RenderStateRoot,
+        });
+
+        // Assert
+        const titleText = screen.getByText("Circle (0, 0), radius 1");
+        expect(titleText).toBeInTheDocument();
+    });
+
+    test("summary reflects radius", () => {
+        // Arrange
+
+        // Act
+        render(<LockedCircleSettings {...defaultProps} radius={5} />, {
+            wrapper: RenderStateRoot,
+        });
+
+        // Assert
+        const titleText = screen.getByText("Circle (0, 0), radius 5");
+        expect(titleText).toBeInTheDocument();
+    });
+
+    test("summary reflects center", () => {
+        // Arrange
+
+        // Act
+        render(<LockedCircleSettings {...defaultProps} center={[3, 5]} />, {
+            wrapper: RenderStateRoot,
+        });
+
+        // Assert
+        const titleText = screen.getByText("Circle (3, 5), radius 1");
+        expect(titleText).toBeInTheDocument();
+    });
+
+    test("summary reflects color", () => {
+        // Arrange
+
+        // Act
+        render(
+            <LockedCircleSettings
+                {...defaultProps}
+                color="green"
+                filled={false}
+            />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
+
+        const swatch = screen.getByLabelText("green, stroke solid, fill none");
+
+        // Assert
+        expect(swatch).toBeInTheDocument();
+    });
+
+    test("summary reflects stroke", () => {
+        // Arrange
+
+        // Act
+        render(
+            <LockedCircleSettings
+                {...defaultProps}
+                color="green"
+                strokeStyle="dashed"
+            />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
+
+        const swatch = screen.getByLabelText("green, stroke dashed, fill none");
+
+        // Assert
+        expect(swatch).toBeInTheDocument();
+    });
+
+    test("summary reflects fill", () => {
+        // Arrange
+
+        // Act
+        render(
+            <LockedCircleSettings
+                {...defaultProps}
+                color="green"
+                fillStyle="translucent"
+            />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
+
+        const swatch = screen.getByLabelText(
+            "green, stroke solid, fill translucent",
+        );
+
+        // Assert
+        expect(swatch).toBeInTheDocument();
+    });
+
+    test("calls onToggle when header is clicked", async () => {
+        // Arrange
+        const onToggle = jest.fn();
+        render(<LockedCircleSettings {...defaultProps} onToggle={onToggle} />, {
+            wrapper: RenderStateRoot,
+        });
+
+        // Act
+        const header = screen.getByRole("button", {
+            name: "Circle (0, 0), radius 1 grayH, stroke solid, fill none",
+        });
+        await userEvent.click(header);
+
+        // Assert
+        expect(onToggle).toHaveBeenCalled();
+    });
+});

--- a/packages/perseus-editor/src/components/__tests__/locked-circle-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-circle-settings.test.tsx
@@ -64,16 +64,9 @@ describe("LockedCircleSettings", () => {
         // Arrange
 
         // Act
-        render(
-            <LockedCircleSettings
-                {...defaultProps}
-                color="green"
-                filled={false}
-            />,
-            {
-                wrapper: RenderStateRoot,
-            },
-        );
+        render(<LockedCircleSettings {...defaultProps} color="green" />, {
+            wrapper: RenderStateRoot,
+        });
 
         const swatch = screen.getByLabelText("green, stroke solid, fill none");
 

--- a/packages/perseus-editor/src/components/circle-swatch.tsx
+++ b/packages/perseus-editor/src/components/circle-swatch.tsx
@@ -1,0 +1,63 @@
+import {lockedFigureColors, lockedCircleFillStyles} from "@khanacademy/perseus";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {color as wbColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {StyleSheet} from "aphrodite";
+import * as React from "react";
+
+import type {
+    LockedFigureColor,
+    LockedCircleFillType,
+} from "@khanacademy/perseus";
+
+type Props = {
+    color: LockedFigureColor;
+    fillStyle: LockedCircleFillType;
+    strokeStyle: "solid" | "dashed";
+};
+
+const CircleSwatch = (props: Props) => {
+    const {color, fillStyle, strokeStyle} = props;
+
+    return (
+        <View
+            aria-label={`${color}, stroke ${strokeStyle}, fill ${fillStyle}`}
+            style={[
+                styles.container,
+                {
+                    border: `4px ${strokeStyle} ${lockedFigureColors[color]}`,
+                },
+            ]}
+        >
+            <View
+                style={[
+                    styles.innerCircle,
+                    {
+                        backgroundColor: lockedFigureColors[color],
+                        opacity: lockedCircleFillStyles[fillStyle],
+                    },
+                ]}
+            />
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        // Add a white outline so that the color swatch is visible when
+        // the dropdown option is highlighted with its blue background.
+        outline: `2px solid ${wbColor.offWhite}`,
+        borderRadius: "50%",
+        width: spacing.large_24,
+        height: spacing.large_24,
+        backgroundColor: wbColor.white,
+        alignItems: "center",
+        justifyContent: "center",
+    },
+    innerCircle: {
+        width: 20,
+        height: 20,
+        borderRadius: "50%",
+    },
+});
+
+export default CircleSwatch;

--- a/packages/perseus-editor/src/components/coordinate-pair-input.tsx
+++ b/packages/perseus-editor/src/components/coordinate-pair-input.tsx
@@ -6,16 +6,22 @@ import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
-import type {LockedPointType} from "@khanacademy/perseus";
+import type {LockedCircleType, LockedPointType} from "@khanacademy/perseus";
 
 type Props = {
     coord: [number, number];
     error?: boolean;
-    onChangeProps: (newProps: Partial<LockedPointType>) => void;
+    // Most of the time, the prop to updated when this coordinate pair input
+    // is updated is is `coord`. For circles, it's `center`.
+    // This prop allows you to specify which prop to update.
+    changedProp?: "coord" | "center";
+    onChangeProps: (
+        newProps: Partial<LockedPointType> | Partial<LockedCircleType>,
+    ) => void;
 };
 
 const CoordinatePairInput = (props: Props) => {
-    const {coord, error, onChangeProps} = props;
+    const {coord, error, changedProp = "coord", onChangeProps} = props;
 
     // Keep track of the coordinates via state as the user is editing them,
     // before they are updated in the props as a valid number.
@@ -46,7 +52,11 @@ const CoordinatePairInput = (props: Props) => {
         // Update the props (update the graph).
         const newCoords = [...coord] satisfies [number, number];
         newCoords[coordIndex] = +newValue;
-        onChangeProps({coord: newCoords});
+
+        const newProp = {};
+        // Either update the `center` or the `coord` prop.
+        newProp[changedProp] = newCoords;
+        onChangeProps(newProp);
     }
 
     return (

--- a/packages/perseus-editor/src/components/coordinate-pair-input.tsx
+++ b/packages/perseus-editor/src/components/coordinate-pair-input.tsx
@@ -6,22 +6,16 @@ import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
-import type {LockedCircleType, LockedPointType} from "@khanacademy/perseus";
+import type {Coord} from "@khanacademy/perseus";
 
 type Props = {
     coord: [number, number];
     error?: boolean;
-    // Most of the time, the prop to updated when this coordinate pair input
-    // is updated is is `coord`. For circles, it's `center`.
-    // This prop allows you to specify which prop to update.
-    changedProp?: "coord" | "center";
-    onChangeProps: (
-        newProps: Partial<LockedPointType> | Partial<LockedCircleType>,
-    ) => void;
+    onChange: (newCoord: Coord) => void;
 };
 
 const CoordinatePairInput = (props: Props) => {
-    const {coord, error, changedProp = "coord", onChangeProps} = props;
+    const {coord, error, onChange} = props;
 
     // Keep track of the coordinates via state as the user is editing them,
     // before they are updated in the props as a valid number.
@@ -52,11 +46,7 @@ const CoordinatePairInput = (props: Props) => {
         // Update the props (update the graph).
         const newCoords = [...coord] satisfies [number, number];
         newCoords[coordIndex] = +newValue;
-
-        const newProp = {};
-        // Either update the `center` or the `coord` prop.
-        newProp[changedProp] = newCoords;
-        onChangeProps(newProp);
+        onChange(newCoords);
     }
 
     return (

--- a/packages/perseus-editor/src/components/defining-point-settings.tsx
+++ b/packages/perseus-editor/src/components/defining-point-settings.tsx
@@ -82,7 +82,9 @@ const DefiningPointSettings = (props: Props) => {
             <CoordinatePairInput
                 coord={coord}
                 error={!!error}
-                onChangeProps={onChangeProps}
+                onChange={(newCoords) => {
+                    onChangeProps({coord: newCoords});
+                }}
             />
 
             {/* Toggle switch */}

--- a/packages/perseus-editor/src/components/locked-circle-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-circle-settings.tsx
@@ -18,6 +18,7 @@ import type {AccordionProps} from "./locked-figure-settings";
 import type {
     LockedCircleFillType,
     LockedCircleType,
+    LockedFigureColor,
 } from "@khanacademy/perseus";
 
 const {InfoTip} = components;
@@ -76,7 +77,7 @@ const LockedCircleSettings = (props: Props) => {
         onChangeProps({radius: +newValue});
     }
 
-    function handleColorChange(newValue) {
+    function handleColorChange(newValue: LockedFigureColor) {
         onChangeProps({color: newValue});
     }
 

--- a/packages/perseus-editor/src/components/locked-circle-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-circle-settings.tsx
@@ -54,10 +54,6 @@ const LockedCircleSettings = (props: Props) => {
     const strokeSelectId = ids.get("stroke-style-select");
     const fillSelectId = ids.get("fill-style-select");
 
-    function handleCenterChange(newCenter) {
-        onChangeProps({center: newCenter.coord});
-    }
-
     function handleRadiusChange(newValue) {
         // Update the local state (update the input field value).
         setRadiusInput(newValue);
@@ -97,9 +93,8 @@ const LockedCircleSettings = (props: Props) => {
             <View style={styles.row}>
                 <CoordinatePairInput
                     coord={center}
-                    onChangeProps={(newCenter) =>
-                        handleCenterChange(newCenter as [number, number])
-                    }
+                    onChangeProps={onChangeProps}
+                    changedProp="center"
                 />
                 <View style={styles.spaceUnder}>
                     <InfoTip>

--- a/packages/perseus-editor/src/components/locked-circle-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-circle-settings.tsx
@@ -1,4 +1,4 @@
-import {components} from "@khanacademy/perseus";
+import {components, lockedCircleFillStyles} from "@khanacademy/perseus";
 import {View, useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
 import {TextField} from "@khanacademy/wonder-blocks-form";
@@ -181,15 +181,11 @@ const LockedCircleSettings = (props: Props) => {
                     // Placeholder is required, but never gets used.
                     placeholder=""
                 >
-                    <OptionItem value="none" label="none">
-                        none
-                    </OptionItem>
-                    <OptionItem value="solid" label="solid">
-                        solid
-                    </OptionItem>
-                    <OptionItem value="translucent" label="translucent">
-                        translucent
-                    </OptionItem>
+                    {Object.keys(lockedCircleFillStyles).map((option) => (
+                        <OptionItem key={option} value={option} label={option}>
+                            {option}
+                        </OptionItem>
+                    ))}
                 </SingleSelect>
             </View>
 

--- a/packages/perseus-editor/src/components/locked-circle-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-circle-settings.tsx
@@ -58,8 +58,16 @@ const LockedCircleSettings = (props: Props) => {
         // Update the local state (update the input field value).
         setRadiusInput(newValue);
 
-        // If the new value is not a number, don't update the props.
-        // If it's empty, keep the props the same value instead of setting to 0.
+        // Personal preference: Stop the previous graph from disappearing
+        // before the user finishes typing a new valid number.
+        //
+        // If the new value is not a number (e.g. "." while starting to type
+        // a decimal value), don't update the props.
+        // If it's empty (e.g. erased the previous value before starting to
+        // type a new value), keep the props the same value instead of
+        // setting to 0.
+        // Without this check, the input would assume a 0 value and make the
+        // figure disappear before the user finishes typing the new value.
         if (isNaN(+newValue) || newValue === "") {
             return;
         }

--- a/packages/perseus-editor/src/components/locked-circle-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-circle-settings.tsx
@@ -16,6 +16,7 @@ import LockedFigureSettingsActions from "./locked-figure-settings-actions";
 
 import type {AccordionProps} from "./locked-figure-settings";
 import type {
+    Coord,
     LockedCircleFillType,
     LockedCircleType,
     LockedFigureColor,
@@ -102,8 +103,9 @@ const LockedCircleSettings = (props: Props) => {
             <View style={styles.row}>
                 <CoordinatePairInput
                     coord={center}
-                    onChangeProps={onChangeProps}
-                    changedProp="center"
+                    onChange={(newCoords: Coord) =>
+                        onChangeProps({center: newCoords})
+                    }
                 />
                 <View style={styles.spaceUnder}>
                     <InfoTip>

--- a/packages/perseus-editor/src/components/locked-circle-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-circle-settings.tsx
@@ -1,0 +1,215 @@
+import {components} from "@khanacademy/perseus";
+import {View, useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
+import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
+import {TextField} from "@khanacademy/wonder-blocks-form";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {LabelMedium, LabelLarge} from "@khanacademy/wonder-blocks-typography";
+import {StyleSheet} from "aphrodite";
+import * as React from "react";
+
+import CircleSwatch from "./circle-swatch";
+import ColorSelect from "./color-select";
+import CoordinatePairInput from "./coordinate-pair-input";
+import LockedFigureSettingsAccordion from "./locked-figure-settings-accordion";
+import LockedFigureSettingsActions from "./locked-figure-settings-actions";
+
+import type {AccordionProps} from "./locked-figure-settings";
+import type {
+    LockedCircleFillType,
+    LockedCircleType,
+} from "@khanacademy/perseus";
+
+const {InfoTip} = components;
+
+export type Props = AccordionProps &
+    LockedCircleType & {
+        /**
+         * Called when the delete button is pressed.
+         */
+        onRemove: () => void;
+        /**
+         * Called when the props (coords, color, etc.) are updated.
+         */
+        onChangeProps: (newProps: Partial<LockedCircleType>) => void;
+    };
+
+const LockedCircleSettings = (props: Props) => {
+    const {
+        center,
+        radius,
+        color,
+        fillStyle,
+        strokeStyle,
+        expanded,
+        onToggle,
+        onChangeProps,
+        onRemove,
+    } = props;
+
+    const [radiusInput, setRadiusInput] = React.useState(radius.toString());
+
+    const ids = useUniqueIdWithMock();
+    const radiusInputId = ids.get("radius-input");
+    const strokeSelectId = ids.get("stroke-style-select");
+    const fillSelectId = ids.get("fill-style-select");
+
+    function handleCenterChange(newCenter) {
+        onChangeProps({center: newCenter.coord});
+    }
+
+    function handleRadiusChange(newValue) {
+        // Update the local state (update the input field value).
+        setRadiusInput(newValue);
+
+        // If the new value is not a number, don't update the props.
+        // If it's empty, keep the props the same value instead of setting to 0.
+        if (isNaN(+newValue) || newValue === "") {
+            return;
+        }
+
+        // Update the props (update the graph).
+        onChangeProps({radius: +newValue});
+    }
+
+    function handleColorChange(newValue) {
+        onChangeProps({color: newValue});
+    }
+
+    return (
+        <LockedFigureSettingsAccordion
+            expanded={expanded}
+            onToggle={onToggle}
+            header={
+                // Summary: Circle, center, radius, color (opacity, dashed)
+                <View style={styles.row}>
+                    <LabelLarge>{`Circle (${center[0]}, ${center[1]}), radius ${radius}`}</LabelLarge>
+                    <Strut size={spacing.xSmall_8} />
+                    <CircleSwatch
+                        color={props.color}
+                        fillStyle={fillStyle}
+                        strokeStyle={strokeStyle}
+                    />
+                </View>
+            }
+        >
+            {/* Center point */}
+            <View style={styles.row}>
+                <CoordinatePairInput
+                    coord={center}
+                    onChangeProps={(newCenter) =>
+                        handleCenterChange(newCenter as [number, number])
+                    }
+                />
+                <View style={styles.spaceUnder}>
+                    <InfoTip>
+                        The coordinates for the center of the circle
+                    </InfoTip>
+                </View>
+            </View>
+
+            {/* Radius */}
+            <View style={[styles.row, styles.spaceUnder]}>
+                <LabelMedium
+                    htmlFor={radiusInputId}
+                    style={styles.label}
+                    tag="label"
+                >
+                    radius
+                </LabelMedium>
+                <TextField
+                    id={radiusInputId}
+                    type="number"
+                    value={radiusInput}
+                    min={0}
+                    onChange={handleRadiusChange}
+                    style={{maxWidth: 72}}
+                />
+                <Strut size={spacing.medium_16} />
+
+                {/* Stroke style */}
+                <LabelMedium
+                    tag="label"
+                    htmlFor={strokeSelectId}
+                    style={styles.label}
+                >
+                    stroke
+                </LabelMedium>
+                <SingleSelect
+                    id={strokeSelectId}
+                    selectedValue={strokeStyle}
+                    onChange={(value: "solid" | "dashed") =>
+                        onChangeProps({strokeStyle: value})
+                    }
+                    // Placeholder is required, but never gets used.
+                    placeholder=""
+                >
+                    <OptionItem value="solid" label="solid">
+                        solid
+                    </OptionItem>
+                    <OptionItem value="dashed" label="dashed">
+                        dashed
+                    </OptionItem>
+                </SingleSelect>
+            </View>
+
+            <View style={[styles.row, styles.spaceUnder]}>
+                {/* Color */}
+                <ColorSelect
+                    selectedValue={color}
+                    onChange={handleColorChange}
+                />
+                <Strut size={spacing.medium_16} />
+
+                {/* Fill opacity */}
+                <LabelMedium
+                    tag="label"
+                    htmlFor={fillSelectId}
+                    style={styles.label}
+                >
+                    fill
+                </LabelMedium>
+                <SingleSelect
+                    id={fillSelectId}
+                    selectedValue={fillStyle}
+                    onChange={(value: LockedCircleFillType) =>
+                        onChangeProps({fillStyle: value})
+                    }
+                    // Placeholder is required, but never gets used.
+                    placeholder=""
+                >
+                    <OptionItem value="none" label="none">
+                        none
+                    </OptionItem>
+                    <OptionItem value="solid" label="solid">
+                        solid
+                    </OptionItem>
+                    <OptionItem value="translucent" label="translucent">
+                        translucent
+                    </OptionItem>
+                </SingleSelect>
+            </View>
+
+            {/* Actions */}
+            <LockedFigureSettingsActions
+                onRemove={onRemove}
+                figureAriaLabel={`locked circle at ${center[0]}, ${center[1]}`}
+            />
+        </LockedFigureSettingsAccordion>
+    );
+};
+
+const styles = StyleSheet.create({
+    row: {
+        flexDirection: "row",
+        alignItems: "center",
+    },
+    label: {
+        marginInlineEnd: spacing.xxSmall_6,
+    },
+    spaceUnder: {
+        marginBottom: spacing.xSmall_8,
+    },
+});
+
+export default LockedCircleSettings;

--- a/packages/perseus-editor/src/components/locked-circle-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-circle-settings.tsx
@@ -121,7 +121,6 @@ const LockedCircleSettings = (props: Props) => {
                     id={radiusInputId}
                     type="number"
                     value={radiusInput}
-                    min={0}
                     onChange={handleRadiusChange}
                     style={{maxWidth: 72}}
                 />

--- a/packages/perseus-editor/src/components/locked-figure-select.tsx
+++ b/packages/perseus-editor/src/components/locked-figure-select.tsx
@@ -19,28 +19,23 @@ type Props = {
 const LockedFigureSelect = (props: Props) => {
     const {id, onChange} = props;
 
+    const figureTypes = ["point", "line", "circle"];
+
     return (
         <View style={styles.container}>
             <ActionMenu
                 menuText="Add locked figure"
                 style={styles.addElementSelect}
             >
-                {[
+                {figureTypes.map((figureType) => (
                     <ActionItem
-                        key={`${id}-point`}
-                        label="Point"
-                        onClick={() => onChange("point")}
+                        key={`${id}-${figureType}`}
+                        label={figureType}
+                        onClick={() => onChange(figureType)}
                     >
-                        Point
-                    </ActionItem>,
-                    <ActionItem
-                        key={`${id}-line`}
-                        label="Line"
-                        onClick={() => onChange("line")}
-                    >
-                        Line
-                    </ActionItem>,
-                ]}
+                        {figureType}
+                    </ActionItem>
+                ))}
             </ActionMenu>
         </View>
     );

--- a/packages/perseus-editor/src/components/locked-figure-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-figure-settings.tsx
@@ -7,9 +7,11 @@
 
 import * as React from "react";
 
+import LockedCircleSettings from "./locked-circle-settings";
 import LockedLineSettings from "./locked-line-settings";
 import LockedPointSettings from "./locked-point-settings";
 
+import type {Props as LockedCircleProps} from "./locked-circle-settings";
 import type {Props as LockedLineProps} from "./locked-line-settings";
 import type {Props as LockedPointProps} from "./locked-point-settings";
 
@@ -28,7 +30,8 @@ export type AccordionProps = {
 };
 
 // Union this type with other locked figure types when they are added.
-type Props = AccordionProps & (LockedPointProps | LockedLineProps);
+type Props = AccordionProps &
+    (LockedPointProps | LockedLineProps | LockedCircleProps);
 
 const LockedFigureSettings = (props: Props) => {
     switch (props.type) {
@@ -36,6 +39,8 @@ const LockedFigureSettings = (props: Props) => {
             return <LockedPointSettings {...props} />;
         case "line":
             return <LockedLineSettings {...props} />;
+        case "circle":
+            return <LockedCircleSettings {...props} />;
     }
 
     return null;

--- a/packages/perseus-editor/src/components/locked-figures-section.tsx
+++ b/packages/perseus-editor/src/components/locked-figures-section.tsx
@@ -96,12 +96,6 @@ const LockedFiguresSection = (props: Props) => {
     return (
         <View>
             {figures?.map((figure, index) => {
-                if (figure.type === "circle") {
-                    // TODO(LEMS-1941): Implement circle locked figure settings.
-                    // Remove this block once circle locked figure settings are
-                    // implemented.
-                    return;
-                }
                 if (figure.type === "vector") {
                     // TODO(LEMS-1950): Add locked vector settings.
                     // Remove this block once vector locked figure settings are
@@ -111,6 +105,7 @@ const LockedFiguresSection = (props: Props) => {
 
                 return (
                     <LockedFigureSettings
+                        key={`${uniqueId}-locked-${figure}-${index}`}
                         showM2Features={props.showM2Features}
                         expanded={expandedStates[index]}
                         onToggle={(newValue) => {
@@ -118,7 +113,6 @@ const LockedFiguresSection = (props: Props) => {
                             newExpanded[index] = newValue;
                             setExpandedStates(newExpanded);
                         }}
-                        key={`${uniqueId}-locked-${figure}-${index}`}
                         {...figure}
                         onChangeProps={(newProps) =>
                             changeProps(index, newProps)

--- a/packages/perseus-editor/src/components/locked-point-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-point-settings.tsx
@@ -59,7 +59,12 @@ const LockedPointSettings = (props: Props) => {
                 </View>
             }
         >
-            <CoordinatePairInput coord={coord} onChangeProps={onChangeProps} />
+            <CoordinatePairInput
+                coord={coord}
+                onChange={(newCoord) => {
+                    onChangeProps({coord: newCoord});
+                }}
+            />
 
             <ColorSelect
                 selectedValue={pointColor}

--- a/packages/perseus-editor/src/components/util.ts
+++ b/packages/perseus-editor/src/components/util.ts
@@ -5,6 +5,8 @@ import type {
     LockedFigureType,
     LockedPointType,
     LockedLineType,
+    LockedVectorType,
+    LockedCircleType,
 } from "@khanacademy/perseus";
 
 export function focusWithChromeStickyFocusBugWorkaround(element: Element) {
@@ -50,6 +52,8 @@ const DEFAULT_COLOR = "grayH";
 
 export function getDefaultFigureForType(type: "point"): LockedPointType;
 export function getDefaultFigureForType(type: "line"): LockedLineType;
+export function getDefaultFigureForType(type: "circle"): LockedCircleType;
+export function getDefaultFigureForType(type: "vector"): LockedVectorType;
 export function getDefaultFigureForType(type: LockedFigureType): LockedFigure;
 export function getDefaultFigureForType(type: LockedFigureType): LockedFigure {
     switch (type) {

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
@@ -54,9 +54,10 @@ describe("InteractiveGraphEditor locked figures", () => {
 
     // Basic functionality
     describe.each`
-        figureType | figureName
-        ${"point"} | ${"Point"}
-        ${"line"}  | ${"Line"}
+        figureType  | figureName
+        ${"point"}  | ${"Point"}
+        ${"line"}   | ${"Line"}
+        ${"circle"} | ${"Circle"}
     `(`$figureType basics`, ({figureType, figureName}) => {
         test("Calls onChange when a locked $figureType is added", async () => {
             // Arrange
@@ -69,8 +70,8 @@ describe("InteractiveGraphEditor locked figures", () => {
                 name: "Add locked figure",
             });
             await userEvent.click(addLockedFigureButton);
-            const addPointButton = screen.getByText(figureName);
-            await userEvent.click(addPointButton);
+            const addFigureButton = screen.getByText(figureType);
+            await userEvent.click(addFigureButton);
 
             // Assert
             expect(onChangeMock).toBeCalledWith({
@@ -561,6 +562,152 @@ describe("InteractiveGraphEditor locked figures", () => {
                         expect.objectContaining({
                             ...defaultLine,
                             showPoint2: true,
+                        }),
+                    ],
+                }),
+            );
+        });
+    });
+
+    describe("circles", () => {
+        test("Calls onChange when a locked circle's center x is changed", async () => {
+            // Arrange
+            const onChangeMock = jest.fn();
+
+            renderEditor({
+                onChange: onChangeMock,
+                lockedFigures: [getDefaultFigureForType("circle")],
+            });
+
+            // Act
+            const xCoordInput = screen.getByLabelText("x coord");
+            await userEvent.clear(xCoordInput);
+            await userEvent.type(xCoordInput, "5");
+            await userEvent.tab();
+
+            // Assert
+            expect(onChangeMock).toBeCalledWith(
+                expect.objectContaining({
+                    lockedFigures: [
+                        expect.objectContaining({
+                            type: "circle",
+                            center: [5, 0],
+                        }),
+                    ],
+                }),
+            );
+        });
+
+        test("Calls onChange when a locked circle's center y is changed", async () => {
+            // Arrange
+            const onChangeMock = jest.fn();
+
+            renderEditor({
+                onChange: onChangeMock,
+                lockedFigures: [getDefaultFigureForType("circle")],
+            });
+
+            // Act
+            const yCoordInput = screen.getByLabelText("y coord");
+            await userEvent.clear(yCoordInput);
+            await userEvent.type(yCoordInput, "5");
+            await userEvent.tab();
+
+            // Assert
+            expect(onChangeMock).toBeCalledWith(
+                expect.objectContaining({
+                    lockedFigures: [
+                        expect.objectContaining({
+                            type: "circle",
+                            center: [0, 5],
+                        }),
+                    ],
+                }),
+            );
+        });
+
+        test("Calls onChange when a locked circle's radius is changed", async () => {
+            // Arrange
+            const onChangeMock = jest.fn();
+
+            renderEditor({
+                onChange: onChangeMock,
+                lockedFigures: [getDefaultFigureForType("circle")],
+            });
+
+            // Act
+            const radiusInput = screen.getByLabelText("radius");
+            await userEvent.clear(radiusInput);
+            await userEvent.type(radiusInput, "5");
+            await userEvent.tab();
+
+            // Assert
+            expect(onChangeMock).toBeCalledWith(
+                expect.objectContaining({
+                    lockedFigures: [
+                        expect.objectContaining({
+                            type: "circle",
+                            radius: 5,
+                        }),
+                    ],
+                }),
+            );
+        });
+
+        test("Calls onChange when locked circle's stroke style is changed", async () => {
+            // Arrange
+            const onChangeMock = jest.fn();
+
+            renderEditor({
+                onChange: onChangeMock,
+                lockedFigures: [getDefaultFigureForType("circle")],
+            });
+
+            // Act
+            const strokeInput = screen.getByRole("button", {
+                name: "stroke",
+            });
+            await userEvent.click(strokeInput);
+            const strokeSelection = screen.getByText("dashed");
+            await userEvent.click(strokeSelection);
+
+            // Assert
+            expect(onChangeMock).toBeCalledWith(
+                expect.objectContaining({
+                    lockedFigures: [
+                        expect.objectContaining({
+                            type: "circle",
+                            strokeStyle: "dashed",
+                        }),
+                    ],
+                }),
+            );
+        });
+
+        test("Calls onChange when a locked circle's fill style is changed", async () => {
+            // Arrange
+            const onChangeMock = jest.fn();
+
+            renderEditor({
+                onChange: onChangeMock,
+                lockedFigures: [getDefaultFigureForType("circle")],
+            });
+
+            // Act
+            const fillInput = screen.getByRole("button", {
+                name: "fill",
+            });
+            await userEvent.click(fillInput);
+            const fillSelection = screen.getByText("translucent");
+            await userEvent.click(fillSelection);
+
+            // Assert
+            expect(onChangeMock).toBeCalledWith(
+                expect.objectContaining({
+                    lockedFigures: [
+                        expect.objectContaining({
+                            type: "circle",
+                            fillStyle: "translucent",
                         }),
                     ],
                 }),

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -65,6 +65,7 @@ export {
     plotterPlotTypes,
     ItemExtras,
     lockedFigureColors,
+    lockedCircleFillStyles,
 } from "./perseus-types";
 export {traverse} from "./traversal";
 export {isItemRenderableByVersion} from "./renderability";
@@ -163,6 +164,7 @@ export type {
     LockedPointType,
     LockedLineType,
     LockedCircleType,
+    LockedCircleFillType,
     LockedVectorType,
     PerseusGraphType,
     PerseusAnswerArea,

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -694,12 +694,19 @@ export type LockedLineType = {
     showPoint2: boolean;
 };
 
+export type LockedCircleFillType = "none" | "solid" | "translucent";
+export const lockedCircleFillStyles: Record<LockedCircleFillType, number> = {
+    none: 0,
+    solid: 1,
+    translucent: 0.4,
+} as const;
+
 export type LockedCircleType = {
     type: "circle";
     center: Coord;
     radius: number;
     color: LockedFigureColor;
-    fillStyle: "none" | "solid" | "translucent";
+    fillStyle: LockedCircleFillType;
     strokeStyle: "solid" | "dashed";
 };
 

--- a/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
@@ -1971,79 +1971,12 @@ export const segmentWithAllLockedRayVariations: PerseusRenderer = {
     },
 };
 
-export const segmentWithLockedFigures: PerseusRenderer = {
-    content: "All locked lines\n\n[[☃ interactive-graph 1]]",
-    images: {},
-    widgets: {
-        "interactive-graph 1": {
-            graded: true,
-            options: {
-                correct: {
-                    coords: [
-                        [
-                            [-7, -7],
-                            [2, -5],
-                        ],
-                    ],
-                    type: "segment",
-                },
-                graph: {
-                    type: "segment",
-                },
-                gridStep: [1, 1],
-                labels: ["x", "y"],
-                markings: "graph",
-                range: [
-                    [-10, 10],
-                    [-10, 10],
-                ],
-                rulerLabel: "",
-                rulerTicks: 10,
-                showProtractor: false,
-                showRuler: false,
-                snapStep: [0.5, 0.5],
-                step: [1, 1],
-                lockedFigures: [
-                    // Just a point
-                    {
-                        type: "point",
-                        coord: [-7, -7],
-                        color: "green",
-                        filled: true,
-                    },
-                    // Point shown, one filled, one open
-                    {
-                        type: "line",
-                        kind: "line",
-                        points: [
-                            {
-                                type: "point",
-                                coord: [-7, -5],
-                                color: "green",
-                                filled: true,
-                            },
-                            {
-                                type: "point",
-                                coord: [2, -3],
-                                color: "green",
-                                filled: false,
-                            },
-                        ],
-                        color: "green",
-                        lineStyle: "solid",
-                        showPoint1: true,
-                        showPoint2: true,
-                    },
-                ],
-            },
-            type: "interactive-graph",
-            version: {
-                major: 0,
-                minor: 0,
-            },
-        },
-    },
-};
+export const segmentWithLockedFigures: PerseusRenderer =
+    interactiveGraphQuestionBuilder()
+        .addLockedPointAt(-7, -7)
+        .addLockedLine([-7, -5], [2, -3])
+        .addLockedCircle([0, 5], 2)
+        .build();
 
 export const segmentWithLockedCircles: PerseusRenderer =
     interactiveGraphQuestionBuilder()

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -1,4 +1,5 @@
 import type {
+    LockedCircleFillType,
     LockedCircleType,
     LockedFigure,
     LockedFigureColor,
@@ -137,7 +138,7 @@ class InteractiveGraphQuestionBuilder {
         radius: number,
         options?: {
             color?: LockedFigureColor;
-            fillStyle?: "none" | "solid" | "translucent";
+            fillStyle?: LockedCircleFillType;
             strokeStyle?: "solid" | "dashed";
         },
     ): InteractiveGraphQuestionBuilder {

--- a/packages/perseus/src/widgets/interactive-graphs/locked-circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-circle.tsx
@@ -1,18 +1,20 @@
 import {Circle} from "mafs";
 import * as React from "react";
 
-import {lockedFigureColors, type LockedCircleType} from "../../perseus-types";
+import {
+    lockedCircleFillStyles,
+    lockedFigureColors,
+    type LockedCircleType,
+} from "../../perseus-types";
 
 const LockedCircle = (props: LockedCircleType) => {
     const {center, radius, color, fillStyle, strokeStyle} = props;
-
-    const fill = {none: 0, solid: 1, translucent: 0.4};
 
     return (
         <Circle
             center={center}
             radius={radius}
-            fillOpacity={fill[fillStyle]}
+            fillOpacity={lockedCircleFillStyles[fillStyle]}
             strokeStyle={strokeStyle}
             color={lockedFigureColors[color]}
         />


### PR DESCRIPTION
## Summary:

Adding/editing/deleting Locked Circle UI!

Note 1: I did not add restrictions to the range or radius here. I will add that in a later PR. 
Note 2: I'm planning to update this to "ellipse" in a follow-up PR.

Issue: https://khanacademy.atlassian.net/browse/LEMS-1941

## Test plan:
[Editor Page storybook with locked figures](http://localhost:6006/?path=/story/perseuseditor-editorpage--mafs-with-locked-figures)
[Locked Circle Settings](http://localhost:6006/?path=/docs/perseuseditor-components-locked-circle-settings--docs)
