### PR TITLE
Add/Edit Locked Vector for Interactive Graph

### DIFF
--- a/.changeset/quick-jobs-jog.md
+++ b/.changeset/quick-jobs-jog.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Add/Edit Locked Vector for Interactive Graph

--- a/packages/perseus-editor/src/components/__stories__/locked-vector-settings.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/locked-vector-settings.stories.tsx
@@ -1,0 +1,81 @@
+import * as React from "react";
+
+import LockedVectorSettings from "../locked-vector-settings";
+import {getDefaultFigureForType} from "../util";
+
+import type {Meta, StoryObj} from "@storybook/react";
+
+export default {
+    title: "PerseusEditor/Components/Locked Vector Settings",
+    component: LockedVectorSettings,
+} as Meta<typeof LockedVectorSettings>;
+
+export const Default = (args): React.ReactElement => {
+    return <LockedVectorSettings {...args} />;
+};
+
+type StoryComponentType = StoryObj<typeof LockedVectorSettings>;
+
+// Set the default values in the control panel.
+Default.args = {
+    ...getDefaultFigureForType("vector"),
+    onChangeProps: () => {},
+    onRemove: () => {},
+};
+
+export const Expanded: StoryComponentType = {
+    render: function Render() {
+        const [props, setProps] = React.useState({
+            ...getDefaultFigureForType("vector"),
+            onRemove: () => {},
+        });
+
+        const handlePropsUpdate = (newProps) => {
+            setProps({
+                ...props,
+                ...newProps,
+            });
+        };
+
+        return (
+            <LockedVectorSettings
+                {...props}
+                expanded={true}
+                onChangeProps={handlePropsUpdate}
+            />
+        );
+    },
+};
+
+/**
+ * If the two points defining the vector are the same, the vector is invalid
+ * as that would give it a length of 0. An error message is displayed
+ * in this case.
+ */
+export const WithInvalidPoints: StoryComponentType = {
+    render: function Render() {
+        const [props, setProps] = React.useState({
+            ...getDefaultFigureForType("vector"),
+            onRemove: () => {},
+        });
+
+        const handlePropsUpdate = (newProps) => {
+            setProps({
+                ...props,
+                ...newProps,
+            });
+        };
+
+        return (
+            <LockedVectorSettings
+                {...props}
+                points={[
+                    [0, 0],
+                    [0, 0],
+                ]}
+                expanded={true}
+                onChangeProps={handlePropsUpdate}
+            />
+        );
+    },
+};

--- a/packages/perseus-editor/src/components/__tests__/locked-figures-section.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-figures-section.test.tsx
@@ -8,8 +8,30 @@ import {getDefaultFigureForType} from "../util";
 
 import type {UserEvent} from "@testing-library/user-event";
 
+const defaultFigures = [
+    getDefaultFigureForType("point"),
+    getDefaultFigureForType("line"),
+    getDefaultFigureForType("vector"),
+];
+
 describe("LockedFiguresSection", () => {
     let userEvent: UserEvent;
+    const getDefaultFigureHeader = (type: "point" | "line" | "vector") => {
+        switch (type) {
+            case "point":
+                return screen.getByRole("button", {
+                    name: "Point (0, 0) grayH, filled",
+                });
+            case "line":
+                return screen.getByRole("button", {
+                    name: "Line (0, 0), (2, 2) grayH, solid",
+                });
+            case "vector":
+                return screen.getByRole("button", {
+                    name: "Vector (0, 0), (2, 2) grayH, solid",
+                });
+        }
+    };
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,
@@ -41,10 +63,7 @@ describe("LockedFiguresSection", () => {
         // Arrange, Act
         render(
             <LockedFiguresSection
-                figures={[
-                    getDefaultFigureForType("point"),
-                    getDefaultFigureForType("line"),
-                ]}
+                figures={defaultFigures}
                 onChange={jest.fn()}
             />,
             {
@@ -55,6 +74,7 @@ describe("LockedFiguresSection", () => {
         // Assert
         expect(screen.getByText("Point (0, 0)")).toBeInTheDocument();
         expect(screen.getByText("Line (0, 0), (2, 2)")).toBeInTheDocument();
+        expect(screen.getByText("Vector (0, 0), (2, 2)")).toBeInTheDocument();
         expect(
             screen.getByRole("button", {name: "Expand all"}),
         ).toBeInTheDocument();
@@ -64,10 +84,7 @@ describe("LockedFiguresSection", () => {
         // Arrange
         render(
             <LockedFiguresSection
-                figures={[
-                    getDefaultFigureForType("point"),
-                    getDefaultFigureForType("line"),
-                ]}
+                figures={defaultFigures}
                 onChange={jest.fn()}
             />,
             {
@@ -76,26 +93,21 @@ describe("LockedFiguresSection", () => {
         );
 
         // Act
-        const pointHeader = screen.getByRole("button", {
-            name: "Point (0, 0) grayH, filled",
-        });
-        const lineHeader = screen.getByRole("button", {
-            name: "Line (0, 0), (2, 2) grayH, solid",
-        });
+        const pointHeader = getDefaultFigureHeader("point");
+        const lineHeader = getDefaultFigureHeader("line");
+        const vectorHeader = getDefaultFigureHeader("vector");
 
         // Assert
         expect(pointHeader.getAttribute("aria-expanded")).toBe("false");
         expect(lineHeader.getAttribute("aria-expanded")).toBe("false");
+        expect(vectorHeader.getAttribute("aria-expanded")).toBe("false");
     });
 
     test("renders all expanded when expand all button is clicked", async () => {
         // Arrange
         render(
             <LockedFiguresSection
-                figures={[
-                    getDefaultFigureForType("point"),
-                    getDefaultFigureForType("line"),
-                ]}
+                figures={defaultFigures}
                 onChange={jest.fn()}
             />,
             {
@@ -107,12 +119,9 @@ describe("LockedFiguresSection", () => {
             name: "Expand all",
         });
 
-        const pointHeader = screen.getByRole("button", {
-            name: "Point (0, 0) grayH, filled",
-        });
-        const lineHeader = screen.getByRole("button", {
-            name: "Line (0, 0), (2, 2) grayH, solid",
-        });
+        const pointHeader = getDefaultFigureHeader("point");
+        const lineHeader = getDefaultFigureHeader("line");
+        const vectorHeader = getDefaultFigureHeader("vector");
 
         // Act
         await userEvent.click(expandAllButton);
@@ -120,16 +129,14 @@ describe("LockedFiguresSection", () => {
         // Assert
         expect(pointHeader.getAttribute("aria-expanded")).toBe("true");
         expect(lineHeader.getAttribute("aria-expanded")).toBe("true");
+        expect(vectorHeader.getAttribute("aria-expanded")).toBe("true");
     });
 
     test("renders all collapsed when collapse all button is clicked", async () => {
         // Arrange
         render(
             <LockedFiguresSection
-                figures={[
-                    getDefaultFigureForType("point"),
-                    getDefaultFigureForType("line"),
-                ]}
+                figures={defaultFigures}
                 onChange={jest.fn()}
             />,
             {
@@ -141,12 +148,9 @@ describe("LockedFiguresSection", () => {
             name: "Expand all",
         });
 
-        const pointHeader = screen.getByRole("button", {
-            name: "Point (0, 0) grayH, filled",
-        });
-        const lineHeader = screen.getByRole("button", {
-            name: "Line (0, 0), (2, 2) grayH, solid",
-        });
+        const pointHeader = getDefaultFigureHeader("point");
+        const lineHeader = getDefaultFigureHeader("line");
+        const vectorHeader = getDefaultFigureHeader("vector");
 
         // Act
         await userEvent.click(expandAllButton);
@@ -159,16 +163,14 @@ describe("LockedFiguresSection", () => {
         // Assert
         expect(pointHeader.getAttribute("aria-expanded")).toBe("false");
         expect(lineHeader.getAttribute("aria-expanded")).toBe("false");
+        expect(vectorHeader.getAttribute("aria-expanded")).toBe("false");
     });
 
     test("render collapse button when some figures are expanded", async () => {
         // Arrange
         render(
             <LockedFiguresSection
-                figures={[
-                    getDefaultFigureForType("point"),
-                    getDefaultFigureForType("line"),
-                ]}
+                figures={defaultFigures}
                 onChange={jest.fn()}
             />,
             {

--- a/packages/perseus-editor/src/components/__tests__/locked-vector-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-vector-settings.test.tsx
@@ -1,0 +1,201 @@
+import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
+import {render, screen} from "@testing-library/react";
+import {userEvent as userEventLib} from "@testing-library/user-event";
+import * as React from "react";
+
+import LockedVectorSettings from "../locked-vector-settings";
+import {getDefaultFigureForType} from "../util";
+
+import type {Props} from "../locked-vector-settings";
+import type {UserEvent} from "@testing-library/user-event";
+
+const defaultProps = {
+    ...getDefaultFigureForType("vector"),
+    onChangeProps: () => {},
+    onRemove: () => {},
+} as Props;
+
+describe("Locked Vector Settings", () => {
+    let userEvent: UserEvent;
+    beforeEach(() => {
+        userEvent = userEventLib.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+    });
+
+    test("renders as expected with default values", () => {
+        // Act
+        render(<LockedVectorSettings {...defaultProps} />, {
+            wrapper: RenderStateRoot,
+        });
+
+        // Assert
+        const titleText = screen.getByText("Vector (0, 0), (2, 2)");
+        expect(titleText).toBeInTheDocument();
+    });
+
+    describe("Heading interactions", () => {
+        test("should show the vector's color by default", () => {
+            // Arrange
+            render(<LockedVectorSettings {...defaultProps} />, {
+                wrapper: RenderStateRoot,
+            });
+
+            // Act
+            const lineSwatch = screen.getByLabelText("grayH, solid");
+
+            // Assert
+            expect(lineSwatch).toBeInTheDocument();
+        });
+
+        test("should use the supplied color in the label", () => {
+            // Arrange
+            render(<LockedVectorSettings {...defaultProps} color="green" />, {
+                wrapper: RenderStateRoot,
+            });
+
+            // Act
+            const lineSwatch = screen.getByLabelText("green, solid");
+
+            // Assert
+            expect(lineSwatch).toBeInTheDocument();
+        });
+
+        test("calls 'onToggle' when header is clicked", async () => {
+            // Arrange
+            const onToggle = jest.fn();
+            render(
+                <LockedVectorSettings {...defaultProps} onToggle={onToggle} />,
+                {
+                    wrapper: RenderStateRoot,
+                },
+            );
+
+            // Act
+            const header = screen.getByRole("button", {
+                name: "Vector (0, 0), (2, 2) grayH, solid",
+            });
+            await userEvent.click(header);
+
+            // Assert
+            expect(onToggle).toHaveBeenCalled();
+        });
+
+        test("expands coordinate points when point headers are clicked", async () => {
+            // Arrange
+            render(<LockedVectorSettings {...defaultProps} />, {
+                wrapper: RenderStateRoot,
+            });
+
+            // Verify initial state
+            const tailHeader = screen.getByRole("button", {
+                name: "Tail (0, 0)",
+            });
+            expect(tailHeader).toHaveAttribute("aria-expanded", "false");
+            const tipHeader = screen.getByRole("button", {
+                name: "Tip (2, 2)",
+            });
+            expect(tipHeader).toHaveAttribute("aria-expanded", "false");
+
+            // Act
+            await userEvent.click(tailHeader);
+            expect(tailHeader).toHaveAttribute("aria-expanded", "true");
+            await userEvent.click(tipHeader);
+            expect(tipHeader).toHaveAttribute("aria-expanded", "true");
+        });
+    });
+
+    describe("Settings interactions", () => {
+        test("calls 'onChangeProps' when color is changed", async () => {
+            // Arrange
+            const onChangeProps = jest.fn();
+            render(
+                <LockedVectorSettings
+                    {...defaultProps}
+                    expanded={true}
+                    onChangeProps={onChangeProps}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            // Change the color
+            const colorSwitch = screen.getByLabelText("color");
+            await userEvent.click(colorSwitch);
+            const colorOption = screen.getByText("green");
+            await userEvent.click(colorOption);
+
+            // Assert
+            expect(onChangeProps).toHaveBeenCalledWith({color: "green"});
+        });
+
+        test("shows an error when the vector length is zero", () => {
+            // Act
+            render(
+                <LockedVectorSettings
+                    {...defaultProps}
+                    points={[
+                        [0, 0],
+                        [0, 0],
+                    ]}
+                    onChangeProps={() => {}}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            const errors = screen.getByText("The vector cannot have length 0.");
+            // Show error for both points
+            expect(errors).toBeInTheDocument();
+        });
+
+        test("does NOT show an error when the length is greater than zero", () => {
+            // Arrange
+
+            // Act
+            render(
+                <LockedVectorSettings
+                    {...defaultProps}
+                    points={[
+                        [0, 0],
+                        [0, 1],
+                    ]}
+                    onChangeProps={() => {}}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            const errors = screen.queryAllByText(
+                "The line cannot have length 0.",
+            );
+            expect(errors).toHaveLength(0);
+        });
+
+        test("updates props when changes made to coordinates", async () => {
+            // Arrange
+            const onChangePropsMock = jest.fn();
+            render(
+                <LockedVectorSettings
+                    {...defaultProps}
+                    onChangeProps={onChangePropsMock}
+                />,
+                {
+                    wrapper: RenderStateRoot,
+                },
+            );
+
+            // Act
+            const coordInputs = screen.getAllByRole(
+                "spinbutton",
+            ) as HTMLInputElement[];
+            for (let index = 0; index < coordInputs.length; index++) {
+                const input = coordInputs[index];
+                const currentValue = parseInt(input.value);
+                await userEvent.type(input, `${currentValue + 1}`);
+                expect(onChangePropsMock).toHaveBeenCalledTimes(1);
+                onChangePropsMock.mockClear();
+            }
+        });
+    });
+});

--- a/packages/perseus-editor/src/components/__tests__/locked-vector-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-vector-settings.test.tsx
@@ -80,29 +80,6 @@ describe("Locked Vector Settings", () => {
             // Assert
             expect(onToggle).toHaveBeenCalled();
         });
-
-        test("expands coordinate points when point headers are clicked", async () => {
-            // Arrange
-            render(<LockedVectorSettings {...defaultProps} />, {
-                wrapper: RenderStateRoot,
-            });
-
-            // Verify initial state
-            const tailHeader = screen.getByRole("button", {
-                name: "Tail (0, 0)",
-            });
-            expect(tailHeader).toHaveAttribute("aria-expanded", "false");
-            const tipHeader = screen.getByRole("button", {
-                name: "Tip (2, 2)",
-            });
-            expect(tipHeader).toHaveAttribute("aria-expanded", "false");
-
-            // Act
-            await userEvent.click(tailHeader);
-            expect(tailHeader).toHaveAttribute("aria-expanded", "true");
-            await userEvent.click(tipHeader);
-            expect(tipHeader).toHaveAttribute("aria-expanded", "true");
-        });
     });
 
     describe("Settings interactions", () => {

--- a/packages/perseus-editor/src/components/locked-figure-select.tsx
+++ b/packages/perseus-editor/src/components/locked-figure-select.tsx
@@ -40,6 +40,13 @@ const LockedFigureSelect = (props: Props) => {
                     >
                         Line
                     </ActionItem>,
+                    <ActionItem
+                        key={`${id}-vector`}
+                        label="Vector"
+                        onClick={() => onChange("vector")}
+                    >
+                        Vector
+                    </ActionItem>,
                 ]}
             </ActionMenu>
         </View>

--- a/packages/perseus-editor/src/components/locked-figure-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-figure-settings.tsx
@@ -9,9 +9,11 @@ import * as React from "react";
 
 import LockedLineSettings from "./locked-line-settings";
 import LockedPointSettings from "./locked-point-settings";
+import LockedVectorSettings from "./locked-vector-settings";
 
 import type {Props as LockedLineProps} from "./locked-line-settings";
 import type {Props as LockedPointProps} from "./locked-point-settings";
+import type {Props as LockedVectorProps} from "./locked-vector-settings";
 
 export type AccordionProps = {
     // Whether to show the M2 features in the locked figure settings.
@@ -28,7 +30,7 @@ export type AccordionProps = {
 };
 
 // Union this type with other locked figure types when they are added.
-type Props = AccordionProps & (LockedPointProps | LockedLineProps);
+type Props = AccordionProps & (LockedPointProps | LockedLineProps | LockedVectorProps);
 
 const LockedFigureSettings = (props: Props) => {
     switch (props.type) {
@@ -36,6 +38,8 @@ const LockedFigureSettings = (props: Props) => {
             return <LockedPointSettings {...props} />;
         case "line":
             return <LockedLineSettings {...props} />;
+        case "vector":
+            return <LockedVectorSettings {...props} />;
     }
 
     return null;

--- a/packages/perseus-editor/src/components/locked-figure-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-figure-settings.tsx
@@ -30,7 +30,8 @@ export type AccordionProps = {
 };
 
 // Union this type with other locked figure types when they are added.
-type Props = AccordionProps & (LockedPointProps | LockedLineProps | LockedVectorProps);
+type Props = AccordionProps &
+    (LockedPointProps | LockedLineProps | LockedVectorProps);
 
 const LockedFigureSettings = (props: Props) => {
     switch (props.type) {

--- a/packages/perseus-editor/src/components/locked-figures-section.tsx
+++ b/packages/perseus-editor/src/components/locked-figures-section.tsx
@@ -102,12 +102,6 @@ const LockedFiguresSection = (props: Props) => {
                     // implemented.
                     return;
                 }
-                if (figure.type === "vector") {
-                    // TODO(LEMS-1950): Add locked vector settings.
-                    // Remove this block once vector locked figure settings are
-                    // implemented.
-                    return;
-                }
 
                 return (
                     <LockedFigureSettings

--- a/packages/perseus-editor/src/components/locked-vector-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-vector-settings.tsx
@@ -6,14 +6,14 @@
  */
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {spacing, color as wbColor} from "@khanacademy/wonder-blocks-tokens";
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
+import {useState} from "react";
 
 import ColorSelect from "./color-select";
 import CoordinatePairInput from "./coordinate-pair-input";
-import DefiningPointSettings from "./defining-point-settings";
 import LineSwatch from "./line-swatch";
 import LockedFigureSettingsAccordion from "./locked-figure-settings-accordion";
 import LockedFigureSettingsActions from "./locked-figure-settings-actions";
@@ -39,6 +39,8 @@ export type Props = LockedVectorType &
     };
 
 const LockedVectorSettings = (props: Props) => {
+    const [tailCoordExpanded, setTailCoordExpanded] = useState(false);
+    const [tipCoordExpanded, setTipCoordExpanded] = useState(false);
     const {points, color: lineColor, onChangeProps, onRemove} = props;
     const [tail, tip] = points;
     const lineLabel = `Vector (${tail[0]}, ${tail[1]}), (${tip[0]}, ${tip[1]})`;
@@ -79,24 +81,47 @@ const LockedVectorSettings = (props: Props) => {
                 />
             </View>
 
-            {/* Coordinates */}
-            {/*
-                TODO: Wrap each coordinate pair input with LockedFigureSettingsAccordion
-            */}
-            <CoordinatePairInput
-                coord={tail}
-                // error={!!error}
-                onChangeProps={(newProps) => {
-                    handleChangePoint(newProps.coord, 0);
-                }}
-            />
-            <CoordinatePairInput
-                coord={tip}
-                // error={!!error}
-                onChangeProps={(newProps) => {
-                    handleChangePoint(newProps.coord, 1);
-                }}
-            />
+            <LockedFigureSettingsAccordion
+                expanded={tailCoordExpanded}
+                onToggle={() => setTailCoordExpanded(!tailCoordExpanded)}
+                containerStyle={styles.container}
+                panelStyle={styles.accordionPanel}
+                header={
+                    // Summary: Point, coords, color (filled/open)
+                    <View style={styles.row}>
+                        <LabelLarge>{`Tail (${tail[0]}, ${tail[1]})`}</LabelLarge>
+                    </View>
+                }
+            >
+                <CoordinatePairInput
+                    coord={tail}
+                    // error={!!error}
+                    onChangeProps={(newProps) => {
+                        handleChangePoint(newProps.coord, 0);
+                    }}
+                />
+            </LockedFigureSettingsAccordion>
+
+            <LockedFigureSettingsAccordion
+                expanded={tipCoordExpanded}
+                onToggle={() => setTipCoordExpanded(!tipCoordExpanded)}
+                containerStyle={styles.container}
+                panelStyle={styles.accordionPanel}
+                header={
+                    // Summary: Point, coords, color (filled/open)
+                    <View style={styles.row}>
+                        <LabelLarge>{`Tip (${tip[0]}, ${tip[1]})`}</LabelLarge>
+                    </View>
+                }
+            >
+                <CoordinatePairInput
+                    coord={tip}
+                    // error={!!error}
+                    onChangeProps={(newProps) => {
+                        handleChangePoint(newProps.coord, 1);
+                    }}
+                />
+            </LockedFigureSettingsAccordion>
 
             {/* Actions */}
             <LockedFigureSettingsActions
@@ -110,6 +135,16 @@ const LockedVectorSettings = (props: Props) => {
 };
 
 const styles = StyleSheet.create({
+    accordionPanel: {
+        paddingBottom: spacing.medium_16,
+    },
+    container: {
+        marginTop: spacing.xSmall_8,
+        marginBottom: 0,
+        marginLeft: -spacing.xxxSmall_4,
+        marginRight: -spacing.xxxSmall_4,
+        backgroundColor: wbColor.white,
+    },
     row: {
         flexDirection: "row",
         alignItems: "center",

--- a/packages/perseus-editor/src/components/locked-vector-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-vector-settings.tsx
@@ -42,8 +42,6 @@ export type Props = LockedVectorType &
     };
 
 const LockedVectorSettings = (props: Props) => {
-    const [tailCoordExpanded, setTailCoordExpanded] = useState(false);
-    const [tipCoordExpanded, setTipCoordExpanded] = useState(false);
     const {points, color: lineColor, onChangeProps, onRemove} = props;
     const [tail, tip] = points;
     const lineLabel = `Vector (${tail[0]}, ${tail[1]}), (${tip[0]}, ${tip[1]})`;
@@ -53,7 +51,7 @@ const LockedVectorSettings = (props: Props) => {
 
     function handleChangePoint(newCoord: Coord | undefined, index: 0 | 1) {
         if (typeof newCoord !== "undefined") {
-            const newPoints = [...points] as [Coord, Coord];
+            const newPoints = [...points] satisfies [tail: Coord, tip: Coord];
             newPoints[index] = [...newCoord];
             onChangeProps({
                 points: newPoints,
@@ -94,13 +92,12 @@ const LockedVectorSettings = (props: Props) => {
                 </LabelMedium>
             )}
 
+            {/* Coordinates */}
             <LockedFigureSettingsAccordion
-                expanded={tailCoordExpanded}
-                onToggle={() => setTailCoordExpanded(!tailCoordExpanded)}
+                expanded={true} // Initial state is expanded
                 containerStyle={styles.container}
                 panelStyle={styles.accordionPanel}
                 header={
-                    // Summary: Point, coords, color (filled/open)
                     <View style={styles.row}>
                         <LabelLarge>{`Tail (${tail[0]}, ${tail[1]})`}</LabelLarge>
                     </View>
@@ -116,12 +113,10 @@ const LockedVectorSettings = (props: Props) => {
             </LockedFigureSettingsAccordion>
 
             <LockedFigureSettingsAccordion
-                expanded={tipCoordExpanded}
-                onToggle={() => setTipCoordExpanded(!tipCoordExpanded)}
+                expanded={true} // Initial state is expanded
                 containerStyle={styles.container}
                 panelStyle={styles.accordionPanel}
                 header={
-                    // Summary: Point, coords, color (filled/open)
                     <View style={styles.row}>
                         <LabelLarge>{`Tip (${tip[0]}, ${tip[1]})`}</LabelLarge>
                     </View>
@@ -160,6 +155,7 @@ const styles = StyleSheet.create({
     },
     errorText: {
         color: wbColor.red,
+        marginTop: spacing.xSmall_8,
     },
     row: {
         flexDirection: "row",

--- a/packages/perseus-editor/src/components/locked-vector-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-vector-settings.tsx
@@ -11,7 +11,6 @@ import {spacing, color as wbColor} from "@khanacademy/wonder-blocks-tokens";
 import {LabelLarge, LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
-import {useState} from "react";
 
 import ColorSelect from "./color-select";
 import CoordinatePairInput from "./coordinate-pair-input";

--- a/packages/perseus-editor/src/components/locked-vector-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-vector-settings.tsx
@@ -4,10 +4,11 @@
  *
  * Used in the interactive graph editor's locked figures section.
  */
+import {vector as kvector} from "@khanacademy/kmath";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {spacing, color as wbColor} from "@khanacademy/wonder-blocks-tokens";
-import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
+import {LabelLarge, LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 import {useState} from "react";
@@ -25,6 +26,8 @@ import type {
     LockedFigureColor,
     LockedVectorType,
 } from "@khanacademy/perseus";
+
+const lengthErrorMessage = "The vector cannot have length 0.";
 
 export type Props = LockedVectorType &
     AccordionProps & {
@@ -45,8 +48,11 @@ const LockedVectorSettings = (props: Props) => {
     const [tail, tip] = points;
     const lineLabel = `Vector (${tail[0]}, ${tail[1]}), (${tip[0]}, ${tip[1]})`;
 
+    // Check if the line has length 0.
+    const isInvalid = kvector.equal(tail, tip);
+
     function handleChangePoint(newCoord: Coord | undefined, index: 0 | 1) {
-        if (newCoord) {
+        if (typeof newCoord !== "undefined") {
             const newPoints = [...points] as [Coord, Coord];
             newPoints[index] = [...newCoord];
             onChangeProps({
@@ -81,6 +87,13 @@ const LockedVectorSettings = (props: Props) => {
                 />
             </View>
 
+            {/* Zero length error message */}
+            {isInvalid && (
+                <LabelMedium style={styles.errorText}>
+                    {lengthErrorMessage}
+                </LabelMedium>
+            )}
+
             <LockedFigureSettingsAccordion
                 expanded={tailCoordExpanded}
                 onToggle={() => setTailCoordExpanded(!tailCoordExpanded)}
@@ -95,7 +108,7 @@ const LockedVectorSettings = (props: Props) => {
             >
                 <CoordinatePairInput
                     coord={tail}
-                    // error={!!error}
+                    error={isInvalid}
                     onChangeProps={(newProps) => {
                         handleChangePoint(newProps.coord, 0);
                     }}
@@ -116,7 +129,7 @@ const LockedVectorSettings = (props: Props) => {
             >
                 <CoordinatePairInput
                     coord={tip}
-                    // error={!!error}
+                    error={isInvalid}
                     onChangeProps={(newProps) => {
                         handleChangePoint(newProps.coord, 1);
                     }}
@@ -144,6 +157,9 @@ const styles = StyleSheet.create({
         marginLeft: -spacing.xxxSmall_4,
         marginRight: -spacing.xxxSmall_4,
         backgroundColor: wbColor.white,
+    },
+    errorText: {
+        color: wbColor.red,
     },
     row: {
         flexDirection: "row",

--- a/packages/perseus-editor/src/components/locked-vector-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-vector-settings.tsx
@@ -1,0 +1,119 @@
+/**
+ * LockedVectorSettings is a component that allows the user to edit the
+ * settings of specifically a locked vector on the graph.
+ *
+ * Used in the interactive graph editor's locked figures section.
+ */
+import {View} from "@khanacademy/wonder-blocks-core";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
+import {StyleSheet} from "aphrodite";
+import * as React from "react";
+
+import ColorSelect from "./color-select";
+import CoordinatePairInput from "./coordinate-pair-input";
+import DefiningPointSettings from "./defining-point-settings";
+import LineSwatch from "./line-swatch";
+import LockedFigureSettingsAccordion from "./locked-figure-settings-accordion";
+import LockedFigureSettingsActions from "./locked-figure-settings-actions";
+
+import type {AccordionProps} from "./locked-figure-settings";
+import type {
+    Coord,
+    LockedFigure,
+    LockedFigureColor,
+    LockedVectorType,
+} from "@khanacademy/perseus";
+
+export type Props = LockedVectorType &
+    AccordionProps & {
+        /**
+         * Called when the delete button is pressed.
+         */
+        onRemove: () => void;
+        /**
+         * Called when the props (points, color, etc.) are updated.
+         */
+        onChangeProps: (newProps: Partial<LockedFigure>) => void;
+    };
+
+const LockedVectorSettings = (props: Props) => {
+    const {points, color: lineColor, onChangeProps, onRemove} = props;
+    const [tail, tip] = points;
+    const lineLabel = `Vector (${tail[0]}, ${tail[1]}), (${tip[0]}, ${tip[1]})`;
+
+    function handleChangePoint(newCoord: Coord | undefined, index: 0 | 1) {
+        if (newCoord) {
+            const newPoints = [...points] as [Coord, Coord];
+            newPoints[index] = [...newCoord];
+            onChangeProps({
+                points: newPoints,
+            });
+        }
+    }
+
+    function handleColorChange(newColor: LockedFigureColor) {
+        onChangeProps({
+            color: newColor,
+        });
+    }
+
+    return (
+        <LockedFigureSettingsAccordion
+            expanded={props.expanded}
+            onToggle={props.onToggle}
+            header={
+                <View style={styles.row}>
+                    <LabelLarge>{lineLabel}</LabelLarge>
+                    <Strut size={spacing.xSmall_8} />
+                    <LineSwatch color={lineColor} lineStyle="solid" />
+                </View>
+            }
+        >
+            <View style={[styles.row, styles.spaceUnder]}>
+                {/* Line color settings */}
+                <ColorSelect
+                    selectedValue={lineColor}
+                    onChange={handleColorChange}
+                />
+            </View>
+
+            {/* Coordinates */}
+            {/*
+                TODO: Wrap each coordinate pair input with LockedFigureSettingsAccordion
+            */}
+            <CoordinatePairInput
+                coord={tail}
+                // error={!!error}
+                onChangeProps={(newProps) => {
+                    handleChangePoint(newProps.coord, 0);
+                }}
+            />
+            <CoordinatePairInput
+                coord={tip}
+                // error={!!error}
+                onChangeProps={(newProps) => {
+                    handleChangePoint(newProps.coord, 1);
+                }}
+            />
+
+            {/* Actions */}
+            <LockedFigureSettingsActions
+                onRemove={onRemove}
+                figureAriaLabel={`locked vector defined by starting point
+                    ${tail[0]}, ${tail[1]} and extending to
+                    ${tip[0]}, ${tip[1]}.`}
+            />
+        </LockedFigureSettingsAccordion>
+    );
+};
+
+const styles = StyleSheet.create({
+    row: {
+        flexDirection: "row",
+        alignItems: "center",
+    },
+});
+
+export default LockedVectorSettings;

--- a/packages/perseus-editor/src/components/util.ts
+++ b/packages/perseus-editor/src/components/util.ts
@@ -5,6 +5,7 @@ import type {
     LockedFigureType,
     LockedPointType,
     LockedLineType,
+    LockedVectorType,
 } from "@khanacademy/perseus";
 
 export function focusWithChromeStickyFocusBugWorkaround(element: Element) {
@@ -50,6 +51,7 @@ const DEFAULT_COLOR = "grayH";
 
 export function getDefaultFigureForType(type: "point"): LockedPointType;
 export function getDefaultFigureForType(type: "line"): LockedLineType;
+export function getDefaultFigureForType(type: "vector"): LockedVectorType;
 export function getDefaultFigureForType(type: LockedFigureType): LockedFigure;
 export function getDefaultFigureForType(type: LockedFigureType): LockedFigure {
     switch (type) {


### PR DESCRIPTION
## Summary:
Content editors need a way to add and edit a locked vector. This PR adds a settings section that is specific to vectors. While the output of a vector is extremely similar to that of a ray, the underlying data is much simpler (just color and coordinates). Therefore, a separate settings UI is being put in place to account for the simplified dataset.

Issue: LEMS-1950

## Test plan:
1. Launch Storybook (`yarn start`)
1. Navigate to Perseus Editor => Widgets => Interactive Graph Editor => [With Locked Lines](http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph-editor--with-locked-lines)
1. Click on the "Add locked figure" drop-down at the bottom of the editor and choose "Vector"
   * A vector with default settings should be added to the example graph
   * A settings section should be added to the bottom of the list of items on the graph
   * The settings should be open, and should show the color and coordinate settings
1. Changing any of the settings should immediately update the vector in the example graph

## Affected UI

### New settings options

![Screenshot 2024-06-04 at 4 08 27 PM](https://github.com/Khan/perseus/assets/13896410/d9264c41-bf9c-4943-934e-a5f7e84db482)
