### PR TITLE
[Interactive Graph Editor] Rename locked circle to locked ellipse

### DIFF
--- a/.changeset/poor-teachers-allow.md
+++ b/.changeset/poor-teachers-allow.md
@@ -3,4 +3,4 @@
 "@khanacademy/perseus-editor": minor
 ---
 
-[Interactive Graph Editor] Implement "Add locked circle" UI
+[Interactive Graph Editor] Implement "Add locked ellipse" UI

--- a/packages/perseus-editor/src/components/__stories__/locked-ellipse-settings.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/locked-ellipse-settings.stories.tsx
@@ -1,24 +1,24 @@
 import * as React from "react";
 
-import LockedCircleSettings from "../locked-circle-settings";
+import LockedEllipseSettings from "../locked-ellipse-settings";
 import {getDefaultFigureForType} from "../util";
 
 import type {Meta, StoryObj} from "@storybook/react";
 
 export default {
-    title: "PerseusEditor/Components/Locked Circle Settings",
-    component: LockedCircleSettings,
-} as Meta<typeof LockedCircleSettings>;
+    title: "PerseusEditor/Components/Locked Ellipse Settings",
+    component: LockedEllipseSettings,
+} as Meta<typeof LockedEllipseSettings>;
 
 export const Default = (args): React.ReactElement => {
-    return <LockedCircleSettings {...args} />;
+    return <LockedEllipseSettings {...args} />;
 };
 
-type StoryComponentType = StoryObj<typeof LockedCircleSettings>;
+type StoryComponentType = StoryObj<typeof LockedEllipseSettings>;
 
 // Set the default values in the control panel.
 Default.args = {
-    ...getDefaultFigureForType("circle"),
+    ...getDefaultFigureForType("ellipse"),
     onChangeProps: () => {},
     onRemove: () => {},
 };
@@ -26,7 +26,7 @@ Default.args = {
 export const Controlled: StoryComponentType = {
     render: function Render() {
         const [props, setProps] = React.useState({
-            ...getDefaultFigureForType("circle"),
+            ...getDefaultFigureForType("ellipse"),
             onRemove: () => {},
         });
 
@@ -38,7 +38,7 @@ export const Controlled: StoryComponentType = {
         };
 
         return (
-            <LockedCircleSettings
+            <LockedEllipseSettings
                 {...props}
                 onChangeProps={handlePropsUpdate}
             />
@@ -53,12 +53,12 @@ Controlled.parameters = {
     },
 };
 
-// Fully expanded view of the locked circle settings to allow snapshot testing.
+// Fully expanded view of the locked ellipse settings to allow snapshot testing.
 export const Expanded: StoryComponentType = {
     render: function Render() {
         const [expanded, setExpanded] = React.useState(true);
         const [props, setProps] = React.useState({
-            ...getDefaultFigureForType("circle"),
+            ...getDefaultFigureForType("ellipse"),
             onRemove: () => {},
         });
 
@@ -70,7 +70,7 @@ export const Expanded: StoryComponentType = {
         };
 
         return (
-            <LockedCircleSettings
+            <LockedEllipseSettings
                 {...props}
                 expanded={expanded}
                 onToggle={setExpanded}

--- a/packages/perseus-editor/src/components/__tests__/locked-ellipse-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-ellipse-settings.test.tsx
@@ -3,18 +3,18 @@ import {render, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
-import LockedCircleSettings from "../locked-circle-settings";
+import LockedEllipseSettings from "../locked-ellipse-settings";
 import {getDefaultFigureForType} from "../util";
 
 import type {UserEvent} from "@testing-library/user-event";
 
 const defaultProps = {
-    ...getDefaultFigureForType("circle"),
+    ...getDefaultFigureForType("ellipse"),
     onChangeProps: () => {},
     onRemove: () => {},
 };
 
-describe("LockedCircleSettings", () => {
+describe("LockedEllipseSettings", () => {
     let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
@@ -25,12 +25,12 @@ describe("LockedCircleSettings", () => {
         // Arrange
 
         // Act
-        render(<LockedCircleSettings {...defaultProps} />, {
+        render(<LockedEllipseSettings {...defaultProps} />, {
             wrapper: RenderStateRoot,
         });
 
         // Assert
-        const titleText = screen.getByText("Circle (0, 0), radius 1");
+        const titleText = screen.getByText("Ellipse (0, 0), radius 1");
         expect(titleText).toBeInTheDocument();
     });
 
@@ -38,12 +38,12 @@ describe("LockedCircleSettings", () => {
         // Arrange
 
         // Act
-        render(<LockedCircleSettings {...defaultProps} radius={5} />, {
+        render(<LockedEllipseSettings {...defaultProps} radius={5} />, {
             wrapper: RenderStateRoot,
         });
 
         // Assert
-        const titleText = screen.getByText("Circle (0, 0), radius 5");
+        const titleText = screen.getByText("Ellipse (0, 0), radius 5");
         expect(titleText).toBeInTheDocument();
     });
 
@@ -51,12 +51,12 @@ describe("LockedCircleSettings", () => {
         // Arrange
 
         // Act
-        render(<LockedCircleSettings {...defaultProps} center={[3, 5]} />, {
+        render(<LockedEllipseSettings {...defaultProps} center={[3, 5]} />, {
             wrapper: RenderStateRoot,
         });
 
         // Assert
-        const titleText = screen.getByText("Circle (3, 5), radius 1");
+        const titleText = screen.getByText("Ellipse (3, 5), radius 1");
         expect(titleText).toBeInTheDocument();
     });
 
@@ -64,7 +64,7 @@ describe("LockedCircleSettings", () => {
         // Arrange
 
         // Act
-        render(<LockedCircleSettings {...defaultProps} color="green" />, {
+        render(<LockedEllipseSettings {...defaultProps} color="green" />, {
             wrapper: RenderStateRoot,
         });
 
@@ -79,7 +79,7 @@ describe("LockedCircleSettings", () => {
 
         // Act
         render(
-            <LockedCircleSettings
+            <LockedEllipseSettings
                 {...defaultProps}
                 color="green"
                 strokeStyle="dashed"
@@ -100,7 +100,7 @@ describe("LockedCircleSettings", () => {
 
         // Act
         render(
-            <LockedCircleSettings
+            <LockedEllipseSettings
                 {...defaultProps}
                 color="green"
                 fillStyle="translucent"
@@ -121,13 +121,16 @@ describe("LockedCircleSettings", () => {
     test("calls onToggle when header is clicked", async () => {
         // Arrange
         const onToggle = jest.fn();
-        render(<LockedCircleSettings {...defaultProps} onToggle={onToggle} />, {
-            wrapper: RenderStateRoot,
-        });
+        render(
+            <LockedEllipseSettings {...defaultProps} onToggle={onToggle} />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
 
         // Act
         const header = screen.getByRole("button", {
-            name: "Circle (0, 0), radius 1 grayH, stroke solid, fill none",
+            name: "Ellipse (0, 0), radius 1 grayH, stroke solid, fill none",
         });
         await userEvent.click(header);
 

--- a/packages/perseus-editor/src/components/__tests__/util.test.ts
+++ b/packages/perseus-editor/src/components/__tests__/util.test.ts
@@ -37,10 +37,10 @@ describe("getDefaultFigureForType", () => {
         });
     });
 
-    test("should return a circle with default values", () => {
-        const figure = getDefaultFigureForType("circle");
+    test("should return an ellipse with default values", () => {
+        const figure = getDefaultFigureForType("ellipse");
         expect(figure).toEqual({
-            type: "circle",
+            type: "ellipse",
             center: [0, 0],
             radius: 1,
             color: "grayH",

--- a/packages/perseus-editor/src/components/ellipse-swatch.tsx
+++ b/packages/perseus-editor/src/components/ellipse-swatch.tsx
@@ -1,4 +1,7 @@
-import {lockedFigureColors, lockedCircleFillStyles} from "@khanacademy/perseus";
+import {
+    lockedFigureColors,
+    lockedEllipseFillStyles,
+} from "@khanacademy/perseus";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {color as wbColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
@@ -6,16 +9,16 @@ import * as React from "react";
 
 import type {
     LockedFigureColor,
-    LockedCircleFillType,
+    LockedEllipseFillType,
 } from "@khanacademy/perseus";
 
 type Props = {
     color: LockedFigureColor;
-    fillStyle: LockedCircleFillType;
+    fillStyle: LockedEllipseFillType;
     strokeStyle: "solid" | "dashed";
 };
 
-const CircleSwatch = (props: Props) => {
+const EllipseSwatch = (props: Props) => {
     const {color, fillStyle, strokeStyle} = props;
 
     return (
@@ -33,7 +36,7 @@ const CircleSwatch = (props: Props) => {
                     styles.innerCircle,
                     {
                         backgroundColor: lockedFigureColors[color],
-                        opacity: lockedCircleFillStyles[fillStyle],
+                        opacity: lockedEllipseFillStyles[fillStyle],
                     },
                 ]}
             />
@@ -60,4 +63,4 @@ const styles = StyleSheet.create({
     },
 });
 
-export default CircleSwatch;
+export default EllipseSwatch;

--- a/packages/perseus-editor/src/components/locked-ellipse-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-ellipse-settings.tsx
@@ -1,4 +1,4 @@
-import {components, lockedCircleFillStyles} from "@khanacademy/perseus";
+import {components, lockedEllipseFillStyles} from "@khanacademy/perseus";
 import {View, useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
 import {TextField} from "@khanacademy/wonder-blocks-form";
@@ -8,24 +8,24 @@ import {LabelMedium, LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
-import CircleSwatch from "./circle-swatch";
 import ColorSelect from "./color-select";
 import CoordinatePairInput from "./coordinate-pair-input";
+import EllipseSwatch from "./ellipse-swatch";
 import LockedFigureSettingsAccordion from "./locked-figure-settings-accordion";
 import LockedFigureSettingsActions from "./locked-figure-settings-actions";
 
 import type {AccordionProps} from "./locked-figure-settings";
 import type {
     Coord,
-    LockedCircleFillType,
-    LockedCircleType,
+    LockedEllipseFillType,
+    LockedEllipseType,
     LockedFigureColor,
 } from "@khanacademy/perseus";
 
 const {InfoTip} = components;
 
 export type Props = AccordionProps &
-    LockedCircleType & {
+    LockedEllipseType & {
         /**
          * Called when the delete button is pressed.
          */
@@ -33,10 +33,10 @@ export type Props = AccordionProps &
         /**
          * Called when the props (coords, color, etc.) are updated.
          */
-        onChangeProps: (newProps: Partial<LockedCircleType>) => void;
+        onChangeProps: (newProps: Partial<LockedEllipseType>) => void;
     };
 
-const LockedCircleSettings = (props: Props) => {
+const LockedEllipseSettings = (props: Props) => {
     const {
         center,
         radius,
@@ -87,11 +87,11 @@ const LockedCircleSettings = (props: Props) => {
             expanded={expanded}
             onToggle={onToggle}
             header={
-                // Summary: Circle, center, radius, color (opacity, dashed)
+                // Summary: Ellipse, center, radius, color (opacity, dashed)
                 <View style={styles.row}>
-                    <LabelLarge>{`Circle (${center[0]}, ${center[1]}), radius ${radius}`}</LabelLarge>
+                    <LabelLarge>{`Ellipse (${center[0]}, ${center[1]}), radius ${radius}`}</LabelLarge>
                     <Strut size={spacing.xSmall_8} />
-                    <CircleSwatch
+                    <EllipseSwatch
                         color={props.color}
                         fillStyle={fillStyle}
                         strokeStyle={strokeStyle}
@@ -109,7 +109,7 @@ const LockedCircleSettings = (props: Props) => {
                 />
                 <View style={styles.spaceUnder}>
                     <InfoTip>
-                        The coordinates for the center of the circle
+                        The coordinates for the center of the ellipse.
                     </InfoTip>
                 </View>
             </View>
@@ -177,13 +177,13 @@ const LockedCircleSettings = (props: Props) => {
                 <SingleSelect
                     id={fillSelectId}
                     selectedValue={fillStyle}
-                    onChange={(value: LockedCircleFillType) =>
+                    onChange={(value: LockedEllipseFillType) =>
                         onChangeProps({fillStyle: value})
                     }
                     // Placeholder is required, but never gets used.
                     placeholder=""
                 >
-                    {Object.keys(lockedCircleFillStyles).map((option) => (
+                    {Object.keys(lockedEllipseFillStyles).map((option) => (
                         <OptionItem key={option} value={option} label={option}>
                             {option}
                         </OptionItem>
@@ -194,7 +194,7 @@ const LockedCircleSettings = (props: Props) => {
             {/* Actions */}
             <LockedFigureSettingsActions
                 onRemove={onRemove}
-                figureAriaLabel={`locked circle at ${center[0]}, ${center[1]}`}
+                figureAriaLabel={`locked ellipse at ${center[0]}, ${center[1]}`}
             />
         </LockedFigureSettingsAccordion>
     );
@@ -213,4 +213,4 @@ const styles = StyleSheet.create({
     },
 });
 
-export default LockedCircleSettings;
+export default LockedEllipseSettings;

--- a/packages/perseus-editor/src/components/locked-figure-select.tsx
+++ b/packages/perseus-editor/src/components/locked-figure-select.tsx
@@ -19,7 +19,7 @@ type Props = {
 const LockedFigureSelect = (props: Props) => {
     const {id, onChange} = props;
 
-    const figureTypes = ["point", "line", "circle", "vector"];
+    const figureTypes = ["point", "line", "ellipse", "vector"];
 
     return (
         <View style={styles.container}>

--- a/packages/perseus-editor/src/components/locked-figure-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-figure-settings.tsx
@@ -7,12 +7,12 @@
 
 import * as React from "react";
 
-import LockedCircleSettings from "./locked-circle-settings";
+import LockedEllipseSettings from "./locked-ellipse-settings";
 import LockedLineSettings from "./locked-line-settings";
 import LockedPointSettings from "./locked-point-settings";
 import LockedVectorSettings from "./locked-vector-settings";
 
-import type {Props as LockedCircleProps} from "./locked-circle-settings";
+import type {Props as LockedEllipseProps} from "./locked-ellipse-settings";
 import type {Props as LockedLineProps} from "./locked-line-settings";
 import type {Props as LockedPointProps} from "./locked-point-settings";
 import type {Props as LockedVectorProps} from "./locked-vector-settings";
@@ -36,7 +36,7 @@ type Props = AccordionProps &
     (
         | LockedPointProps
         | LockedLineProps
-        | LockedCircleProps
+        | LockedEllipseProps
         | LockedVectorProps
     );
 
@@ -46,8 +46,8 @@ const LockedFigureSettings = (props: Props) => {
             return <LockedPointSettings {...props} />;
         case "line":
             return <LockedLineSettings {...props} />;
-        case "circle":
-            return <LockedCircleSettings {...props} />;
+        case "ellipse":
+            return <LockedEllipseSettings {...props} />;
         case "vector":
             return <LockedVectorSettings {...props} />;
     }

--- a/packages/perseus-editor/src/components/util.ts
+++ b/packages/perseus-editor/src/components/util.ts
@@ -5,7 +5,7 @@ import type {
     LockedFigureType,
     LockedPointType,
     LockedLineType,
-    LockedCircleType,
+    LockedEllipseType,
     LockedVectorType,
 } from "@khanacademy/perseus";
 
@@ -52,7 +52,7 @@ const DEFAULT_COLOR = "grayH";
 
 export function getDefaultFigureForType(type: "point"): LockedPointType;
 export function getDefaultFigureForType(type: "line"): LockedLineType;
-export function getDefaultFigureForType(type: "circle"): LockedCircleType;
+export function getDefaultFigureForType(type: "ellipse"): LockedEllipseType;
 export function getDefaultFigureForType(type: "vector"): LockedVectorType;
 export function getDefaultFigureForType(type: LockedFigureType): LockedFigure;
 export function getDefaultFigureForType(type: LockedFigureType): LockedFigure {
@@ -80,9 +80,9 @@ export function getDefaultFigureForType(type: LockedFigureType): LockedFigure {
                 showPoint1: false,
                 showPoint2: false,
             };
-        case "circle":
+        case "ellipse":
             return {
-                type: "circle",
+                type: "ellipse",
                 center: [0, 0],
                 radius: 1,
                 color: DEFAULT_COLOR,

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
@@ -54,10 +54,10 @@ describe("InteractiveGraphEditor locked figures", () => {
 
     // Basic functionality
     describe.each`
-        figureType  | figureName
-        ${"point"}  | ${"Point"}
-        ${"line"}   | ${"Line"}
-        ${"circle"} | ${"Circle"}
+        figureType   | figureName
+        ${"point"}   | ${"Point"}
+        ${"line"}    | ${"Line"}
+        ${"ellipse"} | ${"Ellipse"}
     `(`$figureType basics`, ({figureType, figureName}) => {
         test("Calls onChange when a locked $figureType is added", async () => {
             // Arrange
@@ -569,14 +569,14 @@ describe("InteractiveGraphEditor locked figures", () => {
         });
     });
 
-    describe("circles", () => {
-        test("Calls onChange when a locked circle's center x is changed", async () => {
+    describe("ellipses", () => {
+        test("Calls onChange when a locked ellipse's center x is changed", async () => {
             // Arrange
             const onChangeMock = jest.fn();
 
             renderEditor({
                 onChange: onChangeMock,
-                lockedFigures: [getDefaultFigureForType("circle")],
+                lockedFigures: [getDefaultFigureForType("ellipse")],
             });
 
             // Act
@@ -590,7 +590,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                 expect.objectContaining({
                     lockedFigures: [
                         expect.objectContaining({
-                            type: "circle",
+                            type: "ellipse",
                             center: [5, 0],
                         }),
                     ],
@@ -598,13 +598,13 @@ describe("InteractiveGraphEditor locked figures", () => {
             );
         });
 
-        test("Calls onChange when a locked circle's center y is changed", async () => {
+        test("Calls onChange when a locked ellipse's center y is changed", async () => {
             // Arrange
             const onChangeMock = jest.fn();
 
             renderEditor({
                 onChange: onChangeMock,
-                lockedFigures: [getDefaultFigureForType("circle")],
+                lockedFigures: [getDefaultFigureForType("ellipse")],
             });
 
             // Act
@@ -618,7 +618,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                 expect.objectContaining({
                     lockedFigures: [
                         expect.objectContaining({
-                            type: "circle",
+                            type: "ellipse",
                             center: [0, 5],
                         }),
                     ],
@@ -626,13 +626,13 @@ describe("InteractiveGraphEditor locked figures", () => {
             );
         });
 
-        test("Calls onChange when a locked circle's radius is changed", async () => {
+        test("Calls onChange when a locked ellipse's radius is changed", async () => {
             // Arrange
             const onChangeMock = jest.fn();
 
             renderEditor({
                 onChange: onChangeMock,
-                lockedFigures: [getDefaultFigureForType("circle")],
+                lockedFigures: [getDefaultFigureForType("ellipse")],
             });
 
             // Act
@@ -646,7 +646,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                 expect.objectContaining({
                     lockedFigures: [
                         expect.objectContaining({
-                            type: "circle",
+                            type: "ellipse",
                             radius: 5,
                         }),
                     ],
@@ -654,13 +654,13 @@ describe("InteractiveGraphEditor locked figures", () => {
             );
         });
 
-        test("Calls onChange when locked circle's stroke style is changed", async () => {
+        test("Calls onChange when locked ellipse's stroke style is changed", async () => {
             // Arrange
             const onChangeMock = jest.fn();
 
             renderEditor({
                 onChange: onChangeMock,
-                lockedFigures: [getDefaultFigureForType("circle")],
+                lockedFigures: [getDefaultFigureForType("ellipse")],
             });
 
             // Act
@@ -676,7 +676,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                 expect.objectContaining({
                     lockedFigures: [
                         expect.objectContaining({
-                            type: "circle",
+                            type: "ellipse",
                             strokeStyle: "dashed",
                         }),
                     ],
@@ -684,13 +684,13 @@ describe("InteractiveGraphEditor locked figures", () => {
             );
         });
 
-        test("Calls onChange when a locked circle's fill style is changed", async () => {
+        test("Calls onChange when a locked ellipse's fill style is changed", async () => {
             // Arrange
             const onChangeMock = jest.fn();
 
             renderEditor({
                 onChange: onChangeMock,
-                lockedFigures: [getDefaultFigureForType("circle")],
+                lockedFigures: [getDefaultFigureForType("ellipse")],
             });
 
             // Act
@@ -706,7 +706,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                 expect.objectContaining({
                     lockedFigures: [
                         expect.objectContaining({
-                            type: "circle",
+                            type: "ellipse",
                             fillStyle: "translucent",
                         }),
                     ],

--- a/packages/perseus/CHANGELOG.md
+++ b/packages/perseus/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 -   [#1315](https://github.com/Khan/perseus/pull/1315) [`73e5828a5`](https://github.com/Khan/perseus/commit/73e5828a5ee219435187402f4942dab32fefc2c4) Thanks [@SonicScrewdriver](https://github.com/SonicScrewdriver)! - Creation of the new Mafs-based Sinusoid Graph
 
-*   [#1309](https://github.com/Khan/perseus/pull/1309) [`c8422cd99`](https://github.com/Khan/perseus/commit/c8422cd99bf3c09b66b602c77240262d1ca68533) Thanks [@nishasy](https://github.com/nishasy)! - [Interactive Graph] Render locked circles on interactive graphs
+*   [#1309](https://github.com/Khan/perseus/pull/1309) [`c8422cd99`](https://github.com/Khan/perseus/commit/c8422cd99bf3c09b66b602c77240262d1ca68533) Thanks [@nishasy](https://github.com/nishasy)! - [Interactive Graph] Render locked ellipses on interactive graphs
 
 ### Patch Changes
 

--- a/packages/perseus/CHANGELOG.md
+++ b/packages/perseus/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 -   [#1315](https://github.com/Khan/perseus/pull/1315) [`73e5828a5`](https://github.com/Khan/perseus/commit/73e5828a5ee219435187402f4942dab32fefc2c4) Thanks [@SonicScrewdriver](https://github.com/SonicScrewdriver)! - Creation of the new Mafs-based Sinusoid Graph
 
-*   [#1309](https://github.com/Khan/perseus/pull/1309) [`c8422cd99`](https://github.com/Khan/perseus/commit/c8422cd99bf3c09b66b602c77240262d1ca68533) Thanks [@nishasy](https://github.com/nishasy)! - [Interactive Graph] Render locked ellipses on interactive graphs
+*   [#1309](https://github.com/Khan/perseus/pull/1309) [`c8422cd99`](https://github.com/Khan/perseus/commit/c8422cd99bf3c09b66b602c77240262d1ca68533) Thanks [@nishasy](https://github.com/nishasy)! - [Interactive Graph] Render locked circles on interactive graphs
 
 ### Patch Changes
 

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -65,7 +65,7 @@ export {
     plotterPlotTypes,
     ItemExtras,
     lockedFigureColors,
-    lockedCircleFillStyles,
+    lockedEllipseFillStyles,
 } from "./perseus-types";
 export {traverse} from "./traversal";
 export {isItemRenderableByVersion} from "./renderability";
@@ -163,8 +163,8 @@ export type {
     LockedFigureType,
     LockedPointType,
     LockedLineType,
-    LockedCircleType,
-    LockedCircleFillType,
+    LockedEllipseType,
+    LockedEllipseFillType,
     LockedVectorType,
     PerseusGraphType,
     PerseusAnswerArea,

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -673,7 +673,7 @@ export const lockedFigureColors: Record<LockedFigureColor, string> = {
 export type LockedFigure =
     | LockedPointType
     | LockedLineType
-    | LockedCircleType
+    | LockedEllipseType
     | LockedVectorType;
 export type LockedFigureType = LockedFigure["type"];
 
@@ -694,19 +694,19 @@ export type LockedLineType = {
     showPoint2: boolean;
 };
 
-export type LockedCircleFillType = "none" | "solid" | "translucent";
-export const lockedCircleFillStyles: Record<LockedCircleFillType, number> = {
+export type LockedEllipseFillType = "none" | "solid" | "translucent";
+export const lockedEllipseFillStyles: Record<LockedEllipseFillType, number> = {
     none: 0,
     solid: 1,
     translucent: 0.4,
 } as const;
 
-export type LockedCircleType = {
-    type: "circle";
+export type LockedEllipseType = {
+    type: "ellipse";
     center: Coord;
     radius: number;
     color: LockedFigureColor;
-    fillStyle: LockedCircleFillType;
+    fillStyle: LockedEllipseFillType;
     strokeStyle: "solid" | "dashed";
 };
 

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -153,7 +153,7 @@ export const InteractiveGraphLockedFeaturesFlags = [
     /**
      * Enables/Disables Milestone 2 locked features in the new Mafs
      * interactive-graph widget (the rest of the figure types:
-     * circles, vectors, polygons, functions, labels).
+     * ellipses, vectors, polygons, functions, labels).
      */
     "interactive-graph-locked-features-m2",
 ] as const;

--- a/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
@@ -18,7 +18,7 @@ import {
     segmentWithAllLockedLineVariations,
     segmentWithAllLockedRayVariations,
     sinusoidQuestion,
-    segmentWithLockedCircles,
+    segmentWithLockedEllipses,
     segmentWithLockedVectors,
 } from "../__testdata__/interactive-graph.testdata";
 
@@ -117,8 +117,11 @@ export const AllLockedRays = (args: StoryArgs): React.ReactElement => (
     />
 );
 
-export const LockedCircle = (args: StoryArgs): React.ReactElement => (
-    <RendererWithDebugUI {...mafsOptions} question={segmentWithLockedCircles} />
+export const LockedEllipse = (args: StoryArgs): React.ReactElement => (
+    <RendererWithDebugUI
+        {...mafsOptions}
+        question={segmentWithLockedEllipses}
+    />
 );
 
 export const LockedVector = (args: StoryArgs): React.ReactElement => (

--- a/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
@@ -1975,18 +1975,18 @@ export const segmentWithLockedFigures: PerseusRenderer =
     interactiveGraphQuestionBuilder()
         .addLockedPointAt(-7, -7)
         .addLockedLine([-7, -5], [2, -3])
-        .addLockedCircle([0, 5], 2)
+        .addLockedEllipse([0, 5], 2)
         .build();
 
-export const segmentWithLockedCircles: PerseusRenderer =
+export const segmentWithLockedEllipses: PerseusRenderer =
     interactiveGraphQuestionBuilder()
-        .addLockedCircle([0, 0], 5)
-        .addLockedCircle([-5, 5], 2, {
+        .addLockedEllipse([0, 0], 5)
+        .addLockedEllipse([-5, 5], 2, {
             color: "green",
             fillStyle: "solid",
             strokeStyle: "solid",
         })
-        .addLockedCircle([5, 5], 2, {
+        .addLockedEllipse([5, 5], 2, {
             color: "green",
             fillStyle: "translucent",
             strokeStyle: "dashed",

--- a/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
+++ b/packages/perseus/src/widgets/__tests__/interactive-graph.test.ts
@@ -27,7 +27,7 @@ import {
     rayQuestionWithDefaultCorrect,
     segmentQuestion,
     segmentQuestionDefaultCorrect,
-    segmentWithLockedCircles,
+    segmentWithLockedEllipses,
     segmentWithLockedLineQuestion,
     segmentWithLockedPointsQuestion,
     segmentWithLockedPointsWithColorQuestion,
@@ -538,9 +538,9 @@ describe("locked layer", () => {
         });
     });
 
-    test("should render locked circles", async () => {
+    test("should render locked ellipses", async () => {
         // Arrange
-        const {container} = renderQuestion(segmentWithLockedCircles, {
+        const {container} = renderQuestion(segmentWithLockedEllipses, {
             flags: {
                 mafs: {
                     segment: true,

--- a/packages/perseus/src/widgets/interactive-graphs/graph-locked-layer.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graph-locked-layer.tsx
@@ -1,7 +1,7 @@
 import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
 import * as React from "react";
 
-import LockedCircle from "./locked-circle";
+import LockedEllipse from "./locked-ellipse";
 import LockedLine from "./locked-line";
 import LockedPoint from "./locked-point";
 import LockedVector from "./locked-vector";
@@ -32,9 +32,12 @@ const GraphLockedLayer = (props: Props) => {
                                 {...figure}
                             />
                         );
-                    case "circle":
+                    case "ellipse":
                         return (
-                            <LockedCircle key={`circle-${index}`} {...figure} />
+                            <LockedEllipse
+                                key={`ellipse-${index}`}
+                                {...figure}
+                            />
                         );
                     case "vector":
                         return (

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
@@ -177,15 +177,15 @@ describe("InteractiveGraphQuestionBuilder", () => {
         ]);
     });
 
-    it("adds a locked circle", () => {
+    it("adds a locked ellipse", () => {
         const question: PerseusRenderer = interactiveGraphQuestionBuilder()
-            .addLockedCircle([1, 2], 3)
+            .addLockedEllipse([1, 2], 3)
             .build();
         const graph = question.widgets["interactive-graph 1"];
 
         expect(graph.options.lockedFigures).toEqual([
             {
-                type: "circle",
+                type: "ellipse",
                 center: [1, 2],
                 radius: 3,
                 color: "grayH",
@@ -195,9 +195,9 @@ describe("InteractiveGraphQuestionBuilder", () => {
         ]);
     });
 
-    it("adds a locked circle with options", () => {
+    it("adds a locked ellipse with options", () => {
         const question: PerseusRenderer = interactiveGraphQuestionBuilder()
-            .addLockedCircle([1, 2], 3, {
+            .addLockedEllipse([1, 2], 3, {
                 color: "green",
                 fillStyle: "solid",
                 strokeStyle: "dashed",
@@ -207,7 +207,7 @@ describe("InteractiveGraphQuestionBuilder", () => {
 
         expect(graph.options.lockedFigures).toEqual([
             {
-                type: "circle",
+                type: "ellipse",
                 center: [1, 2],
                 radius: 3,
                 color: "green",

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -1,6 +1,6 @@
 import type {
-    LockedCircleFillType,
-    LockedCircleType,
+    LockedEllipseFillType,
+    LockedEllipseType,
     LockedFigure,
     LockedFigureColor,
     LockedLineType,
@@ -133,17 +133,17 @@ class InteractiveGraphQuestionBuilder {
         return this;
     }
 
-    addLockedCircle(
+    addLockedEllipse(
         center: vec.Vector2,
         radius: number,
         options?: {
             color?: LockedFigureColor;
-            fillStyle?: LockedCircleFillType;
+            fillStyle?: LockedEllipseFillType;
             strokeStyle?: "solid" | "dashed";
         },
     ): InteractiveGraphQuestionBuilder {
-        const circle: LockedCircleType = {
-            type: "circle",
+        const ellipse: LockedEllipseType = {
+            type: "ellipse",
             center: center,
             radius: radius,
             color: "grayH",
@@ -152,7 +152,7 @@ class InteractiveGraphQuestionBuilder {
             ...options,
         };
 
-        this.addLockedFigure(circle);
+        this.addLockedFigure(ellipse);
         return this;
     }
 

--- a/packages/perseus/src/widgets/interactive-graphs/locked-ellipse.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-ellipse.tsx
@@ -2,23 +2,23 @@ import {Circle} from "mafs";
 import * as React from "react";
 
 import {
-    lockedCircleFillStyles,
+    lockedEllipseFillStyles,
     lockedFigureColors,
-    type LockedCircleType,
+    type LockedEllipseType,
 } from "../../perseus-types";
 
-const LockedCircle = (props: LockedCircleType) => {
+const LockedEllipse = (props: LockedEllipseType) => {
     const {center, radius, color, fillStyle, strokeStyle} = props;
 
     return (
         <Circle
             center={center}
             radius={radius}
-            fillOpacity={lockedCircleFillStyles[fillStyle]}
+            fillOpacity={lockedEllipseFillStyles[fillStyle]}
             strokeStyle={strokeStyle}
             color={lockedFigureColors[color]}
         />
     );
 };
 
-export default LockedCircle;
+export default LockedEllipse;


### PR DESCRIPTION
## Summary:
Renaming all instances of locked circle to ellipse. This PR contains
_only_ the rename.

In the next PR, I'm also going to update it so that implements
a Mafs ellipse, which defines the radius in both the x direction
and the y direction.

Issue: https://khanacademy.atlassian.net/browse/LEMS-1941

## Test plan:
`yarn jest`
`yarn typecheck`
`yarn run lint`

I looked at every single instance of "circle" in the Persues repo
and made sure that none of them are related to locked figures.