### PR TITLE
[Interactive-Graph] Merging isValidDestination into interactive-graph-reducer

### DIFF
--- a/.changeset/silly-beds-provide.md
+++ b/.changeset/silly-beds-provide.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Cleaning up internal usage of isValidLocation function.

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.test.ts
@@ -1,7 +1,6 @@
-import {isValidDestination, getQuadraticCoefficients} from "./quadratic";
+import {getQuadraticCoefficients} from "./quadratic";
 
 import type {QuadraticGraphState} from "../types";
-import type {vec} from "mafs";
 
 describe("QuadraticGraph", () => {
     it("should accurately calculate coefficients", () => {
@@ -31,17 +30,5 @@ describe("QuadraticGraph", () => {
             [0, 0],
         ];
         expect(getQuadraticCoefficients(coords)).toBe(undefined);
-    });
-
-    it("should indicate when new coordinates would invalidate the graph", () => {
-        const coords: QuadraticGraphState["coords"] = [
-            [-5, 5],
-            [0, -5],
-            [5, 5],
-        ];
-        const destination: vec.Vector2 = [0, 0];
-        const elementId = 0;
-        const isValid = isValidDestination(destination, elementId, coords);
-        expect(isValid).toBe(false);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
@@ -10,8 +10,8 @@ import type {QuadraticGraphState, MafsGraphProps} from "../types";
 import type {vec} from "mafs";
 
 type QuadraticGraphProps = MafsGraphProps<QuadraticGraphState>;
-type QuadraticCoords = QuadraticGraphState["coords"];
 type QuadraticCoefficient = [number, number, number];
+export type QuadraticCoords = QuadraticGraphState["coords"];
 
 export function QuadraticGraph(props: QuadraticGraphProps) {
     const {dispatch, graphState} = props;
@@ -34,16 +34,6 @@ export function QuadraticGraph(props: QuadraticGraphProps) {
     const y = (x) => (a * x + b) * x + c;
 
     const handleOnMove = (destination: vec.Vector2, elementId: number) => {
-        // If the destination is invalid, we want do not want to move the point
-        const validDestination = isValidDestination(
-            destination,
-            elementId,
-            coords,
-        );
-        if (validDestination === false) {
-            return;
-        }
-
         dispatch(movePoint(elementId, destination));
     };
 
@@ -60,25 +50,6 @@ export function QuadraticGraph(props: QuadraticGraphProps) {
         </>
     );
 }
-
-// Ensure that we are only snapping to coordinates that result in a valid quadratic equation
-export const isValidDestination = (
-    destination: vec.Vector2,
-    elementId: number,
-    coords: QuadraticCoords,
-): boolean => {
-    // Set up the new coords and check if the quadratic coefficients are valid
-    const newCoords: QuadraticCoords = [...coords];
-    newCoords[elementId] = destination;
-    const QuadraticCoefficients = getQuadraticCoefficients(newCoords);
-
-    // If the new destination results in an invalid quadratic equation, we don't want to move the point
-    if (QuadraticCoefficients === undefined) {
-        return false;
-    }
-
-    return true;
-};
 
 // Get the quadratic coefficients from the 3 control points
 // These equations were originally set up in 2013 and may require some

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
@@ -7,7 +7,6 @@ import {movePoint} from "../reducer/interactive-graph-action";
 import {StyledMovablePoint} from "./components/movable-point";
 
 import type {QuadraticGraphState, MafsGraphProps} from "../types";
-import type {vec} from "mafs";
 
 type QuadraticGraphProps = MafsGraphProps<QuadraticGraphState>;
 type QuadraticCoefficient = [number, number, number];

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
@@ -33,10 +33,6 @@ export function QuadraticGraph(props: QuadraticGraphProps) {
     // Calculate the y value based on the current x value
     const y = (x) => (a * x + b) * x + c;
 
-    const handleOnMove = (destination: vec.Vector2, elementId: number) => {
-        dispatch(movePoint(elementId, destination));
-    };
-
     return (
         <>
             <Plot.OfX y={y} color={color.blue} />
@@ -44,7 +40,9 @@ export function QuadraticGraph(props: QuadraticGraphProps) {
                 <StyledMovablePoint
                     key={"point-" + i}
                     point={coord}
-                    onMove={(destination) => handleOnMove(destination, i)}
+                    onMove={(destination) =>
+                        dispatch(movePoint(i, destination))
+                    }
                 />
             ))}
         </>

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -420,6 +420,9 @@ describe("movePoint on a quadratic graph", () => {
             ],
         };
 
+        // An invalid graph happens when the denominator is 0 and are unable to calculate
+        // quadratic coefficients as they hit infinity.
+        // For more details see the getQuadraticCoefficients function that performs this calculation.
         const updated = interactiveGraphReducer(state, movePoint(0, [0, 0]));
 
         invariant(updated.type === "quadratic");

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -62,6 +62,21 @@ const baseSinusoidGraphState: InteractiveGraphState = {
     ],
 };
 
+const baseQuadraticGraphState: InteractiveGraphState = {
+    hasBeenInteractedWith: false,
+    type: "quadratic",
+    range: [
+        [-10, 10],
+        [-10, 10],
+    ],
+    snapStep: [1, 1],
+    coords: [
+        [-1, 1],
+        [0, 0],
+        [1, 1],
+    ],
+};
+
 const basePolygonGraphState: InteractiveGraphState = {
     hasBeenInteractedWith: false,
     type: "polygon",
@@ -381,6 +396,50 @@ describe("movePoint on a polygon graph", () => {
         const updated = interactiveGraphReducer(state, movePoint(0, [1, 3]));
 
         invariant(updated.type === "polygon");
+        expect(updated.coords[0]).toEqual([0, 0]);
+    });
+});
+
+describe("movePoint on a quadratic graph", () => {
+    it("moves a point", () => {
+        const state: InteractiveGraphState = {
+            ...baseQuadraticGraphState,
+            coords: [
+                [0, 0],
+                [0, 2],
+                [2, 2],
+            ],
+        };
+
+        const updated = interactiveGraphReducer(state, movePoint(0, [0, 1]));
+
+        invariant(updated.type === "quadratic");
+        expect(updated.coords[0]).toEqual([0, 1]);
+    });
+
+    it("rejects the move if when new coordinates would invalidate the graph", () => {
+        // const coords: QuadraticGraphState["coords"] = [
+        //     [-5, 5],
+        //     [0, -5],
+        //     [5, 5],
+        // ];
+        // const destination: vec.Vector2 = [0, 0];
+        // const elementId = 0;
+        // const isValid = isValidDestination(destination, elementId, coords);
+        // expect(isValid).toBe(false);
+
+        const state: InteractiveGraphState = {
+            ...baseQuadraticGraphState,
+            coords: [
+                [0, 0],
+                [0, 2],
+                [2, 2],
+            ],
+        };
+
+        const updated = interactiveGraphReducer(state, movePoint(0, [1, 3]));
+
+        invariant(updated.type === "quadratic");
         expect(updated.coords[0]).toEqual([0, 0]);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -402,45 +402,28 @@ describe("movePoint on a polygon graph", () => {
 
 describe("movePoint on a quadratic graph", () => {
     it("moves a point", () => {
-        const state: InteractiveGraphState = {
-            ...baseQuadraticGraphState,
-            coords: [
-                [0, 0],
-                [0, 2],
-                [2, 2],
-            ],
-        };
+        const state: InteractiveGraphState = baseQuadraticGraphState;
 
-        const updated = interactiveGraphReducer(state, movePoint(0, [0, 1]));
+        const updated = interactiveGraphReducer(state, movePoint(0, [-2, 4]));
 
         invariant(updated.type === "quadratic");
-        expect(updated.coords[0]).toEqual([0, 1]);
+        expect(updated.coords[0]).toEqual([-2, 4]);
     });
 
     it("rejects the move if when new coordinates would invalidate the graph", () => {
-        // const coords: QuadraticGraphState["coords"] = [
-        //     [-5, 5],
-        //     [0, -5],
-        //     [5, 5],
-        // ];
-        // const destination: vec.Vector2 = [0, 0];
-        // const elementId = 0;
-        // const isValid = isValidDestination(destination, elementId, coords);
-        // expect(isValid).toBe(false);
-
         const state: InteractiveGraphState = {
             ...baseQuadraticGraphState,
             coords: [
-                [0, 0],
-                [0, 2],
-                [2, 2],
+                [-5, 5],
+                [0, -5],
+                [5, 5],
             ],
         };
 
-        const updated = interactiveGraphReducer(state, movePoint(0, [1, 3]));
+        const updated = interactiveGraphReducer(state, movePoint(0, [0, 0]));
 
         invariant(updated.type === "quadratic");
-        expect(updated.coords[0]).toEqual([0, 0]);
+        expect(updated.coords[0]).toEqual([-5, 5]);
     });
 });
 

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -4,6 +4,7 @@ import {vec} from "mafs";
 import _ from "underscore";
 
 import {polygonSidesIntersect} from "../../../util/geometry";
+import {getQuadraticCoefficients} from "../graphs/quadratic";
 import {snap} from "../utils";
 
 import {
@@ -26,10 +27,9 @@ import {
     type ChangeRange,
 } from "./interactive-graph-action";
 
+import type {QuadraticCoords} from "../graphs/quadratic";
 import type {InteractiveGraphState, PairOfPoints} from "../types";
 import type {Interval} from "mafs";
-
-import {QuadraticCoords, getQuadraticCoefficients} from "../graphs/quadratic";
 
 export function interactiveGraphReducer(
     state: InteractiveGraphState,

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -28,6 +28,7 @@ import {
 
 import type {InteractiveGraphState, PairOfPoints} from "../types";
 import type {Interval} from "mafs";
+import { QuadraticCoords, getQuadraticCoefficients } from "../graphs/quadratic";
 
 export function interactiveGraphReducer(
     state: InteractiveGraphState,
@@ -146,6 +147,8 @@ function doMoveLine(
     }
 }
 
+
+
 function doMoveAll(
     state: InteractiveGraphState,
     action: MoveAll,
@@ -227,6 +230,16 @@ function doMovePoint(
             };
         }
         case "quadratic": {
+            // Set up the new coords and check if the quadratic coefficients are valid
+            const newCoords: QuadraticCoords = [...state.coords];
+            newCoords[action.index] = action.destination;
+            const QuadraticCoefficients = getQuadraticCoefficients(newCoords);
+
+            // If the new destination results in an invalid quadratic equation, we don't want to move the point
+            if (QuadraticCoefficients === undefined) {
+                return state;
+            }
+
             return {
                 ...state,
                 hasBeenInteractedWith: true,

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -28,7 +28,7 @@ import {
 
 import type {InteractiveGraphState, PairOfPoints} from "../types";
 import type {Interval} from "mafs";
-import { QuadraticCoords, getQuadraticCoefficients } from "../graphs/quadratic";
+import {QuadraticCoords, getQuadraticCoefficients} from "../graphs/quadratic";
 
 export function interactiveGraphReducer(
     state: InteractiveGraphState,
@@ -146,8 +146,6 @@ function doMoveLine(
             return state;
     }
 }
-
-
 
 function doMoveAll(
     state: InteractiveGraphState,

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -28,6 +28,7 @@ import {
 
 import type {InteractiveGraphState, PairOfPoints} from "../types";
 import type {Interval} from "mafs";
+
 import {QuadraticCoords, getQuadraticCoefficients} from "../graphs/quadratic";
 
 export function interactiveGraphReducer(


### PR DESCRIPTION
The logic in isValidDestination is quite redundant and would be better served in the interactive-graph-reducer file along with other graphing movement logic.

In addition to this I added quadratic tests to the reducer test to ensure test coverage.

Task: https://khanacademy.atlassian.net/browse/LEMS-2023