### PR TITLE
[Interactive Graph Editor] Remove m1 flag, hook up m2 flag for locked figures

### DIFF
--- a/.changeset/weak-flowers-heal.md
+++ b/.changeset/weak-flowers-heal.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-editor": minor
+---
+
+[Interactive Graph Editor] Remove m1 flag from the code, and put locked vector and locked ellipse UI behind the m2 flag.

--- a/packages/perseus-editor/src/__stories__/editor-page.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/editor-page.stories.tsx
@@ -75,7 +75,60 @@ export const Demo = (): React.ReactElement => {
     );
 };
 
-export const MafsWithLockedFigures = (): React.ReactElement => {
+export const MafsWithLockedFiguresCurrent = (): React.ReactElement => {
+    const [previewDevice, setPreviewDevice] =
+        React.useState<DeviceType>("phone");
+    const [jsonMode, setJsonMode] = React.useState<boolean | undefined>(false);
+    const [answerArea, setAnswerArea] = React.useState<
+        PerseusAnswerArea | undefined | null
+    >();
+    const [question, setQuestion] = React.useState<PerseusRenderer | undefined>(
+        segmentWithLockedFigures,
+    );
+    const [hints, setHints] = React.useState<ReadonlyArray<Hint> | undefined>();
+
+    return (
+        <EditorPage
+            apiOptions={{
+                isMobile: false,
+                flags: {
+                    mafs: {
+                        ...flags.mafs,
+                        "interactive-graph-locked-features-m2": false,
+                    },
+                },
+            }}
+            previewDevice={previewDevice}
+            onPreviewDeviceChange={(newDevice) => setPreviewDevice(newDevice)}
+            developerMode={true}
+            jsonMode={jsonMode}
+            answerArea={answerArea}
+            question={question}
+            hints={hints}
+            frameSource="about:blank"
+            previewURL="about:blank"
+            itemId="1"
+            onChange={(props) => {
+                onChangeAction(props);
+
+                if ("jsonMode" in props) {
+                    setJsonMode(props.jsonMode);
+                }
+                if ("answerArea" in props) {
+                    setAnswerArea(props.answerArea);
+                }
+                if ("question" in props) {
+                    setQuestion(props.question);
+                }
+                if ("hints" in props) {
+                    setHints(props.hints);
+                }
+            }}
+        />
+    );
+};
+
+export const MafsWithLockedFiguresM2Flag = (): React.ReactElement => {
     const [previewDevice, setPreviewDevice] =
         React.useState<DeviceType>("phone");
     const [jsonMode, setJsonMode] = React.useState<boolean | undefined>(false);

--- a/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
+++ b/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
@@ -6,7 +6,6 @@ export const flags = {
         circle: true,
         quadratic: true,
         sinusoid: true,
-        "interactive-graph-locked-features-m1": true,
         "interactive-graph-locked-features-m2": true,
     },
 } satisfies APIOptions["flags"];

--- a/packages/perseus-editor/src/components/__stories__/locked-figures-section.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/locked-figures-section.stories.tsx
@@ -32,6 +32,7 @@ export const Controlled: StoryComponentType = {
 
         return (
             <LockedFiguresSection
+                showM2Features={true}
                 figures={figures}
                 onChange={handlePropsUpdate}
             />
@@ -53,6 +54,7 @@ export const WithProdWidth: StoryComponentType = {
         return (
             <View style={styles.prodSizeContainer}>
                 <LockedFiguresSection
+                    showM2Features={true}
                     figures={figures}
                     onChange={handlePropsUpdate}
                 />

--- a/packages/perseus-editor/src/components/__tests__/locked-figures-section.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-figures-section.test.tsx
@@ -40,9 +40,12 @@ describe("LockedFiguresSection", () => {
 
     test("renders", () => {
         // Arrange, Act
-        render(<LockedFiguresSection onChange={jest.fn()} />, {
-            wrapper: RenderStateRoot,
-        });
+        render(
+            <LockedFiguresSection showM2Features={true} onChange={jest.fn()} />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
 
         // Assert
         expect(screen.getByText("Add locked figure")).toBeInTheDocument();
@@ -50,9 +53,12 @@ describe("LockedFiguresSection", () => {
 
     test("renders no expand/collapse button when there are no figures", () => {
         // Arrange, Act
-        render(<LockedFiguresSection onChange={jest.fn()} />, {
-            wrapper: RenderStateRoot,
-        });
+        render(
+            <LockedFiguresSection showM2Features={true} onChange={jest.fn()} />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
 
         // Assert
         expect(screen.queryByRole("button", {name: "Expand all"})).toBeNull();
@@ -64,6 +70,7 @@ describe("LockedFiguresSection", () => {
         render(
             <LockedFiguresSection
                 figures={defaultFigures}
+                showM2Features={true}
                 onChange={jest.fn()}
             />,
             {
@@ -85,6 +92,7 @@ describe("LockedFiguresSection", () => {
         render(
             <LockedFiguresSection
                 figures={defaultFigures}
+                showM2Features={true}
                 onChange={jest.fn()}
             />,
             {
@@ -108,6 +116,7 @@ describe("LockedFiguresSection", () => {
         render(
             <LockedFiguresSection
                 figures={defaultFigures}
+                showM2Features={true}
                 onChange={jest.fn()}
             />,
             {
@@ -137,6 +146,7 @@ describe("LockedFiguresSection", () => {
         render(
             <LockedFiguresSection
                 figures={defaultFigures}
+                showM2Features={true}
                 onChange={jest.fn()}
             />,
             {
@@ -170,6 +180,7 @@ describe("LockedFiguresSection", () => {
         // Arrange
         render(
             <LockedFiguresSection
+                showM2Features={true}
                 figures={defaultFigures}
                 onChange={jest.fn()}
             />,
@@ -195,6 +206,7 @@ describe("LockedFiguresSection", () => {
         // Arrange
         render(
             <LockedFiguresSection
+                showM2Features={true}
                 figures={[
                     getDefaultFigureForType("point"),
                     {...getDefaultFigureForType("point"), coord: [1, 1]},

--- a/packages/perseus-editor/src/components/locked-figure-select.tsx
+++ b/packages/perseus-editor/src/components/locked-figure-select.tsx
@@ -12,6 +12,8 @@ import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 type Props = {
+    // TODO(LEMS-2016): Remove this prop once the M2 flag is fully rolled out.
+    showM2Features: boolean;
     id: string;
     onChange: (value: string) => void;
 };
@@ -19,7 +21,9 @@ type Props = {
 const LockedFigureSelect = (props: Props) => {
     const {id, onChange} = props;
 
-    const figureTypes = ["point", "line", "ellipse", "vector"];
+    const figureTypes = props.showM2Features
+        ? ["point", "line", "ellipse", "vector"]
+        : ["point", "line"];
 
     return (
         <View style={styles.container}>

--- a/packages/perseus-editor/src/components/locked-figure-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-figure-settings.tsx
@@ -47,9 +47,15 @@ const LockedFigureSettings = (props: Props) => {
         case "line":
             return <LockedLineSettings {...props} />;
         case "ellipse":
-            return <LockedEllipseSettings {...props} />;
+            if (props.showM2Features) {
+                return <LockedEllipseSettings {...props} />;
+            }
+            break;
         case "vector":
-            return <LockedVectorSettings {...props} />;
+            if (props.showM2Features) {
+                return <LockedVectorSettings {...props} />;
+            }
+            break;
     }
 
     return null;

--- a/packages/perseus-editor/src/components/locked-figures-section.tsx
+++ b/packages/perseus-editor/src/components/locked-figures-section.tsx
@@ -20,7 +20,7 @@ import type {LockedFigure, LockedFigureType} from "@khanacademy/perseus";
 type Props = {
     // Whether to show the M2 features in the locked figure settings.
     // TODO(LEMS-2016): Remove this prop once the M2 flag is fully rolled out.
-    showM2Features?: boolean;
+    showM2Features: boolean;
     figures?: Array<LockedFigure>;
     onChange: (props: Partial<InteractiveGraphEditorProps>) => void;
 };
@@ -116,6 +116,7 @@ const LockedFiguresSection = (props: Props) => {
             })}
             <View style={styles.buttonContainer}>
                 <LockedFigureSelect
+                    showM2Features={props.showM2Features}
                     id={`${uniqueId}-select`}
                     onChange={addLockedFigure}
                 />

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
@@ -588,9 +588,6 @@ class InteractiveGraphEditor extends React.Component<Props> {
                     // is using Mafs.
                     this.props.graph &&
                         this.props.apiOptions?.flags?.mafs?.[
-                            "interactive-graph-locked-features-m1"
-                        ] &&
-                        this.props.apiOptions?.flags?.mafs?.[
                             this.props.graph.type
                         ] && (
                             <LockedFiguresSection

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -146,11 +146,6 @@ export const MafsGraphTypeFlags = [
 
 export const InteractiveGraphLockedFeaturesFlags = [
     /**
-     * Enables/Disables Milestone 1 locked features in the new Mafs
-     * interactive-graph widget (points and lines).
-     */
-    "interactive-graph-locked-features-m1",
-    /**
      * Enables/Disables Milestone 2 locked features in the new Mafs
      * interactive-graph widget (the rest of the figure types:
      * ellipses, vectors, polygons, functions, labels).


### PR DESCRIPTION
## Summary:
Now that locked figures m1 has been rolled out, we can remove the flag from
the code. After that, we can also remove the flag from Growthbook.

While I'm here, I also realized the m2 flag wasn't hooked up anywhere, so
I did that as well.

Issue: https://khanacademy.atlassian.net/browse/LEMS-1999

## Test plan:
Storybook
- Go to http://localhost:6006/?path=/story/perseuseditor-editorpage--mafs-with-locked-figures-current
- Confirm that locked ellipses and vectors don't show up in the UI
  - check the settings are not there
  - check that the "add locked figure" dropdown options are not there
- Go to http://localhost:6006/?path=/story/perseuseditor-editorpage--mafs-with-locked-figures-m-2-flag
- Confirm that locked ellipses and vectors show in the UI
  - check that the settings are there
  - check that the "add locked figure" dropdown options are there

| Current | M2 |
| --- | --- |
| ![Screenshot 2024-06-11 at 12 43 32 PM](https://github.com/Khan/perseus/assets/13231763/63fad110-e32a-4e10-bd37-54703dc58e11) | ![Screenshot 2024-06-11 at 12 43 24 PM](https://github.com/Khan/perseus/assets/13231763/81537e69-ca26-4d12-9954-fd7b67d12ce0) |
