### PR TITLE
[Interactive Graph Editor] Remove unnecessary uses of useUniqueId

### DIFF
--- a/.changeset/calm-seas-cheat.md
+++ b/.changeset/calm-seas-cheat.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Interactive Graph Editor] Minor refactor - remove unnecessary uses of useUniqueIdWithMock

--- a/packages/perseus-editor/package.json
+++ b/packages/perseus-editor/package.json
@@ -66,7 +66,7 @@
         "@khanacademy/wonder-blocks-clickable": "4.2.1",
         "@khanacademy/wonder-blocks-core": "6.4.0",
         "@khanacademy/wonder-blocks-dropdown": "5.3.0",
-        "@khanacademy/wonder-blocks-form": "^4.6.2",
+        "@khanacademy/wonder-blocks-form": "^4.7.1",
         "@khanacademy/wonder-blocks-icon": "4.1.0",
         "@khanacademy/wonder-blocks-icon-button": "5.2.1",
         "@khanacademy/wonder-blocks-switch": "1.1.16",

--- a/packages/perseus-editor/src/__stories__/editor-page.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/editor-page.stories.tsx
@@ -128,6 +128,14 @@ export const MafsWithLockedFiguresCurrent = (): React.ReactElement => {
     );
 };
 
+MafsWithLockedFiguresCurrent.parameters = {
+    chromatic: {
+        // Disabling because this isn't visually testing anything on the
+        // initial load of the editor page.
+        disable: true,
+    },
+};
+
 export const MafsWithLockedFiguresM2Flag = (): React.ReactElement => {
     const [previewDevice, setPreviewDevice] =
         React.useState<DeviceType>("phone");
@@ -174,6 +182,14 @@ export const MafsWithLockedFiguresM2Flag = (): React.ReactElement => {
             }}
         />
     );
+};
+
+MafsWithLockedFiguresM2Flag.parameters = {
+    chromatic: {
+        // Disabling because this isn't visually testing anything on the
+        // initial load of the editor page.
+        disable: true,
+    },
 };
 
 export const WithSaveWarnings = (): React.ReactElement => {

--- a/packages/perseus-editor/src/components/angle-input.tsx
+++ b/packages/perseus-editor/src/components/angle-input.tsx
@@ -57,30 +57,33 @@ const AngleInput = (props: Props) => {
 
     return (
         <View style={[styles.row, styles.spaceUnder]}>
-            {/* Angle */}
+            {/* Label */}
             <LabelMedium tag="label">
                 <View style={styles.row}>
                     angle
                     <Strut size={spacing.xxSmall_6} />
                     <TextField
-                        id=""
                         value={angleInput}
                         onChange={handleAngleChange}
                         style={styles.textField}
                     />
                 </View>
             </LabelMedium>
+
+            {/* Spacing */}
             <Strut size={spacing.xxSmall_6} />
-            <View style={styles.row}>
-                <LabelSmall>radians</LabelSmall>
-                <View style={styles.switch}>
-                    <Switch
-                        onChange={handleAngleTypeChange}
-                        checked={isInDegrees}
-                    />
-                </View>
-                <LabelSmall>degrees</LabelSmall>
+
+            {/* Radian/Degree Toggle */}
+            <LabelSmall>radians</LabelSmall>
+            <View style={styles.switch}>
+                <Switch
+                    onChange={handleAngleTypeChange}
+                    checked={isInDegrees}
+                />
             </View>
+            <LabelSmall>degrees</LabelSmall>
+
+            {/* Info Tooltip */}
             <InfoTip>
                 <p>
                     The angle of rotation for the ellipse (if the x radius and y

--- a/packages/perseus-editor/src/components/color-select.tsx
+++ b/packages/perseus-editor/src/components/color-select.tsx
@@ -1,6 +1,7 @@
 import {lockedFigureColors} from "@khanacademy/perseus";
-import {View, useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
+import {View} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import {StyleSheet} from "aphrodite";
@@ -22,34 +23,36 @@ type Props = {
 const ColorSelect = (props: Props) => {
     const {selectedValue, style, onChange} = props;
 
-    const ids = useUniqueIdWithMock();
-    const id = ids.get("color-select");
-
     return (
         <View style={[styles.row, style]}>
-            <LabelMedium htmlFor={id} style={styles.label} tag="label">
-                color
-            </LabelMedium>
-            <SingleSelect
-                id={id}
-                selectedValue={selectedValue}
-                onChange={onChange}
-                // Placeholder is required, but never gets used.
-                placeholder=""
-            >
-                {possibleColors.map((colorName) => (
-                    <OptionItem
-                        key={colorName}
-                        value={colorName}
-                        label={colorName}
-                        leftAccessory={
-                            <ColorSwatch color={colorName} decorative={true} />
-                        }
+            <LabelMedium tag="label">
+                <View style={styles.row}>
+                    color
+                    <Strut size={spacing.xxSmall_6} />
+                    <SingleSelect
+                        selectedValue={selectedValue}
+                        onChange={onChange}
+                        // Placeholder is required, but never gets used.
+                        placeholder=""
                     >
-                        {colorName}
-                    </OptionItem>
-                ))}
-            </SingleSelect>
+                        {possibleColors.map((colorName) => (
+                            <OptionItem
+                                key={colorName}
+                                value={colorName}
+                                label={colorName}
+                                leftAccessory={
+                                    <ColorSwatch
+                                        color={colorName}
+                                        decorative={true}
+                                    />
+                                }
+                            >
+                                {colorName}
+                            </OptionItem>
+                        ))}
+                    </SingleSelect>
+                </View>
+            </LabelMedium>
         </View>
     );
 };
@@ -58,9 +61,6 @@ const styles = StyleSheet.create({
     row: {
         flexDirection: "row",
         alignItems: "center",
-    },
-    label: {
-        marginInlineEnd: spacing.xxxSmall_4,
     },
 });
 

--- a/packages/perseus-editor/src/components/coordinate-pair-input.tsx
+++ b/packages/perseus-editor/src/components/coordinate-pair-input.tsx
@@ -1,4 +1,4 @@
-import {View, useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
+import {View} from "@khanacademy/wonder-blocks-core";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {color as wbColor, spacing} from "@khanacademy/wonder-blocks-tokens";
@@ -26,12 +26,6 @@ const CoordinatePairInput = (props: Props) => {
         coord[1].toString(),
     ]);
 
-    // Generate unique IDs so that the programmatic labels can be associated
-    // with their respective text fields.
-    const ids = useUniqueIdWithMock();
-    const xCoordId = ids.get("x-coord");
-    const yCoordId = ids.get("y-coord");
-
     function handleCoordChange(newValue, coordIndex) {
         // Update the local state (update the input field value).
         const newCoordState = [...coordState];
@@ -53,41 +47,45 @@ const CoordinatePairInput = (props: Props) => {
     return (
         <View>
             <View style={[styles.row, styles.spaceUnder]}>
-                <LabelMedium
-                    htmlFor={xCoordId}
-                    style={styles.label}
-                    tag="label"
-                >
-                    {labels ? labels[0] : "x coord"}
+                <LabelMedium tag="label">
+                    <View style={styles.row}>
+                        {labels ? labels[0] : "x coord"}
+
+                        <Strut size={spacing.xxSmall_6} />
+                        <TextField
+                            type="number"
+                            value={coordState[0]}
+                            onChange={(newValue) =>
+                                handleCoordChange(newValue, 0)
+                            }
+                            style={[
+                                styles.textField,
+                                error ? styles.errorField : undefined,
+                            ]}
+                        />
+                    </View>
                 </LabelMedium>
-                <TextField
-                    id={xCoordId}
-                    type="number"
-                    value={coordState[0]}
-                    onChange={(newValue) => handleCoordChange(newValue, 0)}
-                    style={[
-                        styles.textField,
-                        error ? styles.errorField : undefined,
-                    ]}
-                />
+
                 <Strut size={spacing.medium_16} />
-                <LabelMedium
-                    htmlFor={yCoordId}
-                    style={styles.label}
-                    tag="label"
-                >
-                    {labels ? labels[1] : "y coord"}
+
+                <LabelMedium tag="label">
+                    <View style={styles.row}>
+                        {labels ? labels[1] : "y coord"}
+
+                        <Strut size={spacing.xxSmall_6} />
+                        <TextField
+                            type="number"
+                            value={coordState[1]}
+                            onChange={(newValue) =>
+                                handleCoordChange(newValue, 1)
+                            }
+                            style={[
+                                styles.textField,
+                                error ? styles.errorField : undefined,
+                            ]}
+                        />
+                    </View>
                 </LabelMedium>
-                <TextField
-                    id={yCoordId}
-                    type="number"
-                    value={coordState[1]}
-                    onChange={(newValue) => handleCoordChange(newValue, 1)}
-                    style={[
-                        styles.textField,
-                        error ? styles.errorField : undefined,
-                    ]}
-                />
             </View>
         </View>
     );
@@ -100,9 +98,6 @@ const styles = StyleSheet.create({
     },
     spaceUnder: {
         marginBottom: spacing.xSmall_8,
-    },
-    label: {
-        marginInlineEnd: spacing.xxSmall_6,
     },
     textField: {
         width: spacing.xxxLarge_64,

--- a/packages/perseus-editor/src/components/locked-ellipse-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-ellipse-settings.tsx
@@ -1,5 +1,5 @@
 import {components, lockedEllipseFillStyles} from "@khanacademy/perseus";
-import {View, useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
+import {View} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
@@ -49,10 +49,6 @@ const LockedEllipseSettings = (props: Props) => {
         onChangeProps,
         onRemove,
     } = props;
-
-    const ids = useUniqueIdWithMock();
-    const strokeSelectId = ids.get("stroke-style-select");
-    const fillSelectId = ids.get("fill-style-select");
 
     function handleColorChange(newValue: LockedFigureColor) {
         onChangeProps({color: newValue});
@@ -117,56 +113,56 @@ const LockedEllipseSettings = (props: Props) => {
                 <Strut size={spacing.medium_16} />
 
                 {/* Fill opacity */}
-                <LabelMedium
-                    tag="label"
-                    htmlFor={fillSelectId}
-                    style={styles.label}
-                >
-                    fill
+                <LabelMedium tag="label">
+                    <View style={styles.row}>
+                        fill
+                        <Strut size={spacing.xxSmall_6} />
+                        <SingleSelect
+                            selectedValue={fillStyle}
+                            onChange={(value: LockedEllipseFillType) =>
+                                onChangeProps({fillStyle: value})
+                            }
+                            // Placeholder is required, but never gets used.
+                            placeholder=""
+                        >
+                            {Object.keys(lockedEllipseFillStyles).map(
+                                (option) => (
+                                    <OptionItem
+                                        key={option}
+                                        value={option}
+                                        label={option}
+                                    >
+                                        {option}
+                                    </OptionItem>
+                                ),
+                            )}
+                        </SingleSelect>
+                    </View>
                 </LabelMedium>
-                <SingleSelect
-                    id={fillSelectId}
-                    selectedValue={fillStyle}
-                    onChange={(value: LockedEllipseFillType) =>
-                        onChangeProps({fillStyle: value})
-                    }
-                    // Placeholder is required, but never gets used.
-                    placeholder=""
-                >
-                    {Object.keys(lockedEllipseFillStyles).map((option) => (
-                        <OptionItem key={option} value={option} label={option}>
-                            {option}
-                        </OptionItem>
-                    ))}
-                </SingleSelect>
             </View>
 
             {/* Stroke style */}
-            <View style={styles.row}>
-                <LabelMedium
-                    tag="label"
-                    htmlFor={strokeSelectId}
-                    style={styles.label}
-                >
+            <LabelMedium tag="label">
+                <View style={styles.row}>
                     stroke
-                </LabelMedium>
-                <SingleSelect
-                    id={strokeSelectId}
-                    selectedValue={strokeStyle}
-                    onChange={(value: "solid" | "dashed") =>
-                        onChangeProps({strokeStyle: value})
-                    }
-                    // Placeholder is required, but never gets used.
-                    placeholder=""
-                >
-                    <OptionItem value="solid" label="solid">
-                        solid
-                    </OptionItem>
-                    <OptionItem value="dashed" label="dashed">
-                        dashed
-                    </OptionItem>
-                </SingleSelect>
-            </View>
+                    <Strut size={spacing.xxSmall_6} />
+                    <SingleSelect
+                        selectedValue={strokeStyle}
+                        onChange={(value: "solid" | "dashed") =>
+                            onChangeProps({strokeStyle: value})
+                        }
+                        // Placeholder is required, but never gets used.
+                        placeholder=""
+                    >
+                        <OptionItem value="solid" label="solid">
+                            solid
+                        </OptionItem>
+                        <OptionItem value="dashed" label="dashed">
+                            dashed
+                        </OptionItem>
+                    </SingleSelect>
+                </View>
+            </LabelMedium>
 
             {/* Actions */}
             <LockedFigureSettingsActions
@@ -181,9 +177,6 @@ const styles = StyleSheet.create({
     row: {
         flexDirection: "row",
         alignItems: "center",
-    },
-    label: {
-        marginInlineEnd: spacing.xxSmall_6,
     },
     spaceUnder: {
         marginBottom: spacing.xSmall_8,

--- a/packages/perseus-editor/src/components/locked-line-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-line-settings.tsx
@@ -5,7 +5,7 @@
  * Used in the interactive graph editor's locked figures section.
  */
 import {vector as kvector} from "@khanacademy/kmath";
-import {View, useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
+import {View} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {color as wbColor, spacing} from "@khanacademy/wonder-blocks-tokens";
@@ -53,12 +53,6 @@ const LockedLineSettings = (props: Props) => {
         onRemove,
     } = props;
     const [point1, point2] = points;
-
-    // Generate unique IDs so that the programmatic labels can be associated
-    // with their respective text fields.
-    const ids = useUniqueIdWithMock();
-    const kindSelectId = ids.get("line-kind-select");
-    const styleSelectId = ids.get("line-style-select");
 
     const capitalizeKind = kind.charAt(0).toUpperCase() + kind.slice(1);
     const lineLabel = `${capitalizeKind} (${point1.coord[0]},
@@ -111,30 +105,26 @@ const LockedLineSettings = (props: Props) => {
             }
         >
             {/* Line kind settings */}
-            <View style={[styles.row, styles.spaceUnder]}>
-                <LabelMedium
-                    htmlFor={kindSelectId}
-                    style={styles.label}
-                    tag="label"
-                >
+            <LabelMedium tag="label" style={styles.spaceUnder}>
+                <View style={styles.row}>
                     kind
-                </LabelMedium>
-                <SingleSelect
-                    id={kindSelectId}
-                    selectedValue={kind}
-                    onChange={(value: "line" | "segment" | "ray") =>
-                        onChangeProps({kind: value})
-                    }
-                    // Placeholder is required, but never gets used.
-                    placeholder=""
-                >
-                    <OptionItem value="line" label="line" />
-                    <OptionItem value="ray" label="ray" />
-                    <OptionItem value="segment" label="segment" />
-                </SingleSelect>
-            </View>
+                    <Strut size={spacing.xxxSmall_4} />
+                    <SingleSelect
+                        selectedValue={kind}
+                        onChange={(value: "line" | "segment" | "ray") =>
+                            onChangeProps({kind: value})
+                        }
+                        // Placeholder is required, but never gets used.
+                        placeholder=""
+                    >
+                        <OptionItem value="line" label="line" />
+                        <OptionItem value="ray" label="ray" />
+                        <OptionItem value="segment" label="segment" />
+                    </SingleSelect>
+                </View>
+            </LabelMedium>
 
-            <View style={[styles.row, styles.spaceUnder]}>
+            <View style={styles.row}>
                 {/* Line color settings */}
                 <ColorSelect
                     selectedValue={lineColor}
@@ -143,28 +133,24 @@ const LockedLineSettings = (props: Props) => {
                 <Strut size={spacing.small_12} />
 
                 {/* Line style settings */}
-                <View style={styles.row}>
-                    <LabelMedium
-                        htmlFor={styleSelectId}
-                        style={styles.label}
-                        tag="label"
-                    >
+                <LabelMedium tag="label">
+                    <View style={styles.row}>
                         style
-                    </LabelMedium>
-                    <SingleSelect
-                        id={styleSelectId}
-                        selectedValue={lineStyle}
-                        onChange={(value: "solid" | "dashed") =>
-                            onChangeProps({lineStyle: value})
-                        }
-                        // Placeholder is required, but never gets used.
-                        placeholder=""
-                        style={styles.selectMarginOffset}
-                    >
-                        <OptionItem value="solid" label="solid" />
-                        <OptionItem value="dashed" label="dashed" />
-                    </SingleSelect>
-                </View>
+                        <Strut size={spacing.xxxSmall_4} />
+                        <SingleSelect
+                            selectedValue={lineStyle}
+                            onChange={(value: "solid" | "dashed") =>
+                                onChangeProps({lineStyle: value})
+                            }
+                            // Placeholder is required, but never gets used.
+                            placeholder=""
+                            style={styles.selectMarginOffset}
+                        >
+                            <OptionItem value="solid" label="solid" />
+                            <OptionItem value="dashed" label="dashed" />
+                        </SingleSelect>
+                    </View>
+                </LabelMedium>
             </View>
 
             {/* Points error message */}
@@ -214,9 +200,6 @@ const styles = StyleSheet.create({
     },
     spaceUnder: {
         marginBottom: spacing.xSmall_8,
-    },
-    label: {
-        marginInlineEnd: spacing.xxxSmall_4,
     },
     selectMarginOffset: {
         // Align with the point settings accordions.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2573,15 +2573,15 @@
     "@khanacademy/wonder-blocks-typography" "^2.1.11"
 
 "@khanacademy/wonder-blocks-form@^4.6.2":
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-form/-/wonder-blocks-form-4.6.2.tgz#f660f8f63b682a59fc29286d38a7cbb58d8dc2df"
-  integrity sha512-pfg4r0aIKIjae4hF1q9rk1Qk+U1fbAn2QGTv2SlC6PivvGU/qljMeroAUsp5jLxgv3cy7junQsAmQq0P2Gvu4w==
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-form/-/wonder-blocks-form-4.7.1.tgz#8fd8dbda7e52ce0940124c474fb324dc80f8eb15"
+  integrity sha512-bVSLKbD/X+HDDQ4uUvgzG1j4CX7KEr35syvTVrjio+AR6cS1F8rZINuoFa3PV9gSlPfryA7C36i6PHhyz+s4Dg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@khanacademy/wonder-blocks-clickable" "^4.2.2"
     "@khanacademy/wonder-blocks-core" "^6.4.1"
     "@khanacademy/wonder-blocks-icon" "^4.1.1"
-    "@khanacademy/wonder-blocks-layout" "^2.0.33"
+    "@khanacademy/wonder-blocks-layout" "^2.1.0"
     "@khanacademy/wonder-blocks-tokens" "^1.3.0"
     "@khanacademy/wonder-blocks-typography" "^2.1.12"
 
@@ -2622,10 +2622,10 @@
     "@khanacademy/wonder-blocks-core" "^6.4.0"
     "@khanacademy/wonder-blocks-tokens" "^1.3.0"
 
-"@khanacademy/wonder-blocks-layout@^2.0.33":
-  version "2.0.33"
-  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-layout/-/wonder-blocks-layout-2.0.33.tgz#6a23599fb99a0b620d6820b1727ade66bfacd804"
-  integrity sha512-JjXDpmzIHCyjJfE410V2fpp2i8IDWaE0kbkwxn2RaL1LREwWljJ8R3//PJN24scbtzM+mJIj8LorGVWsw8XjOg==
+"@khanacademy/wonder-blocks-layout@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@khanacademy/wonder-blocks-layout/-/wonder-blocks-layout-2.1.0.tgz#6c8f5b4b6d664edbb541c01a54065eb863f06647"
+  integrity sha512-Qu+XtuDVppErUq1Ya42V7deUPgjxxl+Zjs9VGOHAA12hdZwJ5tgARvyZDWoHlxJ+3neazxmo1IdsZ9DBeP9d4A==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@khanacademy/wonder-blocks-core" "^6.4.1"


### PR DESCRIPTION
## Summary:
There are number of places in the code using `useUniqueIdWithMock` for
programmatic labels, but that is not necessary. You can nest the labeled
element within the `<label>` tag instead.

Changes in this PR:
- Update Wonder Blocks dependency so we can remove id="" from WB TextField
- Disable chromatic on a couple of stories that don't need it
- Remove `useUniqueIdWithMock`

There are a couple of places within the Interactive Graph Editor UI
where `uniqueIdWithMock` is still necessary. Specifically, within
`locked-figures-section.tsx`, as this unique ID is used to make
sure that the individual locked figure sections don't get mixed up
between multiple interacticve graph editors on the same page.

Note: I tried to remove `RenderStateRoot` from all the relevant tests
now that `useUniqueIdWithMock` is no longer there in most files.
But it couldn't be removed. I suspect this is because a number of
Wonder Blocks components that use `useUniqueIdWithMock` anyway.

Issue: none

## Test plan:
`yarn jest`

Storybook
- http://localhost:6006/?path=/story/perseuseditor-editorpage--mafs-with-locked-figures-m-2-flag
- Play around with every single input for every single locked figure
- Confirm they all work as expected.
- Try making two of the same kidn of figure
- Confirm that the label for the second one does not focus on an input
  from the first.