### PR TITLE
Removing purple color for second LinearSystem line.

### DIFF
--- a/.changeset/strong-boats-sip.md
+++ b/.changeset/strong-boats-sip.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Updating for all Linear Systems to have the same color line.

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.tsx
@@ -13,8 +13,6 @@ export const LinearSystemGraph = (props: LinearSystemGraphProps) => {
     const {dispatch} = props;
     const {coords: lines} = props.graphState;
 
-    const colors = ["var(--movable-line-stroke-color)", "var(--mafs-violet)"];
-
     return (
         <>
             {lines?.map((line, i) => (
@@ -36,7 +34,7 @@ export const LinearSystemGraph = (props: LinearSystemGraphProps) => {
                             moveControlPoint(endpointIndex, destination, i),
                         )
                     }
-                    color={colors[i]}
+                    color="var(--movable-line-stroke-color)"
                 />
             ))}
             ;


### PR DESCRIPTION
## Summary:
Changing the second line in a Linear System from the color purple, to blue.

Issue: LEMS-2058

Before:
![image](https://github.com/Khan/perseus/assets/123020281/f25d8102-8d58-4431-8d09-7963d465c166)

After:
![image](https://github.com/Khan/perseus/assets/123020281/e6ed3d33-3f6b-4c3e-84e4-0180ebbcaf4f)

## Test plan:
To manually test, go to storybook, select Interactive Graph Editor and toggle to Linear System.
You will see that instead of the second line being purple, it will be blue now.