### PR TITLE
[Interactive Graph Editor] Show error if a coordinate pair value is out of range.

### DIFF
--- a/.changeset/spotty-kiwis-joke.md
+++ b/.changeset/spotty-kiwis-joke.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-editor": minor
+---
+
+[Interactive Graph Editor] Display error message if locked figures' coordinates are out of range.

--- a/packages/perseus-editor/src/components/__tests__/coordinate-pair-input.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/coordinate-pair-input.test.tsx
@@ -1,0 +1,139 @@
+import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
+import {render, screen} from "@testing-library/react";
+import {userEvent as userEventLib} from "@testing-library/user-event";
+import * as React from "react";
+
+import CoordinatePairInput from '../coordinate-pair-input';
+
+import type {UserEvent} from "@testing-library/user-event";
+
+describe('CoordinatePairInput', () => {
+    let userEvent: UserEvent;
+    beforeEach(() => {
+        userEvent = userEventLib.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+    });
+
+    test("Show correct labels by default", async () => {
+        // Arrange
+        const onChangeProps = jest.fn();
+        render(
+            <CoordinatePairInput
+                coord={[0, 0]}
+                onChange={onChangeProps}
+            />,
+            {
+                wrapper: RenderStateRoot,
+            }
+        );
+
+        // Assert
+        expect(screen.getByLabelText("x coord")).toBeInTheDocument();
+        expect(screen.getByLabelText("y coord")).toBeInTheDocument();
+    });
+
+    test("Shows the correct labels if they are passed in", async () => {
+        // Arrange
+        const onChangeProps = jest.fn();
+        render(
+            <CoordinatePairInput
+                coord={[0, 0]}
+                labels={["coord 1", "coord 2"]}
+                onChange={onChangeProps}
+            />,
+            {
+                wrapper: RenderStateRoot,
+            }
+        );
+
+        // Assert
+        expect(screen.getByLabelText("coord 1")).toBeInTheDocument();
+        expect(screen.getByLabelText("coord 2")).toBeInTheDocument();
+
+    });
+
+    test("Shows an error if the x coord is out of range", async () => {
+        // Arrange
+
+        // Act
+        const onChangeProps = jest.fn();
+        render(
+            <CoordinatePairInput
+                coord={[0, 6]}
+                range={[[5, 10], [5, 10]]}
+                onChange={onChangeProps}
+            />,
+            {
+                wrapper: RenderStateRoot,
+            }
+        );
+
+        // Assert
+        expect(screen.getByText("x coord out of range (5 to 10)")).toBeInTheDocument();
+        expect(screen.queryByText("y coord out of range (5 to 10)")).not.toBeInTheDocument();
+    });
+
+    test("Shows an error if the y coord is out of range", async () => {
+        // Arrange
+
+        // Act
+        const onChangeProps = jest.fn();
+        render(
+            <CoordinatePairInput
+                coord={[6, 0]}
+                range={[[5, 10], [5, 10]]}
+                onChange={onChangeProps}
+            />,
+            {
+                wrapper: RenderStateRoot,
+            }
+        );
+
+        // Assert
+        expect(screen.getByText("y coord out of range (5 to 10)")).toBeInTheDocument();
+        expect(screen.queryByText("x coord out of range (5 to 10)")).not.toBeInTheDocument();
+    });
+
+    test("Shows both errors if both coords are out of range", async () => {
+        // Arrange
+
+        // Act
+        const onChangeProps = jest.fn();
+        render(
+            <CoordinatePairInput
+                coord={[0, 0]}
+                range={[[5, 10], [5, 10]]}
+                onChange={onChangeProps}
+            />,
+            {
+                wrapper: RenderStateRoot,
+            }
+        );
+
+        // Assert
+        expect(screen.getByText("x coord out of range (5 to 10)")).toBeInTheDocument();
+        expect(screen.getByText("y coord out of range (5 to 10)")).toBeInTheDocument();
+    });
+
+    test("Does not show an error if the coord is in range", async () => {
+        // Arrange
+
+        // Act
+        const onChangeProps = jest.fn();
+        render(
+            <CoordinatePairInput
+                coord={[7, 7]}
+                range={[[5, 10], [5, 10]]}
+                onChange={onChangeProps}
+            />,
+            {
+                wrapper: RenderStateRoot,
+            }
+        );
+
+        // Assert
+        expect(screen.queryByText("x coord out of range (5 to 10)")).not.toBeInTheDocument();
+        expect(screen.queryByText("y coord out of range (5 to 10)")).not.toBeInTheDocument();
+    });
+});

--- a/packages/perseus-editor/src/components/__tests__/coordinate-pair-input.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/coordinate-pair-input.test.tsx
@@ -1,31 +1,18 @@
 import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 import {render, screen} from "@testing-library/react";
-import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
-import CoordinatePairInput from '../coordinate-pair-input';
+import CoordinatePairInput from "../coordinate-pair-input";
 
-import type {UserEvent} from "@testing-library/user-event";
-
-describe('CoordinatePairInput', () => {
-    let userEvent: UserEvent;
-    beforeEach(() => {
-        userEvent = userEventLib.setup({
-            advanceTimers: jest.advanceTimersByTime,
-        });
-    });
-
+describe("CoordinatePairInput", () => {
     test("Show correct labels by default", async () => {
         // Arrange
         const onChangeProps = jest.fn();
         render(
-            <CoordinatePairInput
-                coord={[0, 0]}
-                onChange={onChangeProps}
-            />,
+            <CoordinatePairInput coord={[0, 0]} onChange={onChangeProps} />,
             {
                 wrapper: RenderStateRoot,
-            }
+            },
         );
 
         // Assert
@@ -44,13 +31,12 @@ describe('CoordinatePairInput', () => {
             />,
             {
                 wrapper: RenderStateRoot,
-            }
+            },
         );
 
         // Assert
         expect(screen.getByLabelText("coord 1")).toBeInTheDocument();
         expect(screen.getByLabelText("coord 2")).toBeInTheDocument();
-
     });
 
     test("Shows an error if the x coord is out of range", async () => {
@@ -61,17 +47,24 @@ describe('CoordinatePairInput', () => {
         render(
             <CoordinatePairInput
                 coord={[0, 6]}
-                range={[[5, 10], [5, 10]]}
+                range={[
+                    [5, 10],
+                    [5, 10],
+                ]}
                 onChange={onChangeProps}
             />,
             {
                 wrapper: RenderStateRoot,
-            }
+            },
         );
 
         // Assert
-        expect(screen.getByText("x coord out of range (5 to 10)")).toBeInTheDocument();
-        expect(screen.queryByText("y coord out of range (5 to 10)")).not.toBeInTheDocument();
+        expect(
+            screen.getByText("x coord out of range (5 to 10)"),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText("y coord out of range (5 to 10)"),
+        ).not.toBeInTheDocument();
     });
 
     test("Shows an error if the y coord is out of range", async () => {
@@ -82,17 +75,24 @@ describe('CoordinatePairInput', () => {
         render(
             <CoordinatePairInput
                 coord={[6, 0]}
-                range={[[5, 10], [5, 10]]}
+                range={[
+                    [5, 10],
+                    [5, 10],
+                ]}
                 onChange={onChangeProps}
             />,
             {
                 wrapper: RenderStateRoot,
-            }
+            },
         );
 
         // Assert
-        expect(screen.getByText("y coord out of range (5 to 10)")).toBeInTheDocument();
-        expect(screen.queryByText("x coord out of range (5 to 10)")).not.toBeInTheDocument();
+        expect(
+            screen.getByText("y coord out of range (5 to 10)"),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText("x coord out of range (5 to 10)"),
+        ).not.toBeInTheDocument();
     });
 
     test("Shows both errors if both coords are out of range", async () => {
@@ -103,17 +103,24 @@ describe('CoordinatePairInput', () => {
         render(
             <CoordinatePairInput
                 coord={[0, 0]}
-                range={[[5, 10], [5, 10]]}
+                range={[
+                    [5, 10],
+                    [5, 10],
+                ]}
                 onChange={onChangeProps}
             />,
             {
                 wrapper: RenderStateRoot,
-            }
+            },
         );
 
         // Assert
-        expect(screen.getByText("x coord out of range (5 to 10)")).toBeInTheDocument();
-        expect(screen.getByText("y coord out of range (5 to 10)")).toBeInTheDocument();
+        expect(
+            screen.getByText("x coord out of range (5 to 10)"),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText("y coord out of range (5 to 10)"),
+        ).toBeInTheDocument();
     });
 
     test("Does not show an error if the coord is in range", async () => {
@@ -124,16 +131,23 @@ describe('CoordinatePairInput', () => {
         render(
             <CoordinatePairInput
                 coord={[7, 7]}
-                range={[[5, 10], [5, 10]]}
+                range={[
+                    [5, 10],
+                    [5, 10],
+                ]}
                 onChange={onChangeProps}
             />,
             {
                 wrapper: RenderStateRoot,
-            }
+            },
         );
 
         // Assert
-        expect(screen.queryByText("x coord out of range (5 to 10)")).not.toBeInTheDocument();
-        expect(screen.queryByText("y coord out of range (5 to 10)")).not.toBeInTheDocument();
+        expect(
+            screen.queryByText("x coord out of range (5 to 10)"),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByText("y coord out of range (5 to 10)"),
+        ).not.toBeInTheDocument();
     });
 });

--- a/packages/perseus-editor/src/components/coordinate-pair-input.tsx
+++ b/packages/perseus-editor/src/components/coordinate-pair-input.tsx
@@ -47,8 +47,8 @@ const CoordinatePairInput = (props: Props) => {
         const xOutOfRange = coord[0] < range[0][0] || coord[0] > range[0][1];
         const yOutOfRange = coord[1] < range[1][0] || coord[1] > range[1][1];
 
-        const xRangeError = `${labels[0]} out of range ${range[0][0]} to ${range[0][1]}`;
-        const yRangeError = `${labels[1]} out of range ${range[1][0]} to ${range[1][1]}`;
+        const xRangeError = `${labels[0]} out of range (${range[0][0]} to ${range[0][1]})`;
+        const yRangeError = `${labels[1]} out of range (${range[1][0]} to ${range[1][1]})`;
 
         setXRangeError(xOutOfRange ? xRangeError : null);
         setYRangeError(yOutOfRange ? yRangeError : null);

--- a/packages/perseus-editor/src/components/coordinate-pair-input.tsx
+++ b/packages/perseus-editor/src/components/coordinate-pair-input.tsx
@@ -55,15 +55,16 @@ const CoordinatePairInput = (props: Props) => {
                     <TextField
                         type="number"
                         value={coordState[0]}
-                        min={range ? range[0][0] : undefined}
-                        max={range ? range[0][1] : undefined}
-                        onChange={(newValue) => handleCoordChange(newValue, 0)}
+                        onChange={(newValue) =>
+                            handleCoordChange(newValue, 0)
+                        }
                         style={[
                             styles.textField,
                             error ? styles.errorField : undefined,
                         ]}
                     />
                 </LabelMedium>
+
                 <Strut size={spacing.medium_16} />
 
                 <LabelMedium tag="label" style={styles.row}>
@@ -73,9 +74,9 @@ const CoordinatePairInput = (props: Props) => {
                     <TextField
                         type="number"
                         value={coordState[1]}
-                        min={range ? range[1][0] : undefined}
-                        max={range ? range[1][1] : undefined}
-                        onChange={(newValue) => handleCoordChange(newValue, 1)}
+                        onChange={(newValue) =>
+                            handleCoordChange(newValue, 1)
+                        }
                         style={[
                             styles.textField,
                             error ? styles.errorField : undefined,

--- a/packages/perseus-editor/src/components/coordinate-pair-input.tsx
+++ b/packages/perseus-editor/src/components/coordinate-pair-input.tsx
@@ -17,18 +17,18 @@ type Props = {
 };
 
 const CoordinatePairInput = (props: Props) => {
-    const {coord, error, range, onChange} = props;
-    const labels = [
-        props.labels ? props.labels[0] : "x coord",
-        props.labels ? props.labels[1] : "y coord",
-    ];
+    const {
+        coord,
+        labels = ["x coord", "y coord"],
+        error,
+        range,
+        onChange,
+    } = props;
 
-    const [rangeError, setRangeError] = React.useState<Array<string | null>>([
-        null,
-        null,
-    ]);
+    const [xRangeError, setXRangeError] = React.useState<string | null>(null);
+    const [yRangeError, setYRangeError] = React.useState<string | null>(null);
 
-    const hasError = [error || rangeError[0], error || rangeError[1]];
+    const hasError = [error || xRangeError, error || yRangeError];
 
     // Keep track of the coordinates via state as the user is editing them,
     // before they are updated in the props as a valid number.
@@ -50,13 +50,9 @@ const CoordinatePairInput = (props: Props) => {
         const xRangeError = `${labels[0]} out of range ${range[0][0]} to ${range[0][1]}`;
         const yRangeError = `${labels[1]} out of range ${range[1][0]} to ${range[1][1]}`;
 
-        // Set an error if the coords are out of range.
-        const newRangeError = [
-            (xOutOfRange ? xRangeError : null),
-            (yOutOfRange ? yRangeError : null),
-        ];
-        setRangeError(newRangeError);
-    }, [range, coord]);
+        setXRangeError(xOutOfRange ? xRangeError : null);
+        setYRangeError(yOutOfRange ? yRangeError : null);
+    }, [coord, labels, range]);
 
     function handleCoordChange(newValue, coordIndex) {
         // Update the local state (update the input field value).
@@ -78,22 +74,19 @@ const CoordinatePairInput = (props: Props) => {
 
     return (
         <View>
-            {(rangeError[0] || rangeError[1]) && (
-                <View style={styles.spaceUnder}>
-                    {rangeError.map((error, index) => {
-                        if (error) {
-                            return (
-                                <LabelMedium
-                                    key={index}
-                                    style={styles.errorText}
-                                >
-                                    {error}
-                                </LabelMedium>
-                            );
-                        }
-                    })}
-                </View>
+            {/* Errors */}
+            {xRangeError && (
+                <LabelMedium style={styles.errorText}>
+                    {xRangeError}
+                </LabelMedium>
             )}
+            {yRangeError && (
+                <LabelMedium style={styles.errorText}>
+                    {yRangeError}
+                </LabelMedium>
+            )}
+
+            {/* Coordinate input fields */}
             <View style={[styles.row, styles.spaceUnder]}>
                 <LabelMedium tag="label" style={styles.row}>
                     {labels[0]}
@@ -153,7 +146,7 @@ const styles = StyleSheet.create({
     },
     errorText: {
         color: wbColor.red,
-        marginTop: spacing.xxSmall_6,
+        marginBottom: spacing.xSmall_8,
     },
     errorField: {
         borderColor: wbColor.red,

--- a/packages/perseus-editor/src/components/coordinate-pair-input.tsx
+++ b/packages/perseus-editor/src/components/coordinate-pair-input.tsx
@@ -97,9 +97,7 @@ const CoordinatePairInput = (props: Props) => {
                         value={coordState[0]}
                         min={range ? range[0][0] : undefined}
                         max={range ? range[0][1] : undefined}
-                        onChange={(newValue) =>
-                            handleCoordChange(newValue, 0)
-                        }
+                        onChange={(newValue) => handleCoordChange(newValue, 0)}
                         style={[
                             styles.textField,
                             hasError[0] ? styles.errorField : undefined,
@@ -118,9 +116,7 @@ const CoordinatePairInput = (props: Props) => {
                         value={coordState[1]}
                         min={range ? range[1][0] : undefined}
                         max={range ? range[1][1] : undefined}
-                        onChange={(newValue) =>
-                            handleCoordChange(newValue, 1)
-                        }
+                        onChange={(newValue) => handleCoordChange(newValue, 1)}
                         style={[
                             styles.textField,
                             hasError[1] ? styles.errorField : undefined,

--- a/packages/perseus-editor/src/components/coordinate-pair-input.tsx
+++ b/packages/perseus-editor/src/components/coordinate-pair-input.tsx
@@ -17,7 +17,16 @@ type Props = {
 };
 
 const CoordinatePairInput = (props: Props) => {
-    const {coord, labels, error, range, onChange} = props;
+    const {coord, error, range, onChange} = props;
+    const [rangeError, setRangeError] = React.useState<Array<string | null>>([
+        null,
+        null,
+    ]);
+
+    const labels = [
+        props.labels ? props.labels[0] : "x coord",
+        props.labels ? props.labels[1] : "y coord",
+    ];
 
     // Keep track of the coordinates via state as the user is editing them,
     // before they are updated in the props as a valid number.
@@ -45,16 +54,49 @@ const CoordinatePairInput = (props: Props) => {
         onChange(newCoords);
     }
 
+    function validateRange(value, index) {
+        if (range && (+value < range[index][0] || +value > range[index][1])) {
+            return `${labels[index]} outside of range ${range[index][0]} to ${range[index][1]}`;
+        }
+        return null;
+    }
+
+    function onValidate(error, index) {
+        const newRangeError = [...rangeError];
+        newRangeError[index] = error;
+        setRangeError(newRangeError);
+    }
+
     return (
         <View>
+            {(rangeError[0] || rangeError[1]) && (
+                <View style={styles.spaceUnder}>
+                    {rangeError.map((error, index) => {
+                        if (error) {
+                            return (
+                                <LabelMedium
+                                    key={index}
+                                    style={styles.errorText}
+                                >
+                                    {error}
+                                </LabelMedium>
+                            );
+                        }
+                    })}
+                </View>
+            )}
             <View style={[styles.row, styles.spaceUnder]}>
                 <LabelMedium tag="label" style={styles.row}>
-                    {labels ? labels[0] : "x coord"}
+                    {labels[0]}
 
                     <Strut size={spacing.xxSmall_6} />
                     <TextField
                         type="number"
                         value={coordState[0]}
+                        min={range ? range[0][0] : undefined}
+                        max={range ? range[0][1] : undefined}
+                        validate={(value) => validateRange(value, 0)}
+                        onValidate={(error) => onValidate(error, 0)}
                         onChange={(newValue) =>
                             handleCoordChange(newValue, 0)
                         }
@@ -68,12 +110,16 @@ const CoordinatePairInput = (props: Props) => {
                 <Strut size={spacing.medium_16} />
 
                 <LabelMedium tag="label" style={styles.row}>
-                    {labels ? labels[1] : "y coord"}
+                    {labels[1]}
 
                     <Strut size={spacing.xxSmall_6} />
                     <TextField
                         type="number"
                         value={coordState[1]}
+                        min={range ? range[1][0] : undefined}
+                        max={range ? range[1][1] : undefined}
+                        validate={(value) => validateRange(value, 1)}
+                        onValidate={(error) => onValidate(error, 1)}
                         onChange={(newValue) =>
                             handleCoordChange(newValue, 1)
                         }
@@ -99,6 +145,10 @@ const styles = StyleSheet.create({
     },
     textField: {
         width: spacing.xxxLarge_64,
+    },
+    errorText: {
+        color: wbColor.red,
+        marginTop: spacing.xxSmall_6,
     },
     errorField: {
         borderColor: wbColor.red,

--- a/packages/perseus-editor/src/components/locked-ellipse-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-ellipse-settings.tsx
@@ -45,6 +45,9 @@ const LockedEllipseSettings = (props: Props) => {
         onChangeProps({color: newValue});
     }
 
+    const maxXRadius = range[0][1] - range[0][0];
+    const maxYRadius = range[1][1] - range[1][0];
+
     return (
         <LockedFigureSettingsAccordion
             expanded={expanded}
@@ -82,6 +85,12 @@ const LockedEllipseSettings = (props: Props) => {
             <CoordinatePairInput
                 coord={radius}
                 labels={["x radius", "y radius"]}
+                // Don't allow the radius to be so big that the ellipse is
+                // no longer visible on the graph.
+                range={[
+                    [0, maxXRadius],
+                    [0, maxYRadius],
+                ]}
                 onChange={(newCoords: Coord) =>
                     onChangeProps({radius: newCoords})
                 }

--- a/packages/perseus-editor/src/components/locked-line-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-line-settings.tsx
@@ -195,6 +195,7 @@ const styles = StyleSheet.create({
     },
     errorText: {
         color: wbColor.red,
+        marginTop: spacing.xSmall_8,
     },
 });
 

--- a/packages/perseus-editor/src/components/locked-line-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-line-settings.tsx
@@ -183,6 +183,7 @@ const LockedLineSettings = (props: Props) => {
 
 const styles = StyleSheet.create({
     row: {
+        display: "flex",
         flexDirection: "row",
         alignItems: "center",
     },

--- a/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
@@ -2034,6 +2034,7 @@ export const segmentWithLockedFigures: PerseusRenderer =
         .addLockedPointAt(-7, -7)
         .addLockedLine([-7, -5], [2, -3])
         .addLockedEllipse([0, 5], [2, 2])
+        .addLockedVector([0, 0], [8, 2], "pink")
         .build();
 
 export const segmentWithLockedEllipses: PerseusRenderer =


### PR DESCRIPTION
## Summary:
Adding `min` and `max` to the number text fields works for the arrow buttons,
but it doesn't stop someone from typing in a number out of range.

Add error messages so people know if a locked figure is out of range.

I'm going to add this to `getSaveWarnings()` in a future PR.

Issue: https://khanacademy.atlassian.net/browse/LEMS-1988

## Test plan:
Storybook
- https://khan.github.io/perseus/?path=/story/perseuseditor-editorpage--mafs-with-locked-figures-m-2-flag
- For all the locked figure types, type in the coordinate so they're out of range
- Confirm that the respective error messages show up
- Change the range of the graph
- Confirm that the error messages stay or don't stay accordingly

## Screenshots:

| x only | y only | x and y|
| --- | --- | --- |
| <img width="360" alt="Screenshot 2024-06-12 at 4 14 42 PM" src="https://github.com/Khan/perseus/assets/13231763/f1e2dbbf-c0cc-49f5-968c-603b7dc4ee25"> | <img width="383" alt="Screenshot 2024-06-12 at 4 14 54 PM" src="https://github.com/Khan/perseus/assets/13231763/23865578-c012-4a90-a314-291b485b8728"> | <img width="381" alt="Screenshot 2024-06-12 at 4 14 47 PM" src="https://github.com/Khan/perseus/assets/13231763/f8af2839-aac8-4c0f-82ac-27b8e73e9d68"> |

### Demo: errors updating after changing the graph range

https://github.com/Khan/perseus/assets/13231763/36c91725-06b9-4d76-aa74-818e07f459d6
