### PR TITLE
Revert "[Interactive Graph Editor] Restrict the range on locked figures (arrow buttons only) (#1323)"

### DIFF
--- a/.changeset/rotten-hotels-travel.md
+++ b/.changeset/rotten-hotels-travel.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+[Interactive Graph Editor] Revert usage of min and max in range inputs for locked figures UI

--- a/.changeset/selfish-games-melt.md
+++ b/.changeset/selfish-games-melt.md
@@ -1,5 +1,0 @@
----
-"@khanacademy/perseus-editor": minor
----
-
-[Interactive Graph Editor] Use `min` and `max` props on Wonder Blocks TextField to restrict the range when using the arrow buttons to update the coordinates on locked lines and locked points.

--- a/packages/perseus-editor/src/components/__stories__/locked-ellipse-settings.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/locked-ellipse-settings.stories.tsx
@@ -3,7 +3,6 @@ import * as React from "react";
 import LockedEllipseSettings from "../locked-ellipse-settings";
 import {getDefaultFigureForType} from "../util";
 
-import type {Range} from "@khanacademy/perseus";
 import type {Meta, StoryObj} from "@storybook/react";
 
 export default {
@@ -28,10 +27,6 @@ export const Controlled: StoryComponentType = {
     render: function Render() {
         const [props, setProps] = React.useState({
             ...getDefaultFigureForType("ellipse"),
-            range: [
-                [-10, 10],
-                [-10, 10],
-            ] satisfies [Range, Range],
             onRemove: () => {},
         });
 
@@ -64,10 +59,6 @@ export const Expanded: StoryComponentType = {
         const [expanded, setExpanded] = React.useState(true);
         const [props, setProps] = React.useState({
             ...getDefaultFigureForType("ellipse"),
-            range: [
-                [-10, 10],
-                [-10, 10],
-            ] satisfies [Range, Range],
             onRemove: () => {},
         });
 

--- a/packages/perseus-editor/src/components/__stories__/locked-figures-section.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/locked-figures-section.stories.tsx
@@ -6,13 +6,7 @@ import * as React from "react";
 import LockedFiguresSection from "../locked-figures-section";
 import {getDefaultFigureForType} from "../util";
 
-import type {Range} from "@khanacademy/perseus";
 import type {Meta, StoryObj} from "@storybook/react";
-
-const defaultRange = [
-    [-10, 10],
-    [-10, 10],
-] satisfies [Range, Range];
 
 export default {
     title: "PerseusEditor/Components/Locked Figures Section",
@@ -40,7 +34,6 @@ export const Controlled: StoryComponentType = {
             <LockedFiguresSection
                 showM2Features={true}
                 figures={figures}
-                range={defaultRange}
                 onChange={handlePropsUpdate}
             />
         );
@@ -63,7 +56,6 @@ export const WithProdWidth: StoryComponentType = {
                 <LockedFiguresSection
                     showM2Features={true}
                     figures={figures}
-                    range={defaultRange}
                     onChange={handlePropsUpdate}
                 />
             </View>

--- a/packages/perseus-editor/src/components/__stories__/locked-line-settings.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/locked-line-settings.stories.tsx
@@ -3,13 +3,7 @@ import * as React from "react";
 import LockedLineSettings from "../locked-line-settings";
 import {getDefaultFigureForType} from "../util";
 
-import type {Range} from "@khanacademy/perseus";
 import type {Meta, StoryObj} from "@storybook/react";
-
-const defaultRange = [
-    [-10, 10],
-    [-10, 10],
-] satisfies [Range, Range];
 
 export default {
     title: "PerseusEditor/Components/Locked Line Settings",
@@ -44,11 +38,7 @@ export const Controlled: StoryComponentType = {
         };
 
         return (
-            <LockedLineSettings
-                {...props}
-                range={defaultRange}
-                onChangeProps={handlePropsUpdate}
-            />
+            <LockedLineSettings {...props} onChangeProps={handlePropsUpdate} />
         );
     },
 };
@@ -86,7 +76,6 @@ export const WithInvalidPoints: StoryComponentType = {
                     getDefaultFigureForType("point"),
                     getDefaultFigureForType("point"),
                 ]}
-                range={defaultRange}
                 expanded={true}
                 onChangeProps={handlePropsUpdate}
             />
@@ -113,7 +102,6 @@ export const Expanded: StoryComponentType = {
         return (
             <LockedLineSettings
                 {...props}
-                range={defaultRange}
                 expanded={expanded}
                 onToggle={setExpanded}
                 onChangeProps={handlePropsUpdate}
@@ -144,7 +132,6 @@ export const ExpandedNondefaultProps: StoryComponentType = {
         return (
             <LockedLineSettings
                 {...props}
-                range={defaultRange}
                 expanded={expanded}
                 onToggle={setExpanded}
                 onChangeProps={handlePropsUpdate}

--- a/packages/perseus-editor/src/components/__stories__/locked-point-settings.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/locked-point-settings.stories.tsx
@@ -3,13 +3,7 @@ import * as React from "react";
 import LockedPointSettings from "../locked-point-settings";
 import {getDefaultFigureForType} from "../util";
 
-import type {Range} from "@khanacademy/perseus";
 import type {Meta, StoryObj} from "@storybook/react";
-
-const defaultRange = [
-    [-10, 10],
-    [-10, 10],
-] satisfies [Range, Range];
 
 export default {
     title: "PerseusEditor/Components/Locked Point Settings",
@@ -44,11 +38,7 @@ export const Controlled: StoryComponentType = {
         };
 
         return (
-            <LockedPointSettings
-                {...props}
-                range={defaultRange}
-                onChangeProps={handlePropsUpdate}
-            />
+            <LockedPointSettings {...props} onChangeProps={handlePropsUpdate} />
         );
     },
 };
@@ -79,7 +69,6 @@ export const Expanded: StoryComponentType = {
         return (
             <LockedPointSettings
                 {...props}
-                range={defaultRange}
                 expanded={expanded}
                 onToggle={setExpanded}
                 onChangeProps={handlePropsUpdate}
@@ -109,7 +98,6 @@ export const ExpandedNondefaultProps: StoryComponentType = {
         return (
             <LockedPointSettings
                 {...props}
-                range={defaultRange}
                 expanded={expanded}
                 onToggle={setExpanded}
                 onChangeProps={handlePropsUpdate}

--- a/packages/perseus-editor/src/components/__stories__/locked-vector-settings.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/locked-vector-settings.stories.tsx
@@ -3,7 +3,6 @@ import * as React from "react";
 import LockedVectorSettings from "../locked-vector-settings";
 import {getDefaultFigureForType} from "../util";
 
-import type {Range} from "@khanacademy/perseus";
 import type {Meta, StoryObj} from "@storybook/react";
 
 export default {
@@ -28,10 +27,6 @@ export const Expanded: StoryComponentType = {
     render: function Render() {
         const [props, setProps] = React.useState({
             ...getDefaultFigureForType("vector"),
-            range: [
-                [-10, 10],
-                [-10, 10],
-            ] satisfies [Range, Range],
             onRemove: () => {},
         });
 
@@ -61,10 +56,6 @@ export const WithInvalidPoints: StoryComponentType = {
     render: function Render() {
         const [props, setProps] = React.useState({
             ...getDefaultFigureForType("vector"),
-            range: [
-                [-10, 10],
-                [-10, 10],
-            ] satisfies [Range, Range],
             onRemove: () => {},
         });
 

--- a/packages/perseus-editor/src/components/__tests__/locked-ellipse-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-ellipse-settings.test.tsx
@@ -6,15 +6,10 @@ import * as React from "react";
 import LockedEllipseSettings from "../locked-ellipse-settings";
 import {getDefaultFigureForType} from "../util";
 
-import type {Range} from "@khanacademy/perseus";
 import type {UserEvent} from "@testing-library/user-event";
 
 const defaultProps = {
     ...getDefaultFigureForType("ellipse"),
-    range: [
-        [-10, 10],
-        [-10, 10],
-    ] satisfies [Range, Range],
     onChangeProps: () => {},
     onRemove: () => {},
 };

--- a/packages/perseus-editor/src/components/__tests__/locked-figures-section.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-figures-section.test.tsx
@@ -6,13 +6,8 @@ import * as React from "react";
 import LockedFiguresSection from "../locked-figures-section";
 import {getDefaultFigureForType} from "../util";
 
-import type {Range} from "@khanacademy/perseus";
 import type {UserEvent} from "@testing-library/user-event";
 
-const defaultRange = [
-    [-10, 10],
-    [-10, 10],
-] satisfies [Range, Range];
 const defaultFigures = [
     getDefaultFigureForType("point"),
     getDefaultFigureForType("line"),
@@ -46,11 +41,7 @@ describe("LockedFiguresSection", () => {
     test("renders", () => {
         // Arrange, Act
         render(
-            <LockedFiguresSection
-                showM2Features={true}
-                range={defaultRange}
-                onChange={jest.fn()}
-            />,
+            <LockedFiguresSection showM2Features={true} onChange={jest.fn()} />,
             {
                 wrapper: RenderStateRoot,
             },
@@ -63,11 +54,7 @@ describe("LockedFiguresSection", () => {
     test("renders no expand/collapse button when there are no figures", () => {
         // Arrange, Act
         render(
-            <LockedFiguresSection
-                showM2Features={true}
-                range={defaultRange}
-                onChange={jest.fn()}
-            />,
+            <LockedFiguresSection showM2Features={true} onChange={jest.fn()} />,
             {
                 wrapper: RenderStateRoot,
             },
@@ -82,7 +69,6 @@ describe("LockedFiguresSection", () => {
         // Arrange, Act
         render(
             <LockedFiguresSection
-                range={defaultRange}
                 figures={defaultFigures}
                 showM2Features={true}
                 onChange={jest.fn()}
@@ -105,7 +91,6 @@ describe("LockedFiguresSection", () => {
         // Arrange
         render(
             <LockedFiguresSection
-                range={defaultRange}
                 figures={defaultFigures}
                 showM2Features={true}
                 onChange={jest.fn()}
@@ -130,7 +115,6 @@ describe("LockedFiguresSection", () => {
         // Arrange
         render(
             <LockedFiguresSection
-                range={defaultRange}
                 figures={defaultFigures}
                 showM2Features={true}
                 onChange={jest.fn()}
@@ -161,7 +145,6 @@ describe("LockedFiguresSection", () => {
         // Arrange
         render(
             <LockedFiguresSection
-                range={defaultRange}
                 figures={defaultFigures}
                 showM2Features={true}
                 onChange={jest.fn()}
@@ -198,7 +181,6 @@ describe("LockedFiguresSection", () => {
         render(
             <LockedFiguresSection
                 showM2Features={true}
-                range={defaultRange}
                 figures={defaultFigures}
                 onChange={jest.fn()}
             />,
@@ -224,7 +206,6 @@ describe("LockedFiguresSection", () => {
         // Arrange
         render(
             <LockedFiguresSection
-                range={defaultRange}
                 showM2Features={true}
                 figures={[
                     getDefaultFigureForType("point"),

--- a/packages/perseus-editor/src/components/__tests__/locked-line-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-line-settings.test.tsx
@@ -6,15 +6,10 @@ import * as React from "react";
 import LockedLineSettings from "../locked-line-settings";
 import {getDefaultFigureForType} from "../util";
 
-import type {Range} from "@khanacademy/perseus";
 import type {UserEvent} from "@testing-library/user-event";
 
 const defaultProps = {
     ...getDefaultFigureForType("line"),
-    range: [
-        [-10, 10],
-        [-10, 10],
-    ] satisfies [Range, Range],
     onChangeProps: () => {},
     onRemove: () => {},
 };

--- a/packages/perseus-editor/src/components/__tests__/locked-point-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-point-settings.test.tsx
@@ -6,15 +6,10 @@ import * as React from "react";
 import LockedPointSettings from "../locked-point-settings";
 import {getDefaultFigureForType} from "../util";
 
-import type {Range} from "@khanacademy/perseus";
 import type {UserEvent} from "@testing-library/user-event";
 
 const defaultProps = {
     ...getDefaultFigureForType("point"),
-    range: [
-        [-10, 10],
-        [-10, 10],
-    ] satisfies [Range, Range],
     onRemove: () => {},
     onChangeProps: () => {},
 };

--- a/packages/perseus-editor/src/components/__tests__/locked-vector-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-vector-settings.test.tsx
@@ -7,15 +7,10 @@ import LockedVectorSettings from "../locked-vector-settings";
 import {getDefaultFigureForType} from "../util";
 
 import type {Props} from "../locked-vector-settings";
-import type {Range} from "@khanacademy/perseus";
 import type {UserEvent} from "@testing-library/user-event";
 
 const defaultProps = {
     ...getDefaultFigureForType("vector"),
-    range: [
-        [-10, 10],
-        [-10, 10],
-    ] satisfies [Range, Range],
     onChangeProps: () => {},
     onRemove: () => {},
 } as Props;

--- a/packages/perseus-editor/src/components/coordinate-pair-input.tsx
+++ b/packages/perseus-editor/src/components/coordinate-pair-input.tsx
@@ -6,18 +6,17 @@ import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
-import type {Range, Coord} from "@khanacademy/perseus";
+import type {Coord} from "@khanacademy/perseus";
 
 type Props = {
     coord: [number, number];
     labels?: [string, string];
-    range?: [Range, Range];
     error?: boolean;
     onChange: (newCoord: Coord) => void;
 };
 
 const CoordinatePairInput = (props: Props) => {
-    const {coord, labels, error, range, onChange} = props;
+    const {coord, labels, error, onChange} = props;
 
     // Keep track of the coordinates via state as the user is editing them,
     // before they are updated in the props as a valid number.
@@ -55,8 +54,6 @@ const CoordinatePairInput = (props: Props) => {
                     <TextField
                         type="number"
                         value={coordState[0]}
-                        min={range ? range[0][0] : undefined}
-                        max={range ? range[0][1] : undefined}
                         onChange={(newValue) => handleCoordChange(newValue, 0)}
                         style={[
                             styles.textField,
@@ -73,8 +70,6 @@ const CoordinatePairInput = (props: Props) => {
                     <TextField
                         type="number"
                         value={coordState[1]}
-                        min={range ? range[1][0] : undefined}
-                        max={range ? range[1][1] : undefined}
                         onChange={(newValue) => handleCoordChange(newValue, 1)}
                         style={[
                             styles.textField,

--- a/packages/perseus-editor/src/components/defining-point-settings.tsx
+++ b/packages/perseus-editor/src/components/defining-point-settings.tsx
@@ -17,39 +17,33 @@ import CoordinatePairInput from "./coordinate-pair-input";
 import LabeledSwitch from "./labeled-switch";
 import LockedFigureSettingsAccordion from "./locked-figure-settings-accordion";
 
-import type {LockedFigureSettingsCommonProps} from "./locked-figure-settings";
-import type {LockedPointType, Range} from "@khanacademy/perseus";
+import type {AccordionProps} from "./locked-figure-settings";
+import type {LockedPointType} from "@khanacademy/perseus";
 
-export type Props =
-    // Omit `onRemove` because defining points are not removable.
-    Omit<LockedFigureSettingsCommonProps, "onRemove"> &
-        LockedPointType & {
-            /**
-             * Optional label for the point to display in the header summary.
-             * Defaults to "Point".
-             */
-            label: string;
-            /**
-             * Whether the extra point settings are toggled open.
-             */
-            showPoint?: boolean;
-            /**
-             * Optional error message to display.
-             */
-            error?: string | null;
-            /**
-             * The range of the graph. Used to restrict the coordinates.
-             */
-            range?: [Range, Range];
-            /**
-             * Called when the extra settings toggle switch is changed.
-             */
-            onTogglePoint?: (newValue) => void;
-            /**
-             * Called when the props (coords, color, etc.) are updated.
-             */
-            onChangeProps: (newProps: Partial<LockedPointType>) => void;
-        };
+export type Props = AccordionProps &
+    LockedPointType & {
+        /**
+         * Optional label for the point to display in the header summary.
+         * Defaults to "Point".
+         */
+        label: string;
+        /**
+         * Whether the extra point settings are toggled open.
+         */
+        showPoint?: boolean;
+        /**
+         * Optional error message to display.
+         */
+        error?: string | null;
+        /**
+         * Called when the extra settings toggle switch is changed.
+         */
+        onTogglePoint?: (newValue) => void;
+        /**
+         * Called when the props (coords, color, etc.) are updated.
+         */
+        onChangeProps: (newProps: Partial<LockedPointType>) => void;
+    };
 
 const DefiningPointSettings = (props: Props) => {
     const {
@@ -59,7 +53,6 @@ const DefiningPointSettings = (props: Props) => {
         label,
         showPoint = "false",
         error,
-        range,
         onChangeProps,
         onTogglePoint,
     } = props;
@@ -89,7 +82,6 @@ const DefiningPointSettings = (props: Props) => {
             <CoordinatePairInput
                 coord={coord}
                 error={!!error}
-                range={range}
                 onChange={(newCoords) => {
                     onChangeProps({coord: newCoords});
                 }}

--- a/packages/perseus-editor/src/components/locked-ellipse-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-ellipse-settings.tsx
@@ -14,7 +14,7 @@ import EllipseSwatch from "./ellipse-swatch";
 import LockedFigureSettingsAccordion from "./locked-figure-settings-accordion";
 import LockedFigureSettingsActions from "./locked-figure-settings-actions";
 
-import type {LockedFigureSettingsCommonProps} from "./locked-figure-settings";
+import type {AccordionProps} from "./locked-figure-settings";
 import type {
     Coord,
     LockedEllipseFillType,
@@ -24,7 +24,17 @@ import type {
 
 const {InfoTip} = components;
 
-export type Props = LockedFigureSettingsCommonProps & LockedEllipseType;
+export type Props = AccordionProps &
+    LockedEllipseType & {
+        /**
+         * Called when the delete button is pressed.
+         */
+        onRemove: () => void;
+        /**
+         * Called when the props (coords, color, etc.) are updated.
+         */
+        onChangeProps: (newProps: Partial<LockedEllipseType>) => void;
+    };
 
 const LockedEllipseSettings = (props: Props) => {
     const {
@@ -35,7 +45,6 @@ const LockedEllipseSettings = (props: Props) => {
         fillStyle,
         strokeStyle,
         expanded,
-        range,
         onToggle,
         onChangeProps,
         onRemove,
@@ -66,7 +75,6 @@ const LockedEllipseSettings = (props: Props) => {
             <View style={styles.row}>
                 <CoordinatePairInput
                     coord={center}
-                    range={range}
                     onChange={(newCoords: Coord) =>
                         onChangeProps({center: newCoords})
                     }

--- a/packages/perseus-editor/src/components/locked-figure-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-figure-settings.tsx
@@ -16,22 +16,11 @@ import type {Props as LockedEllipseProps} from "./locked-ellipse-settings";
 import type {Props as LockedLineProps} from "./locked-line-settings";
 import type {Props as LockedPointProps} from "./locked-point-settings";
 import type {Props as LockedVectorProps} from "./locked-vector-settings";
-import type {LockedFigure} from "@khanacademy/perseus";
-import type {Interval} from "mafs";
 
-export type LockedFigureSettingsCommonProps = {
+export type AccordionProps = {
     // Whether to show the M2 features in the locked figure settings.
     // TODO(LEMS-2016): Remove this prop once the M2 flag is fully rolled out.
     showM2Features?: boolean;
-    range: [Interval, Interval];
-    /**
-     * Called when the delete button is pressed.
-     */
-    onRemove: () => void;
-    /**
-     * Called when the props (points, color, etc.) are updated.
-     */
-    onChangeProps: (newProps: Partial<LockedFigure>) => void;
     /**
      * Whether this accordion is expanded.
      */
@@ -43,7 +32,7 @@ export type LockedFigureSettingsCommonProps = {
 };
 
 // Union this type with other locked figure types when they are added.
-type Props = LockedFigureSettingsCommonProps &
+type Props = AccordionProps &
     (
         | LockedPointProps
         | LockedLineProps

--- a/packages/perseus-editor/src/components/locked-figures-section.tsx
+++ b/packages/perseus-editor/src/components/locked-figures-section.tsx
@@ -16,14 +16,12 @@ import {getDefaultFigureForType} from "./util";
 
 import type {Props as InteractiveGraphEditorProps} from "../widgets/interactive-graph-editor";
 import type {LockedFigure, LockedFigureType} from "@khanacademy/perseus";
-import type {Interval} from "mafs";
 
 type Props = {
     // Whether to show the M2 features in the locked figure settings.
     // TODO(LEMS-2016): Remove this prop once the M2 flag is fully rolled out.
     showM2Features: boolean;
     figures?: Array<LockedFigure>;
-    range: [Interval, Interval];
     onChange: (props: Partial<InteractiveGraphEditorProps>) => void;
 };
 
@@ -103,7 +101,6 @@ const LockedFiguresSection = (props: Props) => {
                         key={`${uniqueId}-locked-${figure}-${index}`}
                         showM2Features={props.showM2Features}
                         expanded={expandedStates[index]}
-                        range={props.range satisfies [Interval, Interval]}
                         onToggle={(newValue) => {
                             const newExpanded = [...expandedStates];
                             newExpanded[index] = newValue;

--- a/packages/perseus-editor/src/components/locked-line-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-line-settings.tsx
@@ -19,8 +19,9 @@ import LineSwatch from "./line-swatch";
 import LockedFigureSettingsAccordion from "./locked-figure-settings-accordion";
 import LockedFigureSettingsActions from "./locked-figure-settings-actions";
 
-import type {LockedFigureSettingsCommonProps} from "./locked-figure-settings";
+import type {AccordionProps} from "./locked-figure-settings";
 import type {
+    LockedFigure,
     LockedFigureColor,
     LockedLineType,
     LockedPointType,
@@ -28,7 +29,17 @@ import type {
 
 const lengthZeroStr = "The line cannot have length 0.";
 
-export type Props = LockedLineType & LockedFigureSettingsCommonProps;
+export type Props = LockedLineType &
+    AccordionProps & {
+        /**
+         * Called when the delete button is pressed.
+         */
+        onRemove: () => void;
+        /**
+         * Called when the props (points, color, etc.) are updated.
+         */
+        onChangeProps: (newProps: Partial<LockedFigure>) => void;
+    };
 
 const LockedLineSettings = (props: Props) => {
     const {
@@ -38,7 +49,6 @@ const LockedLineSettings = (props: Props) => {
         lineStyle = "solid",
         showPoint1,
         showPoint2,
-        range,
         onChangeProps,
         onRemove,
     } = props;
@@ -151,7 +161,6 @@ const LockedLineSettings = (props: Props) => {
                 label="Point 1"
                 showPoint={showPoint1}
                 error={isInvalid ? lengthZeroStr : null}
-                range={range}
                 {...point1}
                 onTogglePoint={(newValue) =>
                     onChangeProps({showPoint1: newValue})
@@ -162,7 +171,6 @@ const LockedLineSettings = (props: Props) => {
                 label="Point 2"
                 showPoint={showPoint2}
                 error={isInvalid ? lengthZeroStr : null}
-                range={range}
                 {...point2}
                 onTogglePoint={(newValue) =>
                     onChangeProps({showPoint2: newValue})

--- a/packages/perseus-editor/src/components/locked-point-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-point-settings.tsx
@@ -18,17 +18,26 @@ import LabeledSwitch from "./labeled-switch";
 import LockedFigureSettingsAccordion from "./locked-figure-settings-accordion";
 import LockedFigureSettingsActions from "./locked-figure-settings-actions";
 
-import type {LockedFigureSettingsCommonProps} from "./locked-figure-settings";
+import type {AccordionProps} from "./locked-figure-settings";
 import type {LockedPointType} from "@khanacademy/perseus";
 
-export type Props = LockedFigureSettingsCommonProps & LockedPointType;
+export type Props = AccordionProps &
+    LockedPointType & {
+        /**
+         * Called when the delete button is pressed.
+         */
+        onRemove: () => void;
+        /**
+         * Called when the props (coords, color, etc.) are updated.
+         */
+        onChangeProps: (newProps: Partial<LockedPointType>) => void;
+    };
 
 const LockedPointSettings = (props: Props) => {
     const {
         coord,
         color: pointColor,
         filled = true,
-        range,
         onChangeProps,
         onRemove,
     } = props;
@@ -52,7 +61,6 @@ const LockedPointSettings = (props: Props) => {
         >
             <CoordinatePairInput
                 coord={coord}
-                range={range}
                 onChange={(newCoord) => {
                     onChangeProps({coord: newCoord});
                 }}

--- a/packages/perseus-editor/src/components/locked-vector-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-vector-settings.tsx
@@ -18,19 +18,30 @@ import LineSwatch from "./line-swatch";
 import LockedFigureSettingsAccordion from "./locked-figure-settings-accordion";
 import LockedFigureSettingsActions from "./locked-figure-settings-actions";
 
-import type {LockedFigureSettingsCommonProps} from "./locked-figure-settings";
+import type {AccordionProps} from "./locked-figure-settings";
 import type {
     Coord,
+    LockedFigure,
     LockedFigureColor,
     LockedVectorType,
 } from "@khanacademy/perseus";
 
 const lengthErrorMessage = "The vector cannot have length 0.";
 
-export type Props = LockedVectorType & LockedFigureSettingsCommonProps;
+export type Props = LockedVectorType &
+    AccordionProps & {
+        /**
+         * Called when the delete button is pressed.
+         */
+        onRemove: () => void;
+        /**
+         * Called when the props (points, color, etc.) are updated.
+         */
+        onChangeProps: (newProps: Partial<LockedFigure>) => void;
+    };
 
 const LockedVectorSettings = (props: Props) => {
-    const {points, color: lineColor, range, onChangeProps, onRemove} = props;
+    const {points, color: lineColor, onChangeProps, onRemove} = props;
     const [tail, tip] = points;
     const lineLabel = `Vector (${tail[0]}, ${tail[1]}), (${tip[0]}, ${tip[1]})`;
 
@@ -93,7 +104,6 @@ const LockedVectorSettings = (props: Props) => {
             >
                 <CoordinatePairInput
                     coord={tail}
-                    range={range}
                     error={isInvalid}
                     onChange={(newProps) => {
                         handleChangePoint(newProps, 0);
@@ -113,7 +123,6 @@ const LockedVectorSettings = (props: Props) => {
             >
                 <CoordinatePairInput
                     coord={tip}
-                    range={range}
                     error={isInvalid}
                     onChange={(newProps) => {
                         handleChangePoint(newProps, 1);

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
@@ -325,30 +325,6 @@ describe("InteractiveGraphEditor locked figures", () => {
                 expect(onChangeMock).not.toBeCalled();
             },
         );
-
-        test("Range is restricted to the graph", async () => {
-            // Arrange
-            const onChangeMock = jest.fn();
-
-            renderEditor({
-                onChange: onChangeMock,
-                lockedFigures: [defaultPoint],
-                range: [
-                    [-11, 20],
-                    [-15, 5],
-                ],
-            });
-
-            // Act
-            const xCoordInput = screen.getAllByRole("spinbutton")[0];
-            const yCoordInput = screen.getAllByRole("spinbutton")[1];
-
-            // Assert
-            expect(xCoordInput).toHaveAttribute("min", "-11");
-            expect(xCoordInput).toHaveAttribute("max", "20");
-            expect(yCoordInput).toHaveAttribute("min", "-15");
-            expect(yCoordInput).toHaveAttribute("max", "5");
-        });
     });
 
     describe("lines", () => {
@@ -590,37 +566,6 @@ describe("InteractiveGraphEditor locked figures", () => {
                     ],
                 }),
             );
-        });
-
-        test("Range is restricted to the graph", async () => {
-            // Arrange
-            const onChangeMock = jest.fn();
-
-            renderEditor({
-                onChange: onChangeMock,
-                lockedFigures: [defaultLine],
-                range: [
-                    [-11, 20],
-                    [-15, 5],
-                ],
-            });
-
-            // Act
-            const point1XCoordInput = screen.getAllByRole("spinbutton")[0];
-            const point1YCoordInput = screen.getAllByRole("spinbutton")[1];
-            const point2XCoordInput = screen.getAllByRole("spinbutton")[2];
-            const point2YCoordInput = screen.getAllByRole("spinbutton")[3];
-
-            // Assert
-            expect(point1XCoordInput).toHaveAttribute("min", "-11");
-            expect(point1XCoordInput).toHaveAttribute("max", "20");
-            expect(point1YCoordInput).toHaveAttribute("min", "-15");
-            expect(point1YCoordInput).toHaveAttribute("max", "5");
-
-            expect(point2XCoordInput).toHaveAttribute("min", "-11");
-            expect(point2XCoordInput).toHaveAttribute("max", "20");
-            expect(point2YCoordInput).toHaveAttribute("min", "-15");
-            expect(point2YCoordInput).toHaveAttribute("max", "5");
         });
     });
 

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
@@ -597,7 +597,6 @@ class InteractiveGraphEditor extends React.Component<Props> {
                                     ]
                                 }
                                 figures={this.props.lockedFigures}
-                                range={this.props.range}
                                 onChange={this.props.onChange}
                             />
                         )


### PR DESCRIPTION
## Summary:
We decided we no longer want to restrict the range on locked figures.
We trust the content authors to use the locked figures how they see fit.

Issue: https://khanacademy.atlassian.net/browse/LEMS-1988

## Test plan:
`yarn jest`

Storybook:
- Confirm that the arrow buttons no longer restrict the range