### PR TITLE
[Interactive Graph Editor] UI for adding/editing/deleting locked polygon

### DIFF
--- a/.changeset/wild-gifts-grow.md
+++ b/.changeset/wild-gifts-grow.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-editor": minor
+---
+
+[Interactive Graph Editor] UI for adding/editing/deleting a locked polygon

--- a/packages/perseus-editor/src/components/__stories__/locked-polygon-settings.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/locked-polygon-settings.stories.tsx
@@ -1,0 +1,81 @@
+import * as React from "react";
+
+import LockedPolygonSettings from "../locked-polygon-settings";
+import {getDefaultFigureForType} from "../util";
+
+import type {Meta, StoryObj} from "@storybook/react";
+
+export default {
+    title: "PerseusEditor/Components/Locked Polygon Settings",
+    component: LockedPolygonSettings,
+} as Meta<typeof LockedPolygonSettings>;
+
+export const Default = (args): React.ReactElement => {
+    return <LockedPolygonSettings {...args} />;
+};
+
+type StoryComponentType = StoryObj<typeof LockedPolygonSettings>;
+
+// Set the default values in the control panel.
+Default.args = {
+    ...getDefaultFigureForType("polygon"),
+    onChangeProps: () => {},
+    onRemove: () => {},
+};
+
+export const Controlled: StoryComponentType = {
+    render: function Render() {
+        const [props, setProps] = React.useState({
+            ...getDefaultFigureForType("polygon"),
+            onRemove: () => {},
+        });
+
+        const handlePropsUpdate = (newProps) => {
+            setProps({
+                ...props,
+                ...newProps,
+            });
+        };
+
+        return (
+            <LockedPolygonSettings
+                {...props}
+                onChangeProps={handlePropsUpdate}
+            />
+        );
+    },
+};
+
+Controlled.parameters = {
+    chromatic: {
+        // Disabling because this is testing behavior, not visuals.
+        disableSnapshot: true,
+    },
+};
+
+// Fully expanded view of the locked ellipse settings to allow snapshot testing.
+export const Expanded: StoryComponentType = {
+    render: function Render() {
+        const [expanded, setExpanded] = React.useState(true);
+        const [props, setProps] = React.useState({
+            ...getDefaultFigureForType("polygon"),
+            onRemove: () => {},
+        });
+
+        const handlePropsUpdate = (newProps) => {
+            setProps({
+                ...props,
+                ...newProps,
+            });
+        };
+
+        return (
+            <LockedPolygonSettings
+                {...props}
+                expanded={expanded}
+                onToggle={setExpanded}
+                onChangeProps={handlePropsUpdate}
+            />
+        );
+    },
+};

--- a/packages/perseus-editor/src/components/__tests__/locked-polygon-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-polygon-settings.test.tsx
@@ -1,0 +1,166 @@
+import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
+import {render, screen} from "@testing-library/react";
+import {userEvent as userEventLib} from "@testing-library/user-event";
+import * as React from "react";
+
+import LockedPolygonSettings from "../locked-polygon-settings";
+import {getDefaultFigureForType} from "../util";
+
+import type {UserEvent} from "@testing-library/user-event";
+
+const defaultProps = {
+    ...getDefaultFigureForType("polygon"),
+    onChangeProps: () => {},
+    onRemove: () => {},
+};
+
+describe("LockedPolygonSettings", () => {
+    let userEvent: UserEvent;
+    beforeEach(() => {
+        userEvent = userEventLib.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+    });
+    test("renders", () => {
+        // Arrange
+
+        // Act
+        render(<LockedPolygonSettings {...defaultProps} />, {
+            wrapper: RenderStateRoot,
+        });
+
+        // Assert
+        const titleText = screen.getByText("Polygon, 3 sides");
+        expect(titleText).toBeInTheDocument();
+    });
+
+    test("summary reflects number of sides", () => {
+        // Arrange
+
+        // Act
+        render(
+            <LockedPolygonSettings
+                {...defaultProps}
+                points={[
+                    [0, 0],
+                    [1, 1],
+                    [2, 2],
+                    [1, -1],
+                ]}
+            />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
+
+        // Assert
+        const titleText = screen.getByText("Polygon, 4 sides");
+        expect(titleText).toBeInTheDocument();
+    });
+
+    test("summary reflects color", () => {
+        // Arrange
+
+        // Act
+        render(<LockedPolygonSettings {...defaultProps} color="blue" />, {
+            wrapper: RenderStateRoot,
+        });
+
+        // Assert
+        const titleText = screen.getByLabelText(
+            "blue, stroke solid, fill none",
+        );
+        expect(titleText).toBeInTheDocument();
+    });
+
+    test("summary reflects stroke style", () => {
+        // Arrange
+
+        // Act
+        render(
+            <LockedPolygonSettings {...defaultProps} strokeStyle="dashed" />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
+
+        // Assert
+        const titleText = screen.getByLabelText(
+            "grayH, stroke dashed, fill none",
+        );
+        expect(titleText).toBeInTheDocument();
+    });
+
+    test("summary reflects fill style", () => {
+        // Arrange
+
+        // Act
+        render(<LockedPolygonSettings {...defaultProps} fillStyle="solid" />, {
+            wrapper: RenderStateRoot,
+        });
+
+        // Assert
+        const titleText = screen.getByLabelText(
+            "grayH, stroke solid, fill solid",
+        );
+        expect(titleText).toBeInTheDocument();
+    });
+
+    test("shows delete buttons when there are more than 3 points", () => {
+        // Arrange
+
+        // Act
+        render(
+            <LockedPolygonSettings
+                {...defaultProps}
+                points={[
+                    [0, 0],
+                    [1, 1],
+                    [2, 2],
+                    [1, -1],
+                ]}
+            />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
+
+        // Assert
+        const deleteButtons = screen.getAllByLabelText(/Delete polygon point/);
+        expect(deleteButtons).toHaveLength(4);
+    });
+
+    test("does not show delete buttons when there are 3 points", () => {
+        // Arrange
+
+        // Act
+        render(<LockedPolygonSettings {...defaultProps} />, {
+            wrapper: RenderStateRoot,
+        });
+
+        // Assert
+        const deleteButtons =
+            screen.queryAllByLabelText(/Delete polygon point/);
+        expect(deleteButtons).toHaveLength(0);
+    });
+
+    test("calls onToggle when header is clicked", async () => {
+        // Arrange
+        const onToggle = jest.fn();
+        render(
+            <LockedPolygonSettings {...defaultProps} onToggle={onToggle} />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
+
+        // Act
+        const header = screen.getByRole("button", {
+            name: "Polygon, 3 sides grayH, stroke solid, fill none",
+        });
+        await userEvent.click(header);
+
+        // Assert
+        expect(onToggle).toHaveBeenCalled();
+    });
+});

--- a/packages/perseus-editor/src/components/coordinate-pair-input.tsx
+++ b/packages/perseus-editor/src/components/coordinate-pair-input.tsx
@@ -7,16 +7,18 @@ import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 import type {Coord} from "@khanacademy/perseus";
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 type Props = {
     coord: [number, number];
     labels?: [string, string];
     error?: boolean;
+    style?: StyleType;
     onChange: (newCoord: Coord) => void;
 };
 
 const CoordinatePairInput = (props: Props) => {
-    const {coord, labels, error, onChange} = props;
+    const {coord, labels, error, style, onChange} = props;
 
     // Keep track of the coordinates via state as the user is editing them,
     // before they are updated in the props as a valid number.
@@ -45,39 +47,37 @@ const CoordinatePairInput = (props: Props) => {
     }
 
     return (
-        <View>
-            <View style={[styles.row, styles.spaceUnder]}>
-                <LabelMedium tag="label" style={styles.row}>
-                    {labels ? labels[0] : "x coord"}
+        <View style={[styles.row, style]}>
+            <LabelMedium tag="label" style={styles.row}>
+                {labels ? labels[0] : "x coord"}
 
-                    <Strut size={spacing.xxSmall_6} />
-                    <TextField
-                        type="number"
-                        value={coordState[0]}
-                        onChange={(newValue) => handleCoordChange(newValue, 0)}
-                        style={[
-                            styles.textField,
-                            error ? styles.errorField : undefined,
-                        ]}
-                    />
-                </LabelMedium>
-                <Strut size={spacing.medium_16} />
+                <Strut size={spacing.xxSmall_6} />
+                <TextField
+                    type="number"
+                    value={coordState[0]}
+                    onChange={(newValue) => handleCoordChange(newValue, 0)}
+                    style={[
+                        styles.textField,
+                        error ? styles.errorField : undefined,
+                    ]}
+                />
+            </LabelMedium>
+            <Strut size={spacing.medium_16} />
 
-                <LabelMedium tag="label" style={styles.row}>
-                    {labels ? labels[1] : "y coord"}
+            <LabelMedium tag="label" style={styles.row}>
+                {labels ? labels[1] : "y coord"}
 
-                    <Strut size={spacing.xxSmall_6} />
-                    <TextField
-                        type="number"
-                        value={coordState[1]}
-                        onChange={(newValue) => handleCoordChange(newValue, 1)}
-                        style={[
-                            styles.textField,
-                            error ? styles.errorField : undefined,
-                        ]}
-                    />
-                </LabelMedium>
-            </View>
+                <Strut size={spacing.xxSmall_6} />
+                <TextField
+                    type="number"
+                    value={coordState[1]}
+                    onChange={(newValue) => handleCoordChange(newValue, 1)}
+                    style={[
+                        styles.textField,
+                        error ? styles.errorField : undefined,
+                    ]}
+                />
+            </LabelMedium>
         </View>
     );
 };
@@ -87,9 +87,6 @@ const styles = StyleSheet.create({
         display: "flex",
         flexDirection: "row",
         alignItems: "center",
-    },
-    spaceUnder: {
-        marginBottom: spacing.xSmall_8,
     },
     textField: {
         width: spacing.xxxLarge_64,

--- a/packages/perseus-editor/src/components/defining-point-settings.tsx
+++ b/packages/perseus-editor/src/components/defining-point-settings.tsx
@@ -82,6 +82,7 @@ const DefiningPointSettings = (props: Props) => {
             <CoordinatePairInput
                 coord={coord}
                 error={!!error}
+                style={styles.spaceUnder}
                 onChange={(newCoords) => {
                     onChangeProps({coord: newCoords});
                 }}

--- a/packages/perseus-editor/src/components/locked-ellipse-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-ellipse-settings.tsx
@@ -75,6 +75,7 @@ const LockedEllipseSettings = (props: Props) => {
             <View style={styles.row}>
                 <CoordinatePairInput
                     coord={center}
+                    style={styles.spaceUnder}
                     onChange={(newCoords: Coord) =>
                         onChangeProps({center: newCoords})
                     }
@@ -90,6 +91,7 @@ const LockedEllipseSettings = (props: Props) => {
             <CoordinatePairInput
                 coord={radius}
                 labels={["x radius", "y radius"]}
+                style={styles.spaceUnder}
                 onChange={(newCoords: Coord) =>
                     onChangeProps({radius: newCoords})
                 }

--- a/packages/perseus-editor/src/components/locked-figure-select.tsx
+++ b/packages/perseus-editor/src/components/locked-figure-select.tsx
@@ -22,7 +22,7 @@ const LockedFigureSelect = (props: Props) => {
     const {id, onChange} = props;
 
     const figureTypes = props.showM2Features
-        ? ["point", "line", "ellipse", "vector"]
+        ? ["point", "line", "vector", "ellipse", "polygon"]
         : ["point", "line"];
 
     return (

--- a/packages/perseus-editor/src/components/locked-figure-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-figure-settings.tsx
@@ -10,11 +10,13 @@ import * as React from "react";
 import LockedEllipseSettings from "./locked-ellipse-settings";
 import LockedLineSettings from "./locked-line-settings";
 import LockedPointSettings from "./locked-point-settings";
+import LockedPolygonSettings from "./locked-polygon-settings";
 import LockedVectorSettings from "./locked-vector-settings";
 
 import type {Props as LockedEllipseProps} from "./locked-ellipse-settings";
 import type {Props as LockedLineProps} from "./locked-line-settings";
 import type {Props as LockedPointProps} from "./locked-point-settings";
+import type {Props as LockedPolygonProps} from "./locked-polygon-settings";
 import type {Props as LockedVectorProps} from "./locked-vector-settings";
 
 export type AccordionProps = {
@@ -38,6 +40,7 @@ type Props = AccordionProps &
         | LockedLineProps
         | LockedEllipseProps
         | LockedVectorProps
+        | LockedPolygonProps
     );
 
 const LockedFigureSettings = (props: Props) => {
@@ -46,16 +49,20 @@ const LockedFigureSettings = (props: Props) => {
             return <LockedPointSettings {...props} />;
         case "line":
             return <LockedLineSettings {...props} />;
-        case "ellipse":
-            if (props.showM2Features) {
-                return <LockedEllipseSettings {...props} />;
-            }
-            break;
         case "vector":
             if (props.showM2Features) {
                 return <LockedVectorSettings {...props} />;
             }
             break;
+        case "ellipse":
+            if (props.showM2Features) {
+                return <LockedEllipseSettings {...props} />;
+            }
+            break;
+        case "polygon":
+            if (props.showM2Features) {
+                return <LockedPolygonSettings {...props} />;
+            }
     }
 
     return null;

--- a/packages/perseus-editor/src/components/locked-figures-section.tsx
+++ b/packages/perseus-editor/src/components/locked-figures-section.tsx
@@ -96,13 +96,6 @@ const LockedFiguresSection = (props: Props) => {
     return (
         <View>
             {figures?.map((figure, index) => {
-                if (figure.type === "polygon") {
-                    // TODO(LEMS-1943): Implement locked polygon settings.
-                    // Remove this block once locked polygon settings are
-                    // implemented.
-                    return;
-                }
-
                 return (
                     <LockedFigureSettings
                         key={`${uniqueId}-locked-${figure}-${index}`}

--- a/packages/perseus-editor/src/components/locked-point-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-point-settings.tsx
@@ -61,6 +61,7 @@ const LockedPointSettings = (props: Props) => {
         >
             <CoordinatePairInput
                 coord={coord}
+                style={styles.spaceUnder}
                 onChange={(newCoord) => {
                     onChangeProps({coord: newCoord});
                 }}

--- a/packages/perseus-editor/src/components/locked-polygon-settings.tsx
+++ b/packages/perseus-editor/src/components/locked-polygon-settings.tsx
@@ -1,0 +1,229 @@
+import {
+    lockedFigureFillStyles,
+    type Coord,
+    type LockedFigureFillType,
+    type LockedPolygonType,
+    type LockedFigureColor,
+} from "@khanacademy/perseus";
+import Button from "@khanacademy/wonder-blocks-button";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
+import IconButton from "@khanacademy/wonder-blocks-icon-button";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import {spacing, color as wbColor} from "@khanacademy/wonder-blocks-tokens";
+import {LabelLarge, LabelMedium} from "@khanacademy/wonder-blocks-typography";
+import minusCircle from "@phosphor-icons/core/regular/minus-circle.svg";
+import plusCircle from "@phosphor-icons/core/regular/plus-circle.svg";
+import {StyleSheet} from "aphrodite";
+import * as React from "react";
+
+import ColorSelect from "./color-select";
+import CoordinatePairInput from "./coordinate-pair-input";
+import LabeledSwitch from "./labeled-switch";
+import LockedFigureSettingsAccordion from "./locked-figure-settings-accordion";
+import LockedFigureSettingsActions from "./locked-figure-settings-actions";
+import PolygonSwatch from "./polygon-swatch";
+
+import type {AccordionProps} from "./locked-figure-settings";
+
+export type Props = AccordionProps &
+    LockedPolygonType & {
+        /**
+         * Called when the delete button is pressed.
+         */
+        onRemove: () => void;
+        /**
+         * Called when the props (coords, color, etc.) are updated.
+         */
+        onChangeProps: (newProps: Partial<LockedPolygonType>) => void;
+    };
+
+const LockedPolygonSettings = (props: Props) => {
+    const {
+        points,
+        color,
+        showVertices,
+        fillStyle,
+        strokeStyle,
+        expanded,
+        onToggle,
+        onChangeProps,
+    } = props;
+
+    function handleColorChange(newValue: LockedFigureColor) {
+        onChangeProps({color: newValue});
+    }
+
+    return (
+        <LockedFigureSettingsAccordion
+            expanded={expanded}
+            onToggle={onToggle}
+            header={
+                // Summary: Polygon, number of sides, style swatch
+                <View style={styles.row}>
+                    <LabelLarge>{`Polygon, ${points.length} sides`}</LabelLarge>
+                    <Strut size={spacing.xSmall_8} />
+                    <PolygonSwatch
+                        color={color}
+                        fillStyle={fillStyle}
+                        strokeStyle={strokeStyle}
+                    />
+                </View>
+            }
+        >
+            <View style={[styles.row, styles.spaceUnder]}>
+                {/* Color */}
+                <ColorSelect
+                    selectedValue={color}
+                    onChange={handleColorChange}
+                />
+                <Strut size={spacing.medium_16} />
+
+                {/* Fill opacity */}
+                <LabelMedium tag="label" style={styles.row}>
+                    fill
+                    <Strut size={spacing.xxSmall_6} />
+                    <SingleSelect
+                        selectedValue={fillStyle}
+                        onChange={(value: LockedFigureFillType) =>
+                            onChangeProps({fillStyle: value})
+                        }
+                        // Placeholder is required, but never gets used.
+                        placeholder=""
+                    >
+                        {Object.keys(lockedFigureFillStyles).map((option) => (
+                            <OptionItem
+                                key={option}
+                                value={option}
+                                label={option}
+                            >
+                                {option}
+                            </OptionItem>
+                        ))}
+                    </SingleSelect>
+                </LabelMedium>
+            </View>
+
+            {/* Stroke style */}
+            <LabelMedium tag="label" style={[styles.row, styles.spaceUnder]}>
+                stroke
+                <Strut size={spacing.xxSmall_6} />
+                <SingleSelect
+                    selectedValue={strokeStyle}
+                    onChange={(value: "solid" | "dashed") =>
+                        onChangeProps({strokeStyle: value})
+                    }
+                    // Placeholder is required, but never gets used.
+                    placeholder=""
+                >
+                    <OptionItem value="solid" label="solid">
+                        solid
+                    </OptionItem>
+                    <OptionItem value="dashed" label="dashed">
+                        dashed
+                    </OptionItem>
+                </SingleSelect>
+            </LabelMedium>
+
+            {/* Show vertices switch */}
+            <LabeledSwitch
+                label="show vertices"
+                checked={showVertices}
+                onChange={(newValue: boolean) =>
+                    onChangeProps({showVertices: newValue})
+                }
+                style={styles.spaceUnder}
+            />
+
+            <LockedFigureSettingsAccordion
+                header={<LabelLarge>Points</LabelLarge>}
+                expanded={true}
+                containerStyle={styles.pointAccordionContainer}
+                panelStyle={styles.pointAccordionPanel}
+            >
+                {points.map((point, index) => {
+                    const pointLabel = String.fromCharCode(65 + index);
+
+                    return (
+                        <View
+                            key={`locked-polygon-point-${point[0]}-${point[1]}-index-${index}`}
+                            style={[styles.row, styles.spaceUnder]}
+                        >
+                            {/* Give the points alphabet labels */}
+                            <LabelLarge>{`${pointLabel}:`}</LabelLarge>
+                            <Strut size={spacing.medium_16} />
+                            <CoordinatePairInput
+                                coord={point}
+                                labels={["x", "y"]}
+                                onChange={(newValue: Coord) => {
+                                    const newPoints = [...points];
+                                    newPoints[index] = newValue;
+                                    props.onChangeProps({points: newPoints});
+                                }}
+                            />
+                            {
+                                // Only show the minus (delete) buttons if there are
+                                // more than 3 points. 3 points is the minimum number
+                                // of points for a polygon (triangle).
+                                points.length > 3 && (
+                                    <IconButton
+                                        aria-label={`Delete polygon point ${pointLabel}`}
+                                        icon={minusCircle}
+                                        color="destructive"
+                                        onClick={() => {
+                                            const newPoints = [...points];
+                                            newPoints.splice(index, 1);
+                                            props.onChangeProps({
+                                                points: newPoints,
+                                            });
+                                        }}
+                                        style={styles.icon}
+                                    />
+                                )
+                            }
+                        </View>
+                    );
+                })}
+                <Button
+                    kind="tertiary"
+                    startIcon={plusCircle}
+                    onClick={() => {
+                        props.onChangeProps({
+                            points: [...points, [0, 0]],
+                        });
+                    }}
+                >
+                    Add point
+                </Button>
+            </LockedFigureSettingsAccordion>
+
+            {/* Actions */}
+            <LockedFigureSettingsActions
+                onRemove={props.onRemove}
+                figureAriaLabel={`locked polygon with ${points.length} points`}
+            />
+        </LockedFigureSettingsAccordion>
+    );
+};
+
+const styles = StyleSheet.create({
+    row: {
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+    },
+    pointAccordionContainer: {
+        backgroundColor: wbColor.white,
+    },
+    pointAccordionPanel: {
+        alignItems: "start",
+    },
+    icon: {
+        marginInlineStart: spacing.xxxSmall_4,
+    },
+    spaceUnder: {
+        marginBottom: spacing.xSmall_8,
+    },
+});
+
+export default LockedPolygonSettings;

--- a/packages/perseus-editor/src/components/polygon-swatch.tsx
+++ b/packages/perseus-editor/src/components/polygon-swatch.tsx
@@ -1,0 +1,61 @@
+import {lockedFigureColors, lockedFigureFillStyles} from "@khanacademy/perseus";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {color as wbColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {StyleSheet} from "aphrodite";
+import * as React from "react";
+
+import type {
+    LockedFigureColor,
+    LockedFigureFillType,
+} from "@khanacademy/perseus";
+
+type Props = {
+    color: LockedFigureColor;
+    fillStyle: LockedFigureFillType;
+    strokeStyle: "solid" | "dashed";
+};
+
+const PolygonSwatch = (props: Props) => {
+    const {color, fillStyle, strokeStyle} = props;
+
+    return (
+        <View
+            aria-label={`${color}, stroke ${strokeStyle}, fill ${fillStyle}`}
+            style={[
+                styles.container,
+                {
+                    border: `4px ${strokeStyle} ${lockedFigureColors[color]}`,
+                },
+            ]}
+        >
+            <View
+                style={[
+                    styles.innerSquare,
+                    {
+                        backgroundColor: lockedFigureColors[color],
+                        opacity: lockedFigureFillStyles[fillStyle],
+                    },
+                ]}
+            />
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        // Add a white outline so that the color swatch is visible when
+        // the dropdown option is highlighted with its blue background.
+        outline: `2px solid ${wbColor.offWhite}`,
+        width: spacing.large_24,
+        height: spacing.large_24,
+        backgroundColor: wbColor.white,
+        alignItems: "center",
+        justifyContent: "center",
+    },
+    innerSquare: {
+        width: 20,
+        height: 20,
+    },
+});
+
+export default PolygonSwatch;

--- a/packages/perseus-editor/src/widgets/__stories__/interactive-graph-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/interactive-graph-editor.stories.tsx
@@ -217,3 +217,35 @@ export const WithLockedEllipses: StoryComponentType = {
         return <InteractiveGraphEditor {...state} onChange={dispatch} />;
     },
 };
+
+export const WithLockedPolygons: StoryComponentType = {
+    render: function Render() {
+        const reducer = (state, newState) => {
+            return {
+                ...state,
+                ...newState,
+            };
+        };
+
+        const [state, dispatch] = React.useReducer(reducer, {
+            // Use locked figures with mafs only.
+            ...mafsOptions,
+            lockedFigures: [
+                {
+                    type: "polygon",
+                    points: [
+                        [-9, 4],
+                        [-6, 4],
+                        [-6, 1],
+                        [-9, 1],
+                    ],
+                    color: "green",
+                    fillStyle: "translucent",
+                    strokeStyle: "solid",
+                },
+            ],
+        });
+
+        return <InteractiveGraphEditor {...state} onChange={dispatch} />;
+    },
+};

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
@@ -13,6 +13,7 @@ import type {PerseusGraphType} from "@khanacademy/perseus";
 
 const defaultPoint = getDefaultFigureForType("point");
 const defaultLine = getDefaultFigureForType("line");
+const defaultPolygon = getDefaultFigureForType("polygon");
 
 const baseProps = {
     apiOptions: ApiOptions.defaults,
@@ -57,7 +58,9 @@ describe("InteractiveGraphEditor locked figures", () => {
         figureType   | figureName
         ${"point"}   | ${"Point"}
         ${"line"}    | ${"Line"}
+        ${"vector"}  | ${"Vector"}
         ${"ellipse"} | ${"Ellipse"}
+        ${"polygon"} | ${"Polygon"}
     `(`$figureType basics`, ({figureType, figureName}) => {
         test("Calls onChange when a locked $figureType is added", async () => {
             // Arrange
@@ -746,6 +749,224 @@ describe("InteractiveGraphEditor locked figures", () => {
                         expect.objectContaining({
                             type: "ellipse",
                             fillStyle: "translucent",
+                        }),
+                    ],
+                }),
+            );
+        });
+    });
+
+    describe("polygons", () => {
+        test("Calls onChange when fill is changed", async () => {
+            // Arrange
+            const onChangeMock = jest.fn();
+
+            renderEditor({
+                onChange: onChangeMock,
+                lockedFigures: [defaultPolygon],
+            });
+
+            // Act
+            const fillInput = screen.getByRole("button", {
+                name: "fill",
+            });
+            await userEvent.click(fillInput);
+            const fillSelection = screen.getByText("translucent");
+            await userEvent.click(fillSelection);
+
+            // Assert
+            expect(onChangeMock).toBeCalledWith(
+                expect.objectContaining({
+                    lockedFigures: [
+                        expect.objectContaining({
+                            type: "polygon",
+                            fillStyle: "translucent",
+                        }),
+                    ],
+                }),
+            );
+        });
+
+        test("Calls onChange when stroke is changed", async () => {
+            // Arrange
+            const onChangeMock = jest.fn();
+
+            renderEditor({
+                onChange: onChangeMock,
+                lockedFigures: [defaultPolygon],
+            });
+
+            // Act
+            const strokeInput = screen.getByRole("button", {
+                name: "stroke",
+            });
+            await userEvent.click(strokeInput);
+            const strokeSelection = screen.getByText("dashed");
+            await userEvent.click(strokeSelection);
+
+            // Assert
+            expect(onChangeMock).toBeCalledWith(
+                expect.objectContaining({
+                    lockedFigures: [
+                        expect.objectContaining({
+                            type: "polygon",
+                            strokeStyle: "dashed",
+                        }),
+                    ],
+                }),
+            );
+        });
+
+        test("Calls onChange when show vertices is toggled", async () => {
+            // Arrange
+            const onChangeMock = jest.fn();
+
+            renderEditor({
+                onChange: onChangeMock,
+                lockedFigures: [defaultPolygon],
+            });
+
+            // Act
+            const toggle = screen.getByLabelText("show vertices");
+            await userEvent.click(toggle);
+
+            // Assert
+            expect(onChangeMock).toBeCalledWith(
+                expect.objectContaining({
+                    lockedFigures: [
+                        expect.objectContaining({
+                            type: "polygon",
+                            showVertices: true,
+                        }),
+                    ],
+                }),
+            );
+        });
+
+        test("Calls onChange when a point is added", async () => {
+            // Arrange
+            const onChangeMock = jest.fn();
+
+            renderEditor({
+                onChange: onChangeMock,
+                lockedFigures: [defaultPolygon],
+            });
+
+            // Act
+            const addPointButton = screen.getByRole("button", {
+                name: "Add point",
+            });
+            await userEvent.click(addPointButton);
+
+            // Assert
+            expect(onChangeMock).toBeCalledWith(
+                expect.objectContaining({
+                    lockedFigures: [
+                        expect.objectContaining({
+                            type: "polygon",
+                            points: [...defaultPolygon.points, [0, 0]],
+                        }),
+                    ],
+                }),
+            );
+        });
+
+        test("Calls onChange when a point is removed", async () => {
+            // Arrange
+            const onChangeMock = jest.fn();
+
+            const squarePolygonPoints = [
+                [-9, 4],
+                [-6, 4],
+                [-6, 1],
+                [-9, 1],
+            ];
+
+            renderEditor({
+                onChange: onChangeMock,
+                lockedFigures: [
+                    {
+                        ...defaultPolygon,
+                        points: squarePolygonPoints,
+                    },
+                ],
+            });
+
+            // Act
+            const deleteButton = screen.getByLabelText(
+                "Delete polygon point A",
+            );
+            await userEvent.click(deleteButton);
+
+            // Assert
+            expect(onChangeMock).toBeCalledWith(
+                expect.objectContaining({
+                    lockedFigures: [
+                        expect.objectContaining({
+                            type: "polygon",
+                            points: squarePolygonPoints.slice(1),
+                        }),
+                    ],
+                }),
+            );
+        });
+
+        test("Calls onChange when a point's x coordinate is changed", async () => {
+            // Arrange
+            const onChangeMock = jest.fn();
+
+            renderEditor({
+                onChange: onChangeMock,
+                lockedFigures: [defaultPolygon],
+            });
+
+            // Act
+            const xCoordInput = screen.getAllByLabelText("x")[0];
+            await userEvent.clear(xCoordInput);
+            await userEvent.type(xCoordInput, "7");
+
+            // Assert
+            expect(onChangeMock).toBeCalledWith(
+                expect.objectContaining({
+                    lockedFigures: [
+                        expect.objectContaining({
+                            type: "polygon",
+                            points: [
+                                [7, 2],
+                                [-1, 0],
+                                [1, 0],
+                            ],
+                        }),
+                    ],
+                }),
+            );
+        });
+
+        test("Calls onChange when a point's y coordinate is changed", async () => {
+            // Arrange
+            const onChangeMock = jest.fn();
+
+            renderEditor({
+                onChange: onChangeMock,
+                lockedFigures: [defaultPolygon],
+            });
+
+            // Act
+            const yCoordInput = screen.getAllByLabelText("y")[0];
+            await userEvent.clear(yCoordInput);
+            await userEvent.type(yCoordInput, "7");
+
+            // Assert
+            expect(onChangeMock).toBeCalledWith(
+                expect.objectContaining({
+                    lockedFigures: [
+                        expect.objectContaining({
+                            type: "polygon",
+                            points: [
+                                [0, 7],
+                                [-1, 0],
+                                [1, 0],
+                            ],
                         }),
                     ],
                 }),

--- a/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
@@ -2154,8 +2154,17 @@ export const segmentWithLockedFigures: PerseusRenderer =
     interactiveGraphQuestionBuilder()
         .addLockedPointAt(-7, -7)
         .addLockedLine([-7, -5], [2, -3])
-        .addLockedEllipse([0, 5], [4, 2], {angle: Math.PI / 4, color: "green"})
         .addLockedVector([0, 0], [8, 2], "purple")
+        .addLockedEllipse([0, 5], [4, 2], {angle: Math.PI / 4, color: "blue"})
+        .addLockedPolygon(
+            [
+                [-9, 4],
+                [-6, 4],
+                [-6, 1],
+                [-9, 1],
+            ],
+            {color: "pink"},
+        )
         .build();
 
 export const quadraticQuestion: PerseusRenderer = {

--- a/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
@@ -2154,7 +2154,7 @@ export const segmentWithLockedFigures: PerseusRenderer =
     interactiveGraphQuestionBuilder()
         .addLockedPointAt(-7, -7)
         .addLockedLine([-7, -5], [2, -3])
-        .addLockedEllipse([0, 5], [4, 2], {angle: Math.PI / 4})
+        .addLockedEllipse([0, 5], [4, 2], {angle: Math.PI / 4, color: "green"})
         .addLockedVector([0, 0], [8, 2], "purple")
         .build();
 


### PR DESCRIPTION
## Summary:

Adding/editing/deleting Locked Polygon UI!

Issue: https://khanacademy.atlassian.net/browse/LEMS-1943

## Test plan:
[Editor page storybook](http://localhost:6006/?path=/story/perseuseditor-editorpage--mafs-with-locked-figures-m-2-flag)
[Locked Polygon Settings](http://localhost:6006/?path=/docs/perseuseditor-components-locked-polygon-settings--docs)

| 3 points, default | > 3 points, nondefault settings |
| --- | --- |
| <img width="359" alt="Screenshot 2024-06-17 at 5 07 10 PM" src="https://github.com/Khan/perseus/assets/13231763/eb3730ad-26ab-4b5f-abb1-cba662ce0f1c"> | <img width="356" alt="Screenshot 2024-06-17 at 5 07 19 PM" src="https://github.com/Khan/perseus/assets/13231763/4721b4f3-d086-4220-af3a-3a0efd282307"> |
