### PR TITLE
[🔥AUDIT🔥] Add TODO comment

### DIFF
--- a/.changeset/lazy-readers-live.md
+++ b/.changeset/lazy-readers-live.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Add TODO comment

--- a/packages/perseus/src/init.ts
+++ b/packages/perseus/src/init.ts
@@ -5,6 +5,8 @@ import * as Widgets from "./widgets";
 declare const MathJax: any;
 
 export type PerseusOptions = {
+    // TODO(LEMS-1608): remove skipMathJax once we have completely removed the
+    // legacy MathJax 2 renderer from webapp.
     skipMathJax: boolean;
 };
 


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

The `skipMathJax` parameter to `Perseus.init()` controls whether MathJax 2 gets configured
during the `init` call. This is gross because Perseus doesn't even import MathJax 2: it
depends on a global `MathJax` variable existing whenever `skipMathJax` is not passed.

`skipMathJax` is almost always being passed in webapp, except in a couple cases in the 
exercise editor where we need to use the legacy KaTeX+MathJax2 math renderer. The
story referenced in the TODO comment is about removing that legacy renderer from webapp
once all mobile app versions that use it have been deprecated. Once MathJax 2 is gone for
good, we should be able to remove `skipMathJax` and the code it controls from Perseus.

Issue: none

## Test plan:

All CI checks should pass.