### PR TITLE
Add polygon stories to interactive graph and the editor

### DIFF
--- a/packages/perseus-editor/src/widgets/__stories__/interactive-graph-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/interactive-graph-editor.stories.tsx
@@ -92,6 +92,35 @@ export const WithMafs: StoryComponentType = {
 };
 
 /**
+ * Example of what the InteractiveGraphEditor experience is when using
+ * a Mafs-based InteractiveGraph to create Polygons.
+ */
+export const WithMafsPolygon: StoryComponentType = {
+    render: function Render() {
+        const reducer = (state, newState) => {
+            return {
+                ...state,
+                ...newState,
+            };
+        };
+
+        const [state, dispatch] = React.useReducer(reducer, {
+            ...mafsOptions,
+            graph: {type: "polygon"},
+            correct: {
+                type: "polygon",
+                numSides: 4,
+                showAngles: true,
+                showSides: true,
+                snapTo: "angles",
+            },
+        });
+
+        return <InteractiveGraphEditor {...state} onChange={dispatch} />;
+    },
+};
+
+/**
  * This InteractiveGraphEditor has locked points.
  *
  * Locked figures are graph elements such as points, lines, line segements,

--- a/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
@@ -32,6 +32,7 @@ const mafsOptions = {
         flags: {
             mafs: {
                 segment: true,
+                polygon: true,
             },
         },
     },
@@ -69,6 +70,10 @@ export const Point = (args: StoryArgs): React.ReactElement => (
 
 export const Polygon = (args: StoryArgs): React.ReactElement => (
     <RendererWithDebugUI question={polygonQuestion} />
+);
+
+export const PolygonWithMafs = (args: StoryArgs): React.ReactElement => (
+    <RendererWithDebugUI {...mafsOptions} question={polygonQuestion} />
 );
 
 export const Ray = (args: StoryArgs): React.ReactElement => (


### PR DESCRIPTION
## Summary:
Adding some more stories for better visibility and more testing opportunities.

Issue: LEMS-1985

Interactive Graph Editor: 
<img height="450px" src=https://github.com/Khan/perseus/assets/60857422/c44a381a-9e0e-4134-b62c-afdc1ec8cca5)>

Interactive Graph:
<img width="300" src=https://github.com/Khan/perseus/assets/60857422/a7395d36-980a-4cc9-82fa-8923b2a0e877>


## Test plan:
- Check out the Polygon with Mafs story in the Interactive graph section (http://localhost:6006/?path=/story/perseus-widgets-interactive-graph--polygon-with-mafs) and confirm it is there and uses Mafs
- Check out the With Mafs Polygon story in the Interactive graph editor section (http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph-editor--with-mafs-polygon) and confirm it is there and uses Mafs