### PR TITLE
Fallback to legacy graph with unlimited sides polygon

### DIFF
--- a/.changeset/nervous-owls-retire.md
+++ b/.changeset/nervous-owls-retire.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Polygon interactive graphs use the legacy graph when numSides is set to unlimited

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -1815,6 +1815,18 @@ class InteractiveGraph extends React.Component<Props, State> {
     }
 
     render() {
+        if (
+            this.props.graph.type === "polygon" &&
+            this.props.graph.numSides === "unlimited"
+        ) {
+            return (
+                <LegacyInteractiveGraph
+                    ref={this.legacyGraphRef}
+                    {...this.props}
+                />
+            );
+        }
+
         // Mafs shim
         if (this.props.apiOptions?.flags?.["mafs"]?.[this.props.graph.type]) {
             const box = getInteractiveBoxFromSizeClass(


### PR DESCRIPTION
## Summary:
Polygon graphs are almost fully migrated, but work on the unlimited sides feature is not slated to be completed until later. To allow us to move foward with Polygon QE and play testing, we are adding a fallback to the legacy graph for when `numSides` is set to `unlimited`. This can be easily removed once the unlimited sides feature is implemented.

Issue: LEMS-2105

## Test plan:
- Open local host storybook and navigate to the [Interactive Graph Editor withMafs story](http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph-editor--with-mafs)
- Confirm the Line Segment graph is using Mafs
- Change the graph type to Polygon and confirm it is also using Mafs
- Change number of sides to a new number. Confirm it is a Mafs graph. Change number of sides to unlimited. Confirm it is a legacy graph.
- Change back to a specific number of sides and confirm it reverts to a Mafs graph. Change to another graph type and confirm it is also still a Mafs graph.
- Confirm all checks pass.