### PR TITLE
[Interactive Graph] Update the builder with all currently migrated graph types

### DIFF
--- a/.changeset/short-badgers-wonder.md
+++ b/.changeset/short-badgers-wonder.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+[Interactive Graph] Update the interactive graph builder with all currently migrated graph types

--- a/packages/perseus-editor/src/__stories__/editor-page.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/editor-page.stories.tsx
@@ -7,7 +7,17 @@ import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 import {EditorPage} from "..";
-import {segmentWithLockedFigures} from "../../../perseus/src/widgets/__testdata__/interactive-graph.testdata";
+import {
+    circleWithStartingCoordsQuestion,
+    linearSystemWithStartingCoordsQuestion,
+    linearWithStartingCoordsQuestion,
+    quadraticWithStartingCoordsQuestion,
+    rayWithStartingCoordsQuestion,
+    segmentWithLockedFigures,
+    segmentWithStartingCoordsQuestion,
+    segmentsWithStartingCoordsQuestion,
+    sinusoidWithStartingCoordsQuestion,
+} from "../../../perseus/src/widgets/__testdata__/interactive-graph.testdata";
 import {registerAllWidgetsAndEditorsForTesting} from "../util/register-all-widgets-and-editors-for-testing";
 
 import EditorPageWithStorybookPreview from "./editor-page-with-storybook-preview";
@@ -31,6 +41,77 @@ const onChangeAction = action("onChange");
 export const Demo = (): React.ReactElement => {
     return <EditorPageWithStorybookPreview />;
 };
+
+export const InteractiveGraphSegmentWithStartingCoords =
+    (): React.ReactElement => {
+        return (
+            <EditorPageWithStorybookPreview
+                question={segmentWithStartingCoordsQuestion}
+            />
+        );
+    };
+
+export const InteractiveGraphSegmentsWithStartingCoords =
+    (): React.ReactElement => {
+        return (
+            <EditorPageWithStorybookPreview
+                question={segmentsWithStartingCoordsQuestion}
+            />
+        );
+    };
+
+export const InteractiveGraphLinearWithStartingCoords =
+    (): React.ReactElement => {
+        return (
+            <EditorPageWithStorybookPreview
+                question={linearWithStartingCoordsQuestion}
+            />
+        );
+    };
+
+export const InteractiveGraphLinearSystemWithStartingCoords =
+    (): React.ReactElement => {
+        return (
+            <EditorPageWithStorybookPreview
+                question={linearSystemWithStartingCoordsQuestion}
+            />
+        );
+    };
+
+export const InteractiveGraphRayWithStartingCoords = (): React.ReactElement => {
+    return (
+        <EditorPageWithStorybookPreview
+            question={rayWithStartingCoordsQuestion}
+        />
+    );
+};
+
+export const InteractiveGraphCircleWithStartingCoords =
+    (): React.ReactElement => {
+        return (
+            <EditorPageWithStorybookPreview
+                question={circleWithStartingCoordsQuestion}
+            />
+        );
+    };
+
+export const InteractiveGraphQuadraticWithStartingCoords =
+    (): React.ReactElement => {
+        return (
+            <EditorPageWithStorybookPreview
+                question={quadraticWithStartingCoordsQuestion}
+            />
+        );
+    };
+
+export const InteractiveGraphSinusoidWithStartingCoords =
+    (): React.ReactElement => {
+        return (
+            <EditorPageWithStorybookPreview
+                question={sinusoidWithStartingCoordsQuestion}
+            />
+        );
+    };
 
 export const MafsWithLockedFiguresCurrent = (): React.ReactElement => {
     return (

--- a/packages/perseus/src/widgets/__stories__/interactive-graph-regression.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/interactive-graph-regression.stories.tsx
@@ -153,7 +153,7 @@ export const MafsWithMultipleSegments = (
     args: StoryArgs,
 ): React.ReactElement => (
     <MafsQuestionRenderer
-        question={interactiveGraphQuestionBuilder().withSegments(3).build()}
+        question={interactiveGraphQuestionBuilder().withNumSegments(3).build()}
     />
 );
 

--- a/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
@@ -1091,6 +1091,80 @@ export const segmentQuestion: PerseusRenderer = {
     },
 };
 
+export const segmentWithStartingCoordsQuestion: PerseusRenderer =
+    interactiveGraphQuestionBuilder()
+        .withSegments(1, [
+            [
+                [0, 0],
+                [2, 2],
+            ],
+        ])
+        .build();
+
+export const segmentsWithStartingCoordsQuestion: PerseusRenderer =
+    interactiveGraphQuestionBuilder()
+        .withSegments(2, [
+            [
+                [0, 0],
+                [2, 2],
+            ],
+            [
+                [0, 2],
+                [2, 0],
+            ],
+        ])
+        .build();
+
+export const linearWithStartingCoordsQuestion: PerseusRenderer =
+    interactiveGraphQuestionBuilder()
+        .withLinear([
+            [3, 0],
+            [3, 3],
+        ])
+        .build();
+
+export const linearSystemWithStartingCoordsQuestion: PerseusRenderer =
+    interactiveGraphQuestionBuilder()
+        .withLinearSystem([
+            [
+                [-3, 0],
+                [-3, 3],
+            ],
+            [
+                [3, 0],
+                [3, 3],
+            ],
+        ])
+        .build();
+
+export const rayWithStartingCoordsQuestion: PerseusRenderer =
+    interactiveGraphQuestionBuilder()
+        .withRay([
+            [3, 0],
+            [3, 3],
+        ])
+        .build();
+
+export const circleWithStartingCoordsQuestion: PerseusRenderer =
+    interactiveGraphQuestionBuilder().withCircle([9, 9]).build();
+
+export const quadraticWithStartingCoordsQuestion: PerseusRenderer =
+    interactiveGraphQuestionBuilder()
+        .withQuadratic([
+            [-1, -1],
+            [0, 0],
+            [1, -1],
+        ])
+        .build();
+
+export const sinusoidWithStartingCoordsQuestion: PerseusRenderer =
+    interactiveGraphQuestionBuilder()
+        .withSinusoid([
+            [0, 0],
+            [1, -1],
+        ])
+        .build();
+
 export const segmentWithLockedPointsQuestion: PerseusRenderer = {
     content:
         "Line segment $\\overline{OG}$ is rotated $180^\\circ$ about the point $(-2,4)$.  \n\n**Draw the image of this rotation using the interactive graph.**\n\n*The direction of a rotation by a positive angle is counter-clockwise.* \n\n[[☃ interactive-graph 1]]\n\n",

--- a/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
@@ -1093,7 +1093,7 @@ export const segmentQuestion: PerseusRenderer = {
 
 export const segmentWithStartingCoordsQuestion: PerseusRenderer =
     interactiveGraphQuestionBuilder()
-        .withSegments(1, [
+        .withSegments([
             [
                 [0, 0],
                 [2, 2],
@@ -1103,7 +1103,7 @@ export const segmentWithStartingCoordsQuestion: PerseusRenderer =
 
 export const segmentsWithStartingCoordsQuestion: PerseusRenderer =
     interactiveGraphQuestionBuilder()
-        .withSegments(2, [
+        .withSegments([
             [
                 [0, 0],
                 [2, 2],

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
@@ -93,6 +93,209 @@ describe("InteractiveGraphQuestionBuilder", () => {
         );
     });
 
+    it("creates a segment graph with start coords", () => {
+        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withSegments(1, [
+                [
+                    [0, 0],
+                    [2, 2],
+                ],
+            ])
+            .build();
+        const graph = question.widgets["interactive-graph 1"];
+
+        expect(graph.options).toEqual(
+            expect.objectContaining({
+                graph: {
+                    type: "segment",
+                    numSegments: 1,
+                    coords: [
+                        [
+                            [0, 0],
+                            [2, 2],
+                        ],
+                    ],
+                },
+                correct: {
+                    type: "segment",
+                    numSegments: 1,
+                    coords: [
+                        [
+                            [-7, 7],
+                            [2, 5],
+                        ],
+                    ],
+                },
+            }),
+        );
+    });
+
+    it("creates a linear graph", () => {
+        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withLinear()
+            .build();
+
+        const graph = question.widgets["interactive-graph 1"];
+        expect(graph.options).toEqual(
+            expect.objectContaining({
+                graph: {type: "linear"},
+                correct: {
+                    type: "linear",
+                    coords: [
+                        [-10, -5],
+                        [10, 5],
+                    ],
+                },
+            }),
+        );
+    });
+
+    it("creates a linear graph with start coords", () => {
+        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withLinear([
+                [3, 0],
+                [3, 3],
+            ])
+            .build();
+        const graph = question.widgets["interactive-graph 1"];
+        expect(graph.options).toEqual(
+            expect.objectContaining({
+                graph: {
+                    type: "linear",
+                    coords: [
+                        [3, 0],
+                        [3, 3],
+                    ],
+                },
+                correct: {
+                    type: "linear",
+                    coords: [
+                        [-10, -5],
+                        [10, 5],
+                    ],
+                },
+            }),
+        );
+    });
+
+    it("creates a linear system graph", () => {
+        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withLinearSystem()
+            .build();
+        const graph = question.widgets["interactive-graph 1"];
+        expect(graph.options).toEqual(
+            expect.objectContaining({
+                graph: {type: "linear-system"},
+                correct: {
+                    type: "linear-system",
+                    coords: [
+                        [
+                            [-10, -5],
+                            [10, 5],
+                        ],
+                        [
+                            [-10, 5],
+                            [10, -5],
+                        ],
+                    ],
+                },
+            }),
+        );
+    });
+
+    it("creates a linear system graph with start coords", () => {
+        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withLinearSystem([
+                [
+                    [-3, 0],
+                    [-3, 3],
+                ],
+                [
+                    [3, 0],
+                    [3, 3],
+                ],
+            ])
+            .build();
+        const graph = question.widgets["interactive-graph 1"];
+        expect(graph.options).toEqual(
+            expect.objectContaining({
+                graph: {
+                    type: "linear-system",
+                    coords: [
+                        [
+                            [-3, 0],
+                            [-3, 3],
+                        ],
+                        [
+                            [3, 0],
+                            [3, 3],
+                        ],
+                    ],
+                },
+                correct: {
+                    type: "linear-system",
+                    coords: [
+                        [
+                            [-10, -5],
+                            [10, 5],
+                        ],
+                        [
+                            [-10, 5],
+                            [10, -5],
+                        ],
+                    ],
+                },
+            }),
+        );
+    });
+
+    it("creates a ray graph", () => {
+        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withRay()
+            .build();
+        const graph = question.widgets["interactive-graph 1"];
+        expect(graph.options).toEqual(
+            expect.objectContaining({
+                graph: {type: "ray"},
+                correct: {
+                    type: "ray",
+                    coords: [
+                        [-10, -5],
+                        [10, 5],
+                    ],
+                },
+            }),
+        );
+    });
+
+    it("creates a ray graph with start coords", () => {
+        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withRay([
+                [3, 0],
+                [3, 3],
+            ])
+            .build();
+        const graph = question.widgets["interactive-graph 1"];
+        expect(graph.options).toEqual(
+            expect.objectContaining({
+                graph: {
+                    type: "ray",
+                    coords: [
+                        [3, 0],
+                        [3, 3],
+                    ],
+                },
+                correct: {
+                    type: "ray",
+                    coords: [
+                        [-10, -5],
+                        [10, 5],
+                    ],
+                },
+            }),
+        );
+    });
+
     it("creates a circle graph", () => {
         const question: PerseusRenderer = interactiveGraphQuestionBuilder()
             .withCircle()
@@ -102,6 +305,117 @@ describe("InteractiveGraphQuestionBuilder", () => {
             expect.objectContaining({
                 graph: {type: "circle"},
                 correct: {type: "circle", radius: 5, center: [0, 0]},
+            }),
+        );
+    });
+
+    it("creates a circle graph with start coords", () => {
+        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withCircle([9, 9])
+            .build();
+        const graph = question.widgets["interactive-graph 1"];
+        expect(graph.options).toEqual(
+            expect.objectContaining({
+                graph: {type: "circle", center: [9, 9], radius: 5},
+                correct: {type: "circle", radius: 5, center: [0, 0]},
+            }),
+        );
+    });
+
+    it("creates a quadratic graph", () => {
+        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withQuadratic()
+            .build();
+        const graph = question.widgets["interactive-graph 1"];
+        expect(graph.options).toEqual(
+            expect.objectContaining({
+                graph: {type: "quadratic"},
+                correct: {
+                    type: "quadratic",
+                    coords: [
+                        [-10, 5],
+                        [10, 5],
+                        [0, -5],
+                    ],
+                },
+            }),
+        );
+    });
+
+    it("creates a quadratic graph with start coords", () => {
+        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withQuadratic([
+                [-1, -1],
+                [0, 0],
+                [1, -1],
+            ])
+            .build();
+        const graph = question.widgets["interactive-graph 1"];
+        expect(graph.options).toEqual(
+            expect.objectContaining({
+                graph: {
+                    type: "quadratic",
+                    coords: [
+                        [-1, -1],
+                        [0, 0],
+                        [1, -1],
+                    ],
+                },
+                correct: {
+                    type: "quadratic",
+                    coords: [
+                        [-10, 5],
+                        [10, 5],
+                        [0, -5],
+                    ],
+                },
+            }),
+        );
+    });
+
+    it("creates a sinusoid graph", () => {
+        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withSinusoid()
+            .build();
+        const graph = question.widgets["interactive-graph 1"];
+        expect(graph.options).toEqual(
+            expect.objectContaining({
+                graph: {type: "sinusoid"},
+                correct: {
+                    type: "sinusoid",
+                    coords: [
+                        [-10, 5],
+                        [10, 5],
+                    ],
+                },
+            }),
+        );
+    });
+
+    it("creates a sinusoid graph with start coords", () => {
+        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withSinusoid([
+                [0, 0],
+                [1, -1],
+            ])
+            .build();
+        const graph = question.widgets["interactive-graph 1"];
+        expect(graph.options).toEqual(
+            expect.objectContaining({
+                graph: {
+                    type: "sinusoid",
+                    coords: [
+                        [0, 0],
+                        [1, -1],
+                    ],
+                },
+                correct: {
+                    type: "sinusoid",
+                    coords: [
+                        [-10, 5],
+                        [10, 5],
+                    ],
+                },
             }),
         );
     });

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
@@ -68,9 +68,9 @@ describe("InteractiveGraphQuestionBuilder", () => {
         expect(graph.options.step).toEqual([7, 8]);
     });
 
-    it("creates a segment graph with a specified number of segments", () => {
+    it("creates a default segment graph with a specified number of segments", () => {
         const question: PerseusRenderer = interactiveGraphQuestionBuilder()
-            .withSegments(3)
+            .withNumSegments(3)
             .build();
         const graph = question.widgets["interactive-graph 1"];
 
@@ -95,7 +95,7 @@ describe("InteractiveGraphQuestionBuilder", () => {
 
     it("creates a segment graph with start coords", () => {
         const question: PerseusRenderer = interactiveGraphQuestionBuilder()
-            .withSegments(1, [
+            .withSegments([
                 [
                     [0, 0],
                     [2, 2],
@@ -120,6 +120,55 @@ describe("InteractiveGraphQuestionBuilder", () => {
                     type: "segment",
                     numSegments: 1,
                     coords: [
+                        [
+                            [-7, 7],
+                            [2, 5],
+                        ],
+                    ],
+                },
+            }),
+        );
+    });
+
+    it("creates a graph with multiple segments with start coords", () => {
+        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withSegments([
+                [
+                    [0, 0],
+                    [2, 2],
+                ],
+                [
+                    [3, 3],
+                    [5, 5],
+                ],
+            ])
+            .build();
+        const graph = question.widgets["interactive-graph 1"];
+
+        expect(graph.options).toEqual(
+            expect.objectContaining({
+                graph: {
+                    type: "segment",
+                    numSegments: 2,
+                    coords: [
+                        [
+                            [0, 0],
+                            [2, 2],
+                        ],
+                        [
+                            [3, 3],
+                            [5, 5],
+                        ],
+                    ],
+                },
+                correct: {
+                    type: "segment",
+                    numSegments: 2,
+                    coords: [
+                        [
+                            [-7, 7],
+                            [2, 5],
+                        ],
                         [
                             [-7, 7],
                             [2, 5],

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -101,6 +101,7 @@ class InteractiveGraphQuestionBuilder {
 
     withSegments(
         numSegments: number,
+        // This should be the same length as numSegments.
         startCoords?: CollinearTuple[],
     ): InteractiveGraphQuestionBuilder {
         this.interactiveFigureConfig = new SegmentGraphConfig(

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -100,14 +100,17 @@ class InteractiveGraphQuestionBuilder {
     }
 
     withSegments(
-        numSegments: number,
-        // This should be the same length as numSegments.
-        startCoords?: CollinearTuple[],
+        startCoords: CollinearTuple[],
     ): InteractiveGraphQuestionBuilder {
         this.interactiveFigureConfig = new SegmentGraphConfig(
-            numSegments,
+            startCoords.length,
             startCoords,
         );
+        return this;
+    }
+
+    withNumSegments(numSegments: number): InteractiveGraphQuestionBuilder {
+        this.interactiveFigureConfig = new SegmentGraphConfig(numSegments);
         return this;
     }
 

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -9,7 +9,9 @@ import type {
     PerseusGraphType,
     PerseusRenderer,
     LockedPolygonType,
+    CollinearTuple,
 } from "../../perseus-types";
+import type {Coord} from "@khanacademy/perseus";
 import type {Interval, vec} from "mafs";
 
 export function interactiveGraphQuestionBuilder(): InteractiveGraphQuestionBuilder {
@@ -97,13 +99,50 @@ class InteractiveGraphQuestionBuilder {
         return this;
     }
 
-    withSegments(numSegments: number): InteractiveGraphQuestionBuilder {
-        this.interactiveFigureConfig = new SegmentGraphConfig(numSegments);
+    withSegments(
+        numSegments: number,
+        startCoords?: CollinearTuple[],
+    ): InteractiveGraphQuestionBuilder {
+        this.interactiveFigureConfig = new SegmentGraphConfig(
+            numSegments,
+            startCoords,
+        );
         return this;
     }
 
-    withCircle(): InteractiveGraphQuestionBuilder {
-        this.interactiveFigureConfig = new CircleGraphConfig();
+    withLinear(startCoords?: CollinearTuple): InteractiveGraphQuestionBuilder {
+        this.interactiveFigureConfig = new LinearConfig(startCoords);
+        return this;
+    }
+
+    withLinearSystem(
+        startCoords?: CollinearTuple[],
+    ): InteractiveGraphQuestionBuilder {
+        this.interactiveFigureConfig = new LinearSystemConfig(startCoords);
+        return this;
+    }
+
+    withRay(startCoords?: CollinearTuple): InteractiveGraphQuestionBuilder {
+        this.interactiveFigureConfig = new RayConfig(startCoords);
+        return this;
+    }
+
+    withCircle(startCoords?: Coord): InteractiveGraphQuestionBuilder {
+        this.interactiveFigureConfig = new CircleGraphConfig(startCoords);
+        return this;
+    }
+
+    withQuadratic(
+        startCoords?: [Coord, Coord, Coord],
+    ): InteractiveGraphQuestionBuilder {
+        this.interactiveFigureConfig = new QuadraticConfig(startCoords);
+        return this;
+    }
+
+    withSinusoid(
+        startCoords?: [Coord, Coord],
+    ): InteractiveGraphQuestionBuilder {
+        this.interactiveFigureConfig = new SinusoidGraphConfig(startCoords);
         return this;
     }
 
@@ -219,8 +258,11 @@ interface InteractiveFigureConfig {
 
 class SegmentGraphConfig implements InteractiveFigureConfig {
     private numSegments: number;
-    constructor(numSegments: number) {
+    private startCoords?: CollinearTuple[];
+
+    constructor(numSegments: number, startCoords?: CollinearTuple[]) {
         this.numSegments = numSegments;
+        this.startCoords = startCoords;
     }
 
     correct(): PerseusGraphType {
@@ -235,17 +277,148 @@ class SegmentGraphConfig implements InteractiveFigureConfig {
     }
 
     graph(): PerseusGraphType {
-        return {type: "segment", numSegments: this.numSegments};
+        return {
+            type: "segment",
+            numSegments: this.numSegments,
+            coords: this.startCoords,
+        };
+    }
+}
+
+class LinearConfig implements InteractiveFigureConfig {
+    private startCoords?: CollinearTuple;
+
+    constructor(startCoords?: CollinearTuple) {
+        this.startCoords = startCoords;
+    }
+
+    correct(): PerseusGraphType {
+        return {
+            type: "linear",
+            coords: [
+                [-10, -5],
+                [10, 5],
+            ],
+        };
+    }
+
+    graph(): PerseusGraphType {
+        return {type: "linear", coords: this.startCoords};
+    }
+}
+
+class LinearSystemConfig implements InteractiveFigureConfig {
+    private startCoords?: CollinearTuple[];
+
+    constructor(startCoords?: CollinearTuple[]) {
+        this.startCoords = startCoords;
+    }
+
+    correct(): PerseusGraphType {
+        return {
+            type: "linear-system",
+            coords: [
+                [
+                    [-10, -5],
+                    [10, 5],
+                ],
+                [
+                    [-10, 5],
+                    [10, -5],
+                ],
+            ],
+        };
+    }
+
+    graph(): PerseusGraphType {
+        return {type: "linear-system", coords: this.startCoords};
+    }
+}
+
+class RayConfig implements InteractiveFigureConfig {
+    private startCoords?: CollinearTuple;
+
+    constructor(startCoords?: CollinearTuple) {
+        this.startCoords = startCoords;
+    }
+
+    correct(): PerseusGraphType {
+        return {
+            type: "ray",
+            coords: [
+                [-10, -5],
+                [10, 5],
+            ],
+        };
+    }
+
+    graph(): PerseusGraphType {
+        return {type: "ray", coords: this.startCoords};
     }
 }
 
 class CircleGraphConfig implements InteractiveFigureConfig {
+    private startCoords?: Coord;
+
+    constructor(startCoords?: Coord) {
+        this.startCoords = startCoords;
+    }
+
     correct(): PerseusGraphType {
         return {type: "circle", radius: 5, center: [0, 0]};
     }
 
     graph(): PerseusGraphType {
+        if (this.startCoords) {
+            return {type: "circle", center: this.startCoords, radius: 5};
+        }
+
         return {type: "circle"};
+    }
+}
+
+class QuadraticConfig implements InteractiveFigureConfig {
+    private startCoords?: [Coord, Coord, Coord];
+
+    constructor(startCoords?: [Coord, Coord, Coord]) {
+        this.startCoords = startCoords;
+    }
+
+    correct(): PerseusGraphType {
+        return {
+            type: "quadratic",
+            coords: [
+                [-10, 5],
+                [10, 5],
+                [0, -5],
+            ],
+        };
+    }
+
+    graph(): PerseusGraphType {
+        return {type: "quadratic", coords: this.startCoords};
+    }
+}
+
+class SinusoidGraphConfig implements InteractiveFigureConfig {
+    private startCoords?: [Coord, Coord];
+
+    constructor(startCoords?: [Coord, Coord]) {
+        this.startCoords = startCoords;
+    }
+
+    correct(): PerseusGraphType {
+        return {
+            type: "sinusoid",
+            coords: [
+                [-10, 5],
+                [10, 5],
+            ],
+        };
+    }
+
+    graph(): PerseusGraphType {
+        return {type: "sinusoid", coords: this.startCoords};
     }
 }
 


### PR DESCRIPTION
## Summary:

I updated the builder utility with all currently migrated graph types. This
meant adding linear, linear system, ray, quadratic, and sinusoid.

I also added the ability to give them all starting coords. This is necessary
to prove that the starting coords can be set at all.

Now that it's clear they can be set, we can move onto adding the ability
to edit these coordinates in the editor UI in the next task.

NOTE: The task also includes start coords for the Points graph type, but
that doesn't seem to have the mafs flag on in storybook yet, so I didn't
include that here.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2051

## Test plan:
Storybook
- [segment](http://localhost:6006/?path=/story/perseuseditor-editorpage--interactive-graph-segment-with-starting-coords)
- [multiple segments](http://localhost:6006/?path=/story/perseuseditor-editorpage--interactive-graph-segments-with-starting-coords)
- [linear](http://localhost:6006/?path=/story/perseuseditor-editorpage--interactive-graph-linear-with-starting-coords)
- [linear system](http://localhost:6006/?path=/story/perseuseditor-editorpage--interactive-graph-linear-system-with-starting-coords)
- [ray](http://localhost:6006/?path=/story/perseuseditor-editorpage--interactive-graph-ray-with-starting-coords)
- [circle](http://localhost:6006/?path=/story/perseuseditor-editorpage--interactive-graph-circle-with-starting-coords)
- [quadratic](http://localhost:6006/?path=/story/perseuseditor-editorpage--interactive-graph-quadratic-with-starting-coords)
- [sinusoid](http://localhost:6006/?path=/story/perseuseditor-editorpage--interactive-graph-sinusoid-with-starting-coords)

## Storybook previews showing custom start coords

| segment | segments | linear |
| --- | --- | --- |
| <img width="495" alt="Screenshot 2024-06-21 at 5 08 25 PM" src="https://github.com/Khan/perseus/assets/13231763/c41f8d36-f515-44d4-85d7-75fa2f9eb55c"> | <img width="483" alt="Screenshot 2024-06-21 at 5 08 31 PM" src="https://github.com/Khan/perseus/assets/13231763/42414e10-dbe5-4485-a070-40cdbf8f4e72"> | <img width="483" alt="Screenshot 2024-06-21 at 5 08 36 PM" src="https://github.com/Khan/perseus/assets/13231763/7d54a055-6d3e-45da-92db-2a97ba0bbb37"> |
| linear system | ray | circle |
| <img width="481" alt="Screenshot 2024-06-21 at 5 08 40 PM" src="https://github.com/Khan/perseus/assets/13231763/120ca542-3878-4c1f-b87d-201710ebe4e1"> | <img width="486" alt="Screenshot 2024-06-21 at 5 08 44 PM" src="https://github.com/Khan/perseus/assets/13231763/7aafacfb-875c-4b27-82a8-1aad9c8f96fd"> | <img width="479" alt="Screenshot 2024-06-21 at 5 08 49 PM" src="https://github.com/Khan/perseus/assets/13231763/16ea2144-f9ff-4a47-80bc-f38e3bbf2d41"> |
| quadratic | sinusoid | |
| <img width="483" alt="Screenshot 2024-06-21 at 5 08 53 PM" src="https://github.com/Khan/perseus/assets/13231763/10444f80-a6dc-49a9-b26c-0409027cf2bd"> | <img width="481" alt="Screenshot 2024-06-21 at 5 08 58 PM" src="https://github.com/Khan/perseus/assets/13231763/d25e9d0f-ebab-4270-925e-4d66611650f7"> | |

