### PR TITLE
[Interactive Graph Editor] Fix the editor preview for segments, points, and polygons

### DIFF
--- a/.changeset/chilly-dolls-agree.md
+++ b/.changeset/chilly-dolls-agree.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Interactive Graph Editor] Fix the broken storybook preview for segments, points, and polygons

--- a/packages/perseus-editor/src/__stories__/editor-page.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/editor-page.stories.tsx
@@ -11,6 +11,7 @@ import {
     circleWithStartingCoordsQuestion,
     linearSystemWithStartingCoordsQuestion,
     linearWithStartingCoordsQuestion,
+    polygonQuestion,
     quadraticWithStartingCoordsQuestion,
     rayWithStartingCoordsQuestion,
     segmentWithLockedFigures,
@@ -112,6 +113,10 @@ export const InteractiveGraphSinusoidWithStartingCoords =
             />
         );
     };
+
+export const InteractiveGraphPolygon = (): React.ReactElement => {
+    return <EditorPageWithStorybookPreview question={polygonQuestion} />;
+};
 
 export const MafsWithLockedFiguresCurrent = (): React.ReactElement => {
     return (

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
@@ -246,6 +246,7 @@ describe("InteractiveGraphEditor", () => {
         expect(onChangeMock).toBeCalledWith(
             expect.objectContaining({
                 correct: {type: "point", numPoints: 5},
+                graph: {type: "point", numPoints: 5},
             }),
         );
     });
@@ -278,6 +279,12 @@ describe("InteractiveGraphEditor", () => {
         expect(onChangeMock).toBeCalledWith(
             expect.objectContaining({
                 correct: {
+                    type: "polygon",
+                    numSides: 5,
+                    coords: null,
+                    snapTo: "grid",
+                },
+                graph: {
                     type: "polygon",
                     numSides: 5,
                     coords: null,
@@ -356,6 +363,10 @@ describe("InteractiveGraphEditor", () => {
                     type: "polygon",
                     showAngles: true,
                 },
+                graph: {
+                    type: "polygon",
+                    showAngles: true,
+                },
             }),
         );
     });
@@ -388,6 +399,10 @@ describe("InteractiveGraphEditor", () => {
         expect(onChangeMock).toBeCalledWith(
             expect.objectContaining({
                 correct: {
+                    type: "polygon",
+                    showSides: true,
+                },
+                graph: {
                     type: "polygon",
                     showSides: true,
                 },
@@ -428,6 +443,10 @@ describe("InteractiveGraphEditor", () => {
                     type: "segment",
                     numSegments: 5,
                     coords: null,
+                },
+                graph: {
+                    type: "segment",
+                    numSegments: 5,
                 },
             }),
         );

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
@@ -433,7 +433,6 @@ class InteractiveGraphEditor extends React.Component<Props> {
                                             },
                                             graph: {
                                                 ...this.props.graph,
-                                                type: "polygon",
                                                 showAngles:
                                                     !this.props.graph
                                                         .showAngles,
@@ -467,8 +466,7 @@ class InteractiveGraphEditor extends React.Component<Props> {
                                             graph: {
                                                 ...this.props.graph,
                                                 showSides:
-                                                    !this.props.correct
-                                                        .showSides,
+                                                    !this.props.graph.showSides,
                                             },
                                         });
                                     }

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
@@ -317,6 +317,10 @@ class InteractiveGraphEditor extends React.Component<Props> {
                                         type: "point",
                                         numPoints: points,
                                     },
+                                    graph: {
+                                        type: "point",
+                                        numPoints: points,
+                                    },
                                 });
                             }}
                         />
@@ -344,7 +348,10 @@ class InteractiveGraphEditor extends React.Component<Props> {
                                         snapTo: "grid",
                                     };
 
-                                    this.props.onChange({correct: graph});
+                                    this.props.onChange({
+                                        correct: graph,
+                                        graph: graph,
+                                    });
                                 }}
                                 style={styles.singleSelectShort}
                             >
@@ -416,13 +423,23 @@ class InteractiveGraphEditor extends React.Component<Props> {
                                     !!this.props.correct?.showAngles
                                 }
                                 onChange={() => {
-                                    this.props.onChange({
-                                        correct: {
-                                            ...this.props.correct,
-                                            showAngles:
-                                                !this.props.correct.showAngles,
-                                        },
-                                    });
+                                    if (this.props.graph?.type === "polygon") {
+                                        this.props.onChange({
+                                            correct: {
+                                                ...this.props.correct,
+                                                showAngles:
+                                                    !this.props.correct
+                                                        .showAngles,
+                                            },
+                                            graph: {
+                                                ...this.props.graph,
+                                                type: "polygon",
+                                                showAngles:
+                                                    !this.props.graph
+                                                        .showAngles,
+                                            },
+                                        });
+                                    }
                                 }}
                             />
                             <InfoTip>
@@ -439,13 +456,22 @@ class InteractiveGraphEditor extends React.Component<Props> {
                                     !!this.props.correct?.showSides
                                 }
                                 onChange={() => {
-                                    this.props.onChange({
-                                        correct: {
-                                            ...this.props.correct,
-                                            showSides:
-                                                !this.props.correct.showSides,
-                                        },
-                                    });
+                                    if (this.props.graph?.type === "polygon") {
+                                        this.props.onChange({
+                                            correct: {
+                                                ...this.props.correct,
+                                                showSides:
+                                                    !this.props.correct
+                                                        .showSides,
+                                            },
+                                            graph: {
+                                                ...this.props.graph,
+                                                showSides:
+                                                    !this.props.correct
+                                                        .showSides,
+                                            },
+                                        });
+                                    }
                                 }}
                             />
                             <InfoTip>
@@ -464,6 +490,10 @@ class InteractiveGraphEditor extends React.Component<Props> {
                                         type: "segment",
                                         numSegments: sides,
                                         coords: null,
+                                    },
+                                    graph: {
+                                        type: "segment",
+                                        numSegments: sides,
                                     },
                                 });
                             }}


### PR DESCRIPTION
## Summary:
There was an issue where some of the custom settings for segments, points, and polygon
graphs were not updating the right-side storybook preview for interactive graphs
in the EditorPage stories.

The issue is that the `onChange` functions in `interactive-graph-editor.tsx` were
updating the `correct` field, but they were not updating the `graph` field.

Updating the `graph` field as well in this PR.

Issue: none

## Test plan:
Storybook
- Go to http://localhost:6006/?path=/story/perseuseditor-editorpage--interactive-graph-segment-with-starting-coords
- Change the number of segments
- Confirm that the number changes in the right panel, and it matches the preview in the left panel
- Go to http://localhost:6006/?path=/story/perseuseditor-editorpage--interactive-graph-polygon
- Change the number of sides 
- Check the "show angle measures" checkbox
- Check the "show side measure" checkbox
- Confirm that the right side panel updates accordingly and matches the left side panel