### PR TITLE
[Interactive Graph] Update Circle graph type to use  instead of

### DIFF
--- a/.changeset/eighty-tables-joke.md
+++ b/.changeset/eighty-tables-joke.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Interactive Graph] Update Circle graph type to use `coords` instead of `center`

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -767,7 +767,8 @@ export type PerseusGraphTypeAngle = {
 
 export type PerseusGraphTypeCircle = {
     type: "circle";
-    center?: Coord;
+    // The center of the circle.
+    coords?: Coord;
     radius?: number;
 } & PerseusGraphTypeCommon;
 

--- a/packages/perseus/src/util/extract-perseus-data.ts
+++ b/packages/perseus/src/util/extract-perseus-data.ts
@@ -150,10 +150,8 @@ function getAnswersFromWidgets(
                 // Answer is a list of points that should be on the graph
                 // E.g. 'There should be point(s) on [(-1, 1), (1, 1)]'
                 const grapher = widget;
-                // @ts-expect-error - TS2339 - Property 'coords' does not exist on type '{ type: "absolute_value"; coords: [Coord, Coord]; } | { type: "exponential"; asymptote: [Coord, Coord]; coords: [Coord, Coord]; } | { type: "linear"; coords: [...]; } | ... 4 more ... | PerseusGraphType'.
                 if (grapher.options?.correct?.coords) {
                     answers.push(
-                        // @ts-expect-error - TS2339 - Property 'coords' does not exist on type '{ type: "absolute_value"; coords: [Coord, Coord]; } | { type: "exponential"; asymptote: [Coord, Coord]; coords: [Coord, Coord]; } | { type: "linear"; coords: [...]; } | ... 4 more ... | PerseusGraphType'.
                         `There should be point(s) on [${grapher.options.correct?.coords.join(
                             "], [",
                         )}]`,

--- a/packages/perseus/src/widgets/__testdata__/interactive-graph-random.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/interactive-graph-random.testdata.ts
@@ -44,7 +44,7 @@ const randomGraphTypeAngle = (): PerseusGraphTypeAngle => {
 const randomGraphTypeCircle = (): PerseusGraphTypeCircle => {
     return {
         type: "circle",
-        center: randomCoord(),
+        coords: randomCoord(),
         radius: randomInteger(1, 20),
     };
 };

--- a/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
@@ -92,7 +92,7 @@ export const circleQuestion: PerseusRenderer = {
                 },
                 correct: {
                     type: "circle",
-                    center: [-2, -4],
+                    coords: [-2, -4],
                     radius: 2,
                 },
             },
@@ -133,7 +133,7 @@ export const circleQuestionWithDefaultCorrect: PerseusRenderer = {
                 },
                 correct: {
                     type: "circle",
-                    center: [0, 0],
+                    coords: [0, 0],
                     radius: 2,
                 },
             },

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -103,7 +103,6 @@ const deprecatedProps = {
 const _getShouldShowInstructions: (arg1: Props) => boolean = (props) => {
     return (
         _isClickToAddPoints(props) &&
-        // @ts-expect-error - TS2339 - Property 'coords' does not exist on type 'PerseusGraphType'. | TS2339 - Property 'coords' does not exist on type 'PerseusGraphType'.
         (props.graph.coords == null || props.graph.coords.length === 0)
     );
 };
@@ -262,7 +261,6 @@ class LegacyInteractiveGraph extends React.Component<Props, State> {
         props = props || this.props;
         return (
             this.isClickToAddPoints(props) &&
-            // @ts-expect-error - TS2339 - Property 'coords' does not exist on type 'PerseusGraphType'. | TS2339 - Property 'coords' does not exist on type 'PerseusGraphType'.
             (props.graph.coords == null || props.graph.coords.length === 0)
         );
     };
@@ -1909,8 +1907,8 @@ class InteractiveGraph extends React.Component<Props, State> {
         graph: PerseusGraphType,
         props: Props,
     ): ReadonlyArray<Coord> {
+        // @ts-expect-error - TS2339 - Property 'coords' does not exist on type 'PerseusGraphType'.
         return (
-            // @ts-expect-error - TS2339 - Property 'coords' does not exist on type 'PerseusGraphType'.
             graph.coords ||
             InteractiveGraph.pointsFromNormalized(props, [
                 [0.25, 0.75],
@@ -2002,9 +2000,9 @@ class InteractiveGraph extends React.Component<Props, State> {
         graph: PerseusGraphType,
         props: Props,
     ): ReadonlyArray<ReadonlyArray<Coord>> {
+        // The callers assume that we're return an array of points
+        // @ts-expect-error - TS2339 - Property 'coords' does not exist on type 'PerseusGraphType'.
         return (
-            // The callers assume that we're return an array of points
-            // @ts-expect-error - TS2339 - Property 'coords' does not exist on type 'PerseusGraphType'.
             graph.coords ||
             _.map(
                 [
@@ -2223,9 +2221,9 @@ class InteractiveGraph extends React.Component<Props, State> {
     static getCurrentQuadraticCoefficients(props: Props): QuadraticCoefficient {
         // TODO(alpert): Don't duplicate
         const coords =
-            // @ts-expect-error - TS2339 - Property 'coords' does not exist on type 'PerseusGraphType'.
             props.graph.coords ||
             InteractiveGraph.defaultQuadraticCoords(props);
+        // @ts-expect-error - TS2339 - Property 'coords' does not exist on type 'PerseusGraphType'.
         return InteractiveGraph.getQuadraticCoefficients(coords);
     }
 
@@ -2253,8 +2251,8 @@ class InteractiveGraph extends React.Component<Props, State> {
 
     static getCurrentSinusoidCoefficients(props: Props): SineCoefficient {
         const coords =
-            // @ts-expect-error - TS2339 - Property 'coords' does not exist on type 'PerseusGraphType'.
             props.graph.coords || InteractiveGraph.defaultSinusoidCoords(props);
+        // @ts-expect-error - TS2339 - Property 'coords' does not exist on type 'PerseusGraphType'.
         return InteractiveGraph.getSinusoidCoefficients(coords);
     }
 
@@ -2283,9 +2281,7 @@ class InteractiveGraph extends React.Component<Props, State> {
 
     static getCircleEquationString(props: Props): string {
         const graph = props.graph;
-        // TODO(alpert): Don't duplicate
-        // @ts-expect-error - TS2339 - Property 'center' does not exist on type 'PerseusGraphType'.
-        const center = graph.center || [0, 0];
+        const center = graph.coords || [0, 0];
         // @ts-expect-error - TS2339 - Property 'radius' does not exist on type 'PerseusGraphType'.
         const radius = graph.radius || 2;
         return (
@@ -2396,7 +2392,6 @@ class InteractiveGraph extends React.Component<Props, State> {
         // circle's center/radius fields. When those fields are absent, skip
         // all these checks; just go mark the answer as empty.
         const hasValue = Boolean(
-            // @ts-expect-error - TS2339 - Property 'coords' does not exist on type 'PerseusGraphType'.
             userInput.coords ||
                 // @ts-expect-error - TS2339 - Property 'center' does not exist on type 'PerseusGraphType'. | TS2339 - Property 'radius' does not exist on type 'PerseusGraphType'.
                 (userInput.center && userInput.radius),
@@ -2505,7 +2500,7 @@ class InteractiveGraph extends React.Component<Props, State> {
                 rubric.correct.type === "circle"
             ) {
                 if (
-                    deepEq(userInput.center, rubric.correct.center) &&
+                    deepEq(userInput.coords, rubric.correct.coords) &&
                     eq(userInput.radius, rubric.correct.radius)
                 ) {
                     return {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -20,7 +20,7 @@ type CircleGraphProps = MafsGraphProps<CircleGraphState>;
 
 export function CircleGraph(props: CircleGraphProps) {
     const {dispatch, graphState} = props;
-    const {center, radiusPoint} = graphState;
+    const {coords: center, radiusPoint} = graphState;
 
     return (
         <>

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
@@ -353,7 +353,7 @@ describe("InteractiveGraphQuestionBuilder", () => {
         expect(graph.options).toEqual(
             expect.objectContaining({
                 graph: {type: "circle"},
-                correct: {type: "circle", radius: 5, center: [0, 0]},
+                correct: {type: "circle", radius: 5, coords: [0, 0]},
             }),
         );
     });
@@ -365,8 +365,8 @@ describe("InteractiveGraphQuestionBuilder", () => {
         const graph = question.widgets["interactive-graph 1"];
         expect(graph.options).toEqual(
             expect.objectContaining({
-                graph: {type: "circle", center: [9, 9], radius: 5},
-                correct: {type: "circle", radius: 5, center: [0, 0]},
+                graph: {type: "circle", coords: [9, 9], radius: 5},
+                correct: {type: "circle", radius: 5, coords: [0, 0]},
             }),
         );
     });

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -369,12 +369,12 @@ class CircleGraphConfig implements InteractiveFigureConfig {
     }
 
     correct(): PerseusGraphType {
-        return {type: "circle", radius: 5, center: [0, 0]};
+        return {type: "circle", radius: 5, coords: [0, 0]};
     }
 
     graph(): PerseusGraphType {
         if (this.startCoords) {
-            return {type: "circle", center: this.startCoords, radius: 5};
+            return {type: "circle", coords: this.startCoords, radius: 5};
         }
 
         return {type: "circle"};

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.test.ts
@@ -312,11 +312,11 @@ describe("initializeGraphState for circle graphs", () => {
     it("uses the given circle specs, if present", () => {
         const graph = initializeGraphState({
             ...baseGraphData,
-            graph: {type: "circle", center: [1, 2], radius: 5},
+            graph: {type: "circle", coords: [1, 2], radius: 5},
         });
 
         invariant(graph.type === "circle");
-        expect(graph.center).toEqual([1, 2]);
+        expect(graph.coords).toEqual([1, 2]);
         expect(graph.radiusPoint).toEqual([6, 2]);
     });
 
@@ -327,7 +327,7 @@ describe("initializeGraphState for circle graphs", () => {
         });
 
         invariant(graph.type === "circle");
-        expect(graph.center).toEqual([0, 0]);
+        expect(graph.coords).toEqual([0, 0]);
         expect(graph.radiusPoint).toEqual([2, 0]);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
@@ -330,17 +330,17 @@ function getQuadraticCoords(
 }
 
 function getCircleCoords(graph: PerseusGraphTypeCircle): {
-    center: Coord;
+    coords: Coord;
     radiusPoint: Coord;
 } {
-    if (graph.center != null && graph.radius != null) {
+    if (graph.coords != null && graph.radius != null) {
         return {
-            center: graph.center,
-            radiusPoint: vec.add(graph.center, [graph.radius, 0]),
+            coords: graph.coords,
+            radiusPoint: vec.add(graph.coords, [graph.radius, 0]),
         };
     }
     return {
-        center: [0, 0],
+        coords: [0, 0],
         radiusPoint: [2, 0],
     };
 }

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -45,7 +45,7 @@ const baseCircleGraphState: InteractiveGraphState = {
         [-10, 10],
     ],
     snapStep: [1, 1],
-    center: [0, 0],
+    coords: [0, 0],
     radiusPoint: [2, 0],
 };
 
@@ -638,7 +638,7 @@ describe("moveCenter", () => {
 
         // make sure the state object is different
         expect(state).not.toBe(updated);
-        expect((updated as CircleGraphState).center).toEqual([1, 1]);
+        expect((updated as CircleGraphState).coords).toEqual([1, 1]);
     });
 
     it("sets hasBeenInteractedWith", () => {
@@ -660,7 +660,7 @@ describe("moveCenter", () => {
 
         // make sure the state object is different
         expect(state).not.toBe(updated);
-        expect((updated as CircleGraphState).center).toEqual([9, 9]);
+        expect((updated as CircleGraphState).coords).toEqual([9, 9]);
     });
 
     it("updates the radius", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -360,7 +360,7 @@ function doMoveCenter(
             const newRadiusPoint: vec.Vector2 = [
                 ...vec.add(
                     state.radiusPoint,
-                    vec.sub(constrainedCenter, state.center),
+                    vec.sub(constrainedCenter, state.coords),
                 ),
             ];
 
@@ -381,7 +381,7 @@ function doMoveCenter(
             return {
                 ...state,
                 hasBeenInteractedWith: true,
-                center: constrainedCenter,
+                coords: constrainedCenter,
                 radiusPoint: newRadiusPoint,
             };
         }
@@ -403,10 +403,10 @@ function doMoveRadiusPoint(
                 // Constrain to graph range
                 // The +0 is to convert -0 to +0
                 Math.min(Math.max(xMin, action.destination[0] + 0), xMax),
-                state.center[1],
+                state.coords[1],
             ];
 
-            if (_.isEqual(nextRadiusPoint, state.center)) {
+            if (_.isEqual(nextRadiusPoint, state.coords)) {
                 return state;
             }
 

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -57,7 +57,7 @@ export function getGradableGraph(
     if (state.type === "circle" && initialGraph.type === "circle") {
         return {
             ...initialGraph,
-            center: state.center,
+            coords: state.coords,
             radius: getRadius(state),
         };
     }
@@ -88,7 +88,7 @@ export function getGradableGraph(
  * @returns the radius of the circle
  */
 export function getRadius(graph: CircleGraphState): number {
-    const [centerX, centerY] = graph.center;
+    const [centerX, centerY] = graph.coords;
     const [edgeX, edgeY] = graph.radiusPoint;
     return Math.sqrt(
         Math.pow(edgeX - centerX, 2) + Math.pow(edgeY - centerY, 2),

--- a/packages/perseus/src/widgets/interactive-graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/types.ts
@@ -68,7 +68,8 @@ export interface PolygonGraphState extends InteractiveGraphStateCommon {
 
 export interface CircleGraphState extends InteractiveGraphStateCommon {
     type: "circle";
-    center: Coord;
+    // The center of the circle
+    coords: Coord;
     radiusPoint: Coord;
 }
 


### PR DESCRIPTION
## Summary:
I was getting a lot of annoying type errors from the Circle graph type
being a little inconsistent with the other graph types. Specifically,
all the other graph types have `coords` as a field, whereas circle uses
`center` to do essentially the same thing.

To avoid type issues for upcoming work, I'm updating the circle graph type
to use `coords` instead of `center`.

Issue: none

## Test plan:
`yarn jest`
`yarn typecheck`
`yarn run lint`

storybook
- https://khan.github.io/perseus/?path=/story/perseuseditor-editorpage--interactive-graph-circle-with-starting-coords
- Confirm that moving the left preview circle updates the "Correct answer" box correctly.