### PR TITLE
Add a feature flag for Mafs point graphs with fixed numPoints

### DIFF
--- a/.changeset/tricky-rice-nail.md
+++ b/.changeset/tricky-rice-nail.md
@@ -2,4 +2,4 @@
 "@khanacademy/perseus": minor
 ---
 
-Add a "point-fixed" flag to the Mafs feature flags, to control whether point graphs with fixed numbers of points should use Mafs.
+Make the `mafs.point` flag control whether point graphs with fixed numbers of points should use Mafs. Previously, turning on the `mafs.point` flag would  enable Mafs for point graphs with unlimited points as well.

--- a/.changeset/tricky-rice-nail.md
+++ b/.changeset/tricky-rice-nail.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Add a "point-fixed" flag to the Mafs feature flags, to control whether point graphs with fixed numbers of points should use Mafs.

--- a/packages/perseus/src/widgets/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.test.tsx
@@ -2,16 +2,15 @@ import invariant from "tiny-invariant";
 
 import InteractiveGraph, {
     type Rubric,
-    shouldUseMafs
+    shouldUseMafs,
 } from "./interactive-graph";
 
-import type {PerseusGraphType} from "@khanacademy/perseus";
-import {
+import type {
     PerseusGraphTypeLinear,
     PerseusGraphTypePoint,
-    PerseusGraphTypePolygon
+    PerseusGraphTypePolygon,
 } from "../perseus-types";
-import {Coord} from "@khanacademy/perseus";
+import type {PerseusGraphType} from "@khanacademy/perseus";
 
 function createRubric(graph: PerseusGraphType): Rubric {
     return {graph, correct: graph};
@@ -196,8 +195,8 @@ describe("shouldUseMafs", () => {
     it("is false given no mafs flags", () => {
         const graph: PerseusGraphTypeLinear = {
             type: "linear",
-        }
-        const mafsFlags = undefined
+        };
+        const mafsFlags = undefined;
 
         expect(shouldUseMafs(mafsFlags, graph)).toBe(false);
     });
@@ -207,8 +206,8 @@ describe("shouldUseMafs", () => {
         // object.
         const graph: PerseusGraphTypeLinear = {
             type: "linear",
-        }
-        const mafsFlags = true
+        };
+        const mafsFlags = true;
 
         expect(shouldUseMafs(mafsFlags, graph)).toBe(false);
     });
@@ -217,54 +216,54 @@ describe("shouldUseMafs", () => {
         const graph: PerseusGraphTypePoint = {
             type: "point",
             numPoints: 42,
-        }
-        const mafsFlags = {}
+        };
+        const mafsFlags = {};
 
         expect(shouldUseMafs(mafsFlags, graph)).toBe(false);
-    })
+    });
 
     it("is true for a point graph when the `point-fixed` feature flag is on", () => {
         const graph: PerseusGraphTypePoint = {
             type: "point",
             numPoints: 42,
-        }
+        };
         const mafsFlags = {
-            "point-fixed": true
-        }
+            "point-fixed": true,
+        };
 
         expect(shouldUseMafs(mafsFlags, graph)).toBe(true);
-    })
+    });
 
     it("is false for a point graph with numPoints = 'unlimited'", () => {
         const graph: PerseusGraphTypePoint = {
             type: "point",
             numPoints: "unlimited",
-        }
+        };
         const mafsFlags = {
-            "point-fixed": true
-        }
+            "point-fixed": true,
+        };
 
         expect(shouldUseMafs(mafsFlags, graph)).toBe(false);
-    })
+    });
 
     it("is true for a point graph without numPoints set when the feature flag is on", () => {
         // numPoints defaults to 1
         const graph: PerseusGraphTypePoint = {
             type: "point",
-        }
+        };
         const mafsFlags = {
-            "point-fixed": true
-        }
+            "point-fixed": true,
+        };
 
         expect(shouldUseMafs(mafsFlags, graph)).toBe(true);
-    })
+    });
 
     it("is false for a polygon graph when the feature flag is off", () => {
         const graph: PerseusGraphTypePolygon = {
             type: "polygon",
             numSides: 3,
-        }
-        const mafsFlags = {}
+        };
+        const mafsFlags = {};
 
         expect(shouldUseMafs(mafsFlags, graph)).toBe(false);
     });
@@ -273,10 +272,10 @@ describe("shouldUseMafs", () => {
         const graph: PerseusGraphTypePolygon = {
             type: "polygon",
             numSides: 3,
-        }
+        };
         const mafsFlags = {
-            "polygon": true
-        }
+            polygon: true,
+        };
 
         expect(shouldUseMafs(mafsFlags, graph)).toBe(true);
     });
@@ -285,43 +284,43 @@ describe("shouldUseMafs", () => {
         const graph: PerseusGraphTypePolygon = {
             type: "polygon",
             numSides: "unlimited",
-        }
+        };
         const mafsFlags = {
-            "polygon": true
-        }
+            polygon: true,
+        };
 
         expect(shouldUseMafs(mafsFlags, graph)).toBe(false);
-    })
+    });
 
     it("is true for a polygon graph when numSides is not set", () => {
         // numSides defaults to 3
         const graph: PerseusGraphTypePolygon = {
             type: "polygon",
-        }
+        };
         const mafsFlags = {
-            "polygon": true
-        }
+            polygon: true,
+        };
 
         expect(shouldUseMafs(mafsFlags, graph)).toBe(true);
-    })
+    });
 
     it("is false for a linear graph when the feature flag is off", () => {
         const graph: PerseusGraphTypeLinear = {
             type: "linear",
-        }
-        const mafsFlags = {}
+        };
+        const mafsFlags = {};
 
         expect(shouldUseMafs(mafsFlags, graph)).toBe(false);
-    })
+    });
 
     it("is true for a linear graph when the feature flag is on", () => {
         const graph: PerseusGraphTypeLinear = {
             type: "linear",
-        }
+        };
         const mafsFlags = {
-            "linear": true
-        }
+            linear: true,
+        };
 
         expect(shouldUseMafs(mafsFlags, graph)).toBe(true);
-    })
-})
+    });
+});

--- a/packages/perseus/src/widgets/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.test.tsx
@@ -1,8 +1,17 @@
 import invariant from "tiny-invariant";
 
-import InteractiveGraph, {type Rubric} from "./interactive-graph";
+import InteractiveGraph, {
+    type Rubric,
+    shouldUseMafs
+} from "./interactive-graph";
 
 import type {PerseusGraphType} from "@khanacademy/perseus";
+import {
+    PerseusGraphTypeLinear,
+    PerseusGraphTypePoint,
+    PerseusGraphTypePolygon
+} from "../perseus-types";
+import {Coord} from "@khanacademy/perseus";
 
 function createRubric(graph: PerseusGraphType): Rubric {
     return {graph, correct: graph};
@@ -182,3 +191,137 @@ describe("InteractiveGraph.validate on a segment question", () => {
         ]);
     });
 });
+
+describe("shouldUseMafs", () => {
+    it("is false given no mafs flags", () => {
+        const graph: PerseusGraphTypeLinear = {
+            type: "linear",
+        }
+        const mafsFlags = undefined
+
+        expect(shouldUseMafs(mafsFlags, graph)).toBe(false);
+    });
+
+    it("is false when mafs flags is a boolean", () => {
+        // boolean values aren't valid; we expect the mafs flags to be an
+        // object.
+        const graph: PerseusGraphTypeLinear = {
+            type: "linear",
+        }
+        const mafsFlags = true
+
+        expect(shouldUseMafs(mafsFlags, graph)).toBe(false);
+    });
+
+    it("is false for a point graph when the feature flag is off", () => {
+        const graph: PerseusGraphTypePoint = {
+            type: "point",
+            numPoints: 42,
+        }
+        const mafsFlags = {}
+
+        expect(shouldUseMafs(mafsFlags, graph)).toBe(false);
+    })
+
+    it("is true for a point graph when the `point-fixed` feature flag is on", () => {
+        const graph: PerseusGraphTypePoint = {
+            type: "point",
+            numPoints: 42,
+        }
+        const mafsFlags = {
+            "point-fixed": true
+        }
+
+        expect(shouldUseMafs(mafsFlags, graph)).toBe(true);
+    })
+
+    it("is false for a point graph with numPoints = 'unlimited'", () => {
+        const graph: PerseusGraphTypePoint = {
+            type: "point",
+            numPoints: "unlimited",
+        }
+        const mafsFlags = {
+            "point-fixed": true
+        }
+
+        expect(shouldUseMafs(mafsFlags, graph)).toBe(false);
+    })
+
+    it("is true for a point graph without numPoints set when the feature flag is on", () => {
+        // numPoints defaults to 1
+        const graph: PerseusGraphTypePoint = {
+            type: "point",
+        }
+        const mafsFlags = {
+            "point-fixed": true
+        }
+
+        expect(shouldUseMafs(mafsFlags, graph)).toBe(true);
+    })
+
+    it("is false for a polygon graph when the feature flag is off", () => {
+        const graph: PerseusGraphTypePolygon = {
+            type: "polygon",
+            numSides: 3,
+        }
+        const mafsFlags = {}
+
+        expect(shouldUseMafs(mafsFlags, graph)).toBe(false);
+    });
+
+    it("is true for a polygon graph when the feature flag is on", () => {
+        const graph: PerseusGraphTypePolygon = {
+            type: "polygon",
+            numSides: 3,
+        }
+        const mafsFlags = {
+            "polygon": true
+        }
+
+        expect(shouldUseMafs(mafsFlags, graph)).toBe(true);
+    });
+
+    it("is false for a polygon graph when numSides is 'unlimited'", () => {
+        const graph: PerseusGraphTypePolygon = {
+            type: "polygon",
+            numSides: "unlimited",
+        }
+        const mafsFlags = {
+            "polygon": true
+        }
+
+        expect(shouldUseMafs(mafsFlags, graph)).toBe(false);
+    })
+
+    it("is true for a polygon graph when numSides is not set", () => {
+        // numSides defaults to 3
+        const graph: PerseusGraphTypePolygon = {
+            type: "polygon",
+        }
+        const mafsFlags = {
+            "polygon": true
+        }
+
+        expect(shouldUseMafs(mafsFlags, graph)).toBe(true);
+    })
+
+    it("is false for a linear graph when the feature flag is off", () => {
+        const graph: PerseusGraphTypeLinear = {
+            type: "linear",
+        }
+        const mafsFlags = {}
+
+        expect(shouldUseMafs(mafsFlags, graph)).toBe(false);
+    })
+
+    it("is true for a linear graph when the feature flag is on", () => {
+        const graph: PerseusGraphTypeLinear = {
+            type: "linear",
+        }
+        const mafsFlags = {
+            "linear": true
+        }
+
+        expect(shouldUseMafs(mafsFlags, graph)).toBe(true);
+    })
+})

--- a/packages/perseus/src/widgets/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.test.tsx
@@ -222,13 +222,13 @@ describe("shouldUseMafs", () => {
         expect(shouldUseMafs(mafsFlags, graph)).toBe(false);
     });
 
-    it("is true for a point graph when the `point-fixed` feature flag is on", () => {
+    it("is true for a point graph when the `point` feature flag is on", () => {
         const graph: PerseusGraphTypePoint = {
             type: "point",
             numPoints: 42,
         };
         const mafsFlags = {
-            "point-fixed": true,
+            "point": true,
         };
 
         expect(shouldUseMafs(mafsFlags, graph)).toBe(true);
@@ -240,7 +240,7 @@ describe("shouldUseMafs", () => {
             numPoints: "unlimited",
         };
         const mafsFlags = {
-            "point-fixed": true,
+            "point": true,
         };
 
         expect(shouldUseMafs(mafsFlags, graph)).toBe(false);
@@ -252,7 +252,7 @@ describe("shouldUseMafs", () => {
             type: "point",
         };
         const mafsFlags = {
-            "point-fixed": true,
+            "point": true,
         };
 
         expect(shouldUseMafs(mafsFlags, graph)).toBe(true);

--- a/packages/perseus/src/widgets/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.test.tsx
@@ -228,7 +228,7 @@ describe("shouldUseMafs", () => {
             numPoints: 42,
         };
         const mafsFlags = {
-            "point": true,
+            point: true,
         };
 
         expect(shouldUseMafs(mafsFlags, graph)).toBe(true);
@@ -240,7 +240,7 @@ describe("shouldUseMafs", () => {
             numPoints: "unlimited",
         };
         const mafsFlags = {
-            "point": true,
+            point: true,
         };
 
         expect(shouldUseMafs(mafsFlags, graph)).toBe(false);
@@ -252,7 +252,7 @@ describe("shouldUseMafs", () => {
             type: "point",
         };
         const mafsFlags = {
-            "point": true,
+            point: true,
         };
 
         expect(shouldUseMafs(mafsFlags, graph)).toBe(true);

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -2681,7 +2681,7 @@ export function shouldUseMafs(
                 // points
                 return false;
             }
-            return Boolean(mafsFlags["point-fixed"]);
+            return Boolean(mafsFlags["point"]);
         case "polygon":
             if (graph.numSides === UNLIMITED) {
                 // TODO(benchristel): add a feature flag for the "unlimited"

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -13,20 +13,25 @@ import {Errors} from "../logging/log";
 import {PerseusError} from "../perseus-error";
 import Util from "../util";
 import KhanColors from "../util/colors";
+import type {
+    QuadraticCoefficient,
+    Range,
+    SineCoefficient,
+} from "../util/geometry";
 import {
     angleMeasures,
+    canonicalSineCoefficients,
     ccw,
     collinear,
+    getLineEquation,
+    getLineIntersection,
     intersects,
     lawOfCosines,
     magnitude,
     rotate,
-    vector,
     sign,
-    getLineEquation,
-    getLineIntersection,
-    canonicalSineCoefficients,
     similar,
+    vector,
 } from "../util/geometry";
 import GraphUtils from "../util/graph-utils";
 import {polar} from "../util/graphie";
@@ -51,11 +56,6 @@ import type {
     WidgetExports,
     WidgetProps,
 } from "../types";
-import type {
-    QuadraticCoefficient,
-    SineCoefficient,
-    Range,
-} from "../util/geometry";
 
 const {DeprecationMixin} = Util;
 
@@ -1815,20 +1815,8 @@ class InteractiveGraph extends React.Component<Props, State> {
     }
 
     render() {
-        if (
-            this.props.graph.type === "polygon" &&
-            this.props.graph.numSides === "unlimited"
-        ) {
-            return (
-                <LegacyInteractiveGraph
-                    ref={this.legacyGraphRef}
-                    {...this.props}
-                />
-            );
-        }
-
         // Mafs shim
-        if (this.props.apiOptions?.flags?.["mafs"]?.[this.props.graph.type]) {
+        if (shouldUseMafs(this.props.apiOptions?.flags?.["mafs"], this.props.graph)) {
             const box = getInteractiveBoxFromSizeClass(
                 this.props.containerSizeClass,
             );
@@ -2672,6 +2660,37 @@ class InteractiveGraph extends React.Component<Props, State> {
 
     static getUserInputFromProps(props: Props): PerseusGraphType {
         return props.graph;
+    }
+}
+
+// exported for testing
+export function shouldUseMafs(
+    mafsFlags: Record<string, boolean> | undefined | boolean,
+    graph: PerseusGraphType,
+): boolean {
+    if (typeof mafsFlags === "boolean" || typeof mafsFlags === "undefined") {
+        return false;
+    }
+
+    switch (graph.type) {
+        case "point":
+            if (graph.numPoints === UNLIMITED) {
+                // TODO(benchristel): add a feature flag for the "unlimited"
+                // case once we've implemented point graphs with unlimited
+                // points
+                return false
+            }
+            return Boolean(mafsFlags["point-fixed"]);
+        case "polygon":
+            if (graph.numSides === UNLIMITED) {
+                // TODO(benchristel): add a feature flag for the "unlimited"
+                // case once we've implemented polygon graphs with unlimited
+                // sides
+                return false;
+            }
+            return Boolean(mafsFlags["polygon"]);
+        default:
+            return Boolean(mafsFlags[graph.type]);
     }
 }
 

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -13,11 +13,6 @@ import {Errors} from "../logging/log";
 import {PerseusError} from "../perseus-error";
 import Util from "../util";
 import KhanColors from "../util/colors";
-import type {
-    QuadraticCoefficient,
-    Range,
-    SineCoefficient,
-} from "../util/geometry";
 import {
     angleMeasures,
     canonicalSineCoefficients,
@@ -56,6 +51,11 @@ import type {
     WidgetExports,
     WidgetProps,
 } from "../types";
+import type {
+    QuadraticCoefficient,
+    Range,
+    SineCoefficient,
+} from "../util/geometry";
 
 const {DeprecationMixin} = Util;
 
@@ -1816,7 +1816,8 @@ class InteractiveGraph extends React.Component<Props, State> {
 
     render() {
         // Mafs shim
-        if (shouldUseMafs(this.props.apiOptions?.flags?.["mafs"], this.props.graph)) {
+        const mafsFlags = this.props.apiOptions?.flags?.["mafs"];
+        if (shouldUseMafs(mafsFlags, this.props.graph)) {
             const box = getInteractiveBoxFromSizeClass(
                 this.props.containerSizeClass,
             );
@@ -2678,7 +2679,7 @@ export function shouldUseMafs(
                 // TODO(benchristel): add a feature flag for the "unlimited"
                 // case once we've implemented point graphs with unlimited
                 // points
-                return false
+                return false;
             }
             return Boolean(mafsFlags["point-fixed"]);
         case "polygon":


### PR DESCRIPTION
## Summary:
The point graph has two separate user experiences:

- fixed number of points, where you can drag points around, but not add
  or delete them
- unlimited points, where you can add and delete points

We have built the first of these experiences in Mafs, but not the
second. We want to release Mafs graphs with fixed-numPoints before
implementing unlimited points.

This commit adds logic to make that possible with feature flags. It also
moves the existing (similar) logic for polygon graphs so all decisions
about which graph to render are made in one, testable place.

Issue: LEMS-2126

Test plan:

Deploy a webapp ZND. Visit
`/internal-courses/test-everything/test-everything-1/te-interactive-graph/a/survey-of-graph-types`
and verify that only the graphs that should use Mafs are doing so.