### PR TITLE
Add `mafs.point` flag to Renderer prop types

### DIFF
--- a/.changeset/curvy-singers-check.md
+++ b/.changeset/curvy-singers-check.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Add `mafs.point` flag to ApiOptions type

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -134,7 +134,7 @@ export const MafsGraphTypeFlags = [
     "linear-system",
     /** Enables the `ray` interactive-graph type.  */
     "ray",
-    /** Enables the `polygon` interactive-graph type.  */
+    /** Enables the `polygon` interactive-graph type a fixed number of sides. */
     "polygon",
     /** Enables the `circle` interactive-graph type.  */
     "circle",
@@ -142,6 +142,8 @@ export const MafsGraphTypeFlags = [
     "quadratic",
     /** Enables the `sinusoid` interactive-graph type.  */
     "sinusoid",
+    /** Enables the `point` interactive-graph type with a fixed number of points. */
+    "point",
 ] as const;
 
 export const InteractiveGraphLockedFeaturesFlags = [


### PR DESCRIPTION
## Summary:
Perseus renders point graphs with fixed numbers of points using Mafs
when the `mafs.point` flag is on. Previously, however, the apiOptions
type (used in the Renderer props) did not allow this flag to be passed.
This commit makes it so the flag can be passed without a type error.

Issue: none

## Test plan:

- Check out this webapp PR: https://github.com/Khan/webapp/pull/23239
- Upgrade Perseus to the dev version built by CI for this pull request.
- Run the typechecker in webapp's static service.
- There should be no errors.