### PR TITLE
[Interactive Graph: Circle] Add a key prop to the circle drag handle

### DIFF
--- a/.changeset/sour-cougars-draw.md
+++ b/.changeset/sour-cougars-draw.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Interactive Graph: Circle] Add a key prop to the circle drag handle

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -108,6 +108,7 @@ function DragHandle(props: {center: [x: number, y: number]}) {
                 const [xPx, yPx] = vec.add(offsetPx, centerPx);
                 return (
                     <circle
+                        key={`circle-${xPx}-${yPx}`}
                         className="movable-circle-handle-dot"
                         cx={xPx}
                         cy={yPx}


### PR DESCRIPTION
## Summary:
There's always a console error saying that the circle graph drag handle
is missing the `key` prop.

Adding a `key` here.

Issue: none

## Test plan:
Open the console and make sure the error isn't showing up anymore.

`yarn jest packages/perseus/src/widgets/__tests__/interactive-graph.test.ts`
Make sure the logs don't show the console error anymore.

<img width="494" alt="Screenshot 2024-07-01 at 3 10 31 PM" src="https://github.com/Khan/perseus/assets/13231763/2e3cd2cd-7c08-4527-9fcb-aa02b096189f">
