### PR TITLE
Move math functions to a `math/` folder

### DIFF
--- a/.changeset/loud-goats-grow.md
+++ b/.changeset/loud-goats-grow.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Internal: Move graphing-agnostic, mathy functions in the interactive graph code to a math/ folder.

--- a/packages/perseus/src/widgets/interactive-graphs/axis-labels.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-labels.tsx
@@ -7,12 +7,13 @@ import {pointToPixel} from "./graphs/use-transform";
 import useGraphConfig from "./reducer/use-graph-config";
 
 import type {GraphDimensions} from "./types";
+import {MAX, X, Y} from "./math";
 
 export default function AxisLabels() {
     const {range, labels, width, height} = useGraphConfig();
 
-    const yAxisLabelLocation: vec.Vector2 = [0, range[1][1]];
-    const xAxisLabelLocation: vec.Vector2 = [range[0][1], 0];
+    const yAxisLabelLocation: vec.Vector2 = [0, range[Y][MAX]];
+    const xAxisLabelLocation: vec.Vector2 = [range[X][MAX], 0];
 
     const [xAxisLabelText, yAxisLabelText] = labels;
     const graphInfo: GraphDimensions = {

--- a/packages/perseus/src/widgets/interactive-graphs/axis-labels.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-labels.tsx
@@ -4,10 +4,10 @@ import React from "react";
 import {getDependencies} from "../../dependencies";
 
 import {pointToPixel} from "./graphs/use-transform";
+import {MAX, X, Y} from "./math";
 import useGraphConfig from "./reducer/use-graph-config";
 
 import type {GraphDimensions} from "./types";
-import {MAX, X, Y} from "./math";
 
 export default function AxisLabels() {
     const {range, labels, width, height} = useGraphConfig();

--- a/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 
 import {useTransformVectorsToPixels} from "./graphs/use-transform";
+import {MAX, MIN, X, Y} from "./math";
 import useGraphConfig from "./reducer/use-graph-config";
 
 import type {GraphDimensions} from "./types";
 import type {vec} from "mafs";
-import {MAX, MIN, X, Y} from "./math";
 
 const tickSize = 10;
 

--- a/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-ticks.tsx
@@ -5,6 +5,7 @@ import useGraphConfig from "./reducer/use-graph-config";
 
 import type {GraphDimensions} from "./types";
 import type {vec} from "mafs";
+import {MAX, MIN, X, Y} from "./math";
 
 const tickSize = 10;
 
@@ -18,13 +19,13 @@ const YGridTick = ({y, graphInfo}: {y: number; graphInfo: GraphDimensions}) => {
 
     // If the graph is zoomed in, we want to make sure the ticks are still visible
     // even if they are outside the graph's range.
-    if (graphInfo.range[0][0] > 0) {
+    if (graphInfo.range[X][MIN] > 0) {
         // If the graph is on the positive side of the x-axis, lock the ticks to the left side of the graph
-        xPointOnAxis = graphInfo.range[0][0];
+        xPointOnAxis = graphInfo.range[X][MIN];
     }
-    if (graphInfo.range[0][1] < 0) {
+    if (graphInfo.range[X][MAX] < 0) {
         // If the graph is on the negative side of the x-axis, lock the ticks to the right side of the graph
-        xPointOnAxis = graphInfo.range[0][1];
+        xPointOnAxis = graphInfo.range[X][MAX];
     }
 
     const pointOnAxis: vec.Vector2 = [xPointOnAxis, y];
@@ -57,13 +58,13 @@ const XGridTick = ({x, graphInfo}: {x: number; graphInfo: GraphDimensions}) => {
     let yPointOnAxis = 0;
     // If the graph is zoomed in, we want to make sure the ticks are still visible
     // even if they are outside the graph's range.
-    if (graphInfo.range[1][0] > 0) {
+    if (graphInfo.range[Y][MIN] > 0) {
         // If the graph is on the positive side of the y-axis, lock the ticks to the top of the graph
-        yPointOnAxis = graphInfo.range[1][0];
+        yPointOnAxis = graphInfo.range[Y][MIN];
     }
-    if (graphInfo.range[1][1] < 0) {
+    if (graphInfo.range[Y][MAX] < 0) {
         // If the graph is on the negative side of the x-axis, lock the ticks to the bottom of the graph
-        yPointOnAxis = graphInfo.range[1][1];
+        yPointOnAxis = graphInfo.range[Y][MAX];
     }
 
     const pointOnAxis: vec.Vector2 = [x, yPointOnAxis];
@@ -119,11 +120,12 @@ export const AxisTicks = () => {
         height,
     };
 
-    const [xMin, xMax] = range[0];
-    const [yMin, yMax] = range[1];
+    // TODO(benchristel): destructure these in one line
+    const [xMin, xMax] = range[X];
+    const [yMin, yMax] = range[Y];
 
-    const yTickStep = tickStep[1];
-    const xTickStep = tickStep[0];
+    const yTickStep = tickStep[Y];
+    const xTickStep = tickStep[X];
 
     const yGridTicks = generateTickLocations(yTickStep, yMin, yMax);
     const xGridTicks = generateTickLocations(xTickStep, xMin, xMax);

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -2,10 +2,10 @@ import {vec} from "mafs";
 import * as React from "react";
 import {useRef} from "react";
 
+import {snap, X, Y} from "../math";
 import {moveCenter, moveRadiusPoint} from "../reducer/interactive-graph-action";
 import {getRadius} from "../reducer/interactive-graph-state";
 import useGraphConfig from "../reducer/use-graph-config";
-import {snap, X, Y} from "../math";
 
 import {StyledMovablePoint} from "./components/movable-point";
 import {useDraggable} from "./use-draggable";

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -5,7 +5,7 @@ import {useRef} from "react";
 import {moveCenter, moveRadiusPoint} from "../reducer/interactive-graph-action";
 import {getRadius} from "../reducer/interactive-graph-state";
 import useGraphConfig from "../reducer/use-graph-config";
-import {snap} from "../math";
+import {snap, X, Y} from "../math";
 
 import {StyledMovablePoint} from "./components/movable-point";
 import {useDraggable} from "./use-draggable";
@@ -68,17 +68,17 @@ function MovableCircle(props: {
         >
             <ellipse
                 className="focus-ring"
-                cx={centerPx[0]}
-                cy={centerPx[1]}
-                rx={radiiPx[0] + 3}
-                ry={radiiPx[1] + 3}
+                cx={centerPx[X]}
+                cy={centerPx[Y]}
+                rx={radiiPx[X] + 3}
+                ry={radiiPx[Y] + 3}
             />
             <ellipse
                 className="circle"
-                cx={centerPx[0]}
-                cy={centerPx[1]}
-                rx={radiiPx[0]}
-                ry={radiiPx[1]}
+                cx={centerPx[X]}
+                cy={centerPx[Y]}
+                rx={radiiPx[X]}
+                ry={radiiPx[Y]}
             />
             <DragHandle center={center} />
         </g>
@@ -97,10 +97,10 @@ function DragHandle(props: {center: [x: number, y: number]}) {
         <>
             <rect
                 className="movable-circle-handle"
-                x={topLeft[0]}
-                y={topLeft[1]}
-                width={dragHandleDimensions[0]}
-                height={dragHandleDimensions[1]}
+                x={topLeft[X]}
+                y={topLeft[Y]}
+                width={dragHandleDimensions[X]}
+                height={dragHandleDimensions[Y]}
                 rx={cornerRadius}
                 ry={cornerRadius}
             />

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -5,7 +5,7 @@ import {useRef} from "react";
 import {moveCenter, moveRadiusPoint} from "../reducer/interactive-graph-action";
 import {getRadius} from "../reducer/interactive-graph-state";
 import useGraphConfig from "../reducer/use-graph-config";
-import {snap} from "../utils";
+import {snap} from "../math";
 
 import {StyledMovablePoint} from "./components/movable-point";
 import {useDraggable} from "./use-draggable";

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/arrowhead.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/arrowhead.tsx
@@ -2,8 +2,8 @@ import {type vec} from "mafs";
 import * as React from "react";
 
 import {pathBuilder} from "../../../../util/svg";
-import {useTransformVectorsToPixels} from "../use-transform";
 import {X, Y} from "../../math";
+import {useTransformVectorsToPixels} from "../use-transform";
 
 type Props = {
     tip: vec.Vector2;

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/arrowhead.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/arrowhead.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 
 import {pathBuilder} from "../../../../util/svg";
 import {useTransformVectorsToPixels} from "../use-transform";
+import {X, Y} from "../../math";
 
 type Props = {
     tip: vec.Vector2;
@@ -27,7 +28,7 @@ export function Arrowhead(props: Props) {
     return (
         <g
             className="interactive-graph-arrowhead"
-            transform={`translate(${point[0]} ${point[1]}) rotate(${props.angle})`}
+            transform={`translate(${point[X]} ${point[Y]}) rotate(${props.angle})`}
         >
             <g transform="translate(-1.5)">
                 <path

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/axis-tick-labels.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/axis-tick-labels.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 
+import {X, Y} from "../../math";
 import useGraphConfig from "../../reducer/use-graph-config";
 import {pointToPixel} from "../use-transform";
 
 import type {GraphConfig} from "../../reducer/use-graph-config";
 import type {vec} from "mafs";
-import {X, Y} from "../../math";
 
 type ShowTickLabelProps = {
     // The gridStep is the number of units between each grid line

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/axis-tick-labels.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/axis-tick-labels.tsx
@@ -5,6 +5,7 @@ import {pointToPixel} from "../use-transform";
 
 import type {GraphConfig} from "../../reducer/use-graph-config";
 import type {vec} from "mafs";
+import {X, Y} from "../../math";
 
 type ShowTickLabelProps = {
     // The gridStep is the number of units between each grid line
@@ -41,11 +42,12 @@ export const AxisTickLabels = () => {
     const graphConfig = useGraphConfig();
     const {tickStep, range} = graphConfig;
 
-    const [xMin, xMax] = range[0];
-    const [yMin, yMax] = range[1];
+    // TODO(benchristel): use destructuring here
+    const [xMin, xMax] = range[X];
+    const [yMin, yMax] = range[Y];
 
-    const yTickStep = tickStep[1];
-    const xTickStep = tickStep[0];
+    const yTickStep = tickStep[Y];
+    const xTickStep = tickStep[X];
 
     const yGridTicks = generateTickLocations(yTickStep, yMin, yMax);
     const xGridTicks = generateTickLocations(xTickStep, xMin, xMax);

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.test.tsx
@@ -9,7 +9,7 @@ import {MovableLine, trimRange} from "./movable-line";
 import type {Interval, vec} from "mafs";
 
 describe("trimRange", () => {
-    it("does not trim smaller than [[0, 0], [0, 0]]", () => {
+    it("does not trim ranges below a size of 0", () => {
         const graphDimensionsInPixels: vec.Vector2 = [1, 1];
         const range: [Interval, Interval] = [
             [0, 1],
@@ -19,8 +19,8 @@ describe("trimRange", () => {
         const trimmed = trimRange(range, graphDimensionsInPixels);
 
         expect(trimmed).toEqual([
-            [0, 0],
-            [0, 0],
+            [0.5, 0.5],
+            [0.5, 0.5],
         ]);
     });
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 
 import useGraphConfig from "../../reducer/use-graph-config";
 import {TARGET_SIZE} from "../../utils";
-import {snap} from "../../math";
+import {inset, snap} from "../../math";
 import {useDraggable} from "../use-draggable";
 import {useTransformVectorsToPixels} from "../use-transform";
 import {getIntersectionOfRayWithBox} from "../utils";
@@ -228,14 +228,7 @@ export function trimRange(
     const graphUnitsPerPixelY = size(yRange) / pixelsTall;
     const graphUnitsToTrimX = pixelsToTrim * graphUnitsPerPixelX;
     const graphUnitsToTrimY = pixelsToTrim * graphUnitsPerPixelY;
-    return [trim(xRange, graphUnitsToTrimX), trim(yRange, graphUnitsToTrimY)];
-}
-
-function trim(interval: Interval, amount: number): Interval {
-    if (size(interval) < amount * 2) {
-        return [0, 0];
-    }
-    return [interval[0] + amount, interval[1] - amount];
+    return inset([graphUnitsToTrimX, graphUnitsToTrimY], range);
 }
 
 function size(interval: Interval): number {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -3,7 +3,8 @@ import {useRef, useState} from "react";
 import * as React from "react";
 
 import useGraphConfig from "../../reducer/use-graph-config";
-import {snap, TARGET_SIZE} from "../../utils";
+import {TARGET_SIZE} from "../../utils";
+import {snap} from "../../math";
 import {useDraggable} from "../use-draggable";
 import {useTransformVectorsToPixels} from "../use-transform";
 import {getIntersectionOfRayWithBox} from "../utils";

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -2,9 +2,9 @@ import {vec} from "mafs";
 import {useRef, useState} from "react";
 import * as React from "react";
 
+import {inset, snap, size} from "../../math";
 import useGraphConfig from "../../reducer/use-graph-config";
 import {TARGET_SIZE} from "../../utils";
-import {inset, snap} from "../../math";
 import {useDraggable} from "../use-draggable";
 import {useTransformVectorsToPixels} from "../use-transform";
 import {getIntersectionOfRayWithBox} from "../utils";
@@ -14,7 +14,6 @@ import {SVGLine} from "./svg-line";
 import {Vector} from "./vector";
 
 import type {Interval} from "mafs";
-import {size} from "../../math";
 
 type Props = {
     points: Readonly<[vec.Vector2, vec.Vector2]>;

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -14,6 +14,7 @@ import {SVGLine} from "./svg-line";
 import {Vector} from "./vector";
 
 import type {Interval} from "mafs";
+import {size} from "../../math/interval";
 
 type Props = {
     points: Readonly<[vec.Vector2, vec.Vector2]>;
@@ -229,8 +230,4 @@ export function trimRange(
     const graphUnitsToTrimX = pixelsToTrim * graphUnitsPerPixelX;
     const graphUnitsToTrimY = pixelsToTrim * graphUnitsPerPixelY;
     return inset([graphUnitsToTrimX, graphUnitsToTrimY], range);
-}
-
-function size(interval: Interval): number {
-    return interval[1] - interval[0];
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -14,7 +14,7 @@ import {SVGLine} from "./svg-line";
 import {Vector} from "./vector";
 
 import type {Interval} from "mafs";
-import {size} from "../../math/interval";
+import {size} from "../../math";
 
 type Props = {
     points: Readonly<[vec.Vector2, vec.Vector2]>;

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
@@ -3,13 +3,13 @@ import Tooltip from "@khanacademy/wonder-blocks-tooltip";
 import * as React from "react";
 import {forwardRef} from "react";
 
+import {X, Y} from "../../math";
 import useGraphConfig from "../../reducer/use-graph-config";
 import {useTransformVectorsToPixels} from "../use-transform";
 
 import type {CSSCursor} from "./css-cursor";
 import type {vec} from "mafs";
 import type {ForwardedRef} from "react";
-import {X, Y} from "../../math";
 
 type Props = {
     point: vec.Vector2;

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
@@ -9,6 +9,7 @@ import {useTransformVectorsToPixels} from "../use-transform";
 import type {CSSCursor} from "./css-cursor";
 import type {vec} from "mafs";
 import type {ForwardedRef} from "react";
+import {X, Y} from "../../math";
 
 type Props = {
     point: vec.Vector2;
@@ -56,8 +57,9 @@ export const MovablePointView = forwardRef(
 
         const [[x, y]] = useTransformVectorsToPixels(point);
 
-        const [xMin, xMax] = range[0];
-        const [yMin, yMax] = range[1];
+        // TODO(benchristel): destructure range in one line
+        const [xMin, xMax] = range[X];
+        const [yMin, yMax] = range[Y];
 
         const [[verticalStartX]] = useTransformVectorsToPixels([xMin, 0]);
         const [[verticalEndX]] = useTransformVectorsToPixels([xMax, 0]);
@@ -119,7 +121,7 @@ export const MovablePointView = forwardRef(
                     <Tooltip
                         autoUpdate={true}
                         backgroundColor={wbColorName}
-                        content={`(${point[0]}, ${point[1]})`}
+                        content={`(${point[X]}, ${point[Y]})`}
                         contentStyle={{color: "white"}}
                     >
                         {svgForPoint}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import {useRef} from "react";
 
 import useGraphConfig from "../../reducer/use-graph-config";
-import {snap} from "../../utils";
+import {snap} from "../../math";
 import {useDraggable} from "../use-draggable";
 
 import {MovablePointView} from "./movable-point-view";

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
@@ -2,8 +2,8 @@ import {color as WBColor} from "@khanacademy/wonder-blocks-tokens";
 import * as React from "react";
 import {useRef} from "react";
 
-import useGraphConfig from "../../reducer/use-graph-config";
 import {snap} from "../../math";
+import useGraphConfig from "../../reducer/use-graph-config";
 import {useDraggable} from "../use-draggable";
 
 import {MovablePointView} from "./movable-point-view";

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/svg-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/svg-line.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 
+import {X, Y} from "../../math";
+
 import type {vec} from "mafs";
 import type {SVGProps} from "react";
-import {X, Y} from "../../math";
 
 export type Props = {
     start: vec.Vector2;

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/svg-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/svg-line.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import type {vec} from "mafs";
 import type {SVGProps} from "react";
+import {X, Y} from "../../math";
 
 export type Props = {
     start: vec.Vector2;
@@ -15,10 +16,10 @@ export function SVGLine(props: Props) {
     const {start, end, style, className, testId} = props;
     return (
         <line
-            x1={start[0]}
-            y1={start[1]}
-            x2={end[0]}
-            y2={end[1]}
+            x1={start[X]}
+            y1={start[Y]}
+            x2={end[X]}
+            y2={end[Y]}
             style={style}
             className={className}
             data-testid={testId}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -2,7 +2,8 @@ import {Polygon, vec} from "mafs";
 import * as React from "react";
 
 import {moveAll, movePoint} from "../reducer/interactive-graph-action";
-import {TARGET_SIZE, snap} from "../utils";
+import {TARGET_SIZE} from "../utils";
+import {snap} from "../math"
 
 import {Angle} from "./components/angle";
 import {StyledMovablePoint} from "./components/movable-point";

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -1,9 +1,9 @@
 import {Polygon, vec} from "mafs";
 import * as React from "react";
 
+import {snap} from "../math";
 import {moveAll, movePoint} from "../reducer/interactive-graph-action";
 import {TARGET_SIZE} from "../utils";
-import {snap} from "../math"
 
 import {Angle} from "./components/angle";
 import {StyledMovablePoint} from "./components/movable-point";

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
@@ -2,13 +2,13 @@ import {color} from "@khanacademy/wonder-blocks-tokens";
 import {Plot} from "mafs";
 import * as React from "react";
 
+import {X, Y} from "../math";
 import {movePoint} from "../reducer/interactive-graph-action";
 
 import {StyledMovablePoint} from "./components/movable-point";
 
 import type {Coord} from "../../../interactive2/types";
 import type {SinusoidGraphState, MafsGraphProps} from "../types";
-import {X, Y} from "../math";
 
 type SinusoidGraphProps = MafsGraphProps<SinusoidGraphState>;
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
@@ -8,6 +8,7 @@ import {StyledMovablePoint} from "./components/movable-point";
 
 import type {Coord} from "../../../interactive2/types";
 import type {SinusoidGraphState, MafsGraphProps} from "../types";
+import {X, Y} from "../math";
 
 type SinusoidGraphProps = MafsGraphProps<SinusoidGraphState>;
 
@@ -86,15 +87,15 @@ export const getSinusoidCoefficients = (
     const p2 = coords[1];
 
     // If the x-coordinates are the same, we are unable to calculate the coefficients
-    if (p2[0] === p1[0]) {
+    if (p2[X] === p1[X]) {
         return;
     }
 
     // Resulting coefficients are canonical for this sine curve
-    const amplitude = p2[1] - p1[1];
-    const angularFrequency = Math.PI / (2 * (p2[0] - p1[0]));
-    const phase = p1[0] * angularFrequency;
-    const verticalOffset = p1[1];
+    const amplitude = p2[Y] - p1[Y];
+    const angularFrequency = Math.PI / (2 * (p2[X] - p1[X]));
+    const phase = p1[X] * angularFrequency;
+    const verticalOffset = p1[Y];
 
     return {amplitude, angularFrequency, phase, verticalOffset};
 };

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/use-draggable.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/use-draggable.ts
@@ -6,6 +6,7 @@ import invariant from "tiny-invariant";
 import useGraphConfig from "../reducer/use-graph-config";
 
 import type {RefObject} from "react";
+import {X, Y} from "../math";
 
 /**
  * Code in this file is derived from
@@ -68,10 +69,10 @@ export function useDraggable(args: Params): DragState {
                 } = state;
 
                 const direction = [
-                    yDownDirection[0],
-                    -yDownDirection[1],
+                    yDownDirection[X],
+                    -yDownDirection[Y],
                 ] as vec.Vector2;
-                const span = Math.abs(direction[0]) ? xSpan : ySpan;
+                const span = Math.abs(direction[X]) ? xSpan : ySpan;
 
                 let divisions = 50;
                 if (altKey || metaKey) {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/use-draggable.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/use-draggable.ts
@@ -3,10 +3,10 @@ import {useTransformContext, vec} from "mafs";
 import * as React from "react";
 import invariant from "tiny-invariant";
 
+import {X, Y} from "../math";
 import useGraphConfig from "../reducer/use-graph-config";
 
 import type {RefObject} from "react";
-import {X, Y} from "../math";
 
 /**
  * Code in this file is derived from

--- a/packages/perseus/src/widgets/interactive-graphs/grid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/grid.tsx
@@ -3,11 +3,11 @@ import * as React from "react";
 
 import AxisArrows from "./axis-arrows";
 import {AxisTicks} from "./axis-ticks";
+import {X, Y} from "./math";
 
 import type {GraphRange} from "../../perseus-types";
 import type {SizeClass} from "../../util/sizing-utils";
 import type {vec} from "mafs";
-import {X, Y} from "./math";
 
 interface GridProps {
     tickStep: vec.Vector2;

--- a/packages/perseus/src/widgets/interactive-graphs/grid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/grid.tsx
@@ -7,6 +7,7 @@ import {AxisTicks} from "./axis-ticks";
 import type {GraphRange} from "../../perseus-types";
 import type {SizeClass} from "../../util/sizing-utils";
 import type {vec} from "mafs";
+import {X, Y} from "./math";
 
 interface GridProps {
     tickStep: vec.Vector2;
@@ -63,8 +64,8 @@ export const Grid = (props: GridProps) => {
     return props.markings === "none" ? null : (
         <>
             <Coordinates.Cartesian
-                xAxis={axisOptions(props, 0)}
-                yAxis={axisOptions(props, 1)}
+                xAxis={axisOptions(props, X)}
+                yAxis={axisOptions(props, Y)}
             />
             {
                 // Only render the axis ticks and arrows if the markings are set to a full "graph"

--- a/packages/perseus/src/widgets/interactive-graphs/legacy-grid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/legacy-grid.tsx
@@ -6,6 +6,7 @@ import {SvgImage} from "../../components";
 import {interactiveSizes} from "../../styles/constants";
 
 import type {PerseusImageBackground} from "../../perseus-types";
+import {X} from "./math";
 
 interface Props {
     box: [number, number];
@@ -19,7 +20,7 @@ interface Props {
 export const LegacyGrid = ({box, backgroundImage}: Props) => {
     const {url, width, height} = backgroundImage ?? {};
     if (url && typeof url === "string") {
-        const scale = box[0] / interactiveSizes.defaultBoxSize;
+        const scale = box[X] / interactiveSizes.defaultBoxSize;
         return (
             <View
                 style={{

--- a/packages/perseus/src/widgets/interactive-graphs/legacy-grid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/legacy-grid.tsx
@@ -5,8 +5,9 @@ import AssetContext from "../../asset-context";
 import {SvgImage} from "../../components";
 import {interactiveSizes} from "../../styles/constants";
 
-import type {PerseusImageBackground} from "../../perseus-types";
 import {X} from "./math";
+
+import type {PerseusImageBackground} from "../../perseus-types";
 
 interface Props {
     box: [number, number];

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-line.tsx
@@ -10,10 +10,10 @@ import {
     calculateAngleInDegrees,
     getIntersectionOfRayWithBox,
 } from "../graphs/utils";
+import {X, Y} from "../math";
 
 import type {LockedLineType} from "../../../perseus-types";
 import type {Interval} from "mafs";
-import {X, Y} from "../math";
 
 type Props = LockedLineType & {
     range: [Interval, Interval];

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-line.tsx
@@ -13,6 +13,7 @@ import {
 
 import type {LockedLineType} from "../../../perseus-types";
 import type {Interval} from "mafs";
+import {X, Y} from "../math";
 
 type Props = LockedLineType & {
     range: [Interval, Interval];
@@ -107,8 +108,8 @@ const LockedLine = (props: Props) => {
             {line}
             {showPoint1 && (
                 <Point
-                    x={point1.coord[0]}
-                    y={point1.coord[1]}
+                    x={point1.coord[X]}
+                    y={point1.coord[Y]}
                     svgCircleProps={{
                         style: {
                             fill: point1.filled
@@ -122,8 +123,8 @@ const LockedLine = (props: Props) => {
             )}
             {showPoint2 && (
                 <Point
-                    x={point2.coord[0]}
-                    y={point2.coord[1]}
+                    x={point2.coord[X]}
+                    y={point2.coord[Y]}
                     svgCircleProps={{
                         style: {
                             fill: point2.filled

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-polygon.tsx
@@ -7,6 +7,7 @@ import {
 } from "../../../perseus-types";
 
 import type {LockedPolygonType} from "../../../perseus-types";
+import {X, Y} from "../math";
 
 const LockedPolygon = (props: LockedPolygonType) => {
     const {points, color, showVertices, fillStyle, strokeStyle} = props;
@@ -23,8 +24,8 @@ const LockedPolygon = (props: LockedPolygonType) => {
                 points.map((point, index) => (
                     <Point
                         key={`locked-polygon-point-${index}`}
-                        x={point[0]}
-                        y={point[1]}
+                        x={point[X]}
+                        y={point[Y]}
                         color={lockedFigureColors[color]}
                     />
                 ))}

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-polygon.tsx
@@ -5,9 +5,9 @@ import {
     lockedFigureColors,
     lockedFigureFillStyles,
 } from "../../../perseus-types";
+import {X, Y} from "../math";
 
 import type {LockedPolygonType} from "../../../perseus-types";
-import {X, Y} from "../math";
 
 const LockedPolygon = (props: LockedPolygonType) => {
     const {points, color, showVertices, fillStyle, strokeStyle} = props;

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -21,6 +21,7 @@ import {SvgDefs} from "./graphs/components/text-label";
 import {PointGraph} from "./graphs/point";
 import {Grid} from "./grid";
 import {LegacyGrid} from "./legacy-grid";
+import {X, Y} from "./math";
 import {Protractor} from "./protractor";
 import {initializeGraphState} from "./reducer/initialize-graph-state";
 import {
@@ -40,7 +41,6 @@ import type {vec} from "mafs";
 
 import "mafs/core.css";
 import "./mafs-styles.css";
-import {X, Y} from "./math";
 
 export type StatefulMafsGraphProps = {
     box: [number, number];

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -40,6 +40,7 @@ import type {vec} from "mafs";
 
 import "mafs/core.css";
 import "./mafs-styles.css";
+import {X, Y} from "./math";
 
 export type StatefulMafsGraphProps = {
     box: [number, number];
@@ -248,8 +249,8 @@ export const MafsGraph = (props: MafsGraphProps) => {
                     <Mafs
                         preserveAspectRatio={false}
                         viewBox={{
-                            x: state.range[0],
-                            y: state.range[1],
+                            x: state.range[X],
+                            y: state.range[Y],
                             padding: 0,
                         }}
                         pan={false}

--- a/packages/perseus/src/widgets/interactive-graphs/math/box.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/box.test.ts
@@ -1,57 +1,119 @@
-import {Box, ensureValid, inset} from "./box";
+import {ensureValid, inset} from "./box";
+
+import type {Box} from "./box";
 
 describe("inset", () => {
     it("does nothing given amount [0, 0]", () => {
-        const box: Box = [[1, 2], [3, 4]];
-        expect(inset([0, 0], box)).toEqual([[1, 2], [3, 4]]);
+        const box: Box = [
+            [1, 2],
+            [3, 4],
+        ];
+        expect(inset([0, 0], box)).toEqual([
+            [1, 2],
+            [3, 4],
+        ]);
     });
 
     it("does not mutate the given box", () => {
-        const box: Box = [[0, 9], [1, 10]];
+        const box: Box = [
+            [0, 9],
+            [1, 10],
+        ];
         inset([1, 1], box);
-        expect(box).toEqual([[0, 9], [1, 10]])
-    })
+        expect(box).toEqual([
+            [0, 9],
+            [1, 10],
+        ]);
+    });
 
     it("shrinks the box horizontally", () => {
-        const box: Box = [[0, 9], [1, 10]];
-        expect(inset([1, 0], box)).toEqual([[1, 8], [1, 10]])
+        const box: Box = [
+            [0, 9],
+            [1, 10],
+        ];
+        expect(inset([1, 0], box)).toEqual([
+            [1, 8],
+            [1, 10],
+        ]);
     });
 
     it("shrinks the box vertically", () => {
-        const box: Box = [[0, 9], [1, 10]];
-        expect(inset([0, 1], box)).toEqual([[0, 9], [2, 9]])
+        const box: Box = [
+            [0, 9],
+            [1, 10],
+        ];
+        expect(inset([0, 1], box)).toEqual([
+            [0, 9],
+            [2, 9],
+        ]);
     });
 
     it("shrinks in both dimensions", () => {
-        const box: Box = [[0, 9], [1, 10]];
-        expect(inset([1, 1], box)).toEqual([[1, 8], [2, 9]])
+        const box: Box = [
+            [0, 9],
+            [1, 10],
+        ];
+        expect(inset([1, 1], box)).toEqual([
+            [1, 8],
+            [2, 9],
+        ]);
     });
 
     it("expands the box given a negative amount", () => {
-        const box: Box = [[0, 9], [1, 10]];
-        expect(inset([-1, -1], box)).toEqual([[-1, 10], [0, 11]])
+        const box: Box = [
+            [0, 9],
+            [1, 10],
+        ];
+        expect(inset([-1, -1], box)).toEqual([
+            [-1, 10],
+            [0, 11],
+        ]);
     });
 
     it("does not create an invalid box", () => {
-        const box: Box = [[0, 1], [0, 1]];
-        expect(inset([9, 9], box)).toEqual([[0.5, 0.5], [0.5, 0.5]])
+        const box: Box = [
+            [0, 1],
+            [0, 1],
+        ];
+        expect(inset([9, 9], box)).toEqual([
+            [0.5, 0.5],
+            [0.5, 0.5],
+        ]);
     });
 });
 
 describe("ensureValid", () => {
     it("does nothing given a valid box", () => {
-        const box: Box = [[0, 1], [2, 3]];
-        expect(ensureValid(box)).toEqual([[0, 1], [2, 3]]);
-    })
+        const box: Box = [
+            [0, 1],
+            [2, 3],
+        ];
+        expect(ensureValid(box)).toEqual([
+            [0, 1],
+            [2, 3],
+        ]);
+    });
 
     it("fixes a box where the min values are greater than the max", () => {
-        const box: Box = [[4, 0], [10, 1]];
-        expect(ensureValid(box)).toEqual([[2, 2], [5.5, 5.5]]);
-    })
+        const box: Box = [
+            [4, 0],
+            [10, 1],
+        ];
+        expect(ensureValid(box)).toEqual([
+            [2, 2],
+            [5.5, 5.5],
+        ]);
+    });
 
     it("does not mutate the given box", () => {
-        const box: Box = [[4, 0], [10, 1]];
-        ensureValid(box)
-        expect(box).toEqual([[4, 0], [10, 1]])
-    })
-})
+        const box: Box = [
+            [4, 0],
+            [10, 1],
+        ];
+        ensureValid(box);
+        expect(box).toEqual([
+            [4, 0],
+            [10, 1],
+        ]);
+    });
+});

--- a/packages/perseus/src/widgets/interactive-graphs/math/box.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/box.test.ts
@@ -1,4 +1,4 @@
-import {ensureValid, inset} from "./box";
+import {inset} from "./box";
 
 import type {Box} from "./box";
 
@@ -70,7 +70,7 @@ describe("inset", () => {
         ]);
     });
 
-    it("does not create an invalid box", () => {
+    it("does not create an invalid box if the amount is too big", () => {
         const box: Box = [
             [0, 1],
             [0, 1],
@@ -78,42 +78,6 @@ describe("inset", () => {
         expect(inset([9, 9], box)).toEqual([
             [0.5, 0.5],
             [0.5, 0.5],
-        ]);
-    });
-});
-
-describe("ensureValid", () => {
-    it("does nothing given a valid box", () => {
-        const box: Box = [
-            [0, 1],
-            [2, 3],
-        ];
-        expect(ensureValid(box)).toEqual([
-            [0, 1],
-            [2, 3],
-        ]);
-    });
-
-    it("fixes a box where the min values are greater than the max", () => {
-        const box: Box = [
-            [4, 0],
-            [10, 1],
-        ];
-        expect(ensureValid(box)).toEqual([
-            [2, 2],
-            [5.5, 5.5],
-        ]);
-    });
-
-    it("does not mutate the given box", () => {
-        const box: Box = [
-            [4, 0],
-            [10, 1],
-        ];
-        ensureValid(box);
-        expect(box).toEqual([
-            [4, 0],
-            [10, 1],
         ]);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/math/box.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/box.test.ts
@@ -1,0 +1,57 @@
+import {Box, ensureValid, inset} from "./box";
+
+describe("inset", () => {
+    it("does nothing given amount [0, 0]", () => {
+        const box: Box = [[1, 2], [3, 4]];
+        expect(inset([0, 0], box)).toEqual([[1, 2], [3, 4]]);
+    });
+
+    it("does not mutate the given box", () => {
+        const box: Box = [[0, 9], [1, 10]];
+        inset([1, 1], box);
+        expect(box).toEqual([[0, 9], [1, 10]])
+    })
+
+    it("shrinks the box horizontally", () => {
+        const box: Box = [[0, 9], [1, 10]];
+        expect(inset([1, 0], box)).toEqual([[1, 8], [1, 10]])
+    });
+
+    it("shrinks the box vertically", () => {
+        const box: Box = [[0, 9], [1, 10]];
+        expect(inset([0, 1], box)).toEqual([[0, 9], [2, 9]])
+    });
+
+    it("shrinks in both dimensions", () => {
+        const box: Box = [[0, 9], [1, 10]];
+        expect(inset([1, 1], box)).toEqual([[1, 8], [2, 9]])
+    });
+
+    it("expands the box given a negative amount", () => {
+        const box: Box = [[0, 9], [1, 10]];
+        expect(inset([-1, -1], box)).toEqual([[-1, 10], [0, 11]])
+    });
+
+    it("does not create an invalid box", () => {
+        const box: Box = [[0, 1], [0, 1]];
+        expect(inset([9, 9], box)).toEqual([[0.5, 0.5], [0.5, 0.5]])
+    });
+});
+
+describe("ensureValid", () => {
+    it("does nothing given a valid box", () => {
+        const box: Box = [[0, 1], [2, 3]];
+        expect(ensureValid(box)).toEqual([[0, 1], [2, 3]]);
+    })
+
+    it("fixes a box where the min values are greater than the max", () => {
+        const box: Box = [[4, 0], [10, 1]];
+        expect(ensureValid(box)).toEqual([[2, 2], [5.5, 5.5]]);
+    })
+
+    it("does not mutate the given box", () => {
+        const box: Box = [[4, 0], [10, 1]];
+        ensureValid(box)
+        expect(box).toEqual([[4, 0], [10, 1]])
+    })
+})

--- a/packages/perseus/src/widgets/interactive-graphs/math/box.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/box.ts
@@ -1,6 +1,6 @@
 import {clamp} from "./clamp";
 import {X, Y} from "./coordinates";
-import {MAX, MIN} from "./interval";
+import {trim} from "./interval";
 
 import type {Interval, vec} from "mafs";
 
@@ -16,26 +16,5 @@ export function clampToBox(box: Box, point: vec.Vector2): vec.Vector2 {
 // `amount`. If a component of `amount` is negative, the box is expanded in
 // that dimension instead.
 export function inset(amount: vec.Vector2, box: Box): Box {
-    return ensureValid([
-        [box[X][MIN] + amount[X], box[X][MAX] - amount[X]],
-        [box[Y][MIN] + amount[Y], box[Y][MAX] - amount[Y]],
-    ]);
-}
-
-export function ensureValid(box: Box): Box {
-    let [[xMin, xMax], [yMin, yMax]] = box;
-    if (xMin > xMax) {
-        xMin = xMax = average(xMin, xMax);
-    }
-    if (yMin > yMax) {
-        yMin = yMax = average(yMin, yMax);
-    }
-    return [
-        [xMin, xMax],
-        [yMin, yMax],
-    ];
-}
-
-function average(a: number, b: number): number {
-    return (a + b) / 2;
+    return [trim(amount[X], box[X]), trim(amount[Y], box[Y])];
 }

--- a/packages/perseus/src/widgets/interactive-graphs/math/box.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/box.ts
@@ -1,0 +1,39 @@
+import {Interval, vec} from "mafs";
+import {clamp} from "./clamp";
+
+export type Box = [x: Interval, y: Interval];
+
+// Restricts the `point` to be within `box`, by clamping each coordinate to the
+// corresponding interval.
+export function clampToBox(box: Box, point: vec.Vector2): vec.Vector2 {
+    return [
+        // TODO: x and y coordinate functions
+        clamp(point[0], ...box[0]),
+        clamp(point[1], ...box[1])
+    ]
+}
+
+// Reduces the size of `box`, trimming each corner by the given positive
+// `amount`. If a component of `amount` is negative, the box is expanded in
+// that dimension instead.
+export function inset(amount: vec.Vector2, box: Box): Box {
+    return ensureValid([
+        [box[0][0] + amount[0], box[0][1] - amount[0]],
+        [box[1][0] + amount[1], box[1][1] - amount[1]],
+    ]);
+}
+
+export function ensureValid(box: Box): Box {
+    let [[xMin, xMax], [yMin, yMax]] = box
+    if (xMin > xMax) {
+        xMin = xMax = average(xMin, xMax);
+    }
+    if (yMin > yMax) {
+        yMin = yMax = average(yMin, yMax);
+    }
+    return [[xMin, xMax], [yMin, yMax]]
+}
+
+function average(a: number, b: number): number {
+    return (a + b) / 2
+}

--- a/packages/perseus/src/widgets/interactive-graphs/math/box.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/box.ts
@@ -1,17 +1,15 @@
-import {Interval, vec} from "mafs";
 import {clamp} from "./clamp";
 import {X, Y} from "./coordinates";
 import {MAX, MIN} from "./interval";
+
+import type {Interval, vec} from "mafs";
 
 export type Box = [x: Interval, y: Interval];
 
 // Restricts the `point` to be within `box`, by clamping each coordinate to the
 // corresponding interval.
 export function clampToBox(box: Box, point: vec.Vector2): vec.Vector2 {
-    return [
-        clamp(point[X], ...box[X]),
-        clamp(point[Y], ...box[Y])
-    ]
+    return [clamp(point[X], ...box[X]), clamp(point[Y], ...box[Y])];
 }
 
 // Reduces the size of `box`, trimming each corner by the given positive
@@ -25,16 +23,19 @@ export function inset(amount: vec.Vector2, box: Box): Box {
 }
 
 export function ensureValid(box: Box): Box {
-    let [[xMin, xMax], [yMin, yMax]] = box
+    let [[xMin, xMax], [yMin, yMax]] = box;
     if (xMin > xMax) {
         xMin = xMax = average(xMin, xMax);
     }
     if (yMin > yMax) {
         yMin = yMax = average(yMin, yMax);
     }
-    return [[xMin, xMax], [yMin, yMax]]
+    return [
+        [xMin, xMax],
+        [yMin, yMax],
+    ];
 }
 
 function average(a: number, b: number): number {
-    return (a + b) / 2
+    return (a + b) / 2;
 }

--- a/packages/perseus/src/widgets/interactive-graphs/math/box.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/box.ts
@@ -1,6 +1,7 @@
 import {Interval, vec} from "mafs";
 import {clamp} from "./clamp";
-import {x, y} from "./coordinates";
+import {X, Y} from "./coordinates";
+import {MAX, MIN} from "./interval";
 
 export type Box = [x: Interval, y: Interval];
 
@@ -8,8 +9,8 @@ export type Box = [x: Interval, y: Interval];
 // corresponding interval.
 export function clampToBox(box: Box, point: vec.Vector2): vec.Vector2 {
     return [
-        clamp(x(point), ...x(box)),
-        clamp(y(point), ...y(box))
+        clamp(point[X], ...box[X]),
+        clamp(point[Y], ...box[Y])
     ]
 }
 
@@ -18,8 +19,8 @@ export function clampToBox(box: Box, point: vec.Vector2): vec.Vector2 {
 // that dimension instead.
 export function inset(amount: vec.Vector2, box: Box): Box {
     return ensureValid([
-        [x(box)[0] + x(amount), x(box)[1] - x(amount)],
-        [y(box)[0] + y(amount), y(box)[1] - y(amount)],
+        [box[X][MIN] + amount[X], box[X][MAX] - amount[X]],
+        [box[Y][MIN] + amount[Y], box[Y][MAX] - amount[Y]],
     ]);
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/math/box.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/box.ts
@@ -1,5 +1,6 @@
 import {Interval, vec} from "mafs";
 import {clamp} from "./clamp";
+import {x, y} from "./coordinates";
 
 export type Box = [x: Interval, y: Interval];
 
@@ -7,9 +8,8 @@ export type Box = [x: Interval, y: Interval];
 // corresponding interval.
 export function clampToBox(box: Box, point: vec.Vector2): vec.Vector2 {
     return [
-        // TODO: x and y coordinate functions
-        clamp(point[0], ...box[0]),
-        clamp(point[1], ...box[1])
+        clamp(x(point), ...x(box)),
+        clamp(y(point), ...y(box))
     ]
 }
 
@@ -18,8 +18,8 @@ export function clampToBox(box: Box, point: vec.Vector2): vec.Vector2 {
 // that dimension instead.
 export function inset(amount: vec.Vector2, box: Box): Box {
     return ensureValid([
-        [box[0][0] + amount[0], box[0][1] - amount[0]],
-        [box[1][0] + amount[1], box[1][1] - amount[1]],
+        [x(box)[0] + x(amount), x(box)[1] - x(amount)],
+        [y(box)[0] + y(amount), y(box)[1] - y(amount)],
     ]);
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/math/clamp.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/clamp.ts
@@ -1,0 +1,10 @@
+// Restricts `value` to be between `min` and `max`.
+export function clamp(value: number, min: number, max: number): number {
+    if (value < min) {
+        return min;
+    }
+    if (value > max) {
+        return max;
+    }
+    return value;
+}

--- a/packages/perseus/src/widgets/interactive-graphs/math/coordinates.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/coordinates.ts
@@ -1,0 +1,7 @@
+export function x<T>(coord: [x: T, y: T]): T {
+    return coord[0]
+}
+
+export function y<T>(coord: [x: T, y: T]): T {
+    return coord[1]
+}

--- a/packages/perseus/src/widgets/interactive-graphs/math/coordinates.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/coordinates.ts
@@ -1,7 +1,4 @@
-export function x<T>(coord: [x: T, y: T]): T {
-    return coord[0]
-}
-
-export function y<T>(coord: [x: T, y: T]): T {
-    return coord[1]
-}
+// Use X and Y to index into arrays that represent coordinate pairs.
+// e.g. point[X]
+export const X = 0;
+export const Y = 1;

--- a/packages/perseus/src/widgets/interactive-graphs/math/index.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/index.ts
@@ -1,10 +1,2 @@
-// restricts `value` to be between `min` and `max`.
-export function clamp(value: number, min: number, max: number) {
-    if (value < min) {
-        return min;
-    }
-    if (value > max) {
-        return max;
-    }
-    return value;
-}
+export {clamp} from "./clamp";
+export {snap} from "./snap";

--- a/packages/perseus/src/widgets/interactive-graphs/math/index.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/index.ts
@@ -1,3 +1,3 @@
 export {clamp} from "./clamp";
 export {snap} from "./snap";
-export * from "./box";
+export {inset, clampToBox} from "./box";

--- a/packages/perseus/src/widgets/interactive-graphs/math/index.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/index.ts
@@ -1,2 +1,3 @@
 export {clamp} from "./clamp";
 export {snap} from "./snap";
+export * from "./box";

--- a/packages/perseus/src/widgets/interactive-graphs/math/index.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/index.ts
@@ -1,0 +1,10 @@
+// restricts `value` to be between `min` and `max`.
+export function clamp(value: number, min: number, max: number) {
+    if (value < min) {
+        return min;
+    }
+    if (value > max) {
+        return max;
+    }
+    return value;
+}

--- a/packages/perseus/src/widgets/interactive-graphs/math/index.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/index.ts
@@ -1,3 +1,5 @@
 export {clamp} from "./clamp";
 export {snap} from "./snap";
 export {inset, clampToBox} from "./box";
+export {X, Y} from "./coordinates"
+export {MIN, MAX, size} from "./interval"

--- a/packages/perseus/src/widgets/interactive-graphs/math/index.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/index.ts
@@ -1,5 +1,5 @@
 export {clamp} from "./clamp";
 export {snap} from "./snap";
 export {inset, clampToBox} from "./box";
-export {X, Y} from "./coordinates"
-export {MIN, MAX, size} from "./interval"
+export {X, Y} from "./coordinates";
+export {MIN, MAX, size} from "./interval";

--- a/packages/perseus/src/widgets/interactive-graphs/math/interval.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/interval.test.ts
@@ -1,0 +1,23 @@
+import {trim} from "./interval";
+
+describe("trim", () => {
+    it("does nothing given amount 0", () => {
+        const result = trim(0, [2, 5]);
+        expect(result).toEqual([2, 5]);
+    });
+
+    it("removes the given amount from each end of the interval", () => {
+        const result = trim(1, [2, 5]);
+        expect(result).toEqual([3, 4]);
+    });
+
+    it("does not let the size of the interval go below zero", () => {
+        const result = trim(9, [2, 5]);
+        expect(result).toEqual([3.5, 3.5]);
+    });
+
+    it("expands the interval when amount is negative", () => {
+        const result = trim(-1, [2, 5]);
+        expect(result).toEqual([1, 6]);
+    });
+});

--- a/packages/perseus/src/widgets/interactive-graphs/math/interval.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/interval.ts
@@ -1,5 +1,10 @@
 import {Interval} from "mafs";
 
+// Use MIN and MAX to index into arrays that represent intervals.
+// e.g. range[MAX]
+export const MIN = 0
+export const MAX = 1
+
 export function size([min, max]: Interval): number {
     return max - min;
 }

--- a/packages/perseus/src/widgets/interactive-graphs/math/interval.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/interval.ts
@@ -1,9 +1,9 @@
-import {Interval} from "mafs";
+import type {Interval} from "mafs";
 
 // Use MIN and MAX to index into arrays that represent intervals.
 // e.g. range[MAX]
-export const MIN = 0
-export const MAX = 1
+export const MIN = 0;
+export const MAX = 1;
 
 export function size([min, max]: Interval): number {
     return max - min;

--- a/packages/perseus/src/widgets/interactive-graphs/math/interval.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/interval.ts
@@ -8,3 +8,22 @@ export const MAX = 1;
 export function size([min, max]: Interval): number {
     return max - min;
 }
+
+// Removes an equal amount from each end of the interval.
+//
+// If the given amount cannot be removed (because the interval is too small),
+// half the interval's size is removed from each end instead, so the interval
+// ends up with size = 0, and both MAX and MIN equal to its former midpoint.
+//
+// If `amount` is negative, the interval is expanded instead.
+export function trim(amount: number, interval: Interval): Interval {
+    if (amount * 2 > size(interval)) {
+        const middle = average(...interval);
+        return [middle, middle];
+    }
+    return [interval[MIN] + amount, interval[MAX] - amount];
+}
+
+function average(a: number, b: number): number {
+    return (a + b) / 2;
+}

--- a/packages/perseus/src/widgets/interactive-graphs/math/interval.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/interval.ts
@@ -1,0 +1,5 @@
+import {Interval} from "mafs";
+
+export function size([min, max]: Interval): number {
+    return max - min;
+}

--- a/packages/perseus/src/widgets/interactive-graphs/math/snap.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/snap.test.ts
@@ -1,0 +1,15 @@
+import {snap} from "./snap";
+
+describe("snap", () => {
+    it("snaps to next position when over halfway to it", () => {
+        const result = snap([2, 2], [1.1, 1.1]);
+
+        expect(result).toEqual([2, 2]);
+    });
+
+    it("does not snap to next position when less than halfway to it", () => {
+        const result = snap([2, 2], [0.9, 0.9]);
+
+        expect(result).toEqual([0, 0]);
+    });
+});

--- a/packages/perseus/src/widgets/interactive-graphs/math/snap.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/snap.ts
@@ -1,0 +1,14 @@
+import type {vec} from "mafs";
+
+// Rounds each component of `point` to the nearest multiple of the
+// corresponding component of `snapStep`. E.g. if the snap step is [2, 3],
+// the x-coord of the point will be rounded to the nearest multiple of 2, and
+// the y-coord of the point will be rounded to the nearest multiple of 3.
+export function snap(snapStep: vec.Vector2, point: vec.Vector2): vec.Vector2 {
+    const [requestedX, requestedY] = point;
+    const [snapX, snapY] = snapStep;
+    return [
+        Math.round(requestedX / snapX) * snapX,
+        Math.round(requestedY / snapY) * snapY,
+    ];
+}

--- a/packages/perseus/src/widgets/interactive-graphs/protractor.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/protractor.tsx
@@ -14,6 +14,7 @@ import {bound, TARGET_SIZE} from "./utils";
 import type {RefObject} from "react";
 
 import "./protractor.css";
+import {X, Y} from "./math";
 
 const protractorImage =
     "https://ka-perseus-graphie.s3.amazonaws.com/e9d032f2ab8b95979f674fbfa67056442ba1ff6a.png";
@@ -64,9 +65,9 @@ export function Protractor() {
     return (
         <g
             ref={draggableRef}
-            transform={`translate(${topLeftPx[0]}, ${topLeftPx[1]}), rotate(${angle})`}
+            transform={`translate(${topLeftPx[X]}, ${topLeftPx[Y]}), rotate(${angle})`}
             style={{
-                transformOrigin: `${-centerToTopLeft[0]}px ${-centerToTopLeft[1]}px`,
+                transformOrigin: `${-centerToTopLeft[X]}px ${-centerToTopLeft[Y]}px`,
             }}
         >
             <image href={protractorImage} />

--- a/packages/perseus/src/widgets/interactive-graphs/protractor.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/protractor.tsx
@@ -8,13 +8,13 @@ import {pathBuilder} from "../../util/svg";
 import {useDraggable} from "./graphs/use-draggable";
 import {useTransformVectorsToPixels} from "./graphs/use-transform";
 import {calculateAngleInDegrees} from "./graphs/utils";
+import {X, Y} from "./math";
 import useGraphConfig from "./reducer/use-graph-config";
 import {bound, TARGET_SIZE} from "./utils";
 
 import type {RefObject} from "react";
 
 import "./protractor.css";
-import {X, Y} from "./math";
 
 const protractorImage =
     "https://ka-perseus-graphie.s3.amazonaws.com/e9d032f2ab8b95979f674fbfa67056442ba1ff6a.png";

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -16,7 +16,8 @@ import {
 import GraphUtils from "../../../util/graph-utils";
 import {polar} from "../../../util/graphie";
 import {getQuadraticCoefficients} from "../graphs/quadratic";
-import {snap, bound, clamp} from "../utils";
+import {snap, bound} from "../utils";
+import {clamp} from "../math";
 
 import {initializeGraphState} from "./initialize-graph-state";
 import {

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -17,7 +17,7 @@ import GraphUtils from "../../../util/graph-utils";
 import {polar} from "../../../util/graphie";
 import {getQuadraticCoefficients} from "../graphs/quadratic";
 import {bound} from "../utils";
-import {clamp, snap} from "../math";
+import {clamp, snap, X, Y} from "../math";
 
 import {initializeGraphState} from "./initialize-graph-state";
 import {
@@ -295,7 +295,7 @@ function doMovePoint(
             // vertical line. If they are, then we don't want to move the point
             const newCoords: vec.Vector2[] = [...state.coords];
             newCoords[action.index] = boundDestination;
-            if (newCoords[0][0] === newCoords[1][0]) {
+            if (newCoords[0][X] === newCoords[1][X]) {
                 return state;
             }
 
@@ -369,13 +369,13 @@ function doMoveCenter(
             // if it otherwise would be off the chart
             // ex: if the handle is on the right and we move the center
             // to the rightmost position, move the handle to the left
-            const [xMin, xMax] = state.range[0];
+            const [xMin, xMax] = state.range[X];
             const [radX] = newRadiusPoint;
             if (radX < xMin || radX > xMax) {
-                const xJumpDist = (radX - constrainedCenter[0]) * 2;
+                const xJumpDist = (radX - constrainedCenter[X]) * 2;
                 const possibleNewX = radX - xJumpDist;
                 if (possibleNewX >= xMin && possibleNewX <= xMax) {
-                    newRadiusPoint[0] = possibleNewX;
+                    newRadiusPoint[X] = possibleNewX;
                 }
             }
 
@@ -399,11 +399,11 @@ function doMoveRadiusPoint(
 ): InteractiveGraphState {
     switch (state.type) {
         case "circle": {
-            const [xMin, xMax] = state.range[0];
+            const [xMin, xMax] = state.range[X];
             const nextRadiusPoint: vec.Vector2 = [
                 // Constrain to graph range
                 // The +0 is to convert -0 to +0
-                clamp(action.destination[0] + 0, xMin, xMax),
+                clamp(action.destination[X] + 0, xMin, xMax),
                 state.center[1],
             ];
 
@@ -464,10 +464,10 @@ const getDeltaVertex = (
     delta: vec.Vector2,
 ): vec.Vector2 => {
     const [deltaX, deltaY] = delta;
-    const maxXMove = Math.min(...maxMoves.map((move) => move[0]));
-    const maxYMove = Math.min(...maxMoves.map((move) => move[1]));
-    const minXMove = Math.max(...minMoves.map((move) => move[0]));
-    const minYMove = Math.max(...minMoves.map((move) => move[1]));
+    const maxXMove = Math.min(...maxMoves.map((move) => move[X]));
+    const maxYMove = Math.min(...maxMoves.map((move) => move[Y]));
+    const minXMove = Math.max(...minMoves.map((move) => move[X]));
+    const minYMove = Math.max(...minMoves.map((move) => move[Y]));
     const dx = clamp(deltaX, minXMove, maxXMove);
     const dy = clamp(deltaY, minYMove, maxYMove);
     return [dx, dy];

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -16,8 +16,8 @@ import {
 import GraphUtils from "../../../util/graph-utils";
 import {polar} from "../../../util/graphie";
 import {getQuadraticCoefficients} from "../graphs/quadratic";
-import {snap, bound} from "../utils";
-import {clamp} from "../math";
+import {bound} from "../utils";
+import {clamp, snap} from "../math";
 
 import {initializeGraphState} from "./initialize-graph-state";
 import {

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -403,7 +403,7 @@ function doMoveRadiusPoint(
             const nextRadiusPoint: vec.Vector2 = [
                 // Constrain to graph range
                 // The +0 is to convert -0 to +0
-                Math.min(Math.max(xMin, action.destination[0] + 0), xMax),
+                clamp(action.destination[0] + 0, xMin, xMax),
                 state.center[1],
             ];
 

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -16,8 +16,8 @@ import {
 import GraphUtils from "../../../util/graph-utils";
 import {polar} from "../../../util/graphie";
 import {getQuadraticCoefficients} from "../graphs/quadratic";
-import {bound} from "../utils";
 import {clamp, snap, X, Y} from "../math";
+import {bound} from "../utils";
 
 import {initializeGraphState} from "./initialize-graph-state";
 import {

--- a/packages/perseus/src/widgets/interactive-graphs/utils.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/utils.test.ts
@@ -1,4 +1,5 @@
 import {normalizePoints, normalizeCoords} from "./utils";
+
 import type {Coord} from "../../interactive2/types";
 import type {GraphRange} from "../../perseus-types";
 

--- a/packages/perseus/src/widgets/interactive-graphs/utils.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/utils.test.ts
@@ -1,5 +1,4 @@
-import {normalizePoints, normalizeCoords, snap} from "./utils";
-
+import {normalizePoints, normalizeCoords} from "./utils";
 import type {Coord} from "../../interactive2/types";
 import type {GraphRange} from "../../perseus-types";
 
@@ -63,19 +62,5 @@ describe("normalizeCoords", () => {
         const result = normalizeCoords(coordsList, ranges);
 
         expect(result).toEqual(expected);
-    });
-});
-
-describe("snap", () => {
-    it("snaps to next position when over halfway to it", () => {
-        const result = snap([2, 2], [1.1, 1.1]);
-
-        expect(result).toEqual([2, 2]);
-    });
-
-    it("does not snap to next position when less than halfway to it", () => {
-        const result = snap([2, 2], [0.9, 0.9]);
-
-        expect(result).toEqual([0, 0]);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/utils.ts
@@ -1,8 +1,7 @@
 import type {Coord} from "../../interactive2/types";
 import type {PerseusInteractiveGraphWidgetOptions} from "../../perseus-types";
 import type {Interval, vec} from "mafs";
-import {clamp} from "./math";
-import {clampToBox, inset} from "./math/box";
+import {clampToBox, inset} from "./math";
 
 /**
  * 44 is touch best practice and AAA compliant for WCAG

--- a/packages/perseus/src/widgets/interactive-graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/utils.ts
@@ -1,8 +1,8 @@
+import {clampToBox, inset, MIN, size} from "./math";
+
 import type {Coord} from "../../interactive2/types";
 import type {PerseusInteractiveGraphWidgetOptions} from "../../perseus-types";
 import type {Interval, vec} from "mafs";
-import {clampToBox, inset, MIN} from "./math";
-import {size} from "./math";
 
 /**
  * 44 is touch best practice and AAA compliant for WCAG
@@ -55,7 +55,6 @@ export function bound({
     range: [Interval, Interval];
     point: vec.Vector2;
 }): vec.Vector2 {
-    const boundingBox = inset(snapStep, range)
+    const boundingBox = inset(snapStep, range);
     return clampToBox(boundingBox, point);
 }
-

--- a/packages/perseus/src/widgets/interactive-graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/utils.ts
@@ -2,6 +2,7 @@ import type {Coord} from "../../interactive2/types";
 import type {PerseusInteractiveGraphWidgetOptions} from "../../perseus-types";
 import type {Interval, vec} from "mafs";
 import {clampToBox, inset} from "./math";
+import {size} from "./math/interval";
 
 /**
  * 44 is touch best practice and AAA compliant for WCAG
@@ -22,12 +23,10 @@ export const normalizePoints = <A extends Coord[]>(
             coords.map((coord, i) => {
                 const axisRange = range[i];
                 if (noSnap) {
-                    return axisRange[0] + (axisRange[1] - axisRange[0]) * coord;
+                    return axisRange[0] + size(axisRange) * coord;
                 }
                 const axisStep = step[i];
-                const nSteps = Math.floor(
-                    (axisRange[1] - axisRange[0]) / axisStep,
-                );
+                const nSteps = Math.floor(size(axisRange) / axisStep);
                 const tick = Math.round(coord * nSteps);
                 return axisRange[0] + axisStep * tick;
             }) as Coord,
@@ -41,8 +40,7 @@ export const normalizeCoords = <A extends Coord[]>(
     coordsList.map<Coord>(
         (coords) =>
             coords.map((coord, i) => {
-                const extent = ranges[i][1] - ranges[i][0];
-                return (coord + ranges[i][1]) / extent;
+                return (coord + ranges[i][1]) / size(ranges[i]);
             }) as Coord,
     ) as any;
 

--- a/packages/perseus/src/widgets/interactive-graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/utils.ts
@@ -2,6 +2,7 @@ import type {Coord} from "../../interactive2/types";
 import type {PerseusInteractiveGraphWidgetOptions} from "../../perseus-types";
 import type {Interval, vec} from "mafs";
 import {clamp} from "./math";
+import {clampToBox, inset} from "./math/box";
 
 /**
  * 44 is touch best practice and AAA compliant for WCAG
@@ -57,12 +58,7 @@ export function bound({
     range: [Interval, Interval];
     point: vec.Vector2;
 }): vec.Vector2 {
-    const [requestedX, requestedY] = point;
-    const [snapX, snapY] = snapStep;
-    const [[minX, maxX], [minY, maxY]] = range;
-    return [
-        clamp(requestedX, minX + snapX, maxX - snapX),
-        clamp(requestedY, minY + snapY, maxY - snapY),
-    ];
+    const boundingBox = inset(snapStep, range)
+    return clampToBox(boundingBox, point);
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/utils.ts
@@ -46,15 +46,6 @@ export const normalizeCoords = <A extends Coord[]>(
             }) as Coord,
     ) as any;
 
-export function snap(snapStep: vec.Vector2, point: vec.Vector2): vec.Vector2 {
-    const [requestedX, requestedY] = point;
-    const [snapX, snapY] = snapStep;
-    return [
-        Math.round(requestedX / snapX) * snapX,
-        Math.round(requestedY / snapY) * snapY,
-    ];
-}
-
 // Returns the closest point to the given `point` that is within the graph
 // bounds given in `state`.
 export function bound({

--- a/packages/perseus/src/widgets/interactive-graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/utils.ts
@@ -1,6 +1,7 @@
 import type {Coord} from "../../interactive2/types";
 import type {PerseusInteractiveGraphWidgetOptions} from "../../perseus-types";
 import type {Interval, vec} from "mafs";
+import {clamp} from "./math";
 
 /**
  * 44 is touch best practice and AAA compliant for WCAG
@@ -74,12 +75,3 @@ export function bound({
     ];
 }
 
-export function clamp(value: number, min: number, max: number) {
-    if (value < min) {
-        return min;
-    }
-    if (value > max) {
-        return max;
-    }
-    return value;
-}

--- a/packages/perseus/src/widgets/interactive-graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/utils.ts
@@ -1,8 +1,8 @@
 import type {Coord} from "../../interactive2/types";
 import type {PerseusInteractiveGraphWidgetOptions} from "../../perseus-types";
 import type {Interval, vec} from "mafs";
-import {clampToBox, inset} from "./math";
-import {size} from "./math/interval";
+import {clampToBox, inset, MIN} from "./math";
+import {size} from "./math";
 
 /**
  * 44 is touch best practice and AAA compliant for WCAG
@@ -23,12 +23,12 @@ export const normalizePoints = <A extends Coord[]>(
             coords.map((coord, i) => {
                 const axisRange = range[i];
                 if (noSnap) {
-                    return axisRange[0] + size(axisRange) * coord;
+                    return axisRange[MIN] + size(axisRange) * coord;
                 }
                 const axisStep = step[i];
                 const nSteps = Math.floor(size(axisRange) / axisStep);
                 const tick = Math.round(coord * nSteps);
-                return axisRange[0] + axisStep * tick;
+                return axisRange[MIN] + axisStep * tick;
             }) as Coord,
     ) as any;
 


### PR DESCRIPTION
Note to reviewers: it's going to be easiest to review this PR one commit
at a time!

This is the first part of a multi-part refactor. I am submitting this
intermediate PR to get feedback and hopefully avoid running into too many
merge conflicts.

In future PRs, I plan to:

- move more functions into `math/`
- reuse the existing functions in more places
- re-export functions from `kmath` in `math/index.ts`, possibly
  wrapping them with more suitable type signatures
- fix TODOs added in this PR.

Adding a `math/` folder gives us a clear place to put new mathy functions,
and will help us locate and reuse the functions that already exist.

Issue: LEMS-2135

## Test plan:

`yarn test`