### PR TITLE
Move tests next to implementation, and fix filename

### DIFF
--- a/.changeset/ten-paws-wash.md
+++ b/.changeset/ten-paws-wash.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Move and rename test files

--- a/packages/perseus/src/widgets/interactive-graphs/axis-tick-labels.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-tick-labels.test.ts
@@ -1,4 +1,4 @@
-import {showTickLabel} from "../graphs/components/axis-tick-labels";
+import {showTickLabel} from "./graphs/components/axis-tick-labels";
 
 it("should hide the first negative axis tick label if the gridStep > tickStep", () => {
     const gridStep = 2;

--- a/packages/perseus/src/widgets/interactive-graphs/axis-ticks.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/axis-ticks.test.ts
@@ -1,4 +1,4 @@
-import {generateTickLocations} from "../axis-ticks";
+import {generateTickLocations} from "./axis-ticks";
 
 describe("generateTickLocations", () => {
     it("should generate ticks from the origin", () => {


### PR DESCRIPTION
## Summary:
The tests for axis ticks looked lonely hanging out in `__tests__`, so I
moved them next to the associated production code. I also renamed one
file from `tests.ts` to `test.ts` - the name was preventing Jest from
running the tests in that file.

Issue: none

## Test plan:

`yarn test`