### PR TITLE
Move getLines to polygon.tsx

### DIFF
--- a/.changeset/brave-rats-speak.md
+++ b/.changeset/brave-rats-speak.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: move the getLines function to polygon.tsx

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -11,7 +11,7 @@ import {TextLabel} from "./components/text-label";
 import {useDraggable} from "./use-draggable";
 
 import type {MafsGraphProps, PolygonGraphState} from "../types";
-import {CollinearTuple} from "@khanacademy/perseus";
+import type {CollinearTuple} from "@khanacademy/perseus";
 
 type Props = MafsGraphProps<PolygonGraphState>;
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -9,9 +9,9 @@ import {PolygonAngle} from "./components/angle-indicators";
 import {StyledMovablePoint} from "./components/movable-point";
 import {TextLabel} from "./components/text-label";
 import {useDraggable} from "./use-draggable";
-import {getLines} from "./utils";
 
 import type {MafsGraphProps, PolygonGraphState} from "../types";
+import {CollinearTuple} from "@khanacademy/perseus";
 
 type Props = MafsGraphProps<PolygonGraphState>;
 
@@ -124,3 +124,10 @@ export const PolygonGraph = (props: Props) => {
         </>
     );
 };
+
+function getLines(points: readonly vec.Vector2[]): CollinearTuple[] {
+    return points.map((point, i) => {
+        const next = points[(i + 1) % points.length];
+        return [point, next];
+    });
+}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
@@ -42,13 +42,6 @@ export const getIntersectionOfRayWithBox = (
     }
 };
 
-export const getLines = (points: readonly vec.Vector2[]): CollinearTuple[] => {
-    return points.map((point, i) => {
-        const next = points[(i + 1) % points.length];
-        return [point, next];
-    });
-};
-
 function isBetween(x: number, low: number, high: number) {
     return x >= low && x <= high;
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
@@ -1,4 +1,3 @@
-import type {CollinearTuple} from "../../../perseus-types";
 import type {Interval, vec} from "mafs";
 
 /**


### PR DESCRIPTION
## Summary:
It's only used by the polygon graph, and doesn't seem like a good candidate for
reuse (with a name like getLines, how would people find it?) so I moved it
closer to its usage site.

Issue: none

## Test plan:

`yarn test`