### PR TITLE
React 18: Wrap non-RTL actions in act()

### DIFF
--- a/config/test/log-on-fail-reporter.js
+++ b/config/test/log-on-fail-reporter.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-commonjs */
 /**
- * Only log console statements on when the test errors out.
+ * Only log console statements when the test errors out.
  * From: https://gist.github.com/GeeWee/71db0d9911b4a087e4b2486386168b05
  */
 const {getConsoleOutput} = require("@jest/console");

--- a/packages/math-input/src/components/keypad/__tests__/keypad-button.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/keypad-button.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from "@testing-library/react";
+import {act, render, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
@@ -70,7 +70,9 @@ describe("<KeypadButton />", () => {
         );
 
         // Act
-        screen.getByRole("button", {name: "Right parenthesis"}).focus();
+        act(() =>
+            screen.getByRole("button", {name: "Right parenthesis"}).focus(),
+        );
         await userEvent.keyboard("{enter}");
 
         // Assert

--- a/packages/math-input/src/components/tabbar/__tests__/item.test.tsx
+++ b/packages/math-input/src/components/tabbar/__tests__/item.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from "@testing-library/react";
+import {act, render, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
@@ -57,7 +57,7 @@ describe("<TabbarItem />", () => {
                 onClick={() => {}}
             />,
         );
-        jest.runAllTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // Assert
         expect(screen.getByRole("tab", {name: "Numbers"})).toHaveFocus();

--- a/packages/perseus-editor/src/__tests__/editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/editor.test.tsx
@@ -123,7 +123,6 @@ describe("Editor", () => {
         await userEvent.clear(captionInput);
         await userEvent.type(captionInput, "A picture of kittens");
         await userEvent.tab(); // blurring the input triggers onChange to be called
-        jest.runOnlyPendingTimers();
 
         // Assert
         expect(changeFn).toHaveBeenCalledWith(

--- a/packages/perseus-editor/src/widgets/__tests__/expression-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/expression-editor.test.tsx
@@ -1,5 +1,5 @@
 import {Dependencies} from "@khanacademy/perseus";
-import {render, screen} from "@testing-library/react";
+import {act, render, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
@@ -23,7 +23,7 @@ describe("expression-editor", () => {
 
     it("should render", async () => {
         render(<ExpressionEditor onChange={() => undefined} />);
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         expect(await screen.findByText(/Add new answer/)).toBeInTheDocument();
     });
@@ -59,7 +59,7 @@ describe("expression-editor", () => {
                 answerForms={answerForms}
             />,
         );
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         expect(await screen.findByText(/π/)).toBeInTheDocument();
     });
@@ -68,7 +68,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(<ExpressionEditor onChange={onChangeMock} />);
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
             screen.getByRole("checkbox", {
@@ -83,7 +83,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(<ExpressionEditor onChange={onChangeMock} functions={[]} />);
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         const input = screen.getByRole("textbox", {
             name: "Function variables:",
@@ -98,7 +98,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(<ExpressionEditor onChange={onChangeMock} />);
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
             screen.getByRole("checkbox", {
@@ -121,7 +121,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(<ExpressionEditor onChange={onChangeMock} />);
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
             screen.getByRole("checkbox", {
@@ -138,7 +138,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(<ExpressionEditor onChange={onChangeMock} />);
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
             screen.getByRole("checkbox", {
@@ -155,7 +155,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(<ExpressionEditor onChange={onChangeMock} />);
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
             screen.getByRole("checkbox", {
@@ -172,7 +172,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(<ExpressionEditor onChange={onChangeMock} />);
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
             screen.getByRole("checkbox", {
@@ -189,7 +189,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(<ExpressionEditor onChange={onChangeMock} />);
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
             screen.getByRole("checkbox", {
@@ -206,7 +206,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(<ExpressionEditor onChange={onChangeMock} />);
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
             screen.getByRole("button", {
@@ -250,7 +250,7 @@ describe("expression-editor", () => {
                 ]}
             />,
         );
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
             screen.getByRole("button", {
@@ -263,7 +263,7 @@ describe("expression-editor", () => {
                 name: "9",
             }),
         );
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         expect(onChangeMock).toBeCalledWith(
             {
@@ -311,7 +311,7 @@ describe("expression-editor", () => {
                 ]}
             />,
         );
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
             screen.getByRole("checkbox", {
@@ -355,7 +355,7 @@ describe("expression-editor", () => {
                 ]}
             />,
         );
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
             screen.getByRole("checkbox", {
@@ -399,7 +399,7 @@ describe("expression-editor", () => {
                 ]}
             />,
         );
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
             screen.getByRole("button", {

--- a/packages/perseus/src/__tests__/article-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/article-renderer.test.tsx
@@ -4,7 +4,7 @@ import {
     MobileKeypad,
 } from "@khanacademy/math-input";
 import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
-import {screen, render, fireEvent, waitFor} from "@testing-library/react";
+import {screen, render, fireEvent, waitFor, act} from "@testing-library/react";
 import * as React from "react";
 
 import {
@@ -92,7 +92,7 @@ describe("article renderer", () => {
         // If we don't spin the timers here, then the timer fires in the test
         // _after_ and breaks it because we do setState() in the callback,
         // and by that point the component has been unmounted.
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
     });
 
     it("should render the content for a section", () => {

--- a/packages/perseus/src/__tests__/renderer-api.test.tsx
+++ b/packages/perseus/src/__tests__/renderer-api.test.tsx
@@ -171,7 +171,7 @@ describe("Perseus API", function () {
 
             // Act - focus
             await userEvent.click(input);
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
 
             // Assert
             expect(onFocusChange).toHaveBeenCalledTimes(1);
@@ -183,7 +183,7 @@ describe("Perseus API", function () {
             // Act - blur
             onFocusChange.mockReset();
             await userEvent.tab();
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
 
             // Assert
             expect(onFocusChange).toHaveBeenCalledTimes(1);
@@ -200,12 +200,12 @@ describe("Perseus API", function () {
             const input1 = inputs[0];
             const input2 = inputs[1];
             await userEvent.click(input1);
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
 
             // Act - move focus to new input
             onFocusChange.mockReset();
             await userEvent.click(input2);
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
 
             expect(onFocusChange).toHaveBeenCalledTimes(1);
             expect(onFocusChange).toHaveBeenCalledWith(

--- a/packages/perseus/src/__tests__/renderer-api.test.tsx
+++ b/packages/perseus/src/__tests__/renderer-api.test.tsx
@@ -1,5 +1,5 @@
 import {describe, beforeEach, it} from "@jest/globals";
-import {render, screen} from "@testing-library/react";
+import {act, render, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import $ from "jquery";
 import * as React from "react";
@@ -43,7 +43,7 @@ describe("Perseus API", function () {
             const {renderer} = renderQuestion(inputNumber1Item.question);
 
             // Act
-            renderer.setInputValue(["input-number 1"], "5", () => undefined);
+            act(() => renderer.setInputValue(["input-number 1"], "5"));
 
             // Assert
             expect(renderer).toHaveBeenAnsweredCorrectly();
@@ -54,7 +54,7 @@ describe("Perseus API", function () {
             const {renderer} = renderQuestion(inputNumber1Item.question);
 
             // Act
-            renderer.setInputValue(["input-number 1"], "3");
+            act(() => renderer.setInputValue(["input-number 1"], "3"));
 
             // Assert
             expect(renderer).toHaveBeenAnsweredIncorrectly();
@@ -64,20 +64,22 @@ describe("Perseus API", function () {
             // Arrange
             const {renderer} = renderQuestion(inputNumber1Item.question);
 
-            renderer.setInputValue(["input-number 1"], "3");
+            act(() => renderer.setInputValue(["input-number 1"], "3"));
             expect(renderer).toHaveBeenAnsweredIncorrectly();
 
-            renderer.setInputValue(["input-number 1"], "");
+            act(() => renderer.setInputValue(["input-number 1"], ""));
             expect(renderer).toHaveInvalidInput();
         });
 
         it("should be able to accept a callback", function (done) {
             const {renderer} = renderQuestion(inputNumber1Item.question);
-            renderer.setInputValue(["input-number 1"], "3", function () {
-                const guess = renderer.getUserInput()[0];
-                expect(guess.currentValue).toBe("3");
-                done();
-            });
+            act(() =>
+                renderer.setInputValue(["input-number 1"], "3", function () {
+                    const guess = renderer.getUserInput()[0];
+                    expect(guess.currentValue).toBe("3");
+                    done();
+                }),
+            );
             jest.runAllTimers();
         });
     });

--- a/packages/perseus/src/__tests__/renderer.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.test.tsx
@@ -1,5 +1,5 @@
 import {describe, beforeAll, beforeEach, it} from "@jest/globals";
-import {screen, waitFor, within} from "@testing-library/react";
+import {act, screen, waitFor, within} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
@@ -328,12 +328,12 @@ describe("renderer", () => {
             if (imageIndex != null) {
                 const img = images[imageIndex];
                 if (img?.onload) {
-                    img.onload();
+                    act(() => img.onload());
                 }
             } else {
                 images.forEach((i) => {
                     if (i?.onload) {
-                        i.onload();
+                        act(() => i.onload());
                     }
                 });
             }
@@ -990,11 +990,11 @@ describe("renderer", () => {
                 },
                 {onFocusChange},
             );
-            renderer.focusPath(["input-number 1"]);
+            act(() => renderer.focusPath(["input-number 1"]));
             onFocusChange.mockClear();
 
             // Act
-            renderer.focusPath(["input-number 2"]);
+            act(() => renderer.focusPath(["input-number 2"]));
 
             // Assert
             expect(onFocusChange).toHaveBeenCalledWith(
@@ -1024,7 +1024,7 @@ describe("renderer", () => {
             onFocusChange.mockClear();
 
             // Act
-            renderer.blurPath(["input-number 1"]);
+            act(() => renderer.blurPath(["input-number 1"]));
 
             // Assert
             expect(onFocusChange).not.toHaveBeenCalled();
@@ -1047,11 +1047,11 @@ describe("renderer", () => {
                 {onFocusChange},
             );
             // Focus _second_ input number widget
-            screen.getAllByRole("textbox")[1].focus();
+            act(() => screen.getAllByRole("textbox")[1].focus());
             onFocusChange.mockClear();
 
             // Act
-            renderer.blur();
+            act(() => renderer.blur());
             jest.runOnlyPendingTimers(); // There's a _.defer() in this code path
 
             // Assert
@@ -1147,9 +1147,15 @@ describe("renderer", () => {
             const restorationCallback = jest.fn();
 
             // Act
-            renderer.restoreSerializedState(
-                {"mock-widget 1": {}, "mock-widget 2": {}, "mock-widget 3": {}},
-                restorationCallback,
+            act(() =>
+                renderer.restoreSerializedState(
+                    {
+                        "mock-widget 1": {},
+                        "mock-widget 2": {},
+                        "mock-widget 3": {},
+                    },
+                    restorationCallback,
+                ),
             );
             jest.runOnlyPendingTimers();
 
@@ -1648,7 +1654,7 @@ describe("renderer", () => {
             const cb = jest.fn();
 
             // Act
-            renderer.setInputValue(["input-number 2"], "1000", cb);
+            act(() => renderer.setInputValue(["input-number 2"], "1000", cb));
 
             // Assert
             expect(screen.getAllByRole("textbox")[0]).toHaveValue("");
@@ -1673,7 +1679,7 @@ describe("renderer", () => {
             const cb = jest.fn();
 
             // Act
-            renderer.setInputValue(["input-number 2"], "1000", cb);
+            act(() => renderer.setInputValue(["input-number 2"], "1000", cb));
             jest.runOnlyPendingTimers();
 
             // Assert

--- a/packages/perseus/src/__tests__/renderer.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.test.tsx
@@ -67,7 +67,7 @@ describe("renderer", () => {
         // If we don't spin the timers here, then the timer fires in the test
         // _after_ and breaks it because we do setState() in the callback,
         // and by that point the component has been unmounted.
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
     });
 
     describe("snapshots", () => {
@@ -86,7 +86,7 @@ describe("renderer", () => {
             // Act
             await userEvent.click(screen.getByRole("button"));
             await userEvent.click(screen.getAllByRole("option")[2]);
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
 
             // Assert
             expect(container).toMatchSnapshot("correct answer");
@@ -99,7 +99,7 @@ describe("renderer", () => {
             // Act
             await userEvent.click(screen.getByRole("button"));
             await userEvent.click(screen.getAllByRole("option")[1]);
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
 
             // Assert
             expect(container).toMatchSnapshot("incorrect answer");
@@ -748,7 +748,7 @@ describe("renderer", () => {
 
             // Poke the renderer so it's not in it's initial-render state
             await userEvent.click(screen.getByRole("button"));
-            jest.runOnlyPendingTimers(); // There's a setTimeout to open the dropdown
+            act(() => jest.runOnlyPendingTimers()); // There's a setTimeout to open the dropdown
             await userEvent.click(screen.getAllByRole("option")[1]);
         });
 
@@ -924,7 +924,7 @@ describe("renderer", () => {
             // Act
             await userEvent.tab();
             // There's a _.defer() in the blur handling
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
 
             // Assert
             expect(onFocusChange).toHaveBeenCalledWith(
@@ -952,7 +952,7 @@ describe("renderer", () => {
             const {renderer} = renderQuestion(question2);
 
             // Act
-            renderer.focusPath(["input-number 1"]);
+            act(() => renderer.focusPath(["input-number 1"]));
 
             // Assert
             expect(screen.getByRole("textbox")).toHaveFocus();
@@ -964,11 +964,11 @@ describe("renderer", () => {
             const {renderer} = renderQuestion(question2, {
                 onFocusChange,
             });
-            renderer.focusPath(["input-number 1"]);
+            act(() => renderer.focusPath(["input-number 1"]));
             onFocusChange.mockClear();
 
             // Act
-            renderer.focusPath(["input-number 1"]);
+            act(() => renderer.focusPath(["input-number 1"]));
 
             // Assert
             expect(onFocusChange).not.toHaveBeenCalled();
@@ -1020,7 +1020,7 @@ describe("renderer", () => {
                 {onFocusChange},
             );
             // Focus _second_ input number widget
-            screen.getAllByRole("textbox")[1].focus();
+            act(() => screen.getAllByRole("textbox")[1].focus());
             onFocusChange.mockClear();
 
             // Act
@@ -1052,7 +1052,7 @@ describe("renderer", () => {
 
             // Act
             act(() => renderer.blur());
-            jest.runOnlyPendingTimers(); // There's a _.defer() in this code path
+            act(() => jest.runOnlyPendingTimers()); // There's a _.defer() in this code path
 
             // Assert
             expect(onFocusChange).toHaveBeenCalledWith(
@@ -1079,8 +1079,8 @@ describe("renderer", () => {
             );
 
             // Act
-            renderer.blur();
-            jest.runOnlyPendingTimers(); // There's a _.defer() in this code path
+            act(() => renderer.blur());
+            act(() => jest.runOnlyPendingTimers()); // There's a _.defer() in this code path
 
             // Assert
             expect(onFocusChange).not.toHaveBeenCalled();
@@ -1110,10 +1110,12 @@ describe("renderer", () => {
             const {renderer} = renderQuestion(question1);
 
             // Act
-            renderer.restoreSerializedState({
-                "group 1": {},
-                "interactive-chart 1": {},
-            });
+            act(() =>
+                renderer.restoreSerializedState({
+                    "group 1": {},
+                    "interactive-chart 1": {},
+                }),
+            );
 
             // Assert
             expect(errorSpy).toHaveBeenCalledWith(
@@ -1157,7 +1159,7 @@ describe("renderer", () => {
                     restorationCallback,
                 ),
             );
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
 
             // Assert
             expect(restorationCallback).toHaveBeenCalledTimes(1);
@@ -1176,7 +1178,7 @@ describe("renderer", () => {
             });
             // It takes a clock tick after rendering for widgetInfo to be
             // populated (which renderer uses during serialize()).
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
 
             // Act
             const state = renderer.serialize();
@@ -1365,7 +1367,7 @@ describe("renderer", () => {
             expect(widgets.length).toBeGreaterThan(0);
 
             // Act
-            renderer.showRationalesForCurrentlySelectedChoices();
+            act(() => renderer.showRationalesForCurrentlySelectedChoices());
 
             // Assert
             widgets.forEach((w) =>
@@ -1391,7 +1393,7 @@ describe("renderer", () => {
             expect(widgets.length).toBeGreaterThan(0);
 
             // Act
-            renderer.deselectIncorrectSelectedChoices();
+            act(() => renderer.deselectIncorrectSelectedChoices());
 
             // Assert
             widgets.forEach((w) =>
@@ -1680,7 +1682,7 @@ describe("renderer", () => {
 
             // Act
             act(() => renderer.setInputValue(["input-number 2"], "1000", cb));
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
 
             // Assert
             expect(cb).toHaveBeenCalled();
@@ -1710,9 +1712,9 @@ describe("renderer", () => {
 
             // Open the dropdown and select the second (idx: 1) item
             await userEvent.click(screen.getByRole("button"));
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
             await userEvent.click(screen.getAllByRole("option")[1]);
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
 
             // Act
             const userInput = renderer.getUserInputForWidgets();

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -1,5 +1,5 @@
 import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
-import {within, render, screen} from "@testing-library/react";
+import {within, render, screen, act} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
@@ -178,7 +178,7 @@ describe("server item renderer", () => {
         const {renderer} = renderQuestion(itemWithInput);
 
         // Act
-        renderer.setInputValue(["input-number 1"], "99", focus);
+        act(() => renderer.setInputValue(["input-number 1"], "99", focus));
 
         // Assert
         expect(
@@ -413,10 +413,10 @@ describe("server item renderer", () => {
             const {renderer} = renderQuestion(itemWithInput, {
                 onFocusChange,
             });
-            renderer.focus();
+            act(() => renderer.focus());
 
             // Act
-            renderer.blur();
+            act(() => renderer.blur());
 
             // We have some async processes that need to be resolved here
             jest.runAllTimers();
@@ -458,10 +458,10 @@ describe("server item renderer", () => {
                 {onFocusChange, isMobile: true},
                 {keypadElement},
             );
-            renderer.focus();
+            act(() => renderer.focus());
 
             // Act
-            renderer.blur();
+            act(() => renderer.blur());
 
             // We have some async processes that need to be resolved here
             jest.runAllTimers();
@@ -485,7 +485,7 @@ describe("server item renderer", () => {
             });
 
             // Act
-            renderer.focusPath(["input-number 1"]);
+            act(() => renderer.focusPath(["input-number 1"]));
 
             // We have some async processes that need to be resolved here
             jest.runAllTimers();
@@ -543,20 +543,22 @@ describe("server item renderer", () => {
             const {renderer} = renderQuestion(itemWithInput);
 
             // Act
-            renderer.restoreSerializedState(
-                {
-                    hints: [{}, {}, {}],
-                    question: {
-                        "input-number 1": {
-                            answerType: "number",
-                            currentValue: "-42",
-                            rightAlign: undefined,
-                            simplify: "required",
-                            size: "normal",
+            act(() =>
+                renderer.restoreSerializedState(
+                    {
+                        hints: [{}, {}, {}],
+                        question: {
+                            "input-number 1": {
+                                answerType: "number",
+                                currentValue: "-42",
+                                rightAlign: undefined,
+                                simplify: "required",
+                                size: "normal",
+                            },
                         },
                     },
-                },
-                callback,
+                    callback,
+                ),
             );
             jest.runOnlyPendingTimers();
 

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -89,7 +89,7 @@ describe("server item renderer", () => {
         // If we don't spin the timers here, then the timer fires in the test
         // _after_ and breaks it because we do setState() in the callback,
         // and by that point the component has been unmounted.
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
     });
 
     it("should snapshot", () => {
@@ -115,12 +115,12 @@ describe("server item renderer", () => {
         expect(screen.getByRole("textbox")).toBeVisible();
     });
 
-    it("should be invalid if no input provided", () => {
+    it("should be invalid if no input provided", async () => {
         // Arrange
         const {renderer} = renderQuestion(itemWithInput);
 
         // Act
-        const score = renderer.scoreInput();
+        const score = await act(() => renderer.scoreInput());
 
         // Assert
         expect(score.correct).toBe(false);
@@ -133,7 +133,7 @@ describe("server item renderer", () => {
         await userEvent.type(screen.getByRole("textbox"), "-42");
 
         // Act
-        const score = renderer.scoreInput();
+        const score = await act(() => renderer.scoreInput());
 
         // Assert
         expect(score.correct).toBe(true);
@@ -163,7 +163,7 @@ describe("server item renderer", () => {
         const inputs = screen.getAllByRole("textbox");
         await userEvent.type(inputs[0], "1");
         await userEvent.type(inputs[1], "2");
-        jest.runOnlyPendingTimers(); // Renderer uses setTimeout setting widget props
+        act(() => jest.runOnlyPendingTimers()); // Renderer uses setTimeout setting widget props
 
         // Assert
         expect(interactionCallback).toHaveBeenCalledWith({
@@ -332,14 +332,14 @@ describe("server item renderer", () => {
         // this test.
         // @ts-expect-error - TS2352 - Conversion of type 'Widget' to type 'MockAssetLoadingWidget' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
         const widget = mockedWidget as MockAssetLoadingWidget;
-        widget.setAssetStatus("ABC", true);
+        act(() => widget.setAssetStatus("ABC", true));
 
         // Assert
         expect(onRendered).toHaveBeenCalledWith(true);
     });
 
     describe("focus management", () => {
-        it("calls onFocusChange when focusing the renderer", () => {
+        it("calls onFocusChange when focusing the renderer", async () => {
             // Arranged
             const onFocusChange = jest.fn();
             const {renderer} = renderQuestion(itemWithInput, {
@@ -347,7 +347,7 @@ describe("server item renderer", () => {
             });
 
             // Act
-            const gotFocus = renderer.focus();
+            const gotFocus = await act(() => renderer.focus());
 
             // We have some async processes that need to be resolved here
             jest.runAllTimers();
@@ -362,7 +362,7 @@ describe("server item renderer", () => {
             );
         });
 
-        it("activates the keypadElement when focusing the renderer on mobile", () => {
+        it("activates the keypadElement when focusing the renderer on mobile", async () => {
             // Arranged
             const onFocusChange = jest.fn();
             const keypadElementDOMNode = document.createElement("div");
@@ -391,7 +391,7 @@ describe("server item renderer", () => {
             );
 
             // Act
-            const gotFocus = renderer.focus();
+            const gotFocus = await act(() => renderer.focus());
 
             // We have some async processes that need to be resolved here
             jest.runAllTimers();
@@ -560,7 +560,7 @@ describe("server item renderer", () => {
                     callback,
                 ),
             );
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
 
             // Assert
             expect(callback).toHaveBeenCalled();

--- a/packages/perseus/src/components/__tests__/math-input.test.tsx
+++ b/packages/perseus/src/components/__tests__/math-input.test.tsx
@@ -40,7 +40,7 @@ describe("Perseus' MathInput", () => {
                 value=""
             />,
         );
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // Assert
         expect(screen.getByLabelText("test")).toBeInTheDocument();
@@ -58,11 +58,11 @@ describe("Perseus' MathInput", () => {
                 value=""
             />,
         );
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // Act
         await userEvent.type(screen.getByRole("textbox"), "12345");
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // Assert
         expect(mockOnChange).toHaveBeenLastCalledWith("12345");
@@ -80,7 +80,7 @@ describe("Perseus' MathInput", () => {
                 value=""
             />,
         );
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // Act
         screen.getByRole("button").click();
@@ -89,7 +89,7 @@ describe("Perseus' MathInput", () => {
         await userEvent.click(screen.getByRole("button", {name: "2"}));
         await userEvent.click(screen.getByRole("button", {name: "Minus"}));
         await userEvent.click(screen.getByRole("button", {name: "3"}));
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // Assert
         expect(mockOnChange).toHaveBeenLastCalledWith("1+2-3");
@@ -107,7 +107,7 @@ describe("Perseus' MathInput", () => {
                 value=""
             />,
         );
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // Act
         // focusing the input triggers the popover
@@ -117,7 +117,7 @@ describe("Perseus' MathInput", () => {
         await userEvent.click(screen.getByRole("button", {name: "2"}));
         await userEvent.click(screen.getByRole("button", {name: "Divide"}));
         await userEvent.click(screen.getByRole("button", {name: "3"}));
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // Assert
         expect(mockOnChange).toHaveBeenLastCalledWith("1+2\\div3");
@@ -134,7 +134,7 @@ describe("Perseus' MathInput", () => {
                 value=""
             />,
         );
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // Act
         // focusing the input triggers the popover
@@ -156,7 +156,7 @@ describe("Perseus' MathInput", () => {
                 value=""
             />,
         );
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // Act
         // focusing the input triggers the popover
@@ -164,7 +164,7 @@ describe("Perseus' MathInput", () => {
         await userEvent.tab(); // to "123" tab
         await userEvent.tab(); // to "1" button
         await userEvent.keyboard("{enter}");
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // Assert
         expect(screen.getByRole("textbox")).not.toHaveFocus();

--- a/packages/perseus/src/components/__tests__/math-input.test.tsx
+++ b/packages/perseus/src/components/__tests__/math-input.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from "@testing-library/react";
+import {act, render, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 

--- a/packages/perseus/src/components/__tests__/sortable.test.tsx
+++ b/packages/perseus/src/components/__tests__/sortable.test.tsx
@@ -1,4 +1,4 @@
-import {render} from "@testing-library/react";
+import {act, render} from "@testing-library/react";
 import * as React from "react";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
@@ -56,7 +56,8 @@ describe("Sortable", () => {
         expect(container).toMatchSnapshot("first render: displays a spinner");
 
         // Act
-        simulateFakeTeXRendering();
+        // eslint-disable-next-line testing-library/no-unnecessary-act
+        act(() => simulateFakeTeXRendering());
 
         // Assert
         expect(container).toMatchSnapshot(
@@ -89,7 +90,7 @@ describe("moveOptionToIndex", () => {
         }
 
         // @ts-expect-error - TS2339 - Property 'moveOptionToIndex' does not exist on type 'never'.
-        sortable.moveOptionToIndex("a", 1);
+        act(() => sortable.moveOptionToIndex("a", 1));
 
         // @ts-expect-error - TS2339 - Property 'getOptions' does not exist on type 'never'.
         expect(sortable?.getOptions()).toStrictEqual(["b", "a", "c"]);

--- a/packages/perseus/src/components/__tests__/sorter.test.tsx
+++ b/packages/perseus/src/components/__tests__/sorter.test.tsx
@@ -1,3 +1,4 @@
+import {act} from "@testing-library/react";
 import * as React from "react";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
@@ -77,12 +78,10 @@ describe("sorter widget", () => {
         const sorter = renderer.findWidgets("sorter 1")[0];
 
         // Put the options in the correct order
-        ["$0.005$ kilograms", "$15$ grams", "$55$ grams"].forEach(
-            (option, index) => {
-                sorter.moveOptionToIndex(option, 3);
-            },
-        );
 
+        ["$0.005$ kilograms", "$15$ grams", "$55$ grams"].forEach((option) => {
+            act(() => sorter.moveOptionToIndex(option, 3));
+        });
         // Act
         renderer.guessAndScore();
 
@@ -100,7 +99,7 @@ describe("sorter widget", () => {
         // Put the options in the reverse order
         ["$0.005$ kilograms", "$15$ grams", "$55$ grams"].forEach(
             (option, index) => {
-                sorter.moveOptionToIndex(option, 0);
+                act(() => sorter.moveOptionToIndex(option, 0));
             },
         );
 

--- a/packages/perseus/src/components/__tests__/zoomable.test.tsx
+++ b/packages/perseus/src/components/__tests__/zoomable.test.tsx
@@ -1,5 +1,5 @@
 import {describe, beforeEach, it} from "@jest/globals";
-import {fireEvent, render, screen, waitFor} from "@testing-library/react";
+import {act, fireEvent, render, screen, waitFor} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
@@ -28,7 +28,7 @@ const mockSize = (
 const renderAndWaitToSettle = (component: React.ReactElement) => {
     const result = render(component);
 
-    jest.runAllTimers();
+    act(() => jest.runAllTimers());
 
     return result;
 };
@@ -99,11 +99,11 @@ describe("Zoomable", () => {
         );
 
         await userEvent.click(screen.getByText("Some zoomable text"));
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // Act
         await userEvent.click(screen.getByText("Some zoomable text"));
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // Assert
         expect(container).toMatchInlineSnapshot(`
@@ -158,7 +158,7 @@ describe("Zoomable", () => {
 
         // Act
         // The measure action uses a setState and setTimeout(0)
-        jest.runAllTimers();
+        act(() => jest.runAllTimers());
 
         // Assert
         expect(container).toMatchInlineSnapshot(`
@@ -194,7 +194,7 @@ describe("Zoomable", () => {
         });
 
         // Act
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // Assert
         expect(container).toMatchInlineSnapshot(`
@@ -228,11 +228,11 @@ describe("Zoomable", () => {
             </Zoomable>,
         );
         // We need two cycles to get everything rendered and visible
-        jest.runOnlyPendingTimers();
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
+        act(() => jest.runOnlyPendingTimers());
 
         // Act
-        resizeWindowTo(500, 500);
+        act(() => resizeWindowTo(500, 500));
 
         // Assert
         // The children are initially displayed with an opacity of 0 to give
@@ -297,7 +297,7 @@ describe("Zoomable", () => {
 
             // Act
             eventFirer(screen.getByText("Some zoomable text"));
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
 
             // Assert
             expect(props[propName]).not.toHaveBeenCalled();
@@ -315,7 +315,7 @@ describe("Zoomable", () => {
             );
 
             await userEvent.click(screen.getByText("Some zoomable text"));
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
 
             // Act
             eventFirer(screen.getByText("Some zoomable text"));
@@ -351,7 +351,7 @@ describe("Zoomable", () => {
             const rootNode = container.firstElementChild as HTMLElement;
             mockSize(rootNode, {width: 200, height: 200});
 
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
         });
 
         it("should update measurements", async () => {
@@ -406,7 +406,7 @@ describe("Zoomable", () => {
             // Arrange
             // We default to "zoomed", so this "unzooms"
             await userEvent.click(screen.getByText("Some zoomable text"));
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
 
             // Act
             screen.getByText("Some zoomable text").innerHTML =

--- a/packages/perseus/src/multi-items/__tests__/multi-renderer.test.tsx
+++ b/packages/perseus/src/multi-items/__tests__/multi-renderer.test.tsx
@@ -569,7 +569,7 @@ describe("multi-item renderer", () => {
                     callback,
                 ),
             );
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
 
             // Assert
             expect(callback).toHaveBeenCalled();

--- a/packages/perseus/src/multi-items/__tests__/multi-renderer.test.tsx
+++ b/packages/perseus/src/multi-items/__tests__/multi-renderer.test.tsx
@@ -1,5 +1,5 @@
 import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
-import {render, screen} from "@testing-library/react";
+import {act, render, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
@@ -538,7 +538,7 @@ describe("multi-item renderer", () => {
 
             // Act
             // @ts-expect-error - TS2339 - Property 'restoreSerializedState' does not exist on type 'never'.
-            renderer.restoreSerializedState(state);
+            act(() => renderer.restoreSerializedState(state));
 
             // Assert
             expect(screen.getAllByRole("radio")[0]).not.toBeChecked();
@@ -555,17 +555,19 @@ describe("multi-item renderer", () => {
             const callback = jest.fn();
 
             // Act
-            // @ts-expect-error - TS2339 - Property 'restoreSerializedState' does not exist on type 'never'.
-            renderer.restoreSerializedState(
-                {
-                    blurb: {"mock-widget 1": 1},
-                    hints: [2, 3],
-                    question: {
-                        "mock-widget 4": 4,
-                        "mock-widget 5": 5,
+            act(() =>
+                // @ts-expect-error - TS2339 - Property 'restoreSerializedState' does not exist on type 'never'.
+                renderer.restoreSerializedState(
+                    {
+                        blurb: {"mock-widget 1": 1},
+                        hints: [2, 3],
+                        question: {
+                            "mock-widget 4": 4,
+                            "mock-widget 5": 5,
+                        },
                     },
-                },
-                callback,
+                    callback,
+                ),
             );
             jest.runOnlyPendingTimers();
 

--- a/packages/perseus/src/widgets/__tests__/explanation.test.ts
+++ b/packages/perseus/src/widgets/__tests__/explanation.test.ts
@@ -1,4 +1,4 @@
-import {screen} from "@testing-library/react";
+import {act, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
@@ -124,14 +124,16 @@ describe("Explanation", function () {
         verifyExpandCollapseState("Explanation", false);
 
         // Act - expand with the enter key
-        screen.getByRole("button", {name: "Explanation"}).focus();
+        act(() => screen.getByRole("button", {name: "Explanation"}).focus());
         await userEvent.keyboard("{Enter}");
 
         // Assert - elements have attributes changed that represent an expanded state
         verifyExpandCollapseState("Hide explanation!", true);
 
         // Act - collapse with the enter key
-        screen.getByRole("button", {name: "Hide explanation!"}).focus();
+        act(() =>
+            screen.getByRole("button", {name: "Hide explanation!"}).focus(),
+        );
         await userEvent.keyboard("{Enter}");
 
         // Assert - elements have attributes reset to represent a collapsed state
@@ -146,14 +148,16 @@ describe("Explanation", function () {
         verifyExpandCollapseState("Explanation", false);
 
         // Act - expand with a space bar
-        screen.getByRole("button", {name: "Explanation"}).focus();
+        act(() => screen.getByRole("button", {name: "Explanation"}).focus());
         await userEvent.keyboard(" ");
 
         // Assert - elements have attributes changed that represent an expanded state
         verifyExpandCollapseState("Hide explanation!", true);
 
         // Act - collapse with a space bar
-        screen.getByRole("button", {name: "Hide explanation!"}).focus();
+        act(() =>
+            screen.getByRole("button", {name: "Hide explanation!"}).focus(),
+        );
         await userEvent.keyboard(" ");
 
         // Assert - elements have attributes reset to represent a collapsed state

--- a/packages/perseus/src/widgets/__tests__/expression-mobile.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/expression-mobile.test.tsx
@@ -6,6 +6,7 @@ import {
 } from "@khanacademy/math-input";
 import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 import {
+    act,
     fireEvent,
     render,
     screen,

--- a/packages/perseus/src/widgets/__tests__/expression-mobile.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/expression-mobile.test.tsx
@@ -97,7 +97,7 @@ describe("expression mobile", () => {
         // If we don't spin the timers here, then the timer fires in the test
         // _after_ and breaks it because we do setState() in the callback,
         // and by that point the component has been unmounted.
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
     });
 
     it("renders input", () => {

--- a/packages/perseus/src/widgets/__tests__/expression.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/expression.test.tsx
@@ -91,7 +91,7 @@ const assertInvalid = async (
     if (input.length) {
         await userEvent.type(screen.getByRole("textbox"), input);
     }
-    jest.runOnlyPendingTimers();
+    act(() => jest.runOnlyPendingTimers());
     expect(renderer).toHaveInvalidInput();
 };
 
@@ -417,7 +417,7 @@ describe("focus state", () => {
 
         // Act
         const expressionInput = screen.getByRole("textbox");
-        expressionInput.focus();
+        act(() => expressionInput.focus());
 
         // Assert
         expect(expressionInput).toHaveFocus();
@@ -429,8 +429,8 @@ describe("focus state", () => {
 
         // Act
         const expressionInput = screen.getByRole("textbox");
-        expressionInput.focus();
-        expressionInput.blur();
+        act(() => expressionInput.focus());
+        act(() => expressionInput.blur());
 
         // Assert
         expect(expressionInput).not.toHaveFocus();
@@ -442,7 +442,7 @@ describe("focus state", () => {
         const expression = renderer.findWidgets("expression 1")[0];
 
         // act
-        expression.focusInputPath();
+        act(() => expression.focusInputPath());
 
         // Assert
         const expressionInput = screen.getByRole("textbox");
@@ -482,11 +482,11 @@ describe("interaction", () => {
     it("sets input value directly", () => {
         // arrange
         const {renderer} = renderQuestion(expressionItem2.question);
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // act
         act(() => renderer.setInputValue(["expression 1"], "123-x", () => {}));
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
         const score = renderer.guessAndScore()[1];
 
         // Assert
@@ -500,12 +500,12 @@ describe("interaction", () => {
     it("has a developer facility for inserting", () => {
         // arrange
         const {renderer} = renderQuestion(expressionItem2.question);
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         act(() => {
             const expression = renderer.findWidgets("expression 1")[0];
             expression.insert("x+1");
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
         });
 
         // act
@@ -555,9 +555,9 @@ describe("error tooltip", () => {
         const expression = renderer.findWidgets("expression 1")[0];
 
         // Act
-        expression.insert("sen(x)");
-        jest.runOnlyPendingTimers();
-        screen.getByRole("textbox").blur();
+        act(() => expression.insert("sen(x)"));
+        act(() => jest.runOnlyPendingTimers());
+        act(() => screen.getByRole("textbox").blur());
         renderer.guessAndScore();
 
         // Assert

--- a/packages/perseus/src/widgets/__tests__/expression.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/expression.test.tsx
@@ -502,11 +502,9 @@ describe("interaction", () => {
         const {renderer} = renderQuestion(expressionItem2.question);
         act(() => jest.runOnlyPendingTimers());
 
-        act(() => {
-            const expression = renderer.findWidgets("expression 1")[0];
-            expression.insert("x+1");
-            act(() => jest.runOnlyPendingTimers());
-        });
+        const expression = renderer.findWidgets("expression 1")[0];
+        act(() => expression.insert("x+1"));
+        act(() => jest.runOnlyPendingTimers());
 
         // act
         const score = renderer.score();

--- a/packages/perseus/src/widgets/__tests__/graded-group-set.test.ts
+++ b/packages/perseus/src/widgets/__tests__/graded-group-set.test.ts
@@ -199,7 +199,7 @@ describe("graded group widget", () => {
 
         // Act
         // The first "focusable" widget receives focus...
-        renderer.focus();
+        act(() => renderer.focus());
 
         // Assert
         expect(screen.getByRole("textbox")).toHaveFocus();
@@ -210,7 +210,9 @@ describe("graded group widget", () => {
         const {renderer} = renderQuestion(article1);
 
         // Act
-        renderer.focusPath(["graded-group-set 1", "numeric-input 1"]);
+        act(() =>
+            renderer.focusPath(["graded-group-set 1", "numeric-input 1"]),
+        );
 
         // Assert
         expect(screen.getByRole("textbox")).toHaveFocus();
@@ -222,7 +224,7 @@ describe("graded group widget", () => {
         await userEvent.click(screen.getByRole("textbox"));
 
         // Act
-        renderer.blurPath(["graded-group-set 1", "numeric-input 1"]);
+        act(() => renderer.blurPath(["graded-group-set 1", "numeric-input 1"]));
 
         // Assert
         expect(screen.getByRole("textbox")).not.toHaveFocus();

--- a/packages/perseus/src/widgets/__tests__/graded-group-set.test.ts
+++ b/packages/perseus/src/widgets/__tests__/graded-group-set.test.ts
@@ -1,4 +1,4 @@
-import {screen} from "@testing-library/react";
+import {act, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
@@ -181,10 +181,12 @@ describe("graded group widget", () => {
         const cb = jest.fn();
 
         // Act
-        renderer.setInputValue(
-            ["graded-group-set 1", "numeric-input 1"],
-            "999",
-            cb,
+        act(() =>
+            renderer.setInputValue(
+                ["graded-group-set 1", "numeric-input 1"],
+                "999",
+                cb,
+            ),
         );
 
         // Assert

--- a/packages/perseus/src/widgets/__tests__/graded-group.test.ts
+++ b/packages/perseus/src/widgets/__tests__/graded-group.test.ts
@@ -136,7 +136,7 @@ describe("graded-group", () => {
             await userEvent.click(
                 screen.getByRole("button", {name: "Explain"}),
             );
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
 
             // Assert
             expect(
@@ -150,7 +150,7 @@ describe("graded-group", () => {
             await userEvent.click(
                 screen.getByRole("button", {name: "Explain"}),
             );
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
 
             // Act
             await userEvent.click(
@@ -188,7 +188,7 @@ describe("graded-group", () => {
             await userEvent.click(
                 screen.getAllByRole("button", {name: "True"})[3],
             );
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
 
             // Act
             await checkAnswer(userEvent);
@@ -218,7 +218,7 @@ describe("graded-group", () => {
             await userEvent.click(
                 screen.getAllByRole("button", {name: "False"})[3],
             );
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
 
             // Act
             await checkAnswer(userEvent);
@@ -240,7 +240,7 @@ describe("graded-group", () => {
             await userEvent.click(
                 screen.getAllByRole("button", {name: "False"})[1],
             );
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
 
             await checkAnswer(userEvent);
 
@@ -248,7 +248,7 @@ describe("graded-group", () => {
             await userEvent.click(
                 screen.getAllByRole("button", {name: "False"})[2],
             );
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
 
             // Assert
             expect(screen.getByRole("button", {name: "Check"})).toBeVisible();

--- a/packages/perseus/src/widgets/__tests__/graded-group.test.ts
+++ b/packages/perseus/src/widgets/__tests__/graded-group.test.ts
@@ -1,5 +1,5 @@
 import {describe, beforeEach, it} from "@jest/globals";
-import {screen} from "@testing-library/react";
+import {act, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";

--- a/packages/perseus/src/widgets/__tests__/group.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/group.test.tsx
@@ -64,8 +64,8 @@ describe("group widget", () => {
             });
 
             // Act
-            renderer.focus();
-            jest.runOnlyPendingTimers();
+            act(() => renderer.focus());
+            act(() => jest.runOnlyPendingTimers());
 
             // Assert
             expect(onFocusChange).toHaveBeenCalledWith(
@@ -82,11 +82,11 @@ describe("group widget", () => {
                 onFocusChange,
             });
 
-            screen.getAllByRole("textbox")[1].focus();
+            act(() => screen.getAllByRole("textbox")[1].focus());
 
             // This flushes the onFocusChange call resulting from the focus()
-            jest.runOnlyPendingTimers();
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
+            act(() => jest.runOnlyPendingTimers());
             onFocusChange.mockClear();
 
             // Act
@@ -94,8 +94,8 @@ describe("group widget", () => {
             // There's two levels of <Renderer /> here (our main one and one inside
             // the group widget) so we have to wait twice for all the focus
             // management timers to resolve.
-            jest.runOnlyPendingTimers();
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
+            act(() => jest.runOnlyPendingTimers());
 
             // Assert
             expect(onFocusChange).toHaveBeenCalledWith(
@@ -110,7 +110,7 @@ describe("group widget", () => {
 
             // Act
             // focusPath() calls focusInputPath() on the focused widget
-            renderer.focusPath(["group 2", "numeric-input 2"]);
+            act(() => renderer.focusPath(["group 2", "numeric-input 2"]));
 
             // Assert
             expect(screen.getAllByRole("textbox")[1]).toHaveFocus();
@@ -122,12 +122,12 @@ describe("group widget", () => {
             const textbox = screen.getAllByRole("textbox")[1];
 
             act(() => textbox.focus());
-            jest.runOnlyPendingTimers();
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
+            act(() => jest.runOnlyPendingTimers());
 
             // Act
             // blurPath() calls blurInputPath() on the focused widget
-            renderer.blurPath(["group 2", "numeric-input 2"]);
+            act(() => renderer.blurPath(["group 2", "numeric-input 2"]));
 
             // Assert
             expect(textbox).not.toHaveFocus();
@@ -154,8 +154,8 @@ describe("group widget", () => {
 
         // Act
         await userEvent.type(screen.getAllByRole("textbox")[0], "99");
-        jest.runOnlyPendingTimers();
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
+        act(() => jest.runOnlyPendingTimers());
 
         // Assert
         // NOTE: The numeric-input that we typed into is in the second group.
@@ -446,7 +446,7 @@ describe("group widget", () => {
         act(() =>
             renderer.setInputValue(["group 2", "numeric-input 2"], "2021", cb),
         );
-        jest.runOnlyPendingTimers(); // callback occurs after the next render
+        act(() => jest.runOnlyPendingTimers()); // callback occurs after the next render
 
         // Assert
         expect(screen.getAllByRole("textbox")[1]).toHaveValue("2021");

--- a/packages/perseus/src/widgets/__tests__/group.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/group.test.tsx
@@ -1,6 +1,6 @@
 import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 // eslint-disable-next-line testing-library/no-manual-cleanup
-import {cleanup, render, screen} from "@testing-library/react";
+import {act, cleanup, render, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
@@ -90,7 +90,7 @@ describe("group widget", () => {
             onFocusChange.mockClear();
 
             // Act
-            renderer.blur();
+            act(() => renderer.blur());
             // There's two levels of <Renderer /> here (our main one and one inside
             // the group widget) so we have to wait twice for all the focus
             // management timers to resolve.
@@ -121,7 +121,7 @@ describe("group widget", () => {
             const {renderer} = renderQuestion(question1);
             const textbox = screen.getAllByRole("textbox")[1];
 
-            textbox.focus();
+            act(() => textbox.focus());
             jest.runOnlyPendingTimers();
             jest.runOnlyPendingTimers();
 
@@ -358,7 +358,7 @@ describe("group widget", () => {
         const {renderer: renderer1} = renderQuestion(question1);
 
         // Act
-        renderer1.restoreSerializedState(state);
+        act(() => renderer1.restoreSerializedState(state));
 
         // Assert
         expect(screen.getAllByRole("radio")[4]).toBeChecked();
@@ -443,7 +443,9 @@ describe("group widget", () => {
         const cb = jest.fn();
 
         // Act
-        renderer.setInputValue(["group 2", "numeric-input 2"], "2021", cb);
+        act(() =>
+            renderer.setInputValue(["group 2", "numeric-input 2"], "2021", cb),
+        );
         jest.runOnlyPendingTimers(); // callback occurs after the next render
 
         // Assert
@@ -457,7 +459,7 @@ describe("group widget", () => {
         await userEvent.click(screen.getAllByRole("radio")[2]); // Incorrect!
 
         // Act
-        renderer.showRationalesForCurrentlySelectedChoices();
+        act(() => renderer.showRationalesForCurrentlySelectedChoices());
 
         // Assert
         expect(

--- a/packages/perseus/src/widgets/__tests__/input-number.test.ts
+++ b/packages/perseus/src/widgets/__tests__/input-number.test.ts
@@ -2,7 +2,7 @@
  * Disclaimer: Definitely not thorough enough
  */
 import {describe, beforeEach, it} from "@jest/globals";
-import {screen} from "@testing-library/react";
+import {act, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import _ from "underscore";
 
@@ -336,24 +336,24 @@ describe("focus state", () => {
         );
     });
 
-    it("supports focusing", () => {
+    it("supports focusing", async () => {
         //  Arrange
         const {renderer} = renderQuestion(question);
 
         // Act
-        const gotFocus = renderer.focus();
+        const gotFocus = await act(() => renderer.focus());
 
         // Assert
         expect(gotFocus).toBeTrue();
     });
 
-    it("supports blurring", () => {
+    it("supports blurring", async () => {
         //  Arrange
         const {renderer} = renderQuestion(question);
 
         // Act
-        const gotFocus = renderer.focus();
-        renderer.blur();
+        const gotFocus = await act(() => renderer.focus());
+        act(() => renderer.blur());
 
         // Assert
         expect(gotFocus).toBeTrue();

--- a/packages/perseus/src/widgets/__tests__/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/interactive-graph.test.tsx
@@ -1,7 +1,7 @@
 import {describe, beforeEach, it} from "@jest/globals";
 import * as KAS from "@khanacademy/kas";
 import {color as wbColor} from "@khanacademy/wonder-blocks-tokens";
-import {waitFor} from "@testing-library/react";
+import {act, waitFor} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import {Plot} from "mafs";
 import * as React from "react";
@@ -86,10 +86,12 @@ describe("interactive-graph widget", function () {
                 // drag & drop behavior.
                 // We'll want to use cypress tests or similar to ensure this widget
                 // works as expected.
-                updateWidgetState(
-                    renderer,
-                    "interactive-graph 1",
-                    (state) => (state.graph.coords = correct),
+                act(() =>
+                    updateWidgetState(
+                        renderer,
+                        "interactive-graph 1",
+                        (state) => (state.graph.coords = correct),
+                    ),
                 );
 
                 // Assert
@@ -105,10 +107,12 @@ describe("interactive-graph widget", function () {
                 expect(container).toMatchSnapshot("first render");
 
                 // Act
-                updateWidgetState(
-                    renderer,
-                    "interactive-graph 1",
-                    (state) => (state.graph.coords = correct),
+                act(() =>
+                    updateWidgetState(
+                        renderer,
+                        "interactive-graph 1",
+                        (state) => (state.graph.coords = correct),
+                    ),
                 );
 
                 // Assert
@@ -131,10 +135,12 @@ describe("interactive-graph widget", function () {
                 const {renderer} = renderQuestion(question, blankOptions);
 
                 // Act
-                updateWidgetState(
-                    renderer,
-                    "interactive-graph 1",
-                    (state) => (state.graph.coords = incorrect),
+                act(() =>
+                    updateWidgetState(
+                        renderer,
+                        "interactive-graph 1",
+                        (state) => (state.graph.coords = incorrect),
+                    ),
                 );
 
                 // Assert

--- a/packages/perseus/src/widgets/__tests__/matcher.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/matcher.test.tsx
@@ -1,3 +1,4 @@
+import {act} from "@testing-library/react";
 import * as React from "react";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
@@ -80,15 +81,17 @@ describe("matcher widget", () => {
         // Act
         const matcher: Matcher = renderer.findWidgets("matcher 1")[0];
 
-        matcher.moveRightOptionToIndex(
-            "Rapid escalation of greenhouse gas emissions",
-            0,
-        );
+        act(() => {
+            matcher.moveRightOptionToIndex(
+                "Rapid escalation of greenhouse gas emissions",
+                0,
+            );
 
-        matcher.moveLeftOptionToIndex(
-            "Average global temperatures will rise ",
-            0,
-        );
+            matcher.moveLeftOptionToIndex(
+                "Average global temperatures will rise ",
+                0,
+            );
+        });
 
         // Assert
         expect(container).toMatchSnapshot("moved items");
@@ -113,7 +116,7 @@ describe("matcher widget", () => {
             "Rapid escalation of greenhouse gas emissions",
             "The current trajectory of the Milky Way galaxy and those in its immediate proximity",
         ].forEach((option, index) => {
-            matcher.moveRightOptionToIndex(option, 4);
+            act(() => matcher.moveRightOptionToIndex(option, 4));
         });
 
         // Act

--- a/packages/perseus/src/widgets/__tests__/number-line.test.ts
+++ b/packages/perseus/src/widgets/__tests__/number-line.test.ts
@@ -1,3 +1,5 @@
+import {act} from "@testing-library/react";
+
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
 import {question1} from "../__testdata__/number-line.testdata";
@@ -55,7 +57,7 @@ describe("number-line widget", () => {
 
         // Act
         const [numberLine] = renderer.findWidgets("number-line 1");
-        numberLine.movePosition(-2.5);
+        act(() => numberLine.movePosition(-2.5));
 
         // assert
         expect(renderer).toHaveBeenAnsweredCorrectly();
@@ -70,7 +72,8 @@ describe("number-line widget", () => {
 
         // Act
         const [numberLine] = renderer.findWidgets("number-line 1");
-        numberLine.movePosition(3.5);
+        act(() => numberLine.movePosition(3.5));
+
         // Assert
         expect(renderer).toHaveBeenAnsweredIncorrectly();
     });

--- a/packages/perseus/src/widgets/__tests__/numeric-input.test.ts
+++ b/packages/perseus/src/widgets/__tests__/numeric-input.test.ts
@@ -1,4 +1,4 @@
-import {screen} from "@testing-library/react";
+import {act, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
@@ -527,8 +527,8 @@ describe("Numeric input widget", () => {
 
         // Act
         const input = screen.getByRole("textbox", {hidden: true});
-        input.focus();
-        renderer.blur();
+        act(() => input.focus());
+        act(() => renderer.blur());
 
         // Assert
         // eslint-disable-next-line testing-library/no-node-access

--- a/packages/perseus/src/widgets/__tests__/numeric-input.test.ts
+++ b/packages/perseus/src/widgets/__tests__/numeric-input.test.ts
@@ -508,11 +508,11 @@ describe("Numeric input widget", () => {
         expect(container).toMatchSnapshot("mobile render");
     });
 
-    it("can be focused", () => {
+    it("can be focused", async () => {
         const {renderer} = renderQuestion(question1);
 
         // Act
-        const gotFocus = renderer.focus();
+        const gotFocus = await act(() => renderer.focus());
 
         // Assert
         expect(gotFocus).toBeTrue();

--- a/packages/perseus/src/widgets/__tests__/orderer.test.ts
+++ b/packages/perseus/src/widgets/__tests__/orderer.test.ts
@@ -1,3 +1,5 @@
+import {act} from "@testing-library/react";
+
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
 import {question2} from "../__testdata__/orderer.testdata";
@@ -48,7 +50,7 @@ describe("orderer widget", () => {
         const [orderer] = renderer.findWidgets("orderer 1");
 
         // Act
-        orderer.setListValues(["1", "2", "3"]);
+        act(() => orderer.setListValues(["1", "2", "3"]));
 
         // assert
         expect(renderer).toHaveBeenAnsweredCorrectly();
@@ -63,7 +65,7 @@ describe("orderer widget", () => {
         const [orderer] = renderer.findWidgets("orderer 1");
 
         // Act
-        orderer.setListValues(["3", "2", "1"]);
+        act(() => orderer.setListValues(["3", "2", "1"]));
 
         // assert
         expect(renderer).toHaveBeenAnsweredIncorrectly();

--- a/packages/perseus/src/widgets/__tests__/passage-ref.test.ts
+++ b/packages/perseus/src/widgets/__tests__/passage-ref.test.ts
@@ -1,4 +1,4 @@
-import {screen} from "@testing-library/react";
+import {act, screen} from "@testing-library/react";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
@@ -35,7 +35,7 @@ describe("passage-ref widget", () => {
 
         // Act
         const {container} = renderQuestion(question1);
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // Assert
         expect(container).toMatchSnapshot();
@@ -47,7 +47,7 @@ describe("passage-ref widget", () => {
 
         // Act
         renderQuestion(question1);
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // Assert
         expect(screen.getByText("lines ?–?", {exact: false})).toBeVisible();
@@ -63,7 +63,7 @@ describe("passage-ref widget", () => {
 
         // Act
         const {container} = renderQuestion(question1);
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // Assert
         expect(container).toMatchSnapshot();
@@ -79,7 +79,7 @@ describe("passage-ref widget", () => {
 
         // Act
         renderQuestion(question1);
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // Assert
         expect(screen.getByText("line 4", {exact: false})).toBeVisible();
@@ -95,7 +95,7 @@ describe("passage-ref widget", () => {
 
         // Act
         const {container} = renderQuestion(question1);
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // Assert
         expect(container).toMatchSnapshot();
@@ -111,7 +111,7 @@ describe("passage-ref widget", () => {
 
         // Act
         renderQuestion(question1);
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // Assert
         expect(screen.getByText("lines 4–6", {exact: false})).toBeVisible();
@@ -144,7 +144,7 @@ describe("passage-ref widget", () => {
                 },
             },
         });
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // Assert
         expect(
@@ -159,7 +159,7 @@ describe("passage-ref widget", () => {
 
         // Act
         const {renderer} = renderQuestion(question1);
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // Assert
         expect(renderer).toHaveBeenAnsweredIncorrectly();

--- a/packages/perseus/src/widgets/__tests__/passage.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/passage.test.tsx
@@ -118,7 +118,7 @@ describe("passage widget", () => {
             isMobile: false,
         };
         const {renderer} = renderQuestion(question2, apiOptions);
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // Act
         const score = renderer.score();
@@ -140,7 +140,7 @@ describe("passage widget", () => {
             isMobile: false,
         };
         const {renderer} = renderQuestion(question2, apiOptions);
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // @ts-expect-error - TS2503 - Cannot find namespace 'PassageWidgetExport'
         const [passage1]: [PassageWidgetExport.widget] =
@@ -164,7 +164,7 @@ describe("passage widget", () => {
             isMobile: false,
         };
         const {renderer} = renderQuestion(question2, apiOptions);
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // @ts-expect-error - TS2503 - Cannot find namespace 'PassageWidgetExport'
         const [passage1]: [PassageWidgetExport.widget] =

--- a/packages/perseus/src/widgets/__tests__/passage.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/passage.test.tsx
@@ -1,5 +1,5 @@
 import {it, describe, beforeEach} from "@jest/globals";
-import {render, screen} from "@testing-library/react";
+import {act, render, screen} from "@testing-library/react";
 import React from "react";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
@@ -88,7 +88,7 @@ describe("passage widget", () => {
 
             // Act
             const {container} = renderQuestion(question1, apiOptions);
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
 
             // Assert
             expect(container).toMatchSnapshot();
@@ -105,7 +105,7 @@ describe("passage widget", () => {
 
             // Act
             const {container} = renderQuestion(question2, apiOptions);
-            jest.runOnlyPendingTimers();
+            act(() => jest.runOnlyPendingTimers());
 
             // Assert
             expect(container).toMatchSnapshot();

--- a/packages/perseus/src/widgets/__tests__/radio.test.ts
+++ b/packages/perseus/src/widgets/__tests__/radio.test.ts
@@ -150,7 +150,7 @@ describe("single-choice question", () => {
                 // Since this is a single-select setup, just select the first
                 // incorrect choice.
                 await selectOption(userEvent, incorrect[0]);
-                renderer.deselectIncorrectSelectedChoices();
+                act(() => renderer.deselectIncorrectSelectedChoices());
 
                 // Assert
                 screen.getAllByRole("radio").forEach((r) => {
@@ -334,7 +334,7 @@ describe("single-choice question", () => {
 
         // Act
         await selectOption(userEvent, incorrect[0]);
-        renderer.showRationalesForCurrentlySelectedChoices();
+        act(() => renderer.showRationalesForCurrentlySelectedChoices());
 
         // Assert
         expect(

--- a/packages/perseus/src/widgets/__tests__/radio.test.ts
+++ b/packages/perseus/src/widgets/__tests__/radio.test.ts
@@ -134,7 +134,7 @@ describe("single-choice question", () => {
                 });
 
                 // Act
-                const gotFocus = renderer.focus();
+                const gotFocus = await act(() => renderer.focus());
 
                 // Assert
                 expect(gotFocus).toBe(true);
@@ -316,7 +316,7 @@ describe("single-choice question", () => {
         // Act
         renderQuestion(questionWithPassage, apiOptions);
         // Passage refs use `_.defer()` to update their reference ranges.
-        jest.runOnlyPendingTimers();
+        act(() => jest.runOnlyPendingTimers());
 
         // Assert
         // By using a `passage-ref` in a choice, we should now have the

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/no-unassigned-import
+import "jest-extended"; // we love the side effects


### PR DESCRIPTION
## Summary:

This PR is the part of a chain of PRs upgrading Perseus to React 18.

  1. #1400
  2. This PR --> #1401
  3. #1402
  4. #1403

It appears that React 18 and RTL are more sensitive to not having mutating calls wrapped in `act()`. The changes in this PR are all simple changes that wrap function calls that cause DOM changes in `act()` calls. There are a few special cases that are failing yet, but this PR cleans up the straightforward ones. 

Issue: LEMS-1802

## Test plan:

`yarn test` should have many fewer test failures than PR #1400

Upcoming PRs will address the remaining test failures.

### Before 

```sh
$ yarn test 
...
Test Suites: 20 failed, 1 skipped, 168 passed, 188 of 189 total
Tests:       104 failed, 14 skipped, 2469 passed, 2587 total
Snapshots:   22 failed, 1 file obsolete, 137 passed, 159 total
Time:        25.267 s, estimated 26 s
Ran all test suites.
error Command failed with exit code 1.
```

### After

```sh
$ yarn test 
... 
Test Suites: 4 failed, 1 skipped, 184 passed, 188 of 189 total
Tests:       9 failed, 14 skipped, 2564 passed, 2587 total
Snapshots:   4 failed, 1 file obsolete, 155 passed, 159 total
Time:        24.056 s, estimated 25 s
Ran all test suites.
error Command failed with exit code 1.
```