### PR TITLE
React 18: Use RTL functions instead of direct HTML DOM APIs

### DIFF
--- a/packages/perseus/src/components/__tests__/math-input.test.tsx
+++ b/packages/perseus/src/components/__tests__/math-input.test.tsx
@@ -83,7 +83,9 @@ describe("Perseus' MathInput", () => {
         act(() => jest.runOnlyPendingTimers());
 
         // Act
-        screen.getByRole("button").click();
+        await userEvent.click(
+            screen.getByRole("button", {name: /open math keypad/}),
+        );
         await userEvent.click(screen.getByRole("button", {name: "1"}));
         await userEvent.click(screen.getByRole("button", {name: "Plus"}));
         await userEvent.click(screen.getByRole("button", {name: "2"}));
@@ -111,7 +113,9 @@ describe("Perseus' MathInput", () => {
 
         // Act
         // focusing the input triggers the popover
-        screen.getByRole("button").click();
+        await userEvent.click(
+            screen.getByRole("button", {name: /open math keypad/}),
+        );
         await userEvent.click(screen.getByRole("button", {name: "1"}));
         await userEvent.click(screen.getByRole("button", {name: "Plus"}));
         await userEvent.click(screen.getByRole("button", {name: "2"}));
@@ -138,7 +142,9 @@ describe("Perseus' MathInput", () => {
 
         // Act
         // focusing the input triggers the popover
-        screen.getByRole("button").click();
+        await userEvent.click(
+            screen.getByRole("button", {name: /open math keypad/}),
+        );
         await userEvent.click(screen.getByRole("button", {name: "1"}));
 
         // Assert
@@ -160,7 +166,9 @@ describe("Perseus' MathInput", () => {
 
         // Act
         // focusing the input triggers the popover
-        screen.getByRole("button").click();
+        await userEvent.click(
+            screen.getByRole("button", {name: /open math keypad/}),
+        );
         await userEvent.tab(); // to "123" tab
         await userEvent.tab(); // to "1" button
         await userEvent.keyboard("{enter}");
@@ -170,7 +178,7 @@ describe("Perseus' MathInput", () => {
         expect(screen.getByRole("textbox")).not.toHaveFocus();
     });
 
-    it("does not focus on the keypad button when it is clicked with the mouse", () => {
+    it("does not focus on the keypad button when it is clicked with the mouse", async () => {
         // Assemble
         render(
             <MathInput
@@ -183,8 +191,7 @@ describe("Perseus' MathInput", () => {
         );
 
         // Act
-        const button = screen.getByRole("button", {name: "1"});
-        button.click();
+        await userEvent.click(screen.getByRole("button", {name: "1"}));
 
         // Assert
         expect(screen.getByRole("button", {name: "1"})).not.toHaveFocus();

--- a/packages/perseus/src/widgets/__tests__/numeric-input.test.ts
+++ b/packages/perseus/src/widgets/__tests__/numeric-input.test.ts
@@ -515,11 +515,8 @@ describe("Numeric input widget", () => {
         const gotFocus = await act(() => renderer.focus());
 
         // Assert
-        expect(gotFocus).toBeTrue();
-        // eslint-disable-next-line testing-library/no-node-access
-        expect(document.activeElement).toBe(
-            screen.getByRole("textbox", {hidden: true}),
-        );
+        expect(gotFocus).toBe(true);
+        expect(screen.getByRole("textbox", {hidden: true})).toHaveFocus();
     });
 
     it("can be blurred", () => {
@@ -550,24 +547,23 @@ describe("unionAnswerForms utility function", () => {
         const forms = [
             [
                 {
-                    simplify: "required",
+                    simplify: "required" as const,
                     name: "integer",
-                },
+                } as const,
             ],
             [
                 {
-                    simplify: "required",
+                    simplify: "required" as const,
                     name: "integer",
-                },
+                } as const,
             ],
         ];
 
         // act
-        // @ts-expect-error - TS2345 - Argument of type '{ simplify: string; name: string; }[][]' is not assignable to parameter of type 'readonly (readonly PerseusNumericInputAnswerForm[])[]'.
         const result = unionAnswerForms(forms);
 
         // assert
-        expect(result).toBeArrayOfSize(1);
+        expect(result).toHaveLength(1);
     });
 });
 


### PR DESCRIPTION
## Summary:

This PR is the part of a chain of PRs upgrading Perseus to React 18.

  1. #1400
  2. #1401
  3. This PR --> #1402
  4. #1403

This PR fixes a few instances where there exists an RTL API for tests instead of making direct DOM object calls. RTL recommends this approach and this fixes a few more tests.

Issue: LEMS-1802

## Test plan:

`yarn test` more tests pass

### Before

```sh
$ yarn test 
... 
Test Suites: 4 failed, 1 skipped, 184 passed, 188 of 189 total
Tests:       9 failed, 14 skipped, 2564 passed, 2587 total
Snapshots:   4 failed, 1 file obsolete, 155 passed, 159 total
Time:        24.056 s, estimated 25 s
Ran all test suites.
error Command failed with exit code 1.
```

### After 

```sh
$ yarn test 
...
Test Suites: 3 failed, 1 skipped, 185 passed, 188 of 189 total
Tests:       6 failed, 14 skipped, 2567 passed, 2587 total
Snapshots:   4 failed, 1 file obsolete, 155 passed, 159 total
Time:        20.517 s, estimated 24 s
Ran all test suites.
error Command failed with exit code 1.
```

Close! :) 
