### PR TITLE
remove profanity rule

### DIFF
--- a/.changeset/sour-carrots-flash.md
+++ b/.changeset/sour-carrots-flash.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-linter": major
+---
+
+No longer lint for profanity

--- a/packages/perseus-linter/src/__tests__/rule.test.ts
+++ b/packages/perseus-linter/src/__tests__/rule.test.ts
@@ -7,8 +7,6 @@ describe("PerseusLinter lint Rules class", () => {
     const markdown = `
 ## This Heading is in Title Case
 
-This paragraph contains forbidden words. Poop!
-
 This paragraph contains an unescaped $ sign.
 
 #### This heading skipped a level
@@ -87,18 +85,14 @@ the previous heading was level ${previousHeading.level}`;
             });
         });
 
-        expect(warnings).toHaveLength(4);
+        expect(warnings).toHaveLength(3);
+
         expect(warnings[0].rule).toEqual(ruleDescriptions[0].name);
         expect(warnings[0].message).toEqual(ruleDescriptions[0].message);
 
         expect(warnings[1].rule).toEqual(ruleDescriptions[1].name);
         expect(warnings[1].message).toEqual(ruleDescriptions[1].message);
-        expect(warnings[1].start).toEqual(2);
-        expect(warnings[1].end).toEqual(6);
 
         expect(warnings[2].rule).toEqual(ruleDescriptions[2].name);
-        expect(warnings[2].message).toEqual(ruleDescriptions[2].message);
-
-        expect(warnings[3].rule).toEqual(ruleDescriptions[3].name);
     });
 });

--- a/packages/perseus-linter/src/__tests__/rule.test.ts
+++ b/packages/perseus-linter/src/__tests__/rule.test.ts
@@ -23,12 +23,6 @@ This paragraph contains an unescaped $ sign.
 Only capitalize the first word of headings.`,
         },
         {
-            name: "profanity",
-            pattern: "/poop|crap/i",
-            message: `Profanity:
-this is a family website!`,
-        },
-        {
             name: "unescaped-dollar",
             selector: "unescapedDollar",
             message: `Unescaped '$':

--- a/packages/perseus-linter/src/__tests__/rules.test.ts
+++ b/packages/perseus-linter/src/__tests__/rules.test.ts
@@ -26,7 +26,6 @@ import mathStartsWithSpaceRule from "../rules/math-starts-with-space";
 import mathTextEmptyRule from "../rules/math-text-empty";
 import mathWithoutDollarsRule from "../rules/math-without-dollars";
 import nestedListsRule from "../rules/nested-lists";
-import profanityRule from "../rules/profanity";
 import tableMissingCellsRule from "../rules/table-missing-cells";
 import unbalancedCodeDelimitersRule from "../rules/unbalanced-code-delimiters";
 import unescapedDollarRule from "../rules/unescaped-dollar";
@@ -385,18 +384,6 @@ describe("Individual lint rules tests", () => {
     ]);
     // @ts-expect-error - TS2554 - Expected 3 arguments, but got 2.
     expectPass(mathFontSizeRule, ["$\\sqrt{x}$", "inline $\\sqrt{x}$ math"]);
-
-    // @ts-expect-error - TS2554 - Expected 3 arguments, but got 2.
-    expectWarning(profanityRule, [
-        "Shit",
-        "taking a piss",
-        "He said 'Fuck that!'",
-        "cunt",
-        "cocksucker",
-        "motherfucker",
-    ]);
-    // @ts-expect-error - TS2554 - Expected 3 arguments, but got 2.
-    expectPass(profanityRule, ["spit", "miss", "duck"]);
 
     // @ts-expect-error - TS2554 - Expected 3 arguments, but got 2.
     expectWarning(mathWithoutDollarsRule, [

--- a/packages/perseus-linter/src/rules/all-rules.ts
+++ b/packages/perseus-linter/src/rules/all-rules.ts
@@ -30,7 +30,6 @@ import MathStartsWithSpace from "./math-starts-with-space";
 import MathTextEmpty from "./math-text-empty";
 import MathWithoutDollars from "./math-without-dollars";
 import NestedLists from "./nested-lists";
-import Profanity from "./profanity";
 import TableMissingCells from "./table-missing-cells";
 import UnbalancedCodeDelimiters from "./unbalanced-code-delimiters";
 import UnescapedDollar from "./unescaped-dollar";
@@ -63,7 +62,6 @@ export default [
     TableMissingCells,
     UnescapedDollar,
     WidgetInTable,
-    Profanity,
     MathWithoutDollars,
     UnbalancedCodeDelimiters,
     ImageSpacesAroundUrls,

--- a/packages/perseus-linter/src/rules/profanity.ts
+++ b/packages/perseus-linter/src/rules/profanity.ts
@@ -1,9 +1,0 @@
-import Rule from "../rule";
-
-export default Rule.makeRule({
-    name: "profanity",
-    // This list could obviously be expanded a lot, but I figured we
-    // could start with https://en.wikipedia.org/wiki/Seven_dirty_words
-    pattern: /\b(shit|piss|fuck|cunt|cocksucker|motherfucker|tits)\b/i,
-    message: "Avoid profanity",
-}) as Rule;


### PR DESCRIPTION
## Summary:
See: https://khanacademy.slack.com/archives/C01AZ9H8TTQ/p1720805367737349

Why:
- My understanding is that these linters are rules for content creators
- The linter only checked for 7 English words and only looking for the whole word
- While not a big concern, it _is_ code that has to run and be maintained
- Also it's code in our public codebase, so it feels weird to have

So...
- We're running it against people we trust
- It's not very effective at what it's trying to do
- And there are other reasons to remove it

So I just thought I'd remove it.