### PR TITLE
Clarify which actions go with which graph type

### DIFF
--- a/.changeset/pretty-hornets-cheer.md
+++ b/.changeset/pretty-hornets-cheer.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: refactor interactive graph reducer actions to make it clearer which actions go with which graph type

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/angle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/angle.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import {movePoint} from "../reducer/interactive-graph-action";
+import {actions} from "../reducer/interactive-graph-action";
 import useGraphConfig from "../reducer/use-graph-config";
 
 import {Angle} from "./components/angle-indicators";
@@ -31,17 +31,14 @@ export function AngleGraph(props: AngleGraphProps) {
     } = graphState;
 
     // Break the coords into the two end points and the center point
-    const endPoints = [coords[0], coords[2]] satisfies [
-        vec.Vector2,
-        vec.Vector2,
-    ];
+    const endPoints: [vec.Vector2, vec.Vector2] = [coords[0], coords[2]];
     const centerPoint = coords[1];
 
     // Convert the vectors to pixels for rendering the svg lines
-    const angleLines = [
+    const angleLines: CollinearTuple[] = [
         [centerPoint, endPoints[0]],
         [centerPoint, endPoints[1]],
-    ] satisfies CollinearTuple[];
+    ];
 
     const linePixelCoords = [
         useTransformVectorsToPixels(centerPoint, endPoints[0]),
@@ -98,7 +95,7 @@ export function AngleGraph(props: AngleGraphProps) {
                     snapTo={"angles"}
                     point={point}
                     onMove={(destination: vec.Vector2) =>
-                        dispatch(movePoint(i, destination))
+                        dispatch(actions.angle.movePoint(i, destination))
                     }
                 />
             ))}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import {useRef} from "react";
 
 import {snap, X, Y} from "../math";
-import {moveCenter, moveRadiusPoint} from "../reducer/interactive-graph-action";
+import {actions} from "../reducer/interactive-graph-action";
 import {getRadius} from "../reducer/interactive-graph-state";
 import useGraphConfig from "../reducer/use-graph-config";
 
@@ -27,13 +27,13 @@ export function CircleGraph(props: CircleGraphProps) {
             <MovableCircle
                 center={center}
                 radius={getRadius(graphState)}
-                onMove={(newCenter) => dispatch(moveCenter(newCenter))}
+                onMove={(c) => dispatch(actions.circle.moveCenter(c))}
             />
             <StyledMovablePoint
                 point={radiusPoint}
                 cursor="ew-resize"
                 onMove={(newRadiusPoint) => {
-                    dispatch(moveRadiusPoint(newRadiusPoint));
+                    dispatch(actions.circle.moveRadiusPoint(newRadiusPoint));
                 }}
             />
         </>

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import {moveControlPoint, moveLine} from "../reducer/interactive-graph-action";
+import {actions} from "../reducer/interactive-graph-action";
 
 import {MovableLine} from "./components/movable-line";
 
@@ -20,7 +20,7 @@ export const LinearSystemGraph = (props: LinearSystemGraphProps) => {
                     key={i}
                     points={line}
                     onMoveLine={(delta: vec.Vector2) => {
-                        dispatch(moveLine(i, delta));
+                        dispatch(actions.linearSystem.moveLine(i, delta));
                     }}
                     extend={{
                         start: true,
@@ -31,7 +31,11 @@ export const LinearSystemGraph = (props: LinearSystemGraphProps) => {
                         destination: vec.Vector2,
                     ) =>
                         dispatch(
-                            moveControlPoint(endpointIndex, destination, i),
+                            actions.linearSystem.moveControlPoint(
+                                endpointIndex,
+                                destination,
+                                i,
+                            ),
                         )
                     }
                     color="var(--movable-line-stroke-color)"

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import {moveControlPoint, moveLine} from "../reducer/interactive-graph-action";
+import {actions} from "../reducer/interactive-graph-action";
 
 import {MovableLine} from "./components/movable-line";
 
@@ -21,14 +21,16 @@ export const LinearGraph = (props: LinearGraphProps, key: number) => {
             key={0}
             points={line}
             onMoveLine={(delta: vec.Vector2) => {
-                dispatch(moveLine(0, delta));
+                dispatch(actions.linear.moveLine(delta));
             }}
             extend={{
                 start: true,
                 end: true,
             }}
             onMovePoint={(endpointIndex: number, destination: vec.Vector2) =>
-                dispatch(moveControlPoint(endpointIndex, destination, 0))
+                dispatch(
+                    actions.linear.movePoint(endpointIndex, destination, 0),
+                )
             }
             color="var(--movable-line-stroke-color)"
         />

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import {movePoint} from "../reducer/interactive-graph-action";
+import {actions} from "../reducer/interactive-graph-action";
 
 import {StyledMovablePoint} from "./components/movable-point";
 
@@ -17,7 +17,7 @@ export function PointGraph(props: PointGraphProps) {
                     key={i}
                     point={point}
                     onMove={(destination) =>
-                        dispatch(movePoint(i, destination))
+                        dispatch(actions.pointGraph.movePoint(i, destination))
                     }
                 />
             ))}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -2,7 +2,7 @@ import {Polygon, vec} from "mafs";
 import * as React from "react";
 
 import {snap} from "../math";
-import {moveAll, movePoint} from "../reducer/interactive-graph-action";
+import {actions} from "../reducer/interactive-graph-action";
 import {TARGET_SIZE} from "../utils";
 
 import {PolygonAngle} from "./components/angle-indicators";
@@ -35,7 +35,7 @@ export const PolygonGraph = (props: Props) => {
         point: dragReferencePoint,
         onMove: (newPoint) => {
             const delta = vec.sub(newPoint, dragReferencePoint);
-            dispatch(moveAll(delta));
+            dispatch(actions.polygon.moveAll(delta));
         },
         constrain: (p) =>
             ["angles", "sides"].includes(snapToValue) ? p : snap(snapStep, p),
@@ -117,7 +117,7 @@ export const PolygonGraph = (props: Props) => {
                     snapTo={snapTo}
                     point={point}
                     onMove={(destination: vec.Vector2) =>
-                        dispatch(movePoint(i, destination))
+                        dispatch(actions.polygon.movePoint(i, destination))
                     }
                 />
             ))}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
@@ -2,7 +2,7 @@ import {color} from "@khanacademy/wonder-blocks-tokens";
 import {Plot} from "mafs";
 import * as React from "react";
 
-import {movePoint} from "../reducer/interactive-graph-action";
+import {actions} from "../reducer/interactive-graph-action";
 
 import {StyledMovablePoint} from "./components/movable-point";
 
@@ -40,7 +40,7 @@ export function QuadraticGraph(props: QuadraticGraphProps) {
                     key={"point-" + i}
                     point={coord}
                     onMove={(destination) =>
-                        dispatch(movePoint(i, destination))
+                        dispatch(actions.quadratic.movePoint(i, destination))
                     }
                 />
             ))}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/ray.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/ray.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import {moveControlPoint, moveLine} from "../reducer/interactive-graph-action";
+import {actions} from "../reducer/interactive-graph-action";
 
 import {MovableLine} from "./components/movable-line";
 
@@ -13,9 +13,10 @@ export const RayGraph = (props: Props) => {
     const {dispatch} = props;
     const {coords: line} = props.graphState;
 
-    const handleMoveLine = (delta: vec.Vector2) => dispatch(moveLine(0, delta));
+    const handleMoveLine = (delta: vec.Vector2) =>
+        dispatch(actions.ray.moveRay(delta));
     const handleMovePoint = (pointIndex: number, newPoint: vec.Vector2) =>
-        dispatch(moveControlPoint(pointIndex, newPoint, 0));
+        dispatch(actions.ray.moveControlPoint(pointIndex, newPoint, 0));
 
     // Ray graphs only have one line
     return (

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import {moveControlPoint, moveLine} from "../reducer/interactive-graph-action";
+import {actions} from "../reducer/interactive-graph-action";
 
 import {MovableLine} from "./components/movable-line";
 
@@ -20,14 +20,18 @@ export const SegmentGraph = (props: SegmentProps) => {
                     key={i}
                     points={segment}
                     onMoveLine={(delta: vec.Vector2) => {
-                        dispatch(moveLine(i, delta));
+                        dispatch(actions.segment.moveLine(i, delta));
                     }}
                     onMovePoint={(
                         endpointIndex: number,
                         destination: vec.Vector2,
                     ) => {
                         dispatch(
-                            moveControlPoint(endpointIndex, destination, i),
+                            actions.segment.moveControlPoint(
+                                endpointIndex,
+                                destination,
+                                i,
+                            ),
                         );
                     }}
                 />

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
@@ -3,7 +3,7 @@ import {Plot} from "mafs";
 import * as React from "react";
 
 import {X, Y} from "../math";
-import {movePoint} from "../reducer/interactive-graph-action";
+import {actions} from "../reducer/interactive-graph-action";
 
 import {StyledMovablePoint} from "./components/movable-point";
 
@@ -55,7 +55,7 @@ export function SinusoidGraph(props: SinusoidGraphProps) {
                     key={"point-" + i}
                     point={coord}
                     onMove={(destination) =>
-                        dispatch(movePoint(i, destination))
+                        dispatch(actions.sinusoid.movePoint(i, destination))
                     }
                 />
             ))}

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -8,7 +8,7 @@ import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
 
 import {MafsGraph} from "./mafs-graph";
-import {movePoint} from "./reducer/interactive-graph-action";
+import {actions} from "./reducer/interactive-graph-action";
 import {interactiveGraphReducer} from "./reducer/interactive-graph-reducer";
 
 import type {MafsGraphProps} from "./mafs-graph";
@@ -462,7 +462,7 @@ describe("MafsGraph", () => {
         const group = screen.getByTestId("movable-point");
         group.focus();
         await userEvent.keyboard("[ArrowRight]");
-        const action = movePoint(0, [4, 2]);
+        const action = actions.pointGraph.movePoint(0, [4, 2]);
         expect(mockDispatch).toHaveBeenCalledWith(action);
 
         const updatedState = interactiveGraphReducer(state, action);

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
@@ -12,15 +12,82 @@ export type InteractiveGraphAction =
     | ChangeSnapStep
     | ChangeRange;
 
-export const REINITIALIZE = "reinitialize";
-export interface Reinitialize {
-    type: typeof REINITIALIZE;
-    params: InitializeGraphStateParams;
+export const actions = {
+    angle: {
+        movePoint,
+    },
+    circle: {
+        moveCenter,
+        moveRadiusPoint,
+    },
+    linear: {
+        moveLine: (delta: vec.Vector2) => moveLine(0, delta),
+        movePoint: moveControlPoint,
+    },
+    linearSystem: {
+        moveLine,
+        moveControlPoint,
+    },
+    pointGraph: {
+        movePoint,
+    },
+    polygon: {
+        movePoint,
+        moveAll,
+    },
+    quadratic: {
+        movePoint,
+    },
+    ray: {
+        moveRay: (delta: vec.Vector2) => moveLine(0, delta),
+        moveControlPoint,
+    },
+    segment: {
+        moveControlPoint,
+        moveLine,
+    },
+    sinusoid: {
+        movePoint,
+    },
+};
+
+export const MOVE_LINE = "move-line";
+export interface MoveLine {
+    type: typeof MOVE_LINE;
+    itemIndex: number;
+    delta: vec.Vector2;
 }
-export function reinitialize(params: InitializeGraphStateParams): Reinitialize {
+function moveLine(itemIndex: number, delta: vec.Vector2): MoveLine {
     return {
-        type: REINITIALIZE,
-        params,
+        type: MOVE_LINE,
+        itemIndex,
+        delta,
+    };
+}
+
+export const MOVE_ALL = "move-all";
+export interface MoveAll {
+    type: typeof MOVE_ALL;
+    delta: vec.Vector2;
+}
+function moveAll(delta: vec.Vector2): MoveAll {
+    return {
+        type: MOVE_ALL,
+        delta,
+    };
+}
+
+export const MOVE_POINT = "move-point";
+export interface MovePoint {
+    type: typeof MOVE_POINT;
+    index: number;
+    destination: vec.Vector2;
+}
+function movePoint(index: number, destination: vec.Vector2): MovePoint {
+    return {
+        type: MOVE_POINT,
+        index,
+        destination,
     };
 }
 
@@ -31,7 +98,7 @@ export interface MoveControlPoint {
     pointIndex: number;
     destination: vec.Vector2;
 }
-export function moveControlPoint(
+function moveControlPoint(
     pointIndex: number,
     destination: vec.Vector2,
     itemIndex: number,
@@ -44,52 +111,12 @@ export function moveControlPoint(
     };
 }
 
-export const MOVE_ALL = "move-all";
-export const MOVE_LINE = "move-line";
-interface MoveItem {
-    delta: vec.Vector2;
-    itemIndex?: number;
-}
-export interface MoveLine extends MoveItem {
-    type: typeof MOVE_LINE;
-}
-export interface MoveAll extends MoveItem {
-    type: typeof MOVE_ALL;
-}
-/** This action assumes the state.coords holds an array of collinear tuples that define lines */
-export function moveLine(itemIndex: number, delta: vec.Vector2): MoveLine {
-    return {
-        type: MOVE_LINE,
-        itemIndex,
-        delta,
-    };
-}
-/** This action assumes a flat array of vectors */
-export const moveAll = (delta: vec.Vector2): MoveAll => ({
-    type: MOVE_ALL,
-    delta,
-});
-
-export const MOVE_POINT = "move-point";
-export interface MovePoint {
-    type: typeof MOVE_POINT;
-    index: number;
-    destination: vec.Vector2;
-}
-export function movePoint(index: number, destination: vec.Vector2): MovePoint {
-    return {
-        type: MOVE_POINT,
-        index,
-        destination,
-    };
-}
-
 export const MOVE_CENTER = "move-center";
 export interface MoveCenter {
     type: typeof MOVE_CENTER;
     destination: vec.Vector2;
 }
-export function moveCenter(destination: vec.Vector2): MoveCenter {
+function moveCenter(destination: vec.Vector2): MoveCenter {
     return {
         type: MOVE_CENTER,
         destination,
@@ -101,7 +128,7 @@ export interface MoveRadiusPoint {
     type: typeof MOVE_RADIUS_POINT;
     destination: vec.Vector2;
 }
-export function moveRadiusPoint(destination: vec.Vector2): MoveRadiusPoint {
+function moveRadiusPoint(destination: vec.Vector2): MoveRadiusPoint {
     return {
         type: MOVE_RADIUS_POINT,
         destination,
@@ -131,5 +158,17 @@ export function changeRange(range: [x: Interval, y: Interval]): ChangeRange {
     return {
         type: CHANGE_RANGE,
         range,
+    };
+}
+
+export const REINITIALIZE = "reinitialize";
+export interface Reinitialize {
+    type: typeof REINITIALIZE;
+    params: InitializeGraphStateParams;
+}
+export function reinitialize(params: InitializeGraphStateParams): Reinitialize {
+    return {
+        type: REINITIALIZE,
+        params,
     };
 }

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -2,16 +2,7 @@ import invariant from "tiny-invariant";
 
 import {findAngle} from "../math/angles";
 
-import {
-    moveControlPoint,
-    movePoint,
-    moveLine,
-    changeSnapStep,
-    changeRange,
-    moveCenter,
-    moveRadiusPoint,
-    moveAll,
-} from "./interactive-graph-action";
+import {changeSnapStep, changeRange, actions} from "./interactive-graph-action";
 import {interactiveGraphReducer} from "./interactive-graph-reducer";
 
 import type {GraphRange} from "../../../perseus-types";
@@ -126,7 +117,7 @@ describe("moveControlPoint", () => {
 
         const updated = interactiveGraphReducer(
             state,
-            moveControlPoint(0, [5, 6], 0),
+            actions.segment.moveControlPoint(0, [5, 6], 0),
         );
 
         invariant(updated.type === "segment");
@@ -149,7 +140,7 @@ describe("moveControlPoint", () => {
 
         const updated = interactiveGraphReducer(
             state,
-            moveControlPoint(0, [5, 6], 0),
+            actions.segment.moveControlPoint(0, [5, 6], 0),
         );
 
         expect(updated.hasBeenInteractedWith).toBe(true);
@@ -168,7 +159,7 @@ describe("moveControlPoint", () => {
 
         const updated = interactiveGraphReducer(
             state,
-            moveControlPoint(0, [2, 2], 0),
+            actions.segment.moveControlPoint(0, [2, 2], 0),
         );
 
         invariant(updated.type === "segment");
@@ -188,7 +179,10 @@ describe("moveControlPoint", () => {
             ],
         };
 
-        const updated = interactiveGraphReducer(state, movePoint(0, [2, 1]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.sinusoid.movePoint(0, [2, 1]),
+        );
 
         invariant(updated.type === "sinusoid");
         // Assert: the move was canceled
@@ -207,7 +201,10 @@ describe("moveControlPoint", () => {
             ],
         };
 
-        const updated = interactiveGraphReducer(state, movePoint(0, [15, 1]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.sinusoid.movePoint(0, [15, 1]),
+        );
 
         invariant(updated.type === "sinusoid");
         // Assert: the move was canceled
@@ -231,7 +228,7 @@ describe("moveControlPoint", () => {
 
         const updated = interactiveGraphReducer(
             state,
-            moveControlPoint(0, [1.5, 6.6], 0),
+            actions.segment.moveControlPoint(0, [1.5, 6.6], 0),
         );
 
         // Assert
@@ -259,7 +256,7 @@ describe("moveControlPoint", () => {
 
         const updated = interactiveGraphReducer(
             state,
-            moveControlPoint(0, [99, 99], 0),
+            actions.segment.moveControlPoint(0, [99, 99], 0),
         );
 
         invariant(updated.type === "segment");
@@ -279,7 +276,10 @@ describe("moveSegment", () => {
             ],
         };
 
-        const updated = interactiveGraphReducer(state, moveLine(0, [5, -3]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.segment.moveLine(0, [5, -3]),
+        );
 
         invariant(updated.type === "segment");
         expect(updated.coords[0]).toEqual([
@@ -299,7 +299,10 @@ describe("moveSegment", () => {
             ],
         };
 
-        const updated = interactiveGraphReducer(state, moveLine(0, [0.5, 0.5]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.segment.moveLine(0, [0.5, 0.5]),
+        );
 
         invariant(updated.type === "segment");
         expect(updated.coords[0]).toEqual([
@@ -319,7 +322,10 @@ describe("moveSegment", () => {
             ],
         };
 
-        const updated = interactiveGraphReducer(state, moveLine(0, [99, 99]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.segment.moveLine(0, [99, 99]),
+        );
 
         invariant(updated.type === "segment");
         expect(updated.coords[0]).toEqual([
@@ -339,7 +345,10 @@ describe("moveSegment", () => {
             ],
         };
 
-        const updated = interactiveGraphReducer(state, moveLine(0, [1, 1]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.segment.moveLine(0, [1, 1]),
+        );
 
         expect(updated.hasBeenInteractedWith).toBe(true);
     });
@@ -355,7 +364,10 @@ describe("movePoint on a point graph", () => {
             ],
         };
 
-        const updated = interactiveGraphReducer(state, movePoint(0, [5, 6]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.pointGraph.movePoint(0, [5, 6]),
+        );
 
         invariant(updated.type === "point");
         expect(updated.coords[0]).toEqual([5, 6]);
@@ -370,7 +382,7 @@ describe("movePoint on a point graph", () => {
 
         const updated = interactiveGraphReducer(
             state,
-            movePoint(0, [-2, -2.5]),
+            actions.pointGraph.movePoint(0, [-2, -2.5]),
         );
 
         invariant(updated.type === "point");
@@ -383,7 +395,10 @@ describe("movePoint on a point graph", () => {
             coords: [[0, 0]],
         };
 
-        const updated = interactiveGraphReducer(state, movePoint(0, [99, 99]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.pointGraph.movePoint(0, [99, 99]),
+        );
 
         invariant(updated.type === "point");
         expect(updated.coords[0]).toEqual([9, 9]);
@@ -395,7 +410,10 @@ describe("movePoint on a point graph", () => {
             coords: [[1, 2]],
         };
 
-        const updated = interactiveGraphReducer(state, movePoint(0, [1, 1]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.pointGraph.movePoint(0, [1, 1]),
+        );
 
         expect(updated.hasBeenInteractedWith).toBe(true);
     });
@@ -412,7 +430,10 @@ describe("movePoint on an angle graph", () => {
             ],
         };
 
-        const updated = interactiveGraphReducer(state, movePoint(0, [5, 6]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.angle.movePoint(0, [5, 6]),
+        );
 
         invariant(updated.type === "angle");
 
@@ -432,7 +453,10 @@ describe("movePoint on an angle graph", () => {
             snapDegrees: 5,
         };
 
-        const updated = interactiveGraphReducer(state, movePoint(0, [5, 3]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.angle.movePoint(0, [5, 3]),
+        );
 
         invariant(updated.type === "angle");
 
@@ -453,7 +477,10 @@ describe("movePoint on an angle graph", () => {
             ],
         };
 
-        const updated = interactiveGraphReducer(state, movePoint(0, [99, 99]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.angle.movePoint(0, [99, 99]),
+        );
 
         invariant(updated.type === "angle");
 
@@ -470,7 +497,10 @@ describe("movePoint on an angle graph", () => {
                 [0, 5],
             ],
         };
-        const updated = interactiveGraphReducer(state, movePoint(0, [1, 1]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.angle.movePoint(0, [1, 1]),
+        );
 
         expect(updated.hasBeenInteractedWith).toBe(true);
     });
@@ -488,7 +518,10 @@ describe("movePoint on a polygon graph", () => {
             ],
         };
 
-        const updated = interactiveGraphReducer(state, movePoint(0, [0, 1]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.polygon.movePoint(0, [0, 1]),
+        );
 
         invariant(updated.type === "polygon");
         expect(updated.coords[0]).toEqual([0, 1]);
@@ -505,7 +538,10 @@ describe("movePoint on a polygon graph", () => {
             ],
         };
 
-        const updated = interactiveGraphReducer(state, movePoint(0, [1, 3]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.polygon.movePoint(0, [1, 3]),
+        );
 
         invariant(updated.type === "polygon");
         expect(updated.coords[0]).toEqual([0, 0]);
@@ -523,7 +559,10 @@ describe("movePoint on a polygon graph", () => {
             ],
         };
 
-        const updated = interactiveGraphReducer(state, movePoint(0, [1, 3]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.polygon.movePoint(0, [1, 3]),
+        );
 
         invariant(updated.type === "polygon");
         expect(updated.coords[0]).toEqual([0, 0]);
@@ -541,7 +580,10 @@ describe("movePoint on a polygon graph", () => {
             ],
         };
 
-        const updated = interactiveGraphReducer(state, movePoint(0, [1, 3]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.polygon.movePoint(0, [1, 3]),
+        );
 
         invariant(updated.type === "polygon");
         expect(updated.coords[0]).toEqual([0, 0]);
@@ -560,7 +602,10 @@ describe("movePoint on a polygon graph", () => {
         };
 
         // Move all points less than a snapStep to show they are not snapping
-        const updated = interactiveGraphReducer(state, moveAll([0.3, 0]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.polygon.moveAll([0.3, 0]),
+        );
 
         invariant(updated.type === "polygon");
         expect(updated.coords[0]).toEqual([0.3, 0]);
@@ -579,7 +624,10 @@ describe("movePoint on a polygon graph", () => {
         };
 
         // Move all points less than a snapStep to show they are not snapping
-        const updated = interactiveGraphReducer(state, moveAll([0.3, 0]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.polygon.moveAll([0.3, 0]),
+        );
 
         invariant(updated.type === "polygon");
         expect(updated.coords[0]).toEqual([0.3, 0]);
@@ -598,7 +646,10 @@ describe("movePoint on a polygon graph", () => {
             ],
         };
 
-        const updated = interactiveGraphReducer(state, movePoint(0, [3, -2]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.polygon.movePoint(0, [3, -2]),
+        );
 
         invariant(updated.type === "polygon");
         expect(updated.coords[0]).toEqual([
@@ -619,7 +670,10 @@ describe("movePoint on a polygon graph", () => {
             ],
         };
 
-        const updated = interactiveGraphReducer(state, movePoint(0, [3, -2]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.polygon.movePoint(0, [3, -2]),
+        );
 
         invariant(updated.type === "polygon");
         expect(updated.coords[0]).toEqual([
@@ -632,7 +686,10 @@ describe("movePoint on a quadratic graph", () => {
     it("moves a point", () => {
         const state: InteractiveGraphState = baseQuadraticGraphState;
 
-        const updated = interactiveGraphReducer(state, movePoint(0, [-2, 4]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.quadratic.movePoint(0, [-2, 4]),
+        );
 
         invariant(updated.type === "quadratic");
         expect(updated.coords[0]).toEqual([-2, 4]);
@@ -651,7 +708,10 @@ describe("movePoint on a quadratic graph", () => {
         // An invalid graph happens when the denominator is 0 and are unable to calculate
         // quadratic coefficients as they hit infinity.
         // For more details see the getQuadraticCoefficients function that performs this calculation.
-        const updated = interactiveGraphReducer(state, movePoint(0, [0, 0]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.quadratic.movePoint(0, [0, 0]),
+        );
 
         invariant(updated.type === "quadratic");
         expect(updated.coords[0]).toEqual([-5, 5]);
@@ -725,7 +785,10 @@ describe("moveCenter", () => {
             ...baseCircleGraphState,
         };
 
-        const updated = interactiveGraphReducer(state, moveCenter([1, 1]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.circle.moveCenter([1, 1]),
+        );
 
         // make sure the state object is different
         expect(state).not.toBe(updated);
@@ -737,7 +800,10 @@ describe("moveCenter", () => {
             ...baseCircleGraphState,
         };
 
-        const updated = interactiveGraphReducer(state, moveCenter([1, 1]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.circle.moveCenter([1, 1]),
+        );
 
         expect(updated.hasBeenInteractedWith).toBe(true);
     });
@@ -747,7 +813,10 @@ describe("moveCenter", () => {
             ...baseCircleGraphState,
         };
 
-        const updated = interactiveGraphReducer(state, moveCenter([11, 11]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.circle.moveCenter([11, 11]),
+        );
 
         // make sure the state object is different
         expect(state).not.toBe(updated);
@@ -759,7 +828,10 @@ describe("moveCenter", () => {
             ...baseCircleGraphState,
         };
 
-        const updated = interactiveGraphReducer(state, moveCenter([1, 1]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.circle.moveCenter([1, 1]),
+        );
 
         // make sure the state object is different
         expect(state).not.toBe(updated);
@@ -771,7 +843,10 @@ describe("moveCenter", () => {
             ...baseCircleGraphState,
         };
 
-        const updated = interactiveGraphReducer(state, moveCenter([9, 0]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.circle.moveCenter([9, 0]),
+        );
 
         // make sure the state object is different
         expect(state).not.toBe(updated);
@@ -784,7 +859,7 @@ describe("moveCenter", () => {
         };
 
         expect(() =>
-            interactiveGraphReducer(state, moveCenter([1, 1])),
+            interactiveGraphReducer(state, actions.circle.moveCenter([1, 1])),
         ).toThrow();
     });
 });
@@ -795,7 +870,10 @@ describe("doMoveRadiusPoint", () => {
             ...baseCircleGraphState,
         };
 
-        const updated = interactiveGraphReducer(state, moveRadiusPoint([5, 0]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.circle.moveRadiusPoint([5, 0]),
+        );
 
         // make sure the state object is different
         expect(state).not.toBe(updated);
@@ -807,7 +885,10 @@ describe("doMoveRadiusPoint", () => {
             ...baseCircleGraphState,
         };
 
-        const updated = interactiveGraphReducer(state, moveRadiusPoint([4, 0]));
+        const updated = interactiveGraphReducer(
+            state,
+            actions.circle.moveRadiusPoint([4, 0]),
+        );
 
         expect(updated.hasBeenInteractedWith).toBe(true);
     });
@@ -819,7 +900,7 @@ describe("doMoveRadiusPoint", () => {
 
         const updated = interactiveGraphReducer(
             state,
-            moveRadiusPoint([20, 0]),
+            actions.circle.moveRadiusPoint([20, 0]),
         );
 
         // make sure the state object is different
@@ -834,7 +915,7 @@ describe("doMoveRadiusPoint", () => {
 
         const updated = interactiveGraphReducer(
             state,
-            moveRadiusPoint([2, 20]),
+            actions.circle.moveRadiusPoint([2, 20]),
         );
 
         // make sure the state object is different
@@ -848,7 +929,10 @@ describe("doMoveRadiusPoint", () => {
         };
 
         expect(() =>
-            interactiveGraphReducer(state, moveRadiusPoint([5, 0])),
+            interactiveGraphReducer(
+                state,
+                actions.circle.moveRadiusPoint([5, 0]),
+            ),
         ).toThrow();
     });
 });


### PR DESCRIPTION
I could never remember which actions are supposed to be used with which
graph type, so I thought I'd fix that. Now you don't have to guess: you
can type `actions.<graph type>` and your IDE will autocomplete the
available actions for you.

Issue: none

## Test plan:

`yarn test`