### PR TITLE
Update browserslist and caniuse-lite packages weekly

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -42,19 +42,19 @@ jobs:
                   commit-message: "chore: update browserslist"
                   title: Update browserslist
                   body: |
-                     # Summary
+                      # Summary
 
-                     Updates the `browserslist` and `caniuse-lite` npm packages
+                      Updates the `browserslist` and `caniuse-lite` npm packages
 
-                     ## Reviewing notes:
+                      ## Reviewing notes:
 
-                     There should only be changes to the `yarn.lock` file in
-                     this PR. Check that there is only 1 `caniuse-lite` package
-                     reference in the `yarn.lock` file (the intent of this
-                     update is to ensure that `caniuse-lite` is on the latest
-                     version and that there aren't multiple, conflicting
-                     versions that different tools might see).
+                      There should only be changes to the `yarn.lock` file in
+                      this PR. Check that there is only 1 `caniuse-lite` package
+                      reference in the `yarn.lock` file (the intent of this
+                      update is to ensure that `caniuse-lite` is on the latest
+                      version and that there aren't multiple, conflicting
+                      versions that different tools might see).
 
-                     If everything looks fine, please approve this PR and then
-                     land it (either with the Big Green Merge Button ™️ or by
-                     using `git land <this pr #>` in a terminal.
+                      If everything looks fine, please approve this PR and then
+                      land it (either with the Big Green Merge Button ™️ or by
+                      using `git land <this pr #>` in a terminal.

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -5,7 +5,7 @@ on:
     workflow_dispatch:
     schedule:
         # https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
-        #        ┌────────── minute (0 - 59)
+        #        ┌─────────── minute (0 - 59)
         #        │ ┌───────── hour (0 - 23)
         #        │ │ ┌─────── day of the month (1 - 31)
         #        │ │ │ ┌───── month (1 - 12 or JAN-DEC)

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,0 +1,32 @@
+name: Weekly maintenance/update tasks
+on:
+    workflow_dispatch:
+    schedule:
+        - cron: "30 1 * * 1" # Run on Mondays @ 7:30am UTC (3:30am EDT, 12:30 am PDT)
+jobs:
+    update-browserslist:
+        name: Update the browserslist database (used by caniuse-lite)
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                os: [ubuntu-latest]
+                node-version: [20.x]
+        steps:
+            - uses: actions/checkout@v4
+            - name: Install & cache node_modules
+              uses: ./.github/actions/shared-node-cache
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  ssh-private-key: ${{ secrets.KHAN_ACTIONS_BOT_SSH_PRIVATE_KEY }}
+
+            - name: Update browserslist DB
+              run: npx update-browserslist@latest
+
+            - name: Create Pull Request
+              uses: peter-evans/create-pull-request@v6
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  team-reviewers: Perseus
+                  commit-message: "chore: update browserslist"
+                  title: Update browserslist
+                  body: Update browserslist and caniuse-lite packages

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -38,7 +38,7 @@ jobs:
               uses: peter-evans/create-pull-request@v6
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
-                  team-reviewers: Perseus
+                  team-reviewers: perseus, frontend-infra-web
                   commit-message: "chore: update browserslist"
                   title: Update browserslist
                   body: |
@@ -57,4 +57,4 @@ jobs:
 
                       If everything looks fine, please approve this PR and then
                       land it (either with the Big Green Merge Button ™️ or by
-                      using `git land <this pr #>` in a terminal.
+                      using `git land <this pr #>` in a terminal).

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -11,7 +11,7 @@ on:
         #        │ │ │ ┌───── month (1 - 12 or JAN-DEC)
         #        │ │ │ │ ┌─── day of the week (0 - 6 or SUN-SAT)
         #        v v v v v
-        - cron: 30 7 * * 1
+        - cron: 30 7 * * 1 # in UTC
         #       Run on Mondays @ 7:30am UTC (3:30am EDT, 12:30 am PDT)
 
 jobs:

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,8 +1,19 @@
 name: Weekly maintenance/update tasks
 on:
+    # workflow_dispatch allows for manual triggering of the workflow
+    # Useful for testing that it works without waiting on the cron schedule.
     workflow_dispatch:
     schedule:
-        - cron: "30 1 * * 1" # Run on Mondays @ 7:30am UTC (3:30am EDT, 12:30 am PDT)
+        # https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
+        #       ┌─────────── minute (0 - 59)
+        #       │  ┌───────── hour (0 - 23)
+        #       │  │ ┌─────── day of the month (1 - 31)
+        #       │  │ │ ┌───── month (1 - 12 or JAN-DEC)
+        #       │  │ │ │ ┌─── day of the week (0 - 6 or SUN-SAT)
+        #       v  v v v v
+        - cron: 30 1 * * 1
+        #       Run on Mondays @ 7:30am UTC (3:30am EDT, 12:30 am PDT)
+
 jobs:
     update-browserslist:
         name: Update the browserslist database (used by caniuse-lite)
@@ -30,4 +41,20 @@ jobs:
                   team-reviewers: Perseus
                   commit-message: "chore: update browserslist"
                   title: Update browserslist
-                  body: Update browserslist and caniuse-lite packages
+                  body: |
+                     # Summary
+
+                     Updates the `browserslist` and `caniuse-lite` npm packages
+
+                     ## Reviewing notes:
+
+                     There should only be changes to the `yarn.lock` file in
+                     this PR. Check that there is only 1 `caniuse-lite` package
+                     reference in the `yarn.lock` file (the intent of this
+                     update is to ensure that `caniuse-lite` is on the latest
+                     version and that there aren't multiple, conflicting
+                     versions that different tools might see).
+
+                     If everything looks fine, please approve this PR and then
+                     land it (either with the Big Green Merge Button ™️ or by
+                     using `git land <this pr #>` in a terminal.

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -13,6 +13,7 @@ jobs:
                 node-version: [20.x]
         steps:
             - uses: actions/checkout@v4
+
             - name: Install & cache node_modules
               uses: ./.github/actions/shared-node-cache
               with:

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -5,13 +5,13 @@ on:
     workflow_dispatch:
     schedule:
         # https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
-        #       ┌─────────── minute (0 - 59)
-        #       │  ┌───────── hour (0 - 23)
-        #       │  │ ┌─────── day of the month (1 - 31)
-        #       │  │ │ ┌───── month (1 - 12 or JAN-DEC)
-        #       │  │ │ │ ┌─── day of the week (0 - 6 or SUN-SAT)
-        #       v  v v v v
-        - cron: 30 1 * * 1
+        #        ┌────────── minute (0 - 59)
+        #        │ ┌───────── hour (0 - 23)
+        #        │ │ ┌─────── day of the month (1 - 31)
+        #        │ │ │ ┌───── month (1 - 12 or JAN-DEC)
+        #        │ │ │ │ ┌─── day of the week (0 - 6 or SUN-SAT)
+        #        v v v v v
+        - cron: 30 7 * * 1
         #       Run on Mondays @ 7:30am UTC (3:30am EDT, 12:30 am PDT)
 
 jobs:

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -35,7 +35,7 @@ jobs:
               run: npx update-browserslist@latest
 
             - name: Create Pull Request
-              uses: peter-evans/create-pull-request@v6
+              uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   team-reviewers: perseus, frontend-infra-web


### PR DESCRIPTION
## Summary:

This PR introduces a new Github Action that will run weekly (on Monday's at 7:30 am UTC - which maps to somewhere in the night in North America).

We will still need to manually approve and land these PRs to merge the changes (#security). Also, if we do not land the PR before this action runs again, the PR will simply be updated.

Issue: "none"

## Test plan:

We can run this action manually to test. Upon running it, a new PR with the title 'chore: update browserslist' should appear.