### PR TITLE
Remove jest-extended package

### DIFF
--- a/config/test/test.config.js
+++ b/config/test/test.config.js
@@ -61,7 +61,6 @@ module.exports = {
         "<rootDir>/**/*.test.tsx",
     ],
     setupFilesAfterEnv: [
-        "jest-extended/all",
         "<rootDir>/config/test/test-setup.ts",
         "<rootDir>/config/test/custom-matchers.ts",
     ],

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
         "fast-glob": "^3.2.11",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
-        "jest-extended": "^4.0.0",
         "jest-serializer-html": "^7.1.0",
         "jest-specific-snapshot": "^5.0.0",
         "less": "^4.2.0",

--- a/packages/kas/src/__tests__/index.test.ts
+++ b/packages/kas/src/__tests__/index.test.ts
@@ -104,7 +104,7 @@ describe("KAS", () => {
 
         const {equal} = KAS.compare(expr1, expr2);
 
-        expect(equal).toBeTrue();
+        expect(equal).toBe(true);
     });
 
     it("should compare equations", () => {
@@ -113,7 +113,7 @@ describe("KAS", () => {
 
         const {equal} = KAS.compare(eq1, eq2);
 
-        expect(equal).toBeTrue();
+        expect(equal).toBe(true);
     });
 
     it("can collect like terms", () => {

--- a/packages/kas/src/__tests__/units.test.ts
+++ b/packages/kas/src/__tests__/units.test.ts
@@ -160,7 +160,7 @@ describe("units", () => {
                 new KAS.Mul(new KAS.Int(50), new KAS.Unit("m")),
                 new KAS.Int(50),
             ).equal,
-        ).toBeFalse();
+        ).toBe(false);
 
         expect(["50 m", "50 A"]).not.toParseUnitsAsEqual("50 m != 50 A");
         expect(["5000 mA", "5 A"]).toParseUnitsAsEqual("5000 mA = 5 A");

--- a/packages/perseus/src/widget-type-utils.test.ts
+++ b/packages/perseus/src/widget-type-utils.test.ts
@@ -56,7 +56,7 @@ describe("widget-type-utils", () => {
             const result = contentHasWidgetType(type, content, widgetMap);
 
             // Assert
-            expect(result).toBeTrue();
+            expect(result).toBe(true);
         });
 
         it("returns false when not found", () => {
@@ -72,7 +72,7 @@ describe("widget-type-utils", () => {
             const result = contentHasWidgetType(type, content, widgetMap);
 
             // Assert
-            expect(result).toBeFalse();
+            expect(result).toBe(false);
         });
     });
 

--- a/packages/perseus/src/widgets/__tests__/dropdown.test.ts
+++ b/packages/perseus/src/widgets/__tests__/dropdown.test.ts
@@ -96,7 +96,7 @@ describe("Dropdown widget", () => {
         const focused = renderer.focus();
 
         // Assert
-        expect(focused).toBeTrue();
+        expect(focused).toBe(true);
         // TODO(LP-10797): we don't check that the document.activeElement is
         // actually set because the dropdown widget focuses a <div> (it's root
         // element), which is not actually focusable because it doesn't have a

--- a/packages/perseus/src/widgets/__tests__/image.test.ts
+++ b/packages/perseus/src/widgets/__tests__/image.test.ts
@@ -40,7 +40,7 @@ describe.each([true, false])("image widget - isMobile %b", (isMobile) => {
 
     it("should be accessible if background has 'alt' prop", () => {
         // Arrange, Act, and Assert
-        expect(isAccessible(question.widgets["image 1"])).toBeTrue();
+        expect(isAccessible(question.widgets["image 1"])).toBe(true);
     });
 
     it("should be inaccessible if background is missing 'alt' prop", () => {
@@ -56,6 +56,6 @@ describe.each([true, false])("image widget - isMobile %b", (isMobile) => {
         };
 
         // Act and Assert
-        expect(isAccessible(inaccessibleWidgetInfo)).toBeFalse();
+        expect(isAccessible(inaccessibleWidgetInfo)).toBe(false);
     });
 });

--- a/packages/perseus/src/widgets/__tests__/input-number.test.ts
+++ b/packages/perseus/src/widgets/__tests__/input-number.test.ts
@@ -344,7 +344,7 @@ describe("focus state", () => {
         const gotFocus = renderer.focus();
 
         // Assert
-        expect(gotFocus).toBeTrue();
+        expect(gotFocus).toBe(true);
     });
 
     it("supports blurring", () => {
@@ -356,6 +356,6 @@ describe("focus state", () => {
         renderer.blur();
 
         // Assert
-        expect(gotFocus).toBeTrue();
+        expect(gotFocus).toBe(true);
     });
 });

--- a/packages/perseus/src/widgets/__tests__/numeric-input.test.ts
+++ b/packages/perseus/src/widgets/__tests__/numeric-input.test.ts
@@ -515,7 +515,7 @@ describe("Numeric input widget", () => {
         const gotFocus = renderer.focus();
 
         // Assert
-        expect(gotFocus).toBeTrue();
+        expect(gotFocus).toBe(true);
         // eslint-disable-next-line testing-library/no-node-access
         expect(document.activeElement).toBe(
             screen.getByRole("textbox", {hidden: true}),
@@ -567,7 +567,7 @@ describe("unionAnswerForms utility function", () => {
         const result = unionAnswerForms(forms);
 
         // assert
-        expect(result).toBeArrayOfSize(1);
+        expect(result).toHaveLength(1);
     });
 });
 

--- a/packages/perseus/src/widgets/__tests__/radio/choice.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/radio/choice.test.tsx
@@ -170,7 +170,7 @@ describe("choice button", () => {
         await userEvent.click(button);
 
         // Assert
-        expect(checked).toBeTrue();
+        expect(checked).toBe(true);
     });
 
     it("can be unchecked", async () => {
@@ -188,7 +188,7 @@ describe("choice button", () => {
         await userEvent.click(button);
 
         // Assert
-        expect(checked).toBeFalse();
+        expect(checked).toBe(false);
     });
 });
 
@@ -322,6 +322,6 @@ describe("choice input (screen reader only)", () => {
         await userEvent.click(input);
 
         // Assert
-        expect(checked).toBeFalse();
+        expect(checked).toBe(false);
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10466,16 +10466,6 @@ jest-diff@^27.5.1:
     jest-get-type "^27.5.1"
     pretty-format "^27.5.1"
 
-jest-diff@^29.0.0, jest-diff@^29.7.0:
-  version "29.7.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.7.0.tgz#017934a66ebb7ecf6f205e84699be10afd70458a"
-  integrity sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==
-  dependencies:
-    chalk "^4.0.0"
-    diff-sequences "^29.6.3"
-    jest-get-type "^29.6.3"
-    pretty-format "^29.7.0"
-
 jest-diff@^29.5.0:
   version "29.5.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.5.0.tgz#e0d83a58eb5451dcc1fa61b1c3ee4e8f5a290d63"
@@ -10485,6 +10475,16 @@ jest-diff@^29.5.0:
     diff-sequences "^29.4.3"
     jest-get-type "^29.4.3"
     pretty-format "^29.5.0"
+
+jest-diff@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.7.0.tgz#017934a66ebb7ecf6f205e84699be10afd70458a"
+  integrity sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^29.6.3"
+    jest-get-type "^29.6.3"
+    pretty-format "^29.7.0"
 
 jest-docblock@^29.7.0:
   version "29.7.0"
@@ -10530,14 +10530,6 @@ jest-environment-node@^29.7.0:
     jest-mock "^29.7.0"
     jest-util "^29.7.0"
 
-jest-extended@^4.0.0:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/jest-extended/-/jest-extended-4.0.2.tgz#d23b52e687cedf66694e6b2d77f65e211e99e021"
-  integrity sha512-FH7aaPgtGYHc9mRjriS0ZEHYM5/W69tLrFTIdzm+yJgeoCmmrSB/luSfMSqWP9O29QWHPEmJ4qmU6EwsZideog==
-  dependencies:
-    jest-diff "^29.0.0"
-    jest-get-type "^29.0.0"
-
 jest-get-type@^24.3.0, jest-get-type@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
@@ -10548,15 +10540,15 @@ jest-get-type@^27.5.1:
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.5.1.tgz#3cd613c507b0f7ace013df407a1c1cd578bcb4f1"
   integrity sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==
 
-jest-get-type@^29.0.0, jest-get-type@^29.6.3:
-  version "29.6.3"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz#36f499fdcea197c1045a127319c0481723908fd1"
-  integrity sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==
-
 jest-get-type@^29.4.3:
   version "29.4.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.4.3.tgz#1ab7a5207c995161100b5187159ca82dd48b3dd5"
   integrity sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==
+
+jest-get-type@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz#36f499fdcea197c1045a127319c0481723908fd1"
+  integrity sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==
 
 jest-haste-map@^27.5.1:
   version "27.5.1"
@@ -14979,7 +14971,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -14996,6 +14988,15 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -15081,7 +15082,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15094,6 +15095,13 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -16308,8 +16316,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
-  name wrap-ansi-cjs
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -16322,6 +16329,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Summary:

When we moved Perseus out of webapp and back into this repo, we kept a dependency on `jest-extended`. Today, Perseus' use of this package is minimal and there are obvious Jest-native matchers that we can use instead. 

So, today we drop the `jest-extended` dependency.

Issue: "none"

## Test plan:

`yarn test` ✅