### PR TITLE
Simplify and rename an interactive graph reducer action

### DIFF
--- a/.changeset/tricky-ravens-kneel.md
+++ b/.changeset/tricky-ravens-kneel.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: refactor interactive graph reducer actions for clarity

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.tsx
@@ -32,9 +32,9 @@ export const LinearSystemGraph = (props: LinearSystemGraphProps) => {
                     ) =>
                         dispatch(
                             actions.linearSystem.moveControlPoint(
+                                i,
                                 endpointIndex,
                                 destination,
-                                i,
                             ),
                         )
                     }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.tsx
@@ -31,7 +31,7 @@ export const LinearSystemGraph = (props: LinearSystemGraphProps) => {
                         destination: vec.Vector2,
                     ) =>
                         dispatch(
-                            actions.linearSystem.moveControlPoint(
+                            actions.linearSystem.movePointInFigure(
                                 i,
                                 endpointIndex,
                                 destination,

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
@@ -29,7 +29,7 @@ export const LinearGraph = (props: LinearGraphProps, key: number) => {
             }}
             onMovePoint={(endpointIndex: number, destination: vec.Vector2) =>
                 dispatch(
-                    actions.linear.movePoint(endpointIndex, destination, 0),
+                    actions.linear.movePoint(endpointIndex, destination),
                 )
             }
             color="var(--movable-line-stroke-color)"

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
@@ -28,9 +28,7 @@ export const LinearGraph = (props: LinearGraphProps, key: number) => {
                 end: true,
             }}
             onMovePoint={(endpointIndex: number, destination: vec.Vector2) =>
-                dispatch(
-                    actions.linear.movePoint(endpointIndex, destination),
-                )
+                dispatch(actions.linear.movePoint(endpointIndex, destination))
             }
             color="var(--movable-line-stroke-color)"
         />

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/ray.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/ray.tsx
@@ -16,7 +16,7 @@ export const RayGraph = (props: Props) => {
     const handleMoveLine = (delta: vec.Vector2) =>
         dispatch(actions.ray.moveRay(delta));
     const handleMovePoint = (pointIndex: number, newPoint: vec.Vector2) =>
-        dispatch(actions.ray.moveControlPoint(pointIndex, newPoint, 0));
+        dispatch(actions.ray.moveControlPoint(0, pointIndex, newPoint));
 
     // Ray graphs only have one line
     return (

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/ray.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/ray.tsx
@@ -16,7 +16,7 @@ export const RayGraph = (props: Props) => {
     const handleMoveLine = (delta: vec.Vector2) =>
         dispatch(actions.ray.moveRay(delta));
     const handleMovePoint = (pointIndex: number, newPoint: vec.Vector2) =>
-        dispatch(actions.ray.moveControlPoint(0, pointIndex, newPoint));
+        dispatch(actions.ray.movePoint(pointIndex, newPoint));
 
     // Ray graphs only have one line
     return (

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
@@ -28,9 +28,9 @@ export const SegmentGraph = (props: SegmentProps) => {
                     ) => {
                         dispatch(
                             actions.segment.moveControlPoint(
+                                i,
                                 endpointIndex,
                                 destination,
-                                i,
                             ),
                         );
                     }}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
@@ -27,7 +27,7 @@ export const SegmentGraph = (props: SegmentProps) => {
                         destination: vec.Vector2,
                     ) => {
                         dispatch(
-                            actions.segment.moveControlPoint(
+                            actions.segment.movePointInFigure(
                                 i,
                                 endpointIndex,
                                 destination,

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
@@ -22,7 +22,8 @@ export const actions = {
     },
     linear: {
         moveLine: (delta: vec.Vector2) => moveLine(0, delta),
-        movePoint: (pointIndex, destination) => movePointInFigure(0, pointIndex, destination),
+        movePoint: (pointIndex, destination) =>
+            movePointInFigure(0, pointIndex, destination),
     },
     linearSystem: {
         moveLine,
@@ -40,7 +41,8 @@ export const actions = {
     },
     ray: {
         moveRay: (delta: vec.Vector2) => moveLine(0, delta),
-        movePoint: (pointIndex, destination) => movePointInFigure(0, pointIndex, destination)
+        movePoint: (pointIndex, destination) =>
+            movePointInFigure(0, pointIndex, destination),
     },
     segment: {
         movePointInFigure,

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
@@ -22,7 +22,7 @@ export const actions = {
     },
     linear: {
         moveLine: (delta: vec.Vector2) => moveLine(0, delta),
-        movePoint: moveControlPoint,
+        movePoint: (pointIndex, destination) => moveControlPoint(0, pointIndex, destination),
     },
     linearSystem: {
         moveLine,
@@ -99,9 +99,9 @@ export interface MoveControlPoint {
     destination: vec.Vector2;
 }
 function moveControlPoint(
+    itemIndex: number,
     pointIndex: number,
     destination: vec.Vector2,
-    itemIndex: number,
 ): MoveControlPoint {
     return {
         type: MOVE_CONTROL_POINT,

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
@@ -40,7 +40,7 @@ export const actions = {
     },
     ray: {
         moveRay: (delta: vec.Vector2) => moveLine(0, delta),
-        moveControlPoint,
+        movePoint: (pointIndex, destination) => moveControlPoint(0, pointIndex, destination)
     },
     segment: {
         moveControlPoint,

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
@@ -3,7 +3,7 @@ import type {Interval, vec} from "mafs";
 
 export type InteractiveGraphAction =
     | Reinitialize
-    | MoveControlPoint
+    | MovePointInFigure
     | MoveLine
     | MoveAll
     | MovePoint
@@ -22,11 +22,11 @@ export const actions = {
     },
     linear: {
         moveLine: (delta: vec.Vector2) => moveLine(0, delta),
-        movePoint: (pointIndex, destination) => moveControlPoint(0, pointIndex, destination),
+        movePoint: (pointIndex, destination) => movePointInFigure(0, pointIndex, destination),
     },
     linearSystem: {
         moveLine,
-        moveControlPoint,
+        movePointInFigure,
     },
     pointGraph: {
         movePoint,
@@ -40,10 +40,10 @@ export const actions = {
     },
     ray: {
         moveRay: (delta: vec.Vector2) => moveLine(0, delta),
-        movePoint: (pointIndex, destination) => moveControlPoint(0, pointIndex, destination)
+        movePoint: (pointIndex, destination) => movePointInFigure(0, pointIndex, destination)
     },
     segment: {
-        moveControlPoint,
+        movePointInFigure,
         moveLine,
     },
     sinusoid: {
@@ -91,20 +91,20 @@ function movePoint(index: number, destination: vec.Vector2): MovePoint {
     };
 }
 
-export const MOVE_CONTROL_POINT = "move-control-point";
-export interface MoveControlPoint {
-    type: typeof MOVE_CONTROL_POINT;
+export const MOVE_POINT_IN_FIGURE = "move-point-in-figure";
+export interface MovePointInFigure {
+    type: typeof MOVE_POINT_IN_FIGURE;
     figureIndex: number;
     pointIndex: number;
     destination: vec.Vector2;
 }
-function moveControlPoint(
+function movePointInFigure(
     figureIndex: number,
     pointIndex: number,
     destination: vec.Vector2,
-): MoveControlPoint {
+): MovePointInFigure {
     return {
-        type: MOVE_CONTROL_POINT,
+        type: MOVE_POINT_IN_FIGURE,
         figureIndex,
         pointIndex,
         destination,

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
@@ -94,18 +94,18 @@ function movePoint(index: number, destination: vec.Vector2): MovePoint {
 export const MOVE_CONTROL_POINT = "move-control-point";
 export interface MoveControlPoint {
     type: typeof MOVE_CONTROL_POINT;
-    itemIndex: number;
+    figureIndex: number;
     pointIndex: number;
     destination: vec.Vector2;
 }
 function moveControlPoint(
-    itemIndex: number,
+    figureIndex: number,
     pointIndex: number,
     destination: vec.Vector2,
 ): MoveControlPoint {
     return {
         type: MOVE_CONTROL_POINT,
-        itemIndex,
+        figureIndex,
         pointIndex,
         destination,
     };

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -103,7 +103,7 @@ const basePolygonGraphState: InteractiveGraphState = {
         [1, 0],
     ],
 };
-describe("moveControlPoint", () => {
+describe("movePointInFigure", () => {
     it("moves the given point", () => {
         const state: InteractiveGraphState = {
             ...baseSegmentGraphState,
@@ -117,7 +117,7 @@ describe("moveControlPoint", () => {
 
         const updated = interactiveGraphReducer(
             state,
-            actions.segment.moveControlPoint(0, 0, [5, 6]),
+            actions.segment.movePointInFigure(0, 0, [5, 6]),
         );
 
         invariant(updated.type === "segment");
@@ -140,7 +140,7 @@ describe("moveControlPoint", () => {
 
         const updated = interactiveGraphReducer(
             state,
-            actions.segment.moveControlPoint(0, 0, [5, 6]),
+            actions.segment.movePointInFigure(0, 0, [5, 6]),
         );
 
         expect(updated.hasBeenInteractedWith).toBe(true);
@@ -159,7 +159,7 @@ describe("moveControlPoint", () => {
 
         const updated = interactiveGraphReducer(
             state,
-            actions.segment.moveControlPoint(0, 0, [2, 2]),
+            actions.segment.movePointInFigure(0, 0, [2, 2]),
         );
 
         invariant(updated.type === "segment");
@@ -228,7 +228,7 @@ describe("moveControlPoint", () => {
 
         const updated = interactiveGraphReducer(
             state,
-            actions.segment.moveControlPoint(0, 0, [1.5, 6.6]),
+            actions.segment.movePointInFigure(0, 0, [1.5, 6.6]),
         );
 
         // Assert
@@ -256,7 +256,7 @@ describe("moveControlPoint", () => {
 
         const updated = interactiveGraphReducer(
             state,
-            actions.segment.moveControlPoint(0, 0, [99, 99]),
+            actions.segment.movePointInFigure(0, 0, [99, 99]),
         );
 
         invariant(updated.type === "segment");

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -117,7 +117,7 @@ describe("moveControlPoint", () => {
 
         const updated = interactiveGraphReducer(
             state,
-            actions.segment.moveControlPoint(0, [5, 6], 0),
+            actions.segment.moveControlPoint(0, 0, [5, 6]),
         );
 
         invariant(updated.type === "segment");
@@ -140,7 +140,7 @@ describe("moveControlPoint", () => {
 
         const updated = interactiveGraphReducer(
             state,
-            actions.segment.moveControlPoint(0, [5, 6], 0),
+            actions.segment.moveControlPoint(0, 0, [5, 6]),
         );
 
         expect(updated.hasBeenInteractedWith).toBe(true);
@@ -159,7 +159,7 @@ describe("moveControlPoint", () => {
 
         const updated = interactiveGraphReducer(
             state,
-            actions.segment.moveControlPoint(0, [2, 2], 0),
+            actions.segment.moveControlPoint(0, 0, [2, 2]),
         );
 
         invariant(updated.type === "segment");
@@ -228,7 +228,7 @@ describe("moveControlPoint", () => {
 
         const updated = interactiveGraphReducer(
             state,
-            actions.segment.moveControlPoint(0, [1.5, 6.6], 0),
+            actions.segment.moveControlPoint(0, 0, [1.5, 6.6]),
         );
 
         // Assert
@@ -256,7 +256,7 @@ describe("moveControlPoint", () => {
 
         const updated = interactiveGraphReducer(
             state,
-            actions.segment.moveControlPoint(0, [99, 99], 0),
+            actions.segment.moveControlPoint(0, 0, [99, 99]),
         );
 
         invariant(updated.type === "segment");

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -27,13 +27,13 @@ import {
     type InteractiveGraphAction,
     MOVE_ALL,
     MOVE_CENTER,
-    MOVE_CONTROL_POINT,
+    MOVE_POINT_IN_FIGURE,
     MOVE_LINE,
     MOVE_POINT,
     MOVE_RADIUS_POINT,
     type MoveAll,
     type MoveCenter,
-    type MoveControlPoint,
+    type MovePointInFigure,
     type MoveLine,
     type MovePoint,
     type MoveRadiusPoint,
@@ -52,8 +52,8 @@ export function interactiveGraphReducer(
     switch (action.type) {
         case REINITIALIZE:
             return initializeGraphState(action.params);
-        case MOVE_CONTROL_POINT:
-            return doMoveControlPoint(state, action);
+        case MOVE_POINT_IN_FIGURE:
+            return doMovePointInFigure(state, action);
         case MOVE_LINE:
             return doMoveLine(state, action);
         case MOVE_ALL:
@@ -73,9 +73,9 @@ export function interactiveGraphReducer(
     }
 }
 
-function doMoveControlPoint(
+function doMovePointInFigure(
     state: InteractiveGraphState,
-    action: MoveControlPoint,
+    action: MovePointInFigure,
 ): InteractiveGraphState {
     switch (state.type) {
         case "segment":
@@ -123,7 +123,7 @@ function doMoveControlPoint(
         case "quadratic":
         case "sinusoid":
             throw new Error(
-                `Don't use moveControlPoint for ${state.type} graphs. Use movePoint instead!`,
+                `Don't use movePointInFigure for ${state.type} graphs. Use movePoint instead!`,
             );
         default:
             throw new UnreachableCaseError(state);

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -82,7 +82,7 @@ function doMoveControlPoint(
         case "linear-system": {
             const newCoords = updateAtIndex({
                 array: state.coords,
-                index: action.itemIndex,
+                index: action.figureIndex,
                 update: (tuple) =>
                     setAtIndex({
                         array: tuple,
@@ -91,7 +91,7 @@ function doMoveControlPoint(
                     }),
             });
 
-            const coordsToCheck = newCoords[action.itemIndex];
+            const coordsToCheck = newCoords[action.figureIndex];
             if (coordsOverlap(coordsToCheck)) {
                 return state;
             }


### PR DESCRIPTION
## Summary:
The name `moveControlPoint` was not an accurate description of what this action
was doing.  I've renamed it to `movePointInFigure` which hopefully makes it
clear what it's doing and why it takes 3 arguments.  The linear and ray graph
types were using this action, passing a `0` as the `figureIndex` argument
because those graph types only have one figure. I've wrapped the action
constructor for these graph types so they no longer have to pass the dummy
argument.

Issue: none

## Test plan:

`yarn test`