### PR TITLE
Type configured userEvent field for easier testing DX

### DIFF
--- a/.changeset/funny-nails-know.md
+++ b/.changeset/funny-nails-know.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/math-input": patch
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Enhance types in tests using @testing-library/user-event

--- a/packages/math-input/src/components/__tests__/integration.test.tsx
+++ b/packages/math-input/src/components/__tests__/integration.test.tsx
@@ -80,7 +80,7 @@ function ConnectedMathInput({keypadConfiguration = defaultConfiguration}) {
 }
 
 describe("math input integration", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/math-input/src/components/__tests__/integration.test.tsx
+++ b/packages/math-input/src/components/__tests__/integration.test.tsx
@@ -15,6 +15,7 @@ import {MobileKeypad} from "../keypad";
 import {KeypadContext, StatefulKeypadContextProvider} from "../keypad-context";
 
 import type {KeypadConfiguration} from "../../types";
+import type {UserEvent} from "@testing-library/user-event";
 
 const MQ = MathQuill.getInterface(3);
 
@@ -80,7 +81,7 @@ function ConnectedMathInput({keypadConfiguration = defaultConfiguration}) {
 }
 
 describe("math input integration", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/math-input/src/components/keypad/__tests__/keypad-button.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/keypad-button.test.tsx
@@ -6,8 +6,10 @@ import Keys from "../../../data/key-configs";
 import {mockStrings} from "../../../strings";
 import {KeypadButton} from "../keypad-button";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 describe("<KeypadButton />", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/math-input/src/components/keypad/__tests__/keypad-button.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/keypad-button.test.tsx
@@ -7,7 +7,7 @@ import {mockStrings} from "../../../strings";
 import {KeypadButton} from "../keypad-button";
 
 describe("<KeypadButton />", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/math-input/src/components/keypad/__tests__/keypad-v2-mathquill.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/keypad-v2-mathquill.test.tsx
@@ -111,7 +111,7 @@ function V2KeypadWithMathquill(props: Props) {
 }
 
 describe("Keypad v2 with MathQuill", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/math-input/src/components/keypad/__tests__/keypad-v2-mathquill.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/keypad-v2-mathquill.test.tsx
@@ -12,6 +12,7 @@ import Keypad from "../index";
 import type Key from "../../../data/keys";
 import type {MathFieldInterface} from "../../input/mathquill-types";
 import type {AnalyticsEventHandlerFn} from "@khanacademy/perseus-core";
+import type {UserEvent} from "@testing-library/user-event";
 
 type Props = {
     onChangeMathInput: (mathInputTex: string) => void;
@@ -111,7 +112,7 @@ function V2KeypadWithMathquill(props: Props) {
 }
 
 describe("Keypad v2 with MathQuill", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/math-input/src/components/keypad/__tests__/keypad.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/keypad.test.tsx
@@ -26,7 +26,7 @@ const contextToKeyAria = {
 };
 
 describe("keypad", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
 
     beforeEach(() => {
         userEvent = userEventLib.setup({

--- a/packages/math-input/src/components/keypad/__tests__/keypad.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/keypad.test.tsx
@@ -10,6 +10,8 @@ import Keypad from "../index";
 
 import {getTestDataTabs} from "./test-data-tabs";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 const contextToKeyAria = {
     [CursorContext.IN_PARENS]:
         keyConfigs(mockStrings).JUMP_OUT_PARENTHESES.ariaLabel,
@@ -26,7 +28,7 @@ const contextToKeyAria = {
 };
 
 describe("keypad", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
 
     beforeEach(() => {
         userEvent = userEventLib.setup({

--- a/packages/math-input/src/components/tabbar/__tests__/item.test.tsx
+++ b/packages/math-input/src/components/tabbar/__tests__/item.test.tsx
@@ -4,8 +4,10 @@ import * as React from "react";
 
 import TabbarItem from "../item";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 describe("<TabbarItem />", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/math-input/src/components/tabbar/__tests__/item.test.tsx
+++ b/packages/math-input/src/components/tabbar/__tests__/item.test.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import TabbarItem from "../item";
 
 describe("<TabbarItem />", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/math-input/src/components/tabbar/__tests__/tabbar.test.tsx
+++ b/packages/math-input/src/components/tabbar/__tests__/tabbar.test.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import Tabbar from "../tabbar";
 
 describe("<Tabbar />", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/math-input/src/components/tabbar/__tests__/tabbar.test.tsx
+++ b/packages/math-input/src/components/tabbar/__tests__/tabbar.test.tsx
@@ -4,8 +4,10 @@ import * as React from "react";
 
 import Tabbar from "../tabbar";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 describe("<Tabbar />", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/__tests__/editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/editor.test.tsx
@@ -45,7 +45,7 @@ describe("Editor", () => {
         Widgets.registerEditors([ImageEditor]);
     });
 
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/__tests__/editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/editor.test.tsx
@@ -80,8 +80,9 @@ describe("Editor", () => {
         render(<Harnessed onChange={onChangeMock} />);
 
         // Act
-        screen.getByRole("button", {name: "Remove image widget"}),
-            await userEvent.click();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Remove image widget"}),
+        );
 
         // Assert
         expect(onChangeMock).not.toHaveBeenCalled();

--- a/packages/perseus-editor/src/__tests__/editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/editor.test.tsx
@@ -14,6 +14,7 @@ import Editor from "../editor";
 import ImageEditor from "../widgets/image-editor";
 
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
+import type {UserEvent} from "@testing-library/user-event";
 
 const Harnessed = (props: Partial<PropsFor<typeof Editor>>) => {
     return (
@@ -45,7 +46,7 @@ describe("Editor", () => {
         Widgets.registerEditors([ImageEditor]);
     });
 
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/__tests__/hint-editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/hint-editor.test.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import CombinedHintsEditor from "../hint-editor";
 
 describe("CombinedHintsEditor", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/__tests__/hint-editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/hint-editor.test.tsx
@@ -4,8 +4,10 @@ import * as React from "react";
 
 import CombinedHintsEditor from "../hint-editor";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 describe("CombinedHintsEditor", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/__tests__/item-extras-editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/item-extras-editor.test.tsx
@@ -4,8 +4,10 @@ import React, {useState} from "react";
 
 import ItemExtrasEditor from "../item-extras-editor";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 describe("ItemExtrasEditor", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/__tests__/item-extras-editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/item-extras-editor.test.tsx
@@ -5,7 +5,7 @@ import React, {useState} from "react";
 import ItemExtrasEditor from "../item-extras-editor";
 
 describe("ItemExtrasEditor", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/components/__tests__/blur-input.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/blur-input.test.tsx
@@ -4,8 +4,10 @@ import * as React from "react";
 
 import BlurInput from "../blur-input";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 describe("BlurInput", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/components/__tests__/blur-input.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/blur-input.test.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import BlurInput from "../blur-input";
 
 describe("BlurInput", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/components/__tests__/graph-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/graph-settings.test.tsx
@@ -29,7 +29,7 @@ import "@testing-library/jest-dom"; // Imports custom matchers
  */
 
 describe("GraphSettings", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/components/__tests__/graph-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/graph-settings.test.tsx
@@ -6,6 +6,8 @@ import * as React from "react";
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import GraphSettings from "../graph-settings";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 import "@testing-library/jest-dom"; // Imports custom matchers
 
 /**
@@ -29,7 +31,7 @@ import "@testing-library/jest-dom"; // Imports custom matchers
  */
 
 describe("GraphSettings", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/components/__tests__/interactive-graph-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/interactive-graph-settings.test.tsx
@@ -6,6 +6,8 @@ import * as React from "react";
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import InteractiveGraphSettings from "../interactive-graph-settings";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 import "@testing-library/jest-dom"; // Imports custom matchers
 
 function userEventForFakeTimers() {
@@ -21,7 +23,7 @@ function userEventForRealTimers() {
 }
 
 describe("InteractiveGraphSettings", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventForFakeTimers();
         jest.spyOn(Dependencies, "getDependencies").mockReturnValue(

--- a/packages/perseus-editor/src/components/__tests__/interactive-graph-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/interactive-graph-settings.test.tsx
@@ -21,7 +21,7 @@ function userEventForRealTimers() {
 }
 
 describe("InteractiveGraphSettings", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventForFakeTimers();
         jest.spyOn(Dependencies, "getDependencies").mockReturnValue(

--- a/packages/perseus-editor/src/components/__tests__/start-coord-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/start-coord-settings.test.tsx
@@ -7,6 +7,7 @@ import {testDependencies} from "../../../../../testing/test-dependencies";
 import StartCoordSettings from "../start-coord-settings";
 
 import type {Range} from "@khanacademy/perseus";
+import type {UserEvent} from "@testing-library/user-event";
 
 const defaultProps = {
     range: [
@@ -16,7 +17,7 @@ const defaultProps = {
     step: [1, 1] satisfies [number, number],
 };
 describe("StartCoordSettings", () => {
-    let userEvent;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/categorizer-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/categorizer-editor.test.tsx
@@ -7,7 +7,7 @@ import {testDependencies} from "../../../../../testing/test-dependencies";
 import CategorizerEditor from "../categorizer-editor";
 
 describe("categorizer-editor", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/categorizer-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/categorizer-editor.test.tsx
@@ -6,8 +6,10 @@ import * as React from "react";
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import CategorizerEditor from "../categorizer-editor";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 describe("categorizer-editor", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/definition-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/definition-editor.test.tsx
@@ -6,8 +6,10 @@ import * as React from "react";
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import DefinitionEditor from "../definition-editor";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 describe("definition-editor", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/definition-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/definition-editor.test.tsx
@@ -7,7 +7,7 @@ import {testDependencies} from "../../../../../testing/test-dependencies";
 import DefinitionEditor from "../definition-editor";
 
 describe("definition-editor", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/dropdown-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/dropdown-editor.test.tsx
@@ -6,8 +6,10 @@ import * as React from "react";
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import DropdownEditor from "../dropdown-editor";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 describe("dropdown-editor", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/dropdown-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/dropdown-editor.test.tsx
@@ -7,7 +7,7 @@ import {testDependencies} from "../../../../../testing/test-dependencies";
 import DropdownEditor from "../dropdown-editor";
 
 describe("dropdown-editor", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/explanation-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/explanation-editor.test.tsx
@@ -7,7 +7,7 @@ import {testDependencies} from "../../../../../testing/test-dependencies";
 import ExplanationEditor from "../explanation-editor";
 
 describe("explanation-editor", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/explanation-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/explanation-editor.test.tsx
@@ -6,8 +6,10 @@ import * as React from "react";
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import ExplanationEditor from "../explanation-editor";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 describe("explanation-editor", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/expression-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/expression-editor.test.tsx
@@ -7,9 +7,10 @@ import {testDependencies} from "../../../../../testing/test-dependencies";
 import ExpressionEditor from "../expression-editor";
 
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
+import type {UserEvent} from "@testing-library/user-event";
 
 describe("expression-editor", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/expression-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/expression-editor.test.tsx
@@ -9,7 +9,7 @@ import ExpressionEditor from "../expression-editor";
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
 describe("expression-editor", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/input-number-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/input-number-editor.test.tsx
@@ -7,7 +7,7 @@ import {testDependencies} from "../../../../../testing/test-dependencies";
 import InputNumberEditor from "../input-number-editor";
 
 describe("input-number-editor", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/input-number-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/input-number-editor.test.tsx
@@ -6,8 +6,10 @@ import * as React from "react";
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import InputNumberEditor from "../input-number-editor";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 describe("input-number-editor", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
@@ -42,7 +42,7 @@ const renderEditor = (props) => {
 };
 
 describe("InteractiveGraphEditor locked figures", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
@@ -10,6 +10,7 @@ import {getDefaultFigureForType} from "../../components/util";
 import InteractiveGraphEditor from "../interactive-graph-editor";
 
 import type {PerseusGraphType} from "@khanacademy/perseus";
+import type {UserEvent} from "@testing-library/user-event";
 
 const defaultPoint = getDefaultFigureForType("point");
 const defaultLine = getDefaultFigureForType("line");
@@ -42,7 +43,7 @@ const renderEditor = (props) => {
 };
 
 describe("InteractiveGraphEditor locked figures", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
@@ -31,7 +31,7 @@ const mafsProps: PropsFor<typeof InteractiveGraphEditor> = {
 };
 
 describe("InteractiveGraphEditor", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
@@ -11,6 +11,7 @@ import InteractiveGraphEditor from "../interactive-graph-editor";
 
 import type {PerseusGraphType} from "@khanacademy/perseus";
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
+import type {UserEvent} from "@testing-library/user-event";
 
 const baseProps = {
     apiOptions: ApiOptions.defaults,
@@ -31,7 +32,7 @@ const mafsProps: PropsFor<typeof InteractiveGraphEditor> = {
 };
 
 describe("InteractiveGraphEditor", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/matcher-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/matcher-editor.test.tsx
@@ -6,8 +6,10 @@ import * as React from "react";
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import MatcherEditor from "../matcher-editor";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 describe("matcher-editor", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/matcher-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/matcher-editor.test.tsx
@@ -7,7 +7,7 @@ import {testDependencies} from "../../../../../testing/test-dependencies";
 import MatcherEditor from "../matcher-editor";
 
 describe("matcher-editor", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/number-line-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/number-line-editor.test.tsx
@@ -7,7 +7,7 @@ import {testDependencies} from "../../../../../testing/test-dependencies";
 import NumberLineEditor from "../number-line-editor";
 
 describe("number-line-editor", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/number-line-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/number-line-editor.test.tsx
@@ -6,8 +6,10 @@ import * as React from "react";
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import NumberLineEditor from "../number-line-editor";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 describe("number-line-editor", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/numeric-input-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/numeric-input-editor.test.tsx
@@ -6,8 +6,10 @@ import * as React from "react";
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import NumericInputEditor from "../numeric-input-editor";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 describe("numeric-input-editor", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/numeric-input-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/numeric-input-editor.test.tsx
@@ -7,7 +7,7 @@ import {testDependencies} from "../../../../../testing/test-dependencies";
 import NumericInputEditor from "../numeric-input-editor";
 
 describe("numeric-input-editor", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/python-program-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/python-program-editor.test.tsx
@@ -7,7 +7,7 @@ import {testDependencies} from "../../../../../testing/test-dependencies";
 import PythonProgramEditor, {validateOptions} from "../python-program-editor";
 
 describe("python-program-editor", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/python-program-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/python-program-editor.test.tsx
@@ -6,8 +6,10 @@ import * as React from "react";
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import PythonProgramEditor, {validateOptions} from "../python-program-editor";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 describe("python-program-editor", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/radio-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/radio-editor.test.tsx
@@ -7,8 +7,10 @@ import * as React from "react";
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import RadioEditor from "../radio/editor";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 describe("radio-editor", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/radio-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/radio-editor.test.tsx
@@ -8,7 +8,7 @@ import {testDependencies} from "../../../../../testing/test-dependencies";
 import RadioEditor from "../radio/editor";
 
 describe("radio-editor", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/sorter-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/sorter-editor.test.tsx
@@ -6,8 +6,10 @@ import * as React from "react";
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import SorterEditor from "../sorter-editor";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 describe("sorter-editor", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus-editor/src/widgets/__tests__/sorter-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/sorter-editor.test.tsx
@@ -7,7 +7,7 @@ import {testDependencies} from "../../../../../testing/test-dependencies";
 import SorterEditor from "../sorter-editor";
 
 describe("sorter-editor", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/__tests__/renderer.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.test.tsx
@@ -26,6 +26,7 @@ import MockWidgetExport from "./mock-widget";
 
 import type {DropdownWidget} from "../perseus-types";
 import type {APIOptions} from "../types";
+import type {UserEvent} from "@testing-library/user-event";
 
 // NOTE(jeremy): We can't use an automatic mock for the translation linter,
 // because one of it's "instance" methods is created using `debounce` and Jest
@@ -51,7 +52,7 @@ describe("renderer", () => {
         registerWidget("mock-widget", MockWidgetExport);
     });
 
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/__tests__/renderer.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.test.tsx
@@ -51,7 +51,7 @@ describe("renderer", () => {
         registerWidget("mock-widget", MockWidgetExport);
     });
 
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -73,7 +73,7 @@ describe("server item renderer", () => {
         registerWidget("mock-widget", MockWidgetExport);
     });
 
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -32,6 +32,7 @@ import type {PerseusItem} from "../perseus-types";
 import type {APIOptions} from "../types";
 import type {KeypadAPI} from "@khanacademy/math-input";
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
+import type {UserEvent} from "@testing-library/user-event";
 
 // This looks alot like `widgets/__tests__/renderQuestion.jsx', except we use
 // the ServerItemRenderer instead of Renderer
@@ -73,7 +74,7 @@ describe("server item renderer", () => {
         registerWidget("mock-widget", MockWidgetExport);
     });
 
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/components/__tests__/math-input.test.tsx
+++ b/packages/perseus/src/components/__tests__/math-input.test.tsx
@@ -6,6 +6,8 @@ import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
 import MathInput from "../math-input";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 const allButtonSets = {
     advancedRelations: true,
     basicRelations: true,
@@ -16,7 +18,7 @@ const allButtonSets = {
 };
 
 describe("Perseus' MathInput", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/components/__tests__/math-input.test.tsx
+++ b/packages/perseus/src/components/__tests__/math-input.test.tsx
@@ -16,7 +16,7 @@ const allButtonSets = {
 };
 
 describe("Perseus' MathInput", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/components/__tests__/zoomable.test.tsx
+++ b/packages/perseus/src/components/__tests__/zoomable.test.tsx
@@ -34,7 +34,7 @@ const renderAndWaitToSettle = (component: React.ReactElement) => {
 };
 
 describe("Zoomable", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/components/__tests__/zoomable.test.tsx
+++ b/packages/perseus/src/components/__tests__/zoomable.test.tsx
@@ -5,6 +5,8 @@ import * as React from "react";
 
 import Zoomable from "../zoomable";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 const mockSize = (
     el: HTMLElement | null | undefined,
     size: {
@@ -34,7 +36,7 @@ const renderAndWaitToSettle = (component: React.ReactElement) => {
 };
 
 describe("Zoomable", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/multi-items/__tests__/multi-renderer.test.tsx
+++ b/packages/perseus/src/multi-items/__tests__/multi-renderer.test.tsx
@@ -95,7 +95,7 @@ describe("multi-item renderer", () => {
         registerWidget("mock-widget", MockWidgetExport);
     });
 
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/multi-items/__tests__/multi-renderer.test.tsx
+++ b/packages/perseus/src/multi-items/__tests__/multi-renderer.test.tsx
@@ -23,6 +23,7 @@ import type {Widget} from "../../renderer";
 import type {FilterCriterion} from "../../types";
 import type {Item} from "../item-types";
 import type {Tree} from "../tree-types";
+import type {UserEvent} from "@testing-library/user-event";
 
 // A little helper used in the render callback of a MultiRenderer.
 type Props = {renderers: any};
@@ -95,7 +96,7 @@ describe("multi-item renderer", () => {
         registerWidget("mock-widget", MockWidgetExport);
     });
 
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/__tests__/categorizer.test.ts
+++ b/packages/perseus/src/widgets/__tests__/categorizer.test.ts
@@ -11,9 +11,10 @@ import {renderQuestion} from "./renderQuestion";
 
 import type {APIOptions} from "../../types";
 import type {Rubric} from "../categorizer";
+import type {UserEvent} from "@testing-library/user-event";
 
 describe("categorizer widget", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/__tests__/categorizer.test.ts
+++ b/packages/perseus/src/widgets/__tests__/categorizer.test.ts
@@ -13,7 +13,7 @@ import type {APIOptions} from "../../types";
 import type {Rubric} from "../categorizer";
 
 describe("categorizer widget", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/__tests__/definition.test.ts
+++ b/packages/perseus/src/widgets/__tests__/definition.test.ts
@@ -6,6 +6,8 @@ import * as Dependencies from "../../dependencies";
 
 import {renderQuestion} from "./renderQuestion";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 const question = {
     content:
         "Read the excerpt and answer the question below. \n\nThe Governor and Council of the Massachusetts had much conference many days; and at last . . . . concluded a peace and friendship with [[\u2603 definition 1]], upon these conditions.",
@@ -30,7 +32,7 @@ const question = {
 } as const;
 
 describe("Definition widget", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/__tests__/definition.test.ts
+++ b/packages/perseus/src/widgets/__tests__/definition.test.ts
@@ -30,7 +30,7 @@ const question = {
 } as const;
 
 describe("Definition widget", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/__tests__/dropdown.test.ts
+++ b/packages/perseus/src/widgets/__tests__/dropdown.test.ts
@@ -7,8 +7,10 @@ import {question1} from "../__testdata__/dropdown.testdata";
 
 import {renderQuestion} from "./renderQuestion";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 describe("Dropdown widget", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/__tests__/dropdown.test.ts
+++ b/packages/perseus/src/widgets/__tests__/dropdown.test.ts
@@ -8,7 +8,7 @@ import {question1} from "../__testdata__/dropdown.testdata";
 import {renderQuestion} from "./renderQuestion";
 
 describe("Dropdown widget", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/__tests__/explanation.test.ts
+++ b/packages/perseus/src/widgets/__tests__/explanation.test.ts
@@ -9,8 +9,10 @@ import ExplanationWidgetExports from "../explanation";
 
 import {renderQuestion} from "./renderQuestion";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 describe("Explanation", function () {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
 
     // NOTE: Since the visibility of an element is controlled by CSS,
     //          the only way that we can verify in RTL that an element is visible or not (expanded/collapsed)

--- a/packages/perseus/src/widgets/__tests__/explanation.test.ts
+++ b/packages/perseus/src/widgets/__tests__/explanation.test.ts
@@ -10,7 +10,7 @@ import ExplanationWidgetExports from "../explanation";
 import {renderQuestion} from "./renderQuestion";
 
 describe("Explanation", function () {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
 
     // NOTE: Since the visibility of an element is controlled by CSS,
     //          the only way that we can verify in RTL that an element is visible or not (expanded/collapsed)

--- a/packages/perseus/src/widgets/__tests__/expression-mobile.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/expression-mobile.test.tsx
@@ -25,6 +25,8 @@ import {registerWidget} from "../../widgets";
 import {expressionItem2} from "../__testdata__/expression.testdata";
 import ExpressionExport from "../expression";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 const MQ = mathQuillInstance;
 
 function RendererWithContext({item}) {
@@ -81,7 +83,7 @@ describe("expression mobile", () => {
         registerWidget("expression", ExpressionExport);
     });
 
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/__tests__/expression-mobile.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/expression-mobile.test.tsx
@@ -81,7 +81,7 @@ describe("expression mobile", () => {
         registerWidget("expression", ExpressionExport);
     });
 
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/__tests__/expression.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/expression.test.tsx
@@ -20,6 +20,7 @@ import {renderQuestion} from "./renderQuestion";
 
 import type {PerseusItem} from "../../perseus-types";
 import type {APIOptions} from "../../types";
+import type {UserEvent} from "@testing-library/user-event";
 
 const renderAndAnswer = async (
     userEvent: ReturnType<(typeof userEventLib)["setup"]>,
@@ -96,7 +97,7 @@ const assertInvalid = async (
 };
 
 describe("Expression Widget", function () {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/__tests__/expression.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/expression.test.tsx
@@ -96,7 +96,7 @@ const assertInvalid = async (
 };
 
 describe("Expression Widget", function () {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/__tests__/graded-group-set.test.ts
+++ b/packages/perseus/src/widgets/__tests__/graded-group-set.test.ts
@@ -8,7 +8,7 @@ import {article1} from "../__testdata__/graded-group-set.testdata";
 import {renderQuestion} from "./renderQuestion";
 
 describe("graded group widget", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/__tests__/graded-group-set.test.ts
+++ b/packages/perseus/src/widgets/__tests__/graded-group-set.test.ts
@@ -7,8 +7,10 @@ import {article1} from "../__testdata__/graded-group-set.testdata";
 
 import {renderQuestion} from "./renderQuestion";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 describe("graded group widget", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/__tests__/graded-group.test.ts
+++ b/packages/perseus/src/widgets/__tests__/graded-group.test.ts
@@ -9,6 +9,7 @@ import {question1} from "../__testdata__/graded-group.testdata";
 import {renderQuestion} from "./renderQuestion";
 
 import type {APIOptions} from "../../types";
+import type {UserEvent} from "@testing-library/user-event";
 
 const checkAnswer = async (
     userEvent: ReturnType<(typeof userEventLib)["setup"]>,
@@ -21,7 +22,7 @@ const checkAnswer = async (
 };
 
 describe("graded-group", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
 
     beforeEach(() => {
         userEvent = userEventLib.setup({

--- a/packages/perseus/src/widgets/__tests__/graded-group.test.ts
+++ b/packages/perseus/src/widgets/__tests__/graded-group.test.ts
@@ -21,7 +21,7 @@ const checkAnswer = async (
 };
 
 describe("graded-group", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
 
     beforeEach(() => {
         userEvent = userEventLib.setup({

--- a/packages/perseus/src/widgets/__tests__/group.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/group.test.tsx
@@ -13,8 +13,10 @@ import {question1} from "../__testdata__/group.testdata";
 
 import {renderQuestion} from "./renderQuestion";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 describe("group widget", () => {
-    let userEvent;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/__tests__/input-number.test.ts
+++ b/packages/perseus/src/widgets/__tests__/input-number.test.ts
@@ -18,6 +18,7 @@ import type {
     PerseusInputNumberWidgetOptions,
     PerseusRenderer,
 } from "../../perseus-types";
+import type {UserEvent} from "@testing-library/user-event";
 
 const {transform} = InputNumber;
 
@@ -28,7 +29,7 @@ const options: PerseusInputNumberWidgetOptions = {
 };
 
 describe("input-number", function () {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/__tests__/input-number.test.ts
+++ b/packages/perseus/src/widgets/__tests__/input-number.test.ts
@@ -28,7 +28,7 @@ const options: PerseusInputNumberWidgetOptions = {
 };
 
 describe("input-number", function () {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/__tests__/matrix.test.ts
+++ b/packages/perseus/src/widgets/__tests__/matrix.test.ts
@@ -8,9 +8,10 @@ import {question1} from "../__testdata__/matrix.testdata";
 import {renderQuestion} from "./renderQuestion";
 
 import type {APIOptions} from "../../types";
+import type {UserEvent} from "@testing-library/user-event";
 
 describe("matrix widget", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/__tests__/matrix.test.ts
+++ b/packages/perseus/src/widgets/__tests__/matrix.test.ts
@@ -10,7 +10,7 @@ import {renderQuestion} from "./renderQuestion";
 import type {APIOptions} from "../../types";
 
 describe("matrix widget", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/__tests__/numeric-input.test.ts
+++ b/packages/perseus/src/widgets/__tests__/numeric-input.test.ts
@@ -22,11 +22,12 @@ import {
 import {renderQuestion} from "./renderQuestion";
 
 import type {Rubric} from "../numeric-input";
+import type {UserEvent} from "@testing-library/user-event";
 
 describe("numeric-input widget", () => {
     const [question, correct, incorrect] = question1AndAnswer;
 
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,
@@ -409,7 +410,7 @@ describe("static function validate", () => {
 });
 
 describe("Numeric input widget", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/__tests__/numeric-input.test.ts
+++ b/packages/perseus/src/widgets/__tests__/numeric-input.test.ts
@@ -26,7 +26,7 @@ import type {Rubric} from "../numeric-input";
 describe("numeric-input widget", () => {
     const [question, correct, incorrect] = question1AndAnswer;
 
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,
@@ -409,7 +409,7 @@ describe("static function validate", () => {
 });
 
 describe("Numeric input widget", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/__tests__/radio.test.ts
+++ b/packages/perseus/src/widgets/__tests__/radio.test.ts
@@ -32,7 +32,7 @@ const selectOption = async (
 };
 
 describe("single-choice question", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,
@@ -620,7 +620,7 @@ describe("multi-choice question", () => {
 
     const apiOptions: APIOptions = Object.freeze({});
 
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/__tests__/radio.test.ts
+++ b/packages/perseus/src/widgets/__tests__/radio.test.ts
@@ -15,6 +15,7 @@ import {renderQuestion} from "./renderQuestion";
 
 import type {PerseusRenderer} from "../../perseus-types";
 import type {APIOptions} from "../../types";
+import type {UserEvent} from "@testing-library/user-event";
 
 const selectOption = async (
     userEvent: ReturnType<(typeof userEventLib)["setup"]>,
@@ -32,7 +33,7 @@ const selectOption = async (
 };
 
 describe("single-choice question", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,
@@ -620,7 +621,7 @@ describe("multi-choice question", () => {
 
     const apiOptions: APIOptions = Object.freeze({});
 
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/__tests__/radio/base-radio.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/radio/base-radio.test.tsx
@@ -10,6 +10,7 @@ import {generateChoice} from "../../__testdata__/base-radio.testdata";
 import BaseRadio from "../../radio/base-radio";
 
 import type {APIOptions} from "../../../types";
+import type {UserEvent} from "@testing-library/user-event";
 
 function renderBaseRadio(props) {
     const apiOptions: APIOptions = Object.freeze({});
@@ -44,7 +45,7 @@ function renderBaseRadio(props) {
 }
 
 describe("base-radio", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
 
     beforeEach(() => {
         userEvent = userEventLib.setup({

--- a/packages/perseus/src/widgets/__tests__/radio/base-radio.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/radio/base-radio.test.tsx
@@ -44,7 +44,7 @@ function renderBaseRadio(props) {
 }
 
 describe("base-radio", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
 
     beforeEach(() => {
         userEvent = userEventLib.setup({

--- a/packages/perseus/src/widgets/__tests__/radio/choice.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/radio/choice.test.tsx
@@ -109,7 +109,7 @@ describe("all choice options", () => {
 
 // Tests 1 of 2 element types used to select a choice
 describe("choice button", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
 
     beforeEach(() => {
         userEvent = userEventLib.setup({
@@ -194,7 +194,7 @@ describe("choice button", () => {
 
 // Tests 2 of 2 element types used to select a choice
 describe("choice input (screen reader only)", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
 
     beforeEach(() => {
         userEvent = userEventLib.setup({

--- a/packages/perseus/src/widgets/__tests__/radio/choice.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/radio/choice.test.tsx
@@ -6,6 +6,8 @@ import * as React from "react";
 
 import Choice from "../../radio/choice";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 function renderChoice(options) {
     const defaultOptions = {
         checked: false,
@@ -109,7 +111,7 @@ describe("all choice options", () => {
 
 // Tests 1 of 2 element types used to select a choice
 describe("choice button", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
 
     beforeEach(() => {
         userEvent = userEventLib.setup({
@@ -194,7 +196,7 @@ describe("choice button", () => {
 
 // Tests 2 of 2 element types used to select a choice
 describe("choice input (screen reader only)", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
 
     beforeEach(() => {
         userEvent = userEventLib.setup({

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/use-draggable.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/use-draggable.test.tsx
@@ -6,6 +6,7 @@ import {useRef} from "react";
 
 import {useDraggable} from "./use-draggable";
 
+import type {UserEvent} from "@testing-library/user-event";
 import type {vec, Interval} from "mafs";
 
 function TestDraggable(props: {
@@ -29,7 +30,7 @@ function TestDraggable(props: {
 }
 
 describe("useDraggable", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/use-draggable.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/use-draggable.test.tsx
@@ -29,7 +29,7 @@ function TestDraggable(props: {
 }
 
 describe("useDraggable", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/label-image.test.ts
+++ b/packages/perseus/src/widgets/label-image.test.ts
@@ -20,7 +20,7 @@ const emptyMarker = {
 } as const;
 
 describe("LabelImage", function () {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/label-image.test.ts
+++ b/packages/perseus/src/widgets/label-image.test.ts
@@ -11,6 +11,8 @@ import {textQuestion} from "./__testdata__/label-image.testdata";
 import {renderQuestion} from "./__tests__/renderQuestion";
 import {LabelImage} from "./label-image";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 const emptyMarker = {
     label: "",
     answers: [],
@@ -20,7 +22,7 @@ const emptyMarker = {
 } as const;
 
 describe("LabelImage", function () {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/label-image/__tests__/hide-answers-toggle.test.tsx
+++ b/packages/perseus/src/widgets/label-image/__tests__/hide-answers-toggle.test.tsx
@@ -9,7 +9,7 @@ import {HideAnswersToggle} from "../hide-answers-toggle";
 const labelText = mockStrings.hideAnswersToggleLabel;
 
 describe("HideAnswersToggle", () => {
-    let userEvent;
+    let userEvent: ReturnType<typeof userEventLib.setup>;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,

--- a/packages/perseus/src/widgets/label-image/__tests__/hide-answers-toggle.test.tsx
+++ b/packages/perseus/src/widgets/label-image/__tests__/hide-answers-toggle.test.tsx
@@ -6,10 +6,12 @@ import * as React from "react";
 import {mockStrings} from "../../../strings";
 import {HideAnswersToggle} from "../hide-answers-toggle";
 
+import type {UserEvent} from "@testing-library/user-event";
+
 const labelText = mockStrings.hideAnswersToggleLabel;
 
 describe("HideAnswersToggle", () => {
-    let userEvent: ReturnType<typeof userEventLib.setup>;
+    let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
             advanceTimers: jest.advanceTimersByTime,


### PR DESCRIPTION
## Summary:

When I upgraded Perseus to `user-event` v14, tests that used fake timers needed to initialize an instance of the `user-event` library (because we needed to tell it how to advance the fake timers in Jest). 

The configured variable was untyped and meant that we don't get any intellisense/code completion when using it, so this PR properly types the `let userEvent` declarations!

### Before 

<img width="258" alt="image" src="https://github.com/user-attachments/assets/97f791f6-870b-4e73-8fe9-182caac3bd0e">

### After 

<img width="541" alt="image" src="https://github.com/user-attachments/assets/2f902e20-2815-4f32-a69f-978437a3c17b">


Issue: "none"

## Test plan:

Open one of the affected test files and type `userEvent.` in one of the tests. Note that your editor (if it supports this) should list the functions available on the `userEvent` instance!