### PR TITLE
Resolve LEMS-2186 - no longer need 'off by 0.5' startCoords

### DIFF
--- a/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
@@ -225,18 +225,7 @@ export const polygonWithFourSidesSnappingQuestion: PerseusRenderer =
         .build();
 
 export const polygonQuestionDefaultCorrect: PerseusRenderer =
-    interactiveGraphQuestionBuilder()
-        .withPolygon("grid", {
-            startCoords: [
-                // TODO(LEMS-2186): figure out why this test is off by 0.5.
-                // This should be able to pass without any options
-                // provided.
-                [3, -1.5],
-                [0, 4.5],
-                [-3, -1.5],
-            ],
-        })
-        .build();
+    interactiveGraphQuestionBuilder().withPolygon("grid").build();
 
 export const rayQuestion: PerseusRenderer = interactiveGraphQuestionBuilder()
     .withContent(
@@ -276,15 +265,6 @@ export const segmentQuestion: PerseusRenderer =
 export const segmentQuestionDefaultCorrect: PerseusRenderer =
     interactiveGraphQuestionBuilder()
         .withSegments({
-            startCoords: [
-                [
-                    // TODO(LEMS-2186): figure out why this test is off by 0.5.
-                    // This should be able to pass without any options
-                    // provided. (i.e. We should be able to use [-5, 5] here.)
-                    [-5, 5.5],
-                    [5, 5],
-                ],
-            ],
             coords: [
                 [
                     [-5, 5],

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,2 +1,0 @@
-// eslint-disable-next-line import/no-unassigned-import
-import "jest-extended"; // we love the side effects


### PR DESCRIPTION
## Summary:

At the end of the React 18 work I noticed two failing tests in the Interactive Graph suite. I found that its the two tests that had to be customized to pass related to `startCoords`. 

If I remove this customization, all tests pass. My hunch is that with React 16 and the older `@testing-library` package, there was some async DOM updates/events that didn't flush all the way leaving the graph in a non-final state after keypresses, thus failing the tests. 

Issue: LEMS-2186

## Test plan:

`yarn test` ✅✨🎉😍