### PR TITLE
Lower the intensity of the protractor handle hover animation

### DIFF
--- a/.changeset/few-trainers-march.md
+++ b/.changeset/few-trainers-march.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Tweak the animation of the protractor rotation handle. It's now slightly slower and the magnification is less extreme.

--- a/packages/perseus/src/widgets/interactive-graphs/protractor.css
+++ b/packages/perseus/src/widgets/interactive-graphs/protractor.css
@@ -3,11 +3,11 @@
     /* `pointer-events: all` is needed to make the hit target the size of the
      * entire <g> element and not just its visible subelements */
     pointer-events: all;
-    transition: transform 0.1s ease-out;
+    transition: transform 0.15s ease-out;
 }
 
 .MafsView .protractor-rotation-handle:hover {
-    transform: scale(1.3);
+    transform: scale(1.2);
 }
 
 .MafsView .protractor-rotation-handle-arrow-arc {


### PR DESCRIPTION
## Summary:
During a playtest, Nicole noted that the rotation handle for the new
interactive graph protractor had a hover animation that felt out of
place. The animation was faster than the hover animation for movable
points. The protractor handle also enlarged more than the points do when
you hovered over it.

This commit brings the protractor handle animation in line with the
movable point animations.

Issue: none

Test plan:

Copy this data into the interactive graph flipbook:

```json
{"content":"**Construct a $130^\\circ$ angle.**\n\n[[☃ interactive-graph 1]]\n\n\n","images":{"https://ka-perseus-images.s3.amazonaws.com/02564832cdaa56aa507437df41dd13e1fefbe595.png":{"height":160,"width":398},"https://ka-perseus-images.s3.amazonaws.com/37521922ea42bbbf67622075e1ea51e095f37479.png":{"height":291,"width":401}},"widgets":{"interactive-graph 1":{"alignment":"default","graded":true,"options":{"backgroundImage":{"bottom":0,"left":0,"scale":1,"url":null},"correct":{"coords":[[6.662476544422285,-1.0599696426100849],[0,-9],[-7.530523827277034,-8.999999999999998]],"match":"congruent","showAngles":false,"snapDegrees":5,"type":"angle"},"graph":{"showAngles":false,"snapDegrees":5,"type":"angle"},"labels":["x","y"],"markings":"none","range":[[-10,10],[-10,10]],"rulerLabel":"","rulerTicks":10,"showProtractor":true,"showRuler":false,"step":[1,1]},"static":false,"type":"interactive-graph","version":{"major":0,"minor":0}}}}
```

The protractor handle animation should feel unobtrusive.