### PR TITLE
Ensure endpoints cannot be placed too close to the vertex on Angle Graphs

### DIFF
--- a/.changeset/soft-mangos-teach.md
+++ b/.changeset/soft-mangos-teach.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Bug fix to ensure that Angle graph endpoints cannot get too close to the vertex.

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -467,6 +467,48 @@ describe("movePoint on an angle graph", () => {
         ).toBeCloseTo(30);
     });
 
+    it("doesn't allow the endpoints to get too close to the vertex", () => {
+        const state: InteractiveGraphState = {
+            ...baseAngleGraphState,
+            coords: [
+                [5, 5],
+                [0, 0],
+                [5, 0],
+            ],
+            snapDegrees: 5,
+        };
+
+        const updated = interactiveGraphReducer(
+            state,
+            actions.angle.movePoint(0, [1, 1]),
+        );
+        invariant(updated.type === "angle");
+
+        // The point should not have moved as it would have been too close to the vertex
+        expect(updated.coords[0]).toEqual([5, 5]);
+    });
+
+    it("doesn't allow the vertex to get too close to the endpoints", () => {
+        const state: InteractiveGraphState = {
+            ...baseAngleGraphState,
+            coords: [
+                [9, 0],
+                [6, 0],
+                [9, 1],
+            ],
+            snapDegrees: 5,
+        };
+
+        const updated = interactiveGraphReducer(
+            state,
+            actions.angle.movePoint(1, [9, 0]),
+        );
+        invariant(updated.type === "angle");
+
+        // The point should not have moved as it would have been too close to the vertex
+        expect(updated.coords[1]).toEqual([6, 0]);
+    });
+
     it("keeps points within the graph bounds", () => {
         const state: InteractiveGraphState = {
             ...baseAngleGraphState,

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -667,6 +667,7 @@ function boundAndSnapAngleEndPoints(
 ) {
     const snap = snapDegrees || 1;
     const offsetDegrees = angleOffsetDeg || 0;
+    const startingPoint = coords[index];
 
     // Needed to prevent updating the original coords before the checks for
     // degenerate triangles and overlapping sides
@@ -691,6 +692,11 @@ function boundAndSnapAngleEndPoints(
 
     // Get the vertex of the angle
     const vertex = coords[1];
+
+    // Ensure that the point cannot be moved too close to the vertex
+    if (tooClose(vertex, boundPoint, range)) {
+        return startingPoint;
+    }
 
     // Gets the angle between the coords and the vertex
     let angle = findAngle(coordsCopy[index], vertex);


### PR DESCRIPTION
## Summary:
In a play-test bug report, it was noted that sometimes the angle graph gets stuck. Upon further investigation, it was determined that this was due to the "tooClose" logic only being considered when we are moving the vertex, and not the end points. 

This PR rectifies that omission and ensures that points can never be closer than 2 graph units to the vertex. The resulting behaviour mimics the legacy graph. Some new tests were also added to help catch any future regressions of this behaviour. 

Issue: LEMS-2153

## Test plan:
- Manual Testing in Flipbook 
- New regression tests 