### PR TITLE
Fix flaky tests (following React 18/RTL upgrade)

### DIFF
--- a/packages/perseus/src/widgets/__tests__/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/interactive-graph.test.tsx
@@ -224,7 +224,9 @@ describe("a mafs graph", () => {
                 renderQuestion(question, apiOptions);
             });
 
-            it("rejects incorrect answer", async () => {
+            // TODO(Jeremy): This test is currently skipped because it is
+            // failing sporadically after the React 18 upgrade.
+            xit("rejects incorrect answer", async () => {
                 // Arrange
                 const {renderer} = renderQuestion(question, apiOptions);
 
@@ -239,7 +241,9 @@ describe("a mafs graph", () => {
                 });
             });
 
-            it("accepts correct answer", async () => {
+            // TODO(Jeremy): This test is currently skipped because it is
+            // failing sporadically after the React 18 upgrade.
+            xit("accepts correct answer", async () => {
                 const {renderer} = renderQuestion(question, apiOptions);
 
                 await userEvent.tab();

--- a/packages/perseus/src/widgets/__tests__/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/interactive-graph.test.tsx
@@ -224,9 +224,7 @@ describe("a mafs graph", () => {
                 renderQuestion(question, apiOptions);
             });
 
-            // TODO(Jeremy): This test is currently skipped because it is
-            // failing sporadically after the React 18 upgrade.
-            xit("rejects incorrect answer", async () => {
+            it("rejects incorrect answer", async () => {
                 // Arrange
                 const {renderer} = renderQuestion(question, apiOptions);
 
@@ -236,14 +234,15 @@ describe("a mafs graph", () => {
                 await userEvent.keyboard("{arrowup}{arrowright}");
 
                 // Assert
-                await waitFor(() => {
-                    expect(renderer).toHaveBeenAnsweredIncorrectly();
-                });
+                await waitFor(
+                    () => {
+                        expect(renderer).toHaveBeenAnsweredIncorrectly();
+                    },
+                    {timeout: 5000},
+                );
             });
 
-            // TODO(Jeremy): This test is currently skipped because it is
-            // failing sporadically after the React 18 upgrade.
-            xit("accepts correct answer", async () => {
+            it("accepts correct answer", async () => {
                 const {renderer} = renderQuestion(question, apiOptions);
 
                 await userEvent.tab();
@@ -252,9 +251,12 @@ describe("a mafs graph", () => {
                 await userEvent.keyboard("{arrowup}{arrowdown}");
 
                 // Assert
-                await waitFor(() => {
-                    expect(renderer).toHaveBeenAnsweredCorrectly();
-                });
+                await waitFor(
+                    () => {
+                        expect(renderer).toHaveBeenAnsweredCorrectly();
+                    },
+                    {timeout: 5000},
+                );
             });
         },
     );


### PR DESCRIPTION
## Summary:

Matthew noticed that these tests fail sometimes in CI. They also fail sporadically (especially, it seems, on older/slower laptops). 

Extending the timeout for the final `waitFor()` calls seems to fix them and give the graph enough time to process the actions that are dispatched by the keypresses. 

Issue: LEMS-1802 

## Test plan:

All tests pass. 
All tests pass in CI. 
All tests pass in CI again.