### PR TITLE
Fix use-draggable hook to ignore 'keyup' events

### DIFF
--- a/.changeset/stale-geese-protect.md
+++ b/.changeset/stale-geese-protect.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+useDraggable - fix to ignore keyup events (we don't want to treat keyup events as an intent to move - we have keydown for that)

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/use-draggable.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/use-draggable.test.tsx
@@ -216,7 +216,7 @@ describe("useDraggable", () => {
         expect(screen.getByRole("button")).toHaveFocus();
 
         // Act:
-        await userEvent.keyboard("{arrowright>1}{arrowup>1}");
+        await userEvent.keyboard("{arrowright}{arrowup}");
 
         // Assert: the element moved one step to the right and then one step up
         expect(onMoveSpy.mock.calls).toEqual([[[1, 0]], [[0, 1]]]);

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/use-draggable.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/use-draggable.ts
@@ -61,6 +61,17 @@ export function useDraggable(args: Params): DragState {
             const isKeyboard = type.includes("key");
             if (isKeyboard) {
                 event?.preventDefault();
+
+                // When a key is held down, we see multiple "keydown" events,
+                // followed by a single "keyup" event.
+                // For a single keypress, we only see a "keydown" event, no
+                // "keyup".
+                // We never want to process the keyup event as an intent to
+                // move so we bail on further processing here.
+                if (type === "keyup") {
+                    return;
+                }
+
                 const {
                     direction: yDownDirection,
                     altKey,

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -525,7 +525,7 @@ describe("MafsGraph", () => {
 
         const group = screen.getByTestId("movable-line");
         group.focus();
-        await userEvent.keyboard("{arrowdown>1}");
+        await userEvent.keyboard("{arrowdown}");
 
         const state = getState();
         invariant(
@@ -576,7 +576,7 @@ describe("MafsGraph", () => {
 
         const group = screen.getByTestId("movable-line");
         group.focus();
-        await userEvent.keyboard("{arrowup>1}");
+        await userEvent.keyboard("{arrowup}");
 
         const state = getState();
         invariant(
@@ -627,7 +627,7 @@ describe("MafsGraph", () => {
 
         const group = screen.getByTestId("movable-line");
         group.focus();
-        await userEvent.keyboard("{arrowright>1}");
+        await userEvent.keyboard("{arrowright}");
 
         const state = getState();
         invariant(
@@ -678,7 +678,7 @@ describe("MafsGraph", () => {
 
         const group = screen.getByTestId("movable-line");
         group.focus();
-        await userEvent.keyboard("{arrowleft>1}");
+        await userEvent.keyboard("{arrowleft}");
 
         const state = getState();
         invariant(


### PR DESCRIPTION
## Summary:

While @nicolecomputer and I were investigating why the `interactive-graph.test.tsx` tests _sometimes_ failed in CI and other slower environments, we found that the `useDraggable()` hook was handling both `keydown` as well as `keyup` events.

Through some testing we discovered also that the browser sends only a `keydown` event for a single keypress. When the key is held down, we saw a series of `keydown` events and then a single `keyup` event when the key was released. 

To that end, we've adjusted `useDraggable` to ignore all `keyup` events.

Issue: LEMS-1820, LEMS-1934

## Test plan:

`yarn test` all tests pass
In storybook, you can notice that there's one fewer moves when selecting a point and then holding down the arrow key to move it. Previously, there was a final move because of the `keyup` processing. Now that's gone and the effect "feels" more correct.