### PR TITLE
[🔥AUDIT🔥] Use github token that has repo access so we can tag Org teams

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -37,7 +37,7 @@ jobs:
             - name: Create Pull Request
               uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
               with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
+                  token: ${{ secrets.KHAN_ACTIONS_BOT_TOKEN }}
                   team-reviewers: perseus, frontend-infra-web
                   commit-message: "chore: update browserslist"
                   title: Update browserslist


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:

After landing the new Github Action to periodically update the `caniuse` database, I noticed the action failing. It turns out that the `GITHUB_TOKEN` is scoped to this repo only and we need a token that has Org permissions so that we can tag teams defined at the org level. 

See: https://khanacademy.slack.com/archives/CEA6W0F6F/p1721743441208509?thread_ts=1721692544.947749&cid=CEA6W0F6F

This PR switches to a token that has those permissions.

Issue: "none"

## Test plan: