### PR TITLE
[Interactive Graph Editor] Refactor and clean up start coords UI implementation

### DIFF
--- a/.changeset/great-planets-fix.md
+++ b/.changeset/great-planets-fix.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Cleaned up the `startCoords` code in the stateful mafs graph useEffect

--- a/.changeset/twelve-pianos-collect.md
+++ b/.changeset/twelve-pianos-collect.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Interactive Graph Editor] Refactor and clean up start coords UI implementation

--- a/packages/perseus-editor/src/components/__tests__/start-coords-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/start-coords-settings.test.tsx
@@ -82,7 +82,10 @@ describe("StartCoordSettings", () => {
         await userEvent.click(resetButton);
 
         // Assert
-        expect(onChangeMock).toHaveBeenCalledWith(undefined);
+        expect(onChangeMock).toHaveBeenCalledWith([
+            [-5, 5],
+            [5, 5],
+        ]);
     });
 
     describe.each`

--- a/packages/perseus-editor/src/components/__tests__/start-coords-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/start-coords-settings.test.tsx
@@ -46,20 +46,43 @@ describe("StartCoordSettings", () => {
 
         // Assert
         expect(
-            screen.getByRole("button", {name: "Use default start coords"}),
+            screen.getByRole("button", {name: "Use default start coordinates"}),
         ).toBeInTheDocument();
 
         await userEvent.click(heading);
 
         expect(
-            screen.queryByRole("button", {name: "Use default start coords"}),
+            screen.queryByRole("button", {
+                name: "Use default start coordinates",
+            }),
         ).not.toBeInTheDocument();
 
         await userEvent.click(heading);
 
         expect(
-            screen.getByRole("button", {name: "Use default start coords"}),
+            screen.getByRole("button", {name: "Use default start coordinates"}),
         ).toBeInTheDocument();
+    });
+
+    test("clicking the reset button resets the start coordinates", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+        render(
+            <StartCoordsSettings
+                {...defaultProps}
+                type="linear"
+                onChange={onChangeMock}
+            />,
+        );
+
+        // Act
+        const resetButton = screen.getByRole("button", {
+            name: "Use default start coordinates",
+        });
+        await userEvent.click(resetButton);
+
+        // Assert
+        expect(onChangeMock).toHaveBeenCalledWith(undefined);
     });
 
     describe.each`
@@ -80,13 +103,13 @@ describe("StartCoordSettings", () => {
             );
 
             const resetButton = screen.getByRole("button", {
-                name: "Use default start coords",
+                name: "Use default start coordinates",
             });
 
             // Assert
             expect(screen.getByText("Start coordinates")).toBeInTheDocument();
-            expect(screen.getByText("Point 1")).toBeInTheDocument();
-            expect(screen.getByText("Point 2")).toBeInTheDocument();
+            expect(screen.getByText("Point 1:")).toBeInTheDocument();
+            expect(screen.getByText("Point 2:")).toBeInTheDocument();
             expect(resetButton).toBeInTheDocument();
         });
 
@@ -113,7 +136,7 @@ describe("StartCoordSettings", () => {
 
                 // Assert
                 const input = screen.getAllByRole("spinbutton", {
-                    name: `${coord} coord`,
+                    name: `${coord}`,
                 })[lineIndex];
                 await userEvent.clear(input);
                 await userEvent.type(input, "101");
@@ -127,35 +150,6 @@ describe("StartCoordSettings", () => {
                 expect(onChangeMock).toHaveBeenLastCalledWith(expectedCoords);
             },
         );
-
-        test(`calls onChange when reset button is clicked ${type} graph`, async () => {
-            // Arrange
-            const onChangeMock = jest.fn();
-
-            // Act
-            render(
-                <StartCoordsSettings
-                    {...defaultProps}
-                    startCoords={[
-                        [-15, 15],
-                        [15, 15],
-                    ]}
-                    type={type}
-                    onChange={onChangeMock}
-                />,
-            );
-
-            // Assert
-            const resetButton = screen.getByRole("button", {
-                name: "Use default start coords",
-            });
-            await userEvent.click(resetButton);
-
-            expect(onChangeMock).toHaveBeenLastCalledWith([
-                [-5, 5],
-                [5, 5],
-            ]);
-        });
     });
 
     // startCoords with type CollinearTuple[]
@@ -177,8 +171,8 @@ describe("StartCoordSettings", () => {
             // Assert
             expect(screen.getByText("Start coordinates")).toBeInTheDocument();
             expect(screen.getByText("Segment 1")).toBeInTheDocument();
-            expect(screen.getByText("Point 1")).toBeInTheDocument();
-            expect(screen.getByText("Point 2")).toBeInTheDocument();
+            expect(screen.getByText("Point 1:")).toBeInTheDocument();
+            expect(screen.getByText("Point 2:")).toBeInTheDocument();
         });
 
         test("shows the start coordinates UI for 2 segments", () => {
@@ -199,23 +193,23 @@ describe("StartCoordSettings", () => {
             expect(screen.getByText("Start coordinates")).toBeInTheDocument();
             expect(screen.getByText("Segment 1")).toBeInTheDocument();
             expect(screen.getByText("Segment 2")).toBeInTheDocument();
-            expect(screen.getAllByText("Point 1")).toHaveLength(2);
-            expect(screen.getAllByText("Point 2")).toHaveLength(2);
+            expect(screen.getAllByText("Point 1:")).toHaveLength(2);
+            expect(screen.getAllByText("Point 2:")).toHaveLength(2);
         });
 
         test.each`
-            segmentIndex | pointIndex | coordIndex
-            ${0}         | ${0}       | ${0}
-            ${0}         | ${0}       | ${1}
-            ${0}         | ${1}       | ${0}
-            ${0}         | ${1}       | ${1}
-            ${1}         | ${0}       | ${0}
-            ${1}         | ${0}       | ${1}
-            ${1}         | ${1}       | ${0}
-            ${1}         | ${1}       | ${1}
+            segmentIndex | pointIndex | coordIndex | coord
+            ${0}         | ${0}       | ${0}       | ${"x"}
+            ${0}         | ${0}       | ${1}       | ${"y"}
+            ${0}         | ${1}       | ${0}       | ${"x"}
+            ${0}         | ${1}       | ${1}       | ${"y"}
+            ${1}         | ${0}       | ${0}       | ${"x"}
+            ${1}         | ${0}       | ${1}       | ${"y"}
+            ${1}         | ${1}       | ${0}       | ${"x"}
+            ${1}         | ${1}       | ${1}       | ${"y"}
         `(
             `calls onChange when $coord coord is changed (segment $segmentIndex)`,
-            async ({segmentIndex, pointIndex, coordIndex}) => {
+            async ({segmentIndex, pointIndex, coordIndex, coord}) => {
                 // Arrange
                 const onChangeMock = jest.fn();
 
@@ -244,8 +238,8 @@ describe("StartCoordSettings", () => {
 
                 // Assert
                 const input = screen.getAllByRole("spinbutton", {
-                    name: /coord/,
-                })[segmentIndex * 4 + pointIndex * 2 + coordIndex];
+                    name: coord,
+                })[segmentIndex * 2 + pointIndex];
                 await userEvent.clear(input);
                 await userEvent.type(input, "101");
 
@@ -255,49 +249,6 @@ describe("StartCoordSettings", () => {
                 expect(onChangeMock).toHaveBeenLastCalledWith(expectedCoords);
             },
         );
-
-        test(`calls onChange when reset button is clicked`, async () => {
-            // Arrange
-            const onChangeMock = jest.fn();
-
-            // Act
-            render(
-                <StartCoordsSettings
-                    {...defaultProps}
-                    type="segment"
-                    numSegments={2}
-                    startCoords={[
-                        [
-                            [-15, 15],
-                            [15, 15],
-                        ],
-                        [
-                            [-15, -15],
-                            [15, -15],
-                        ],
-                    ]}
-                    onChange={onChangeMock}
-                />,
-                {wrapper: RenderStateRoot},
-            );
-
-            // Assert
-            const resetButton = screen.getByRole("button", {
-                name: "Use default start coords",
-            });
-            await userEvent.click(resetButton);
-
-            expect(onChangeMock).toHaveBeenLastCalledWith([
-                [
-                    [-5, 5],
-                    [5, 5],
-                ],
-                [
-                    [-5, -5],
-                    [5, -5],
-                ],
-            ]);
-        });
     });
 
     // startCoords with type CollinearTuple[]
@@ -319,23 +270,23 @@ describe("StartCoordSettings", () => {
             expect(screen.getByText("Start coordinates")).toBeInTheDocument();
             expect(screen.getByText("Line 1")).toBeInTheDocument();
             expect(screen.getByText("Line 2")).toBeInTheDocument();
-            expect(screen.getAllByText("Point 1")).toHaveLength(2);
-            expect(screen.getAllByText("Point 2")).toHaveLength(2);
+            expect(screen.getAllByText("Point 1:")).toHaveLength(2);
+            expect(screen.getAllByText("Point 2:")).toHaveLength(2);
         });
 
         test.each`
-            lineIndex | pointIndex | coordIndex
-            ${0}      | ${0}       | ${0}
-            ${0}      | ${0}       | ${1}
-            ${0}      | ${1}       | ${0}
-            ${0}      | ${1}       | ${1}
-            ${1}      | ${0}       | ${0}
-            ${1}      | ${0}       | ${1}
-            ${1}      | ${1}       | ${0}
-            ${1}      | ${1}       | ${1}
+            lineIndex | pointIndex | coordIndex | coord
+            ${0}      | ${0}       | ${0}       | ${"x"}
+            ${0}      | ${0}       | ${1}       | ${"y"}
+            ${0}      | ${1}       | ${0}       | ${"x"}
+            ${0}      | ${1}       | ${1}       | ${"y"}
+            ${1}      | ${0}       | ${0}       | ${"x"}
+            ${1}      | ${0}       | ${1}       | ${"y"}
+            ${1}      | ${1}       | ${0}       | ${"x"}
+            ${1}      | ${1}       | ${1}       | ${"y"}
         `(
             `calls onChange when $coord coord is changed (line $lineIndex)`,
-            async ({lineIndex, pointIndex, coordIndex}) => {
+            async ({lineIndex, pointIndex, coordIndex, coord}) => {
                 // Arrange
                 const onChangeMock = jest.fn();
 
@@ -363,8 +314,8 @@ describe("StartCoordSettings", () => {
 
                 // Assert
                 const input = screen.getAllByRole("spinbutton", {
-                    name: /coord/,
-                })[lineIndex * 4 + pointIndex * 2 + coordIndex];
+                    name: coord,
+                })[lineIndex * 2 + pointIndex];
                 await userEvent.clear(input);
                 await userEvent.type(input, "101");
 
@@ -374,47 +325,5 @@ describe("StartCoordSettings", () => {
                 expect(onChangeMock).toHaveBeenLastCalledWith(expectedCoords);
             },
         );
-
-        test(`calls onChange when reset button is clicked`, async () => {
-            // Arrange
-            const onChangeMock = jest.fn();
-
-            // Act
-            render(
-                <StartCoordsSettings
-                    {...defaultProps}
-                    type="linear-system"
-                    startCoords={[
-                        [
-                            [-15, 15],
-                            [15, 15],
-                        ],
-                        [
-                            [-15, -15],
-                            [15, -15],
-                        ],
-                    ]}
-                    onChange={onChangeMock}
-                />,
-                {wrapper: RenderStateRoot},
-            );
-
-            // Assert
-            const resetButton = screen.getByRole("button", {
-                name: "Use default start coords",
-            });
-            await userEvent.click(resetButton);
-
-            expect(onChangeMock).toHaveBeenLastCalledWith([
-                [
-                    [-5, 5],
-                    [5, 5],
-                ],
-                [
-                    [-5, -5],
-                    [5, -5],
-                ],
-            ]);
-        });
     });
 });

--- a/packages/perseus-editor/src/components/__tests__/util.test.ts
+++ b/packages/perseus-editor/src/components/__tests__/util.test.ts
@@ -1,4 +1,11 @@
-import {degreeToRadian, getDefaultFigureForType, radianToDegree} from "../util";
+import {
+    degreeToRadian,
+    getDefaultFigureForType,
+    radianToDegree,
+    getDefaultGraphStartCoords,
+} from "../util";
+
+import type {PerseusGraphType, Range} from "@khanacademy/perseus";
 
 describe("getDefaultFigureForType", () => {
     test("should return a point with default values", () => {
@@ -126,4 +133,110 @@ describe("radianToDegree", () => {
             expect(radianToDegree(radians)).toBe(degrees);
         },
     );
+});
+
+describe("getDefaultGraphStartCoords", () => {
+    test("should get default start coords for a linear graph", () => {
+        // Arrange
+        const graph: PerseusGraphType = {type: "linear"};
+        const range = [
+            [-10, 10],
+            [-10, 10],
+        ] satisfies [Range, Range];
+        const step = [1, 1] satisfies [number, number];
+
+        // Act
+        const defaultCoords = getDefaultGraphStartCoords(graph, range, step);
+
+        expect(defaultCoords).toEqual([
+            [-5, 5],
+            [5, 5],
+        ]);
+    });
+
+    test("should get default start coords for a ray graph", () => {
+        // Arrange
+        const graph: PerseusGraphType = {type: "ray"};
+        const range = [
+            [-10, 10],
+            [-10, 10],
+        ] satisfies [Range, Range];
+        const step = [1, 1] satisfies [number, number];
+
+        // Act
+        const defaultCoords = getDefaultGraphStartCoords(graph, range, step);
+
+        expect(defaultCoords).toEqual([
+            [-5, 5],
+            [5, 5],
+        ]);
+    });
+
+    test("should get default start coords for a segment graph", () => {
+        // Arrange
+        const graph: PerseusGraphType = {type: "segment"};
+        const range = [
+            [-10, 10],
+            [-10, 10],
+        ] satisfies [Range, Range];
+        const step = [1, 1] satisfies [number, number];
+
+        // Act
+        const defaultCoords = getDefaultGraphStartCoords(graph, range, step);
+
+        expect(defaultCoords).toEqual([
+            [
+                [-5, 5],
+                [5, 5],
+            ],
+        ]);
+    });
+
+    test("should get default start coords for a segment graph with multiple segments", () => {
+        // Arrange
+        const graph: PerseusGraphType = {type: "segment", numSegments: 2};
+        const range = [
+            [-10, 10],
+            [-10, 10],
+        ] satisfies [Range, Range];
+        const step = [1, 1] satisfies [number, number];
+
+        // Act
+        const defaultCoords = getDefaultGraphStartCoords(graph, range, step);
+
+        expect(defaultCoords).toEqual([
+            [
+                [-5, 5],
+                [5, 5],
+            ],
+            [
+                [-5, -5],
+                [5, -5],
+            ],
+        ]);
+    });
+
+    test("should get default start coords for a linear system graph", () => {
+        // Arrange
+        const graph: PerseusGraphType = {type: "linear-system"};
+        const range = [
+            [-10, 10],
+            [-10, 10],
+        ] satisfies [Range, Range];
+        const step = [1, 1] satisfies [number, number];
+
+        // Act
+        const defaultCoords = getDefaultGraphStartCoords(graph, range, step);
+
+        expect(defaultCoords).toEqual([
+            [
+                [-5, 5],
+                [5, 5],
+            ],
+            [
+                [-5, -5],
+                [5, -5],
+            ],
+        ]);
+    });
 });

--- a/packages/perseus-editor/src/components/start-coords-line.tsx
+++ b/packages/perseus-editor/src/components/start-coords-line.tsx
@@ -1,0 +1,55 @@
+import {View} from "@khanacademy/wonder-blocks-core";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
+import {StyleSheet} from "aphrodite";
+import * as React from "react";
+
+import CoordinatePairInput from "./coordinate-pair-input";
+
+import type {CollinearTuple, PerseusGraphType} from "@khanacademy/perseus";
+
+type Props = {
+    startCoords: CollinearTuple;
+    onChange: (startCoords: PerseusGraphType["startCoords"]) => void;
+};
+
+const StartCoordsLine = (props: Props) => {
+    const {startCoords, onChange} = props;
+
+    return (
+        <>
+            <View style={styles.tile}>
+                <LabelLarge>Point 1:</LabelLarge>
+                <Strut size={spacing.small_12} />
+                <CoordinatePairInput
+                    coord={startCoords[0]}
+                    labels={["x", "y"]}
+                    onChange={(value) => onChange([value, startCoords[1]])}
+                />
+            </View>
+            <View style={styles.tile}>
+                <LabelLarge>Point 2:</LabelLarge>
+                <Strut size={spacing.small_12} />
+                <CoordinatePairInput
+                    coord={startCoords[1]}
+                    labels={["x", "y"]}
+                    onChange={(value) => onChange([startCoords[0], value])}
+                />
+            </View>
+        </>
+    );
+};
+
+const styles = StyleSheet.create({
+    tile: {
+        backgroundColor: color.fadedBlue8,
+        marginTop: spacing.xSmall_8,
+        padding: spacing.small_12,
+        borderRadius: spacing.xSmall_8,
+        flexDirection: "row",
+        alignItems: "center",
+    },
+});
+
+export default StartCoordsLine;

--- a/packages/perseus-editor/src/components/start-coords-multiline.tsx
+++ b/packages/perseus-editor/src/components/start-coords-multiline.tsx
@@ -1,0 +1,72 @@
+import {View} from "@khanacademy/wonder-blocks-core";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
+import {StyleSheet} from "aphrodite";
+import * as React from "react";
+
+import CoordinatePairInput from "./coordinate-pair-input";
+import PerseusEditorAccordion from "./perseus-editor-accordion";
+
+import type {CollinearTuple, PerseusGraphType} from "@khanacademy/perseus";
+
+type Props = {
+    type: "linear-system" | "segment";
+    startCoords: CollinearTuple[];
+    onChange: (startCoords: PerseusGraphType["startCoords"]) => void;
+};
+
+const StartCoordsMultiline = (props: Props) => {
+    const {startCoords, type, onChange} = props;
+
+    const graphName = type === "segment" ? "Segment" : "Line";
+
+    return (
+        <>
+            {startCoords.map((coordPair, i) => (
+                <PerseusEditorAccordion
+                    key={`segment-${i}-start-coords`}
+                    header={<LabelLarge>{`${graphName} ${i + 1}`}</LabelLarge>}
+                    expanded={true}
+                >
+                    <View style={styles.nestedTile}>
+                        <LabelLarge>Point 1:</LabelLarge>
+                        <Strut size={spacing.small_12} />
+                        <CoordinatePairInput
+                            coord={coordPair[0]}
+                            labels={["x", "y"]}
+                            onChange={(value) => {
+                                const newCoords = [...startCoords];
+                                newCoords[i] = [value, coordPair[1]];
+                                onChange(newCoords);
+                            }}
+                        />
+                    </View>
+                    <View style={styles.nestedTile}>
+                        <LabelLarge>Point 2:</LabelLarge>
+                        <Strut size={spacing.small_12} />
+                        <CoordinatePairInput
+                            coord={coordPair[1]}
+                            labels={["x", "y"]}
+                            onChange={(value) => {
+                                const newCoords = [...startCoords];
+                                newCoords[i] = [coordPair[0], value];
+                                onChange(newCoords);
+                            }}
+                        />
+                    </View>
+                </PerseusEditorAccordion>
+            ))}
+        </>
+    );
+};
+
+const styles = StyleSheet.create({
+    nestedTile: {
+        paddingBottom: spacing.small_12,
+        flexDirection: "row",
+        alignItems: "center",
+    },
+});
+
+export default StartCoordsMultiline;

--- a/packages/perseus-editor/src/components/start-coords-settings.tsx
+++ b/packages/perseus-editor/src/components/start-coords-settings.tsx
@@ -13,6 +13,7 @@ import * as React from "react";
 import Heading from "./heading";
 import StartCoordsLine from "./start-coords-line";
 import StartCoordsMultiline from "./start-coords-multiline";
+import {getDefaultGraphStartCoords} from "./util";
 
 import type {PerseusGraphType, Range} from "@khanacademy/perseus";
 
@@ -60,7 +61,7 @@ const StartCoordsSettingsInner = (props: Props) => {
 };
 
 const StartCoordsSettings = (props: Props) => {
-    const {onChange} = props;
+    const {range, step, onChange} = props;
     const [isOpen, setIsOpen] = React.useState(true);
 
     return (
@@ -86,7 +87,9 @@ const StartCoordsSettings = (props: Props) => {
                         kind="tertiary"
                         size="small"
                         onClick={() => {
-                            onChange(undefined);
+                            onChange(
+                                getDefaultGraphStartCoords(props, range, step),
+                            );
                         }}
                     >
                         Use default start coordinates

--- a/packages/perseus-editor/src/components/start-coords-settings.tsx
+++ b/packages/perseus-editor/src/components/start-coords-settings.tsx
@@ -6,21 +6,15 @@ import {
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
-import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import arrowCounterClockwise from "@phosphor-icons/core/bold/arrow-counter-clockwise-bold.svg";
-import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
-import CoordinatePairInput from "./coordinate-pair-input";
 import Heading from "./heading";
-import PerseusEditorAccordion from "./perseus-editor-accordion";
+import StartCoordsLine from "./start-coords-line";
+import StartCoordsMultiline from "./start-coords-multiline";
 
-import type {
-    PerseusGraphType,
-    Range,
-    CollinearTuple,
-} from "@khanacademy/perseus";
+import type {PerseusGraphType, Range} from "@khanacademy/perseus";
 
 type Props = PerseusGraphType & {
     range: [x: Range, y: Range];
@@ -29,82 +23,36 @@ type Props = PerseusGraphType & {
 };
 
 const StartCoordsSettingsInner = (props: Props) => {
-    const {type, range, step, startCoords, onChange} = props;
+    const {type, range, step, onChange} = props;
 
     switch (type) {
-        // coords with type CollinearTuple
+        // Graphs with startCoords of type CollinearTuple
         case "linear":
         case "ray":
-            // If startCoords is already set (in the editor), use that value.
-            // Otherwise, calculate the default startCoords.
-            const linearCoords =
-                startCoords ?? getLineCoords(props, range, step);
+            // Gets the startCoords from props if they're passed in,
+            // otherwise calculates the default startCoords.
+            const linearCoords = getLineCoords(props, range, step);
             return (
-                <>
-                    <View style={styles.tile}>
-                        <LabelLarge>Point 1</LabelLarge>
-                        <CoordinatePairInput
-                            coord={linearCoords[0]}
-                            onChange={(value) =>
-                                onChange([value, linearCoords[1]])
-                            }
-                        />
-                    </View>
-                    <View style={styles.tile}>
-                        <LabelLarge>Point 2</LabelLarge>
-                        <CoordinatePairInput
-                            coord={linearCoords[1]}
-                            onChange={(value) =>
-                                onChange([linearCoords[0], value])
-                            }
-                        />
-                    </View>
-                </>
+                <StartCoordsLine
+                    startCoords={linearCoords}
+                    onChange={onChange}
+                />
             );
-        // coords with type CollinearTuple[]
+        // Graphs with startCoords of type CollinearTuple[]
         case "linear-system":
         case "segment":
-            const multiLineCoords: CollinearTuple[] =
-                startCoords ??
-                (type === "segment"
+            const multiLineCoords =
+                // Gets the startCoords from props if they're passed in,
+                // otherwise calculates the default startCoords.
+                type === "segment"
                     ? getSegmentCoords(props, range, step)
-                    : getLinearSystemCoords(props, range, step));
-            const graphName = type === "segment" ? "Segment" : "Line";
+                    : getLinearSystemCoords(props, range, step);
             return (
-                <>
-                    {multiLineCoords.map((coordPair, i) => (
-                        <PerseusEditorAccordion
-                            key={`segment-${i}-start-coords`}
-                            header={
-                                <LabelLarge>{`${graphName} ${i + 1}`}</LabelLarge>
-                            }
-                            expanded={true}
-                        >
-                            <View style={styles.nestedTile}>
-                                <LabelLarge>Point 1</LabelLarge>
-                                <CoordinatePairInput
-                                    coord={coordPair[0]}
-                                    onChange={(value) => {
-                                        const newCoords = [...multiLineCoords];
-                                        newCoords[i] = [value, coordPair[1]];
-                                        onChange(newCoords);
-                                    }}
-                                />
-                            </View>
-                            <View style={styles.nestedTile}>
-                                <LabelLarge>Point 2</LabelLarge>
-                                <CoordinatePairInput
-                                    coord={coordPair[1]}
-                                    onChange={(value) => {
-                                        const newCoords = [...multiLineCoords];
-                                        newCoords[i] = [coordPair[0], value];
-                                        onChange(newCoords);
-                                    }}
-                                />
-                            </View>
-                        </PerseusEditorAccordion>
-                    ))}
-                </>
+                <StartCoordsMultiline
+                    type={type}
+                    startCoords={multiLineCoords}
+                    onChange={onChange}
+                />
             );
         default:
             return null;
@@ -112,49 +60,11 @@ const StartCoordsSettingsInner = (props: Props) => {
 };
 
 const StartCoordsSettings = (props: Props) => {
-    const {type, range, step, onChange} = props;
+    const {onChange} = props;
     const [isOpen, setIsOpen] = React.useState(true);
 
-    if (
-        type !== "linear" &&
-        type !== "ray" &&
-        type !== "segment" &&
-        type !== "linear-system"
-    ) {
-        return null;
-    }
-
-    let defaultStartCoords: PerseusGraphType["startCoords"];
-    // Passing in undefined start coords to get default coords
-    switch (type) {
-        case "linear":
-        case "ray":
-            defaultStartCoords = getLineCoords(
-                {...props, startCoords: undefined},
-                range,
-                step,
-            );
-            break;
-        case "segment":
-            defaultStartCoords = getSegmentCoords(
-                {...props, startCoords: undefined},
-                range,
-                step,
-            );
-            break;
-        case "linear-system":
-            defaultStartCoords = getLinearSystemCoords(
-                {...props, startCoords: undefined},
-                range,
-                step,
-            );
-            break;
-        default:
-            return null;
-    }
-
     return (
-        <View style={styles.container}>
+        <View>
             {/* Heading for the collapsible section */}
             <Heading
                 isCollapsible={true}
@@ -166,6 +76,7 @@ const StartCoordsSettings = (props: Props) => {
             {/* Start coordinates main UI */}
             {isOpen && (
                 <>
+                    {/* Start coordinates input */}
                     <StartCoordsSettingsInner {...props} />
 
                     {/* Button to reset to default */}
@@ -175,27 +86,15 @@ const StartCoordsSettings = (props: Props) => {
                         kind="tertiary"
                         size="small"
                         onClick={() => {
-                            onChange(defaultStartCoords);
+                            onChange(undefined);
                         }}
                     >
-                        Use default start coords
+                        Use default start coordinates
                     </Button>
                 </>
             )}
         </View>
     );
 };
-
-const styles = StyleSheet.create({
-    tile: {
-        backgroundColor: color.fadedBlue8,
-        marginTop: spacing.xSmall_8,
-        padding: spacing.small_12,
-        borderRadius: spacing.xSmall_8,
-    },
-    nestedTile: {
-        paddingBottom: spacing.small_12,
-    },
-});
 
 export default StartCoordsSettings;

--- a/packages/perseus-editor/src/components/util.ts
+++ b/packages/perseus-editor/src/components/util.ts
@@ -1,6 +1,12 @@
+import {
+    getLineCoords,
+    getLinearSystemCoords,
+    getSegmentCoords,
+} from "@khanacademy/perseus";
 import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
 
 import type {
+    Range,
     LockedFigure,
     LockedFigureType,
     LockedPointType,
@@ -9,6 +15,7 @@ import type {
     LockedVectorType,
     LockedPolygonType,
     LockedFunctionType,
+    PerseusGraphType,
 } from "@khanacademy/perseus";
 
 export function focusWithChromeStickyFocusBugWorkaround(element: Element) {
@@ -134,4 +141,34 @@ export function degreeToRadian(degrees: number) {
 }
 export function radianToDegree(radians: number) {
     return (radians / Math.PI) * 180;
+}
+
+export function getDefaultGraphStartCoords(
+    graph: PerseusGraphType,
+    range: [x: Range, y: Range],
+    step: [x: number, y: number],
+): PerseusGraphType["startCoords"] {
+    switch (graph.type) {
+        case "linear":
+        case "ray":
+            return getLineCoords(
+                {...graph, startCoords: undefined},
+                range,
+                step,
+            );
+        case "segment":
+            return getSegmentCoords(
+                {...graph, startCoords: undefined},
+                range,
+                step,
+            );
+        case "linear-system":
+            return getLinearSystemCoords(
+                {...graph, startCoords: undefined},
+                range,
+                step,
+            );
+        default:
+            return undefined;
+    }
 }

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
@@ -54,6 +54,22 @@ describe("InteractiveGraphEditor locked figures", () => {
         );
     });
 
+    const assertAndCloseStartCoordsSection = async () => {
+        // Confirm the "Start coordinates" section is open.
+        const resetCoordsButton = screen.getByRole("button", {
+            name: "Use default start coordinates",
+        });
+        expect(resetCoordsButton).toBeInTheDocument();
+
+        // Close the "Start coordinates" section first to remove
+        // other inputs from the DOM.
+        const startCoordinatesHeading = screen.getByRole("button", {
+            name: "Start coordinates",
+        });
+
+        await userEvent.click(startCoordinatesHeading);
+    };
+
     // Basic functionality
     describe.each`
         figureType   | figureName
@@ -324,12 +340,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                 lockedFigures: [getDefaultFigureForType(figureType)],
             });
 
-            // Close the "Start coordinates" section first to remove
-            // other accordions from the DOM.
-            const startCoordinatesHeading = screen.getByRole("button", {
-                name: "Start coordinates",
-            });
-            await userEvent.click(startCoordinatesHeading);
+            await assertAndCloseStartCoordsSection();
 
             // Act
             // There may be accordions within the settings, such as the
@@ -384,12 +395,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                 lockedFigures: [defaultPoint],
             });
 
-            // Close the "Start coordinates" section first to remove
-            // other accordions from the DOM.
-            const startCoordinatesHeading = screen.getByRole("button", {
-                name: "Start coordinates",
-            });
-            await userEvent.click(startCoordinatesHeading);
+            await assertAndCloseStartCoordsSection();
 
             // Act
             const xCoordInput = screen.getByLabelText("x coord");
@@ -418,12 +424,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                 lockedFigures: [defaultPoint],
             });
 
-            // Close the "Start coordinates" section first to remove
-            // other accordions from the DOM.
-            const startCoordinatesHeading = screen.getByRole("button", {
-                name: "Start coordinates",
-            });
-            await userEvent.click(startCoordinatesHeading);
+            await assertAndCloseStartCoordsSection();
 
             // Act
             const xCoordInput = screen.getByLabelText("y coord");
@@ -452,12 +453,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                 lockedFigures: [defaultPoint],
             });
 
-            // Close the "Start coordinates" section first to remove
-            // other accordions from the DOM.
-            const startCoordinatesHeading = screen.getByRole("button", {
-                name: "Start coordinates",
-            });
-            await userEvent.click(startCoordinatesHeading);
+            await assertAndCloseStartCoordsSection();
 
             // Act
             const fillInput = screen.getByRole("switch", {
@@ -486,12 +482,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                 lockedFigures: [defaultPoint],
             });
 
-            // Close the "Start coordinates" section first to remove
-            // other accordions from the DOM.
-            const startCoordinatesHeading = screen.getByRole("button", {
-                name: "Start coordinates",
-            });
-            await userEvent.click(startCoordinatesHeading);
+            await assertAndCloseStartCoordsSection();
 
             // Act
             const xCoordInput = screen.getByLabelText("x coord");
@@ -511,12 +502,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                 lockedFigures: [defaultPoint],
             });
 
-            // Close the "Start coordinates" section first to remove
-            // other accordions from the DOM.
-            const startCoordinatesHeading = screen.getByRole("button", {
-                name: "Start coordinates",
-            });
-            await userEvent.click(startCoordinatesHeading);
+            await assertAndCloseStartCoordsSection();
 
             // Act
             const yCoordInput = screen.getByLabelText("y coord");
@@ -544,12 +530,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                     lockedFigures: [defaultPoint],
                 });
 
-                // Close the "Start coordinates" section first to remove
-                // other accordions from the DOM.
-                const startCoordinatesHeading = screen.getByRole("button", {
-                    name: "Start coordinates",
-                });
-                await userEvent.click(startCoordinatesHeading);
+                await assertAndCloseStartCoordsSection();
 
                 // Act
                 const coordInput = screen.getByLabelText(`${coord} coord`);
@@ -573,12 +554,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                 lockedFigures: [defaultLine],
             });
 
-            // Close the "Start coordinates" section first to remove
-            // other accordions from the DOM.
-            const startCoordinatesHeading = screen.getByRole("button", {
-                name: "Start coordinates",
-            });
-            await userEvent.click(startCoordinatesHeading);
+            await assertAndCloseStartCoordsSection();
 
             // Act
             const styleInput = screen.getByRole("button", {
@@ -610,12 +586,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                 lockedFigures: [defaultLine],
             });
 
-            // Close the "Start coordinates" section first to remove
-            // other accordions from the DOM.
-            const startCoordinatesHeading = screen.getByRole("button", {
-                name: "Start coordinates",
-            });
-            await userEvent.click(startCoordinatesHeading);
+            await assertAndCloseStartCoordsSection();
 
             // Act
             const point1Input = screen.getAllByLabelText("x coord")[0];
@@ -649,12 +620,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                 lockedFigures: [defaultLine],
             });
 
-            // Close the "Start coordinates" section first to remove
-            // other accordions from the DOM.
-            const startCoordinatesHeading = screen.getByRole("button", {
-                name: "Start coordinates",
-            });
-            await userEvent.click(startCoordinatesHeading);
+            await assertAndCloseStartCoordsSection();
 
             // Act
             const point2Input = screen.getAllByLabelText("y coord")[0];
@@ -688,12 +654,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                 lockedFigures: [defaultLine],
             });
 
-            // Close the "Start coordinates" section first to remove
-            // other accordions from the DOM.
-            const startCoordinatesHeading = screen.getByRole("button", {
-                name: "Start coordinates",
-            });
-            await userEvent.click(startCoordinatesHeading);
+            await assertAndCloseStartCoordsSection();
 
             // Act
             const point1Input = screen.getAllByLabelText("x coord")[1];
@@ -727,12 +688,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                 lockedFigures: [defaultLine],
             });
 
-            // Close the "Start coordinates" section first to remove
-            // other accordions from the DOM.
-            const startCoordinatesHeading = screen.getByRole("button", {
-                name: "Start coordinates",
-            });
-            await userEvent.click(startCoordinatesHeading);
+            await assertAndCloseStartCoordsSection();
 
             // Act
             const point1Input = screen.getAllByLabelText("y coord")[1];
@@ -850,12 +806,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                 lockedFigures: [getDefaultFigureForType("ellipse")],
             });
 
-            // Close the "Start coordinates" section first to remove
-            // other accordions from the DOM.
-            const startCoordinatesHeading = screen.getByRole("button", {
-                name: "Start coordinates",
-            });
-            await userEvent.click(startCoordinatesHeading);
+            await assertAndCloseStartCoordsSection();
 
             // Act
             const xCoordInput = screen.getByLabelText("x coord");
@@ -885,12 +836,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                 lockedFigures: [getDefaultFigureForType("ellipse")],
             });
 
-            // Close the "Start coordinates" section first to remove
-            // other accordions from the DOM.
-            const startCoordinatesHeading = screen.getByRole("button", {
-                name: "Start coordinates",
-            });
-            await userEvent.click(startCoordinatesHeading);
+            await assertAndCloseStartCoordsSection();
 
             // Act
             const yCoordInput = screen.getByLabelText("y coord");
@@ -1202,14 +1148,9 @@ describe("InteractiveGraphEditor locked figures", () => {
                 lockedFigures: [defaultPolygon],
             });
 
-            // Close the "Start coordinates" section first to remove
-            // other accordions from the DOM.
-            const startCoordinatesHeading = screen.getByRole("button", {
-                name: "Start coordinates",
-            });
-            await userEvent.click(startCoordinatesHeading);
-
             // Act
+            await assertAndCloseStartCoordsSection();
+
             const xCoordInput = screen.getAllByLabelText("x")[0];
             await userEvent.clear(xCoordInput);
             await userEvent.type(xCoordInput, "7");
@@ -1240,12 +1181,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                 lockedFigures: [defaultPolygon],
             });
 
-            // Close the "Start coordinates" section first to remove
-            // other accordions from the DOM.
-            const startCoordinatesHeading = screen.getByRole("button", {
-                name: "Start coordinates",
-            });
-            await userEvent.click(startCoordinatesHeading);
+            await assertAndCloseStartCoordsSection();
 
             // Act
             const yCoordInput = screen.getAllByLabelText("y")[0];

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
@@ -1202,6 +1202,13 @@ describe("InteractiveGraphEditor locked figures", () => {
                 lockedFigures: [defaultPolygon],
             });
 
+            // Close the "Start coordinates" section first to remove
+            // other accordions from the DOM.
+            const startCoordinatesHeading = screen.getByRole("button", {
+                name: "Start coordinates",
+            });
+            await userEvent.click(startCoordinatesHeading);
+
             // Act
             const xCoordInput = screen.getAllByLabelText("x")[0];
             await userEvent.clear(xCoordInput);
@@ -1232,6 +1239,13 @@ describe("InteractiveGraphEditor locked figures", () => {
                 onChange: onChangeMock,
                 lockedFigures: [defaultPolygon],
             });
+
+            // Close the "Start coordinates" section first to remove
+            // other accordions from the DOM.
+            const startCoordinatesHeading = screen.getByRole("button", {
+                name: "Start coordinates",
+            });
+            await userEvent.click(startCoordinatesHeading);
 
             // Act
             const yCoordInput = screen.getAllByLabelText("y")[0];

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
@@ -638,4 +638,38 @@ describe("InteractiveGraphEditor", () => {
         // Assert
         expect(ref.current?.getSaveWarnings()).toEqual([]);
     });
+
+    test("calls changeStartCoords when the startCoords are changed", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+
+        render(
+            <InteractiveGraphEditor
+                {...mafsProps}
+                graph={{type: "linear"}}
+                correct={{type: "linear"}}
+                onChange={onChangeMock}
+            />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
+
+        // Act
+        const xInput = screen.getAllByRole("spinbutton", {name: "x"})[0];
+        await userEvent.type(xInput, "1");
+
+        // Assert
+        expect(onChangeMock).toBeCalledWith(
+            expect.objectContaining({
+                graph: {
+                    type: "linear",
+                    startCoords: [
+                        [-51, 5],
+                        [5, 5],
+                    ],
+                },
+            }),
+        );
+    });
 });

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
@@ -490,10 +490,7 @@ class InteractiveGraphEditor extends React.Component<Props> {
                         />
                     </LabeledRow>
                 )}
-                {(this.props.graph?.type === "linear" ||
-                    this.props.graph?.type === "ray" ||
-                    this.props.graph?.type === "segment" ||
-                    this.props.graph?.type === "linear-system") &&
+                {this.props.graph?.type &&
                     this.props.apiOptions.flags?.mafs?.["start-coords-ui"] && (
                         <StartCoordsSettings
                             {...this.props.graph}
@@ -644,12 +641,7 @@ class InteractiveGraphEditor extends React.Component<Props> {
     };
 
     changeStartCoords = (coords) => {
-        if (
-            this.props.graph?.type !== "linear" &&
-            this.props.graph?.type !== "ray" &&
-            this.props.graph?.type !== "segment" &&
-            this.props.graph?.type !== "linear-system"
-        ) {
+        if (!this.props.graph?.type) {
             return;
         }
 

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
@@ -100,7 +100,6 @@ export const StatefulMafsGraph = React.forwardRef<
     const snapTo = graph.type === "polygon" ? graph.snapTo : null;
     const showAngles = graph.type === "polygon" ? graph.showAngles : null;
     const showSides = graph.type === "polygon" ? graph.showSides : null;
-    const startCoords = graph.startCoords ?? null;
 
     const originalPropsRef = useRef(props);
     const latestPropsRef = useLatestRef(props);
@@ -119,9 +118,8 @@ export const StatefulMafsGraph = React.forwardRef<
         snapTo,
         showAngles,
         showSides,
-        startCoords,
         latestPropsRef,
-        startCoords,
+        graph.startCoords,
     ]);
 
     return <MafsGraph {...props} state={state} dispatch={dispatch} />;


### PR DESCRIPTION
## Summary:
The StartCoordsSettings file was getting unruly and hard to follow. I'm refactoring
it here to make it easier to add more types, and to make it generally more
maintainable.

- Broke out the main UI input section for each graph type into its own file
- Removed the unnecessary switch statement (only need to pass in `undefined` to
  reset to default coords)
- Updated the button to "Use default start coordinates" instead of "Use default
  start coords" as per Sarah Third's recommendation
- Updated the labels from "x/y coords" to just "x/y" to save space and look
  cleaner. (I did get [permission from the content authors](https://khanacademy.slack.com/archives/C04EA1QAKN0/p1721860247138389) for this.)
- Removed all the checks for the graph type. The feature is behind a feature
  flag, so no one should run into the start coords for an unimplemented
  graph type in prod or anything
- Updated tests accordingly

Issue: https://khanacademy.atlassian.net/browse/LEMS-2052

## Test plan:
`yarn jest packages/perseus-editor/src/components/__tests__/start-coords-settings.test.tsx`
`yarn jest packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx`

Storybook
- https://khan.github.io/perseus/?path=/docs/perseuseditor-widgets-interactive-graph--docs

## Screenshots

| Before | After |
| --- | --- |
| <img width="381" alt="Screenshot 2024-07-24 at 5 28 48 PM" src="https://github.com/user-attachments/assets/736b8fd5-9ebd-4943-8227-16acc0e477b2"> | <img width="375" alt="Screenshot 2024-07-24 at 5 28 55 PM" src="https://github.com/user-attachments/assets/5f744d18-8fbf-4f22-8e1a-a2060989975f"> |
| <img width="378" alt="Screenshot 2024-07-24 at 5 29 14 PM" src="https://github.com/user-attachments/assets/c33f22c5-3568-453a-9a05-f8023d2ba46c"> | <img width="377" alt="Screenshot 2024-07-24 at 5 29 19 PM" src="https://github.com/user-attachments/assets/68158083-03cc-42dc-82e1-b983cdfc2425"> |
