### PR TITLE
Upgrade Mafs to v0.19.0 (Domain-restricted functions)

### DIFF
--- a/.changeset/new-fireants-draw.md
+++ b/.changeset/new-fireants-draw.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Upgrade Mafs Dependency to v0.19.0 for Domain Restricted Functions

--- a/packages/perseus/package.json
+++ b/packages/perseus/package.json
@@ -47,7 +47,7 @@
         "@khanacademy/pure-markdown": "^0.3.7",
         "@khanacademy/simple-markdown": "^0.13.0",
         "@use-gesture/react": "^10.2.27",
-        "mafs": "0.18.7"
+        "mafs": "0.19.0"
     },
     "devDependencies": {
         "@khanacademy/wonder-blocks-banner": "3.0.42",

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -7,10 +7,6 @@ import type {Interval, vec} from "mafs";
 // Range is replaced within this file with Interval, but it is used elsewhere
 // and exported from the package, so we need to keep it around.
 export type Range = Interval;
-export type Domain = {
-    min?: number;
-    max?: number;
-};
 export type Size = [number, number];
 export type CollinearTuple = [vec.Vector2, vec.Vector2];
 export type ShowSolutions = "all" | "selected" | "none";
@@ -745,7 +741,7 @@ export type LockedFunctionType = {
         [k: string]: any;
     };
     directionalAxis: "x" | "y";
-    domain?: Domain;
+    domain?: Interval;
 };
 
 export type PerseusGraphType =

--- a/packages/perseus/src/widgets/__stories__/locked-functions.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/locked-functions.stories.tsx
@@ -49,7 +49,7 @@ export const DomainRestrictedMin = (args: StoryArgs): React.ReactElement => (
     <RendererWithDebugUI
         {...mafsOptions}
         question={segmentWithLockedFunction("sin(x)", {
-            domain: {min: -5},
+            domain: [-5, Infinity],
         })}
     />
 );
@@ -58,7 +58,7 @@ export const DomainRestrictedMax = (args: StoryArgs): React.ReactElement => (
     <RendererWithDebugUI
         {...mafsOptions}
         question={segmentWithLockedFunction("sin(x)", {
-            domain: {max: 5},
+            domain: [-Infinity, 5],
         })}
     />
 );
@@ -67,7 +67,7 @@ export const DomainRestrictedBoth = (args: StoryArgs): React.ReactElement => (
     <RendererWithDebugUI
         {...mafsOptions}
         question={segmentWithLockedFunction("sin(x)", {
-            domain: {min: -5, max: 5},
+            domain: [-5, 5],
         })}
     />
 );

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
@@ -976,7 +976,7 @@ describe("InteractiveGraphQuestionBuilder", () => {
                 color: "green",
                 strokeStyle: "dashed",
                 directionalAxis: "y",
-                domain: {min: -5, max: 5},
+                domain: [-5, 5],
             })
             .build();
         const graph = question.widgets["interactive-graph 1"];
@@ -988,7 +988,7 @@ describe("InteractiveGraphQuestionBuilder", () => {
                 color: "green",
                 strokeStyle: "dashed",
                 directionalAxis: "y",
-                domain: {min: -5, max: 5},
+                domain: [-5, 5],
             },
         ]);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -11679,10 +11679,10 @@ lz-string@^1.5.0:
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
   integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
 
-mafs@0.18.7:
-  version "0.18.7"
-  resolved "https://registry.yarnpkg.com/mafs/-/mafs-0.18.7.tgz#1e17de9fc54d1a1253c6b0125fb42a5449344dae"
-  integrity sha512-NGUORtHXFZDK87A0R6wWNNZ/sTq8vpbwt92Z0RdT3nImZiNHRYEZ05X7Uv2Sd7WlqxdxJI1X/i1bSOjoLC3L9A==
+mafs@0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/mafs/-/mafs-0.19.0.tgz#23b534d8602f194a7b1be7c4ff2e000afde9c240"
+  integrity sha512-mDHQhCbkIYjpuycY8mMV8O+o3ZOIGPgxliipcRE6aBGOXFvlwP2qvz9FQFdIr5W/BfcMY7CkgOqbPQJiKCr74w==
   dependencies:
     "@use-gesture/react" "^10.2.27"
     computer-modern "^0.1.2"
@@ -15135,7 +15135,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -15152,15 +15152,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -15246,7 +15237,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15259,13 +15250,6 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -16480,7 +16464,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -16493,15 +16477,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Summary:
With this upgrade, Mafs now supports domain restrictions when plotting functions. Once this upgrade is in place, locked functions will have domain restrictions as an option.

Issue: LEMS-2140

## Test plan:
1. Launch Storybook (yarn start)
1. Navigate to Perseus => Widgets => Interactive Graph => Locked Functions
   * [Minimum domain](http://localhost:6006/?path=/story/perseus-widgets-interactive-graph-locked-functions--domain-restricted-min): Starts at x=-5 and plots all values greater (i.e. to the right).
   * [Maximum domain](http://localhost:6006/?path=/story/perseus-widgets-interactive-graph-locked-functions--domain-restricted-max): Ends at x=5 and plots all values less than (i.e. to the left).
   * [Combined restrictions](http://localhost:6006/?path=/story/perseus-widgets-interactive-graph-locked-functions--domain-restricted-both): Starts at x=-5 and ends at x=5 and plots values in between.

## Expected Outcomes:

**Minimum domain:**
![Minimum domain](https://github.com/user-attachments/assets/2227accd-067a-40f9-b1cc-55bc53ddee86)

**Maximum domain:**
![Maximum domain](https://github.com/user-attachments/assets/888c19ad-8ce6-4b3c-97be-89e7a4adfa69)

**Combined restrictions:**
![Combined restrictions](https://github.com/user-attachments/assets/bdac1da4-c226-44f8-b7df-d556cd34ddea)
