### PR TITLE
Add static mode to interactive graph

### DIFF
--- a/.changeset/gentle-dragons-hide.md
+++ b/.changeset/gentle-dragons-hide.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Add static mode to interactive graph

--- a/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
@@ -20,6 +20,8 @@ import {
     segmentWithLockedEllipses,
     segmentWithLockedVectors,
     segmentWithLockedPolygons,
+    staticGraph,
+    staticGraphWithAnotherQuestion,
 } from "../__testdata__/interactive-graph.testdata";
 
 export default {
@@ -138,6 +140,19 @@ export const LockedPolygon = (args: StoryArgs): React.ReactElement => (
 
 export const Sinusoid = (args: StoryArgs): React.ReactElement => (
     <RendererWithDebugUI question={sinusoidQuestion} />
+);
+
+export const StaticGraph = (args: StoryArgs): React.ReactElement => (
+    <RendererWithDebugUI {...mafsOptions} question={staticGraph} />
+);
+
+export const StaticGraphWithAnotherWidget = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <RendererWithDebugUI
+        {...mafsOptions}
+        question={staticGraphWithAnotherQuestion()}
+    />
 );
 
 // TODO(jeremy): As of Jan 2022 there are no peresus items in production that

--- a/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
@@ -1,7 +1,7 @@
 import {interactiveGraphQuestionBuilder} from "../interactive-graphs/interactive-graph-question-builder";
 
 import type {Coord} from "../../interactive2/types";
-import type {PerseusRenderer} from "../../perseus-types";
+import type {PerseusRenderer, RadioWidget} from "../../perseus-types";
 import type {LockedFunctionOptions} from "../interactive-graphs/interactive-graph-question-builder";
 
 // Data for the interactive graph widget
@@ -734,3 +734,86 @@ export const quadraticQuestion: PerseusRenderer =
 
 export const quadraticQuestionWithDefaultCorrect: PerseusRenderer =
     interactiveGraphQuestionBuilder().withQuadratic().build();
+
+export const staticGraph: PerseusRenderer = interactiveGraphQuestionBuilder()
+    .addLockedPointAt(-7, -7)
+    .addLockedLine([-7, -5], [2, -3])
+    .addLockedVector([0, 0], [8, 2], "purple")
+    .addLockedEllipse([0, 5], [4, 2], {angle: Math.PI / 4, color: "blue"})
+    .addLockedPolygon(
+        [
+            [-9, 4],
+            [-6, 4],
+            [-6, 1],
+            [-9, 1],
+        ],
+        {color: "pink"},
+    )
+    .withStaticMode(true)
+    .build();
+
+export const staticGraphWithAnotherQuestion: () => PerseusRenderer = () => {
+    const result = interactiveGraphQuestionBuilder()
+        .addLockedPointAt(-7, -7)
+        .addLockedLine([-7, -5], [2, -3])
+        .addLockedVector([0, 0], [8, 2], "purple")
+        .addLockedEllipse([0, 5], [4, 2], {angle: Math.PI / 4, color: "blue"})
+        .addLockedPolygon(
+            [
+                [-9, 4],
+                [-6, 4],
+                [-6, 1],
+                [-9, 1],
+            ],
+            {color: "pink"},
+        )
+        .withStaticMode(true)
+        .build();
+    result["widgets"] = {
+        ...result["widgets"],
+        "radio 1": {
+            graded: true,
+            version: {
+                major: 1,
+                minor: 0,
+            },
+            static: false,
+            type: "radio",
+            options: {
+                displayCount: null,
+                choices: [
+                    {
+                        content: "$-8$ and $8$",
+                        correct: false,
+                        clue: "The square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number, so $x$ is equal to *only* $8$.",
+                    },
+                    {
+                        content: "$-8$",
+                        correct: false,
+                        clue: "While $(-8)^2=64$, the square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number.",
+                    },
+                    {
+                        content: "The right answer !!!\n\n",
+                        correct: true,
+                        isNoneOfTheAbove: false,
+                        clue: "$8$ is the positive square root of $64$.",
+                    },
+                    {
+                        content: "No value of $x$ satisfies the equation.",
+                        correct: false,
+                        isNoneOfTheAbove: false,
+                        clue: "$8$ satisfies the equation.",
+                    },
+                ],
+                countChoices: false,
+                hasNoneOfTheAbove: false,
+                multipleSelect: false,
+                randomize: false,
+                deselectEnabled: false,
+            },
+            alignment: "default",
+        } as RadioWidget,
+    };
+    result["content"] = "[[\u2603 radio 1]]\n\n" + result["content"];
+    return result;
+};

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -2692,9 +2692,12 @@ export function shouldUseMafs(
             return Boolean(mafsFlags[graph.type]);
     }
 }
+// We don't need to change any of the original props for static mode
+const staticTransform = _.identity;
 
 export default {
     name: "interactive-graph",
     displayName: "Interactive graph",
     widget: InteractiveGraph,
+    staticTransform: staticTransform,
 } as WidgetExports<typeof InteractiveGraph>;

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -48,6 +48,7 @@ class InteractiveGraphQuestionBuilder {
         new SegmentGraphConfig();
     private lockedFigures: LockedFigure[] = [];
     private snapTo: "grid" | "angles" | "sides" = "grid";
+    private staticMode: boolean = false;
 
     build(): PerseusRenderer {
         return {
@@ -56,6 +57,7 @@ class InteractiveGraphQuestionBuilder {
             widgets: {
                 "interactive-graph 1": {
                     graded: true,
+                    static: this.staticMode,
                     options: {
                         correct: this.interactiveFigureConfig.correct(),
                         backgroundImage: this.backgroundImage,
@@ -84,6 +86,11 @@ class InteractiveGraphQuestionBuilder {
 
     withContent(content: string): InteractiveGraphQuestionBuilder {
         this.content = content;
+        return this;
+    }
+
+    withStaticMode(staticMode: boolean): InteractiveGraphQuestionBuilder {
+        this.staticMode = staticMode;
         return this;
     }
 


### PR DESCRIPTION
## Summary:
Adds static mode and a helper to the builder function to mark a graph as static.

New button in content editor:
<img width="494" alt="Screenshot 2024-07-29 at 2 41 59 PM" src="https://github.com/user-attachments/assets/1dfe4e59-19df-4533-b723-1b8a816edebc">

Grading:
<img width="928" alt="Screenshot 2024-07-29 at 2 31 29 PM" src="https://github.com/user-attachments/assets/6b1463db-8eb9-4523-b19f-610620c31e08">
<img width="1314" alt="Screenshot 2024-07-29 at 2 31 05 PM" src="https://github.com/user-attachments/assets/5d008848-075a-448c-a07d-7f90ed3b6cf9">




Issue: LC-2019

## Test plan:
- Visit storybook
- There should be two new stories

- **In "Static Graph" you should not be able to interact with the graph**
- **In "Static Graph With Another Widget" you should be graded only on the radio widget**

- Go to the editor demo
- **You should be able to toggle static"**