### PR TITLE
Use :focus-visible to show focus indictor on polygon

### DIFF
--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.tsx
@@ -16,7 +16,6 @@ interface PolygonAngleProps {
     centerPoint: vec.Vector2;
     endPoints: [vec.Vector2, vec.Vector2];
     polygonLines: readonly CollinearTuple[];
-    active: boolean;
     range: [Interval, Interval];
     showAngles: boolean;
     snapTo: "grid" | "angles" | "sides";


### PR DESCRIPTION
I felt like suggesting these changes inline on https://github.com/Khan/perseus/pull/1455 would be too cumbersome, so I'm doing it in a PR instead.