### PR TITLE
[Interactive Graph Editor - Stories] Fix broken default and controlled stories

### DIFF
--- a/.changeset/wicked-rocks-exist.md
+++ b/.changeset/wicked-rocks-exist.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Interactive Graph Editor - Storybook] Fix broken default and controlled stories

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
@@ -473,7 +473,7 @@ class InteractiveGraphEditor extends React.Component<Props> {
                     </LabeledRow>
                 )}
                 {this.props.graph?.type &&
-                    this.props.apiOptions.flags?.mafs?.["start-coords-ui"] && (
+                    this.props.apiOptions?.flags?.mafs?.["start-coords-ui"] && (
                         <StartCoordsSettings
                             {...this.props.graph}
                             range={this.props.range}


### PR DESCRIPTION
## Summary:
The stories are broken because of a missing null check.

Adding that here.

Issue: none

## Test plan:
`yarn start`
Check that the following stories work
- http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph-editor--default
- http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph-editor--controlled