### PR TITLE
[Hint Mode: Start Coords] Add separate flags for graph types

### DIFF
--- a/.changeset/slow-taxis-give.md
+++ b/.changeset/slow-taxis-give.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+[Hint Mode: Start Coords] Add separate flags for graph types

--- a/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
+++ b/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
@@ -11,9 +11,24 @@ export const flags = {
         linear: true,
         "linear-system": true,
         ray: true,
-        "start-coords-ui": true,
+
+        // Locked figures flags
         "interactive-graph-locked-features-m2": true,
         "interactive-graph-locked-features-m2b": true,
+
+        // Start coords UI flags
+        "start-coords-ui": {
+            angle: false,
+            segment: true,
+            circle: true,
+            quadratic: false,
+            sinusoid: false,
+            polygon: false,
+            linear: true,
+            "linear-system": true,
+            ray: true,
+            point: false,
+        },
     },
 } satisfies APIOptions["flags"];
 

--- a/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
+++ b/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
@@ -17,18 +17,7 @@ export const flags = {
         "interactive-graph-locked-features-m2b": true,
 
         // Start coords UI flags
-        "start-coords-ui": {
-            angle: false,
-            segment: true,
-            circle: true,
-            quadratic: false,
-            sinusoid: false,
-            polygon: false,
-            linear: true,
-            "linear-system": true,
-            ray: true,
-            point: false,
-        },
+        "start-coords-ui-phase-1": true,
     },
 } satisfies APIOptions["flags"];
 

--- a/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
+++ b/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
@@ -17,6 +17,7 @@ export const flags = {
         "interactive-graph-locked-features-m2b": true,
 
         // Start coords UI flags
+        // TODO(LEMS-2228): Remove flags once this is fully released
         "start-coords-ui-phase-1": true,
     },
 } satisfies APIOptions["flags"];

--- a/packages/perseus-editor/src/__stories__/interactive-graph-editor.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/interactive-graph-editor.stories.tsx
@@ -122,7 +122,6 @@ export const MafsWithLockedFiguresCurrent = (): React.ReactElement => {
                 flags: {
                     mafs: {
                         ...flags.mafs,
-                        "start-coords-ui": false,
                         "interactive-graph-locked-features-m2": false,
                         "interactive-graph-locked-features-m2b": false,
                     },
@@ -149,7 +148,6 @@ export const MafsWithLockedFiguresM2Flag = (): React.ReactElement => {
                 flags: {
                     mafs: {
                         ...flags.mafs,
-                        "start-coords-ui": false,
                         "interactive-graph-locked-features-m2": true,
                         "interactive-graph-locked-features-m2b": false,
                     },

--- a/packages/perseus-editor/src/components/start-coords-settings.tsx
+++ b/packages/perseus-editor/src/components/start-coords-settings.tsx
@@ -21,6 +21,8 @@ import {getDefaultGraphStartCoords} from "./util";
 import type {PerseusGraphType, Range} from "@khanacademy/perseus";
 
 type Props = PerseusGraphType & {
+    // TODO(LEMS-2228): Remove flags once this is fully released
+    phase1: boolean;
     range: [x: Range, y: Range];
     step: [x: number, y: number];
     onChange: (startCoords: PerseusGraphType["startCoords"]) => void;
@@ -77,6 +79,19 @@ const StartCoordsSettingsInner = (props: Props) => {
 const StartCoordsSettings = (props: Props) => {
     const {range, step, onChange} = props;
     const [isOpen, setIsOpen] = React.useState(true);
+
+    if (
+        props.phase1 &&
+        !(
+            props.type === "linear" ||
+            props.type === "linear-system" ||
+            props.type === "ray" ||
+            props.type === "segment" ||
+            props.type === "circle"
+        )
+    ) {
+        return null;
+    }
 
     return (
         <View>

--- a/packages/perseus-editor/src/components/start-coords-settings.tsx
+++ b/packages/perseus-editor/src/components/start-coords-settings.tsx
@@ -21,8 +21,6 @@ import {getDefaultGraphStartCoords} from "./util";
 import type {PerseusGraphType, Range} from "@khanacademy/perseus";
 
 type Props = PerseusGraphType & {
-    // TODO(LEMS-2228): Remove flags once this is fully released
-    phase1?: boolean;
     range: [x: Range, y: Range];
     step: [x: number, y: number];
     onChange: (startCoords: PerseusGraphType["startCoords"]) => void;
@@ -79,23 +77,6 @@ const StartCoordsSettingsInner = (props: Props) => {
 const StartCoordsSettings = (props: Props) => {
     const {range, step, onChange} = props;
     const [isOpen, setIsOpen] = React.useState(true);
-
-    if (!props.phase1) {
-        return null;
-    }
-
-    if (
-        props.phase1 &&
-        !(
-            props.type === "linear" ||
-            props.type === "linear-system" ||
-            props.type === "ray" ||
-            props.type === "segment" ||
-            props.type === "circle"
-        )
-    ) {
-        return null;
-    }
 
     return (
         <View>

--- a/packages/perseus-editor/src/components/start-coords-settings.tsx
+++ b/packages/perseus-editor/src/components/start-coords-settings.tsx
@@ -22,7 +22,7 @@ import type {PerseusGraphType, Range} from "@khanacademy/perseus";
 
 type Props = PerseusGraphType & {
     // TODO(LEMS-2228): Remove flags once this is fully released
-    phase1: boolean;
+    phase1?: boolean;
     range: [x: Range, y: Range];
     step: [x: number, y: number];
     onChange: (startCoords: PerseusGraphType["startCoords"]) => void;
@@ -79,6 +79,10 @@ const StartCoordsSettingsInner = (props: Props) => {
 const StartCoordsSettings = (props: Props) => {
     const {range, step, onChange} = props;
     const [isOpen, setIsOpen] = React.useState(true);
+
+    if (!props.phase1) {
+        return null;
+    }
 
     if (
         props.phase1 &&

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
@@ -672,4 +672,60 @@ describe("InteractiveGraphEditor", () => {
             }),
         );
     });
+
+    test.each`
+        type               | shouldRender
+        ${"linear"}        | ${true}
+        ${"ray"}           | ${true}
+        ${"linear-system"} | ${true}
+        ${"segment"}       | ${true}
+        ${"circle"}        | ${true}
+        ${"quadratic"}     | ${false}
+        ${"sinusoid"}      | ${false}
+        ${"polygon"}       | ${false}
+        ${"angle"}         | ${false}
+        ${"point"}         | ${false}
+    `(
+        "should render for $type graphs if phase1 flag is on: $shouldRender",
+        async ({type, shouldRender}) => {
+            // Arrange
+
+            // Act
+            render(
+                <InteractiveGraphEditor
+                    {...baseProps}
+                    apiOptions={{
+                        ...ApiOptions.defaults,
+                        flags: {
+                            ...flags,
+                            mafs: {
+                                ...flags.mafs,
+                                "start-coords-ui-phase-1": shouldRender,
+                            },
+                        },
+                    }}
+                    graph={{type}}
+                    correct={{type}}
+                />,
+                {
+                    wrapper: RenderStateRoot,
+                },
+            );
+
+            // Assert
+            if (shouldRender) {
+                expect(
+                    await screen.findByRole("button", {
+                        name: "Use default start coordinates",
+                    }),
+                ).toBeInTheDocument();
+            } else {
+                expect(
+                    screen.queryByRole("button", {
+                        name: "Use default start coordinates",
+                    }),
+                ).toBeNull();
+            }
+        },
+    );
 });

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
@@ -62,6 +62,15 @@ const POLYGON_SIDES = _.map(_.range(3, 13), function (value) {
     );
 });
 
+// TODO(LEMS-2228): Remove flags once this is fully released
+const startCoordsUiPhase1Types = [
+    "linear",
+    "linear-system",
+    "ray",
+    "segment",
+    "circle",
+];
+
 type Range = [min: number, max: number];
 
 export type Props = {
@@ -472,19 +481,21 @@ class InteractiveGraphEditor extends React.Component<Props> {
                         />
                     </LabeledRow>
                 )}
-                {this.props.graph?.type && (
-                    <StartCoordsSettings
-                        {...this.props.graph}
-                        phase1={
-                            this.props.apiOptions?.flags?.mafs?.[
-                                "start-coords-ui-phase-1"
-                            ]
-                        }
-                        range={this.props.range}
-                        step={this.props.step}
-                        onChange={this.changeStartCoords}
-                    />
-                )}
+                {this.props.graph?.type &&
+                    // TODO(LEMS-2228): Remove flags once this is fully released
+                    this.props.apiOptions?.flags?.mafs?.[
+                        "start-coords-ui-phase-1"
+                    ] &&
+                    startCoordsUiPhase1Types.includes(
+                        this.props.graph.type,
+                    ) && (
+                        <StartCoordsSettings
+                            {...this.props.graph}
+                            range={this.props.range}
+                            step={this.props.step}
+                            onChange={this.changeStartCoords}
+                        />
+                    )}
                 <InteractiveGraphSettings
                     box={getInteractiveBoxFromSizeClass(sizeClass)}
                     range={this.props.range}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
@@ -473,7 +473,7 @@ class InteractiveGraphEditor extends React.Component<Props> {
                     </LabeledRow>
                 )}
                 {this.props.graph?.type &&
-                    this.props.apiOptions?.flags?.mafs?.["start-coords-ui"] && (
+                    (this.props.apiOptions?.flags?.mafs?.["start-coords-ui"][this.props.graph.type]) && (
                         <StartCoordsSettings
                             {...this.props.graph}
                             range={this.props.range}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
@@ -473,9 +473,12 @@ class InteractiveGraphEditor extends React.Component<Props> {
                     </LabeledRow>
                 )}
                 {this.props.graph?.type &&
-                    (this.props.apiOptions?.flags?.mafs?.["start-coords-ui"][this.props.graph.type]) && (
+                    this.props.apiOptions?.flags?.mafs?.[
+                        "start-coords-ui-phase-1"
+                    ] && (
                         <StartCoordsSettings
                             {...this.props.graph}
+                            phase1={true}
                             range={this.props.range}
                             step={this.props.step}
                             onChange={this.changeStartCoords}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
@@ -472,18 +472,19 @@ class InteractiveGraphEditor extends React.Component<Props> {
                         />
                     </LabeledRow>
                 )}
-                {this.props.graph?.type &&
-                    this.props.apiOptions?.flags?.mafs?.[
-                        "start-coords-ui-phase-1"
-                    ] && (
-                        <StartCoordsSettings
-                            {...this.props.graph}
-                            phase1={true}
-                            range={this.props.range}
-                            step={this.props.step}
-                            onChange={this.changeStartCoords}
-                        />
-                    )}
+                {this.props.graph?.type && (
+                    <StartCoordsSettings
+                        {...this.props.graph}
+                        phase1={
+                            this.props.apiOptions?.flags?.mafs?.[
+                                "start-coords-ui-phase-1"
+                            ]
+                        }
+                        range={this.props.range}
+                        step={this.props.step}
+                        onChange={this.changeStartCoords}
+                    />
+                )}
                 <InteractiveGraphSettings
                     box={getInteractiveBoxFromSizeClass(sizeClass)}
                     range={this.props.range}

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -162,13 +162,6 @@ export const InteractiveGraphLockedFeaturesFlags = [
     "interactive-graph-locked-features-m2b",
 ] as const;
 
-export const InteractiveGraphEditorFlags = [
-    /**
-     * Enables the UI for setting the start coordinates of a graph.
-     */
-    "start-coords-ui",
-] as const;
-
 /**
  * APIOptions provides different ways to customize the behaviour of Perseus.
  *
@@ -304,7 +297,7 @@ export type APIOptions = Readonly<{
             | ({[Key in (typeof MafsGraphTypeFlags)[number]]?: boolean} & {
                   [Key in (typeof InteractiveGraphLockedFeaturesFlags)[number]]?: boolean;
               } & {
-                  [Key in (typeof InteractiveGraphEditorFlags)[number]]?: boolean;
+                  "start-coords-ui": {[Key in (typeof MafsGraphTypeFlags)[number]]?: boolean};
               });
     };
     /**

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -162,6 +162,14 @@ export const InteractiveGraphLockedFeaturesFlags = [
     "interactive-graph-locked-features-m2b",
 ] as const;
 
+export const InteractiveGraphEditorFlags = [
+    /**
+     * Enables the UI for setting the start coordinates of a graph.
+     * Includes linear, linear-system, ray, segment, and circle graphs.
+     */
+    "start-coords-ui-phase-1",
+] as const;
+
 /**
  * APIOptions provides different ways to customize the behaviour of Perseus.
  *
@@ -297,7 +305,7 @@ export type APIOptions = Readonly<{
             | ({[Key in (typeof MafsGraphTypeFlags)[number]]?: boolean} & {
                   [Key in (typeof InteractiveGraphLockedFeaturesFlags)[number]]?: boolean;
               } & {
-                  "start-coords-ui": {[Key in (typeof MafsGraphTypeFlags)[number]]?: boolean};
+                  [Key in (typeof InteractiveGraphEditorFlags)[number]]?: boolean;
               });
     };
     /**


### PR DESCRIPTION
## Summary:
We want to be able to release the start coords UI even if
only a subset of graph types are ready. To accomodate this,
I'm adding individual flags for each graph type.

Issue: none

## Test plan:
Storybook
- http://localhost:6006/?path=/docs/perseuseditor-widgets-interactive-graph--docs
- Confirm that the UI shows up for the currently landed graphs - segment, ray, linear, linear-system, circle
- Confirm that the UI does not show up for the graphs that are not done yet - sinusoid, quadratic, angle, polygon, point