### PR TITLE
[Interactive Graph Editor] Fix the dropdowns overlapping labels in locked figures settings

### DIFF
--- a/.changeset/nervous-dancers-exist.md
+++ b/.changeset/nervous-dancers-exist.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Interactive Graph Editor] Fix the dropdowns overlapping labels in locked figures settings

--- a/packages/perseus-editor/src/components/graph-locked-figures/color-select.tsx
+++ b/packages/perseus-editor/src/components/graph-locked-figures/color-select.tsx
@@ -58,6 +58,9 @@ const styles = StyleSheet.create({
         display: "flex",
         flexDirection: "row",
         alignItems: "center",
+        // Set minWidth to "auto" to prevent the component from bleeding
+        // into the margins. (minWidth is 0 by default.)
+        minWidth: "auto",
     },
 });
 

--- a/packages/perseus-editor/src/components/graph-locked-figures/locked-ellipse-settings.tsx
+++ b/packages/perseus-editor/src/components/graph-locked-figures/locked-ellipse-settings.tsx
@@ -113,7 +113,10 @@ const LockedEllipseSettings = (props: Props) => {
                 <Strut size={spacing.medium_16} />
 
                 {/* Fill opacity */}
-                <LabelMedium tag="label" style={styles.row}>
+                <LabelMedium
+                    tag="label"
+                    style={[styles.row, styles.truncatedWidth]}
+                >
                     fill
                     <Strut size={spacing.xxSmall_6} />
                     <SingleSelect
@@ -171,6 +174,10 @@ const styles = StyleSheet.create({
     },
     spaceUnder: {
         marginBottom: spacing.xSmall_8,
+    },
+    truncatedWidth: {
+        // Allow truncation, stop bleeding over the edge.
+        minWidth: 0,
     },
 });
 

--- a/packages/perseus-editor/src/components/graph-locked-figures/locked-line-settings.tsx
+++ b/packages/perseus-editor/src/components/graph-locked-figures/locked-line-settings.tsx
@@ -129,7 +129,10 @@ const LockedLineSettings = (props: Props) => {
                 <Strut size={spacing.small_12} />
 
                 {/* Line style settings */}
-                <LabelMedium tag="label" style={styles.row}>
+                <LabelMedium
+                    tag="label"
+                    style={[styles.row, styles.truncatedWidth]}
+                >
                     style
                     <Strut size={spacing.xxxSmall_4} />
                     <SingleSelect
@@ -202,6 +205,10 @@ const styles = StyleSheet.create({
     },
     errorText: {
         color: wbColor.red,
+    },
+    truncatedWidth: {
+        // Allow truncation, stop bleeding over the edge.
+        minWidth: 0,
     },
 });
 

--- a/packages/perseus-editor/src/components/graph-locked-figures/locked-polygon-settings.tsx
+++ b/packages/perseus-editor/src/components/graph-locked-figures/locked-polygon-settings.tsx
@@ -79,7 +79,10 @@ const LockedPolygonSettings = (props: Props) => {
                 <Strut size={spacing.medium_16} />
 
                 {/* Fill opacity */}
-                <LabelMedium tag="label" style={styles.row}>
+                <LabelMedium
+                    tag="label"
+                    style={[styles.row, styles.truncatedWidth]}
+                >
                     fill
                     <Strut size={spacing.xxSmall_6} />
                     <SingleSelect
@@ -218,6 +221,10 @@ const styles = StyleSheet.create({
     },
     spaceUnder: {
         marginBottom: spacing.xSmall_8,
+    },
+    truncatedWidth: {
+        // Allow truncation, stop bleeding over the edge.
+        minWidth: 0,
     },
 });
 


### PR DESCRIPTION
## Summary:
There was an issue where some of the dropdowns in the locked figures settings are
expanding to fit their content, and thereby overlapping other labels. The intended
behavior is for the dropdown label to truncate.

Fixing that with CSS here.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2118

## Test plan:
Storybook
- http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--mafs-with-locked-figures-m-2-b-flag
- Use the dev tools to make all the locked figure settings 306px to reflect how they
  are in webapp.
- Set all the dropdowns to their longest options.
- Confirm that they truncate, and that the horizontal space between the labels
  and dropdowns is there.