### PR TITLE
Migrate ItemExtrasEditor to Wonder-Blocks

### DIFF
--- a/.changeset/young-suns-beg.md
+++ b/.changeset/young-suns-beg.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Migrate ItemExtrasEditor to WB checkboxes

--- a/packages/perseus-editor/src/__tests__/item-extras-editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/item-extras-editor.test.tsx
@@ -19,19 +19,19 @@ describe("ItemExtrasEditor", () => {
         render(<ItemExtrasEditor onChange={() => {}} />);
 
         // Assert
-        expect(screen.getByLabelText("Show calculator:")).not.toBeChecked();
-        expect(screen.getByLabelText("Show periodic table:")).not.toBeChecked();
+        expect(screen.getByLabelText("Show calculator")).not.toBeChecked();
+        expect(screen.getByLabelText("Show periodic table")).not.toBeChecked();
         expect(
-            screen.queryByText("Include key/legend with periodic table:"),
+            screen.queryByText("Include key/legend with periodic table"),
         ).not.toBeInTheDocument();
         expect(
-            screen.getByLabelText("Show z table (statistics):"),
+            screen.getByLabelText("Show z table (statistics)"),
         ).not.toBeChecked();
         expect(
-            screen.getByLabelText("Show t table (statistics):"),
+            screen.getByLabelText("Show t table (statistics)"),
         ).not.toBeChecked();
         expect(
-            screen.getByLabelText("Show chi-squared table (statistics):"),
+            screen.getByLabelText("Show chi-squared table (statistics)"),
         ).not.toBeChecked();
     });
 
@@ -39,7 +39,7 @@ describe("ItemExtrasEditor", () => {
         // Arrange
         const onChangeMock = jest.fn();
         render(<ItemExtrasEditor calculator={false} onChange={onChangeMock} />);
-        const checkbox = screen.getByLabelText("Show calculator:");
+        const checkbox = screen.getByLabelText("Show calculator");
 
         // Act
         await userEvent.click(checkbox);
@@ -58,7 +58,7 @@ describe("ItemExtrasEditor", () => {
                 onChange={onChangeMock}
             />,
         );
-        const checkbox = screen.getByLabelText("Show periodic table:");
+        const checkbox = screen.getByLabelText("Show periodic table");
 
         // Act
         await userEvent.click(checkbox);
@@ -66,7 +66,7 @@ describe("ItemExtrasEditor", () => {
         // Assert
         // visible when periodicTable is checked
         expect(
-            screen.getByText("Include key/legend with periodic table:"),
+            screen.getByText("Include key/legend with periodic table"),
         ).toBeInTheDocument();
         expect(onChangeMock).toHaveBeenCalledWith({
             periodicTable: false,
@@ -119,21 +119,17 @@ describe("ItemExtrasEditor", () => {
             render(<TestComponent />);
 
             // Act
-            const checkbox = screen.getByLabelText(
-                "Show financial calculator:",
-            );
+            const checkbox = screen.getByLabelText("Show financial calculator");
             await userEvent.click(checkbox);
 
             // Assert
             expect(checkbox).toBeChecked();
             expect(
-                screen.getByLabelText("Include monthly payment:"),
+                screen.getByLabelText("Include monthly payment"),
             ).toBeChecked();
+            expect(screen.getByLabelText("Include total amount")).toBeChecked();
             expect(
-                screen.getByLabelText("Include total amount:"),
-            ).toBeChecked();
-            expect(
-                screen.getByLabelText("Include time-to-pay-off:"),
+                screen.getByLabelText("Include time-to-pay-off"),
             ).toBeChecked();
         });
 
@@ -143,16 +139,16 @@ describe("ItemExtrasEditor", () => {
 
             // Assert
             expect(
-                screen.getByLabelText("Show financial calculator:"),
+                screen.getByLabelText("Show financial calculator"),
             ).toBeChecked();
             expect(
-                screen.getByLabelText("Include monthly payment:"),
+                screen.getByLabelText("Include monthly payment"),
             ).toBeChecked();
             expect(
-                screen.getByLabelText("Include total amount:"),
+                screen.getByLabelText("Include total amount"),
             ).not.toBeChecked();
             expect(
-                screen.getByLabelText("Include time-to-pay-off:"),
+                screen.getByLabelText("Include time-to-pay-off"),
             ).not.toBeChecked();
         });
 
@@ -162,21 +158,21 @@ describe("ItemExtrasEditor", () => {
 
             // Act
             await userEvent.click(
-                screen.getByLabelText("Include monthly payment:"),
+                screen.getByLabelText("Include monthly payment"),
             );
 
             // Assert
             expect(
-                screen.getByLabelText("Show financial calculator:"),
+                screen.getByLabelText("Show financial calculator"),
             ).not.toBeChecked();
             expect(
-                screen.queryByLabelText("Include monthly payment:"),
+                screen.queryByLabelText("Include monthly payment"),
             ).not.toBeInTheDocument();
             expect(
-                screen.queryByLabelText("Include total amount:"),
+                screen.queryByLabelText("Include total amount"),
             ).not.toBeInTheDocument();
             expect(
-                screen.queryByLabelText("Include time-to-pay-off:"),
+                screen.queryByLabelText("Include time-to-pay-off"),
             ).not.toBeInTheDocument();
         });
 
@@ -184,9 +180,7 @@ describe("ItemExtrasEditor", () => {
             // Arrange
             const onChangeMock = jest.fn();
             render(<ItemExtrasEditor onChange={onChangeMock} />);
-            const checkbox = screen.getByLabelText(
-                "Show financial calculator:",
-            );
+            const checkbox = screen.getByLabelText("Show financial calculator");
 
             // Act
             await userEvent.click(checkbox);
@@ -210,9 +204,7 @@ describe("ItemExtrasEditor", () => {
                     financialCalculatorTimeToPayOff={true}
                 />,
             );
-            const checkbox = screen.getByLabelText(
-                "Show financial calculator:",
-            );
+            const checkbox = screen.getByLabelText("Show financial calculator");
 
             // Act
             await userEvent.click(checkbox);

--- a/packages/perseus-editor/src/__tests__/item-extras-editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/item-extras-editor.test.tsx
@@ -19,19 +19,25 @@ describe("ItemExtrasEditor", () => {
         render(<ItemExtrasEditor onChange={() => {}} />);
 
         // Assert
-        expect(screen.getByLabelText("Show calculator")).not.toBeChecked();
-        expect(screen.getByLabelText("Show periodic table")).not.toBeChecked();
+        expect(
+            screen.getByRole("checkbox", {name: "Show calculator"}),
+        ).not.toBeChecked();
+        expect(
+            screen.getByRole("checkbox", {name: "Show periodic table"}),
+        ).not.toBeChecked();
         expect(
             screen.queryByText("Include key/legend with periodic table"),
         ).not.toBeInTheDocument();
         expect(
-            screen.getByLabelText("Show z table (statistics)"),
+            screen.getByRole("checkbox", {name: "Show z table (statistics)"}),
         ).not.toBeChecked();
         expect(
-            screen.getByLabelText("Show t table (statistics)"),
+            screen.getByRole("checkbox", {name: "Show t table (statistics)"}),
         ).not.toBeChecked();
         expect(
-            screen.getByLabelText("Show chi-squared table (statistics)"),
+            screen.getByRole("checkbox", {
+                name: "Show chi-squared table (statistics)",
+            }),
         ).not.toBeChecked();
     });
 
@@ -39,7 +45,9 @@ describe("ItemExtrasEditor", () => {
         // Arrange
         const onChangeMock = jest.fn();
         render(<ItemExtrasEditor calculator={false} onChange={onChangeMock} />);
-        const checkbox = screen.getByLabelText("Show calculator");
+        const checkbox = screen.getByRole("checkbox", {
+            name: "Show calculator",
+        });
 
         // Act
         await userEvent.click(checkbox);
@@ -58,7 +66,9 @@ describe("ItemExtrasEditor", () => {
                 onChange={onChangeMock}
             />,
         );
-        const checkbox = screen.getByLabelText("Show periodic table");
+        const checkbox = screen.getByRole("checkbox", {
+            name: "Show periodic table",
+        });
 
         // Act
         await userEvent.click(checkbox);
@@ -119,17 +129,21 @@ describe("ItemExtrasEditor", () => {
             render(<TestComponent />);
 
             // Act
-            const checkbox = screen.getByLabelText("Show financial calculator");
+            const checkbox = screen.getByRole("checkbox", {
+                name: "Show financial calculator",
+            });
             await userEvent.click(checkbox);
 
             // Assert
             expect(checkbox).toBeChecked();
             expect(
-                screen.getByLabelText("Include monthly payment"),
+                screen.getByRole("checkbox", {name: "Include monthly payment"}),
             ).toBeChecked();
-            expect(screen.getByLabelText("Include total amount")).toBeChecked();
             expect(
-                screen.getByLabelText("Include time-to-pay-off"),
+                screen.getByRole("checkbox", {name: "Include total amount"}),
+            ).toBeChecked();
+            expect(
+                screen.getByRole("checkbox", {name: "Include time-to-pay-off"}),
             ).toBeChecked();
         });
 
@@ -139,16 +153,18 @@ describe("ItemExtrasEditor", () => {
 
             // Assert
             expect(
-                screen.getByLabelText("Show financial calculator"),
+                screen.getByRole("checkbox", {
+                    name: "Show financial calculator",
+                }),
             ).toBeChecked();
             expect(
-                screen.getByLabelText("Include monthly payment"),
+                screen.getByRole("checkbox", {name: "Include monthly payment"}),
             ).toBeChecked();
             expect(
-                screen.getByLabelText("Include total amount"),
+                screen.getByRole("checkbox", {name: "Include total amount"}),
             ).not.toBeChecked();
             expect(
-                screen.getByLabelText("Include time-to-pay-off"),
+                screen.getByRole("checkbox", {name: "Include time-to-pay-off"}),
             ).not.toBeChecked();
         });
 
@@ -158,12 +174,14 @@ describe("ItemExtrasEditor", () => {
 
             // Act
             await userEvent.click(
-                screen.getByLabelText("Include monthly payment"),
+                screen.getByRole("checkbox", {name: "Include monthly payment"}),
             );
 
             // Assert
             expect(
-                screen.getByLabelText("Show financial calculator"),
+                screen.getByRole("checkbox", {
+                    name: "Show financial calculator",
+                }),
             ).not.toBeChecked();
             expect(
                 screen.queryByLabelText("Include monthly payment"),
@@ -180,7 +198,9 @@ describe("ItemExtrasEditor", () => {
             // Arrange
             const onChangeMock = jest.fn();
             render(<ItemExtrasEditor onChange={onChangeMock} />);
-            const checkbox = screen.getByLabelText("Show financial calculator");
+            const checkbox = screen.getByRole("checkbox", {
+                name: "Show financial calculator",
+            });
 
             // Act
             await userEvent.click(checkbox);
@@ -204,7 +224,9 @@ describe("ItemExtrasEditor", () => {
                     financialCalculatorTimeToPayOff={true}
                 />,
             );
-            const checkbox = screen.getByLabelText("Show financial calculator");
+            const checkbox = screen.getByRole("checkbox", {
+                name: "Show financial calculator",
+            });
 
             // Act
             await userEvent.click(checkbox);

--- a/packages/perseus-editor/src/item-extras-editor.tsx
+++ b/packages/perseus-editor/src/item-extras-editor.tsx
@@ -1,11 +1,11 @@
 import {components, ItemExtras} from "@khanacademy/perseus";
-import {StyleSheet} from "aphrodite"
+import {View} from "@khanacademy/wonder-blocks-core";
+import {Checkbox} from "@khanacademy/wonder-blocks-form";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 import type {PerseusAnswerArea} from "@khanacademy/perseus";
-import { Checkbox } from "@khanacademy/wonder-blocks-form";
-import { View } from "@khanacademy/wonder-blocks-core";
-import { spacing } from "@khanacademy/wonder-blocks-tokens";
 
 const {InfoTip} = components;
 
@@ -66,12 +66,9 @@ class ItemExtrasEditor extends React.Component<Props> {
                             // these need to be reset. All checked by
                             // default.
                             this.props.onChange({
-                                financialCalculatorMonthlyPayment:
-                                    e,
-                                financialCalculatorTotalAmount:
-                                    e,
-                                financialCalculatorTimeToPayOff:
-                                    e,
+                                financialCalculatorMonthlyPayment: e,
+                                financialCalculatorTotalAmount: e,
+                                financialCalculatorTimeToPayOff: e,
                             });
                         }}
                     />
@@ -86,8 +83,7 @@ class ItemExtrasEditor extends React.Component<Props> {
                                 }
                                 onChange={(e) => {
                                     this.props.onChange({
-                                        financialCalculatorMonthlyPayment:
-                                            e,
+                                        financialCalculatorMonthlyPayment: e,
                                     });
                                 }}
                                 indent
@@ -100,8 +96,7 @@ class ItemExtrasEditor extends React.Component<Props> {
                                 }
                                 onChange={(e) => {
                                     this.props.onChange({
-                                        financialCalculatorTotalAmount:
-                                            e,
+                                        financialCalculatorTotalAmount: e,
                                     });
                                 }}
                                 indent
@@ -114,8 +109,7 @@ class ItemExtrasEditor extends React.Component<Props> {
                                 }
                                 onChange={(e) => {
                                     this.props.onChange({
-                                        financialCalculatorTimeToPayOff:
-                                            e,
+                                        financialCalculatorTimeToPayOff: e,
                                     });
                                 }}
                                 indent
@@ -197,9 +191,13 @@ const ItemExtraCheckbox = (props: {
     onChange: (newState: boolean) => void;
     indent?: boolean;
 }) => (
-    <View style={[styles.checkbox, props.indent ? styles.indented :undefined]}>
+    <View style={[styles.checkbox, props.indent ? styles.indented : undefined]}>
         <Checkbox
-            label={<View style={{flexDirection: "row"}}>{props.label} <InfoTip>{props.infoTip}</InfoTip></View>}
+            label={
+                <View style={{flexDirection: "row"}}>
+                    {props.label} <InfoTip>{props.infoTip}</InfoTip>
+                </View>
+            }
             checked={props.checked}
             onChange={(newState) => props.onChange(newState)}
         />
@@ -207,9 +205,9 @@ const ItemExtraCheckbox = (props: {
 );
 
 const styles = StyleSheet.create({
-    indented:{
-        marginInlineStart: spacing.large_24
-    }
-})
+    indented: {
+        marginInlineStart: spacing.large_24,
+    },
+});
 
 export default ItemExtrasEditor;

--- a/packages/perseus-editor/src/item-extras-editor.tsx
+++ b/packages/perseus-editor/src/item-extras-editor.tsx
@@ -50,9 +50,9 @@ class ItemExtrasEditor extends React.Component<Props> {
                         label="Show calculator"
                         infoTip="Use the calculator when completing difficult calculations is NOT the intent of the question. DON’T use the calculator when testing the student’s ability to complete different types of computations."
                         checked={this.props.calculator}
-                        onChange={(e) => {
+                        onChange={(newCheckedState) => {
                             this.props.onChange({
-                                calculator: e,
+                                calculator: newCheckedState,
                             });
                         }}
                     />
@@ -61,14 +61,16 @@ class ItemExtrasEditor extends React.Component<Props> {
                         label="Show financial calculator"
                         infoTip="This provides the student with the ability to view a financial calculator, e.g., for answering financial questions. Once checked, requires at least one of the three options below to be checked."
                         checked={this.shouldShowFinancialCalculatorOptions()}
-                        onChange={(e) => {
+                        onChange={(newCheckedState) => {
                             // If the financial calculator is unchecked,
                             // these need to be reset. All checked by
                             // default.
                             this.props.onChange({
-                                financialCalculatorMonthlyPayment: e,
-                                financialCalculatorTotalAmount: e,
-                                financialCalculatorTimeToPayOff: e,
+                                financialCalculatorMonthlyPayment:
+                                    newCheckedState,
+                                financialCalculatorTotalAmount: newCheckedState,
+                                financialCalculatorTimeToPayOff:
+                                    newCheckedState,
                             });
                         }}
                     />
@@ -81,9 +83,10 @@ class ItemExtrasEditor extends React.Component<Props> {
                                 checked={
                                     this.props.financialCalculatorMonthlyPayment
                                 }
-                                onChange={(e) => {
+                                onChange={(newCheckedState) => {
                                     this.props.onChange({
-                                        financialCalculatorMonthlyPayment: e,
+                                        financialCalculatorMonthlyPayment:
+                                            newCheckedState,
                                     });
                                 }}
                                 indent
@@ -94,9 +97,10 @@ class ItemExtrasEditor extends React.Component<Props> {
                                 checked={
                                     this.props.financialCalculatorTotalAmount
                                 }
-                                onChange={(e) => {
+                                onChange={(newCheckedState) => {
                                     this.props.onChange({
-                                        financialCalculatorTotalAmount: e,
+                                        financialCalculatorTotalAmount:
+                                            newCheckedState,
                                     });
                                 }}
                                 indent
@@ -107,9 +111,10 @@ class ItemExtrasEditor extends React.Component<Props> {
                                 checked={
                                     this.props.financialCalculatorTimeToPayOff
                                 }
-                                onChange={(e) => {
+                                onChange={(newCheckedState) => {
                                     this.props.onChange({
-                                        financialCalculatorTimeToPayOff: e,
+                                        financialCalculatorTimeToPayOff:
+                                            newCheckedState,
                                     });
                                 }}
                                 indent
@@ -121,9 +126,9 @@ class ItemExtrasEditor extends React.Component<Props> {
                         label="Show periodic table"
                         infoTip="This provides the student with the ability to view a periodic table of the elements, e.g., for answering chemistry questions."
                         checked={this.props.periodicTable}
-                        onChange={(e) => {
+                        onChange={(newCheckedState) => {
                             this.props.onChange({
-                                periodicTable: e,
+                                periodicTable: newCheckedState,
                                 // If the periodic table is unchecked,
                                 // this needs to be reset. If table is
                                 // checked, it should already be false.
@@ -137,9 +142,9 @@ class ItemExtrasEditor extends React.Component<Props> {
                             label="Include key/legend with periodic table"
                             infoTip="Include a key for HS courses; omit for AP chemistry."
                             checked={this.props.periodicTableWithKey}
-                            onChange={(e) => {
+                            onChange={(newCheckedState) => {
                                 this.props.onChange({
-                                    periodicTableWithKey: e,
+                                    periodicTableWithKey: newCheckedState,
                                 });
                             }}
                             indent
@@ -150,9 +155,9 @@ class ItemExtrasEditor extends React.Component<Props> {
                         label="Show z table (statistics)"
                         infoTip="This provides the student with the ability to view a table of critical values for the z distribution, e.g. for answering statistics questions."
                         checked={this.props.zTable}
-                        onChange={(e) => {
+                        onChange={(newCheckedState) => {
                             this.props.onChange({
-                                zTable: e,
+                                zTable: newCheckedState,
                             });
                         }}
                     />
@@ -161,9 +166,9 @@ class ItemExtrasEditor extends React.Component<Props> {
                         label="Show t table (statistics)"
                         infoTip="This provides the student with the ability to view a table of critical values for the Student's t distribution, e.g. for answering statistics questions."
                         checked={this.props.tTable}
-                        onChange={(e) => {
+                        onChange={(newCheckedState) => {
                             this.props.onChange({
-                                tTable: e,
+                                tTable: newCheckedState,
                             });
                         }}
                     />
@@ -172,9 +177,9 @@ class ItemExtrasEditor extends React.Component<Props> {
                         label="Show chi-squared table (statistics)"
                         infoTip="This provides the student with the ability to view a table of critical values for the chi-squared distribution, e.g. for answering statistics questions."
                         checked={this.props.chi2Table}
-                        onChange={(e) => {
+                        onChange={(newCheckedState) => {
                             this.props.onChange({
-                                chi2Table: e,
+                                chi2Table: newCheckedState,
                             });
                         }}
                     />
@@ -188,7 +193,7 @@ const ItemExtraCheckbox = (props: {
     label: string;
     infoTip: string;
     checked: boolean;
-    onChange: (newState: boolean) => void;
+    onChange: (newCheckedState: boolean) => void;
     indent?: boolean;
 }) => (
     <View style={[styles.checkbox, props.indent ? styles.indented : undefined]}>
@@ -199,7 +204,7 @@ const ItemExtraCheckbox = (props: {
                 </View>
             }
             checked={props.checked}
-            onChange={(newState) => props.onChange(newState)}
+            onChange={(newCheckedState) => props.onChange(newCheckedState)}
         />
     </View>
 );

--- a/packages/perseus-editor/src/item-extras-editor.tsx
+++ b/packages/perseus-editor/src/item-extras-editor.tsx
@@ -1,7 +1,11 @@
 import {components, ItemExtras} from "@khanacademy/perseus";
+import {StyleSheet} from "aphrodite"
 import * as React from "react";
 
 import type {PerseusAnswerArea} from "@khanacademy/perseus";
+import { Checkbox } from "@khanacademy/wonder-blocks-form";
+import { View } from "@khanacademy/wonder-blocks-core";
+import { spacing } from "@khanacademy/wonder-blocks-tokens";
 
 const {InfoTip} = components;
 
@@ -43,18 +47,18 @@ class ItemExtrasEditor extends React.Component<Props> {
             <div className="perseus-answer-editor">
                 <div className="perseus-answer-options">
                     <ItemExtraCheckbox
-                        label="Show calculator:"
+                        label="Show calculator"
                         infoTip="Use the calculator when completing difficult calculations is NOT the intent of the question. DON’T use the calculator when testing the student’s ability to complete different types of computations."
                         checked={this.props.calculator}
                         onChange={(e) => {
                             this.props.onChange({
-                                calculator: e.target.checked,
+                                calculator: e,
                             });
                         }}
                     />
 
                     <ItemExtraCheckbox
-                        label="Show financial calculator:"
+                        label="Show financial calculator"
                         infoTip="This provides the student with the ability to view a financial calculator, e.g., for answering financial questions. Once checked, requires at least one of the three options below to be checked."
                         checked={this.shouldShowFinancialCalculatorOptions()}
                         onChange={(e) => {
@@ -63,11 +67,11 @@ class ItemExtrasEditor extends React.Component<Props> {
                             // default.
                             this.props.onChange({
                                 financialCalculatorMonthlyPayment:
-                                    e.target.checked,
+                                    e,
                                 financialCalculatorTotalAmount:
-                                    e.target.checked,
+                                    e,
                                 financialCalculatorTimeToPayOff:
-                                    e.target.checked,
+                                    e,
                             });
                         }}
                     />
@@ -75,7 +79,7 @@ class ItemExtrasEditor extends React.Component<Props> {
                     {this.shouldShowFinancialCalculatorOptions() && (
                         <>
                             <ItemExtraCheckbox
-                                label="Include monthly payment:"
+                                label="Include monthly payment"
                                 infoTip="This provides the student with the ability to view a monthly payment calculator; e.g., given a loan amount, interest rate, and term, what is the monthly payment?"
                                 checked={
                                     this.props.financialCalculatorMonthlyPayment
@@ -83,13 +87,13 @@ class ItemExtrasEditor extends React.Component<Props> {
                                 onChange={(e) => {
                                     this.props.onChange({
                                         financialCalculatorMonthlyPayment:
-                                            e.target.checked,
+                                            e,
                                     });
                                 }}
                                 indent
                             />
                             <ItemExtraCheckbox
-                                label="Include total amount:"
+                                label="Include total amount"
                                 infoTip="This provides the student with the ability to view a total amount calculator; e.g., given a monthly payment, interest rate, and term, what is the total amount to be paid?"
                                 checked={
                                     this.props.financialCalculatorTotalAmount
@@ -97,13 +101,13 @@ class ItemExtrasEditor extends React.Component<Props> {
                                 onChange={(e) => {
                                     this.props.onChange({
                                         financialCalculatorTotalAmount:
-                                            e.target.checked,
+                                            e,
                                     });
                                 }}
                                 indent
                             />
                             <ItemExtraCheckbox
-                                label="Include time-to-pay-off:"
+                                label="Include time-to-pay-off"
                                 infoTip="This provides the student with the ability to view a time to pay off calculator; e.g., given a loan amount, interest rate, and monthly payment, how long will it take to pay off the loan?"
                                 checked={
                                     this.props.financialCalculatorTimeToPayOff
@@ -111,7 +115,7 @@ class ItemExtrasEditor extends React.Component<Props> {
                                 onChange={(e) => {
                                     this.props.onChange({
                                         financialCalculatorTimeToPayOff:
-                                            e.target.checked,
+                                            e,
                                     });
                                 }}
                                 indent
@@ -120,12 +124,12 @@ class ItemExtrasEditor extends React.Component<Props> {
                     )}
 
                     <ItemExtraCheckbox
-                        label="Show periodic table:"
+                        label="Show periodic table"
                         infoTip="This provides the student with the ability to view a periodic table of the elements, e.g., for answering chemistry questions."
                         checked={this.props.periodicTable}
                         onChange={(e) => {
                             this.props.onChange({
-                                periodicTable: e.target.checked,
+                                periodicTable: e,
                                 // If the periodic table is unchecked,
                                 // this needs to be reset. If table is
                                 // checked, it should already be false.
@@ -136,12 +140,12 @@ class ItemExtrasEditor extends React.Component<Props> {
 
                     {this.props.periodicTable && (
                         <ItemExtraCheckbox
-                            label="Include key/legend with periodic table:"
+                            label="Include key/legend with periodic table"
                             infoTip="Include a key for HS courses; omit for AP chemistry."
                             checked={this.props.periodicTableWithKey}
                             onChange={(e) => {
                                 this.props.onChange({
-                                    periodicTableWithKey: e.target.checked,
+                                    periodicTableWithKey: e,
                                 });
                             }}
                             indent
@@ -149,34 +153,34 @@ class ItemExtrasEditor extends React.Component<Props> {
                     )}
 
                     <ItemExtraCheckbox
-                        label="Show z table (statistics):"
+                        label="Show z table (statistics)"
                         infoTip="This provides the student with the ability to view a table of critical values for the z distribution, e.g. for answering statistics questions."
                         checked={this.props.zTable}
                         onChange={(e) => {
                             this.props.onChange({
-                                zTable: e.target.checked,
+                                zTable: e,
                             });
                         }}
                     />
 
                     <ItemExtraCheckbox
-                        label="Show t table (statistics):"
+                        label="Show t table (statistics)"
                         infoTip="This provides the student with the ability to view a table of critical values for the Student's t distribution, e.g. for answering statistics questions."
                         checked={this.props.tTable}
                         onChange={(e) => {
                             this.props.onChange({
-                                tTable: e.target.checked,
+                                tTable: e,
                             });
                         }}
                     />
 
                     <ItemExtraCheckbox
-                        label="Show chi-squared table (statistics):"
+                        label="Show chi-squared table (statistics)"
                         infoTip="This provides the student with the ability to view a table of critical values for the chi-squared distribution, e.g. for answering statistics questions."
                         checked={this.props.chi2Table}
                         onChange={(e) => {
                             this.props.onChange({
-                                chi2Table: e.target.checked,
+                                chi2Table: e,
                             });
                         }}
                     />
@@ -190,24 +194,22 @@ const ItemExtraCheckbox = (props: {
     label: string;
     infoTip: string;
     checked: boolean;
-    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    onChange: (newState: boolean) => void;
     indent?: boolean;
 }) => (
-    <div
-        style={{
-            marginLeft: props.indent ? "10px" : "0px",
-        }}
-    >
-        <label>
-            {props.label}
-            <input
-                type="checkbox"
-                checked={props.checked}
-                onChange={props.onChange}
-            />
-        </label>
-        <InfoTip>{props.infoTip}</InfoTip>
-    </div>
+    <View style={[styles.checkbox, props.indent ? styles.indented :undefined]}>
+        <Checkbox
+            label={<View style={{flexDirection: "row"}}>{props.label} <InfoTip>{props.infoTip}</InfoTip></View>}
+            checked={props.checked}
+            onChange={(newState) => props.onChange(newState)}
+        />
+    </View>
 );
+
+const styles = StyleSheet.create({
+    indented:{
+        marginInlineStart: spacing.large_24
+    }
+})
 
 export default ItemExtrasEditor;

--- a/packages/perseus-editor/src/styles/perseus-editor.less
+++ b/packages/perseus-editor/src/styles/perseus-editor.less
@@ -158,6 +158,10 @@
     padding: @editorPadding;
 }
 
+.perseus-answer-options * {
+    margin-bottom: 4px;
+}
+
 .perseus-answer-widget {
     border: @editorBorder;
     border-radius: 0 0 @editorBorderRadius @editorBorderRadius;


### PR DESCRIPTION
## Summary:

While working in the Perseus Editor I took a few minutes to convert the item extras editor to use WB checkboxes. This results in much nicer layout (checkboxes all on the left, better typography).

| Before | After | 
|---|---|
| <img alt="Screenshot 2024-08-01 at 4 09 02 PM" src="https://github.com/user-attachments/assets/6ceb926b-fb45-45f8-9c28-f3d5b8d1e378"> | <img alt="Screenshot 2024-08-01 at 4 08 52 PM" src="https://github.com/user-attachments/assets/a6b1937e-b8d5-4adc-a8b4-bb1fde40f152"> | 


Issue: LEMS-1809

## Test plan:

Run storybook and look at the Editor Page or Item Extras Editor stories. 

I also verified that it still serializes the right data out and that nested checkboxes work.