### PR TITLE
[Interactive Graph Editor] Add white as a fill option for locked ellipses and polygons

### DIFF
--- a/.changeset/gentle-roses-pump.md
+++ b/.changeset/gentle-roses-pump.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+[Interactive Graph Editor] Add "white" as a fill option for locked ellipses and polygons

--- a/packages/perseus-editor/src/components/graph-locked-figures/ellipse-swatch.tsx
+++ b/packages/perseus-editor/src/components/graph-locked-figures/ellipse-swatch.tsx
@@ -33,7 +33,10 @@ const EllipseSwatch = (props: Props) => {
                     styles.innerCircle,
                     {
                         backgroundColor: lockedFigureColors[color],
-                        opacity: lockedFigureFillStyles[fillStyle],
+                        opacity:
+                            fillStyle === "white"
+                                ? 0
+                                : lockedFigureFillStyles[fillStyle],
                     },
                 ]}
             />

--- a/packages/perseus-editor/src/components/graph-locked-figures/polygon-swatch.tsx
+++ b/packages/perseus-editor/src/components/graph-locked-figures/polygon-swatch.tsx
@@ -33,7 +33,10 @@ const PolygonSwatch = (props: Props) => {
                     styles.innerSquare,
                     {
                         backgroundColor: lockedFigureColors[color],
-                        opacity: lockedFigureFillStyles[fillStyle],
+                        opacity:
+                            fillStyle === "white"
+                                ? 0
+                                : lockedFigureFillStyles[fillStyle],
                     },
                 ]}
             />

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -722,11 +722,12 @@ export type LockedVectorType = {
     color: LockedFigureColor;
 };
 
-export type LockedFigureFillType = "none" | "solid" | "translucent";
+export type LockedFigureFillType = "none" | "white" | "translucent" | "solid";
 export const lockedFigureFillStyles: Record<LockedFigureFillType, number> = {
     none: 0,
-    solid: 1,
+    white: 1,
     translucent: 0.4,
+    solid: 1,
 } as const;
 
 export type LockedEllipseType = {

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-ellipse.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-ellipse.tsx
@@ -18,6 +18,17 @@ const LockedEllipse = (props: LockedEllipseType) => {
             fillOpacity={lockedFigureFillStyles[fillStyle]}
             strokeStyle={strokeStyle}
             color={lockedFigureColors[color]}
+            // We need to override the svg props if we want to have a
+            // different fill color than the stroke color (specifically,
+            // in the case where the fillStyle is "white").
+            svgEllipseProps={{
+                style: {
+                    fill:
+                        fillStyle === "white"
+                            ? "white"
+                            : lockedFigureColors[color],
+                },
+            }}
         />
     );
 };

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-polygon.tsx
@@ -19,6 +19,17 @@ const LockedPolygon = (props: LockedPolygonType) => {
                 fillOpacity={lockedFigureFillStyles[fillStyle]}
                 strokeStyle={strokeStyle}
                 color={lockedFigureColors[color]}
+                // We need to override the svg props if we want to have a
+                // different fill color than the stroke color (specifically,
+                // in the case where the fillStyle is "white").
+                svgPolygonProps={{
+                    style: {
+                        fill:
+                            fillStyle === "white"
+                                ? "white"
+                                : lockedFigureColors[color],
+                    },
+                }}
             />
             {showVertices &&
                 points.map((point, index) => (


### PR DESCRIPTION
## Summary:
We got a request from content authors to add a "white" fill type for locked ellipses
and polygons. Adding that here.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2119

## Test plan:
Storybook
- http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--mafs-with-locked-figures-m-2-b-flag
- Go through all the fill options for locked ellipses and locked polygons
- Confirm that the swatch in the summary also updates corrently