### PR TITLE
[Hint Mode: Start Coords] Add start coords UI for point graphs (limited only)

### DIFF
--- a/.changeset/tasty-eggs-drop.md
+++ b/.changeset/tasty-eggs-drop.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-editor": minor
+---
+
+[Hint Mode: Start Coords] Add start coords UI for point graphs

--- a/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
+++ b/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
@@ -20,6 +20,7 @@ export const flags = {
         // TODO(LEMS-2228): Remove flags once this is fully released
         "start-coords-ui-phase-1": true,
         "start-coords-ui-phase-2": true,
+        "start-coords-ui-point": true,
     },
 } satisfies APIOptions["flags"];
 

--- a/packages/perseus-editor/src/components/__tests__/start-coords-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/start-coords-settings.test.tsx
@@ -523,4 +523,87 @@ describe("StartCoordSettings", () => {
             },
         );
     });
+
+    describe("point graph", () => {
+        test("shows the start coordinates UI: 1 point (default)", () => {
+            // Arrange
+
+            // Act
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="point"
+                    onChange={() => {}}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            expect(screen.getByText("Start coordinates")).toBeInTheDocument();
+            expect(screen.getByText("Point 1:")).toBeInTheDocument();
+        });
+
+        test("shows the start coordinates UI: 6 points", () => {
+            // Arrange
+
+            // Act
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="point"
+                    numPoints={6}
+                    onChange={() => {}}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            expect(screen.getByText("Start coordinates")).toBeInTheDocument();
+            expect(screen.getByText("Point 1:")).toBeInTheDocument();
+            expect(screen.getByText("Point 2:")).toBeInTheDocument();
+            expect(screen.getByText("Point 3:")).toBeInTheDocument();
+            expect(screen.getByText("Point 4:")).toBeInTheDocument();
+            expect(screen.getByText("Point 5:")).toBeInTheDocument();
+            expect(screen.getByText("Point 6:")).toBeInTheDocument();
+        });
+
+        test.each`
+            pointIndex | coord
+            ${0}       | ${"x"}
+            ${0}       | ${"y"}
+            ${1}       | ${"x"}
+            ${1}       | ${"y"}
+        `(
+            "calls onChange when $coord coord is changed (line $pointIndex)",
+            async ({pointIndex, coord}) => {
+                // Arrange
+                const onChangeMock = jest.fn();
+
+                // Act
+                render(
+                    <StartCoordsSettings
+                        {...defaultProps}
+                        type="point"
+                        numPoints={2}
+                        onChange={onChangeMock}
+                    />,
+                );
+
+                // Assert
+                const input = screen.getAllByRole("spinbutton", {
+                    name: `${coord}`,
+                })[pointIndex];
+                await userEvent.clear(input);
+                await userEvent.type(input, "101");
+
+                const expectedCoords = [
+                    [-5, 0],
+                    [5, 0],
+                ];
+                expectedCoords[pointIndex][coord === "x" ? 0 : 1] = 101;
+
+                expect(onChangeMock).toHaveBeenLastCalledWith(expectedCoords);
+            },
+        );
+    });
 });

--- a/packages/perseus-editor/src/components/__tests__/util.test.ts
+++ b/packages/perseus-editor/src/components/__tests__/util.test.ts
@@ -256,6 +256,76 @@ describe("getDefaultGraphStartCoords", () => {
 
         expect(defaultCoords).toEqual({center: [0, 0], radius: 2});
     });
+
+    test("should get default start coords for a sinusoid graph", () => {
+        // Arrange
+        const graph: PerseusGraphType = {type: "sinusoid"};
+        const range = [
+            [-10, 10],
+            [-10, 10],
+        ] satisfies [Range, Range];
+        const step = [1, 1] satisfies [number, number];
+
+        // Act
+        const defaultCoords = getDefaultGraphStartCoords(graph, range, step);
+
+        expect(defaultCoords).toEqual([
+            [0, 0],
+            [3, 2],
+        ]);
+    });
+
+    test("should get default start coords for a quadratic graph", () => {
+        // Arrange
+        const graph: PerseusGraphType = {type: "quadratic"};
+        const range = [
+            [-10, 10],
+            [-10, 10],
+        ] satisfies [Range, Range];
+        const step = [1, 1] satisfies [number, number];
+
+        // Act
+        const defaultCoords = getDefaultGraphStartCoords(graph, range, step);
+
+        expect(defaultCoords).toEqual([
+            [-5, 5],
+            [0, -5],
+            [5, 5],
+        ]);
+    });
+
+    test("should get default start coords for a point graph", () => {
+        // Arrange
+        const graph: PerseusGraphType = {type: "point"};
+        const range = [
+            [-10, 10],
+            [-10, 10],
+        ] satisfies [Range, Range];
+        const step = [1, 1] satisfies [number, number];
+
+        // Act
+        const defaultCoords = getDefaultGraphStartCoords(graph, range, step);
+
+        expect(defaultCoords).toEqual([[0, 0]]);
+    });
+
+    test("should get default start coords for a point graph with multiple points", () => {
+        // Arrange
+        const graph: PerseusGraphType = {type: "point", numPoints: 2};
+        const range = [
+            [-10, 10],
+            [-10, 10],
+        ] satisfies [Range, Range];
+        const step = [1, 1] satisfies [number, number];
+
+        // Act
+        const defaultCoords = getDefaultGraphStartCoords(graph, range, step);
+
+        expect(defaultCoords).toEqual([
+            [-5, 0],
+            [5, 0],
+        ]);
+    });
 });
 
 describe("getSinusoidEquation", () => {

--- a/packages/perseus-editor/src/components/start-coords-circle.tsx
+++ b/packages/perseus-editor/src/components/start-coords-circle.tsx
@@ -15,7 +15,6 @@ type Props = {
         center: Coord;
         radius: number;
     };
-    // center: number;
     onChange: (startCoords: PerseusGraphType["startCoords"]) => void;
 };
 

--- a/packages/perseus-editor/src/components/start-coords-point.tsx
+++ b/packages/perseus-editor/src/components/start-coords-point.tsx
@@ -1,0 +1,54 @@
+import {View} from "@khanacademy/wonder-blocks-core";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
+import {StyleSheet} from "aphrodite";
+import * as React from "react";
+
+import CoordinatePairInput from "./coordinate-pair-input";
+
+import type {Coord, PerseusGraphType} from "@khanacademy/perseus";
+
+type Props = {
+    startCoords: ReadonlyArray<Coord>;
+    onChange: (startCoords: PerseusGraphType["startCoords"]) => void;
+};
+
+const StartCoordsPoint = (props: Props) => {
+    const {startCoords, onChange} = props;
+
+    return (
+        <>
+            {startCoords.map((coord, index) => {
+                return (
+                    <View key={index} style={styles.tile}>
+                        <LabelLarge>{`Point ${index + 1}:`}</LabelLarge>
+                        <Strut size={spacing.small_12} />
+                        <CoordinatePairInput
+                            coord={coord}
+                            labels={["x", "y"]}
+                            onChange={(newCoord) => {
+                                const newStartCoords = [...startCoords];
+                                newStartCoords[index] = newCoord;
+                                onChange(newStartCoords);
+                            }}
+                        />
+                    </View>
+                );
+            })}
+        </>
+    );
+};
+
+const styles = StyleSheet.create({
+    tile: {
+        backgroundColor: color.fadedBlue8,
+        marginTop: spacing.xSmall_8,
+        padding: spacing.small_12,
+        borderRadius: spacing.xSmall_8,
+        flexDirection: "row",
+        alignItems: "center",
+    },
+});
+
+export default StartCoordsPoint;

--- a/packages/perseus-editor/src/components/start-coords-settings.tsx
+++ b/packages/perseus-editor/src/components/start-coords-settings.tsx
@@ -3,6 +3,7 @@ import {
     getCircleCoords,
     getLineCoords,
     getLinearSystemCoords,
+    getPointCoords,
     getQuadraticCoords,
     getSegmentCoords,
     getSinusoidCoords,
@@ -18,6 +19,7 @@ import Heading from "./heading";
 import StartCoordsCircle from "./start-coords-circle";
 import StartCoordsLine from "./start-coords-line";
 import StartCoordsMultiline from "./start-coords-multiline";
+import StartCoordsPoint from "./start-coords-point";
 import StartCoordsQuadratic from "./start-coords-quadratic";
 import StartCoordsSinusoid from "./start-coords-sinusoid";
 import {getDefaultGraphStartCoords} from "./util";
@@ -86,6 +88,14 @@ const StartCoordsSettingsInner = (props: Props) => {
             return (
                 <StartCoordsQuadratic
                     startCoords={quadraticCoords}
+                    onChange={onChange}
+                />
+            );
+        case "point":
+            const pointCoords = getPointCoords(props, range, step);
+            return (
+                <StartCoordsPoint
+                    startCoords={pointCoords}
                     onChange={onChange}
                 />
             );

--- a/packages/perseus-editor/src/components/util.ts
+++ b/packages/perseus-editor/src/components/util.ts
@@ -3,6 +3,7 @@ import {
     getCircleCoords,
     getLineCoords,
     getLinearSystemCoords,
+    getPointCoords,
     getQuadraticCoords,
     getSegmentCoords,
     getSinusoidCoords,
@@ -194,6 +195,12 @@ export function getDefaultGraphStartCoords(
                 range,
                 step,
             );
+        case "point":
+            return getPointCoords(
+                {...graph, startCoords: undefined},
+                range,
+                step,
+            );
         default:
             return undefined;
     }
@@ -252,4 +259,38 @@ export const getQuadraticEquation = (startCoords: [Coord, Coord, Coord]) => {
     return (
         "y = " + a.toFixed(3) + "x^2 + " + b.toFixed(3) + "x + " + c.toFixed(3)
     );
+};
+
+export const shouldShowStartCoordsUI = (flags, graph) => {
+    // TODO(LEMS-2228): Remove flags once this is fully released
+    const startCoordsUiPhase1Types = [
+        "linear",
+        "linear-system",
+        "ray",
+        "segment",
+        "circle",
+    ];
+    const startCoordsUiPhase2Types = ["sinusoid", "quadratic"];
+
+    const startCoordsPhase1 = flags?.mafs?.["start-coords-ui-phase-1"];
+    const startCoordsPhase2 = flags?.mafs?.["start-coords-ui-phase-2"];
+    const startCoordsPoint = flags?.mafs?.["start-coords-ui-point"];
+
+    if (startCoordsPhase1 && startCoordsUiPhase1Types.includes(graph.type)) {
+        return true;
+    }
+
+    if (startCoordsPhase2 && startCoordsUiPhase2Types.includes(graph.type)) {
+        return true;
+    }
+
+    if (
+        startCoordsPoint &&
+        graph.type === "point" &&
+        graph.numPoints !== "unlimited"
+    ) {
+        return true;
+    }
+
+    return false;
 };

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
@@ -702,6 +702,7 @@ describe("InteractiveGraphEditor", () => {
                                 ...flags.mafs,
                                 "start-coords-ui-phase-1": shouldRender,
                                 "start-coords-ui-phase-2": false,
+                                "start-coords-ui-point": false,
                             },
                         },
                     }}
@@ -759,6 +760,65 @@ describe("InteractiveGraphEditor", () => {
                                 ...flags.mafs,
                                 "start-coords-ui-phase-1": false,
                                 "start-coords-ui-phase-2": shouldRender,
+                                "start-coords-ui-point": false,
+                            },
+                        },
+                    }}
+                    graph={{type}}
+                    correct={{type}}
+                />,
+                {
+                    wrapper: RenderStateRoot,
+                },
+            );
+
+            // Assert
+            if (shouldRender) {
+                expect(
+                    await screen.findByRole("button", {
+                        name: "Use default start coordinates",
+                    }),
+                ).toBeInTheDocument();
+            } else {
+                expect(
+                    screen.queryByRole("button", {
+                        name: "Use default start coordinates",
+                    }),
+                ).toBeNull();
+            }
+        },
+    );
+
+    test.each`
+        type               | shouldRender
+        ${"linear"}        | ${false}
+        ${"ray"}           | ${false}
+        ${"linear-system"} | ${false}
+        ${"segment"}       | ${false}
+        ${"circle"}        | ${false}
+        ${"quadratic"}     | ${false}
+        ${"sinusoid"}      | ${false}
+        ${"polygon"}       | ${false}
+        ${"angle"}         | ${false}
+        ${"point"}         | ${true}
+    `(
+        "should render for $type graphs if point flag is on: $shouldRender",
+        async ({type, shouldRender}) => {
+            // Arrange
+
+            // Act
+            render(
+                <InteractiveGraphEditor
+                    {...baseProps}
+                    apiOptions={{
+                        ...ApiOptions.defaults,
+                        flags: {
+                            ...flags,
+                            mafs: {
+                                ...flags.mafs,
+                                "start-coords-ui-phase-1": false,
+                                "start-coords-ui-phase-2": false,
+                                "start-coords-ui-point": shouldRender,
                             },
                         },
                     }}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
@@ -25,6 +25,7 @@ import {InteractiveGraphCorrectAnswer} from "../components/interactive-graph-cor
 import InteractiveGraphSettings from "../components/interactive-graph-settings";
 import SegmentCountSelector from "../components/segment-count-selector";
 import StartCoordsSettings from "../components/start-coords-settings";
+import {shouldShowStartCoordsUI} from "../components/util";
 import {parsePointCount} from "../util/points";
 
 import type {
@@ -61,16 +62,6 @@ const POLYGON_SIDES = _.map(_.range(3, 13), function (value) {
         />
     );
 });
-
-// TODO(LEMS-2228): Remove flags once this is fully released
-const startCoordsUiPhase1Types = [
-    "linear",
-    "linear-system",
-    "ray",
-    "segment",
-    "circle",
-];
-const startCoordsUiPhase2Types = ["sinusoid", "quadratic"];
 
 type Range = [min: number, max: number];
 
@@ -269,18 +260,6 @@ class InteractiveGraphEditor extends React.Component<Props> {
         } else {
             graph = <div className="perseus-error">{this.props.valid}</div>;
         }
-
-        const startCoordsPhase1 =
-            this.props.apiOptions?.flags?.mafs?.["start-coords-ui-phase-1"];
-        const startCoordsPhase2 =
-            this.props.apiOptions?.flags?.mafs?.["start-coords-ui-phase-2"];
-
-        const displayStartCoordsUI =
-            this.props.graph &&
-            ((startCoordsPhase1 &&
-                startCoordsUiPhase1Types.includes(this.props.graph.type)) ||
-                (startCoordsPhase2 &&
-                    startCoordsUiPhase2Types.includes(this.props.graph.type)));
 
         return (
             <View>
@@ -496,7 +475,10 @@ class InteractiveGraphEditor extends React.Component<Props> {
                 )}
                 {this.props.graph?.type &&
                     // TODO(LEMS-2228): Remove flags once this is fully released
-                    displayStartCoordsUI && (
+                    shouldShowStartCoordsUI(
+                        this.props.apiOptions.flags,
+                        this.props.graph,
+                    ) && (
                         <StartCoordsSettings
                             {...this.props.graph}
                             range={this.props.range}

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -122,6 +122,7 @@ export {
     getCircleCoords,
     getLineCoords,
     getLinearSystemCoords,
+    getPointCoords,
     getSegmentCoords,
     getSinusoidCoords,
     getQuadraticCoords,

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -164,9 +164,14 @@ export const InteractiveGraphEditorFlags = [
     "start-coords-ui-phase-1",
     /**
      * Enables the UI for setting the start coordinates of a graph.
-     * Includes sinusoid graph.
+     * Includes sinusoid and quadratic graphs.
      */
     "start-coords-ui-phase-2",
+    /**
+     * Enables the UI for setting the start coordinates of a graph.
+     * Includes point graph.
+     */
+    "start-coords-ui-point",
 ] as const;
 
 /**

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
@@ -110,7 +110,7 @@ export function initializeGraphState(
     }
 }
 
-function getPointCoords(
+export function getPointCoords(
     graph: PerseusGraphTypePoint,
     range: [x: Interval, y: Interval],
     step: [x: number, y: number],


### PR DESCRIPTION
## Summary:
Add the UI to specify start coords for Point graph type.

- Add the point graph type to start-coord-settings.tsx
- Create a start-coords-point.tsx file with the main UI
- Add the start coords UI point flag
- Move the logic for determining whether the UI should be
  shown based on the feature flags out into the util file.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2209

## Test plan:
`yarn jest`

Storybook
- http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--interactive-graph-point

<img width="381" alt="image" src="https://github.com/user-attachments/assets/9785deae-e886-4ec9-b2c5-f9eb22384f5f">
