### PR TITLE
Export compiled CSS in package.json

### DIFF
--- a/.changeset/nine-ducks-enjoy.md
+++ b/.changeset/nine-ducks-enjoy.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/math-input": patch
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Explicitly export bundled css in package.json

--- a/packages/math-input/package.json
+++ b/packages/math-input/package.json
@@ -30,7 +30,8 @@
             "require": "./dist/strings.js",
             "types": "./dist/strings.d.ts",
             "source": "./src/strings.ts"
-        }
+        },
+        "./*.css": "./dist/*.css"
     },
     "files": [
         "dist"

--- a/packages/math-input/package.json
+++ b/packages/math-input/package.json
@@ -31,7 +31,7 @@
             "types": "./dist/strings.d.ts",
             "source": "./src/strings.ts"
         },
-        "./index.css": "./dist/index.css"
+        "./styles.css": "./dist/index.css"
     },
     "files": [
         "dist"

--- a/packages/math-input/package.json
+++ b/packages/math-input/package.json
@@ -31,7 +31,7 @@
             "types": "./dist/strings.d.ts",
             "source": "./src/strings.ts"
         },
-        "./*.css": "./dist/*.css"
+        "./index.css": "./dist/index.css"
     },
     "files": [
         "dist"

--- a/packages/perseus-editor/package.json
+++ b/packages/perseus-editor/package.json
@@ -25,7 +25,7 @@
             "types": "./dist/index.d.ts",
             "source": "./src/index.ts"
         },
-        "./*.css": "./dist/*.css"
+        "./index.css": "./dist/index.css"
     },
     "files": [
         "dist"

--- a/packages/perseus-editor/package.json
+++ b/packages/perseus-editor/package.json
@@ -18,6 +18,15 @@
     "module": "dist/es/index.js",
     "main": "dist/index.js",
     "source": "src/index.ts",
+    "exports": {
+        ".": {
+            "import": "./dist/es/index.js",
+            "require": "./dist/index.js",
+            "types": "./dist/index.d.ts",
+            "source": "./src/index.ts"
+        },
+        "./*.css": "./dist/*.css"
+    },
     "files": [
         "dist"
     ],

--- a/packages/perseus-editor/package.json
+++ b/packages/perseus-editor/package.json
@@ -25,7 +25,7 @@
             "types": "./dist/index.d.ts",
             "source": "./src/index.ts"
         },
-        "./index.css": "./dist/index.css"
+        "./styles.css": "./dist/index.css"
     },
     "files": [
         "dist"

--- a/packages/perseus/package.json
+++ b/packages/perseus/package.json
@@ -30,7 +30,8 @@
             "require": "./dist/strings.js",
             "types": "./dist/strings.d.ts",
             "source": "./src/strings.ts"
-        }
+        },
+        "./*.css": "./dist/*.css"
     },
     "files": [
         "dist"

--- a/packages/perseus/package.json
+++ b/packages/perseus/package.json
@@ -31,7 +31,7 @@
             "types": "./dist/strings.d.ts",
             "source": "./src/strings.ts"
         },
-        "./index.css": "./dist/index.css"
+        "./styles.css": "./dist/index.css"
     },
     "files": [
         "dist"

--- a/packages/perseus/package.json
+++ b/packages/perseus/package.json
@@ -31,7 +31,7 @@
             "types": "./dist/strings.d.ts",
             "source": "./src/strings.ts"
         },
-        "./*.css": "./dist/*.css"
+        "./index.css": "./dist/index.css"
     },
     "files": [
         "dist"


### PR DESCRIPTION
## Summary:

Recently we changed some of our packages to use the modern syntax for declaring packge exports: namely the `exports` key. When a package defines this key, it no longer allows arbitrary relative exports (ie. `import X from '@khanacademy/perseus/dist/some-file.js';`). 

This: 

<img width="568" alt="image" src="https://github.com/user-attachments/assets/8ee2898e-00ff-49a0-a690-93c71e359897">

Becomes: 

<img width="482" alt="image" src="https://github.com/user-attachments/assets/9127d53c-52ad-4b1d-ba11-bcd45af585b4">


As a result, our bundled CSS was no longer exported. In webapp today, we need to import the bundled CSS using a fully-relative path (ie. `import '../../node_modules/@khanacademy/perseus/dist/index.css''`). This is clunky and the import paths are not portable. 

So, this PR fixes it by exporting all CSS files from our bundles.

Issue: "none"

## Test plan:

Update webapp with the snapshot npm package and then check if we can change our CSS imports to `import '@khanacademy/perseus/index.css';`
