### PR TITLE
[Hint Mode: Start Coords] Correct flag logic for polygon graph start coords UI

### DIFF
--- a/.changeset/clean-glasses-watch.md
+++ b/.changeset/clean-glasses-watch.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Hint Mode: Start Coords] Correct flag logic for polygon graph start coords UI

--- a/packages/perseus-editor/src/components/util.ts
+++ b/packages/perseus-editor/src/components/util.ts
@@ -303,7 +303,7 @@ export const shouldShowStartCoordsUI = (flags, graph) => {
     if (
         startCoordsPolygon &&
         graph.type === "polygon" &&
-        graph.numPoints !== "unlimited" &&
+        graph.numSides !== "unlimited" &&
         // Pre-initialized graph with undefined snapTo value
         // initializes to snapTo="grid"
         (graph.snapTo === "grid" || graph.snapTo === undefined)

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
@@ -673,6 +673,8 @@ describe("InteractiveGraphEditor", () => {
         );
     });
 
+    // TODO(LEMS-2228): Remove flag-related code once
+    // start coords UI is rolled out 100%
     test.each`
         type               | shouldRender
         ${"linear"}        | ${true}
@@ -908,4 +910,96 @@ describe("InteractiveGraphEditor", () => {
             }
         },
     );
+
+    test("should not render for point graphs with unlimited points", async () => {
+        // Arrange
+
+        // Act
+        render(
+            <InteractiveGraphEditor
+                {...mafsProps}
+                graph={{type: "point", numPoints: "unlimited"}}
+                correct={{type: "point", numPoints: "unlimited"}}
+            />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
+
+        // Assert
+        expect(
+            screen.queryByRole("button", {
+                name: "Use default start coordinates",
+            }),
+        ).toBeNull();
+    });
+
+    test("should not render for polygon graphs with unlimited sides", async () => {
+        // Arrange
+
+        // Act
+        render(
+            <InteractiveGraphEditor
+                {...mafsProps}
+                graph={{type: "polygon", numSides: "unlimited"}}
+                correct={{type: "polygon", numSides: "unlimited"}}
+            />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
+
+        // Assert
+        expect(
+            screen.queryByRole("button", {
+                name: "Use default start coordinates",
+            }),
+        ).toBeNull();
+    });
+
+    test("should not render for polygon graphs with non-grid snapTo (angles)", async () => {
+        // Arrange
+
+        // Act
+        render(
+            <InteractiveGraphEditor
+                {...mafsProps}
+                graph={{type: "polygon", snapTo: "angles"}}
+                correct={{type: "polygon", snapTo: "angles"}}
+            />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
+
+        // Assert
+        expect(
+            screen.queryByRole("button", {
+                name: "Use default start coordinates",
+            }),
+        ).toBeNull();
+    });
+
+    test("should not render for polygon graphs with non-grid snapTo (sides)", async () => {
+        // Arrange
+
+        // Act
+        render(
+            <InteractiveGraphEditor
+                {...mafsProps}
+                graph={{type: "polygon", snapTo: "sides"}}
+                correct={{type: "polygon", snapTo: "sides"}}
+            />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
+
+        // Assert
+        expect(
+            screen.queryByRole("button", {
+                name: "Use default start coordinates",
+            }),
+        ).toBeNull();
+    });
 });


### PR DESCRIPTION
## Summary:
I noticed that the "Reset to default coordinates" button still shows up for
polygon graphs with unlimited sides, but it's not supposed to. I figured out
that this is because I accidentally used `numPoints` instead of `numSides` in
the logic.

- Fix the flags logic
- Add tests

Issue: https://khanacademy.atlassian.net/browse/LEMS-2072

## Test plan:
`yarn jest packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx`

Storybook
- Go to http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--interactive-graph-polygon
- Set number of sides to "unlimited sides"
- Confirm that the start coords UI no longer shows up