### PR TITLE
[Hint Mode: Start Coords] Build the foundation for adding start coords UI for angle graphs

### DIFF
--- a/.changeset/eleven-paws-serve.md
+++ b/.changeset/eleven-paws-serve.md
@@ -1,4 +1,5 @@
 ---
+"@khanacademy/perseus": minor
 "@khanacademy/perseus-editor": minor
 ---
 

--- a/.changeset/friendly-lemons-battle.md
+++ b/.changeset/friendly-lemons-battle.md
@@ -2,4 +2,4 @@
 "@khanacademy/perseus-editor": minor
 ---
 
-[Hint Mode: Start Coords] Add start coords UI for angle graphs
+[Hint Mode: Start Coords] Build the foundation for adding start coords UI for angle graphs

--- a/.changeset/friendly-lemons-battle.md
+++ b/.changeset/friendly-lemons-battle.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+[Hint Mode: Start Coords] Add start coords UI for angle graphs

--- a/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
+++ b/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
@@ -22,6 +22,7 @@ export const flags = {
         "start-coords-ui-phase-2": true,
         "start-coords-ui-point": true,
         "start-coords-ui-polygon": true,
+        "start-coords-ui-angle": true,
     },
 } satisfies APIOptions["flags"];
 

--- a/packages/perseus-editor/src/__stories__/interactive-graph-editor.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/interactive-graph-editor.stories.tsx
@@ -8,12 +8,12 @@ import * as React from "react";
 
 import {EditorPage} from "..";
 import {
-    angleQuestionWithDefaultCorrect,
+    angleWithStartingCoordsQuestion,
     circleWithStartingCoordsQuestion,
     linearSystemWithStartingCoordsQuestion,
     linearWithStartingCoordsQuestion,
     pointQuestionWithStartingCoords,
-    polygonQuestionDefaultCorrect,
+    polygonWithStartingCoordsQuestion,
     quadraticWithStartingCoordsQuestion,
     rayWithStartingCoordsQuestion,
     segmentWithLockedFigures,
@@ -114,7 +114,7 @@ export const InteractiveGraphPoint = (): React.ReactElement => (
 export const InteractiveGraphPolygon = (): React.ReactElement => {
     return (
         <EditorPageWithStorybookPreview
-            question={polygonQuestionDefaultCorrect}
+            question={polygonWithStartingCoordsQuestion}
         />
     );
 };
@@ -122,7 +122,7 @@ export const InteractiveGraphPolygon = (): React.ReactElement => {
 export const InteractiveGraphAngle = (): React.ReactElement => {
     return (
         <EditorPageWithStorybookPreview
-            question={angleQuestionWithDefaultCorrect}
+            question={angleWithStartingCoordsQuestion}
         />
     );
 };

--- a/packages/perseus-editor/src/__stories__/interactive-graph-editor.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/interactive-graph-editor.stories.tsx
@@ -8,11 +8,12 @@ import * as React from "react";
 
 import {EditorPage} from "..";
 import {
+    angleQuestionWithDefaultCorrect,
     circleWithStartingCoordsQuestion,
     linearSystemWithStartingCoordsQuestion,
     linearWithStartingCoordsQuestion,
     pointQuestionWithStartingCoords,
-    polygonQuestion,
+    polygonQuestionDefaultCorrect,
     quadraticWithStartingCoordsQuestion,
     rayWithStartingCoordsQuestion,
     segmentWithLockedFigures,
@@ -111,7 +112,19 @@ export const InteractiveGraphPoint = (): React.ReactElement => (
 );
 
 export const InteractiveGraphPolygon = (): React.ReactElement => {
-    return <EditorPageWithStorybookPreview question={polygonQuestion} />;
+    return (
+        <EditorPageWithStorybookPreview
+            question={polygonQuestionDefaultCorrect}
+        />
+    );
+};
+
+export const InteractiveGraphAngle = (): React.ReactElement => {
+    return (
+        <EditorPageWithStorybookPreview
+            question={angleQuestionWithDefaultCorrect}
+        />
+    );
 };
 
 export const MafsWithLockedFiguresCurrent = (): React.ReactElement => {

--- a/packages/perseus-editor/src/components/__tests__/util.test.ts
+++ b/packages/perseus-editor/src/components/__tests__/util.test.ts
@@ -365,6 +365,26 @@ describe("getDefaultGraphStartCoords", () => {
             [-3, -3],
         ]);
     });
+
+    test("should get default start coords for an angle graph", () => {
+        // Arrange
+        const graph: PerseusGraphType = {type: "angle"};
+        const range = [
+            [-10, 10],
+            [-10, 10],
+        ] satisfies [Range, Range];
+        const step = [1, 1] satisfies [number, number];
+
+        // Act
+        const defaultCoords = getDefaultGraphStartCoords(graph, range, step);
+
+        // Default correct answer is 20 degree angle at (0, 0)
+        expect(defaultCoords).toEqual([
+            [7, 0],
+            [0, 0],
+            [6.5778483455013586, 2.394141003279681],
+        ]);
+    });
 });
 
 describe("getSinusoidEquation", () => {

--- a/packages/perseus-editor/src/components/start-coords-angle.tsx
+++ b/packages/perseus-editor/src/components/start-coords-angle.tsx
@@ -1,0 +1,28 @@
+import {View} from "@khanacademy/wonder-blocks-core";
+import * as React from "react";
+
+import type {Coord, PerseusGraphType} from "@khanacademy/perseus";
+
+type Props = {
+    startCoords: [Coord, Coord, Coord];
+    onChange: (startCoords: PerseusGraphType["startCoords"]) => void;
+};
+
+const StartCoordsAngle = (props: Props) => {
+    const {startCoords} = props;
+    return (
+        <View>
+            WIP
+            <br /> Start coords:
+            {startCoords.map((coord, index) => {
+                return (
+                    <View key={index}>
+                        {`Point ${index + 1}: (${coord[0]}, ${coord[1]})`}
+                    </View>
+                );
+            })}
+        </View>
+    );
+};
+
+export default StartCoordsAngle;

--- a/packages/perseus-editor/src/components/start-coords-settings.tsx
+++ b/packages/perseus-editor/src/components/start-coords-settings.tsx
@@ -1,5 +1,6 @@
 import {vector as kvector} from "@khanacademy/kmath";
 import {
+    getAngleCoords,
     getCircleCoords,
     getLineCoords,
     getLinearSystemCoords,
@@ -17,6 +18,7 @@ import arrowCounterClockwise from "@phosphor-icons/core/bold/arrow-counter-clock
 import * as React from "react";
 
 import Heading from "./heading";
+import StartCoordsAngle from "./start-coords-angle";
 import StartCoordsCircle from "./start-coords-circle";
 import StartCoordsLine from "./start-coords-line";
 import StartCoordsMultiline from "./start-coords-multiline";
@@ -102,6 +104,14 @@ const StartCoordsSettingsInner = (props: Props) => {
             return (
                 <StartCoordsPoint
                     startCoords={pointCoords}
+                    onChange={onChange}
+                />
+            );
+        case "angle":
+            const angleCoords = getAngleCoords({graph: props, range, step});
+            return (
+                <StartCoordsAngle
+                    startCoords={angleCoords}
                     onChange={onChange}
                 />
             );

--- a/packages/perseus-editor/src/components/util.ts
+++ b/packages/perseus-editor/src/components/util.ts
@@ -1,5 +1,6 @@
 import {vector as kvector} from "@khanacademy/kmath";
 import {
+    getAngleCoords,
     getCircleCoords,
     getLineCoords,
     getLinearSystemCoords,
@@ -208,6 +209,12 @@ export function getDefaultGraphStartCoords(
                 range,
                 step,
             );
+        case "angle":
+            return getAngleCoords({
+                graph: {...graph, startCoords: undefined},
+                range,
+                step,
+            });
         default:
             return undefined;
     }
@@ -283,12 +290,17 @@ export const shouldShowStartCoordsUI = (flags, graph) => {
     const startCoordsPhase2 = flags?.mafs?.["start-coords-ui-phase-2"];
     const startCoordsPoint = flags?.mafs?.["start-coords-ui-point"];
     const startCoordsPolygon = flags?.mafs?.["start-coords-ui-polygon"];
+    const startCoordsAngle = flags?.mafs?.["start-coords-ui-angle"];
 
     if (startCoordsPhase1 && startCoordsUiPhase1Types.includes(graph.type)) {
         return true;
     }
 
     if (startCoordsPhase2 && startCoordsUiPhase2Types.includes(graph.type)) {
+        return true;
+    }
+
+    if (startCoordsAngle && graph.type === "angle") {
         return true;
     }
 

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
@@ -706,6 +706,7 @@ describe("InteractiveGraphEditor", () => {
                                 "start-coords-ui-phase-2": false,
                                 "start-coords-ui-point": false,
                                 "start-coords-ui-polygon": false,
+                                "start-coords-ui-angle": false,
                             },
                         },
                     }}
@@ -765,6 +766,7 @@ describe("InteractiveGraphEditor", () => {
                                 "start-coords-ui-phase-2": true,
                                 "start-coords-ui-point": false,
                                 "start-coords-ui-polygon": false,
+                                "start-coords-ui-angle": false,
                             },
                         },
                     }}
@@ -824,6 +826,7 @@ describe("InteractiveGraphEditor", () => {
                                 "start-coords-ui-phase-2": false,
                                 "start-coords-ui-point": true,
                                 "start-coords-ui-polygon": false,
+                                "start-coords-ui-angle": false,
                             },
                         },
                     }}
@@ -883,6 +886,67 @@ describe("InteractiveGraphEditor", () => {
                                 "start-coords-ui-phase-2": false,
                                 "start-coords-ui-point": false,
                                 "start-coords-ui-polygon": true,
+                                "start-coords-ui-angle": false,
+                            },
+                        },
+                    }}
+                    graph={{type}}
+                    correct={{type}}
+                />,
+                {
+                    wrapper: RenderStateRoot,
+                },
+            );
+
+            // Assert
+            if (shouldRender) {
+                expect(
+                    await screen.findByRole("button", {
+                        name: "Use default start coordinates",
+                    }),
+                ).toBeInTheDocument();
+            } else {
+                expect(
+                    screen.queryByRole("button", {
+                        name: "Use default start coordinates",
+                    }),
+                ).toBeNull();
+            }
+        },
+    );
+
+    test.each`
+        type               | shouldRender
+        ${"linear"}        | ${false}
+        ${"ray"}           | ${false}
+        ${"linear-system"} | ${false}
+        ${"segment"}       | ${false}
+        ${"circle"}        | ${false}
+        ${"quadratic"}     | ${false}
+        ${"sinusoid"}      | ${false}
+        ${"polygon"}       | ${false}
+        ${"angle"}         | ${true}
+        ${"point"}         | ${false}
+    `(
+        "should render for $type graphs if angle flag is on: $shouldRender",
+        async ({type, shouldRender}) => {
+            // Arrange
+
+            // Act
+            render(
+                <InteractiveGraphEditor
+                    {...baseProps}
+                    apiOptions={{
+                        ...ApiOptions.defaults,
+                        flags: {
+                            ...flags,
+                            mafs: {
+                                ...flags.mafs,
+                                "start-coords-ui-phase-1": false,
+                                "start-coords-ui-phase-2": false,
+                                "start-coords-ui-point": false,
+                                "start-coords-ui-polygon": false,
+                                "start-coords-ui-angle": true,
                             },
                         },
                     }}

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -127,6 +127,7 @@ export {
     getSegmentCoords,
     getSinusoidCoords,
     getQuadraticCoords,
+    getAngleCoords,
 } from "./widgets/interactive-graphs/reducer/initialize-graph-state";
 
 /**

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -177,6 +177,11 @@ export const InteractiveGraphEditorFlags = [
      * Includes polygon graph.
      */
     "start-coords-ui-polygon",
+    /**
+     * Enables the UI for setting the start coordinates of a graph.
+     * Includes angle graph.
+     */
+    "start-coords-ui-angle",
 ] as const;
 
 /**

--- a/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
@@ -32,6 +32,17 @@ export const angleQuestion: PerseusRenderer = interactiveGraphQuestionBuilder()
 export const angleQuestionWithDefaultCorrect: PerseusRenderer =
     interactiveGraphQuestionBuilder().withAngle().build();
 
+export const angleWithStartingCoordsQuestion: PerseusRenderer =
+    interactiveGraphQuestionBuilder()
+        .withAngle({
+            startCoords: [
+                [5, 1],
+                [1, 1],
+                [4, 5],
+            ],
+        })
+        .build();
+
 export const circleQuestion: PerseusRenderer = interactiveGraphQuestionBuilder()
     .withCircle({center: [-2, -4], radius: 2})
     .build();
@@ -126,6 +137,18 @@ export const polygonQuestion: PerseusRenderer =
                 [3.5, 2],
                 [3.5, 5],
                 [-0.5, 2],
+            ],
+        })
+        .build();
+
+export const polygonWithStartingCoordsQuestion: PerseusRenderer =
+    interactiveGraphQuestionBuilder()
+        .withPolygon("grid", {
+            startCoords: [
+                [6, 6],
+                [8, 6],
+                [8, 8],
+                [6, 8],
             ],
         })
         .build();

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
@@ -394,7 +394,7 @@ export function getCircleCoords(graph: PerseusGraphTypeCircle): {
     };
 }
 
-const getAngleCoords = (params: {
+export const getAngleCoords = (params: {
     graph: PerseusGraphTypeAngle;
     range: [x: Interval, y: Interval];
     step: [x: number, y: number];

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
@@ -404,6 +404,10 @@ export const getAngleCoords = (params: {
         return graph.coords;
     }
 
+    if (graph.startCoords) {
+        return graph.startCoords;
+    }
+
     const {snapDegrees, angleOffsetDeg} = graph;
     const snap = snapDegrees || 1;
     let angle = snap;


### PR DESCRIPTION
## Summary:
This PR includes the foundation/prerequisites for adding the start coords UI for angle graphs.

- Add the polygon graph type to start-coords-settings.tsx
- Create a WORK IN PROGRESS start-coords-angle.tsx file. This will be properly filled in
  in the following PR, whose main purpose will be adding the body for the UI.
- Add the start coords UI angle flag
- Add a storybook story for angle graphs (and update polygon story to start with start coords)
- Update the angle initializer to account for start coords

Issue: https://khanacademy.atlassian.net/browse/LEMS-2073

## Test plan:
`yarn jest`

Storybook
- http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--interactive-graph-angle

<img width="897" alt="image" src="https://github.com/user-attachments/assets/c448bcb2-ae47-4e55-8efb-e6f42e000466">

