### PR TITLE
Frameless Preview - 1: ContentRenderer

### DIFF
--- a/dev/vite.config.ts
+++ b/dev/vite.config.ts
@@ -10,7 +10,41 @@ const packageAliases = {};
 glob.sync(resolve(__dirname, "../packages/*/package.json")).forEach(
     (packageJsonPath) => {
         const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
-        packageAliases[pkg.name] = join(dirname(packageJsonPath), pkg.source);
+
+        // "exports" is the more modern way to declare package exports. Some,
+        // but not all, Perseus packages delcare "exports".
+        if ("exports" in pkg) {
+            // Not all packages export strings, but for those that do we need
+            // to set up an alias so Vite properly resolves them.
+            // Eg `import {strings, mockStrings} from "@khanacademy/perseus/strings";`
+            // And MOST IMPORTANTLY, this alias _must_ precede the main
+            // import, otherwise Vite will just use the main export and tack
+            // `/strings` onto the end, resulting in a path like this:
+            // `packages/perseus/src/index.ts/strings`
+            const stringsSource = pkg.exports["./strings"]?.source;
+            if (stringsSource != null) {
+                packageAliases[`${pkg.name}/strings`] = join(
+                    dirname(packageJsonPath),
+                    stringsSource,
+                );
+            }
+
+            const mainSource = pkg.exports["."]?.source;
+            if (mainSource == null) {
+                throw new Error(
+                    "Package declares 'exports', but not provide a main export (exports[\".\"])",
+                );
+            }
+            packageAliases[pkg.name] = join(
+                dirname(packageJsonPath),
+                mainSource,
+            );
+        } else {
+            packageAliases[pkg.name] = join(
+                dirname(packageJsonPath),
+                pkg.source,
+            );
+        }
     },
 );
 

--- a/packages/perseus-editor/src/__stories__/content-renderer.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/content-renderer.stories.tsx
@@ -77,8 +77,27 @@ export const WithLintErrors: Story = {
 
 Here is some unclosed math: $1+1=3
 
-We should use \`\\dfrac{}\` instead of \`\\frac{}\`: $\\frac{3}{5}$`,
-            widgets: {},
+We should use \`\\dfrac{}\` instead of \`\\frac{}\`: $\\frac{3}{5}$
+
+What is the best color in the world?
+
+[[☃ radio 1]]`,
+            widgets: {
+                "radio 1": {
+                    type: "radio",
+                    options: {
+                        choices: [
+                            {content: "Red"},
+                            {content: "# Green"},
+                            {content: "Blue", correct: true},
+                            {
+                                content: "None of these!",
+                                isNoneOfTheAbove: true,
+                            },
+                        ],
+                    },
+                },
+            },
             images: {},
         },
     },

--- a/packages/perseus-editor/src/__stories__/content-renderer.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/content-renderer.stories.tsx
@@ -1,5 +1,7 @@
 import {View} from "@khanacademy/wonder-blocks-core";
+import Switch from "@khanacademy/wonder-blocks-switch";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import {useState} from "react";
 
 import {articleWithImages} from "../../../perseus/src/__testdata__/article-renderer.testdata";
@@ -59,5 +61,25 @@ export const Exercise: Story = {
 export const Article: Story = {
     args: {
         question: articleWithImages,
+    },
+};
+
+export const WithLintErrors: Story = {
+    args: {
+        linterContext: {
+            contentType: "exercise",
+            highlightLint: true,
+            stack: [],
+            paths: [],
+        },
+        question: {
+            content: `# H1s bad
+
+Here is some unclosed math: $1+1=3
+
+We should use \`\\dfrac{}\` instead of \`\\frac{}\`: $\\frac{3}{5}$`,
+            widgets: {},
+            images: {},
+        },
     },
 };

--- a/packages/perseus-editor/src/__stories__/content-renderer.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/content-renderer.stories.tsx
@@ -1,0 +1,152 @@
+import {View} from "@khanacademy/wonder-blocks-core";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {useState} from "react";
+
+import {question} from "../../../perseus/src/widgets/__testdata__/radio.testdata";
+import DeviceFramer from "../components/device-framer";
+import ViewportResizer from "../components/viewport-resizer";
+import ContentRenderer from "../content-renderer";
+
+import type {DeviceType, PerseusRenderer} from "@khanacademy/perseus";
+import type {Meta, StoryObj} from "@storybook/react";
+
+import "../styles/perseus-editor.less";
+
+const PreviewWrapper = (props) => {
+    const [previewDevice, setPreviewDevice] = useState<DeviceType>("phone");
+
+    return (
+        <View>
+            <ViewportResizer
+                deviceType={previewDevice}
+                onViewportSizeChanged={setPreviewDevice}
+            />
+            <DeviceFramer nochrome={false} deviceType={previewDevice}>
+                <ContentRenderer
+                    apiOptions={{
+                        isMobile: previewDevice === "desktop" ? false : true,
+                    }}
+                    {...props}
+                />
+            </DeviceFramer>
+        </View>
+    );
+};
+
+const meta: Meta<typeof ContentRenderer> = {
+    title: "PerseusEditor/Content Renderer",
+    component: ContentRenderer,
+    decorators: [
+        (Story) => (
+            <View style={{margin: spacing.xxSmall_6}}>
+                <Story />
+            </View>
+        ),
+    ],
+    render: (props) => <PreviewWrapper {...props} />,
+};
+
+export default meta;
+type Story = StoryObj<typeof ContentRenderer>;
+
+const sampleArticleSection: PerseusRenderer = {
+    content:
+        "The word \"radiation\" sometimes gets a bad rap. People often associate radiation with something dangerous or scary, without really knowing what it is. In reality, we're surrounded by radiation all the time. \n\n**Radiation** is energy that travels through space (not just \"outer space\"—any space). Radiation can also interact with matter. How radiation interacts with matter depends on the type of radiation and the type of matter.\n\nRadiation comes in many forms, one of which is *electromagnetic radiation*. Without electromagnetic radiation life on Earth would not be possible, nor would most modern technologies.\n\n[[☃ image 13]]\n\nLet's take a closer look at this important and fascinating type of radiation.\n\n##Electromagnetic radiation\n\nAs the name suggests, **electromagnetic (EM) radiation** is energy transferred by *electromagnetic fields* oscillating through space.\n\nEM radiation is strange—it has both wave and particle properties. Let's take a look at both.\n\n###Electromagnetic waves\n\nAn animated model of an EM wave is shown below.\n[[☃ image 1]]\nThe electric field $(\\vec{\\textbf{E}})$ is shown in $\\color{blue}\\textbf{blue}$, and the magnetic field $(\\vec{\\textbf{B}})$ is shown in $\\color{red}\\textbf{red}$. They're perpendicular to each other.\n\nA changing electric field creates a magnetic field, and a changing magnetic field creates an electric field. So, once the EM wave is generated it propagates itself through space!\n\nAs with any wave, EM waves have wavelength, frequency, and speed. The wave model of EM radiation works best on large scales. But what about the atomic scale?\n\n###Photons\n\nAt the quantum level, EM radiation exists as particles. A particle of EM radiation is called a **photon**.\n\nWe can think of photons as wave *packets*—tiny bundles of EM radiation containing specific amounts of energy. Photons are visually represented using the following symbol.\n\n[[☃ image 3]]\n\nAll EM radiation, whether modeled as waves or photons, travels at the **speed of light** $\\textbf{(c)}$ in a vacuum: \n\n$\\text{c}=3\\times10^8\\space\\pu{m/s}=300{,}000{,}000\\space\\pu{m/s}$\n\nBut, EM radiation travels at a slower speed in matter, such as water or glass.",
+    images: {},
+    widgets: {
+        "image 13": {
+            type: "image",
+            alignment: "block",
+            static: false,
+            graded: true,
+            options: {
+                static: false,
+                title: "",
+                range: [
+                    [0, 10],
+                    [0, 10],
+                ],
+                box: [600, 254],
+                backgroundImage: {
+                    url: "https://cdn.kastatic.org/ka-content-images/358a87c20ab6ee70447f5fcb547010f69986828e.jpg",
+                    width: 600,
+                    height: 254,
+                },
+                labels: [],
+                alt: "From space, the sun appears over Earth's horizon, illuminating the atmosphere as a blue layer above Earth. Above the atmosphere, space appears black.",
+                caption:
+                    "*Sunrise photo from the International Space Station. Earth's atmosphere scatters electromagnetic radiation from the sun, producing a bright sky during the day.*",
+            },
+            version: {
+                major: 0,
+                minor: 0,
+            },
+        },
+        "image 1": {
+            type: "image",
+            alignment: "block",
+            static: false,
+            graded: true,
+            options: {
+                static: false,
+                title: "",
+                range: [
+                    [0, 10],
+                    [0, 10],
+                ],
+                box: [627, 522],
+                backgroundImage: {
+                    url: "https://cdn.kastatic.org/ka-content-images/8100369eaf3b581d4e7bfc9f1062625309def486.gif",
+                    width: 627,
+                    height: 522,
+                },
+                labels: [],
+                alt: "An animation shows a blue electric field arrow oscillating up and down. Connected to the base of the electric field arrow is a magnetic field arrow, which oscillates from side to side. The two fields oscillate in unison: when one extends the other extends too, creating a repeating wave pattern.",
+                caption: "",
+            },
+            version: {
+                major: 0,
+                minor: 0,
+            },
+        },
+        "image 3": {
+            type: "image",
+            alignment: "block",
+            static: false,
+            graded: true,
+            options: {
+                static: false,
+                title: "",
+                range: [
+                    [0, 10],
+                    [0, 10],
+                ],
+                box: [350, 130],
+                backgroundImage: {
+                    url: "https://cdn.kastatic.org/ka-content-images/74edeeb6c6605a4e854e3a3e9db69c01dcf5508f.svg",
+                    width: 350,
+                    height: 130,
+                },
+                labels: [],
+                alt: "A squiggly curve drawn from left to right. The right end of the curve has an arrow point. The curve begins with a small amount of wiggle on the left, which grows in amplitude in the middle and then decreases again on the right. The result is a small wave packet.",
+                caption: "",
+            },
+            version: {
+                major: 0,
+                minor: 0,
+            },
+        },
+    },
+};
+
+export const Exercise: Story = {
+    args: {
+        question,
+    },
+};
+
+export const Article: Story = {
+    args: {
+        question: sampleArticleSection,
+    },
+};

--- a/packages/perseus-editor/src/__stories__/content-renderer.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/content-renderer.stories.tsx
@@ -2,12 +2,13 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {useState} from "react";
 
+import {articleWithImages} from "../../../perseus/src/__testdata__/article-renderer.testdata";
 import {question} from "../../../perseus/src/widgets/__testdata__/radio.testdata";
 import DeviceFramer from "../components/device-framer";
 import ViewportResizer from "../components/viewport-resizer";
 import ContentRenderer from "../content-renderer";
 
-import type {DeviceType, PerseusRenderer} from "@khanacademy/perseus";
+import type {DeviceType} from "@khanacademy/perseus";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import "../styles/perseus-editor.less";
@@ -49,96 +50,6 @@ const meta: Meta<typeof ContentRenderer> = {
 export default meta;
 type Story = StoryObj<typeof ContentRenderer>;
 
-const sampleArticleSection: PerseusRenderer = {
-    content:
-        "The word \"radiation\" sometimes gets a bad rap. People often associate radiation with something dangerous or scary, without really knowing what it is. In reality, we're surrounded by radiation all the time. \n\n**Radiation** is energy that travels through space (not just \"outer space\"—any space). Radiation can also interact with matter. How radiation interacts with matter depends on the type of radiation and the type of matter.\n\nRadiation comes in many forms, one of which is *electromagnetic radiation*. Without electromagnetic radiation life on Earth would not be possible, nor would most modern technologies.\n\n[[☃ image 13]]\n\nLet's take a closer look at this important and fascinating type of radiation.\n\n##Electromagnetic radiation\n\nAs the name suggests, **electromagnetic (EM) radiation** is energy transferred by *electromagnetic fields* oscillating through space.\n\nEM radiation is strange—it has both wave and particle properties. Let's take a look at both.\n\n###Electromagnetic waves\n\nAn animated model of an EM wave is shown below.\n[[☃ image 1]]\nThe electric field $(\\vec{\\textbf{E}})$ is shown in $\\color{blue}\\textbf{blue}$, and the magnetic field $(\\vec{\\textbf{B}})$ is shown in $\\color{red}\\textbf{red}$. They're perpendicular to each other.\n\nA changing electric field creates a magnetic field, and a changing magnetic field creates an electric field. So, once the EM wave is generated it propagates itself through space!\n\nAs with any wave, EM waves have wavelength, frequency, and speed. The wave model of EM radiation works best on large scales. But what about the atomic scale?\n\n###Photons\n\nAt the quantum level, EM radiation exists as particles. A particle of EM radiation is called a **photon**.\n\nWe can think of photons as wave *packets*—tiny bundles of EM radiation containing specific amounts of energy. Photons are visually represented using the following symbol.\n\n[[☃ image 3]]\n\nAll EM radiation, whether modeled as waves or photons, travels at the **speed of light** $\\textbf{(c)}$ in a vacuum: \n\n$\\text{c}=3\\times10^8\\space\\pu{m/s}=300{,}000{,}000\\space\\pu{m/s}$\n\nBut, EM radiation travels at a slower speed in matter, such as water or glass.",
-    images: {},
-    widgets: {
-        "image 13": {
-            type: "image",
-            alignment: "block",
-            static: false,
-            graded: true,
-            options: {
-                static: false,
-                title: "",
-                range: [
-                    [0, 10],
-                    [0, 10],
-                ],
-                box: [600, 254],
-                backgroundImage: {
-                    url: "https://cdn.kastatic.org/ka-content-images/358a87c20ab6ee70447f5fcb547010f69986828e.jpg",
-                    width: 600,
-                    height: 254,
-                },
-                labels: [],
-                alt: "From space, the sun appears over Earth's horizon, illuminating the atmosphere as a blue layer above Earth. Above the atmosphere, space appears black.",
-                caption:
-                    "*Sunrise photo from the International Space Station. Earth's atmosphere scatters electromagnetic radiation from the sun, producing a bright sky during the day.*",
-            },
-            version: {
-                major: 0,
-                minor: 0,
-            },
-        },
-        "image 1": {
-            type: "image",
-            alignment: "block",
-            static: false,
-            graded: true,
-            options: {
-                static: false,
-                title: "",
-                range: [
-                    [0, 10],
-                    [0, 10],
-                ],
-                box: [627, 522],
-                backgroundImage: {
-                    url: "https://cdn.kastatic.org/ka-content-images/8100369eaf3b581d4e7bfc9f1062625309def486.gif",
-                    width: 627,
-                    height: 522,
-                },
-                labels: [],
-                alt: "An animation shows a blue electric field arrow oscillating up and down. Connected to the base of the electric field arrow is a magnetic field arrow, which oscillates from side to side. The two fields oscillate in unison: when one extends the other extends too, creating a repeating wave pattern.",
-                caption: "",
-            },
-            version: {
-                major: 0,
-                minor: 0,
-            },
-        },
-        "image 3": {
-            type: "image",
-            alignment: "block",
-            static: false,
-            graded: true,
-            options: {
-                static: false,
-                title: "",
-                range: [
-                    [0, 10],
-                    [0, 10],
-                ],
-                box: [350, 130],
-                backgroundImage: {
-                    url: "https://cdn.kastatic.org/ka-content-images/74edeeb6c6605a4e854e3a3e9db69c01dcf5508f.svg",
-                    width: 350,
-                    height: 130,
-                },
-                labels: [],
-                alt: "A squiggly curve drawn from left to right. The right end of the curve has an arrow point. The curve begins with a small amount of wiggle on the left, which grows in amplitude in the middle and then decreases again on the right. The result is a small wave packet.",
-                caption: "",
-            },
-            version: {
-                major: 0,
-                minor: 0,
-            },
-        },
-    },
-};
-
 export const Exercise: Story = {
     args: {
         question,
@@ -147,6 +58,6 @@ export const Exercise: Story = {
 
 export const Article: Story = {
     args: {
-        question: sampleArticleSection,
+        question: articleWithImages,
     },
 };

--- a/packages/perseus-editor/src/components/device-framer.tsx
+++ b/packages/perseus-editor/src/components/device-framer.tsx
@@ -60,7 +60,7 @@ const DeviceFramer = ({
     );
 
     if (nochrome) {
-        // Render content inside a variable height iframe.  Used on the
+        // Render content inside a variable height div.  Used on the
         // "edit" table of the content editor. In this mode, PerseusFrame
         // will draw the border and reserve space on the right for
         // lint indicators.

--- a/packages/perseus-editor/src/content-renderer.tsx
+++ b/packages/perseus-editor/src/content-renderer.tsx
@@ -20,11 +20,17 @@ function ComponentRenderer({
     apiOptions?: APIOptions;
 }) {
     return (
-        <View>
+        <View style={{marginRight: "40px"}}>
             <StatefulKeypadContextProvider>
                 <Renderer
                     strings={mockStrings}
                     apiOptions={apiOptions}
+                    linterContext={{
+                        contentType: "exercise",
+                        highlightLint: true,
+                        paths: [],
+                        stack: [],
+                    }}
                     {...question}
                 />
                 <KeypadContext.Consumer>

--- a/packages/perseus-editor/src/content-renderer.tsx
+++ b/packages/perseus-editor/src/content-renderer.tsx
@@ -3,24 +3,29 @@ import {
     MobileKeypad,
     StatefulKeypadContextProvider,
 } from "@khanacademy/math-input";
-import {Renderer} from "@khanacademy/perseus";
+import {Renderer, constants} from "@khanacademy/perseus";
+// eslint-disable-next-line monorepo/no-internal-import
+import {mockStrings} from "@khanacademy/perseus/strings";
 import {View} from "@khanacademy/wonder-blocks-core";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 // eslint-disable-next-line import/no-relative-packages
-import {mockStrings} from "../../perseus/src/strings";
 
 import type {APIOptions, PerseusRenderer} from "@khanacademy/perseus";
 
 function ComponentRenderer({
     question,
     apiOptions,
+    seamless,
 }: {
     question?: PerseusRenderer;
     apiOptions?: APIOptions;
+    seamless?: boolean;
 }) {
     return (
-        <View style={{marginRight: "40px"}}>
+        <View style={[styles.container, !seamless ? styles.gutter : undefined]}>
             <StatefulKeypadContextProvider>
                 <KeypadContext.Consumer>
                     {({setKeypadActive, keypadElement, setKeypadElement}) => (
@@ -30,10 +35,10 @@ function ComponentRenderer({
                                 apiOptions={apiOptions}
                                 keypadElement={keypadElement}
                                 linterContext={{
-                        contentType: "exercise",
-                        highlightLint: true,
-                        paths: [],
-                        stack: [],
+                                    contentType: "exercise",
+                                    highlightLint: true,
+                                    paths: [],
+                                    stack: [],
                                 }}
                                 {...question}
                             />
@@ -51,4 +56,8 @@ function ComponentRenderer({
     );
 }
 
+const styles = StyleSheet.create({
+    container: {padding: spacing.xxxSmall_4},
+    gutter: {marginRight: constants.lintGutterWidth},
+});
 export default ComponentRenderer;

--- a/packages/perseus-editor/src/content-renderer.tsx
+++ b/packages/perseus-editor/src/content-renderer.tsx
@@ -4,6 +4,7 @@ import {
     StatefulKeypadContextProvider,
 } from "@khanacademy/math-input";
 import {Renderer, constants} from "@khanacademy/perseus";
+// eslint-disable-next-line monorepo/no-internal-import
 import {mockStrings} from "@khanacademy/perseus/strings";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";

--- a/packages/perseus-editor/src/content-renderer.tsx
+++ b/packages/perseus-editor/src/content-renderer.tsx
@@ -26,8 +26,13 @@ function ContentRenderer({
     linterContext?: LinterContextProps;
     legacyPerseusLint?: ReadonlyArray<string>;
 }) {
+    const className = apiOptions?.isMobile ? "perseus-mobile" : "";
+
     return (
-        <View style={[styles.container, !seamless ? styles.gutter : undefined]}>
+        <View
+            className={`framework-perseus ${className}`}
+            style={[styles.container, !seamless ? styles.gutter : undefined]}
+        >
             <StatefulKeypadContextProvider>
                 <KeypadContext.Consumer>
                     {({setKeypadActive, keypadElement, setKeypadElement}) => (

--- a/packages/perseus-editor/src/content-renderer.tsx
+++ b/packages/perseus-editor/src/content-renderer.tsx
@@ -4,14 +4,11 @@ import {
     StatefulKeypadContextProvider,
 } from "@khanacademy/math-input";
 import {Renderer, constants} from "@khanacademy/perseus";
-// eslint-disable-next-line monorepo/no-internal-import
 import {mockStrings} from "@khanacademy/perseus/strings";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
-
-// eslint-disable-next-line import/no-relative-packages
 
 import type {APIOptions, PerseusRenderer} from "@khanacademy/perseus";
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
@@ -58,7 +55,11 @@ function ContentRenderer({
 }
 
 const styles = StyleSheet.create({
-    container: {padding: spacing.xxxSmall_4},
+    container: {
+        padding: spacing.xxxSmall_4,
+        containerType: "inline-size",
+        containerName: "perseus-root",
+    },
     gutter: {marginRight: constants.lintGutterWidth},
 });
 

--- a/packages/perseus-editor/src/content-renderer.tsx
+++ b/packages/perseus-editor/src/content-renderer.tsx
@@ -14,15 +14,20 @@ import * as React from "react";
 // eslint-disable-next-line import/no-relative-packages
 
 import type {APIOptions, PerseusRenderer} from "@khanacademy/perseus";
+import type {LinterContextProps} from "@khanacademy/perseus-linter";
 
-function ComponentRenderer({
+function ContentRenderer({
     question,
     apiOptions,
     seamless,
+    linterContext,
+    legacyPerseusLint,
 }: {
     question?: PerseusRenderer;
     apiOptions?: APIOptions;
     seamless?: boolean;
+    linterContext?: LinterContextProps;
+    legacyPerseusLint?: ReadonlyArray<string>;
 }) {
     return (
         <View style={[styles.container, !seamless ? styles.gutter : undefined]}>
@@ -34,12 +39,8 @@ function ComponentRenderer({
                                 strings={mockStrings}
                                 apiOptions={apiOptions}
                                 keypadElement={keypadElement}
-                                linterContext={{
-                                    contentType: "exercise",
-                                    highlightLint: true,
-                                    paths: [],
-                                    stack: [],
-                                }}
+                                linterContext={linterContext}
+                                legacyPerseusLint={legacyPerseusLint}
                                 {...question}
                             />
 
@@ -60,4 +61,5 @@ const styles = StyleSheet.create({
     container: {padding: spacing.xxxSmall_4},
     gutter: {marginRight: constants.lintGutterWidth},
 });
-export default ComponentRenderer;
+
+export default ContentRenderer;

--- a/packages/perseus-editor/src/content-renderer.tsx
+++ b/packages/perseus-editor/src/content-renderer.tsx
@@ -1,0 +1,50 @@
+import {
+    KeypadContext,
+    MobileKeypad,
+    StatefulKeypadContextProvider,
+} from "@khanacademy/math-input";
+import {Renderer} from "@khanacademy/perseus";
+import {View} from "@khanacademy/wonder-blocks-core";
+import * as React from "react";
+
+// eslint-disable-next-line import/no-relative-packages
+import {mockStrings} from "../../perseus/src/strings";
+
+import type {APIOptions, PerseusRenderer} from "@khanacademy/perseus";
+
+function ComponentRenderer({
+    question,
+    apiOptions,
+}: {
+    question?: PerseusRenderer;
+    apiOptions?: APIOptions;
+}) {
+    return (
+        <View>
+            <StatefulKeypadContextProvider>
+                <Renderer
+                    strings={mockStrings}
+                    apiOptions={apiOptions}
+                    {...question}
+                />
+                <KeypadContext.Consumer>
+                    {({setKeypadActive, setKeypadElement}) => {
+                        return (
+                            <MobileKeypad
+                                onAnalyticsEvent={() => Promise.resolve()}
+                                onDismiss={() => setKeypadActive(false)}
+                                onElementMounted={(element) => {
+                                    if (element) {
+                                        setKeypadElement(element);
+                                    }
+                                }}
+                            />
+                        );
+                    }}
+                </KeypadContext.Consumer>
+            </StatefulKeypadContextProvider>
+        </View>
+    );
+}
+
+export default ComponentRenderer;

--- a/packages/perseus-editor/src/content-renderer.tsx
+++ b/packages/perseus-editor/src/content-renderer.tsx
@@ -22,31 +22,29 @@ function ComponentRenderer({
     return (
         <View style={{marginRight: "40px"}}>
             <StatefulKeypadContextProvider>
-                <Renderer
-                    strings={mockStrings}
-                    apiOptions={apiOptions}
-                    linterContext={{
+                <KeypadContext.Consumer>
+                    {({setKeypadActive, keypadElement, setKeypadElement}) => (
+                        <>
+                            <Renderer
+                                strings={mockStrings}
+                                apiOptions={apiOptions}
+                                keypadElement={keypadElement}
+                                linterContext={{
                         contentType: "exercise",
                         highlightLint: true,
                         paths: [],
                         stack: [],
-                    }}
-                    {...question}
-                />
-                <KeypadContext.Consumer>
-                    {({setKeypadActive, setKeypadElement}) => {
-                        return (
+                                }}
+                                {...question}
+                            />
+
                             <MobileKeypad
                                 onAnalyticsEvent={() => Promise.resolve()}
                                 onDismiss={() => setKeypadActive(false)}
-                                onElementMounted={(element) => {
-                                    if (element) {
-                                        setKeypadElement(element);
-                                    }
-                                }}
+                                onElementMounted={setKeypadElement}
                             />
-                        );
-                    }}
+                        </>
+                    )}
                 </KeypadContext.Consumer>
             </StatefulKeypadContextProvider>
         </View>

--- a/packages/perseus-editor/src/item-editor.tsx
+++ b/packages/perseus-editor/src/item-editor.tsx
@@ -5,6 +5,7 @@ import _ from "underscore";
 import DeviceFramer from "./components/device-framer";
 import Editor from "./editor";
 import IframeContentRenderer from "./iframe-content-renderer";
+import ContentRenderer from "./content-renderer";
 import ItemExtrasEditor from "./item-extras-editor";
 
 import type {
@@ -89,9 +90,6 @@ class ItemEditor extends React.Component<Props> {
     };
 
     render(): React.ReactNode {
-        const isMobile =
-            this.props.deviceType === "phone" ||
-            this.props.deviceType === "tablet";
         return (
             <div className="perseus-editor-table">
                 <div className="perseus-editor-row perseus-question-container">
@@ -120,13 +118,9 @@ class ItemEditor extends React.Component<Props> {
                                 deviceType={this.props.deviceType}
                                 nochrome={true}
                             >
-                                <IframeContentRenderer
-                                    ref={this.frame}
-                                    key={this.props.deviceType}
-                                    datasetKey="mobile"
-                                    datasetValue={isMobile}
-                                    seamless={true}
-                                    url={this.props.previewURL}
+                                <ContentRenderer
+                                    apiOptions={this.props.apiOptions}
+                                    question={this.props.question}
                                 />
                             </DeviceFramer>
                             <div

--- a/packages/perseus/src/__testdata__/article-renderer.testdata.ts
+++ b/packages/perseus/src/__testdata__/article-renderer.testdata.ts
@@ -33,6 +33,96 @@ export const singleSectionArticle: PerseusRenderer = {
     },
 };
 
+export const articleWithImages: PerseusRenderer = {
+    content:
+        "The word \"radiation\" sometimes gets a bad rap. People often associate radiation with something dangerous or scary, without really knowing what it is. In reality, we're surrounded by radiation all the time. \n\n**Radiation** is energy that travels through space (not just \"outer space\"—any space). Radiation can also interact with matter. How radiation interacts with matter depends on the type of radiation and the type of matter.\n\nRadiation comes in many forms, one of which is *electromagnetic radiation*. Without electromagnetic radiation life on Earth would not be possible, nor would most modern technologies.\n\n[[☃ image 13]]\n\nLet's take a closer look at this important and fascinating type of radiation.\n\n##Electromagnetic radiation\n\nAs the name suggests, **electromagnetic (EM) radiation** is energy transferred by *electromagnetic fields* oscillating through space.\n\nEM radiation is strange—it has both wave and particle properties. Let's take a look at both.\n\n###Electromagnetic waves\n\nAn animated model of an EM wave is shown below.\n[[☃ image 1]]\nThe electric field $(\\vec{\\textbf{E}})$ is shown in $\\color{blue}\\textbf{blue}$, and the magnetic field $(\\vec{\\textbf{B}})$ is shown in $\\color{red}\\textbf{red}$. They're perpendicular to each other.\n\nA changing electric field creates a magnetic field, and a changing magnetic field creates an electric field. So, once the EM wave is generated it propagates itself through space!\n\nAs with any wave, EM waves have wavelength, frequency, and speed. The wave model of EM radiation works best on large scales. But what about the atomic scale?\n\n###Photons\n\nAt the quantum level, EM radiation exists as particles. A particle of EM radiation is called a **photon**.\n\nWe can think of photons as wave *packets*—tiny bundles of EM radiation containing specific amounts of energy. Photons are visually represented using the following symbol.\n\n[[☃ image 3]]\n\nAll EM radiation, whether modeled as waves or photons, travels at the **speed of light** $\\textbf{(c)}$ in a vacuum: \n\n$\\text{c}=3\\times10^8\\space\\pu{m/s}=300{,}000{,}000\\space\\pu{m/s}$\n\nBut, EM radiation travels at a slower speed in matter, such as water or glass.",
+    images: {},
+    widgets: {
+        "image 13": {
+            type: "image",
+            alignment: "block",
+            static: false,
+            graded: true,
+            options: {
+                static: false,
+                title: "",
+                range: [
+                    [0, 10],
+                    [0, 10],
+                ],
+                box: [600, 254],
+                backgroundImage: {
+                    url: "https://cdn.kastatic.org/ka-content-images/358a87c20ab6ee70447f5fcb547010f69986828e.jpg",
+                    width: 600,
+                    height: 254,
+                },
+                labels: [],
+                alt: "From space, the sun appears over Earth's horizon, illuminating the atmosphere as a blue layer above Earth. Above the atmosphere, space appears black.",
+                caption:
+                    "*Sunrise photo from the International Space Station. Earth's atmosphere scatters electromagnetic radiation from the sun, producing a bright sky during the day.*",
+            },
+            version: {
+                major: 0,
+                minor: 0,
+            },
+        },
+        "image 1": {
+            type: "image",
+            alignment: "block",
+            static: false,
+            graded: true,
+            options: {
+                static: false,
+                title: "",
+                range: [
+                    [0, 10],
+                    [0, 10],
+                ],
+                box: [627, 522],
+                backgroundImage: {
+                    url: "https://cdn.kastatic.org/ka-content-images/8100369eaf3b581d4e7bfc9f1062625309def486.gif",
+                    width: 627,
+                    height: 522,
+                },
+                labels: [],
+                alt: "An animation shows a blue electric field arrow oscillating up and down. Connected to the base of the electric field arrow is a magnetic field arrow, which oscillates from side to side. The two fields oscillate in unison: when one extends the other extends too, creating a repeating wave pattern.",
+                caption: "",
+            },
+            version: {
+                major: 0,
+                minor: 0,
+            },
+        },
+        "image 3": {
+            type: "image",
+            alignment: "block",
+            static: false,
+            graded: true,
+            options: {
+                static: false,
+                title: "",
+                range: [
+                    [0, 10],
+                    [0, 10],
+                ],
+                box: [350, 130],
+                backgroundImage: {
+                    url: "https://cdn.kastatic.org/ka-content-images/74edeeb6c6605a4e854e3a3e9db69c01dcf5508f.svg",
+                    width: 350,
+                    height: 130,
+                },
+                labels: [],
+                alt: "A squiggly curve drawn from left to right. The right end of the curve has an arrow point. The curve begins with a small amount of wiggle on the left, which grows in amplitude in the middle and then decreases again on the right. The result is a small wave packet.",
+                caption: "",
+            },
+            version: {
+                major: 0,
+                minor: 0,
+            },
+        },
+    },
+};
+
 export const passageArticle: PerseusRenderer = {
     content:
         "###Group/Pair Activity \n\nThis passage is adapted from Ed Yong, “Turtles Use the Earth’s Magnetic Field as Global GPS.” ©2011 by Kalmbach Publishing Co.\n\n[[☃ passage 1]]\n\n**Question 9**\n\nThe passage most strongly suggests that Adelita used which of the following to navigate her 9,000-mile journey?\n\nA) The current of the North Atlantic gyre\n\nB) Cues from electromagnetic coils designed by Putman and Lohmann\n\nC) The inclination and intensity of Earth’s magnetic field\n\nD) A simulated “magnetic signature” configured by Lohmann\n\n10) Which choice provides the best evidence for the answer to the previous question?\n\nA) Lines 1–2 (“In 1996...way”)\n\nB) Lines 20–21 (“Using...surface”)\n\nC) Lines 36–37 (“In the wild...stars”)\n\nD) Lines 43–45 (“Neither...it is”)\n\n**Question 12** \n\nBased on the passage, which choice best describes the relationship between Putman’s and Lohmann’s research?\n\nA) Putman’s research contradicts Lohmann’s.\n\nB) Putman’s research builds on Lohmann’s.\n\nC) Lohmann’s research confirms Putman’s.\n\nD) Lohmann’s research corrects Putman’s.",

--- a/packages/perseus/src/components/lint.tsx
+++ b/packages/perseus/src/components/lint.tsx
@@ -1,17 +1,10 @@
 import {StyleSheet, css} from "aphrodite";
 import * as React from "react";
 import Tooltip from "@khanacademy/wonder-blocks-tooltip";
-
+import ExclamationIcon from "@phosphor-icons/core/regular/warning-circle.svg";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import * as constants from "../styles/constants";
-
-import InlineIcon from "./inline-icon";
 import {color, font} from "@khanacademy/wonder-blocks-tokens";
-
-const exclamationIcon = {
-    path: "M6 11a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm0-9a1 1 0 0 1 1 1v4a1 1 0 1 1-2 0V3a1 1 0 0 1 1-1z",
-    height: 12,
-    width: 12,
-} as const;
 
 enum Severity {
     Error = 1,
@@ -107,7 +100,7 @@ class Lint extends React.Component<Props> {
                 >
                     <span className={css(styles.indicator, severityStyle)}>
                         {this.props.severity === 1 && (
-                            <InlineIcon {...exclamationIcon} />
+                            <PhosphorIcon icon={ExclamationIcon} />
                         )}
                     </span>
                 </a>

--- a/packages/perseus/src/components/lint.tsx
+++ b/packages/perseus/src/components/lint.tsx
@@ -1,10 +1,11 @@
 import {StyleSheet, css} from "aphrodite";
 import * as React from "react";
-import ReactDOM from "react-dom";
+import Tooltip from "@khanacademy/wonder-blocks-tooltip";
 
 import * as constants from "../styles/constants";
 
 import InlineIcon from "./inline-icon";
+import {color, font} from "@khanacademy/wonder-blocks-tokens";
 
 const exclamationIcon = {
     path: "M6 11a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm0-9a1 1 0 0 1 1 1v4a1 1 0 1 1-2 0V3a1 1 0 0 1 1-1z",
@@ -38,10 +39,6 @@ type Props = {
     severity?: Severity;
 };
 
-type State = {
-    tooltipAbove: boolean;
-};
-
 /**
  * This component renders "lint" nodes in a markdown parse tree. Lint nodes
  * are inserted into the tree by the Perseus linter (see
@@ -64,43 +61,12 @@ type State = {
  * that has a right margin (like anything blockquoted) the circle will appear
  * to the left of where it belongs.  And if there is more
  **/
-class Lint extends React.Component<Props, State> {
+class Lint extends React.Component<Props> {
     _positionTimeout: number | undefined;
-
-    state: State = {
-        tooltipAbove: true,
-    };
-
-    componentDidMount() {
-        // TODO(somewhatabstract): Use WB timing
-        // eslint-disable-next-line no-restricted-syntax
-        this._positionTimeout = window.setTimeout(this.getPosition);
-    }
-
-    componentWillUnmount() {
-        // TODO(somewhatabstract): Use WB timing
-        // eslint-disable-next-line no-restricted-syntax
-        window.clearTimeout(this._positionTimeout);
-    }
-
-    // We can't call setState in componentDidMount without risking a render
-    // thrash, and we can't call getBoundingClientRect in render, so we
-    // borrow a timeout approach from learnstorm-dashboard.jsx and set our
-    // state once the component has mounted and we can get what we need.
-    getPosition: () => void = () => {
-        // @ts-expect-error - TS2531 - Object is possibly 'null'. | TS2339 - Property 'getBoundingClientRect' does not exist on type 'Element | Text'.
-        const rect = ReactDOM.findDOMNode(this).getBoundingClientRect();
-        // TODO(scottgrant): This is a magic number! We don't know the size
-        // of the tooltip at this point, so we're arbitrarily choosing a
-        // point at which to flip the tooltip's position.
-        this.setState({tooltipAbove: rect.top > 100});
-    };
 
     // Render the <a> element that holds the indicator icon and the tooltip
     // We pass different styles for the inline and block cases
     renderLink: (arg1: any) => React.ReactElement = (style) => {
-        const tooltipAbove = this.state.tooltipAbove;
-
         let severityStyle;
         let warningText;
         let warningTextStyle;
@@ -119,38 +85,33 @@ class Lint extends React.Component<Props, State> {
         }
 
         return (
-            <a
-                href={`https://khanacademy.org/r/linter-rules#${this.props.ruleName}`}
-                target="lint-help-window"
-                className={css(style)}
+            <Tooltip
+                backgroundColor={"offBlack"}
+                content={
+                    <>
+                        {this.props.message.split("\n\n").map((m, i) => (
+                            <p key={i} className={css(styles.tooltipParagraph)}>
+                                <span className={css(warningTextStyle)}>
+                                    {warningText}:{" "}
+                                </span>
+                                {m}
+                            </p>
+                        ))}
+                    </>
+                }
             >
-                <span className={css(styles.indicator, severityStyle)}>
-                    {this.props.severity === 1 && (
-                        <InlineIcon {...exclamationIcon} />
-                    )}
-                </span>
-                <div
-                    className={css(
-                        styles.tooltip,
-                        tooltipAbove && styles.tooltipAbove,
-                    )}
+                <a
+                    href={`https://khanacademy.org/r/linter-rules#${this.props.ruleName}`}
+                    target="lint-help-window"
+                    className={css(style)}
                 >
-                    {this.props.message.split("\n\n").map((m, i) => (
-                        <p key={i} className={css(styles.tooltipParagraph)}>
-                            <span className={css(warningTextStyle)}>
-                                {warningText}:{" "}
-                            </span>
-                            {m}
-                        </p>
-                    ))}
-                    <div
-                        className={css(
-                            styles.tail,
-                            tooltipAbove && styles.tailAbove,
+                    <span className={css(styles.indicator, severityStyle)}>
+                        {this.props.severity === 1 && (
+                            <InlineIcon {...exclamationIcon} />
                         )}
-                    />
-                </div>
-            </a>
+                    </span>
+                </a>
+            </Tooltip>
         );
     };
 
@@ -386,60 +347,11 @@ const styles = StyleSheet.create({
         backgroundColor: "#ffbe26",
     },
 
-    // These are the styles for the tooltip
-    tooltip: {
-        // Absolute positioning relative to the lint indicator circle.
-        position: "absolute",
-        right: -12,
-
-        // The tooltip is hidden by default; only displayed on hover
-        display: "none",
-
-        // When it is displayed, it goes on top!
-        zIndex: 1000,
-
-        // These styles control what the tooltip looks like
-        color: constants.white,
-        backgroundColor: constants.gray17,
-        opacity: 0.9,
-        fontFamily: constants.baseFontFamily,
-        fontSize: "12px",
-        lineHeight: "15px",
-        width: "320px",
-        borderRadius: "4px",
-    },
-    // If we're going to render the tooltip above the warning circle, we use
-    // the previous rules in tooltip, but change the position slightly.
-    tooltipAbove: {
-        bottom: 32,
-    },
-
-    // We give the tooltip a little triangular "tail" that points down at
-    // the lint indicator circle. This is inside the tooltip and positioned
-    // relative to it. It also shares the opacity of the tooltip. We're using
-    // the standard CSS trick for drawing triangles with a thick border.
-    tail: {
-        position: "absolute",
-        top: -12,
-        right: 16,
-        width: 0,
-        height: 0,
-
-        // This is the CSS triangle trick
-        borderLeft: "8px solid transparent",
-        borderRight: "8px solid transparent",
-        borderBottom: "12px solid " + constants.gray17,
-    },
-    tailAbove: {
-        bottom: -12,
-        borderBottom: "none",
-        borderTop: "12px solid " + constants.gray17,
-        top: "auto",
-    },
-
     // Each warning in the tooltip is its own <p>. They are 12 pixels from
     // the edges of the tooltip and 12 pixels from each other.
     tooltipParagraph: {
+        fontFamily: font.family.sans,
+        color: color.white,
         margin: 12,
     },
 

--- a/packages/perseus/src/components/lint.tsx
+++ b/packages/perseus/src/components/lint.tsx
@@ -1,10 +1,16 @@
 import {StyleSheet, css} from "aphrodite";
 import * as React from "react";
-import Tooltip from "@khanacademy/wonder-blocks-tooltip";
-import ExclamationIcon from "@phosphor-icons/core/regular/warning-circle.svg";
-import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
+import ReactDOM from "react-dom";
+
 import * as constants from "../styles/constants";
-import {color, font} from "@khanacademy/wonder-blocks-tokens";
+
+import InlineIcon from "./inline-icon";
+
+const exclamationIcon = {
+    path: "M6 11a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm0-9a1 1 0 0 1 1 1v4a1 1 0 1 1-2 0V3a1 1 0 0 1 1-1z",
+    height: 12,
+    width: 12,
+} as const;
 
 enum Severity {
     Error = 1,
@@ -32,6 +38,10 @@ type Props = {
     severity?: Severity;
 };
 
+type State = {
+    tooltipAbove: boolean;
+};
+
 /**
  * This component renders "lint" nodes in a markdown parse tree. Lint nodes
  * are inserted into the tree by the Perseus linter (see
@@ -54,12 +64,43 @@ type Props = {
  * that has a right margin (like anything blockquoted) the circle will appear
  * to the left of where it belongs.  And if there is more
  **/
-class Lint extends React.Component<Props> {
+class Lint extends React.Component<Props, State> {
     _positionTimeout: number | undefined;
+
+    state: State = {
+        tooltipAbove: true,
+    };
+
+    componentDidMount() {
+        // TODO(somewhatabstract): Use WB timing
+        // eslint-disable-next-line no-restricted-syntax
+        this._positionTimeout = window.setTimeout(this.getPosition);
+    }
+
+    componentWillUnmount() {
+        // TODO(somewhatabstract): Use WB timing
+        // eslint-disable-next-line no-restricted-syntax
+        window.clearTimeout(this._positionTimeout);
+    }
+
+    // We can't call setState in componentDidMount without risking a render
+    // thrash, and we can't call getBoundingClientRect in render, so we
+    // borrow a timeout approach from learnstorm-dashboard.jsx and set our
+    // state once the component has mounted and we can get what we need.
+    getPosition: () => void = () => {
+        // @ts-expect-error - TS2531 - Object is possibly 'null'. | TS2339 - Property 'getBoundingClientRect' does not exist on type 'Element | Text'.
+        const rect = ReactDOM.findDOMNode(this).getBoundingClientRect();
+        // TODO(scottgrant): This is a magic number! We don't know the size
+        // of the tooltip at this point, so we're arbitrarily choosing a
+        // point at which to flip the tooltip's position.
+        this.setState({tooltipAbove: rect.top > 100});
+    };
 
     // Render the <a> element that holds the indicator icon and the tooltip
     // We pass different styles for the inline and block cases
     renderLink: (arg1: any) => React.ReactElement = (style) => {
+        const tooltipAbove = this.state.tooltipAbove;
+
         let severityStyle;
         let warningText;
         let warningTextStyle;
@@ -78,33 +119,38 @@ class Lint extends React.Component<Props> {
         }
 
         return (
-            <Tooltip
-                backgroundColor={"offBlack"}
-                content={
-                    <>
-                        {this.props.message.split("\n\n").map((m, i) => (
-                            <p key={i} className={css(styles.tooltipParagraph)}>
-                                <span className={css(warningTextStyle)}>
-                                    {warningText}:{" "}
-                                </span>
-                                {m}
-                            </p>
-                        ))}
-                    </>
-                }
+            <a
+                href={`https://khanacademy.org/r/linter-rules#${this.props.ruleName}`}
+                target="lint-help-window"
+                className={css(style)}
             >
-                <a
-                    href={`https://khanacademy.org/r/linter-rules#${this.props.ruleName}`}
-                    target="lint-help-window"
-                    className={css(style)}
+                <span className={css(styles.indicator, severityStyle)}>
+                    {this.props.severity === 1 && (
+                        <InlineIcon {...exclamationIcon} />
+                    )}
+                </span>
+                <div
+                    className={css(
+                        styles.tooltip,
+                        tooltipAbove && styles.tooltipAbove,
+                    )}
                 >
-                    <span className={css(styles.indicator, severityStyle)}>
-                        {this.props.severity === 1 && (
-                            <PhosphorIcon icon={ExclamationIcon} />
+                    {this.props.message.split("\n\n").map((m, i) => (
+                        <p key={i} className={css(styles.tooltipParagraph)}>
+                            <span className={css(warningTextStyle)}>
+                                {warningText}:{" "}
+                            </span>
+                            {m}
+                        </p>
+                    ))}
+                    <div
+                        className={css(
+                            styles.tail,
+                            tooltipAbove && styles.tailAbove,
                         )}
-                    </span>
-                </a>
-            </Tooltip>
+                    />
+                </div>
+            </a>
         );
     };
 
@@ -340,11 +386,60 @@ const styles = StyleSheet.create({
         backgroundColor: "#ffbe26",
     },
 
+    // These are the styles for the tooltip
+    tooltip: {
+        // Absolute positioning relative to the lint indicator circle.
+        position: "absolute",
+        right: -12,
+
+        // The tooltip is hidden by default; only displayed on hover
+        display: "none",
+
+        // When it is displayed, it goes on top!
+        zIndex: 1000,
+
+        // These styles control what the tooltip looks like
+        color: constants.white,
+        backgroundColor: constants.gray17,
+        opacity: 0.9,
+        fontFamily: constants.baseFontFamily,
+        fontSize: "12px",
+        lineHeight: "15px",
+        width: "320px",
+        borderRadius: "4px",
+    },
+    // If we're going to render the tooltip above the warning circle, we use
+    // the previous rules in tooltip, but change the position slightly.
+    tooltipAbove: {
+        bottom: 32,
+    },
+
+    // We give the tooltip a little triangular "tail" that points down at
+    // the lint indicator circle. This is inside the tooltip and positioned
+    // relative to it. It also shares the opacity of the tooltip. We're using
+    // the standard CSS trick for drawing triangles with a thick border.
+    tail: {
+        position: "absolute",
+        top: -12,
+        right: 16,
+        width: 0,
+        height: 0,
+
+        // This is the CSS triangle trick
+        borderLeft: "8px solid transparent",
+        borderRight: "8px solid transparent",
+        borderBottom: "12px solid " + constants.gray17,
+    },
+    tailAbove: {
+        bottom: -12,
+        borderBottom: "none",
+        borderTop: "12px solid " + constants.gray17,
+        top: "auto",
+    },
+
     // Each warning in the tooltip is its own <p>. They are 12 pixels from
     // the edges of the tooltip and 12 pixels from each other.
     tooltipParagraph: {
-        fontFamily: font.family.sans,
-        color: color.white,
         margin: 12,
     },
 


### PR DESCRIPTION
## Summary:

This PR introduces a new component `ContentRenderer` (in the spirit of the original `IframeContentRenderer`). It previews Perseus content but no longer uses an `<iframe />` for preview. 

The IFrame preview system has several shortcomings that this series of PRs will address:

  1. The preview system is slow to load (it loads the entire webapp App Shell) including user authorization status.
  1. The preview system does not work in Storybook - we could likely get something working but it would involve copying some code from webapp over and then exposing a new http endpoint to serve up the preview page
  1. The preview system is complicated in that it uses `postMessage` to communicate between the host editor and the preview page. This code is split between Perseus and webapp and the contract is entirely implicit (there's no strong Typescript types or even any sort of code contract that defines what is passed between the host and iframe). 

<img width="1025" alt="image" src="https://github.com/user-attachments/assets/2b9ee49c-eb9b-4c2a-a3c5-5b30eefd5910">

And an example showing lint errors being displayed:

<img width="820" alt="image" src="https://github.com/user-attachments/assets/be14473f-881f-4208-8cbd-86551e952662">


Issue: LEMS-1809

## Test plan:

`yarn start`
Navigate to the `ContentRenderer` story