### PR TITLE
fix(LEMS-2083): fix color contrast issues

### DIFF
--- a/.changeset/smooth-hornets-march.md
+++ b/.changeset/smooth-hornets-march.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/math-input": patch
+"@khanacademy/perseus": patch
+---
+
+updates math input to fix color contrast issues

--- a/packages/math-input/src/components/tabbar/item.tsx
+++ b/packages/math-input/src/components/tabbar/item.tsx
@@ -21,7 +21,6 @@ const styles = StyleSheet.create({
         marginLeft: 1,
     },
     hovered: {
-        background: `linear-gradient(0deg, rgba(24, 101, 242, 0.32), rgba(24, 101, 242, 0.32)), ${color.white}`,
         border: "1px solid #1865F2",
     },
     pressed: {

--- a/packages/perseus/src/components/math-input.tsx
+++ b/packages/perseus/src/components/math-input.tsx
@@ -521,7 +521,7 @@ const styles = StyleSheet.create({
         backgroundColor: color.offBlack8,
     },
     iconActive: {
-        border: "2px solid white",
+        border: `2px solid ${color.white}`,
         backgroundColor: color.offBlack64,
     },
     outerWrapper: {

--- a/packages/perseus/src/components/math-input.tsx
+++ b/packages/perseus/src/components/math-input.tsx
@@ -517,9 +517,11 @@ const styles = StyleSheet.create({
         borderRadius: 1,
     },
     iconInactive: {
+        border: `2px solid transparent`,
         backgroundColor: color.offBlack8,
     },
     iconActive: {
+        border: "2px solid white",
         backgroundColor: color.offBlack64,
     },
     outerWrapper: {

--- a/packages/perseus/src/components/math-input.tsx
+++ b/packages/perseus/src/components/math-input.tsx
@@ -517,7 +517,7 @@ const styles = StyleSheet.create({
         borderRadius: 1,
     },
     iconInactive: {
-        border: `2px solid transparent`,
+        border: "2px solid transparent",
         backgroundColor: color.offBlack8,
     },
     iconActive: {


### PR DESCRIPTION
## Summary:
- Removes hover color from math input tabs 
- Adds white border to open math keyboard button to increase contrast between icon and active state border

Issue: LEMS-2083

## Test plan:
1. Navigate to [Math Input in storybook ](https://650db21c3f5d1b2f13c02952-edopglbcau.chromatic.com/)
2. Open the expression widget 
3. Hover over tabs 
4. Close expression widget 

### Expected behavior
(Step 3)
- On Hover, tabs should not have a background color 

(Step 4)
- Focus state (active) for math keyboard button should have extra white space between the border of the input and the icon

## Screenshots 
### Before

https://github.com/user-attachments/assets/05bd0962-5bd6-4875-bbb3-f519ab4bdc93
 

### After 

https://github.com/user-attachments/assets/701a0ec5-3449-4800-9e47-3531546b2a52

