### PR TITLE
Add "static" toggle to Interactive Graph widget

### DIFF
--- a/.changeset/gentle-dragons-hide.md
+++ b/.changeset/gentle-dragons-hide.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Add static mode to interactive graph

--- a/packages/perseus-editor/src/__stories__/editor-page-with-storybook-preview.tsx
+++ b/packages/perseus-editor/src/__stories__/editor-page-with-storybook-preview.tsx
@@ -123,7 +123,6 @@ function EditorPageWithStorybookPreview(props: Props) {
                             <Renderer
                                 strings={mockStrings}
                                 apiOptions={apiOptions}
-                                hintMode={true}
                                 {...hint}
                             />
                         </View>

--- a/packages/perseus/src/__tests__/renderer.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.test.tsx
@@ -1352,30 +1352,6 @@ describe("renderer", () => {
             expect(el).not.toBeNull();
         });
 
-        it("should force the widget to be non-static if it has a problem number", () => {
-            // Arrange/Act
-            const {renderer} = renderQuestion(
-                {
-                    ...question1,
-                    widgets: {
-                        ...question1.widgets,
-                        "dropdown 1": {
-                            ...question1.widgets["dropdown 1"],
-                            static: true,
-                        },
-                    },
-                },
-                {},
-                {problemNum: 1},
-            );
-
-            // Assert
-            const [dropdownWidget] = renderer.findWidgets("dropdown 1");
-
-            // Act
-            expect(dropdownWidget.props.static).toBe(false);
-        });
-
         it("should ask each widget to show rationales", () => {
             // Arrange
             const {renderer} = renderQuestion(mockedItem);

--- a/packages/perseus/src/hint-renderer.tsx
+++ b/packages/perseus/src/hint-renderer.tsx
@@ -106,7 +106,6 @@ class HintRenderer extends React.Component<Props> {
                 <Renderer
                     // eslint-disable-next-line react/no-string-refs
                     ref="renderer"
-                    hintMode={true}
                     widgets={hint.widgets}
                     content={hint.content || ""}
                     images={hint.images}

--- a/packages/perseus/src/mixins/widget-prop-denylist.ts
+++ b/packages/perseus/src/mixins/widget-prop-denylist.ts
@@ -23,7 +23,6 @@ const denylist = [
     "apiOptions",
     "questionCompleted",
     "findWidgets",
-    "hintMode",
     // added by src/editor.jsx, for widgets removing themselves
     // this is soooo not the right place for this, but alas.
     "onRemove",

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -177,13 +177,6 @@ type Props = Partial<React.ContextType<typeof DependenciesContext>> & {
     questionCompleted?: boolean;
     reviewMode?: boolean | null | undefined;
     /**
-     * Some widgets (e.g. InteractiveGraph) support "hint mode", a state where
-     * the widget is non-editable, may have a partial solution filled in,
-     * and may have special styling. Setting hintMode to true will turn on hint
-     * mode for all rendered widgets.
-     */
-    hintMode?: boolean;
-    /**
      * If set to "all", all rationales or solutions will be shown. If set to
      * "selected", soltions will only be shown for selected choices. If set to
      * "none", solutions will not be shown-- equivalent to `undefined`.
@@ -247,7 +240,6 @@ type DefaultProps = Required<
         | "questionCompleted"
         | "showSolutions"
         | "reviewMode"
-        | "hintMode"
         | "serializedState"
         | "widgets"
     >
@@ -294,7 +286,6 @@ class Renderer extends React.Component<Props, State> {
         findExternalWidgets: () => [],
         alwaysUpdate: false,
         reviewMode: false,
-        hintMode: false,
         serializedState: null,
         onSerializedStateUpdated: () => {},
         linterContext: PerseusLinter.linterContextDefault,
@@ -676,7 +667,6 @@ class Renderer extends React.Component<Props, State> {
             onBlur: _.partial(this._onWidgetBlur, id),
             findWidgets: this.findWidgets,
             reviewModeRubric: reviewModeRubric,
-            hintMode: this.props.hintMode,
             onChange: (newProps, cb, silent = false) => {
                 this._setWidgetProps(id, newProps, cb, silent);
             },

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -655,9 +655,7 @@ class Renderer extends React.Component<Props, State> {
             ...widgetProps,
             widgetId: id,
             alignment: widgetInfo && widgetInfo.alignment,
-            // When determining if a widget is static, we verify that the widget is not an
-            // exercise question by verifying that it has no problem number.
-            static: widgetInfo && widgetInfo.static && !this.props.problemNum,
+            static: widgetInfo?.static,
             problemNum: this.props.problemNum,
             apiOptions: this.getApiOptions(),
             keypadElement: this.props.keypadElement,

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -588,7 +588,6 @@ export type WidgetProps<
     onBlur: (blurPath: FocusPath) => void;
     findWidgets: (arg1: FilterCriterion) => ReadonlyArray<Widget>;
     reviewModeRubric: Rubric;
-    hintMode: boolean;
     onChange: ChangeHandler;
     // This is slightly different from the `trackInteraction` function in
     // APIOptions. This provides the widget an easy way to notify the renderer

--- a/packages/perseus/src/widgets/__stories__/expression.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/expression.stories.tsx
@@ -94,7 +94,6 @@ export const DesktopKitchenSink = (args: StoryArgs): React.ReactElement => {
                 trackInteraction={() => {}}
                 widgetId="expression"
                 reviewModeRubric={reviewModeRubric}
-                hintMode={false}
                 keypadConfiguration={keypadConfiguration}
             />
         </div>

--- a/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
@@ -163,14 +163,14 @@ export const AngleWithMafs = (args: StoryArgs): React.ReactElement => (
 );
 
 export const StaticGraph = (args: StoryArgs): React.ReactElement => (
-    <RendererWithDebugUI {...mafsOptions} question={staticGraph} />
+    <RendererWithDebugUI apiOptions={enableMafs} question={staticGraph} />
 );
 
 export const StaticGraphWithAnotherWidget = (
     args: StoryArgs,
 ): React.ReactElement => (
     <RendererWithDebugUI
-        {...mafsOptions}
+        apiOptions={enableMafs}
         question={staticGraphWithAnotherQuestion()}
     />
 );

--- a/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
@@ -163,7 +163,10 @@ export const AngleWithMafs = (args: StoryArgs): React.ReactElement => (
 );
 
 export const StaticGraph = (args: StoryArgs): React.ReactElement => (
-    <RendererWithDebugUI apiOptions={enableMafs} question={staticGraphQuestion} />
+    <RendererWithDebugUI
+        apiOptions={enableMafs}
+        question={staticGraphQuestion}
+    />
 );
 
 export const StaticGraphWithAnotherWidget = (

--- a/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
@@ -20,8 +20,8 @@ import {
     segmentWithLockedEllipses,
     segmentWithLockedVectors,
     segmentWithLockedPolygons,
-    staticGraph,
-    staticGraphWithAnotherQuestion,
+    staticGraphQuestion,
+    staticGraphQuestionWithAnotherWidget,
 } from "../__testdata__/interactive-graph.testdata";
 
 import type {APIOptions} from "@khanacademy/perseus";
@@ -163,7 +163,7 @@ export const AngleWithMafs = (args: StoryArgs): React.ReactElement => (
 );
 
 export const StaticGraph = (args: StoryArgs): React.ReactElement => (
-    <RendererWithDebugUI apiOptions={enableMafs} question={staticGraph} />
+    <RendererWithDebugUI apiOptions={enableMafs} question={staticGraphQuestion} />
 );
 
 export const StaticGraphWithAnotherWidget = (
@@ -171,7 +171,7 @@ export const StaticGraphWithAnotherWidget = (
 ): React.ReactElement => (
     <RendererWithDebugUI
         apiOptions={enableMafs}
-        question={staticGraphWithAnotherQuestion()}
+        question={staticGraphQuestionWithAnotherWidget()}
     />
 );
 

--- a/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
@@ -20,6 +20,8 @@ import {
     segmentWithLockedEllipses,
     segmentWithLockedVectors,
     segmentWithLockedPolygons,
+    staticGraph,
+    staticGraphWithAnotherQuestion,
 } from "../__testdata__/interactive-graph.testdata";
 
 import type {APIOptions} from "@khanacademy/perseus";
@@ -158,6 +160,19 @@ export const Sinusoid = (args: StoryArgs): React.ReactElement => (
 
 export const AngleWithMafs = (args: StoryArgs): React.ReactElement => (
     <RendererWithDebugUI apiOptions={enableMafs} question={angleQuestion} />
+);
+
+export const StaticGraph = (args: StoryArgs): React.ReactElement => (
+    <RendererWithDebugUI {...mafsOptions} question={staticGraph} />
+);
+
+export const StaticGraphWithAnotherWidget = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <RendererWithDebugUI
+        {...mafsOptions}
+        question={staticGraphWithAnotherQuestion()}
+    />
 );
 
 // TODO(jeremy): As of Jan 2022 there are no peresus items in production that

--- a/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
@@ -809,25 +809,8 @@ export const quadraticQuestion: PerseusRenderer =
 export const quadraticQuestionWithDefaultCorrect: PerseusRenderer =
     interactiveGraphQuestionBuilder().withQuadratic().build();
 
-export const staticGraphQuestion: PerseusRenderer = interactiveGraphQuestionBuilder()
-    .addLockedPointAt(-7, -7)
-    .addLockedLine([-7, -5], [2, -3])
-    .addLockedVector([0, 0], [8, 2], "purple")
-    .addLockedEllipse([0, 5], [4, 2], {angle: Math.PI / 4, color: "blue"})
-    .addLockedPolygon(
-        [
-            [-9, 4],
-            [-6, 4],
-            [-6, 1],
-            [-9, 1],
-        ],
-        {color: "pink"},
-    )
-    .withStaticMode(true)
-    .build();
-
-export const staticGraphQuestionWithAnotherWidget: () => PerseusRenderer = () => {
-    const result = interactiveGraphQuestionBuilder()
+export const staticGraphQuestion: PerseusRenderer =
+    interactiveGraphQuestionBuilder()
         .addLockedPointAt(-7, -7)
         .addLockedLine([-7, -5], [2, -3])
         .addLockedVector([0, 0], [8, 2], "purple")
@@ -843,51 +826,73 @@ export const staticGraphQuestionWithAnotherWidget: () => PerseusRenderer = () =>
         )
         .withStaticMode(true)
         .build();
-    result["widgets"] = {
-        ...result["widgets"],
-        "radio 1": {
-            graded: true,
-            version: {
-                major: 1,
-                minor: 0,
-            },
-            static: false,
-            type: "radio",
-            options: {
-                displayCount: null,
-                choices: [
-                    {
-                        content: "$-8$ and $8$",
-                        correct: false,
-                        clue: "The square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number, so $x$ is equal to *only* $8$.",
-                    },
-                    {
-                        content: "$-8$",
-                        correct: false,
-                        clue: "While $(-8)^2=64$, the square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number.",
-                    },
-                    {
-                        content: "The right answer !!!\n\n",
-                        correct: true,
-                        isNoneOfTheAbove: false,
-                        clue: "$8$ is the positive square root of $64$.",
-                    },
-                    {
-                        content: "No value of $x$ satisfies the equation.",
-                        correct: false,
-                        isNoneOfTheAbove: false,
-                        clue: "$8$ satisfies the equation.",
-                    },
+
+export const staticGraphQuestionWithAnotherWidget: () => PerseusRenderer =
+    () => {
+        const result = interactiveGraphQuestionBuilder()
+            .addLockedPointAt(-7, -7)
+            .addLockedLine([-7, -5], [2, -3])
+            .addLockedVector([0, 0], [8, 2], "purple")
+            .addLockedEllipse([0, 5], [4, 2], {
+                angle: Math.PI / 4,
+                color: "blue",
+            })
+            .addLockedPolygon(
+                [
+                    [-9, 4],
+                    [-6, 4],
+                    [-6, 1],
+                    [-9, 1],
                 ],
-                countChoices: false,
-                hasNoneOfTheAbove: false,
-                multipleSelect: false,
-                randomize: false,
-                deselectEnabled: false,
-            },
-            alignment: "default",
-        } as RadioWidget,
+                {color: "pink"},
+            )
+            .withStaticMode(true)
+            .build();
+        result["widgets"] = {
+            ...result["widgets"],
+            "radio 1": {
+                graded: true,
+                version: {
+                    major: 1,
+                    minor: 0,
+                },
+                static: false,
+                type: "radio",
+                options: {
+                    displayCount: null,
+                    choices: [
+                        {
+                            content: "$-8$ and $8$",
+                            correct: false,
+                            clue: "The square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number, so $x$ is equal to *only* $8$.",
+                        },
+                        {
+                            content: "$-8$",
+                            correct: false,
+                            clue: "While $(-8)^2=64$, the square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number.",
+                        },
+                        {
+                            content: "The right answer !!!\n\n",
+                            correct: true,
+                            isNoneOfTheAbove: false,
+                            clue: "$8$ is the positive square root of $64$.",
+                        },
+                        {
+                            content: "No value of $x$ satisfies the equation.",
+                            correct: false,
+                            isNoneOfTheAbove: false,
+                            clue: "$8$ satisfies the equation.",
+                        },
+                    ],
+                    countChoices: false,
+                    hasNoneOfTheAbove: false,
+                    multipleSelect: false,
+                    randomize: false,
+                    deselectEnabled: false,
+                },
+                alignment: "default",
+            } as RadioWidget,
+        };
+        result["content"] = "[[\u2603 radio 1]]\n\n" + result["content"];
+        return result;
     };
-    result["content"] = "[[\u2603 radio 1]]\n\n" + result["content"];
-    return result;
-};

--- a/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
@@ -1,7 +1,7 @@
 import {interactiveGraphQuestionBuilder} from "../interactive-graphs/interactive-graph-question-builder";
 
 import type {Coord} from "../../interactive2/types";
-import type {PerseusRenderer} from "../../perseus-types";
+import type {PerseusRenderer, RadioWidget} from "../../perseus-types";
 import type {LockedFunctionOptions} from "../interactive-graphs/interactive-graph-question-builder";
 
 // Data for the interactive graph widget
@@ -808,3 +808,86 @@ export const quadraticQuestion: PerseusRenderer =
 
 export const quadraticQuestionWithDefaultCorrect: PerseusRenderer =
     interactiveGraphQuestionBuilder().withQuadratic().build();
+
+export const staticGraph: PerseusRenderer = interactiveGraphQuestionBuilder()
+    .addLockedPointAt(-7, -7)
+    .addLockedLine([-7, -5], [2, -3])
+    .addLockedVector([0, 0], [8, 2], "purple")
+    .addLockedEllipse([0, 5], [4, 2], {angle: Math.PI / 4, color: "blue"})
+    .addLockedPolygon(
+        [
+            [-9, 4],
+            [-6, 4],
+            [-6, 1],
+            [-9, 1],
+        ],
+        {color: "pink"},
+    )
+    .withStaticMode(true)
+    .build();
+
+export const staticGraphWithAnotherQuestion: () => PerseusRenderer = () => {
+    const result = interactiveGraphQuestionBuilder()
+        .addLockedPointAt(-7, -7)
+        .addLockedLine([-7, -5], [2, -3])
+        .addLockedVector([0, 0], [8, 2], "purple")
+        .addLockedEllipse([0, 5], [4, 2], {angle: Math.PI / 4, color: "blue"})
+        .addLockedPolygon(
+            [
+                [-9, 4],
+                [-6, 4],
+                [-6, 1],
+                [-9, 1],
+            ],
+            {color: "pink"},
+        )
+        .withStaticMode(true)
+        .build();
+    result["widgets"] = {
+        ...result["widgets"],
+        "radio 1": {
+            graded: true,
+            version: {
+                major: 1,
+                minor: 0,
+            },
+            static: false,
+            type: "radio",
+            options: {
+                displayCount: null,
+                choices: [
+                    {
+                        content: "$-8$ and $8$",
+                        correct: false,
+                        clue: "The square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number, so $x$ is equal to *only* $8$.",
+                    },
+                    {
+                        content: "$-8$",
+                        correct: false,
+                        clue: "While $(-8)^2=64$, the square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number.",
+                    },
+                    {
+                        content: "The right answer !!!\n\n",
+                        correct: true,
+                        isNoneOfTheAbove: false,
+                        clue: "$8$ is the positive square root of $64$.",
+                    },
+                    {
+                        content: "No value of $x$ satisfies the equation.",
+                        correct: false,
+                        isNoneOfTheAbove: false,
+                        clue: "$8$ satisfies the equation.",
+                    },
+                ],
+                countChoices: false,
+                hasNoneOfTheAbove: false,
+                multipleSelect: false,
+                randomize: false,
+                deselectEnabled: false,
+            },
+            alignment: "default",
+        } as RadioWidget,
+    };
+    result["content"] = "[[\u2603 radio 1]]\n\n" + result["content"];
+    return result;
+};

--- a/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/__testdata__/interactive-graph.testdata.ts
@@ -809,7 +809,7 @@ export const quadraticQuestion: PerseusRenderer =
 export const quadraticQuestionWithDefaultCorrect: PerseusRenderer =
     interactiveGraphQuestionBuilder().withQuadratic().build();
 
-export const staticGraph: PerseusRenderer = interactiveGraphQuestionBuilder()
+export const staticGraphQuestion: PerseusRenderer = interactiveGraphQuestionBuilder()
     .addLockedPointAt(-7, -7)
     .addLockedLine([-7, -5], [2, -3])
     .addLockedVector([0, 0], [8, 2], "purple")
@@ -826,7 +826,7 @@ export const staticGraph: PerseusRenderer = interactiveGraphQuestionBuilder()
     .withStaticMode(true)
     .build();
 
-export const staticGraphWithAnotherQuestion: () => PerseusRenderer = () => {
+export const staticGraphQuestionWithAnotherWidget: () => PerseusRenderer = () => {
     const result = interactiveGraphQuestionBuilder()
         .addLockedPointAt(-7, -7)
         .addLockedLine([-7, -5], [2, -3])

--- a/packages/perseus/src/widgets/__tests__/passage.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/passage.test.tsx
@@ -48,7 +48,6 @@ function renderPassage(
         reviewModeRubric: {
             ...widgetPropsBase,
         },
-        hintMode: false,
         static: true,
         trackInteraction: () => {},
         widgetId: "passage",

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -1826,7 +1826,6 @@ class InteractiveGraph extends React.Component<Props, State> {
                     snapStep={snapStep}
                     box={box}
                     showTooltips={!!this.props.showTooltips}
-                    hintMode={this.props.hintMode}
                     readOnly={this.props.apiOptions?.readOnly}
                 />
             );

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -2684,9 +2684,12 @@ export function shouldUseMafs(
             return Boolean(mafsFlags[graph.type]);
     }
 }
+// We don't need to change any of the original props for static mode
+const staticTransform = _.identity;
 
 export default {
     name: "interactive-graph",
     displayName: "Interactive graph",
     widget: InteractiveGraph,
+    staticTransform: staticTransform,
 } as WidgetExports<typeof InteractiveGraph>;

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -48,6 +48,7 @@ class InteractiveGraphQuestionBuilder {
         new SegmentGraphConfig();
     private lockedFigures: LockedFigure[] = [];
     private snapTo: "grid" | "angles" | "sides" = "grid";
+    private staticMode: boolean = false;
 
     build(): PerseusRenderer {
         return {
@@ -56,6 +57,7 @@ class InteractiveGraphQuestionBuilder {
             widgets: {
                 "interactive-graph 1": {
                     graded: true,
+                    static: this.staticMode,
                     options: {
                         correct: this.interactiveFigureConfig.correct(),
                         backgroundImage: this.backgroundImage,
@@ -81,6 +83,11 @@ class InteractiveGraphQuestionBuilder {
 
     withContent(content: string): InteractiveGraphQuestionBuilder {
         this.content = content;
+        return this;
+    }
+
+    withStaticMode(staticMode: boolean): InteractiveGraphQuestionBuilder {
+        this.staticMode = staticMode;
         return this;
     }
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -27,6 +27,7 @@ function getBaseMafsGraphProps(): MafsGraphProps {
         showProtractor: false,
         readOnly: false,
         labels: ["x", "y"],
+        static: false,
         dispatch: () => {},
         state: {
             type: "segment",

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -25,7 +25,6 @@ function getBaseMafsGraphProps(): MafsGraphProps {
         containerSizeClass: "small",
         showTooltips: false,
         showProtractor: false,
-        hintMode: false,
         readOnly: false,
         labels: ["x", "y"],
         dispatch: () => {},

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -45,12 +45,11 @@ export type MafsGraphProps = {
     labels: InteractiveGraphProps["labels"];
     state: InteractiveGraphState;
     dispatch: React.Dispatch<InteractiveGraphAction>;
-    hintMode: boolean;
     readOnly: boolean;
 };
 
 export const MafsGraph = (props: MafsGraphProps) => {
-    const {state, dispatch, labels, hintMode, readOnly} = props;
+    const {state, dispatch, labels, readOnly} = props;
     const [width, height] = props.box;
     const tickStep = props.step as vec.Vector2;
     return (
@@ -66,7 +65,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                 width,
                 height,
                 labels,
-                disableKeyboardInteraction: hintMode || readOnly,
+                disableKeyboardInteraction: readOnly,
             }}
         >
             <View
@@ -79,7 +78,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                     boxSizing: "content-box",
                     marginLeft: "20px",
                     marginBottom: "20px",
-                    pointerEvents: hintMode ? "none" : "auto",
+                    pointerEvents: "auto",
                 }}
             >
                 <LegacyGrid

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -46,6 +46,7 @@ export type MafsGraphProps = {
     state: InteractiveGraphState;
     dispatch: React.Dispatch<InteractiveGraphAction>;
     readOnly: boolean;
+    static: boolean | null | undefined;
 };
 
 export const MafsGraph = (props: MafsGraphProps) => {
@@ -65,7 +66,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                 width,
                 height,
                 labels,
-                disableKeyboardInteraction: readOnly,
+                disableKeyboardInteraction: readOnly || !!props.static,
             }}
         >
             <View
@@ -78,7 +79,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                     boxSizing: "content-box",
                     marginLeft: "20px",
                     marginBottom: "20px",
-                    pointerEvents: "auto",
+                    pointerEvents: props.static ? "none" : "auto",
                 }}
             >
                 <LegacyGrid

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.test.tsx
@@ -25,7 +25,6 @@ function getBaseStatefulMafsGraphProps(): StatefulMafsGraphProps {
         onChange: () => {},
         showTooltips: false,
         showProtractor: false,
-        hintMode: false,
         readOnly: false,
         labels: ["x", "y"],
         graph: {type: "segment"},

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.test.tsx
@@ -28,6 +28,7 @@ function getBaseStatefulMafsGraphProps(): StatefulMafsGraphProps {
         readOnly: false,
         labels: ["x", "y"],
         graph: {type: "segment"},
+        static: false,
     };
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.test.tsx
@@ -28,6 +28,7 @@ function getBaseStatefulMafsGraphProps(): StatefulMafsGraphProps {
         readOnly: false,
         labels: ["x", "y"],
         graph: {type: "segment"},
+        correct: {type: "segment"},
         static: false,
     };
 }

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
@@ -130,7 +130,13 @@ export const StatefulMafsGraph = React.forwardRef<
     ]);
 
     if (props.static) {
-        return <MafsGraph {...props} state={initializeGraphState({...props, graph: props.correct})} dispatch={dispatch}  />
+        return (
+            <MafsGraph
+                {...props}
+                state={initializeGraphState({...props, graph: props.correct})}
+                dispatch={dispatch}
+            />
+        );
     }
 
     return <MafsGraph {...props} state={state} dispatch={dispatch} />;

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
@@ -20,6 +20,7 @@ export type StatefulMafsGraphProps = {
     box: [number, number];
     backgroundImage?: InteractiveGraphProps["backgroundImage"];
     graph: PerseusGraphType;
+    correct: PerseusGraphType;
     lockedFigures?: InteractiveGraphProps["lockedFigures"];
     range: InteractiveGraphProps["range"];
     snapStep: InteractiveGraphProps["snapStep"];
@@ -127,6 +128,10 @@ export const StatefulMafsGraph = React.forwardRef<
         latestPropsRef,
         graph.startCoords,
     ]);
+
+    if (props.static) {
+        return <MafsGraph {...props} state={initializeGraphState({...props, graph: props.correct})} dispatch={dispatch}  />
+    }
 
     return <MafsGraph {...props} state={state} dispatch={dispatch} />;
 });

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
@@ -31,7 +31,6 @@ export type StatefulMafsGraphProps = {
     showTooltips: Required<InteractiveGraphProps["showTooltips"]>;
     showProtractor: boolean;
     labels: InteractiveGraphProps["labels"];
-    hintMode: boolean;
     readOnly: boolean;
 };
 

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
@@ -129,6 +129,8 @@ export const StatefulMafsGraph = React.forwardRef<
         graph.startCoords,
     ]);
 
+    // If the graph is static, it always displays the correct answer. This is
+    // standard behavior for Perseus widgets (e.g. compare the Radio widget).
     if (props.static) {
         return (
             <MafsGraph

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
@@ -29,10 +29,10 @@ export type StatefulMafsGraphProps = {
     markings: InteractiveGraphProps["markings"];
     onChange: InteractiveGraphProps["onChange"];
     showTooltips: Required<InteractiveGraphProps["showTooltips"]>;
-    static: InteractiveGraphProps["static"];
     showProtractor: boolean;
     labels: InteractiveGraphProps["labels"];
     readOnly: boolean;
+    static: InteractiveGraphProps["static"];
 };
 
 // Rather than be tightly bound to how data was structured in

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
@@ -29,6 +29,7 @@ export type StatefulMafsGraphProps = {
     markings: InteractiveGraphProps["markings"];
     onChange: InteractiveGraphProps["onChange"];
     showTooltips: Required<InteractiveGraphProps["showTooltips"]>;
+    static: InteractiveGraphProps["static"];
     showProtractor: boolean;
     labels: InteractiveGraphProps["labels"];
     readOnly: boolean;


### PR DESCRIPTION
## Summary:
Some of our widgets (e.g. Radio) have a "static" mode which can be toggled on
in the exercise editor. When a widget is in static mode, the "answer" to the
widget is displayed, the widget is not graded, and the learner cannot alter
the widget's state.

Content creators need to be able to set interactive graphs to static mode so
that graphs can be added to hints, to demonstrate the solution steps for an
exercise. Previously, we implemented a special "hint mode" for interactive
graphs to accommodate this use case. Hint mode was based on a couple faulty
assumptions:

- We did not clearly understand what static mode was or when it was turned on.
  We confused static mode with the "read only" state of a widget, which occurs
  when a learner has successfully answered the question. Similar to static mode,
  the read-only state makes the widget non-interactable. However, while static
  mode is configurable by content creators, read-only state is not; it is set
  or unset dynamically, based on the learner's progress through an exercise.
- We assumed that graphs in hints would always be non-interactable, so we
  turned on hint mode automatically in hints (and turned it off in question
  stems) rather than giving content creators a manual toggle. This assumption
  turned out to be incorrect; we now know of at least one question where a hint
  contains a graph that the learner is supposed to be able to manipulate. See:
  https://khanacademy.slack.com/archives/C067UM1QAR4/p1723045477082029

Hint mode (which this feature replaces) was never released to content creators,
so we are okay to drop support for it.

This PR removes hint mode and adds a "static" toggle to the Interactive
Graph widget editor. It builds on work that @nicolecomputer did in
https://github.com/Khan/perseus/pull/1457. Her feature branch is merged into
this one.

Issue: LEMS-2251, LEMS-2053, LEMS-2054

## Test plan:

- Deploy this to a ZND
- Create an exercise in the Test Everything course
- Create a static interactive graph
- Verify that the preview is non-interactable (with mouse and keyboard) when
  the "static" toggle is on, and interactable when "static" is off.
- Save and publish the exercise.
- Go through the exercise as a learner and verify that you cannot manipulate
  the static graphs.
- Verify that the presence of a static graph does not affect how a question is
  graded.