### PR TITLE
Remove .babelrc.js files in package dirs that are no longer needed (Jest is bugfixed)

### DIFF
--- a/packages/kmath/.babelrc.js
+++ b/packages/kmath/.babelrc.js
@@ -1,8 +1,0 @@
-/**
- * HACK(somewhatabstract): Due to https://github.com/facebook/jest/issues/11741,
- * we need to have this file, or updating inline snapshots can fail rather
- * cryptically.
- *
- * We should remove this when jest is fixed.
- */
-module.exports = require("../../config/build/babel.config");

--- a/packages/perseus-core/.babelrc.js
+++ b/packages/perseus-core/.babelrc.js
@@ -1,8 +1,0 @@
-/**
- * HACK(kevinb): Due to https://github.com/facebook/jest/issues/11741,
- * we need to have this file, or updating inline snapshots can fail rather
- * cryptically.
- *
- * We should remove this when jest is fixed.
- */
-module.exports = require("../../config/build/babel.config");

--- a/packages/perseus-editor/.babelrc.js
+++ b/packages/perseus-editor/.babelrc.js
@@ -1,8 +1,0 @@
-/**
- * HACK(kevinb): Due to https://github.com/facebook/jest/issues/11741,
- * we need to have this file, or updating inline snapshots can fail rather
- * cryptically.
- *
- * We should remove this when jest is fixed.
- */
-module.exports = require("../../config/build/babel.config");

--- a/packages/perseus/.babelrc.js
+++ b/packages/perseus/.babelrc.js
@@ -1,8 +1,0 @@
-/**
- * HACK(kevinb): Due to https://github.com/facebook/jest/issues/11741,
- * we need to have this file, or updating inline snapshots can fail rather
- * cryptically.
- *
- * We should remove this when jest is fixed.
- */
-module.exports = require("../../config/build/babel.config");


### PR DESCRIPTION
## Summary:

When we extracted Perseus to its own repo, we had to put a small `.babelrc.js` file in some package folders so that Jest would work (https://github.com/facebook/jest/issues/11741). We are now on a version of Jest that is fixed and so no longer need these files (we do have a root babel config that covers everything). 

Issue: "none"

## Test plan:

`yarn test` ✅