### PR TITLE
[Start Coords] Fix the radius input in circle graph start coords UI

### DIFF
--- a/.changeset/light-islands-lick.md
+++ b/.changeset/light-islands-lick.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Start Coords] Fix the radius input in circle graph start coords UI

--- a/packages/perseus-editor/src/components/__tests__/start-coords-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/start-coords-settings.test.tsx
@@ -390,6 +390,79 @@ describe("StartCoordSettings", () => {
                 expect(onChangeMock).toHaveBeenLastCalledWith(expectedCoords);
             },
         );
+
+        test("does not call onChange when the radius is not a number", async () => {
+            // Arrange
+            const onChangeMock = jest.fn();
+
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="circle"
+                    onChange={onChangeMock}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            const input = screen.getByRole("spinbutton", {
+                name: "Radius:",
+            });
+            await userEvent.type(input, "-");
+
+            // Assert
+            expect(onChangeMock).not.toHaveBeenCalled();
+        });
+
+        test("does not call onChange when the radius is empty", async () => {
+            // Arrange
+            const onChangeMock = jest.fn();
+
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="circle"
+                    onChange={onChangeMock}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            const input = screen.getByRole("spinbutton", {
+                name: "Radius:",
+            });
+            await userEvent.clear(input);
+
+            // Assert
+            expect(onChangeMock).not.toHaveBeenCalled();
+        });
+
+        test("allows the user to type a decimal radius", async () => {
+            // Arrange
+            const onChangeMock = jest.fn();
+
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="circle"
+                    onChange={onChangeMock}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            const input = screen.getByRole("spinbutton", {
+                name: "Radius:",
+            });
+            await userEvent.clear(input);
+            await userEvent.type(input, "0.5");
+
+            // Assert
+            expect(onChangeMock).toHaveBeenCalledWith({
+                center: [0, 0],
+                radius: 0.5,
+            });
+        });
     });
 
     describe("sinusoid graph", () => {

--- a/packages/perseus-editor/src/components/start-coords-circle.tsx
+++ b/packages/perseus-editor/src/components/start-coords-circle.tsx
@@ -21,6 +21,33 @@ type Props = {
 const StartCoordsCircle = (props: Props) => {
     const {startCoords, onChange} = props;
 
+    const [radiusState, setRadiusState] = React.useState(
+        startCoords.radius.toString(),
+    );
+
+    // Update the local state when the props change. (Specifically, when
+    // the radius is reset from the "Use default start coordinates" button.)
+    React.useEffect(() => {
+        setRadiusState(startCoords.radius.toString());
+    }, [startCoords.radius]);
+
+    function handleRadiuschange(newValue: string) {
+        // Update the local state to update the input field.
+        setRadiusState(newValue);
+
+        // Assume the user is in the middle of typing. Don't update
+        // the props until they've finished typing a valid number.
+        if (isNaN(+newValue) || newValue === "" || +newValue === 0) {
+            return;
+        }
+
+        // Update the props (update the graph).
+        onChange({
+            center: startCoords.center,
+            radius: parseFloat(newValue),
+        });
+    }
+
     return (
         <View style={styles.tile}>
             {/* Center */}
@@ -38,20 +65,15 @@ const StartCoordsCircle = (props: Props) => {
             <Strut size={spacing.small_12} />
 
             {/* Radius */}
-            <View style={styles.row}>
-                <LabelLarge>Radius:</LabelLarge>
+            <LabelLarge tag="label" style={styles.row}>
+                Radius:
                 <Strut size={spacing.small_12} />
                 <ScrolllessNumberTextField
-                    value={startCoords.radius.toString()}
-                    onChange={(value) => {
-                        onChange({
-                            center: startCoords.center,
-                            radius: parseFloat(value),
-                        });
-                    }}
+                    value={radiusState}
+                    onChange={handleRadiuschange}
                     style={styles.textField}
                 />
-            </View>
+            </LabelLarge>
         </View>
     );
 };
@@ -64,6 +86,7 @@ const styles = StyleSheet.create({
         borderRadius: spacing.xSmall_8,
     },
     row: {
+        display: "flex",
         flexDirection: "row",
         alignItems: "center",
     },


### PR DESCRIPTION
## Summary:
The Radius input in the Circle graph start coords UI is not allowing
people to type in non-numbers, even mid-typing a valid number.

For example, when typing "0" to start "0.5", it auto-updates to 2 (default radius),
and it doesn't allow typing "." to start ".5".

This is happening because the radius is only reading the prop updates and passing
the evaluated value instead of storing the state for the input.

Adding a `React.useState` in the `start-coords-circle.tsx` file to fix this.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2073

## Test plan:
`yarn jest packages/perseus-editor/src/components/__tests__/start-coords-settings.test.tsx`

Storybook
- Before: https://khan.github.io/perseus/?path=/story/perseuseditor-widgets-interactive-graph--interactive-graph-circle
- After: http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--interactive-graph-circle

## Demos:

In both videos, I'm highlighting the input and typing in "0" and then pressing backspace.

### Before

Notice that "0" auto-updates the field to "2" and backspacing does nothing.

https://github.com/user-attachments/assets/1880175e-d888-4547-bd50-2d8ff4b960ce

### After

Typing in 0, ., and backspace work as expected.

https://github.com/user-attachments/assets/e738d3ba-f3ba-49c6-9515-1f75ee54e327