### PR TITLE
Lint against static widgets in question stems

### DIFF
--- a/.changeset/shy-toes-hug.md
+++ b/.changeset/shy-toes-hug.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-linter": minor
+---
+
+Warn content creators when a static widget appears in a question stem

--- a/packages/perseus-linter/src/__tests__/rules.test.ts
+++ b/packages/perseus-linter/src/__tests__/rules.test.ts
@@ -540,9 +540,7 @@ describe("Individual lint rules tests", () => {
             stack: ["hint"],
             widgets: {
                 "radio 1": {
-                    options: {
-                        static: true,
-                    },
+                    static: true,
                 },
             },
         })
@@ -556,9 +554,7 @@ describe("Individual lint rules tests", () => {
             stack: [],
             widgets: {
                 "radio 1": {
-                    options: {
-                        static: true,
-                    },
+                    static: true,
                 },
             },
         })
@@ -572,9 +568,7 @@ describe("Individual lint rules tests", () => {
             stack: [],
             widgets: {
                 "radio 1": {
-                    options: {
-                        static: false,
-                    },
+                    static: false,
                 },
             },
         })
@@ -598,9 +592,7 @@ describe("Individual lint rules tests", () => {
             stack: [],
             widgets: {
                 "radio 1": {
-                    options: {
-                        static: true,
-                    },
+                    static: true,
                 },
             },
         })

--- a/packages/perseus-linter/src/__tests__/rules.test.ts
+++ b/packages/perseus-linter/src/__tests__/rules.test.ts
@@ -26,12 +26,12 @@ import mathStartsWithSpaceRule from "../rules/math-starts-with-space";
 import mathTextEmptyRule from "../rules/math-text-empty";
 import mathWithoutDollarsRule from "../rules/math-without-dollars";
 import nestedListsRule from "../rules/nested-lists";
+import StaticWidgetInQuestionStem from "../rules/static-widget-in-question-stem";
 import tableMissingCellsRule from "../rules/table-missing-cells";
 import unbalancedCodeDelimitersRule from "../rules/unbalanced-code-delimiters";
 import unescapedDollarRule from "../rules/unescaped-dollar";
 import widgetInTableRule from "../rules/widget-in-table";
 import TreeTransformer from "../tree-transformer";
-import {staticWidgetInQuestionStem} from "../rules/static-widget-in-question-stem";
 
 type Rule = any;
 
@@ -535,7 +535,7 @@ describe("Individual lint rules tests", () => {
     ]);
 
     test("Rule static-widget-in-question-stem allows static widgets in hints", () => {
-        const problems = testRule(staticWidgetInQuestionStem, "[[☃ radio 1]]", {
+        const problems = testRule(StaticWidgetInQuestionStem, "[[☃ radio 1]]", {
             contentType: "exercise",
             stack: ["hint"],
             widgets: {
@@ -551,7 +551,7 @@ describe("Individual lint rules tests", () => {
     });
 
     test("Rule static-widget-in-question-stem allows static widgets in articles", () => {
-        const problems = testRule(staticWidgetInQuestionStem, "[[☃ radio 1]]", {
+        const problems = testRule(StaticWidgetInQuestionStem, "[[☃ radio 1]]", {
             contentType: "article",
             stack: [],
             widgets: {
@@ -567,7 +567,7 @@ describe("Individual lint rules tests", () => {
     });
 
     test("Rule static-widget-in-question-stem allows non-static widgets in question stems", () => {
-        const problems = testRule(staticWidgetInQuestionStem, "[[☃ radio 1]]", {
+        const problems = testRule(StaticWidgetInQuestionStem, "[[☃ radio 1]]", {
             contentType: "exercise",
             stack: [],
             widgets: {
@@ -583,7 +583,7 @@ describe("Individual lint rules tests", () => {
     });
 
     test("Rule static-widget-in-question-stem tolerates widget with no definition", () => {
-        const problems = testRule(staticWidgetInQuestionStem, "[[☃ radio 1]]", {
+        const problems = testRule(StaticWidgetInQuestionStem, "[[☃ radio 1]]", {
             contentType: "exercise",
             stack: [],
             widgets: {},
@@ -593,7 +593,7 @@ describe("Individual lint rules tests", () => {
     });
 
     test("Rule static-widget-in-question-stem allows warns about static widgets in question stems", () => {
-        const problems = testRule(staticWidgetInQuestionStem, "[[☃ radio 1]]", {
+        const problems = testRule(StaticWidgetInQuestionStem, "[[☃ radio 1]]", {
             contentType: "exercise",
             stack: [],
             widgets: {

--- a/packages/perseus-linter/src/__tests__/rules.test.ts
+++ b/packages/perseus-linter/src/__tests__/rules.test.ts
@@ -36,7 +36,11 @@ import TreeTransformer from "../tree-transformer";
 type Rule = any;
 
 describe("Individual lint rules tests", () => {
-    function testRule(rule: Rule, markdown: string, context): {message: string}[] | null {
+    function testRule(
+        rule: Rule,
+        markdown: string,
+        context,
+    ): {message: string}[] | null {
         const tree = PureMarkdown.parse(markdown);
         const tt = new TreeTransformer(tree);
         const warnings = [];
@@ -535,69 +539,91 @@ describe("Individual lint rules tests", () => {
     ]);
 
     test("Rule static-widget-in-question-stem allows static widgets in hints", () => {
-        const problems = testRule(StaticWidgetInQuestionStem, "[[☃ radio 1]]", {
-            contentType: "exercise",
-            stack: ["hint"],
-            widgets: {
-                "radio 1": {
-                    static: true,
+        const problems = testRule(
+            StaticWidgetInQuestionStem,
+            "[[☃ radio 1]]",
+            {
+                contentType: "exercise",
+                stack: ["hint"],
+                widgets: {
+                    "radio 1": {
+                        static: true,
+                    },
                 },
             },
-        })
+        );
 
-        expect(problems).toBe(null)
+        expect(problems).toBe(null);
     });
 
     test("Rule static-widget-in-question-stem allows static widgets in articles", () => {
-        const problems = testRule(StaticWidgetInQuestionStem, "[[☃ radio 1]]", {
-            contentType: "article",
-            stack: [],
-            widgets: {
-                "radio 1": {
-                    static: true,
+        const problems = testRule(
+            StaticWidgetInQuestionStem,
+            "[[☃ radio 1]]",
+            {
+                contentType: "article",
+                stack: [],
+                widgets: {
+                    "radio 1": {
+                        static: true,
+                    },
                 },
             },
-        })
+        );
 
-        expect(problems).toBe(null)
+        expect(problems).toBe(null);
     });
 
     test("Rule static-widget-in-question-stem allows non-static widgets in question stems", () => {
-        const problems = testRule(StaticWidgetInQuestionStem, "[[☃ radio 1]]", {
-            contentType: "exercise",
-            stack: [],
-            widgets: {
-                "radio 1": {
-                    static: false,
+        const problems = testRule(
+            StaticWidgetInQuestionStem,
+            "[[☃ radio 1]]",
+            {
+                contentType: "exercise",
+                stack: [],
+                widgets: {
+                    "radio 1": {
+                        static: false,
+                    },
                 },
             },
-        })
+        );
 
-        expect(problems).toBe(null)
+        expect(problems).toBe(null);
     });
 
     test("Rule static-widget-in-question-stem tolerates widget with no definition", () => {
-        const problems = testRule(StaticWidgetInQuestionStem, "[[☃ radio 1]]", {
-            contentType: "exercise",
-            stack: [],
-            widgets: {},
-        })
+        const problems = testRule(
+            StaticWidgetInQuestionStem,
+            "[[☃ radio 1]]",
+            {
+                contentType: "exercise",
+                stack: [],
+                widgets: {},
+            },
+        );
 
-        expect(problems).toBe(null)
+        expect(problems).toBe(null);
     });
 
     test("Rule static-widget-in-question-stem allows warns about static widgets in question stems", () => {
-        const problems = testRule(StaticWidgetInQuestionStem, "[[☃ radio 1]]", {
-            contentType: "exercise",
-            stack: [],
-            widgets: {
-                "radio 1": {
-                    static: true,
+        const problems = testRule(
+            StaticWidgetInQuestionStem,
+            "[[☃ radio 1]]",
+            {
+                contentType: "exercise",
+                stack: [],
+                widgets: {
+                    "radio 1": {
+                        static: true,
+                    },
                 },
             },
-        })
+        );
 
-        expect(problems?.length).toBe(1)
-        expect(problems?.[0]?.message).toBe("Widget in question stem is static (non-interactive).")
+        expect(problems?.length).toBe(1);
+        expect(problems?.[0]?.message).toBe(
+            "Widget in question stem is static (non-interactive).",
+        );
     });
 });

--- a/packages/perseus-linter/src/rules/all-rules.ts
+++ b/packages/perseus-linter/src/rules/all-rules.ts
@@ -30,6 +30,7 @@ import MathStartsWithSpace from "./math-starts-with-space";
 import MathTextEmpty from "./math-text-empty";
 import MathWithoutDollars from "./math-without-dollars";
 import NestedLists from "./nested-lists";
+import StaticWidgetInQuestionStem from "./static-widget-in-question-stem"
 import TableMissingCells from "./table-missing-cells";
 import UnbalancedCodeDelimiters from "./unbalanced-code-delimiters";
 import UnescapedDollar from "./unescaped-dollar";
@@ -59,6 +60,7 @@ export default [
     MathStartsWithSpace,
     MathTextEmpty,
     NestedLists,
+    StaticWidgetInQuestionStem,
     TableMissingCells,
     UnescapedDollar,
     WidgetInTable,

--- a/packages/perseus-linter/src/rules/all-rules.ts
+++ b/packages/perseus-linter/src/rules/all-rules.ts
@@ -30,7 +30,7 @@ import MathStartsWithSpace from "./math-starts-with-space";
 import MathTextEmpty from "./math-text-empty";
 import MathWithoutDollars from "./math-without-dollars";
 import NestedLists from "./nested-lists";
-import StaticWidgetInQuestionStem from "./static-widget-in-question-stem"
+import StaticWidgetInQuestionStem from "./static-widget-in-question-stem";
 import TableMissingCells from "./table-missing-cells";
 import UnbalancedCodeDelimiters from "./unbalanced-code-delimiters";
 import UnescapedDollar from "./unescaped-dollar";

--- a/packages/perseus-linter/src/rules/static-widget-in-question-stem.ts
+++ b/packages/perseus-linter/src/rules/static-widget-in-question-stem.ts
@@ -1,4 +1,4 @@
-import {Rule} from "@khanacademy/perseus-linter";
+import Rule from "../rule";
 
 export default Rule.makeRule({
     name: "static-widget-in-question-stem",
@@ -18,7 +18,7 @@ export default Rule.makeRule({
             return;
         }
 
-        if (widget.options.static) {
+        if (widget.static) {
             return `Widget in question stem is static (non-interactive).`
         }
     }

--- a/packages/perseus-linter/src/rules/static-widget-in-question-stem.ts
+++ b/packages/perseus-linter/src/rules/static-widget-in-question-stem.ts
@@ -19,7 +19,7 @@ export default Rule.makeRule({
         }
 
         if (widget.static) {
-            return `Widget in question stem is static (non-interactive).`
+            return `Widget in question stem is static (non-interactive).`;
         }
-    }
-})
+    },
+});

--- a/packages/perseus-linter/src/rules/static-widget-in-question-stem.ts
+++ b/packages/perseus-linter/src/rules/static-widget-in-question-stem.ts
@@ -1,0 +1,25 @@
+import {Rule} from "@khanacademy/perseus-linter";
+
+export const staticWidgetInQuestionStem = Rule.makeRule({
+    name: "static-widget-in-question-stem",
+    severity: Rule.Severity.WARNING,
+    selector: "widget",
+    lint: (state, content, nodes, match, context) => {
+        if (context.contentType !== "exercise") {
+            return;
+        }
+
+        if (context.stack.includes("hint")) {
+            return;
+        }
+
+        const widget = context?.widgets?.[state.currentNode().id];
+        if (!widget) {
+            return;
+        }
+
+        if (widget.options.static) {
+            return `Widget in question stem is static (non-interactive).`
+        }
+    }
+})

--- a/packages/perseus-linter/src/rules/static-widget-in-question-stem.ts
+++ b/packages/perseus-linter/src/rules/static-widget-in-question-stem.ts
@@ -1,6 +1,6 @@
 import {Rule} from "@khanacademy/perseus-linter";
 
-export const staticWidgetInQuestionStem = Rule.makeRule({
+export default Rule.makeRule({
     name: "static-widget-in-question-stem",
     severity: Rule.Severity.WARNING,
     selector: "widget",


### PR DESCRIPTION
We have logic in the Perseus renderer that prevents widgets from being static
in question stems. This logic was put in place to prevent content creators from
accidentally creating exercises that couldn't be answered (because all their
widgets were static). However the implementation is pretty hacky (it checks
problemNum to know if the renderer is in a question stem), and doesn't work in
the exercise editor preview, or in Perseus storybook. The resulting behavior is
very surprising: `static` widgets in question stems are non-interactive in the
exercise editor but are interactive in the learner experience.

Because this is so confusing, we want to remove the special-case logic and let
`static` always do what it says on the tin. But we still want to ensure that
unanswerable exercises aren't published. To that end, this commit adds a linter
that will do that.

Issue: LEMS-2251

## Test plan:

Deploy a ZND and edit an exercise.

- Add a static widget to a question stem; you should get a linter warning.
- Add a static widget to a hint; you should not get a linter warning.
- Add a non-static widget to a question; you should not get a linter warning.
- Add a static widget to an article; you should not get a linter warning.

Note that only Radio widgets can be made static, currently.

<img width="805" alt="Screen Shot 2024-08-13 at 2 40 06 PM" src="https://github.com/user-attachments/assets/7a3cf4d1-431c-4b06-aa5f-82981fe69771">

