### PR TITLE
[Start Coords] Implement start coords UI for angle graphs

### DIFF
--- a/.changeset/lovely-crabs-talk.md
+++ b/.changeset/lovely-crabs-talk.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+[Start Coords] Implement start coords UI for angle graphs

--- a/packages/perseus-editor/src/components/__tests__/start-coords-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/start-coords-settings.test.tsx
@@ -765,4 +765,118 @@ describe("StartCoordSettings", () => {
             },
         );
     });
+
+    describe("angle graph", () => {
+        test("shows the start coordinates UI (default)", () => {
+            // Arrange
+
+            // Act
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="angle"
+                    onChange={() => {}}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            const xInputs = screen.getAllByRole("spinbutton", {name: "x"});
+            const yInputs = screen.getAllByRole("spinbutton", {name: "y"});
+
+            // Assert
+            expect(screen.getByText("Start coordinates")).toBeInTheDocument();
+            // Default angle on initialization
+            expect(screen.getByText("20° angle at (0, 0)")).toBeInTheDocument();
+            expect(screen.getByText("Vertex:")).toBeInTheDocument();
+            expect(screen.getByText("Point 1:")).toBeInTheDocument();
+            expect(screen.getByText("Point 2:")).toBeInTheDocument();
+            expect(xInputs).toHaveLength(3);
+            expect(yInputs).toHaveLength(3);
+            expect(xInputs[0]).toHaveValue(7);
+            expect(yInputs[0]).toHaveValue(0);
+            expect(xInputs[1]).toHaveValue(0);
+            expect(yInputs[1]).toHaveValue(0);
+            expect(xInputs[2]).toHaveValue(6.5778483455013586);
+            expect(yInputs[2]).toHaveValue(2.394141003279681);
+        });
+
+        test("shows the start coords UI (specified coords)", () => {
+            // Arrange
+
+            // Act
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="angle"
+                    onChange={() => {}}
+                    startCoords={[
+                        [7, 1],
+                        [1, 1],
+                        [1, 7],
+                    ]}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            const xInputs = screen.getAllByRole("spinbutton", {name: "x"});
+            const yInputs = screen.getAllByRole("spinbutton", {name: "y"});
+
+            // Assert
+            expect(screen.getByText("Start coordinates")).toBeInTheDocument();
+            // Default angle on initialization
+            expect(screen.getByText("90° angle at (1, 1)")).toBeInTheDocument();
+            expect(screen.getByText("Vertex:")).toBeInTheDocument();
+            expect(screen.getByText("Point 1:")).toBeInTheDocument();
+            expect(screen.getByText("Point 2:")).toBeInTheDocument();
+            expect(xInputs).toHaveLength(3);
+            expect(yInputs).toHaveLength(3);
+            expect(xInputs[0]).toHaveValue(7);
+            expect(yInputs[0]).toHaveValue(1);
+            expect(xInputs[1]).toHaveValue(1);
+            expect(yInputs[1]).toHaveValue(1);
+            expect(xInputs[2]).toHaveValue(1);
+            expect(yInputs[2]).toHaveValue(7);
+        });
+
+        test.each`
+            pointIndex | coord
+            ${0}       | ${"x"}
+            ${0}       | ${"y"}
+            ${1}       | ${"x"}
+            ${1}       | ${"y"}
+            ${2}       | ${"x"}
+            ${2}       | ${"y"}
+        `(
+            "calls onChange when $coord coord is changed (line $pointIndex)",
+            async ({pointIndex, coord}) => {
+                // Arrange
+                const onChangeMock = jest.fn();
+
+                // Act
+                render(
+                    <StartCoordsSettings
+                        {...defaultProps}
+                        type="angle"
+                        onChange={onChangeMock}
+                    />,
+                );
+
+                // Assert
+                const input = screen.getAllByRole("spinbutton", {
+                    name: `${coord}`,
+                })[pointIndex];
+                await userEvent.clear(input);
+                await userEvent.type(input, "101");
+
+                const expectedCoords = [
+                    [7, 0],
+                    [0, 0],
+                    [6.5778483455013586, 2.394141003279681],
+                ];
+                expectedCoords[pointIndex][coord === "x" ? 0 : 1] = 101;
+
+                expect(onChangeMock).toHaveBeenLastCalledWith(expectedCoords);
+            },
+        );
+    });
 });

--- a/packages/perseus-editor/src/components/__tests__/util.test.ts
+++ b/packages/perseus-editor/src/components/__tests__/util.test.ts
@@ -5,6 +5,7 @@ import {
     getDefaultGraphStartCoords,
     getSinusoidEquation,
     getQuadraticEquation,
+    getAngleEquation,
 } from "../util";
 
 import type {PerseusGraphType, Range} from "@khanacademy/perseus";
@@ -436,4 +437,33 @@ describe("getQuadraticEquation", () => {
 
         expect(equation).toBe("Division by zero error");
     });
+});
+
+describe("getAngleEquation", () => {
+    test.each`
+        point1      | vertex    | point2                                     | expected
+        ${[7, 0]}   | ${[0, 0]} | ${[6.5778483455013586, 2.394141003279681]} | ${"20° angle at (0, 0)"}
+        ${[5, 1]}   | ${[1, 1]} | ${[1, 5]}                                  | ${"90° angle at (1, 1)"}
+        ${[2, 1]}   | ${[1, 1]} | ${[2, 1]}                                  | ${"0° angle at (1, 1)"}
+        ${[2, 1]}   | ${[2, 1]} | ${[2, 1]}                                  | ${"0° angle at (2, 1)"}
+        ${[5, 0]}   | ${[0, 0]} | ${[0, 5]}                                  | ${"90° angle at (0, 0)"}
+        ${[5, 0]}   | ${[0, 0]} | ${[-5, 5]}                                 | ${"135° angle at (0, 0)"}
+        ${[5, 0]}   | ${[0, 0]} | ${[-5, -5]}                                | ${"225° angle at (0, 0)"}
+        ${[5, 0]}   | ${[0, 0]} | ${[5, -5]}                                 | ${"315° angle at (0, 0)"}
+        ${[0, 5]}   | ${[0, 0]} | ${[5, 0]}                                  | ${"-90° angle at (0, 0)"}
+        ${[-5, 5]}  | ${[0, 0]} | ${[5, 0]}                                  | ${"-135° angle at (0, 0)"}
+        ${[-5, -5]} | ${[0, 0]} | ${[5, 0]}                                  | ${"-225° angle at (0, 0)"}
+        ${[5, -5]}  | ${[0, 0]} | ${[5, 0]}                                  | ${"-315° angle at (0, 0)"}
+    `(
+        "should return the correct equation",
+        ({point1, vertex, point2, expected}) => {
+            // Arrange
+
+            // Act
+            const equation = getAngleEquation([point1, vertex, point2]);
+
+            // Assert
+            expect(equation).toBe(expected);
+        },
+    );
 });

--- a/packages/perseus-editor/src/components/start-coords-angle.tsx
+++ b/packages/perseus-editor/src/components/start-coords-angle.tsx
@@ -1,5 +1,16 @@
 import {View} from "@khanacademy/wonder-blocks-core";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import {color, font, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {
+    BodyMonospace,
+    LabelLarge,
+    LabelMedium,
+} from "@khanacademy/wonder-blocks-typography";
+import {StyleSheet} from "aphrodite";
 import * as React from "react";
+
+import CoordinatePairInput from "./coordinate-pair-input";
+import {getAngleEquation} from "./util";
 
 import type {Coord, PerseusGraphType} from "@khanacademy/perseus";
 
@@ -9,20 +20,75 @@ type Props = {
 };
 
 const StartCoordsAngle = (props: Props) => {
-    const {startCoords} = props;
+    const {startCoords, onChange} = props;
     return (
-        <View>
-            WIP
-            <br /> Start coords:
-            {startCoords.map((coord, index) => {
-                return (
-                    <View key={index}>
-                        {`Point ${index + 1}: (${coord[0]}, ${coord[1]})`}
-                    </View>
-                );
-            })}
-        </View>
+        <>
+            {/* Current equation */}
+            <View style={styles.equationSection}>
+                <LabelMedium>Starting equation:</LabelMedium>
+                <BodyMonospace style={styles.equationBody}>
+                    {getAngleEquation(startCoords)}
+                </BodyMonospace>
+            </View>
+
+            {/* Points UI */}
+            <View style={styles.tile}>
+                <LabelLarge>Point 1:</LabelLarge>
+                <Strut size={spacing.small_12} />
+                <CoordinatePairInput
+                    coord={startCoords[0]}
+                    labels={["x", "y"]}
+                    onChange={(value) =>
+                        onChange([value, startCoords[1], startCoords[2]])
+                    }
+                />
+            </View>
+            <View style={styles.tile}>
+                <LabelLarge>Vertex:</LabelLarge>
+                <Strut size={spacing.small_12} />
+                <CoordinatePairInput
+                    coord={startCoords[1]}
+                    labels={["x", "y"]}
+                    onChange={(value) =>
+                        onChange([startCoords[0], value, startCoords[2]])
+                    }
+                />
+            </View>
+            <View style={styles.tile}>
+                <LabelLarge>Point 2:</LabelLarge>
+                <Strut size={spacing.small_12} />
+                <CoordinatePairInput
+                    coord={startCoords[2]}
+                    labels={["x", "y"]}
+                    onChange={(value) =>
+                        onChange([startCoords[0], startCoords[1], value])
+                    }
+                />
+            </View>
+        </>
     );
 };
+
+const styles = StyleSheet.create({
+    tile: {
+        backgroundColor: color.fadedBlue8,
+        marginTop: spacing.xSmall_8,
+        padding: spacing.small_12,
+        borderRadius: spacing.xSmall_8,
+        flexDirection: "row",
+        alignItems: "center",
+    },
+    equationSection: {
+        marginTop: spacing.small_12,
+    },
+    equationBody: {
+        backgroundColor: color.fadedOffBlack8,
+        border: `1px solid ${color.fadedOffBlack32}`,
+        marginTop: spacing.xSmall_8,
+        paddingLeft: spacing.xSmall_8,
+        paddingRight: spacing.xSmall_8,
+        fontSize: font.size.xSmall,
+    },
+});
 
 export default StartCoordsAngle;

--- a/packages/perseus-editor/src/components/util.ts
+++ b/packages/perseus-editor/src/components/util.ts
@@ -275,6 +275,22 @@ export const getQuadraticEquation = (startCoords: [Coord, Coord, Coord]) => {
     );
 };
 
+const findAngle = (point1: Coord, point2: Coord) => {
+    const x = point1[0] - point2[0];
+    const y = point1[1] - point2[1];
+
+    return (180 + (Math.atan2(-y, -x) * 180) / Math.PI + 360) % 360;
+};
+
+export const getAngleEquation = (startCoords: [Coord, Coord, Coord]) => {
+    const [point1, vertex, point2] = startCoords;
+
+    const angle = findAngle(point2, vertex) - findAngle(point1, vertex);
+    const roundedAngle = angle.toFixed(0);
+
+    return `${roundedAngle}\u00B0 angle at (${vertex[0]}, ${vertex[1]})`;
+};
+
 export const shouldShowStartCoordsUI = (flags, graph) => {
     // TODO(LEMS-2228): Remove flags once this is fully released
     const startCoordsUiPhase1Types = [


### PR DESCRIPTION
## Summary:
Implement the body of the start coords UI for angle graphs (replace the "WIP" placeholder).

The implementation for `getAngleEquation()` util function is taken from [interactive-graph.tsx](https://github.com/Khan/perseus/blob/f083200340545f41275f0696dbfc967f45028b0c/packages/perseus/src/widgets/interactive-graph.tsx#L2354)
and rewritten to work here without having to import the InteractiveGraphWidget component from
perseus. Using this custom implementation, we can pass in just the coordinates to get our equation
instead of having to pass in all the graph props in the original function, which leads to a whole 
slew of TypeScript errors.

There's also the consideration of adding an "angle" field to allow content authors to edit the angle
directly, but this adds a lot of complexity. If this feature is requested in the future, we can add it then.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2073

## Test plan:
`yarn jest packages/perseus-editor/src/components/__tests__/start-coords-settings.test.tsx`
`yarn jest packages/perseus-editor/src/components/__tests__/util.test.ts`

Storybook
http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--interactive-graph-angle

<img width="945" alt="Screenshot 2024-08-13 at 5 12 05 PM" src="https://github.com/user-attachments/assets/9e56a4f4-e04f-46f9-b1f0-18b79be7826e">

