### PR TITLE
Replace the 'Set as static' button with a switch

### DIFF
--- a/.changeset/stupid-steaks-flow.md
+++ b/.changeset/stupid-steaks-flow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+Replace the "(un)set as static" button in the widget editor with a toggle switch

--- a/packages/perseus-editor/src/components/widget-editor.tsx
+++ b/packages/perseus-editor/src/components/widget-editor.tsx
@@ -5,6 +5,10 @@ import {
     Widgets,
     WIDGET_PROP_DENYLIST,
 } from "@khanacademy/perseus";
+import {useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
+import Switch from "@khanacademy/wonder-blocks-switch";
 import * as React from "react";
 import _ from "underscore";
 
@@ -12,10 +16,6 @@ import SectionControlButton from "./section-control-button";
 
 import type Editor from "../editor";
 import type {APIOptions, Alignment, PerseusWidget} from "@khanacademy/perseus";
-import Switch from "@khanacademy/wonder-blocks-switch";
-import {useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
-import Spacing from "@khanacademy/wonder-blocks-spacing";
 
 const {InlineIcon} = components;
 const {iconChevronDown, iconChevronRight, iconTrash} = icons;

--- a/packages/perseus-editor/src/components/widget-editor.tsx
+++ b/packages/perseus-editor/src/components/widget-editor.tsx
@@ -12,6 +12,10 @@ import SectionControlButton from "./section-control-button";
 
 import type Editor from "../editor";
 import type {APIOptions, Alignment, PerseusWidget} from "@khanacademy/perseus";
+import Switch from "@khanacademy/wonder-blocks-switch";
+import {useUniqueIdWithMock} from "@khanacademy/wonder-blocks-core";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import Spacing from "@khanacademy/wonder-blocks-spacing";
 
 const {InlineIcon} = components;
 const {iconChevronDown, iconChevronRight, iconTrash} = icons;
@@ -91,11 +95,11 @@ class WidgetEditor extends React.Component<
         this.props.onChange(newWidgetInfo, cb, silent);
     };
 
-    _toggleStatic = (e: Event) => {
-        e.preventDefault();
-        const newWidgetInfo = Object.assign({}, this.state.widgetInfo, {
-            static: !this.state.widgetInfo.static,
-        }) as PerseusWidget;
+    _setStatic = (value: boolean) => {
+        const newWidgetInfo = {
+            ...this.state.widgetInfo,
+            static: value,
+        } as PerseusWidget;
         this.props.onChange(newWidgetInfo);
     };
 
@@ -170,16 +174,10 @@ class WidgetEditor extends React.Component<
                     </a>
 
                     {supportsStaticMode && (
-                        <input
-                            type="button"
-                            // @ts-expect-error - TS2322 - Type '(e: Event) => void' is not assignable to type 'MouseEventHandler<HTMLInputElement>'.
-                            onClick={this._toggleStatic}
-                            className="simple-button--small"
-                            value={
-                                widgetInfo.static
-                                    ? "Unset as static"
-                                    : "Set as static"
-                            }
+                        <LabeledSwitch
+                            label="Static"
+                            checked={!!widgetInfo.static}
+                            onChange={this._setStatic}
                         />
                     )}
                     {supportedAlignments.length > 1 && (
@@ -220,6 +218,23 @@ class WidgetEditor extends React.Component<
             </div>
         );
     }
+}
+
+function LabeledSwitch(props: {
+    label: string;
+    checked: boolean;
+    onChange: (value: boolean) => unknown;
+}) {
+    const {label, ...switchProps} = props;
+    const ids = useUniqueIdWithMock();
+    const id = ids.get("switch");
+    return (
+        <>
+            <label htmlFor={id}>{label}</label>
+            <Strut size={Spacing.xxSmall_6} />
+            <Switch id={id} {...switchProps} />
+        </>
+    );
 }
 
 export default WidgetEditor;


### PR DESCRIPTION
## Summary:
We discussed this [in slack][1], and Charlie thought it was a good idea.

[1]: https://khanacademy.slack.com/archives/C067UM1QAR4/p1723576041577949?thread_ts=1723487579.845949&cid=C067UM1QAR4

Issue: none

## Test plan:

Run `yarn storybook`

View: http://localhost:6006/?path=/docs/perseuseditor-widgets-interactive-graph--docs

Verify that you can toggle the "Static" switch. The graph in the preview should
be interactive when the switch is turned off, and should be non-interactive
(and display the answer) when the switch is on.
<img width="434" alt="Screenshot of Perseus Storybook" src="https://github.com/user-attachments/assets/ccd25ac8-cba6-4fba-9c67-734d34d11415">
