### PR TITLE
[🔥AUDIT🔥] Fonts: fix path to Lato-Regular.woff2 in Storybook

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,7 +1,7 @@
 <!-- Preload WB fonts to prevent layout shifting due to font rendering -->
 <link
     rel="preload"
-    href="fonts/pre/Lato-Regular.woff2"
+    href="fonts/lato/Lato-Regular.woff2"
     as="font"
     type="font/woff2"
     crossorigin


### PR DESCRIPTION
## Summary:

While working in Storybook and looking at the dev tools, I noticed that the `Lato-Regular.woff2` font wasn't loading. I believe the path is wrong so I've fixed it. And now it loads according to the browser dev tools.

<img width="526" alt="image" src="https://github.com/user-attachments/assets/47a53cca-a181-4b4d-97bb-65dc116d5a23">

Issue: "none"

## Test plan:

Run storybook: `yarn start`
Open dev tools and filter the network requests by `lato-regular`.
The font file should be loaded.