### PR TITLE
Perseus Editor: Add ContentPreview component

### DIFF
--- a/.changeset/nasty-cobras-try.md
+++ b/.changeset/nasty-cobras-try.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Migrate Lint component to use WonderBlocks ToolTip

--- a/.changeset/quiet-glasses-join.md
+++ b/.changeset/quiet-glasses-join.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+Add ContentPreview component

--- a/.changeset/wise-cougars-hunt.md
+++ b/.changeset/wise-cougars-hunt.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-dev-ui": patch
+---
+
+Update vite config to alias `/strings` expots to correct strings.ts file per package

--- a/dev/vite.config.ts
+++ b/dev/vite.config.ts
@@ -12,7 +12,7 @@ glob.sync(resolve(__dirname, "../packages/*/package.json")).forEach(
         const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
 
         // "exports" is the more modern way to declare package exports. Some,
-        // but not all, Perseus packages delcare "exports".
+        // but not all, Perseus packages declare "exports".
         if ("exports" in pkg) {
             // Not all packages export strings, but for those that do we need
             // to set up an alias so Vite properly resolves them.

--- a/dev/vite.config.ts
+++ b/dev/vite.config.ts
@@ -10,7 +10,41 @@ const packageAliases = {};
 glob.sync(resolve(__dirname, "../packages/*/package.json")).forEach(
     (packageJsonPath) => {
         const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
-        packageAliases[pkg.name] = join(dirname(packageJsonPath), pkg.source);
+
+        // "exports" is the more modern way to declare package exports. Some,
+        // but not all, Perseus packages delcare "exports".
+        if ("exports" in pkg) {
+            // Not all packages export strings, but for those that do we need
+            // to set up an alias so Vite properly resolves them.
+            // Eg `import {strings, mockStrings} from "@khanacademy/perseus/strings";`
+            // And MOST IMPORTANTLY, this alias _must_ precede the main
+            // import, otherwise Vite will just use the main export and tack
+            // `/strings` onto the end, resulting in a path like this:
+            // `packages/perseus/src/index.ts/strings`
+            const stringsSource = pkg.exports["./strings"]?.source;
+            if (stringsSource != null) {
+                packageAliases[`${pkg.name}/strings`] = join(
+                    dirname(packageJsonPath),
+                    stringsSource,
+                );
+            }
+
+            const mainSource = pkg.exports["."]?.source;
+            if (mainSource == null) {
+                throw new Error(
+                    `Package declares 'exports', but not provide a main export (exports["."])`,
+                );
+            }
+            packageAliases[pkg.name] = join(
+                dirname(packageJsonPath),
+                mainSource,
+            );
+        } else {
+            packageAliases[pkg.name] = join(
+                dirname(packageJsonPath),
+                pkg.source,
+            );
+        }
     },
 );
 

--- a/packages/perseus-editor/package.json
+++ b/packages/perseus-editor/package.json
@@ -35,6 +35,7 @@
     },
     "dependencies": {
         "@khanacademy/kas": "^0.3.11",
+        "@khanacademy/keypad-context": "^1.0.0",
         "@khanacademy/kmath": "^0.1.13",
         "@khanacademy/math-input": "^21.0.0",
         "@khanacademy/perseus": "^28.2.0",

--- a/packages/perseus-editor/src/__stories__/content-preview.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/content-preview.stories.tsx
@@ -2,6 +2,7 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {useState} from "react";
 
+import {mockStrings} from "../../../perseus/src/strings";
 import {articleWithImages} from "../../../perseus/src/__testdata__/article-renderer.testdata";
 import {question} from "../../../perseus/src/widgets/__testdata__/radio.testdata";
 import DeviceFramer from "../components/device-framer";
@@ -32,6 +33,9 @@ const PreviewWrapper = (props) => {
 const meta: Meta<typeof ContentPreview> = {
     title: "PerseusEditor/Content Preview",
     component: ContentPreview,
+    args: {
+        strings: mockStrings,
+    },
     decorators: [
         (Story) => (
             <View style={{margin: spacing.xxSmall_6}}>

--- a/packages/perseus-editor/src/__stories__/content-preview.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/content-preview.stories.tsx
@@ -1,0 +1,147 @@
+import {View} from "@khanacademy/wonder-blocks-core";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {useState} from "react";
+
+import {question} from "../../../perseus/src/widgets/__testdata__/radio.testdata";
+import DeviceFramer from "../components/device-framer";
+import ViewportResizer from "../components/viewport-resizer";
+import ContentPreview from "../content-preview";
+
+import type {DeviceType, PerseusRenderer} from "@khanacademy/perseus";
+import type {Meta, StoryObj} from "@storybook/react";
+
+import "../styles/perseus-editor.less";
+
+const PreviewWrapper = (props) => {
+    const [previewDevice, setPreviewDevice] = useState<DeviceType>("phone");
+
+    return (
+        <View>
+            <ViewportResizer
+                deviceType={previewDevice}
+                onViewportSizeChanged={setPreviewDevice}
+            />
+            <DeviceFramer nochrome={false} deviceType={previewDevice}>
+                <ContentPreview {...props} />
+            </DeviceFramer>
+        </View>
+    );
+};
+
+const meta: Meta<typeof ContentPreview> = {
+    title: "PerseusEditor/Content Preview",
+    component: ContentPreview,
+    decorators: [
+        (Story) => (
+            <View style={{margin: spacing.xxSmall_6}}>
+                <Story />
+            </View>
+        ),
+    ],
+    render: (props) => <PreviewWrapper {...props} />,
+};
+
+export default meta;
+type Story = StoryObj<typeof ContentPreview>;
+
+const sampleArticleSection: PerseusRenderer = {
+    content:
+        "The word \"radiation\" sometimes gets a bad rap. People often associate radiation with something dangerous or scary, without really knowing what it is. In reality, we're surrounded by radiation all the time. \n\n**Radiation** is energy that travels through space (not just \"outer space\"—any space). Radiation can also interact with matter. How radiation interacts with matter depends on the type of radiation and the type of matter.\n\nRadiation comes in many forms, one of which is *electromagnetic radiation*. Without electromagnetic radiation life on Earth would not be possible, nor would most modern technologies.\n\n[[☃ image 13]]\n\nLet's take a closer look at this important and fascinating type of radiation.\n\n##Electromagnetic radiation\n\nAs the name suggests, **electromagnetic (EM) radiation** is energy transferred by *electromagnetic fields* oscillating through space.\n\nEM radiation is strange—it has both wave and particle properties. Let's take a look at both.\n\n###Electromagnetic waves\n\nAn animated model of an EM wave is shown below.\n[[☃ image 1]]\nThe electric field $(\\vec{\\textbf{E}})$ is shown in $\\color{blue}\\textbf{blue}$, and the magnetic field $(\\vec{\\textbf{B}})$ is shown in $\\color{red}\\textbf{red}$. They're perpendicular to each other.\n\nA changing electric field creates a magnetic field, and a changing magnetic field creates an electric field. So, once the EM wave is generated it propagates itself through space!\n\nAs with any wave, EM waves have wavelength, frequency, and speed. The wave model of EM radiation works best on large scales. But what about the atomic scale?\n\n###Photons\n\nAt the quantum level, EM radiation exists as particles. A particle of EM radiation is called a **photon**.\n\nWe can think of photons as wave *packets*—tiny bundles of EM radiation containing specific amounts of energy. Photons are visually represented using the following symbol.\n\n[[☃ image 3]]\n\nAll EM radiation, whether modeled as waves or photons, travels at the **speed of light** $\\textbf{(c)}$ in a vacuum: \n\n$\\text{c}=3\\times10^8\\space\\pu{m/s}=300{,}000{,}000\\space\\pu{m/s}$\n\nBut, EM radiation travels at a slower speed in matter, such as water or glass.",
+    images: {},
+    widgets: {
+        "image 13": {
+            type: "image",
+            alignment: "block",
+            static: false,
+            graded: true,
+            options: {
+                static: false,
+                title: "",
+                range: [
+                    [0, 10],
+                    [0, 10],
+                ],
+                box: [600, 254],
+                backgroundImage: {
+                    url: "https://cdn.kastatic.org/ka-content-images/358a87c20ab6ee70447f5fcb547010f69986828e.jpg",
+                    width: 600,
+                    height: 254,
+                },
+                labels: [],
+                alt: "From space, the sun appears over Earth's horizon, illuminating the atmosphere as a blue layer above Earth. Above the atmosphere, space appears black.",
+                caption:
+                    "*Sunrise photo from the International Space Station. Earth's atmosphere scatters electromagnetic radiation from the sun, producing a bright sky during the day.*",
+            },
+            version: {
+                major: 0,
+                minor: 0,
+            },
+        },
+        "image 1": {
+            type: "image",
+            alignment: "block",
+            static: false,
+            graded: true,
+            options: {
+                static: false,
+                title: "",
+                range: [
+                    [0, 10],
+                    [0, 10],
+                ],
+                box: [627, 522],
+                backgroundImage: {
+                    url: "https://cdn.kastatic.org/ka-content-images/8100369eaf3b581d4e7bfc9f1062625309def486.gif",
+                    width: 627,
+                    height: 522,
+                },
+                labels: [],
+                alt: "An animation shows a blue electric field arrow oscillating up and down. Connected to the base of the electric field arrow is a magnetic field arrow, which oscillates from side to side. The two fields oscillate in unison: when one extends the other extends too, creating a repeating wave pattern.",
+                caption: "",
+            },
+            version: {
+                major: 0,
+                minor: 0,
+            },
+        },
+        "image 3": {
+            type: "image",
+            alignment: "block",
+            static: false,
+            graded: true,
+            options: {
+                static: false,
+                title: "",
+                range: [
+                    [0, 10],
+                    [0, 10],
+                ],
+                box: [350, 130],
+                backgroundImage: {
+                    url: "https://cdn.kastatic.org/ka-content-images/74edeeb6c6605a4e854e3a3e9db69c01dcf5508f.svg",
+                    width: 350,
+                    height: 130,
+                },
+                labels: [],
+                alt: "A squiggly curve drawn from left to right. The right end of the curve has an arrow point. The curve begins with a small amount of wiggle on the left, which grows in amplitude in the middle and then decreases again on the right. The result is a small wave packet.",
+                caption: "",
+            },
+            version: {
+                major: 0,
+                minor: 0,
+            },
+        },
+    },
+};
+
+export const Exercise: Story = {
+    args: {
+        question,
+    },
+};
+
+export const Article: Story = {
+    args: {
+        question: sampleArticleSection,
+    },
+};

--- a/packages/perseus-editor/src/__stories__/content-preview.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/content-preview.stories.tsx
@@ -56,3 +56,23 @@ export const Article: Story = {
         question: articleWithImages,
     },
 };
+
+export const WithLintErrors: Story = {
+    args: {
+        linterContext: {
+            contentType: "exercise",
+            highlightLint: true,
+            stack: [],
+            paths: [],
+        },
+        question: {
+            content: `# H1s bad
+
+Here is some unclosed math: $1+1=3
+
+We should use \`\\dfrac{}\` instead of \`\\frac{}\`: $\\frac{3}{5}$`,
+            widgets: {},
+            images: {},
+        },
+    },
+};

--- a/packages/perseus-editor/src/__stories__/content-preview.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/content-preview.stories.tsx
@@ -70,8 +70,27 @@ export const WithLintErrors: Story = {
 
 Here is some unclosed math: $1+1=3
 
-We should use \`\\dfrac{}\` instead of \`\\frac{}\`: $\\frac{3}{5}$`,
-            widgets: {},
+We should use \`\\dfrac{}\` instead of \`\\frac{}\`: $\\frac{3}{5}$
+
+What is the best color in the world?
+
+[[☃ radio 1]]`,
+            widgets: {
+                "radio 1": {
+                    type: "radio",
+                    options: {
+                        choices: [
+                            {content: "Red"},
+                            {content: "# Green"},
+                            {content: "Blue", correct: true},
+                            {
+                                content: "None of these!",
+                                isNoneOfTheAbove: true,
+                            },
+                        ],
+                    },
+                },
+            },
             images: {},
         },
     },

--- a/packages/perseus-editor/src/__stories__/content-preview.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/content-preview.stories.tsx
@@ -2,12 +2,13 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {useState} from "react";
 
+import {articleWithImages} from "../../../perseus/src/__testdata__/article-renderer.testdata";
 import {question} from "../../../perseus/src/widgets/__testdata__/radio.testdata";
 import DeviceFramer from "../components/device-framer";
 import ViewportResizer from "../components/viewport-resizer";
 import ContentPreview from "../content-preview";
 
-import type {DeviceType, PerseusRenderer} from "@khanacademy/perseus";
+import type {DeviceType} from "@khanacademy/perseus";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import "../styles/perseus-editor.less";
@@ -44,96 +45,6 @@ const meta: Meta<typeof ContentPreview> = {
 export default meta;
 type Story = StoryObj<typeof ContentPreview>;
 
-const sampleArticleSection: PerseusRenderer = {
-    content:
-        "The word \"radiation\" sometimes gets a bad rap. People often associate radiation with something dangerous or scary, without really knowing what it is. In reality, we're surrounded by radiation all the time. \n\n**Radiation** is energy that travels through space (not just \"outer space\"—any space). Radiation can also interact with matter. How radiation interacts with matter depends on the type of radiation and the type of matter.\n\nRadiation comes in many forms, one of which is *electromagnetic radiation*. Without electromagnetic radiation life on Earth would not be possible, nor would most modern technologies.\n\n[[☃ image 13]]\n\nLet's take a closer look at this important and fascinating type of radiation.\n\n##Electromagnetic radiation\n\nAs the name suggests, **electromagnetic (EM) radiation** is energy transferred by *electromagnetic fields* oscillating through space.\n\nEM radiation is strange—it has both wave and particle properties. Let's take a look at both.\n\n###Electromagnetic waves\n\nAn animated model of an EM wave is shown below.\n[[☃ image 1]]\nThe electric field $(\\vec{\\textbf{E}})$ is shown in $\\color{blue}\\textbf{blue}$, and the magnetic field $(\\vec{\\textbf{B}})$ is shown in $\\color{red}\\textbf{red}$. They're perpendicular to each other.\n\nA changing electric field creates a magnetic field, and a changing magnetic field creates an electric field. So, once the EM wave is generated it propagates itself through space!\n\nAs with any wave, EM waves have wavelength, frequency, and speed. The wave model of EM radiation works best on large scales. But what about the atomic scale?\n\n###Photons\n\nAt the quantum level, EM radiation exists as particles. A particle of EM radiation is called a **photon**.\n\nWe can think of photons as wave *packets*—tiny bundles of EM radiation containing specific amounts of energy. Photons are visually represented using the following symbol.\n\n[[☃ image 3]]\n\nAll EM radiation, whether modeled as waves or photons, travels at the **speed of light** $\\textbf{(c)}$ in a vacuum: \n\n$\\text{c}=3\\times10^8\\space\\pu{m/s}=300{,}000{,}000\\space\\pu{m/s}$\n\nBut, EM radiation travels at a slower speed in matter, such as water or glass.",
-    images: {},
-    widgets: {
-        "image 13": {
-            type: "image",
-            alignment: "block",
-            static: false,
-            graded: true,
-            options: {
-                static: false,
-                title: "",
-                range: [
-                    [0, 10],
-                    [0, 10],
-                ],
-                box: [600, 254],
-                backgroundImage: {
-                    url: "https://cdn.kastatic.org/ka-content-images/358a87c20ab6ee70447f5fcb547010f69986828e.jpg",
-                    width: 600,
-                    height: 254,
-                },
-                labels: [],
-                alt: "From space, the sun appears over Earth's horizon, illuminating the atmosphere as a blue layer above Earth. Above the atmosphere, space appears black.",
-                caption:
-                    "*Sunrise photo from the International Space Station. Earth's atmosphere scatters electromagnetic radiation from the sun, producing a bright sky during the day.*",
-            },
-            version: {
-                major: 0,
-                minor: 0,
-            },
-        },
-        "image 1": {
-            type: "image",
-            alignment: "block",
-            static: false,
-            graded: true,
-            options: {
-                static: false,
-                title: "",
-                range: [
-                    [0, 10],
-                    [0, 10],
-                ],
-                box: [627, 522],
-                backgroundImage: {
-                    url: "https://cdn.kastatic.org/ka-content-images/8100369eaf3b581d4e7bfc9f1062625309def486.gif",
-                    width: 627,
-                    height: 522,
-                },
-                labels: [],
-                alt: "An animation shows a blue electric field arrow oscillating up and down. Connected to the base of the electric field arrow is a magnetic field arrow, which oscillates from side to side. The two fields oscillate in unison: when one extends the other extends too, creating a repeating wave pattern.",
-                caption: "",
-            },
-            version: {
-                major: 0,
-                minor: 0,
-            },
-        },
-        "image 3": {
-            type: "image",
-            alignment: "block",
-            static: false,
-            graded: true,
-            options: {
-                static: false,
-                title: "",
-                range: [
-                    [0, 10],
-                    [0, 10],
-                ],
-                box: [350, 130],
-                backgroundImage: {
-                    url: "https://cdn.kastatic.org/ka-content-images/74edeeb6c6605a4e854e3a3e9db69c01dcf5508f.svg",
-                    width: 350,
-                    height: 130,
-                },
-                labels: [],
-                alt: "A squiggly curve drawn from left to right. The right end of the curve has an arrow point. The curve begins with a small amount of wiggle on the left, which grows in amplitude in the middle and then decreases again on the right. The result is a small wave packet.",
-                caption: "",
-            },
-            version: {
-                major: 0,
-                minor: 0,
-            },
-        },
-    },
-};
-
 export const Exercise: Story = {
     args: {
         question,
@@ -142,6 +53,6 @@ export const Exercise: Story = {
 
 export const Article: Story = {
     args: {
-        question: sampleArticleSection,
+        question: articleWithImages,
     },
 };

--- a/packages/perseus-editor/src/__stories__/content-preview.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/content-preview.stories.tsx
@@ -2,8 +2,8 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {useState} from "react";
 
-import {mockStrings} from "../../../perseus/src/strings";
 import {articleWithImages} from "../../../perseus/src/__testdata__/article-renderer.testdata";
+import {mockStrings} from "../../../perseus/src/strings";
 import {question} from "../../../perseus/src/widgets/__testdata__/radio.testdata";
 import DeviceFramer from "../components/device-framer";
 import ViewportResizer from "../components/viewport-resizer";

--- a/packages/perseus-editor/src/content-preview.tsx
+++ b/packages/perseus-editor/src/content-preview.tsx
@@ -1,0 +1,49 @@
+import {
+    KeypadContext,
+    MobileKeypad,
+    StatefulKeypadContextProvider,
+} from "@khanacademy/math-input";
+import {Renderer} from "@khanacademy/perseus";
+// eslint-disable-next-line monorepo/no-internal-import
+import {mockStrings} from "@khanacademy/perseus/strings";
+import {View} from "@khanacademy/wonder-blocks-core";
+import * as React from "react";
+
+import type {APIOptions, PerseusRenderer} from "@khanacademy/perseus";
+
+function ContentPreview({
+    question,
+    apiOptions,
+}: {
+    question?: PerseusRenderer;
+    apiOptions?: APIOptions;
+}) {
+    return (
+        <View>
+            <StatefulKeypadContextProvider>
+                <Renderer
+                    strings={mockStrings}
+                    apiOptions={apiOptions}
+                    {...question}
+                />
+                <KeypadContext.Consumer>
+                    {({setKeypadActive, setKeypadElement}) => {
+                        return (
+                            <MobileKeypad
+                                onAnalyticsEvent={() => Promise.resolve()}
+                                onDismiss={() => setKeypadActive(false)}
+                                onElementMounted={(element) => {
+                                    if (element) {
+                                        setKeypadElement(element);
+                                    }
+                                }}
+                            />
+                        );
+                    }}
+                </KeypadContext.Consumer>
+            </StatefulKeypadContextProvider>
+        </View>
+    );
+}
+
+export default ContentPreview;

--- a/packages/perseus-editor/src/content-preview.tsx
+++ b/packages/perseus-editor/src/content-preview.tsx
@@ -21,9 +21,13 @@ function ContentPreview({
     return (
         <View style={{marginRight: "40px"}}>
             <StatefulKeypadContextProvider>
+                <KeypadContext.Consumer>
+                    {({setKeypadActive, keypadElement, setKeypadElement}) => (
+                        <>
                 <Renderer
                     strings={mockStrings}
                     apiOptions={apiOptions}
+                                keypadElement={keypadElement}
                     linterContext={{
                         contentType: "exercise",
                         highlightLint: true,
@@ -32,20 +36,14 @@ function ContentPreview({
                     }}
                     {...question}
                 />
-                <KeypadContext.Consumer>
-                    {({setKeypadActive, setKeypadElement}) => {
-                        return (
+
                             <MobileKeypad
                                 onAnalyticsEvent={() => Promise.resolve()}
                                 onDismiss={() => setKeypadActive(false)}
-                                onElementMounted={(element) => {
-                                    if (element) {
-                                        setKeypadElement(element);
-                                    }
-                                }}
+                                onElementMounted={setKeypadElement}
                             />
-                        );
-                    }}
+                        </>
+                    )}
                 </KeypadContext.Consumer>
             </StatefulKeypadContextProvider>
         </View>

--- a/packages/perseus-editor/src/content-preview.tsx
+++ b/packages/perseus-editor/src/content-preview.tsx
@@ -1,21 +1,21 @@
 import {
     KeypadContext,
-    MobileKeypad,
     StatefulKeypadContextProvider,
-} from "@khanacademy/math-input";
-import {Renderer, constants} from "@khanacademy/perseus";
+} from "@khanacademy/keypad-context";
+import {MobileKeypad} from "@khanacademy/math-input";
+import {
+    Renderer,
+    constants,
+    type APIOptions,
+    type DeviceType,
+    type PerseusRenderer,
+} from "@khanacademy/perseus";
 // eslint-disable-next-line monorepo/no-internal-import
 import {mockStrings} from "@khanacademy/perseus/strings";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
-import * as React from "react";
 
-import type {
-    APIOptions,
-    DeviceType,
-    PerseusRenderer,
-} from "@khanacademy/perseus";
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
 
 /**

--- a/packages/perseus-editor/src/content-preview.tsx
+++ b/packages/perseus-editor/src/content-preview.tsx
@@ -4,7 +4,6 @@ import {
     StatefulKeypadContextProvider,
 } from "@khanacademy/math-input";
 import {Renderer, constants} from "@khanacademy/perseus";
-// eslint-disable-next-line monorepo/no-internal-import
 import {mockStrings} from "@khanacademy/perseus/strings";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
@@ -56,7 +55,11 @@ function ContentPreview({
 }
 
 const styles = StyleSheet.create({
-    container: {padding: spacing.xxxSmall_4},
+    container: {
+        padding: spacing.xxxSmall_4,
+        containerType: "inline-size",
+        containerName: "perseus-root",
+    },
     gutter: {marginRight: constants.lintGutterWidth},
 });
 

--- a/packages/perseus-editor/src/content-preview.tsx
+++ b/packages/perseus-editor/src/content-preview.tsx
@@ -3,10 +3,12 @@ import {
     MobileKeypad,
     StatefulKeypadContextProvider,
 } from "@khanacademy/math-input";
-import {Renderer} from "@khanacademy/perseus";
+import {Renderer, constants} from "@khanacademy/perseus";
 // eslint-disable-next-line monorepo/no-internal-import
 import {mockStrings} from "@khanacademy/perseus/strings";
 import {View} from "@khanacademy/wonder-blocks-core";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 import type {APIOptions, PerseusRenderer} from "@khanacademy/perseus";
@@ -14,28 +16,30 @@ import type {APIOptions, PerseusRenderer} from "@khanacademy/perseus";
 function ContentPreview({
     question,
     apiOptions,
+    seamless,
 }: {
     question?: PerseusRenderer;
     apiOptions?: APIOptions;
+    seamless?: boolean;
 }) {
     return (
-        <View style={{marginRight: "40px"}}>
+        <View style={[styles.container, !seamless ? styles.gutter : undefined]}>
             <StatefulKeypadContextProvider>
                 <KeypadContext.Consumer>
                     {({setKeypadActive, keypadElement, setKeypadElement}) => (
                         <>
-                <Renderer
-                    strings={mockStrings}
-                    apiOptions={apiOptions}
+                            <Renderer
+                                strings={mockStrings}
+                                apiOptions={apiOptions}
                                 keypadElement={keypadElement}
-                    linterContext={{
-                        contentType: "exercise",
-                        highlightLint: true,
-                        paths: [],
-                        stack: [],
-                    }}
-                    {...question}
-                />
+                                linterContext={{
+                                    contentType: "exercise",
+                                    highlightLint: true,
+                                    paths: [],
+                                    stack: [],
+                                }}
+                                {...question}
+                            />
 
                             <MobileKeypad
                                 onAnalyticsEvent={() => Promise.resolve()}
@@ -49,5 +53,10 @@ function ContentPreview({
         </View>
     );
 }
+
+const styles = StyleSheet.create({
+    container: {padding: spacing.xxxSmall_4},
+    gutter: {marginRight: constants.lintGutterWidth},
+});
 
 export default ContentPreview;

--- a/packages/perseus-editor/src/content-preview.tsx
+++ b/packages/perseus-editor/src/content-preview.tsx
@@ -10,9 +10,7 @@ import {
     type DeviceType,
     type PerseusRenderer,
 } from "@khanacademy/perseus";
-// eslint-disable-next-line monorepo/no-internal-import
-import {mockStrings} from "@khanacademy/perseus/strings";
-import {View} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
 
@@ -35,6 +33,7 @@ function ContentPreview({
     linterContext,
     legacyPerseusLint,
     previewDevice,
+    strings,
 }: {
     question?: PerseusRenderer;
     apiOptions?: APIOptions;
@@ -42,6 +41,7 @@ function ContentPreview({
     linterContext?: LinterContextProps;
     legacyPerseusLint?: ReadonlyArray<string>;
     previewDevice: DeviceType;
+    strings: PropsFor<typeof Renderer>["strings"];
 }) {
     const isMobile = previewDevice !== "desktop";
 
@@ -57,7 +57,7 @@ function ContentPreview({
                     {({setKeypadActive, keypadElement, setKeypadElement}) => (
                         <>
                             <Renderer
-                                strings={mockStrings}
+                                strings={strings}
                                 apiOptions={{...apiOptions, isMobile}}
                                 keypadElement={keypadElement}
                                 linterContext={linterContext}

--- a/packages/perseus-editor/src/content-preview.tsx
+++ b/packages/perseus-editor/src/content-preview.tsx
@@ -10,11 +10,12 @@ import {
     type DeviceType,
     type PerseusRenderer,
 } from "@khanacademy/perseus";
-import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
+import {View} from "@khanacademy/wonder-blocks-core";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
 
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
 /**
  * The `ContentPreview` component provides a simple preview system for Perseus

--- a/packages/perseus-editor/src/content-preview.tsx
+++ b/packages/perseus-editor/src/content-preview.tsx
@@ -26,8 +26,13 @@ function ContentPreview({
     linterContext?: LinterContextProps;
     legacyPerseusLint?: ReadonlyArray<string>;
 }) {
+    const className = apiOptions?.isMobile ? "perseus-mobile" : "";
+
     return (
-        <View style={[styles.container, !seamless ? styles.gutter : undefined]}>
+        <View
+            className={`framework-perseus ${className}`}
+            style={[styles.container, !seamless ? styles.gutter : undefined]}
+        >
             <StatefulKeypadContextProvider>
                 <KeypadContext.Consumer>
                     {({setKeypadActive, keypadElement, setKeypadElement}) => (

--- a/packages/perseus-editor/src/content-preview.tsx
+++ b/packages/perseus-editor/src/content-preview.tsx
@@ -19,11 +19,17 @@ function ContentPreview({
     apiOptions?: APIOptions;
 }) {
     return (
-        <View>
+        <View style={{marginRight: "40px"}}>
             <StatefulKeypadContextProvider>
                 <Renderer
                     strings={mockStrings}
                     apiOptions={apiOptions}
+                    linterContext={{
+                        contentType: "exercise",
+                        highlightLint: true,
+                        paths: [],
+                        stack: [],
+                    }}
                     {...question}
                 />
                 <KeypadContext.Consumer>

--- a/packages/perseus-editor/src/content-preview.tsx
+++ b/packages/perseus-editor/src/content-preview.tsx
@@ -12,15 +12,20 @@ import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 import type {APIOptions, PerseusRenderer} from "@khanacademy/perseus";
+import type {LinterContextProps} from "@khanacademy/perseus-linter";
 
 function ContentPreview({
     question,
     apiOptions,
     seamless,
+    linterContext,
+    legacyPerseusLint,
 }: {
     question?: PerseusRenderer;
     apiOptions?: APIOptions;
     seamless?: boolean;
+    linterContext?: LinterContextProps;
+    legacyPerseusLint?: ReadonlyArray<string>;
 }) {
     return (
         <View style={[styles.container, !seamless ? styles.gutter : undefined]}>
@@ -32,12 +37,8 @@ function ContentPreview({
                                 strings={mockStrings}
                                 apiOptions={apiOptions}
                                 keypadElement={keypadElement}
-                                linterContext={{
-                                    contentType: "exercise",
-                                    highlightLint: true,
-                                    paths: [],
-                                    stack: [],
-                                }}
+                                linterContext={linterContext}
+                                legacyPerseusLint={legacyPerseusLint}
                                 {...question}
                             />
 

--- a/packages/perseus-editor/src/content-preview.tsx
+++ b/packages/perseus-editor/src/content-preview.tsx
@@ -4,29 +4,48 @@ import {
     StatefulKeypadContextProvider,
 } from "@khanacademy/math-input";
 import {Renderer, constants} from "@khanacademy/perseus";
+// eslint-disable-next-line monorepo/no-internal-import
 import {mockStrings} from "@khanacademy/perseus/strings";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
-import type {APIOptions, PerseusRenderer} from "@khanacademy/perseus";
+import type {
+    APIOptions,
+    DeviceType,
+    PerseusRenderer,
+} from "@khanacademy/perseus";
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
 
+/**
+ * The `ContentPreview` component provides a simple preview system for Perseus
+ * Content. Due to how Persus styles are built, the preview styling matches the
+ * current device based on the viewport width (using `@media` queries for
+ * `min-width` and `max-width`).
+ *
+ * The preview will render the mobile variant (styling and layout) when the
+ * `previewDevice` is phone or tablet. Note that the styling cannot be matched
+ * 100% due to the above `@media` query limitation.
+ */
 function ContentPreview({
     question,
     apiOptions,
     seamless,
     linterContext,
     legacyPerseusLint,
+    previewDevice,
 }: {
     question?: PerseusRenderer;
     apiOptions?: APIOptions;
     seamless?: boolean;
     linterContext?: LinterContextProps;
     legacyPerseusLint?: ReadonlyArray<string>;
+    previewDevice: DeviceType;
 }) {
-    const className = apiOptions?.isMobile ? "perseus-mobile" : "";
+    const isMobile = previewDevice !== "desktop";
+
+    const className = isMobile ? "perseus-mobile" : "";
 
     return (
         <View
@@ -39,7 +58,7 @@ function ContentPreview({
                         <>
                             <Renderer
                                 strings={mockStrings}
-                                apiOptions={apiOptions}
+                                apiOptions={{...apiOptions, isMobile}}
                                 keypadElement={keypadElement}
                                 linterContext={linterContext}
                                 legacyPerseusLint={legacyPerseusLint}

--- a/packages/perseus-editor/src/index.ts
+++ b/packages/perseus-editor/src/index.ts
@@ -9,6 +9,7 @@ export {default as StructuredItemDiff} from "./diffs/structured-item-diff";
 export {default as EditorPage} from "./editor-page";
 export {default as Editor} from "./editor";
 export {default as i18n} from "./i18n";
+export {default as ContentPreview} from "./content-preview";
 export {default as IframeContentRenderer} from "./iframe-content-renderer";
 export {default as MultiRendererEditor} from "./multirenderer-editor";
 export {default as StatefulEditorPage} from "./stateful-editor-page";

--- a/packages/perseus/src/__testdata__/article-renderer.testdata.ts
+++ b/packages/perseus/src/__testdata__/article-renderer.testdata.ts
@@ -33,6 +33,96 @@ export const singleSectionArticle: PerseusRenderer = {
     },
 };
 
+export const articleWithImages: PerseusRenderer = {
+    content:
+        "The word \"radiation\" sometimes gets a bad rap. People often associate radiation with something dangerous or scary, without really knowing what it is. In reality, we're surrounded by radiation all the time. \n\n**Radiation** is energy that travels through space (not just \"outer space\"—any space). Radiation can also interact with matter. How radiation interacts with matter depends on the type of radiation and the type of matter.\n\nRadiation comes in many forms, one of which is *electromagnetic radiation*. Without electromagnetic radiation life on Earth would not be possible, nor would most modern technologies.\n\n[[☃ image 13]]\n\nLet's take a closer look at this important and fascinating type of radiation.\n\n##Electromagnetic radiation\n\nAs the name suggests, **electromagnetic (EM) radiation** is energy transferred by *electromagnetic fields* oscillating through space.\n\nEM radiation is strange—it has both wave and particle properties. Let's take a look at both.\n\n###Electromagnetic waves\n\nAn animated model of an EM wave is shown below.\n[[☃ image 1]]\nThe electric field $(\\vec{\\textbf{E}})$ is shown in $\\color{blue}\\textbf{blue}$, and the magnetic field $(\\vec{\\textbf{B}})$ is shown in $\\color{red}\\textbf{red}$. They're perpendicular to each other.\n\nA changing electric field creates a magnetic field, and a changing magnetic field creates an electric field. So, once the EM wave is generated it propagates itself through space!\n\nAs with any wave, EM waves have wavelength, frequency, and speed. The wave model of EM radiation works best on large scales. But what about the atomic scale?\n\n###Photons\n\nAt the quantum level, EM radiation exists as particles. A particle of EM radiation is called a **photon**.\n\nWe can think of photons as wave *packets*—tiny bundles of EM radiation containing specific amounts of energy. Photons are visually represented using the following symbol.\n\n[[☃ image 3]]\n\nAll EM radiation, whether modeled as waves or photons, travels at the **speed of light** $\\textbf{(c)}$ in a vacuum: \n\n$\\text{c}=3\\times10^8\\space\\pu{m/s}=300{,}000{,}000\\space\\pu{m/s}$\n\nBut, EM radiation travels at a slower speed in matter, such as water or glass.",
+    images: {},
+    widgets: {
+        "image 13": {
+            type: "image",
+            alignment: "block",
+            static: false,
+            graded: true,
+            options: {
+                static: false,
+                title: "",
+                range: [
+                    [0, 10],
+                    [0, 10],
+                ],
+                box: [600, 254],
+                backgroundImage: {
+                    url: "https://cdn.kastatic.org/ka-content-images/358a87c20ab6ee70447f5fcb547010f69986828e.jpg",
+                    width: 600,
+                    height: 254,
+                },
+                labels: [],
+                alt: "From space, the sun appears over Earth's horizon, illuminating the atmosphere as a blue layer above Earth. Above the atmosphere, space appears black.",
+                caption:
+                    "*Sunrise photo from the International Space Station. Earth's atmosphere scatters electromagnetic radiation from the sun, producing a bright sky during the day.*",
+            },
+            version: {
+                major: 0,
+                minor: 0,
+            },
+        },
+        "image 1": {
+            type: "image",
+            alignment: "block",
+            static: false,
+            graded: true,
+            options: {
+                static: false,
+                title: "",
+                range: [
+                    [0, 10],
+                    [0, 10],
+                ],
+                box: [627, 522],
+                backgroundImage: {
+                    url: "https://cdn.kastatic.org/ka-content-images/8100369eaf3b581d4e7bfc9f1062625309def486.gif",
+                    width: 627,
+                    height: 522,
+                },
+                labels: [],
+                alt: "An animation shows a blue electric field arrow oscillating up and down. Connected to the base of the electric field arrow is a magnetic field arrow, which oscillates from side to side. The two fields oscillate in unison: when one extends the other extends too, creating a repeating wave pattern.",
+                caption: "",
+            },
+            version: {
+                major: 0,
+                minor: 0,
+            },
+        },
+        "image 3": {
+            type: "image",
+            alignment: "block",
+            static: false,
+            graded: true,
+            options: {
+                static: false,
+                title: "",
+                range: [
+                    [0, 10],
+                    [0, 10],
+                ],
+                box: [350, 130],
+                backgroundImage: {
+                    url: "https://cdn.kastatic.org/ka-content-images/74edeeb6c6605a4e854e3a3e9db69c01dcf5508f.svg",
+                    width: 350,
+                    height: 130,
+                },
+                labels: [],
+                alt: "A squiggly curve drawn from left to right. The right end of the curve has an arrow point. The curve begins with a small amount of wiggle on the left, which grows in amplitude in the middle and then decreases again on the right. The result is a small wave packet.",
+                caption: "",
+            },
+            version: {
+                major: 0,
+                minor: 0,
+            },
+        },
+    },
+};
+
 export const passageArticle: PerseusRenderer = {
     content:
         "###Group/Pair Activity \n\nThis passage is adapted from Ed Yong, “Turtles Use the Earth’s Magnetic Field as Global GPS.” ©2011 by Kalmbach Publishing Co.\n\n[[☃ passage 1]]\n\n**Question 9**\n\nThe passage most strongly suggests that Adelita used which of the following to navigate her 9,000-mile journey?\n\nA) The current of the North Atlantic gyre\n\nB) Cues from electromagnetic coils designed by Putman and Lohmann\n\nC) The inclination and intensity of Earth’s magnetic field\n\nD) A simulated “magnetic signature” configured by Lohmann\n\n10) Which choice provides the best evidence for the answer to the previous question?\n\nA) Lines 1–2 (“In 1996...way”)\n\nB) Lines 20–21 (“Using...surface”)\n\nC) Lines 36–37 (“In the wild...stars”)\n\nD) Lines 43–45 (“Neither...it is”)\n\n**Question 12** \n\nBased on the passage, which choice best describes the relationship between Putman’s and Lohmann’s research?\n\nA) Putman’s research contradicts Lohmann’s.\n\nB) Putman’s research builds on Lohmann’s.\n\nC) Lohmann’s research confirms Putman’s.\n\nD) Lohmann’s research corrects Putman’s.",

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -1,5 +1,5 @@
 import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
-import {within, render, screen, act} from "@testing-library/react";
+import {within, logRoles, render, screen, act} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
@@ -588,7 +588,7 @@ describe("server item renderer", () => {
             ).not.toBeInTheDocument();
         });
 
-        it("should show linting errors when highlightLint is true", () => {
+        it("should show linting errors when highlightLint is true", async () => {
             // Arrange and Act
             renderQuestion(itemWithLintingError, undefined, {
                 linterContext: {
@@ -598,6 +598,12 @@ describe("server item renderer", () => {
                     stack: [],
                 },
             });
+
+            // Linting errors are surfaced as a link with a warning or error
+            // icon inside them. We need to click on it to open the tooltip
+            // that contains the error message.
+            const lintIcon = screen.getByRole("link");
+            await userEvent.click(lintIcon);
 
             expect(
                 screen.getByText("Don't use level-1 headings", {exact: false}),

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -1,5 +1,5 @@
 import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
-import {within, logRoles, render, screen, act} from "@testing-library/react";
+import {within, render, screen, act} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 

--- a/packages/perseus/src/components/lint.tsx
+++ b/packages/perseus/src/components/lint.tsx
@@ -1,11 +1,11 @@
+import {color, font} from "@khanacademy/wonder-blocks-tokens";
+import Tooltip from "@khanacademy/wonder-blocks-tooltip";
 import {StyleSheet, css} from "aphrodite";
 import * as React from "react";
-import Tooltip from "@khanacademy/wonder-blocks-tooltip";
 
 import * as constants from "../styles/constants";
 
 import InlineIcon from "./inline-icon";
-import {color, font} from "@khanacademy/wonder-blocks-tokens";
 
 const exclamationIcon = {
     path: "M6 11a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm0-9a1 1 0 0 1 1 1v4a1 1 0 1 1-2 0V3a1 1 0 0 1 1-1z",

--- a/packages/perseus/src/components/lint.tsx
+++ b/packages/perseus/src/components/lint.tsx
@@ -1,10 +1,11 @@
 import {StyleSheet, css} from "aphrodite";
 import * as React from "react";
-import ReactDOM from "react-dom";
+import Tooltip from "@khanacademy/wonder-blocks-tooltip";
 
 import * as constants from "../styles/constants";
 
 import InlineIcon from "./inline-icon";
+import {color, font} from "@khanacademy/wonder-blocks-tokens";
 
 const exclamationIcon = {
     path: "M6 11a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm0-9a1 1 0 0 1 1 1v4a1 1 0 1 1-2 0V3a1 1 0 0 1 1-1z",
@@ -38,10 +39,6 @@ type Props = {
     severity?: Severity;
 };
 
-type State = {
-    tooltipAbove: boolean;
-};
-
 /**
  * This component renders "lint" nodes in a markdown parse tree. Lint nodes
  * are inserted into the tree by the Perseus linter (see
@@ -64,43 +61,12 @@ type State = {
  * that has a right margin (like anything blockquoted) the circle will appear
  * to the left of where it belongs.  And if there is more
  **/
-class Lint extends React.Component<Props, State> {
+class Lint extends React.Component<Props> {
     _positionTimeout: number | undefined;
-
-    state: State = {
-        tooltipAbove: true,
-    };
-
-    componentDidMount() {
-        // TODO(somewhatabstract): Use WB timing
-        // eslint-disable-next-line no-restricted-syntax
-        this._positionTimeout = window.setTimeout(this.getPosition);
-    }
-
-    componentWillUnmount() {
-        // TODO(somewhatabstract): Use WB timing
-        // eslint-disable-next-line no-restricted-syntax
-        window.clearTimeout(this._positionTimeout);
-    }
-
-    // We can't call setState in componentDidMount without risking a render
-    // thrash, and we can't call getBoundingClientRect in render, so we
-    // borrow a timeout approach from learnstorm-dashboard.jsx and set our
-    // state once the component has mounted and we can get what we need.
-    getPosition: () => void = () => {
-        // @ts-expect-error - TS2531 - Object is possibly 'null'. | TS2339 - Property 'getBoundingClientRect' does not exist on type 'Element | Text'.
-        const rect = ReactDOM.findDOMNode(this).getBoundingClientRect();
-        // TODO(scottgrant): This is a magic number! We don't know the size
-        // of the tooltip at this point, so we're arbitrarily choosing a
-        // point at which to flip the tooltip's position.
-        this.setState({tooltipAbove: rect.top > 100});
-    };
 
     // Render the <a> element that holds the indicator icon and the tooltip
     // We pass different styles for the inline and block cases
     renderLink: (arg1: any) => React.ReactElement = (style) => {
-        const tooltipAbove = this.state.tooltipAbove;
-
         let severityStyle;
         let warningText;
         let warningTextStyle;
@@ -119,38 +85,33 @@ class Lint extends React.Component<Props, State> {
         }
 
         return (
-            <a
-                href={`https://khanacademy.org/r/linter-rules#${this.props.ruleName}`}
-                target="lint-help-window"
-                className={css(style)}
+            <Tooltip
+                backgroundColor={"offBlack"}
+                content={
+                    <>
+                        {this.props.message.split("\n\n").map((m, i) => (
+                            <p key={i} className={css(styles.tooltipParagraph)}>
+                                <span className={css(warningTextStyle)}>
+                                    {warningText}:{" "}
+                                </span>
+                                {m}
+                            </p>
+                        ))}
+                    </>
+                }
             >
-                <span className={css(styles.indicator, severityStyle)}>
-                    {this.props.severity === 1 && (
-                        <InlineIcon {...exclamationIcon} />
-                    )}
-                </span>
-                <div
-                    className={css(
-                        styles.tooltip,
-                        tooltipAbove && styles.tooltipAbove,
-                    )}
+                <a
+                    href={`https://khanacademy.org/r/linter-rules#${this.props.ruleName}`}
+                    target="lint-help-window"
+                    className={css(style)}
                 >
-                    {this.props.message.split("\n\n").map((m, i) => (
-                        <p key={i} className={css(styles.tooltipParagraph)}>
-                            <span className={css(warningTextStyle)}>
-                                {warningText}:{" "}
-                            </span>
-                            {m}
-                        </p>
-                    ))}
-                    <div
-                        className={css(
-                            styles.tail,
-                            tooltipAbove && styles.tailAbove,
+                    <span className={css(styles.indicator, severityStyle)}>
+                        {this.props.severity === 1 && (
+                            <InlineIcon {...exclamationIcon} />
                         )}
-                    />
-                </div>
-            </a>
+                    </span>
+                </a>
+            </Tooltip>
         );
     };
 
@@ -386,60 +347,11 @@ const styles = StyleSheet.create({
         backgroundColor: "#ffbe26",
     },
 
-    // These are the styles for the tooltip
-    tooltip: {
-        // Absolute positioning relative to the lint indicator circle.
-        position: "absolute",
-        right: -12,
-
-        // The tooltip is hidden by default; only displayed on hover
-        display: "none",
-
-        // When it is displayed, it goes on top!
-        zIndex: 1000,
-
-        // These styles control what the tooltip looks like
-        color: constants.white,
-        backgroundColor: constants.gray17,
-        opacity: 0.9,
-        fontFamily: constants.baseFontFamily,
-        fontSize: "12px",
-        lineHeight: "15px",
-        width: "320px",
-        borderRadius: "4px",
-    },
-    // If we're going to render the tooltip above the warning circle, we use
-    // the previous rules in tooltip, but change the position slightly.
-    tooltipAbove: {
-        bottom: 32,
-    },
-
-    // We give the tooltip a little triangular "tail" that points down at
-    // the lint indicator circle. This is inside the tooltip and positioned
-    // relative to it. It also shares the opacity of the tooltip. We're using
-    // the standard CSS trick for drawing triangles with a thick border.
-    tail: {
-        position: "absolute",
-        top: -12,
-        right: 16,
-        width: 0,
-        height: 0,
-
-        // This is the CSS triangle trick
-        borderLeft: "8px solid transparent",
-        borderRight: "8px solid transparent",
-        borderBottom: "12px solid " + constants.gray17,
-    },
-    tailAbove: {
-        bottom: -12,
-        borderBottom: "none",
-        borderTop: "12px solid " + constants.gray17,
-        top: "auto",
-    },
-
     // Each warning in the tooltip is its own <p>. They are 12 pixels from
     // the edges of the tooltip and 12 pixels from each other.
     tooltipParagraph: {
+        fontFamily: font.family.sans,
+        color: color.white,
         margin: 12,
     },
 


### PR DESCRIPTION
## Summary:

This PR introduces a new editor component: `ContentPreview`. It is a thin wrapper around `ServerItemRenderer` which provides an easy way for editors to preview a given Perseus Item. 

It should be noted that due to current Perseus styling, the preview will _not_ match production 100%. This is because Perseus styles are adjusted based `@media` queries on device width.

<img width="768" alt="image" src="https://github.com/user-attachments/assets/6b0a9369-f814-446f-9ce5-0f3c6db94518">

Issue: LEMS-1809

## Test plan:

View the prevew in Storybook. `yarn start` ==> http://localhost:6006/?path=/docs/perseuseditor-content-preview--docs