### PR TITLE
[🔥AUDIT🔥] Import internally using relative paths instead of package name

### DIFF
--- a/.changeset/tough-bananas-arrive.md
+++ b/.changeset/tough-bananas-arrive.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Update internal imports to use relative paths instead of package name

--- a/packages/perseus/src/interactive2/__tests__/movable-mock.ts
+++ b/packages/perseus/src/interactive2/__tests__/movable-mock.ts
@@ -7,7 +7,7 @@ import _ from "underscore";
 import {Graphie} from "../../util/graphie";
 import {Movable} from "../movable";
 
-import type {Coord} from "@khanacademy/perseus";
+import type {Coord} from "../types";
 
 const createMock = function (): any {
     return new MovableMock(new Graphie(document.createElement("div")), {});

--- a/packages/perseus/src/interactive2/arrowhead.ts
+++ b/packages/perseus/src/interactive2/arrowhead.ts
@@ -6,8 +6,8 @@ import KhanMath from "../util/math";
 import {getClipPoint} from "./get-clip-point";
 import WrappedPath from "./wrapped-path";
 
+import type {Coord} from "./types";
 import type {Graphie} from "../util/graphie";
-import type {Coord} from "@khanacademy/perseus";
 
 export class Arrowhead extends WrappedPath {
     private static scale = 1.4;

--- a/packages/perseus/src/interactive2/get-clip-point.ts
+++ b/packages/perseus/src/interactive2/get-clip-point.ts
@@ -1,6 +1,6 @@
 import {vector as kvector} from "@khanacademy/kmath";
 
-import type {Coord} from "@khanacademy/perseus";
+import type {Coord} from "./types";
 
 // Given `coord` and `angle`, find the point where a line extended
 // from `coord` in the direction of `angle` would be clipped by the

--- a/packages/perseus/src/interactive2/movable-point.tsx
+++ b/packages/perseus/src/interactive2/movable-point.tsx
@@ -67,9 +67,8 @@ import objective_ from "./objective_";
 import WrappedEllipse from "./wrapped-ellipse";
 
 import type {Movable} from "./movable";
-import type {Constraint, ConstraintCallbacks} from "./types";
+import type {Constraint, ConstraintCallbacks, Coord} from "./types";
 import type {Graphie} from "../util/graphie";
-import type {Coord} from "@khanacademy/perseus";
 
 const assert = InteractiveUtil.assert;
 const normalizeOptions = InteractiveUtil.normalizeOptions;

--- a/packages/perseus/src/util/test-utils.testdata.ts
+++ b/packages/perseus/src/util/test-utils.testdata.ts
@@ -1,4 +1,4 @@
-import type {PerseusItem} from "@khanacademy/perseus";
+import type {PerseusItem} from "../perseus-types";
 
 export const basicObject: PerseusItem = {
     question: {

--- a/packages/perseus/src/widgets/__stories__/interactive-graph-regression.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/interactive-graph-regression.stories.tsx
@@ -4,7 +4,7 @@ import Renderer from "../../renderer";
 import {mockStrings} from "../../strings";
 import {interactiveGraphQuestionBuilder} from "../interactive-graphs/interactive-graph-question-builder";
 
-import type {PerseusRenderer} from "@khanacademy/perseus";
+import type {PerseusRenderer} from "../../perseus-types";
 
 type StoryArgs = Record<any, any>;
 

--- a/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/interactive-graph.stories.tsx
@@ -22,7 +22,7 @@ import {
     segmentWithLockedPolygons,
 } from "../__testdata__/interactive-graph.testdata";
 
-import type {APIOptions} from "@khanacademy/perseus";
+import type {APIOptions} from "../../types";
 
 export default {
     title: "Perseus/Widgets/Interactive Graph",

--- a/packages/perseus/src/widgets/__stories__/random-widgets.stories.tsx
+++ b/packages/perseus/src/widgets/__stories__/random-widgets.stories.tsx
@@ -9,7 +9,7 @@ import {randomExpressionGenerator} from "../__testdata__/expression.testdata";
 import {randomInteractiveGraphGenerator} from "../__testdata__/interactive-graph-random.testdata";
 import {randomRadioGenerator} from "../__testdata__/radio.testdata";
 
-import type {PerseusRenderer} from "@khanacademy/perseus";
+import type {PerseusRenderer} from "../../perseus-types";
 
 export default {
     title: "Perseus/Randomized Widgets",

--- a/packages/perseus/src/widgets/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.test.tsx
@@ -9,8 +9,8 @@ import type {
     PerseusGraphTypeLinear,
     PerseusGraphTypePoint,
     PerseusGraphTypePolygon,
+    PerseusGraphType,
 } from "../perseus-types";
-import type {PerseusGraphType} from "@khanacademy/perseus";
 
 function createRubric(graph: PerseusGraphType): Rubric {
     return {graph, correct: graph};

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -11,8 +11,8 @@ import {MovablePoint} from "./components/movable-point";
 import {TextLabel} from "./components/text-label";
 import {useDraggable} from "./use-draggable";
 
+import type {CollinearTuple} from "../../../perseus-types";
 import type {MafsGraphProps, PolygonGraphState} from "../types";
-import type {CollinearTuple} from "@khanacademy/perseus";
 
 type Props = MafsGraphProps<PolygonGraphState>;
 

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -1,3 +1,4 @@
+import type {Coord} from "../../interactive2/types";
 import type {
     CollinearTuple,
     LockedEllipseType,
@@ -12,7 +13,6 @@ import type {
     PerseusGraphType,
     PerseusRenderer,
 } from "../../perseus-types";
-import type {Coord} from "@khanacademy/perseus";
 import type {Interval, vec} from "mafs";
 
 export type LockedFunctionOptions = Omit<

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
@@ -4,6 +4,7 @@ import {vec} from "mafs";
 import {magnitude, vector} from "../../../util/geometry";
 import {normalizeCoords, normalizePoints} from "../utils";
 
+import type {Coord} from "../../../interactive2/types";
 import type {
     PerseusGraphType,
     PerseusGraphTypeAngle,
@@ -18,7 +19,6 @@ import type {
     PerseusGraphTypeSinusoid,
 } from "../../../perseus-types";
 import type {InteractiveGraphState, PairOfPoints} from "../types";
-import type {Coord} from "@khanacademy/perseus";
 import type {Interval} from "mafs";
 
 export type InitializeGraphStateParams = {

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -40,13 +40,13 @@ import {
     REINITIALIZE,
 } from "./interactive-graph-action";
 
+import type {Coord} from "../../../interactive2/types";
 import type {QuadraticCoords} from "../graphs/quadratic";
 import type {
     AngleGraphState,
     InteractiveGraphState,
     PairOfPoints,
 } from "../types";
-import type {Coord} from "@khanacademy/perseus";
 import type {Interval} from "mafs";
 
 const minDistanceBetweenAngleVertexAndSidePoint = 2;

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
@@ -2,8 +2,8 @@ import invariant from "tiny-invariant";
 
 import {getGradableGraph} from "./interactive-graph-state";
 
+import type {PerseusGraphType} from "../../../perseus-types";
 import type {InteractiveGraphState} from "../types";
-import type {PerseusGraphType} from "@khanacademy/perseus";
 
 const defaultAngleState: InteractiveGraphState = {
     type: "angle",

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -1,7 +1,8 @@
 import {clockwise} from "../../../util/geometry";
 
+import type {Coord} from "../../../interactive2/types";
+import type {PerseusGraphType} from "../../../perseus-types";
 import type {CircleGraphState, InteractiveGraphState} from "../types";
-import type {Coord, PerseusGraphType} from "@khanacademy/perseus";
 
 export function getGradableGraph(
     state: InteractiveGraphState,

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
@@ -13,8 +13,8 @@ import {interactiveGraphReducer} from "./reducer/interactive-graph-reducer";
 import {getGradableGraph, getRadius} from "./reducer/interactive-graph-state";
 
 import type {InteractiveGraphProps, InteractiveGraphState} from "./types";
+import type {PerseusGraphType} from "../../perseus-types";
 import type {Widget} from "../../renderer";
-import type {PerseusGraphType} from "@khanacademy/perseus";
 
 export type StatefulMafsGraphProps = {
     box: [number, number];

--- a/packages/perseus/src/widgets/interactive-graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/types.ts
@@ -1,7 +1,7 @@
 import type {InteractiveGraphAction} from "./reducer/interactive-graph-action";
+import type {Coord} from "../../interactive2/types";
 import type {PerseusInteractiveGraphWidgetOptions} from "../../perseus-types";
 import type {WidgetProps} from "../../types";
-import type {Coord} from "@khanacademy/perseus";
 import type {Interval, vec} from "mafs";
 
 export type InteractiveGraphProps = WidgetProps<

--- a/packages/perseus/src/widgets/measurer.tsx
+++ b/packages/perseus/src/widgets/measurer.tsx
@@ -10,9 +10,9 @@ import SvgImage from "../components/svg-image";
 import {ApiOptions} from "../perseus-api";
 import GraphUtils from "../util/graph-utils";
 
+import type {Coord} from "../interactive2/types";
 import type {WidgetExports} from "../types";
 import type {Interval} from "../util/interval";
-import type {Coord} from "@khanacademy/perseus";
 
 const defaultImage = {
     url: null,


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:

I noticed we had quite a few places in the Perseus package that imported things using the `@khanacademy/perseus` package name. This seems odd and is a bit misleading when reading the code ("why do we import usign the public package name here?").

Issue: "none"

## Test plan: