### PR TITLE
[Interactive Graph] Stop the Mafs graphs from being user selectable

### DIFF
--- a/.changeset/unlucky-carrots-sparkle.md
+++ b/.changeset/unlucky-carrots-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Interactive Graph] Stop the Mafs graphs from being user selectable

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -80,6 +80,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                     marginLeft: "20px",
                     marginBottom: "20px",
                     pointerEvents: props.static ? "none" : "auto",
+                    userSelect: "none",
                 }}
             >
                 <LegacyGrid


### PR DESCRIPTION
## Summary:
Currently, graphs can be selected and copied when the user drag-selects them.
We don't want this to be the case. It causes a bunch of graph information to
be awkwardly copied, such as the background image or all the axis tick labels.

Here, I'm adding `user-select: none` to the Mafs graph to stop this behavior.

NOTE: This works perfectly in Safari and Firefox, but there is a known bug
in Chrome that makes it so that the drag-selected element (which does
successfully look non-selected) still gets copied to the clipboard.
As this is a browser-specific issue, I did not try to fix it here. I think
there might be a super roundabout way to to this, like blocking mouse events
on specific parts of the graph, but I'm not sure that's worth it for a
behavior like this that's out of our control.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2151

## Test plan:
Storybook
- For tick labels
  - http://localhost:6006/?path=/story/perseus-widgets-interactive-graph--segment-with-mafs-and-locked-points
- For background image
  - http://localhost:6006/?path=/story/perseus-widgets-interactive-graph--angle-with-mafs

- Try to copy the graph (start dragging from any text above it to make it easier)
- Paste into a notes app. Confirm that the graph info doesn't paste. (Except in Chrome)

## Recordings:

### Before

https://github.com/user-attachments/assets/0baced92-e0b5-4df3-9198-2e8ae6439370

### After

https://github.com/user-attachments/assets/92c55f1e-2e91-4c43-b97f-9852317c0576


