### PR TITLE
[Interactive Graph Locked Figures] Add controls to move a whole locked polygon

### DIFF
--- a/.changeset/fifty-owls-grin.md
+++ b/.changeset/fifty-owls-grin.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Interactive Graph Locked Figures] Add controls to move a whole locked polygon

--- a/packages/perseus-editor/src/components/__tests__/locked-polygon-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-polygon-settings.test.tsx
@@ -164,4 +164,140 @@ describe("LockedPolygonSettings", () => {
         // Assert
         expect(onToggle).toHaveBeenCalled();
     });
+
+    test("calls onChange when the whole polygon is moved up", async () => {
+        // Arrange
+        const onChangeSpy = jest.fn();
+        render(
+            <LockedPolygonSettings
+                {...defaultProps}
+                onChangeProps={onChangeSpy}
+                points={[
+                    [1, 1],
+                    [2, 1],
+                    [2, 2],
+                    [1, 2],
+                ]}
+            />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
+
+        // Act
+        const moveUpButton = screen.getByLabelText("Move polygon up");
+        await userEvent.click(moveUpButton);
+
+        // Assert
+        expect(onChangeSpy).toHaveBeenCalledWith({
+            points: [
+                [1, 2],
+                [2, 2],
+                [2, 3],
+                [1, 3],
+            ],
+        });
+    });
+
+    test("calls onChange when the whole polygon is moved down", async () => {
+        // Arrange
+        const onChangeSpy = jest.fn();
+        render(
+            <LockedPolygonSettings
+                {...defaultProps}
+                onChangeProps={onChangeSpy}
+                points={[
+                    [1, 1],
+                    [2, 1],
+                    [2, 2],
+                    [1, 2],
+                ]}
+            />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
+
+        // Act
+        const moveUpButton = screen.getByLabelText("Move polygon down");
+        await userEvent.click(moveUpButton);
+
+        // Assert
+        expect(onChangeSpy).toHaveBeenCalledWith({
+            points: [
+                [1, 0],
+                [2, 0],
+                [2, 1],
+                [1, 1],
+            ],
+        });
+    });
+
+    test("calls onChange when the whole polygon is moved left", async () => {
+        // Arrange
+        const onChangeSpy = jest.fn();
+        render(
+            <LockedPolygonSettings
+                {...defaultProps}
+                onChangeProps={onChangeSpy}
+                points={[
+                    [1, 1],
+                    [2, 1],
+                    [2, 2],
+                    [1, 2],
+                ]}
+            />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
+
+        // Act
+        const moveUpButton = screen.getByLabelText("Move polygon left");
+        await userEvent.click(moveUpButton);
+
+        // Assert
+        expect(onChangeSpy).toHaveBeenCalledWith({
+            points: [
+                [0, 1],
+                [1, 1],
+                [1, 2],
+                [0, 2],
+            ],
+        });
+    });
+
+    test("calls onChange when the whole polygon is moved right", async () => {
+        // Arrange
+        const onChangeSpy = jest.fn();
+        render(
+            <LockedPolygonSettings
+                {...defaultProps}
+                onChangeProps={onChangeSpy}
+                points={[
+                    [1, 1],
+                    [2, 1],
+                    [2, 2],
+                    [1, 2],
+                ]}
+            />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
+
+        // Act
+        const moveUpButton = screen.getByLabelText("Move polygon right");
+        await userEvent.click(moveUpButton);
+
+        // Assert
+        expect(onChangeSpy).toHaveBeenCalledWith({
+            points: [
+                [2, 1],
+                [3, 1],
+                [3, 2],
+                [2, 2],
+            ],
+        });
+    });
 });

--- a/packages/perseus-editor/src/components/__tests__/locked-polygon-settings.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-polygon-settings.test.tsx
@@ -219,8 +219,8 @@ describe("LockedPolygonSettings", () => {
         );
 
         // Act
-        const moveUpButton = screen.getByLabelText("Move polygon down");
-        await userEvent.click(moveUpButton);
+        const moveDownButton = screen.getByLabelText("Move polygon down");
+        await userEvent.click(moveDownButton);
 
         // Assert
         expect(onChangeSpy).toHaveBeenCalledWith({
@@ -253,8 +253,8 @@ describe("LockedPolygonSettings", () => {
         );
 
         // Act
-        const moveUpButton = screen.getByLabelText("Move polygon left");
-        await userEvent.click(moveUpButton);
+        const moveLeftButton = screen.getByLabelText("Move polygon left");
+        await userEvent.click(moveLeftButton);
 
         // Assert
         expect(onChangeSpy).toHaveBeenCalledWith({
@@ -287,8 +287,8 @@ describe("LockedPolygonSettings", () => {
         );
 
         // Act
-        const moveUpButton = screen.getByLabelText("Move polygon right");
-        await userEvent.click(moveUpButton);
+        const moveRightButton = screen.getByLabelText("Move polygon right");
+        await userEvent.click(moveRightButton);
 
         // Assert
         expect(onChangeSpy).toHaveBeenCalledWith({

--- a/packages/perseus-editor/src/components/graph-locked-figures/locked-polygon-settings.tsx
+++ b/packages/perseus-editor/src/components/graph-locked-figures/locked-polygon-settings.tsx
@@ -9,9 +9,13 @@ import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
+import {Spring, Strut} from "@khanacademy/wonder-blocks-layout";
 import {spacing, color as wbColor} from "@khanacademy/wonder-blocks-tokens";
 import {LabelLarge, LabelMedium} from "@khanacademy/wonder-blocks-typography";
+import arrowFatDown from "@phosphor-icons/core/regular/arrow-fat-down.svg";
+import arrowFatLeft from "@phosphor-icons/core/regular/arrow-fat-left.svg";
+import arrowFatRight from "@phosphor-icons/core/regular/arrow-fat-right.svg";
+import arrowFatUp from "@phosphor-icons/core/regular/arrow-fat-up.svg";
 import minusCircle from "@phosphor-icons/core/regular/minus-circle.svg";
 import plusCircle from "@phosphor-icons/core/regular/plus-circle.svg";
 import {StyleSheet} from "aphrodite";
@@ -52,6 +56,31 @@ const LockedPolygonSettings = (props: Props) => {
 
     function handleColorChange(newValue: LockedFigureColor) {
         onChangeProps({color: newValue});
+    }
+
+    function handlePolygonMove(movement: "up" | "down" | "left" | "right") {
+        switch (movement) {
+            case "up":
+                onChangeProps({
+                    points: points.map(([x, y]) => [x, y + 1]),
+                });
+                break;
+            case "down":
+                onChangeProps({
+                    points: points.map(([x, y]) => [x, y - 1]),
+                });
+                break;
+            case "left":
+                onChangeProps({
+                    points: points.map(([x, y]) => [x - 1, y]),
+                });
+                break;
+            case "right":
+                onChangeProps({
+                    points: points.map(([x, y]) => [x + 1, y]),
+                });
+                break;
+        }
     }
 
     return (
@@ -172,17 +201,55 @@ const LockedPolygonSettings = (props: Props) => {
                         </View>
                     );
                 })}
-                <Button
-                    kind="tertiary"
-                    startIcon={plusCircle}
-                    onClick={() => {
-                        props.onChangeProps({
-                            points: [...points, [0, 0]],
-                        });
-                    }}
-                >
-                    Add point
-                </Button>
+                <View style={[styles.row, styles.polygonActionsContainer]}>
+                    <Button
+                        kind="tertiary"
+                        startIcon={plusCircle}
+                        onClick={() => {
+                            props.onChangeProps({
+                                points: [...points, [0, 0]],
+                            });
+                        }}
+                    >
+                        Add point
+                    </Button>
+
+                    <Spring />
+
+                    {/* Buttons to move the entire polygon */}
+                    <View style={styles.movementButtonsContainer}>
+                        <IconButton
+                            aria-label="Move polygon up"
+                            style={styles.iconButton}
+                            size="small"
+                            icon={arrowFatUp}
+                            onClick={() => handlePolygonMove("up")}
+                        />
+                        <View style={styles.row}>
+                            <IconButton
+                                aria-label="Move polygon left"
+                                style={styles.iconButton}
+                                size="small"
+                                icon={arrowFatLeft}
+                                onClick={() => handlePolygonMove("left")}
+                            />
+                            <IconButton
+                                aria-label="Move polygon down"
+                                style={styles.iconButton}
+                                size="small"
+                                icon={arrowFatDown}
+                                onClick={() => handlePolygonMove("down")}
+                            />
+                            <IconButton
+                                aria-label="Move polygon right"
+                                style={styles.iconButton}
+                                size="small"
+                                icon={arrowFatRight}
+                                onClick={() => handlePolygonMove("right")}
+                            />
+                        </View>
+                    </View>
+                </View>
             </PerseusEditorAccordion>
 
             {/* Actions */}
@@ -209,6 +276,18 @@ const styles = StyleSheet.create({
     },
     icon: {
         marginInlineStart: spacing.xxxSmall_4,
+    },
+    polygonActionsContainer: {
+        width: "100%",
+    },
+    iconButton: {
+        margin: 0,
+    },
+    movementButtonsContainer: {
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        minWidth: "fit-content",
     },
     spaceUnder: {
         marginBottom: spacing.xSmall_8,


### PR DESCRIPTION
## Summary:
Right now, if someone wants to move an entire locked polygon, they’d have to
manually change every single point’s coordinate pair.

I added some arrow buttons to accomplish this.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2115

## Test plan:
`yarn jest packages/perseus-editor/src/components/__tests__/locked-polygon-settings.test.tsx`

Storybook
- http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--mafs-with-locked-figures-current
- Open the locked polygon settings
- Play around with the buttons and confirm that the polygon moves accordingly

## Screenshots & video:

NOTE: The arrows might look like they're too far to the right, but it doesn't look like this
in prod where the width of the settings is shortened to 306px by webapp styles.

<img width="377" alt="Screenshot 2024-08-14 at 4 14 34 PM" src="https://github.com/user-attachments/assets/2038cb91-eeaf-4b78-a7be-3fda9da4c302">

https://github.com/user-attachments/assets/87b6a085-24a2-4085-90d4-6c0e11b97de3
