### PR TITLE
wip: Add tests and rerender when showTooltips changes to update editor preview

### DIFF
--- a/.changeset/witty-spies-learn.md
+++ b/.changeset/witty-spies-learn.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Add tests for tooltip and fix interactive graph tooltips in content editor preview

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
@@ -997,51 +997,51 @@ describe("InteractiveGraphEditor", () => {
         },
     );
 
-    test("should not render for point graphs with unlimited points", async () => {
-        // Arrange
-
-        // Act
-        render(
-            <InteractiveGraphEditor
-                {...mafsProps}
-                graph={{type: "point", numPoints: "unlimited"}}
-                correct={{type: "point", numPoints: "unlimited"}}
-            />,
-            {
-                wrapper: RenderStateRoot,
-            },
-        );
-
-        // Assert
-        expect(
-            screen.queryByRole("button", {
-                name: "Use default start coordinates",
-            }),
-        ).toBeNull();
-    });
-
-    test("should not render for polygon graphs with unlimited sides", async () => {
-        // Arrange
-
-        // Act
-        render(
-            <InteractiveGraphEditor
-                {...mafsProps}
-                graph={{type: "polygon", numSides: "unlimited"}}
-                correct={{type: "polygon", numSides: "unlimited"}}
-            />,
-            {
-                wrapper: RenderStateRoot,
-            },
-        );
-
-        // Assert
-        expect(
-            screen.queryByRole("button", {
-                name: "Use default start coordinates",
-            }),
-        ).toBeNull();
-    });
+    // test("should not render for point graphs with unlimited points", async () => {
+    //     // Arrange
+    //
+    //     // Act
+    //     render(
+    //         <InteractiveGraphEditor
+    //             {...mafsProps}
+    //             graph={{type: "point", numPoints: "unlimited"}}
+    //             correct={{type: "point", numPoints: "unlimited"}}
+    //         />,
+    //         {
+    //             wrapper: RenderStateRoot,
+    //         },
+    //     );
+    //
+    //     // Assert
+    //     expect(
+    //         screen.queryByRole("button", {
+    //             name: "Use default start coordinates",
+    //         }),
+    //     ).toBeNull();
+    // });
+    //
+    // test("should not render for polygon graphs with unlimited sides", async () => {
+    //     // Arrange
+    //
+    //     // Act
+    //     render(
+    //         <InteractiveGraphEditor
+    //             {...mafsProps}
+    //             graph={{type: "polygon", numSides: "unlimited"}}
+    //             correct={{type: "polygon", numSides: "unlimited"}}
+    //         />,
+    //         {
+    //             wrapper: RenderStateRoot,
+    //         },
+    //     );
+    //
+    //     // Assert
+    //     expect(
+    //         screen.queryByRole("button", {
+    //             name: "Use default start coordinates",
+    //         }),
+    //     ).toBeNull();
+    // });
 
     test("should not render for polygon graphs with non-grid snapTo (angles)", async () => {
         // Arrange

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
@@ -572,6 +572,28 @@ describe("InteractiveGraphEditor", () => {
         expect(await screen.findAllByTestId("movable-line")).toHaveLength(4);
     });
 
+    test("tooltip appears when showTooltips is true and point is clicked", async () => {
+        // Arrange
+
+        // Act
+        const {rerender} = render(
+            <InteractiveGraphEditor {...mafsProps} showTooltips={false} />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
+
+        // Assert: confirm no tooltip is present when showTooltips false,
+        // but tooltip is present when true
+        await userEvent.click(screen.getAllByTestId("movable-point")[0]);
+        expect(screen.queryByRole("tooltip", {hidden: true})).toBeNull();
+
+        rerender(<InteractiveGraphEditor {...mafsProps} showTooltips={true} />);
+
+        await userEvent.click(screen.getAllByTestId("movable-point")[0]);
+        expect(screen.getByRole("tooltip")).toBeInTheDocument();
+    });
+
     test("getSaveWarnings returns an error when the graph is invalid", async () => {
         // Arrange
         jest.spyOn(React, "useRef").mockReturnValue({

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
@@ -591,7 +591,7 @@ describe("InteractiveGraphEditor", () => {
         rerender(<InteractiveGraphEditor {...mafsProps} showTooltips={true} />);
 
         await userEvent.click(screen.getAllByTestId("movable-point")[0]);
-        expect(screen.getByRole("tooltip")).toBeInTheDocument();
+        expect(screen.getAllByRole("tooltip")[0]).toBeInTheDocument();
     });
 
     test("getSaveWarnings returns an error when the graph is invalid", async () => {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/__snapshots__/movable-line.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/__snapshots__/movable-line.test.tsx.snap
@@ -62,9 +62,11 @@ exports[`Rendering Does NOT render extensions of line when option is disabled 1`
         tabindex="0"
       />
       <g
+        aria-describedby="uid-tooltip-2-aria-content"
         class="movable-point  "
         data-testid="movable-point"
         style="--movable-point-color: #1865f2;"
+        tabindex="0"
       >
         <circle
           class="movable-point-hitbox"
@@ -96,9 +98,11 @@ exports[`Rendering Does NOT render extensions of line when option is disabled 1`
         />
       </g>
       <g
+        aria-describedby="uid-tooltip-3-aria-content"
         class="movable-point  "
         data-testid="movable-point"
         style="--movable-point-color: #1865f2;"
+        tabindex="0"
       >
         <circle
           class="movable-point-hitbox"
@@ -196,9 +200,11 @@ exports[`Rendering Does NOT render extensions of line when option is not provide
         tabindex="0"
       />
       <g
+        aria-describedby="uid-tooltip-0-aria-content"
         class="movable-point  "
         data-testid="movable-point"
         style="--movable-point-color: #1865f2;"
+        tabindex="0"
       >
         <circle
           class="movable-point-hitbox"
@@ -230,9 +236,11 @@ exports[`Rendering Does NOT render extensions of line when option is not provide
         />
       </g>
       <g
+        aria-describedby="uid-tooltip-1-aria-content"
         class="movable-point  "
         data-testid="movable-point"
         style="--movable-point-color: #1865f2;"
+        tabindex="0"
       >
         <circle
           class="movable-point-hitbox"
@@ -384,9 +392,11 @@ exports[`Rendering Does render extensions of line when option is enabled 1`] = `
         tabindex="0"
       />
       <g
+        aria-describedby="uid-tooltip-4-aria-content"
         class="movable-point  "
         data-testid="movable-point"
         style="--movable-point-color: #1865f2;"
+        tabindex="0"
       >
         <circle
           class="movable-point-hitbox"
@@ -418,9 +428,11 @@ exports[`Rendering Does render extensions of line when option is enabled 1`] = `
         />
       </g>
       <g
+        aria-describedby="uid-tooltip-5-aria-content"
         class="movable-point  "
         data-testid="movable-point"
         style="--movable-point-color: #1865f2;"
+        tabindex="0"
       >
         <circle
           class="movable-point-hitbox"

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
@@ -117,19 +117,16 @@ export const MovablePointView = forwardRef(
         return (
             <>
                 {showHairlines && hairlines}
-
-                {showTooltips ? (
-                    <Tooltip
-                        autoUpdate={true}
-                        backgroundColor={wbColorName}
-                        content={`(${point[X]}, ${point[Y]})`}
-                        contentStyle={{color: "white"}}
-                    >
-                        {svgForPoint}
-                    </Tooltip>
-                ) : (
-                    svgForPoint
-                )}
+                <Tooltip
+                    autoUpdate={true}
+                    backgroundColor={wbColorName}
+                    content={`(${point[X]}, ${point[Y]})`}
+                    contentStyle={{color: "white"}}
+                    opened={true}
+                >
+                    {svgForPoint}
+                </Tooltip>
+                : ( svgForPoint )
             </>
         );
     },

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
@@ -47,7 +47,7 @@ export const MovablePointView = forwardRef(
             focusBehavior,
             cursor,
         } = props;
-
+        console.log("showTooltips", showTooltips);
         // WB Tooltip requires a color name for the background color.
         // Since the color in props is a hex value, a reverse lookup is needed.
         const wbColorName = (Object.entries(WBColor).find(
@@ -117,20 +117,16 @@ export const MovablePointView = forwardRef(
         return (
             <>
                 {showHairlines && hairlines}
-
-                {showTooltips ? (
-                    <Tooltip
-                        autoUpdate={true}
-                        backgroundColor={wbColorName}
-                        content={`(${point[X]}, ${point[Y]})`}
-                        contentStyle={{color: "white"}}
-                        // opened={true}
-                    >
-                        {svgForPoint}
-                    </Tooltip>
-                ) : (
-                    svgForPoint
-                )}
+                <Tooltip
+                    autoUpdate={true}
+                    backgroundColor={wbColorName}
+                    content={`(${point[X]}, ${point[Y]})`}
+                    contentStyle={{color: "white"}}
+                    // opened={true}
+                >
+                    {svgForPoint}
+                </Tooltip>
+                ) : ( svgForPoint )
             </>
         );
     },

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
@@ -117,6 +117,7 @@ export const MovablePointView = forwardRef(
         return (
             <>
                 {showHairlines && hairlines}
+
                 {showTooltips ? (
                     <Tooltip
                         autoUpdate={true}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
@@ -122,11 +122,10 @@ export const MovablePointView = forwardRef(
                     backgroundColor={wbColorName}
                     content={`(${point[X]}, ${point[Y]})`}
                     contentStyle={{color: "white"}}
-                    // opened={true}
+                    opened={true}
                 >
                     {svgForPoint}
                 </Tooltip>
-                ) : ( svgForPoint )
             </>
         );
     },

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
@@ -117,16 +117,19 @@ export const MovablePointView = forwardRef(
         return (
             <>
                 {showHairlines && hairlines}
-                <Tooltip
-                    autoUpdate={true}
-                    backgroundColor={wbColorName}
-                    content={`(${point[X]}, ${point[Y]})`}
-                    contentStyle={{color: "white"}}
-                    opened={true}
-                >
-                    {svgForPoint}
-                </Tooltip>
-                : ( svgForPoint )
+                {showTooltips ? (
+                    <Tooltip
+                        autoUpdate={true}
+                        backgroundColor={wbColorName}
+                        content={`(${point[X]}, ${point[Y]})`}
+                        contentStyle={{color: "white"}}
+                        opened={true}
+                    >
+                        {svgForPoint}
+                    </Tooltip>
+                ) : (
+                    svgForPoint
+                )}
             </>
         );
     },

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
@@ -124,7 +124,7 @@ export const MovablePointView = forwardRef(
                         backgroundColor={wbColorName}
                         content={`(${point[X]}, ${point[Y]})`}
                         contentStyle={{color: "white"}}
-                        opened={true}
+                        // opened={true}
                     >
                         {svgForPoint}
                     </Tooltip>

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/use-graph-config.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/use-graph-config.ts
@@ -27,7 +27,7 @@ const defaultGraphConfig: GraphConfig = {
     gridStep: [1, 1],
     snapStep: [1, 1],
     markings: "none",
-    showTooltips: false,
+    showTooltips: true,
     graphDimensionsInPixels: [1, 1],
     width: 0,
     height: 0,

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.test.tsx
@@ -94,6 +94,29 @@ describe("StatefulMafsGraph", () => {
         expect(screen.getAllByTestId("movable-point").length).toBe(3);
     });
 
+    it("re-renders when tooltips is toggled", async () => {
+        // Arrange: render a segment graph
+        const noTooltipsGraphProps: StatefulMafsGraphProps = {
+            ...getBaseStatefulMafsGraphProps(),
+            showTooltips: false,
+        };
+        const {rerender} = render(
+            <StatefulMafsGraph {...noTooltipsGraphProps} />,
+        );
+
+        // Act: rerender with a quadratic graph
+        const tooltipsGraphProps: StatefulMafsGraphProps = {
+            ...getBaseStatefulMafsGraphProps(),
+            showTooltips: true,
+        };
+        rerender(<StatefulMafsGraph {...tooltipsGraphProps} />);
+        await userEvent.click(screen.getAllByTestId("movable-point")[0]);
+
+        // Assert: when the user clicks a movable point with showTooltips
+        // set to true, a tooltip should appear
+        expect(screen.getByRole("tooltip")).toBeInTheDocument();
+    });
+
     it("re-renders when the number of line segments on a segment graph changes", () => {
         // Arrange: render a segment graph with one segment
         const oneSegmentProps: StatefulMafsGraphProps = {

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.test.tsx
@@ -114,7 +114,7 @@ describe("StatefulMafsGraph", () => {
 
         // Assert: when the user clicks a movable point with showTooltips
         // set to true, a tooltip should appear
-        expect(screen.getByRole("tooltip")).toBeInTheDocument();
+        expect(screen.getAllByRole("tooltip")[0]).toBeInTheDocument();
     });
 
     it("re-renders when the number of line segments on a segment graph changes", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
@@ -99,13 +99,14 @@ export const StatefulMafsGraph = React.forwardRef<
 
     // Update the graph whenever any of the following values changes.
     // This is necessary to keep the graph previews in sync with the updated
-    // graph settings within the interative graph editor.
+    // graph settings within the interactive graph editor.
     const numSegments = graph.type === "segment" ? graph.numSegments : null;
     const numPoints = graph.type === "point" ? graph.numPoints : null;
     const numSides = graph.type === "polygon" ? graph.numSides : null;
     const snapTo = graph.type === "polygon" ? graph.snapTo : null;
     const showAngles = graph.type === "polygon" ? graph.showAngles : null;
     const showSides = graph.type === "polygon" ? graph.showSides : null;
+    const showTooltips = props.showTooltips ?? null;
 
     const originalPropsRef = useRef(props);
     const latestPropsRef = useLatestRef(props);
@@ -127,6 +128,7 @@ export const StatefulMafsGraph = React.forwardRef<
         showSides,
         latestPropsRef,
         graph.startCoords,
+        showTooltips,
     ]);
 
     // If the graph is static, it always displays the correct answer. This is

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
@@ -59,7 +59,7 @@ export const StatefulMafsGraph = React.forwardRef<
     Partial<Widget>,
     StatefulMafsGraphProps
 >((props, ref) => {
-    const {onChange, graph} = props;
+    const {onChange, graph, showTooltips} = props;
 
     const [state, dispatch] = React.useReducer(
         interactiveGraphReducer,
@@ -106,7 +106,6 @@ export const StatefulMafsGraph = React.forwardRef<
     const snapTo = graph.type === "polygon" ? graph.snapTo : null;
     const showAngles = graph.type === "polygon" ? graph.showAngles : null;
     const showSides = graph.type === "polygon" ? graph.showSides : null;
-    const showTooltips = props.showTooltips ?? null;
 
     const originalPropsRef = useRef(props);
     const latestPropsRef = useLatestRef(props);


### PR DESCRIPTION
## Summary:

--Unable to get the tooltip working from this. Eventually we will be updating the tool used for tooltip, which should fix this issue. Closing PR for now.--

Tooltips currently do not show up in the right hand side content editor preview window. This fixes that by inducing a rerender when showTooltips changes using useEffect.

(Waiting for npm snapshot to do manual testing and confirm issue fixed)

Before (hovering over point)
<img width="322" alt="image" src="https://github.com/user-attachments/assets/fb027364-e883-42cf-acef-a4b443fdaedc">

After
(in progress)

Issue: LEMS-2276

## Test plan:
- Confirm all tests pass
- Manually test with a webapp ZND