### PR TITLE
Update Mathquill Mathfield with Portuguese trig functions

### DIFF
--- a/.changeset/orange-rules-knock.md
+++ b/.changeset/orange-rules-knock.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/math-input": patch
+"@khanacademy/perseus": patch
+---
+
+Use Portuguese sen and tg when updating Mathquill from the keypad

--- a/packages/math-input/src/components/input/math-wrapper.ts
+++ b/packages/math-input/src/components/input/math-wrapper.ts
@@ -63,7 +63,7 @@ class MathWrapper {
         this.callbacks = callbacks;
 
         this.mobileKeyTranslator = {
-            ...getKeyTranslator(locale),
+            ...getKeyTranslator(locale, strings),
             // note(Matthew): our mobile backspace logic is really complicated
             // and for some reason doesn't really work in the desktop experience.
             // So we default to the basic backspace functionality in the

--- a/packages/math-input/src/components/input/mathquill-helpers.ts
+++ b/packages/math-input/src/components/input/mathquill-helpers.ts
@@ -157,7 +157,7 @@ export function maybeFindCommand(initialNode) {
     // a command being prefixed with a backslash leads to undesired
     // behavior. For example, Greek symbols, left parentheses, and square
     // roots all get treated as commands.
-    const validCommands = ["\\log", "\\ln", "\\cos", "\\sin", "\\sen", "\\tan"];
+    const validCommands = ["\\log", "\\ln", "\\cos", "\\sin", "\\tan"];
 
     let name = "";
     let startNode;

--- a/packages/math-input/src/components/input/mathquill-helpers.ts
+++ b/packages/math-input/src/components/input/mathquill-helpers.ts
@@ -157,7 +157,7 @@ export function maybeFindCommand(initialNode) {
     // a command being prefixed with a backslash leads to undesired
     // behavior. For example, Greek symbols, left parentheses, and square
     // roots all get treated as commands.
-    const validCommands = ["\\log", "\\ln", "\\cos", "\\sin", "\\tan"];
+    const validCommands = ["\\log", "\\ln", "\\cos", "\\sin", "\\sen", "\\tan"];
 
     let name = "";
     let startNode;

--- a/packages/math-input/src/components/key-handlers/key-translator.ts
+++ b/packages/math-input/src/components/key-handlers/key-translator.ts
@@ -42,13 +42,20 @@ function buildGenericCallback(
 
 function buildNormalFunctionCallback(command: string) {
     return function (mathField: MathFieldInterface) {
-        mathField.write(`\\${command}\\left(\\right)`);
+        mathField.write(`${command}\\left(\\right)`);
         mathField.keystroke("Left");
     };
 }
 
+type KeyTranslatorStrings = {
+    sin: string;
+    cos: string;
+    tan: string;
+};
+
 export const getKeyTranslator = (
     locale: string,
+    strings: KeyTranslatorStrings,
 ): Record<Key, MathFieldUpdaterCallback> => ({
     EXP: handleExponent,
     EXP_2: handleExponent,
@@ -66,9 +73,9 @@ export const getKeyTranslator = (
 
     LOG: buildNormalFunctionCallback("log"),
     LN: buildNormalFunctionCallback("ln"),
-    SIN: buildNormalFunctionCallback("sin"),
-    COS: buildNormalFunctionCallback("cos"),
-    TAN: buildNormalFunctionCallback("tan"),
+    SIN: buildNormalFunctionCallback(strings.sin),
+    COS: buildNormalFunctionCallback(strings.cos),
+    TAN: buildNormalFunctionCallback(strings.tan),
 
     CDOT: buildGenericCallback("\\cdot"),
     DECIMAL: buildGenericCallback(getDecimalSeparator(locale)),

--- a/packages/math-input/src/components/key-handlers/key-translator.ts
+++ b/packages/math-input/src/components/key-handlers/key-translator.ts
@@ -67,7 +67,7 @@ function buildTranslatableFunctionCallback(
 
 function buildNormalFunctionCallback(command: string) {
     return function (mathField: MathFieldInterface) {
-        mathField.write(`${command}\\left(\\right)`);
+        mathField.write(`\\${command}\\left(\\right)`);
         mathField.keystroke("Left");
     };
 }

--- a/packages/math-input/src/components/key-handlers/key-translator.ts
+++ b/packages/math-input/src/components/key-handlers/key-translator.ts
@@ -40,6 +40,31 @@ function buildGenericCallback(
     };
 }
 
+/**
+ * This lets us use translated functions
+ * (like tg->tan and sen->sin) when we know it's safe to.
+ * This lets us progressively support translations without needing
+ * to support every language all at once.
+ *
+ * @param {string} command - the translated command/function to check
+ * @param {string[]} supportedTranslations - list of translations we support
+ * @param {string} defaultCommand - what to fallback to if the command isn't supported
+ */
+function buildTranslatableFunctionCallback(
+    command: string,
+    supportedTranslations: string[],
+    defaultCommand: string,
+) {
+    const cmd = command;
+    if (!supportedTranslations.includes(cmd)) {
+        cmd = defaultCommand;
+    }
+    return function (mathField: MathFieldInterface) {
+        mathField.write(`${cmd}\\left(\\right)`);
+        mathField.keystroke("Left");
+    };
+}
+
 function buildNormalFunctionCallback(command: string) {
     return function (mathField: MathFieldInterface) {
         mathField.write(`${command}\\left(\\right)`);
@@ -73,9 +98,10 @@ export const getKeyTranslator = (
 
     LOG: buildNormalFunctionCallback("log"),
     LN: buildNormalFunctionCallback("ln"),
-    SIN: buildNormalFunctionCallback(strings.sin),
+
     COS: buildNormalFunctionCallback(strings.cos),
-    TAN: buildNormalFunctionCallback(strings.tan),
+    SIN: buildTranslatableFunctionCallback(strings.sin, ["sin", "sen"], "sin"),
+    TAN: buildTranslatableFunctionCallback(strings.tan, ["tan", "tg"], "tan"),
 
     CDOT: buildGenericCallback("\\cdot"),
     DECIMAL: buildGenericCallback(getDecimalSeparator(locale)),

--- a/packages/math-input/src/components/key-handlers/key-translator.ts
+++ b/packages/math-input/src/components/key-handlers/key-translator.ts
@@ -55,10 +55,9 @@ function buildTranslatableFunctionCallback(
     supportedTranslations: string[],
     defaultCommand: string,
 ) {
-    const cmd = command;
-    if (!supportedTranslations.includes(cmd)) {
-        cmd = defaultCommand;
-    }
+    const cmd = supportedTranslations.includes(command)
+        ? command
+        : defaultCommand;
     return function (mathField: MathFieldInterface) {
         mathField.write(`${cmd}\\left(\\right)`);
         mathField.keystroke("Left");

--- a/packages/math-input/src/components/keypad/__tests__/keypad-v2-mathquill.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/keypad-v2-mathquill.test.tsx
@@ -48,7 +48,11 @@ function V2KeypadWithMathquill(props: Props) {
         }
     }, [mathField, strings, onChangeMathInput]);
 
-    const keyTranslator = getKeyTranslator("en");
+    const keyTranslator = getKeyTranslator("en", {
+        sin: "sin",
+        cos: "cos",
+        tan: "tan",
+    });
 
     function handleClickKey(key: Key) {
         if (!mathField) {

--- a/packages/math-input/src/components/keypad/__tests__/keypad-v2-mathquill.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/keypad-v2-mathquill.test.tsx
@@ -344,7 +344,7 @@ describe("Keypad v2 with MathQuill", () => {
 
         // Act
         await userEvent.click(screen.getByRole("tab", {name: "Geometry"}));
-        await userEvent.click(screen.getByText("sin"));
+        await userEvent.click(screen.getByRole("button", {name: "Sine"}));
         await userEvent.click(screen.getByRole("tab", {name: "Numbers"}));
         await userEvent.click(screen.getByRole("button", {name: "4"}));
         await userEvent.click(screen.getByRole("button", {name: "2"}));
@@ -367,6 +367,8 @@ describe("Keypad v2 with MathQuill", () => {
 
         // Act
         await userEvent.click(screen.getByRole("tab", {name: "Geometry"}));
+        // This needs to stay as "getByText" because we're validating translations
+        // and aria-labels are in English
         await userEvent.click(screen.getByText("sen"));
         await userEvent.click(screen.getByRole("tab", {name: "Numbers"}));
         await userEvent.click(screen.getByRole("button", {name: "4"}));
@@ -387,7 +389,7 @@ describe("Keypad v2 with MathQuill", () => {
 
         // Act
         await userEvent.click(screen.getByRole("tab", {name: "Geometry"}));
-        await userEvent.click(screen.getByText("tan"));
+        await userEvent.click(screen.getByRole("button", {name: "Tangent"}));
         await userEvent.click(screen.getByRole("tab", {name: "Numbers"}));
         await userEvent.click(screen.getByRole("button", {name: "4"}));
         await userEvent.click(screen.getByRole("button", {name: "2"}));
@@ -410,6 +412,8 @@ describe("Keypad v2 with MathQuill", () => {
 
         // Act
         await userEvent.click(screen.getByRole("tab", {name: "Geometry"}));
+        // This needs to stay as "getByText" because we're validating translations
+        // and aria-labels are in English
         await userEvent.click(screen.getByText("tg"));
         await userEvent.click(screen.getByRole("tab", {name: "Numbers"}));
         await userEvent.click(screen.getByRole("button", {name: "4"}));

--- a/packages/math-input/src/components/keypad/__tests__/keypad-v2-mathquill.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/keypad-v2-mathquill.test.tsx
@@ -31,6 +31,9 @@ function V2KeypadWithMathquill(props: Props) {
     if (props.portuguese) {
         strings.sin = "sen";
         strings.tan = "tg";
+    } else {
+        strings.sin = "sin";
+        strings.tan = "tan";
     }
 
     React.useEffect(() => {
@@ -332,6 +335,26 @@ describe("Keypad v2 with MathQuill", () => {
         });
     });
 
+    it("handles english sin trig function", async () => {
+        // Arrange
+        const mockMathInputCallback = jest.fn();
+        render(
+            <V2KeypadWithMathquill onChangeMathInput={mockMathInputCallback} />,
+        );
+
+        // Act
+        await userEvent.click(screen.getByRole("tab", {name: "Geometry"}));
+        await userEvent.click(screen.getByText("sin"));
+        await userEvent.click(screen.getByRole("tab", {name: "Numbers"}));
+        await userEvent.click(screen.getByRole("button", {name: "4"}));
+        await userEvent.click(screen.getByRole("button", {name: "2"}));
+
+        // Assert
+        expect(mockMathInputCallback).toHaveBeenLastCalledWith(
+            "\\sin\\left(42\\right)",
+        );
+    });
+
     it("handles portuguese sen trig function", async () => {
         // Arrange
         const mockMathInputCallback = jest.fn();
@@ -352,6 +375,26 @@ describe("Keypad v2 with MathQuill", () => {
         // Assert
         expect(mockMathInputCallback).toHaveBeenLastCalledWith(
             "\\operatorname{sen}\\left(42\\right)",
+        );
+    });
+
+    it("handles english tan trig function", async () => {
+        // Arrange
+        const mockMathInputCallback = jest.fn();
+        render(
+            <V2KeypadWithMathquill onChangeMathInput={mockMathInputCallback} />,
+        );
+
+        // Act
+        await userEvent.click(screen.getByRole("tab", {name: "Geometry"}));
+        await userEvent.click(screen.getByText("tan"));
+        await userEvent.click(screen.getByRole("tab", {name: "Numbers"}));
+        await userEvent.click(screen.getByRole("button", {name: "4"}));
+        await userEvent.click(screen.getByRole("button", {name: "2"}));
+
+        // Assert
+        expect(mockMathInputCallback).toHaveBeenLastCalledWith(
+            "\\tan\\left(42\\right)",
         );
     });
 

--- a/packages/math-input/src/components/keypad/__tests__/keypad-v2-mathquill.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/keypad-v2-mathquill.test.tsx
@@ -30,6 +30,7 @@ function V2KeypadWithMathquill(props: Props) {
 
     if (props.portuguese) {
         strings.sin = "sen";
+        strings.tan = "tg";
     }
 
     React.useEffect(() => {
@@ -331,7 +332,6 @@ describe("Keypad v2 with MathQuill", () => {
         });
     });
 
-    // Portuguese trig names
     it("handles portuguese sen trig function", async () => {
         // Arrange
         const mockMathInputCallback = jest.fn();
@@ -352,6 +352,29 @@ describe("Keypad v2 with MathQuill", () => {
         // Assert
         expect(mockMathInputCallback).toHaveBeenLastCalledWith(
             "\\operatorname{sen}\\left(42\\right)",
+        );
+    });
+
+    it("handles portuguese tg trig function", async () => {
+        // Arrange
+        const mockMathInputCallback = jest.fn();
+        render(
+            <V2KeypadWithMathquill
+                onChangeMathInput={mockMathInputCallback}
+                portuguese
+            />,
+        );
+
+        // Act
+        await userEvent.click(screen.getByRole("tab", {name: "Geometry"}));
+        await userEvent.click(screen.getByText("tg"));
+        await userEvent.click(screen.getByRole("tab", {name: "Numbers"}));
+        await userEvent.click(screen.getByRole("button", {name: "4"}));
+        await userEvent.click(screen.getByRole("button", {name: "2"}));
+
+        // Assert
+        expect(mockMathInputCallback).toHaveBeenLastCalledWith(
+            "\\operatorname{tg}\\left(42\\right)",
         );
     });
 });

--- a/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
+++ b/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
@@ -44,7 +44,11 @@ export function V2KeypadWithMathquill() {
         }
     }, [mathField]);
 
-    const keyTranslator = getKeyTranslator("en");
+    const keyTranslator = getKeyTranslator("en", {
+        sin: "sen",
+        cos: "cos",
+        tan: "tan",
+    });
 
     function handleClickKey(key: Key) {
         if (!mathField) {
@@ -56,6 +60,8 @@ export function V2KeypadWithMathquill() {
         }
 
         const mathFieldCallback = keyTranslator[key];
+        console.log("keypad-mathquill.stories");
+        console.log({keyTranslator, key, mathFieldCallback});
         if (mathFieldCallback) {
             mathFieldCallback(mathField, key);
             setCursorContext(getCursorContext(mathField));
@@ -88,7 +94,7 @@ export function V2KeypadWithMathquill() {
                             trigonometry
                             onAnalyticsEvent={async (event) => {
                                 // eslint-disable-next-line no-console
-                                console.log("Send Event:", event);
+                                // console.log("Send Event:", event);
                             }}
                             showDismiss
                         />

--- a/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
+++ b/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
@@ -45,9 +45,9 @@ export function V2KeypadWithMathquill() {
     }, [mathField]);
 
     const keyTranslator = getKeyTranslator("en", {
-        sin: "sen",
+        sin: "sin",
         cos: "cos",
-        tan: "tg",
+        tan: "tan",
     });
 
     function handleClickKey(key: Key) {

--- a/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
+++ b/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
@@ -60,8 +60,6 @@ export function V2KeypadWithMathquill() {
         }
 
         const mathFieldCallback = keyTranslator[key];
-        console.log("keypad-mathquill.stories");
-        console.log({keyTranslator, key, mathFieldCallback});
         if (mathFieldCallback) {
             mathFieldCallback(mathField, key);
             setCursorContext(getCursorContext(mathField));
@@ -92,10 +90,7 @@ export function V2KeypadWithMathquill() {
                             convertDotToTimes
                             preAlgebra
                             trigonometry
-                            onAnalyticsEvent={async (event) => {
-                                // eslint-disable-next-line no-console
-                                // console.log("Send Event:", event);
-                            }}
+                            onAnalyticsEvent={async () => {}}
                             showDismiss
                         />
                     </PopoverContentCore>

--- a/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
+++ b/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
@@ -47,7 +47,7 @@ export function V2KeypadWithMathquill() {
     const keyTranslator = getKeyTranslator("en", {
         sin: "sen",
         cos: "cos",
-        tan: "tan",
+        tan: "tg",
     });
 
     function handleClickKey(key: Key) {

--- a/packages/math-input/src/components/keypad/keypad-pages/geometry-page.tsx
+++ b/packages/math-input/src/components/keypad/keypad-pages/geometry-page.tsx
@@ -14,22 +14,29 @@ export default function GeometryPage(props: Props) {
     const {onClickKey} = props;
     const {strings} = useMathInputI18n();
     const Keys = KeyConfigs(strings);
+
+    function handleclick(...rest) {
+        console.log("geometry-page.tsx");
+        console.log(rest);
+        onClickKey(...rest);
+    }
+
     return (
         <>
             {/* Row 1 */}
             <KeypadButton
                 keyConfig={Keys.SIN}
-                onClickKey={onClickKey}
+                onClickKey={handleclick}
                 coord={[0, 0]}
             />
             <KeypadButton
                 keyConfig={Keys.COS}
-                onClickKey={onClickKey}
+                onClickKey={handleclick}
                 coord={[1, 0]}
             />
             <KeypadButton
                 keyConfig={Keys.TAN}
-                onClickKey={onClickKey}
+                onClickKey={handleclick}
                 coord={[2, 0]}
             />
         </>

--- a/packages/math-input/src/components/keypad/keypad-pages/geometry-page.tsx
+++ b/packages/math-input/src/components/keypad/keypad-pages/geometry-page.tsx
@@ -15,28 +15,22 @@ export default function GeometryPage(props: Props) {
     const {strings} = useMathInputI18n();
     const Keys = KeyConfigs(strings);
 
-    function handleclick(...rest) {
-        console.log("geometry-page.tsx");
-        console.log(rest);
-        onClickKey(...rest);
-    }
-
     return (
         <>
             {/* Row 1 */}
             <KeypadButton
                 keyConfig={Keys.SIN}
-                onClickKey={handleclick}
+                onClickKey={onClickKey}
                 coord={[0, 0]}
             />
             <KeypadButton
                 keyConfig={Keys.COS}
-                onClickKey={handleclick}
+                onClickKey={onClickKey}
                 coord={[1, 0]}
             />
             <KeypadButton
                 keyConfig={Keys.TAN}
-                onClickKey={handleclick}
+                onClickKey={onClickKey}
                 coord={[2, 0]}
             />
         </>

--- a/packages/perseus/src/components/math-input.tsx
+++ b/packages/perseus/src/components/math-input.tsx
@@ -132,7 +132,7 @@ class InnerMathInput extends React.Component<InnerProps, State> {
         const input = this.mathField();
         const {locale} = this.context;
         const customKeyTranslator = {
-            ...getKeyTranslator(locale),
+            ...getKeyTranslator(locale, this.context.strings),
             // If there's something in the input that can become part of a
             // fraction, typing "/" puts it in the numerator. If not, typing
             // "/" does nothing. In that case, enter a \frac.
@@ -259,7 +259,9 @@ class InnerMathInput extends React.Component<InnerProps, State> {
 
     handleKeypadPress: (key: Keys, e: any) => void = (key, e) => {
         const {locale} = this.context;
-        const translator = getKeyTranslator(locale)[key];
+        const translator = getKeyTranslator(locale, this.context.strings)[key];
+        console.log("math-input.tsx");
+        console.log({translator, key});
         const mathField = this.mathField();
 
         if (mathField) {

--- a/packages/perseus/src/components/math-input.tsx
+++ b/packages/perseus/src/components/math-input.tsx
@@ -260,8 +260,6 @@ class InnerMathInput extends React.Component<InnerProps, State> {
     handleKeypadPress: (key: Keys, e: any) => void = (key, e) => {
         const {locale} = this.context;
         const translator = getKeyTranslator(locale, this.context.strings)[key];
-        console.log("math-input.tsx");
-        console.log({translator, key});
         const mathField = this.mathField();
 
         if (mathField) {

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -125,6 +125,9 @@ export type PerseusStrings = {
     videoWrapper: string;
     mathInputTitle: string;
     mathInputDescription: string;
+    sin: string;
+    cos: string;
+    tan: string;
 };
 
 /**
@@ -291,6 +294,9 @@ export const strings: {
     mathInputTitle: "mathematics keyboard",
     mathInputDescription:
         "Use keyboard/mouse to interact with math-based input fields",
+    sin: "sin",
+    cos: "cos",
+    tan: "tan",
 };
 
 /**
@@ -441,4 +447,7 @@ export const mockStrings: PerseusStrings = {
     mathInputTitle: "mathematics keyboard",
     mathInputDescription:
         "Use keyboard/mouse to interact with math-based input fields",
+    sin: "sin",
+    cos: "cos",
+    tan: "tan",
 };

--- a/packages/perseus/src/widgets/__tests__/expression.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/expression.test.tsx
@@ -238,6 +238,11 @@ describe("Expression Widget", function () {
             const item = expressionItemWithAnswer("sin(x)");
             await assertIncorrect(userEvent, item, "2");
         });
+
+        it("allows portugese sen", async () => {
+            const item = expressionItemWithAnswer("sin(x)");
+            await assertCorrect(userEvent, item, "sen(x)");
+        });
     });
 
     describe("analytics", () => {

--- a/packages/perseus/src/widgets/__tests__/expression.test.tsx
+++ b/packages/perseus/src/widgets/__tests__/expression.test.tsx
@@ -240,8 +240,13 @@ describe("Expression Widget", function () {
         });
 
         it("allows portugese sen", async () => {
-            const item = expressionItemWithAnswer("sin(x)");
-            await assertCorrect(userEvent, item, "sen(x)");
+            const item = expressionItemWithAnswer("sin(42)");
+            await assertCorrect(userEvent, item, "sen(42)");
+        });
+
+        it("allows portugese tg", async () => {
+            const item = expressionItemWithAnswer("tan(42)");
+            await assertCorrect(userEvent, item, "tg(42)");
         });
     });
 


### PR DESCRIPTION
## Summary:
So basically:
- These two PRs ([1](https://github.com/Khan/perseus/pull/921) and [2](https://github.com/Khan/webapp/pull/19111)) helped add support for Portuguese trig functions when typed in the input.
- This [PR](https://github.com/Khan/perseus/pull/1497) added support for the text of trig buttons to be translated, however the input would still update with "sin" if the "sen" button was pressed.
- The PR being reviewed updates the input correctly; so if the "sen" button is pressed, the input is updated with "sen"

How this works:
- When a button is pressed, the keypad yells into the void that "SIN" was pressed
- The keypad translator has a callback for updating the input when "SIN" is pressed
  - BEFORE: it would just updated the input with `sin()`
  - NOW: it looks for the translated version of "sin", checks it against known safe translations, and either updates it with a known safe translation or the default "sin"

Issue: LEMS-1621

## Test plan:
Once the strings are translated:
- Go to a Portuguese page with an expression widget
- Go to a question that requires the "sin" button
- Open the keypad
- Note the button is "sen" instead of "sin"
- Click the "sen" button
- Note the input is updated with "sen()"
- Fill out the correct answer and submit
- Note the validator accepts "sen" instead of "sin"