### PR TITLE
Design updates

### DIFF
--- a/.changeset/chilled-moose-design.md
+++ b/.changeset/chilled-moose-design.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-editor": minor
+---
+
+Design update for PhET widget

--- a/packages/perseus/src/widgets/__tests__/phet-sim.test.ts
+++ b/packages/perseus/src/widgets/__tests__/phet-sim.test.ts
@@ -57,7 +57,7 @@ describe("phet-sim widget", () => {
         await waitFor(() => {
             expect(screen.queryByTitle("Google")).toHaveAttribute(
                 "srcDoc",
-                "Sorry, this simulation cannot load.",
+                "null",
             );
         });
     });

--- a/packages/perseus/src/widgets/__tests__/phet-sim.test.ts
+++ b/packages/perseus/src/widgets/__tests__/phet-sim.test.ts
@@ -55,10 +55,9 @@ describe("phet-sim widget", () => {
 
         // Assert
         await waitFor(() => {
-            expect(screen.queryByTitle("Google")).toHaveAttribute(
-                "srcDoc",
-                "null",
-            );
+            expect(
+                screen.getByText("Sorry, this simulation cannot load."),
+            ).toBeDefined();
         });
     });
 

--- a/packages/perseus/src/widgets/phet-sim.tsx
+++ b/packages/perseus/src/widgets/phet-sim.tsx
@@ -16,8 +16,9 @@ import {getDependencies} from "../dependencies";
 import * as Changeable from "../mixins/changeable";
 import {phoneMargin} from "../styles/constants";
 import {
+    basicBorderColor,
     borderRadiusLarge,
-    tableBackgroundHover,
+    grayExtraLight,
 } from "../styles/global-constants";
 
 import type {PerseusPhetSimWidgetOptions} from "../perseus-types";
@@ -94,10 +95,10 @@ export class PhetSim extends React.Component<Props, State> {
                     style={{
                         minWidth: 400,
                         width: "100%",
-                        height: 225,
+                        height: 360,
+                        borderWidth: 0,
                     }}
                     src={this.state.url?.toString()}
-                    srcDoc={this.state.url !== null ? undefined : "null"}
                     allow="fullscreen"
                 />
                 <IconButton
@@ -234,7 +235,6 @@ export default {
     name: "phet-sim",
     displayName: "PhET Simulation",
     widget: PhetSim,
-    // Let's not expose it to all content creators yet
     hidden: false,
     isLintable: true,
 } as WidgetExports<typeof PhetSim>;
@@ -242,9 +242,10 @@ export default {
 const styles = StyleSheet.create({
     container: {
         borderRadius: borderRadiusLarge,
-        backgroundColor: tableBackgroundHover,
+        borderWidth: 1,
+        borderColor: basicBorderColor,
         padding: phoneMargin,
         paddingBottom: 0,
-        width: 500,
+        width: 650,
     },
 });

--- a/packages/perseus/src/widgets/phet-sim.tsx
+++ b/packages/perseus/src/widgets/phet-sim.tsx
@@ -193,7 +193,7 @@ export class PhetSim extends React.Component<Props, State> {
             /https:\/\/phet\.colorado\.edu\/sims\/html\/([a-zA-Z0-9-]+)\/.*/g;
         const match: RegExpExecArray | null = phetRegex.exec(url.toString());
         // Do not show a locale warning on a non-simulation URL
-        if (!match) {
+        if (match === null) {
             return false;
         }
         const simName = match[1];
@@ -203,14 +203,19 @@ export class PhetSim extends React.Component<Props, State> {
         if (!response.ok) {
             return false;
         }
-        const responseJson = await response.json();
-        if (!responseJson) {
+
+        let responseJson: any;
+        try {
+            responseJson = await response.json();
+        } catch {
+            // If the file exists but there is no content to parse into a JSON,
+            // response.json() will throw an error that we want to catch.
             return false;
         }
-        const locales = Object.keys(responseJson);
+        const locales: string[] = Object.keys(responseJson);
 
         // Only display a locale warning if there is no fallback language
-        const baseLocale = this.locale.split("_")[0];
+        const baseLocale: string = this.locale.split("_")[0];
         for (const l of locales) {
             if (baseLocale === l.split("_")[0]) {
                 return false;

--- a/packages/perseus/src/widgets/phet-sim.tsx
+++ b/packages/perseus/src/widgets/phet-sim.tsx
@@ -15,11 +15,7 @@ import {PerseusI18nContext} from "../components/i18n-context";
 import {getDependencies} from "../dependencies";
 import * as Changeable from "../mixins/changeable";
 import {phoneMargin} from "../styles/constants";
-import {
-    basicBorderColor,
-    borderRadiusLarge,
-    grayExtraLight,
-} from "../styles/global-constants";
+import {basicBorderColor, borderRadiusLarge} from "../styles/global-constants";
 
 import type {PerseusPhetSimWidgetOptions} from "../perseus-types";
 import type {WidgetExports, WidgetProps} from "../types";

--- a/packages/perseus/src/widgets/phet-sim.tsx
+++ b/packages/perseus/src/widgets/phet-sim.tsx
@@ -82,11 +82,17 @@ export class PhetSim extends React.Component<Props, State> {
             <View style={styles.container}>
                 {this.state.banner !== null && (
                     // TODO(anna): Make this banner focusable
-                    <Banner
-                        layout="floating"
-                        kind={this.state.banner.kind}
-                        text={this.state.banner.message}
-                    />
+                    <View
+                        style={{
+                            marginBottom: phoneMargin,
+                        }}
+                    >
+                        <Banner
+                            layout="floating"
+                            kind={this.state.banner.kind}
+                            text={this.state.banner.message}
+                        />
+                    </View>
                 )}
                 <iframe
                     ref={this.iframeRef}

--- a/packages/perseus/src/widgets/phet-sim.tsx
+++ b/packages/perseus/src/widgets/phet-sim.tsx
@@ -96,8 +96,8 @@ export class PhetSim extends React.Component<Props, State> {
                     sandbox={sandboxProperties}
                     style={{
                         minWidth: 400,
-                        width: "100%",
                         height: 360,
+                        width: "100%",
                         borderWidth: 0,
                     }}
                     src={this.state.url?.toString()}
@@ -237,7 +237,8 @@ export default {
     name: "phet-sim",
     displayName: "PhET Simulation",
     widget: PhetSim,
-    hidden: false,
+    // Let's not expose it to all content creators yet
+    hidden: true,
     isLintable: true,
 } as WidgetExports<typeof PhetSim>;
 

--- a/packages/perseus/src/widgets/phet-sim.tsx
+++ b/packages/perseus/src/widgets/phet-sim.tsx
@@ -112,6 +112,7 @@ export class PhetSim extends React.Component<Props, State> {
                         marginBottom: 5,
                         alignSelf: "flex-end",
                     }}
+                    disabled={this.state.url === null}
                 />
             </View>
         );


### PR DESCRIPTION
## Summary:
Update PhET widget design:
* Draws an outline around the entire widget, connecting the iframe and fullscreen button into a cohesive unit 
* Displays simulation load error message as a banner
* Displays empty iframe if the simulation did not load
* Disables fullscreen button if the simulation did not load 
* Adds space between the banner and iframe
* Removes iframe outline
* Makes iframe larger and closer to 16:9 ratio instead of square

Issue: [LEMS-2279](https://khanacademy.atlassian.net/browse/LEMS-2279)

<img width="1041" alt="PhET widget with no errors, displaying new outline around the widget" src="https://github.com/user-attachments/assets/7c669925-1387-490b-9f75-ab110b0feac9">

<img width="1041" alt="PhET widget with locale error, displaying new outline around the widget and space between warning banner and iframe" src="https://github.com/user-attachments/assets/c2886c24-4ad2-410f-b13a-9119f6803345">

<img width="1041" alt="PhET widget with simulation load error, displaying new outline around the widget, disabled fullscreen button, empty iframe, and simulation load error banner" src="https://github.com/user-attachments/assets/8fea7998-3f3c-487a-a44b-a1441b2496c7">

## Test plan:

- Verify that the widget shows up appropriately in Storybook
  - Set URL to a valid PhET simulation (like https://phet.colorado.edu/sims/html/projectile-data-lab/latest/projectile-data-lab_all.html) and verify that the simulation appears correctly
  - Change URL to a non-PhET origin and verify that the error shows up and matches the appropriate PR screenshot
  - Click the fullscreen button and verify that the iframe goes into fullscreen mode
- `yarn jest packages/perseus/src/widgets/__tests__/phet-sim.test.ts`

[LEMS-2279]: https://khanacademy.atlassian.net/browse/LEMS-2279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ