### PR TITLE
[Interactive Graph Storybook] Give Storybook preview a fixed width

### DIFF
--- a/packages/perseus-editor/src/__stories__/editor-page-with-storybook-preview.tsx
+++ b/packages/perseus-editor/src/__stories__/editor-page-with-storybook-preview.tsx
@@ -137,6 +137,7 @@ const styles = StyleSheet.create({
     panel: {
         position: "fixed",
         right: 0,
+        minWidth: 500,
         height: "90vh",
         overflow: "auto",
         flex: "none",


### PR DESCRIPTION
## Summary:
Something caused the storybook preview to collapse horizontally.

Adding a fixed width here so that the graph can be viewed.

Issue: none

## Test plan:
Storybook
- http://localhost:6006/?path=/docs/perseuseditor-widgets-interactive-graph--docs

## Screenshots:

| Before | After |
| --- | --- |
| ![Screenshot 2024-08-22 at 11 58 29 AM](https://github.com/user-attachments/assets/d483be2d-bced-4a7a-be86-6ea95bc0d32a) | <img width="571" alt="Screenshot 2024-08-22 at 12 01 42 PM" src="https://github.com/user-attachments/assets/8d77a2e3-b6a7-40d0-b43a-010d769d95f1"> |
