### PR TITLE
[Locked labels] Bugfix from merge conflict: Add back locked label settings

### DIFF
--- a/.changeset/green-otters-lick.md
+++ b/.changeset/green-otters-lick.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Locked labels] Bugfix from merge conflict: Add back locked label settings

--- a/packages/perseus-editor/src/components/graph-locked-figures/locked-figures-section.tsx
+++ b/packages/perseus-editor/src/components/graph-locked-figures/locked-figures-section.tsx
@@ -163,13 +163,6 @@ const LockedFiguresSection = (props: Props) => {
             {isExpanded && (
                 <View>
                     {figures?.map((figure, index) => {
-                        if (figure.type === "label") {
-                            // TODO(LEMS-1795): Add locked label settings.
-                            // Remove this block once label locked figure
-                            // settings are implemented.
-                            return;
-                        }
-
                         return (
                             <LockedFigureSettings
                                 key={`${uniqueId}-locked-${figure}-${index}`}


### PR DESCRIPTION
## Summary:
Somehow I messed up a merge and it added back the line that
stops the locked label settings from showing up.

Removing that check so that the locked label settings show up again.

Issue: https://khanacademy.atlassian.net/browse/LEMS-1795

## Test plan:
Storybook
- http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--mafs-with-locked-labels-flag

| Before | After |
| --- | --- |
| <img width="383" alt="Screenshot 2024-08-23 at 2 06 13 PM" src="https://github.com/user-attachments/assets/6e62e23d-a711-489d-9c82-1cf4bbfbe734"> | <img width="379" alt="Screenshot 2024-08-23 at 2 06 21 PM" src="https://github.com/user-attachments/assets/9530faac-4e6c-456d-a3bb-390a67c4dcbf"> |
