### PR TITLE
HintEditor: migrate to React refs

### DIFF
--- a/.changeset/big-plums-confess.md
+++ b/.changeset/big-plums-confess.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+HintEditor: migrate to React refs


### PR DESCRIPTION
## Summary:

This PR migrates the HintEditor to use React refs instead of legacy string refs. This improves safety.

Issue: LEMS-1809

## Test plan:

`yarn tsc`
`yarn test`