### PR TITLE
ArticleEditor: migrate to React refs

### DIFF
--- a/.changeset/lemon-mugs-teach.md
+++ b/.changeset/lemon-mugs-teach.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+ArticleEditor: migrate to React refs


### PR DESCRIPTION
## Summary:

This PR migrates the `ArticleEditor` from string refs to proper React refs. This improves type safety.

Issue: LEMS-1809

## Test plan:

`yarn tsc`
`yarn test`