### PR TITLE
Editors: better type serialize() functions

### DIFF
--- a/.changeset/rude-meals-cough.md
+++ b/.changeset/rude-meals-cough.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Editors: better type serialize() functions

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -193,13 +193,15 @@ class EditorPage extends React.Component<Props, State> {
         return issues1.concat(issues2);
     }
 
-    serialize(options?: {keepDeletedWidgets?: boolean}): any | PerseusItem {
+    serialize(options?: {keepDeletedWidgets?: boolean}): PerseusItem {
         if (this.props.jsonMode) {
             return this.state.json;
         }
-        return _.extend(this.itemEditor.current?.serialize(options), {
-            hints: this.hintsEditor.current?.serialize(options),
-        });
+        return {
+            ...this.itemEditor.current!.serialize(options),
+            hints: this.hintsEditor.current!.serialize(options) ?? [],
+            answer: undefined,
+        };
     }
 
     handleChange: ChangeHandler = (toChange, cb, silent) => {

--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -826,11 +826,7 @@ class Editor extends React.Component<Props, State> {
         }
     };
 
-    serialize: (options?: any) => {
-        content: string;
-        images: any;
-        widgets: Record<any, any>;
-    } = (options: any) => {
+    serialize(options?: any): PerseusRenderer {
         // need to serialize the widgets since the state might not be
         // completely represented in props. ahem //transformer// (and
         // interactive-graph and plotter).
@@ -864,7 +860,7 @@ class Editor extends React.Component<Props, State> {
             images: this.props.images,
             widgets: widgets,
         };
-    };
+    }
 
     render(): React.ReactNode {
         let pieces;

--- a/packages/perseus-editor/src/hint-editor.tsx
+++ b/packages/perseus-editor/src/hint-editor.tsx
@@ -20,6 +20,7 @@ import type {
     ChangeHandler,
     DeviceType,
     ImageUploader,
+    PerseusRenderer,
 } from "@khanacademy/perseus";
 
 const {InfoTip, InlineIcon} = components;
@@ -383,16 +384,18 @@ class CombinedHintsEditor extends React.Component<CombinedHintsEditorProps> {
             .value();
     };
 
-    serialize: (options?: any) => ReadonlyArray<string> = (options: any) => {
+    serialize: (options?: any) => ReadonlyArray<PerseusRenderer> = (
+        options: any,
+    ) => {
         return this.props.hints.map((hint, i) => {
             return this.serializeHint(i, options);
         });
     };
 
-    serializeHint: (index: number, options?: any) => string = (
-        index: number,
-        options: any,
-    ): string => {
+    serializeHint: (index: number, options?: any) => PerseusRenderer = (
+        index,
+        options,
+    ) => {
         // eslint-disable-next-line react/no-string-refs
         // @ts-expect-error - TS2339 - Property 'serialize' does not exist on type 'ReactInstance'.
         return this.refs["hintEditor" + index].serialize(options);

--- a/packages/perseus-editor/src/hint-editor.tsx
+++ b/packages/perseus-editor/src/hint-editor.tsx
@@ -88,12 +88,12 @@ export class HintEditor extends React.Component<HintEditorProps> {
         return this.editor.current?.getSaveWarnings();
     };
 
-    serialize: (options?: any) => any = (options: any) => {
+    serialize(options?: any): Hint {
         return {
             ...this.editor.current!.serialize(options),
             replace: this.props.replace ?? undefined,
         };
-    };
+    }
 
     render(): React.ReactNode {
         return (

--- a/packages/perseus-editor/src/item-editor.tsx
+++ b/packages/perseus-editor/src/item-editor.tsx
@@ -13,6 +13,8 @@ import type {
     ChangeHandler,
     DeviceType,
     PerseusRenderer,
+    PerseusAnswerArea,
+    Version,
 } from "@khanacademy/perseus";
 
 const ITEM_DATA_VERSION = itemDataVersion;
@@ -74,16 +76,13 @@ class ItemEditor extends React.Component<Props> {
     };
 
     serialize: (options?: any) => {
-        answerArea: any;
-        itemDataVersion: {
-            major: number;
-            minor: number;
-        };
-        question: any;
+        answerArea: PerseusAnswerArea;
+        itemDataVersion: Version;
+        question: PerseusRenderer;
     } = (options: any) => {
         return {
-            question: this.questionEditor.current?.serialize(options),
-            answerArea: this.itemExtrasEditor.current?.serialize(),
+            question: this.questionEditor.current!.serialize(options),
+            answerArea: this.itemExtrasEditor.current!.serialize(),
             itemDataVersion: ITEM_DATA_VERSION,
         };
     };


### PR DESCRIPTION
## Summary:

This PR improves typing of the `serialize()` methods on the various editors. This function is used to return the edited data to higher-up components (and ultimately out of Perseus itself). 

Better typing helps us to ensure that we're returning the right data in the right format/structure.

Issue: LEMS-1809

## Test plan:

`yarn tsc`
`yarn test`