### PR TITLE
IframeContentRenderer: strongly type sendNewData()

### DIFF
--- a/.changeset/four-ladybugs-act.md
+++ b/.changeset/four-ladybugs-act.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+IframeContentRenderer: strongly type sendNewData()

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -156,7 +156,7 @@ class EditorPage extends React.Component<Props, State> {
 
         this.itemEditor.current?.triggerPreviewUpdate({
             type: "question",
-            data: _({
+            data: {
                 item: this.serialize(),
                 apiOptions: deviceBasedApiOptions,
                 initialHintsVisible: 0,
@@ -166,17 +166,11 @@ class EditorPage extends React.Component<Props, State> {
                     highlightLint: this.state.highlightLint,
                     // TODO(CP-4838): is it okay to use [] as a default?
                     paths: this.props.contentPaths || [],
+                    stack: [],
                 },
                 reviewMode: true,
                 legacyPerseusLint: this.itemEditor.current?.getSaveWarnings(),
-            }).extend(
-                _(this.props).pick(
-                    "workAreaSelector",
-                    "solutionAreaSelector",
-                    "hintsAreaSelector",
-                    "problemNum",
-                ),
-            ),
+            },
         });
     }
 

--- a/packages/perseus-editor/src/hint-editor.tsx
+++ b/packages/perseus-editor/src/hint-editor.tsx
@@ -199,7 +199,7 @@ class CombinedHintEditor extends React.Component<CombinedHintEditorProps> {
         this.updatePreview();
     }
 
-    updatePreview = () => {
+    updatePreview() {
         const shouldBold =
             this.props.isLast && !/\*\*/.test(this.props.hint.content);
 
@@ -212,12 +212,13 @@ class CombinedHintEditor extends React.Component<CombinedHintEditorProps> {
                 apiOptions: this.props.apiOptions,
                 linterContext: {
                     contentType: "hint",
-                    highlightLint: this.props.highlightLint,
+                    highlightLint: this.props.highlightLint ?? false,
                     paths: this.props.contentPaths,
+                    stack: [],
                 },
             },
         });
-    };
+    }
 
     getSaveWarnings = () => {
         return this.editor.current?.getSaveWarnings();

--- a/packages/perseus-editor/src/iframe-content-renderer.tsx
+++ b/packages/perseus-editor/src/iframe-content-renderer.tsx
@@ -30,7 +30,7 @@ type ArticleData = {
     legacyPerseusLint: ReadonlyArray<string>;
 };
 
-export type SendNewData =
+export type NewDataMessage =
     | {
           type: "question";
           data: {
@@ -206,7 +206,7 @@ class IframeContentRenderer extends React.Component<Props> {
         this._frame = frame;
     }
 
-    sendNewData(data: SendNewData) {
+    sendNewData(data: NewDataMessage) {
         const frame = this._frame;
         if (this._isMounted && data && frame?.contentWindow) {
             this._lastData = data;

--- a/packages/perseus-editor/src/iframe-content-renderer.tsx
+++ b/packages/perseus-editor/src/iframe-content-renderer.tsx
@@ -14,6 +14,48 @@
 import {Log} from "@khanacademy/perseus";
 import * as React from "react";
 
+import type {
+    APIOptions,
+    DeviceType,
+    PerseusItem,
+    PerseusRenderer,
+} from "@khanacademy/perseus";
+import type {LinterContextProps} from "@khanacademy/perseus-linter";
+
+type ArticleData = {
+    apiOptions: APIOptions;
+    json: Partial<PerseusRenderer>;
+    useNewStyles: boolean;
+    linterContext: LinterContextProps;
+    legacyPerseusLint: ReadonlyArray<string>;
+};
+
+export type SendNewData =
+    | {
+          type: "question";
+          data: {
+              item: PerseusItem;
+              apiOptions: APIOptions;
+              initialHintsVisible: number;
+              device: DeviceType;
+              linterContext: LinterContextProps;
+              reviewMode: boolean;
+              legacyPerseusLint: ReadonlyArray<string>;
+          };
+      }
+    | {
+          type: "hint";
+          data: {
+              hint: PerseusRenderer;
+              bold: boolean;
+              pos: number;
+              apiOptions?: APIOptions;
+              linterContext: LinterContextProps;
+          };
+      }
+    | {type: "article-all"; data: ReadonlyArray<ArticleData>}
+    | {type: "article"; data: ArticleData};
+
 let nextIframeID = 0;
 const requestIframeData: Record<string, any> = {};
 const updateIframeHeight: Record<string, any> = {};
@@ -164,7 +206,7 @@ class IframeContentRenderer extends React.Component<Props> {
         this._frame = frame;
     }
 
-    sendNewData(data: any) {
+    sendNewData(data: SendNewData) {
         const frame = this._frame;
         if (this._isMounted && data && frame?.contentWindow) {
             this._lastData = data;

--- a/packages/perseus-editor/src/item-editor.tsx
+++ b/packages/perseus-editor/src/item-editor.tsx
@@ -7,7 +7,7 @@ import Editor from "./editor";
 import IframeContentRenderer from "./iframe-content-renderer";
 import ItemExtrasEditor from "./item-extras-editor";
 
-import type {SendNewData} from "./iframe-content-renderer";
+import type {NewDataMessage} from "./iframe-content-renderer";
 import type {
     APIOptions,
     ImageUploader,
@@ -58,7 +58,7 @@ class ItemEditor extends React.Component<Props> {
         this.props.onChange(_(props).extend(newProps), cb, silent);
     };
 
-    triggerPreviewUpdate(newData: Extract<SendNewData, {type: "question"}>) {
+    triggerPreviewUpdate(newData: Extract<NewDataMessage, {type: "question"}>) {
         this.frame.current?.sendNewData(newData);
     }
 

--- a/packages/perseus-editor/src/item-editor.tsx
+++ b/packages/perseus-editor/src/item-editor.tsx
@@ -7,6 +7,7 @@ import Editor from "./editor";
 import IframeContentRenderer from "./iframe-content-renderer";
 import ItemExtrasEditor from "./item-extras-editor";
 
+import type {SendNewData} from "./iframe-content-renderer";
 import type {
     APIOptions,
     ImageUploader,
@@ -57,9 +58,9 @@ class ItemEditor extends React.Component<Props> {
         this.props.onChange(_(props).extend(newProps), cb, silent);
     };
 
-    triggerPreviewUpdate: (newData?: any) => void = (newData: any) => {
+    triggerPreviewUpdate(newData: Extract<SendNewData, {type: "question"}>) {
         this.frame.current?.sendNewData(newData);
-    };
+    }
 
     handleEditorChange: ChangeHandler = (newProps, cb, silent) => {
         const question = _.extend({}, this.props.question, newProps);


### PR DESCRIPTION
## Summary:

This PR improves typing on the editor's `sendNewData` method. This method is used to push edits to the preview iframe. Prior to this PR the data being sent was not clearly typed and hard to understand. 

Issue: LEMS-1809

## Test plan:

`yarn tsc`
`yarn test`