### PR TITLE
IframeContentRenderer: simplify iframeID assignment so typing can improve

### DIFF
--- a/.changeset/violet-squids-sit.md
+++ b/.changeset/violet-squids-sit.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+IframeContentRenderer: simplify iframeID assignment so typing can improve

--- a/packages/perseus-editor/src/iframe-content-renderer.tsx
+++ b/packages/perseus-editor/src/iframe-content-renderer.tsx
@@ -115,16 +115,13 @@ class IframeContentRenderer extends React.Component<Props> {
     _lastData: any;
     // @ts-expect-error - TS2564 - Property '_lastHeight' has no initializer and is not definitely assigned in the constructor.
     _lastHeight: number;
-    // @ts-expect-error - TS2564 - Property 'iframeID' has no initializer and is not definitely assigned in the constructor.
-    iframeID: number;
+
+    iframeID = nextIframeID++;
 
     componentDidMount() {
         // TODO(scottgrant): This is a hack to remove the deprecated call to
         // this.isMounted() but is still considered an anti-pattern.
         this._isMounted = true;
-
-        this.iframeID = nextIframeID;
-        nextIframeID++;
 
         this._prepareFrame();
         requestIframeData[this.iframeID] = () => {


### PR DESCRIPTION
## Summary:

The IframeContentRenderer used to assign itself an `iframeID` in `componentDidMount`. There's no reason it can't assign that to itself when the component is contructed. I've moved the id generation to be in the member declaration, which means the type can be implicitly, but strongly, defined there. 

Issue: LEMS-1809

## Test plan:

`yarn tsc`
`yarn test`