### PR TITLE
The final 'Upload Coverage' step doesn't need local source or node_modules

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -208,14 +208,6 @@ jobs:
                 node-version: [20.x]
         needs: [cypress, coverage]
         steps:
-            - uses: actions/checkout@v4
-
-            - name: Install & cache node_modules
-              uses: ./.github/actions/shared-node-cache
-              with:
-                  node-version: ${{ matrix.node-version }}
-                  ssh-private-key: ${{ secrets.KHAN_ACTIONS_BOT_SSH_PRIVATE_KEY }}
-
             - name: Download Jest Coverage
               uses: actions/download-artifact@v4
               with:


### PR DESCRIPTION
## Summary:

I noticed this last step in our CI runs takes a bit of time for what amounts to downloading 2 files and then uploading them to Codecov. 

This action uses only other Github shared actions and so it doesn't need to checkout the source or install node_modules. This should speed up this last step in our CI runs somewhat. 

Issue: "none"

## Test plan:

I'll need to land this and then watch the next PR that runs this action.