### PR TITLE
Fix incorrect comment

### DIFF
--- a/.changeset/yellow-zoos-trade.md
+++ b/.changeset/yellow-zoos-trade.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: fix incorrect comment

--- a/packages/perseus/src/widgets/interactive-graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/types.ts
@@ -88,7 +88,7 @@ export interface AngleGraphState extends InteractiveGraphStateCommon {
     type: "angle";
     // Whether to show the angle measurements.  default: false
     showAngles?: boolean;
-    // Allow Reflex Angles if an "angle" type.  default: true
+    // Allow Reflex Angles if an "angle" type.  default: false
     allowReflexAngles?: boolean;
     // The angle offset in degrees if an "angle" type. default: 0
     angleOffsetDeg?: number;


### PR DESCRIPTION
The doc comment for `allowReflexAngles` was wrong. This PR fixes it.

Issue: none

## Test plan:
`yarn test`