### PR TITLE
Don't cache node modules in CI

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -69,11 +69,8 @@ jobs:
             - name: Checking out latest commit
               uses: actions/checkout@v4
 
-            - name: Install & cache node_modules
-              uses: ./.github/actions/shared-node-cache
-              with:
-                  node-version: ${{ matrix.node-version }}
-                  ssh-private-key: ${{ secrets.KHAN_ACTIONS_BOT_SSH_PRIVATE_KEY }}
+            - name: Install node_modules
+              run: yarn install
 
             - name: Get All Changed Files
               uses: Khan/actions@get-changed-files-v2

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -72,8 +72,8 @@ jobs:
             - name: Force Node version
               uses: actions/setup-node@v4
               with:
-                node-version: ${{ matrix.node-version }}
-                cache: yarn
+                  node-version: ${{ matrix.node-version }}
+                  cache: yarn
 
             - name: Install node_modules
               run: yarn install

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -69,6 +69,12 @@ jobs:
             - name: Checking out latest commit
               uses: actions/checkout@v4
 
+            - name: Force Node version
+              uses: actions/setup-node@v4
+              with:
+                node-version: ${{ matrix.node-version }}
+                cache: yarn
+
             - name: Install node_modules
               run: yarn install
 


### PR DESCRIPTION
This PR is an experiment to debug an issue where snapshot tests are failing. We
might not want to merge this.

## Test plan:
Jest should pass on CI.