### PR TITLE
PhET widget: remove simpleValidate

### DIFF
--- a/.changeset/afraid-colts-sneeze.md
+++ b/.changeset/afraid-colts-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Remove simpleValidate from PhET widget

--- a/packages/perseus/src/widgets/phet-simulation.tsx
+++ b/packages/perseus/src/widgets/phet-simulation.tsx
@@ -72,11 +72,6 @@ export class PhetSimulation extends React.Component<Props, State> {
         return Changeable.change.apply(this, args);
     };
 
-    simpleValidate: (arg1: any) => any = (rubric) => {
-        // @ts-expect-error - TS2339 - Property 'validate' does not exist on type 'typeof PhetSimulation'.
-        return PhetSimulation.validate(this.getUserInput(), rubric);
-    };
-
     // kaLocales and PhET locales use different formats and abbreviations.
     // PhET accepts different formats, i.e. kaLocale's hyphens, but it does not accept
     // different abbreviations, so in points of divergence of abbreviations, we need to


### PR DESCRIPTION
## Summary:
Remove `simpleValidate()` from the PhET widget because it is a non-answerable widget.
* Because widgets without a `simpleValidate()` are handled correctly by our grading infrastructure (they are simply not graded), as per Jeremy's suggestion, we will remove the function from PhET!
* Also resolves `TypeError: JE.validate is not a function` error on PhET simulation content

Issue: LEMS-2287

## Test plan:
* `yarn jest packages/perseus/src/widgets/__tests__/phet-simulation.test.ts`
* `yarn jest packages/perseus-editor/src/widgets/__tests__/phet-simulation-editor.test.tsx`
* Verify that the widget and editor still show up in Storybook
* Verify that the widget shows up and remains ungraded on [Test Everything](https://www.khanacademy.org/internal-courses/test-everything/test-everything-1/x6df8cbb5b9ebc9c6:phet-simulation/e/projectile-data-lab)