### PR TITLE
Add save warnings to PhET widget editor and unhide widget

### DIFF
--- a/.changeset/thirty-pans-hammer.md
+++ b/.changeset/thirty-pans-hammer.md
@@ -1,6 +1,6 @@
 ---
-"@khanacademy/perseus": patch
-"@khanacademy/perseus-editor": patch
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-editor": minor
 ---
 
-Add save warnings to PhET widget editor
+Add save warnings to PhET widget editor and un-hide widget from content editor widget dropdown

--- a/.changeset/thirty-pans-hammer.md
+++ b/.changeset/thirty-pans-hammer.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Add save warnings to PhET widget editor

--- a/packages/perseus-editor/src/widgets/phet-simulation-editor.tsx
+++ b/packages/perseus-editor/src/widgets/phet-simulation-editor.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @khanacademy/ts-no-error-suppressions */
+import {makeSafeUrl} from "@khanacademy/perseus";
 import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
 import * as React from "react";
 
@@ -29,6 +30,13 @@ class PhetSimulationEditor extends React.Component<Props> {
             url: this.props.url,
             description: this.props.description,
         };
+    }
+
+    getSaveWarnings(): ReadonlyArray<string> {
+        if (makeSafeUrl(this.props.url, "en") === null) {
+            return ["Please enter a URL from the PhET domain."];
+        }
+        return [];
     }
 
     render(): React.ReactNode {

--- a/packages/perseus-editor/src/widgets/phet-simulation-editor.tsx
+++ b/packages/perseus-editor/src/widgets/phet-simulation-editor.tsx
@@ -32,12 +32,12 @@ class PhetSimulationEditor extends React.Component<Props> {
         };
     }
 
-    getSaveWarnings(): ReadonlyArray<string> {
+    getSaveWarnings: () => ReadonlyArray<string> = () => {
         if (makeSafeUrl(this.props.url, "en") === null) {
             return ["Please enter a URL from the PhET domain."];
         }
         return [];
-    }
+    };
 
     render(): React.ReactNode {
         return (

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -130,6 +130,8 @@ export {
     getAngleCoords,
 } from "./widgets/interactive-graphs/reducer/initialize-graph-state";
 
+export {makeSafeUrl} from "./widgets/phet-simulation";
+
 /**
  * Mixins
  */

--- a/packages/perseus/src/widgets/phet-simulation/index.ts
+++ b/packages/perseus/src/widgets/phet-simulation/index.ts
@@ -1,1 +1,1 @@
-export {default} from "./phet-simulation";
+export {default, makeSafeUrl} from "./phet-simulation";

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
@@ -250,7 +250,5 @@ export default {
     name: "phet-simulation",
     displayName: "PhET Simulation",
     widget: PhetSimulation,
-    // Hides widget from content creators until full release
-    hidden: true,
     isLintable: true,
 } as WidgetExports<typeof PhetSimulation>;


### PR DESCRIPTION
## Summary:
* Add `getSaveWarnings()` function to PhET widget editor so that a widget cannot be saved with a non-PhET URL
* Unhide the widget from the content editor

<img width="1465" alt="A save warning popup, Are you sure you want to save your changes with errors? phet-simulation 1: Please enter a URL from the PhET domain." src="https://github.com/user-attachments/assets/34ac2131-5237-4aa3-9f63-91d379d8e12c">

Issue: LEMS-2292

## Test plan:
* `yarn jest packages/perseus/src/widgets/__tests__/phet-simulation.test.ts`
* `yarn jest packages/perseus-editor/src/widgets/__tests__/phet-simulation-editor.test.tsx`
* Verify that the widget and editor still show up in Storybook
* Verify that the editor displays an error when a non-PhET URL is typed into the PhET widget content editor