### PR TITLE
Use setup-node to install and cache node_modules

### DIFF
--- a/.github/actions/shared-node-cache/action.yml
+++ b/.github/actions/shared-node-cache/action.yml
@@ -19,4 +19,5 @@ runs:
               cache: yarn
 
         - name: yarn install
+          shell: sh
           run: yarn install

--- a/.github/actions/shared-node-cache/action.yml
+++ b/.github/actions/shared-node-cache/action.yml
@@ -12,11 +12,11 @@ inputs:
 runs:
     using: "composite"
     steps:
-      - name: Set up node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ inputs.node-version }}
-          cache: yarn
+        - name: Set up node
+          uses: actions/setup-node@v4
+          with:
+              node-version: ${{ inputs.node-version }}
+              cache: yarn
 
-      - name: yarn install
-        run: yarn install
+        - name: yarn install
+          run: yarn install

--- a/.github/actions/shared-node-cache/action.yml
+++ b/.github/actions/shared-node-cache/action.yml
@@ -6,22 +6,17 @@ inputs:
     node-version:
         description: "Node version to use"
         required: true
-    ssh-private-key:
-        description: "A private SSH key so that we can obtain private dependencies like our event schema package"
-        required: true
 
 # The steps this action runs.
 # The order of the two steps below needs to be maintained.
-# The ssh-agent step needs to be before the Node.js/Install step because our package.json uses
-# git+ssh. As this requires a valid SSH key, the ssh-agent action must be before the yarn install.
 runs:
     using: "composite"
     steps:
-        - uses: webfactory/ssh-agent@v0.9.0
-          with:
-              ssh-private-key: ${{ inputs.ssh-private-key }}
+      - name: Set up node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: yarn
 
-        - name: Use Node.js ${{ inputs.node-version }} & Install & cache node_modules
-          uses: Khan/actions@shared-node-cache-v2
-          with:
-              node-version: ${{ inputs.node-version }}
+      - name: yarn install
+        run: yarn install

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -25,14 +25,10 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - name: Set up node
-              uses: actions/setup-node@v4
+            - name: Install & cache node_modules
+              uses: ./.github/actions/shared-node-cache
               with:
                   node-version: ${{ matrix.node-version }}
-                  cache: yarn
-
-            - name: yarn install
-              run: yarn install
 
             - name: Update browserslist DB
               run: npx update-browserslist-db@latest

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -25,11 +25,14 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - name: Install & cache node_modules
-              uses: ./.github/actions/shared-node-cache
+            - name: Set up node
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node-version }}
-                  ssh-private-key: ${{ secrets.KHAN_ACTIONS_BOT_SSH_PRIVATE_KEY }}
+                  cache: yarn
+
+            - name: yarn install
+              run: yarn install
 
             - name: Update browserslist DB
               run: npx update-browserslist-db@latest

--- a/.github/workflows/node-ci-main.yml
+++ b/.github/workflows/node-ci-main.yml
@@ -35,14 +35,10 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - name: Set up node
-              uses: actions/setup-node@v4
+            - name: Install & cache node_modules
+              uses: ./.github/actions/shared-node-cache
               with:
                   node-version: ${{ matrix.node-version }}
-                  cache: yarn
-
-            - name: yarn install
-              run: yarn install
 
     coverage:
         needs: [prime_cache_primary]
@@ -55,14 +51,10 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - name: Set up node
-              uses: actions/setup-node@v4
+            - name: Install & cache node_modules
+              uses: ./.github/actions/shared-node-cache
               with:
                   node-version: ${{ matrix.node-version }}
-                  cache: yarn
-
-            - name: yarn install
-              run: yarn install
 
             - name: Jest with coverage
               run: yarn coverage
@@ -85,14 +77,10 @@ jobs:
             - name: Checking out latest commit
               uses: actions/checkout@v4
 
-            - name: Set up node
-              uses: actions/setup-node@v4
+            - name: Install & cache node_modules
+              uses: ./.github/actions/shared-node-cache
               with:
                   node-version: ${{ matrix.node-version }}
-                  cache: yarn
-
-            - name: yarn install
-              run: yarn install
 
             - name: Run test with coverage
               run: yarn cypress:ci

--- a/.github/workflows/node-ci-main.yml
+++ b/.github/workflows/node-ci-main.yml
@@ -34,11 +34,15 @@ jobs:
                 node-version: [20.x]
         steps:
             - uses: actions/checkout@v4
-            - name: Install & cache node_modules
-              uses: ./.github/actions/shared-node-cache
+
+            - name: Set up node
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node-version }}
-                  ssh-private-key: ${{ secrets.KHAN_ACTIONS_BOT_SSH_PRIVATE_KEY }}
+                  cache: yarn
+
+            - name: yarn install
+              run: yarn install
 
     coverage:
         needs: [prime_cache_primary]
@@ -51,11 +55,14 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - name: Install & cache node_modules
-              uses: ./.github/actions/shared-node-cache
+            - name: Set up node
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node-version }}
-                  ssh-private-key: ${{ secrets.KHAN_ACTIONS_BOT_SSH_PRIVATE_KEY }}
+                  cache: yarn
+
+            - name: yarn install
+              run: yarn install
 
             - name: Jest with coverage
               run: yarn coverage
@@ -78,11 +85,14 @@ jobs:
             - name: Checking out latest commit
               uses: actions/checkout@v4
 
-            - name: Install & cache node_modules
-              uses: ./.github/actions/shared-node-cache
+            - name: Set up node
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node-version }}
-                  ssh-private-key: ${{ secrets.KHAN_ACTIONS_BOT_SSH_PRIVATE_KEY }}
+                  cache: yarn
+
+            - name: yarn install
+              run: yarn install
 
             - name: Run test with coverage
               run: yarn cypress:ci

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -69,11 +69,14 @@ jobs:
             - name: Checking out latest commit
               uses: actions/checkout@v4
 
-            - name: Install & cache node_modules
-              uses: ./.github/actions/shared-node-cache
+            - name: Set up node
+              uses: actions/setup-node@v4
               with:
-                  node-version: ${{ matrix.node-version }}
-                  ssh-private-key: ${{ secrets.KHAN_ACTIONS_BOT_SSH_PRIVATE_KEY }}
+                node-version: ${{ matrix.node-version }}
+                cache: yarn
+
+            - name: yarn install
+              run: yarn install
 
             - name: Get All Changed Files
               uses: Khan/actions@get-changed-files-v2
@@ -148,11 +151,14 @@ jobs:
             - name: Checking out latest commit
               uses: actions/checkout@v4
 
-            - name: Install & cache node_modules
-              uses: ./.github/actions/shared-node-cache
+            - name: Set up node
+              uses: actions/setup-node@v4
               with:
-                  node-version: ${{ matrix.node-version }}
-                  ssh-private-key: ${{ secrets.KHAN_ACTIONS_BOT_SSH_PRIVATE_KEY }}
+                node-version: ${{ matrix.node-version }}
+                cache: yarn
+
+            - name: yarn install
+              run: yarn install
 
             - name: Run test with coverage
               run: yarn cypress:ci
@@ -182,11 +188,14 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - name: Install & cache node_modules
-              uses: ./.github/actions/shared-node-cache
+            - name: Set up node
+              uses: actions/setup-node@v4
               with:
-                  node-version: ${{ matrix.node-version }}
-                  ssh-private-key: ${{ secrets.KHAN_ACTIONS_BOT_SSH_PRIVATE_KEY }}
+                node-version: ${{ matrix.node-version }}
+                cache: yarn
+
+            - name: yarn install
+              run: yarn install
 
             - name: Jest with coverage
               run: yarn coverage
@@ -244,11 +253,15 @@ jobs:
             - name: Checking out latest commit
               uses: actions/checkout@v4
 
-            - name: Install & cache node_modules
-              uses: ./.github/actions/shared-node-cache
+            - name: Set up node
+              uses: actions/setup-node@v4
               with:
-                  node-version: ${{ matrix.node-version }}
-                  ssh-private-key: ${{ secrets.KHAN_ACTIONS_BOT_SSH_PRIVATE_KEY }}
+                node-version: ${{ matrix.node-version }}
+                cache: yarn
+
+            - name: yarn install
+              run: yarn install
+
             # Make sure our packages aren't growing unexpectedly
             # This must come last as it builds the old code last and so leaves the
             # wrong code in place for the next job; in other words, it leaves the repo on a base branch.
@@ -292,11 +305,14 @@ jobs:
                   git checkout main
                   git checkout $REF
 
-            - name: Install & cache node_modules
-              uses: ./.github/actions/shared-node-cache
+            - name: Set up node
+              uses: actions/setup-node@v4
               with:
-                  node-version: ${{ matrix.node-version }}
-                  ssh-private-key: ${{ secrets.KHAN_ACTIONS_BOT_SSH_PRIVATE_KEY }}
+                node-version: ${{ matrix.node-version }}
+                cache: yarn
+
+            - name: yarn install
+              run: yarn install
 
             - name: Publish Snapshot Release to npm
               id: publish-snapshot

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -69,14 +69,10 @@ jobs:
             - name: Checking out latest commit
               uses: actions/checkout@v4
 
-            - name: Set up node
-              uses: actions/setup-node@v4
+            - name: Install & cache node_modules
+              uses: ./.github/actions/shared-node-cache
               with:
                   node-version: ${{ matrix.node-version }}
-                  cache: yarn
-
-            - name: yarn install
-              run: yarn install
 
             - name: Get All Changed Files
               uses: Khan/actions@get-changed-files-v2
@@ -151,14 +147,10 @@ jobs:
             - name: Checking out latest commit
               uses: actions/checkout@v4
 
-            - name: Set up node
-              uses: actions/setup-node@v4
+            - name: Install & cache node_modules
+              uses: ./.github/actions/shared-node-cache
               with:
                   node-version: ${{ matrix.node-version }}
-                  cache: yarn
-
-            - name: yarn install
-              run: yarn install
 
             - name: Run test with coverage
               run: yarn cypress:ci
@@ -188,14 +180,10 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - name: Set up node
-              uses: actions/setup-node@v4
+            - name: Install & cache node_modules
+              uses: ./.github/actions/shared-node-cache
               with:
                   node-version: ${{ matrix.node-version }}
-                  cache: yarn
-
-            - name: yarn install
-              run: yarn install
 
             - name: Jest with coverage
               run: yarn coverage
@@ -253,14 +241,10 @@ jobs:
             - name: Checking out latest commit
               uses: actions/checkout@v4
 
-            - name: Set up node
-              uses: actions/setup-node@v4
+            - name: Install & cache node_modules
+              uses: ./.github/actions/shared-node-cache
               with:
                   node-version: ${{ matrix.node-version }}
-                  cache: yarn
-
-            - name: yarn install
-              run: yarn install
 
             # Make sure our packages aren't growing unexpectedly
             # This must come last as it builds the old code last and so leaves the
@@ -305,14 +289,10 @@ jobs:
                   git checkout main
                   git checkout $REF
 
-            - name: Set up node
-              uses: actions/setup-node@v4
+            - name: Install & cache node_modules
+              uses: ./.github/actions/shared-node-cache
               with:
                   node-version: ${{ matrix.node-version }}
-                  cache: yarn
-
-            - name: yarn install
-              run: yarn install
 
             - name: Publish Snapshot Release to npm
               id: publish-snapshot

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -72,8 +72,8 @@ jobs:
             - name: Set up node
               uses: actions/setup-node@v4
               with:
-                node-version: ${{ matrix.node-version }}
-                cache: yarn
+                  node-version: ${{ matrix.node-version }}
+                  cache: yarn
 
             - name: yarn install
               run: yarn install
@@ -154,8 +154,8 @@ jobs:
             - name: Set up node
               uses: actions/setup-node@v4
               with:
-                node-version: ${{ matrix.node-version }}
-                cache: yarn
+                  node-version: ${{ matrix.node-version }}
+                  cache: yarn
 
             - name: yarn install
               run: yarn install
@@ -191,8 +191,8 @@ jobs:
             - name: Set up node
               uses: actions/setup-node@v4
               with:
-                node-version: ${{ matrix.node-version }}
-                cache: yarn
+                  node-version: ${{ matrix.node-version }}
+                  cache: yarn
 
             - name: yarn install
               run: yarn install
@@ -256,8 +256,8 @@ jobs:
             - name: Set up node
               uses: actions/setup-node@v4
               with:
-                node-version: ${{ matrix.node-version }}
-                cache: yarn
+                  node-version: ${{ matrix.node-version }}
+                  cache: yarn
 
             - name: yarn install
               run: yarn install
@@ -308,8 +308,8 @@ jobs:
             - name: Set up node
               uses: actions/setup-node@v4
               with:
-                node-version: ${{ matrix.node-version }}
-                cache: yarn
+                  node-version: ${{ matrix.node-version }}
+                  cache: yarn
 
             - name: yarn install
               run: yarn install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,8 @@ jobs:
             - name: Set up node
               uses: actions/setup-node@v4
               with:
-                node-version: ${{ matrix.node-version }}
-                cache: yarn
+                  node-version: ${{ matrix.node-version }}
+                  cache: yarn
 
             - name: yarn install
               run: yarn install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,14 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Install & cache node_modules
-              uses: ./.github/actions/shared-node-cache
+            - name: Set up node
+              uses: actions/setup-node@v4
               with:
-                  node-version: ${{ matrix.node-version }}
-                  ssh-private-key: ${{ secrets.KHAN_ACTIONS_BOT_SSH_PRIVATE_KEY }}
+                node-version: ${{ matrix.node-version }}
+                cache: yarn
+
+            - name: yarn install
+              run: yarn install
 
             - name: Build Storybook
               # Generate a static version of storybook inside "storybook-static/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,14 +41,10 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Set up node
-              uses: actions/setup-node@v4
+            - name: Install & cache node_modules
+              uses: ./.github/actions/shared-node-cache
               with:
                   node-version: ${{ matrix.node-version }}
-                  cache: yarn
-
-            - name: yarn install
-              run: yarn install
 
             - name: Build Storybook
               # Generate a static version of storybook inside "storybook-static/"

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -32,14 +32,10 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Set up node
-              uses: actions/setup-node@v4
+            - name: Install & cache node_modules
+              uses: ./.github/actions/shared-node-cache
               with:
                   node-version: ${{ matrix.node-version }}
-                  cache: yarn
-
-            - name: yarn install
-              run: yarn install
 
             - name: Publish to Chromatic for visual testing
               uses: chromaui/action@v11

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -32,11 +32,14 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Install & cache node_modules
-              uses: ./.github/actions/shared-node-cache
+            - name: Set up node
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node-version }}
-                  ssh-private-key: ${{ secrets.KHAN_ACTIONS_BOT_SSH_PRIVATE_KEY }}
+                  cache: yarn
+
+            - name: yarn install
+              run: yarn install
 
             - name: Publish to Chromatic for visual testing
               uses: chromaui/action@v11


### PR DESCRIPTION
## Summary:
We've been seeing intermittent CI test failures in that appear to be caused by incorrect
NPM packages being installed. Clearing the node_modules cache used by our GitHub actions
resolves the issue... temporarily.

In the case of a cache miss, we restore node_modules from the "wrong" cache and
`yarn install` on top of that. Usually, this installs the correct versions of any
packages that need updating, and everything works. But we think that sometimes, it might
not.

The setup-node action from GitHub implements node_modules caching, and doesn't restore
from fallback caches. This PR switches our CI jobs to use `setup-node`, which we hope
will resolve the caching issues.

## Test plan:

Look. See CI. See CI run. Run, CI, run.