### PR TITLE
Remove Util.DeprecationMixin

### DIFF
--- a/.changeset/nervous-singers-reply.md
+++ b/.changeset/nervous-singers-reply.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Remove unused handling of deprecated Interactive Graph prop

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-unsafe */
 import {vector as kvector} from "@khanacademy/kmath";
 import {
     components,
@@ -37,19 +36,12 @@ import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
 const {InfoTip} = components;
 const {containerSizeClass, getInteractiveBoxFromSizeClass} = SizingUtils;
-const DeprecationMixin = Util.DeprecationMixin;
 const InteractiveGraph = InteractiveGraphWidget.widget;
 
 type InteractiveGraphProps = PropsFor<typeof InteractiveGraph>;
 
 const defaultBackgroundImage = {
     url: null,
-} as const;
-
-const deprecatedProps = {
-    showGraph: function (props) {
-        return {markings: props.showGraph ? "graph" : "none"};
-    },
 } as const;
 
 const POLYGON_SIDES = _.map(_.range(3, 13), function (value) {
@@ -175,14 +167,6 @@ class InteractiveGraphEditor extends React.Component<Props> {
             coords: null,
         },
     };
-
-    // TODO(jack): Use versioning instead of DeprecationMixin
-    deprecatedProps = deprecatedProps;
-
-    // TODO(jangmi, CP-3288): Remove usage of `UNSAFE_componentWillMount`
-    UNSAFE_componentWillMount() {
-        DeprecationMixin.UNSAFE_componentWillMount.call(this);
-    }
 
     changeMatchType = (newValue) => {
         const correct = {

--- a/packages/perseus/src/util.ts
+++ b/packages/perseus/src/util.ts
@@ -530,51 +530,6 @@ function constrainedTickStepsFromTickSteps(
 }
 
 /**
- * Transparently update deprecated props so that the code to deal
- * with them only lives in one place: (Widget).deprecatedProps
- *
- * For example, if a boolean `foo` was deprecated in favor of a
- * number 'bar':
- *      deprecatedProps: {
- *          foo: function(props) {
- *              return {bar: props.foo ? 1 : 0};
- *          }
- *      }
- */
-const DeprecationMixin: any = {
-    // This lifecycle stage is only called before first render
-    // TODO(jangmi, CP-3288): Remove usage of `UNSAFE_componentWillMount`
-    UNSAFE_componentWillMount: function () {
-        const newProps: Record<string, any> = {};
-
-        _.each(
-            this.deprecatedProps,
-            function (func, prop) {
-                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                if (_.has(this.props, prop)) {
-                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                    _.extend(newProps, func(this.props));
-                }
-            },
-            this,
-        );
-
-        if (!_.isEmpty(newProps)) {
-            // Set new props directly so that widget renders correctly
-            // when it first mounts, even though these will be overwritten
-            // almost immediately afterwards...
-            _.extend(this.props, newProps);
-
-            // ...when we propagate the new props upwards and they come
-            // back down again.
-            // TODO(jeff, CP-3128): Use Wonder Blocks Timing API
-            // eslint-disable-next-line no-restricted-syntax
-            setTimeout(this.props.onChange, 0, newProps);
-        }
-    },
-};
-
-/**
  * Approximate equality on numbers and primitives.
  */
 function eq<T>(x: T, y: T): boolean {
@@ -963,7 +918,6 @@ const Util = {
     gridStepFromTickStep,
     tickStepFromNumTicks,
     constrainedTickStepsFromTickSteps,
-    DeprecationMixin,
     eq,
     deepEq,
     parseQueryString,

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @babel/no-invalid-this, react/no-unsafe, react/sort-comp */
+/* eslint-disable @babel/no-invalid-this, react/sort-comp */
 import {number as knumber, point as kpoint} from "@khanacademy/kmath";
 import {Errors, PerseusError} from "@khanacademy/perseus-core";
 import $ from "jquery";
@@ -56,8 +56,6 @@ import type {
     SineCoefficient,
 } from "../util/geometry";
 
-const {DeprecationMixin} = Util;
-
 const TRASH_ICON_URI =
     "https://ka-perseus-graphie.s3.amazonaws.com/b1452c0d79fd0f7ff4c3af9488474a0a0decb361.png";
 
@@ -92,12 +90,6 @@ function capitalize(str) {
 function numSteps(range: Range, step: number) {
     return Math.floor((range[1] - range[0]) / step);
 }
-
-const deprecatedProps = {
-    showGraph: function (props) {
-        return {markings: props.showGraph ? "graph" : "none"};
-    },
-} as const;
 
 const _getShouldShowInstructions: (arg1: Props) => boolean = (props) => {
     return (
@@ -190,11 +182,6 @@ class LegacyInteractiveGraph extends React.Component<Props, State> {
         shouldShowInstructions: _getShouldShowInstructions(this.props),
     };
 
-    // TODO(jangmi, CP-3288): Remove usage of `UNSAFE_componentWillMount`
-    UNSAFE_componentWillMount() {
-        DeprecationMixin.UNSAFE_componentWillMount.call(this);
-    }
-
     componentDidMount() {
         if (this.refs.graph) {
             // eslint-disable-next-line react/no-string-refs
@@ -263,8 +250,6 @@ class LegacyInteractiveGraph extends React.Component<Props, State> {
             (props.graph.coords == null || props.graph.coords.length === 0)
         );
     };
-
-    deprecatedProps: any = deprecatedProps;
 
     setGraphie: (arg1: any) => void = (newGraphie) => {
         this.graphie = newGraphie;

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @babel/no-invalid-this, react/sort-comp */
+/* eslint-disable @babel/no-invalid-this, react/no-unsafe, react/sort-comp */
 import {number as knumber, point as kpoint} from "@khanacademy/kmath";
 import {Errors, PerseusError} from "@khanacademy/perseus-core";
 import $ from "jquery";


### PR DESCRIPTION
## Summary:
`Util.DeprecationMixin` was only being used to remove a deprecated `showGraph`
prop from the InteractiveGraph widget and its editor component. `showGraph` no
longer appears anywhere in our content, so the "mixin" (which, given the
naming, is likely a relic from the `React.createClass` era) is not needed
anymore.

Issue: none

## Test plan:
Edit and save an interactive graph in the editor.