### PR TITLE
Type the `correct` prop passed to InteractiveGraphEditor

### DIFF
--- a/.changeset/rude-mangos-boil.md
+++ b/.changeset/rude-mangos-boil.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Internal: improve type safety of interactive graph editor

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
@@ -1,26 +1,20 @@
 import {vector as kvector} from "@khanacademy/kmath";
-import type {
-    APIOptionsWithDefaults,
-    LockedFigure,
-    PerseusImageBackground,
-    PerseusInteractiveGraphWidgetOptions,
-} from "@khanacademy/perseus";
 import {
     components,
     InteractiveGraphWidget,
     interactiveSizes,
-    PerseusGraphType,
     SizingUtils,
     Util,
 } from "@khanacademy/perseus";
-import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelSmall} from "@khanacademy/wonder-blocks-typography";
+import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
+import invariant from "tiny-invariant";
 import _ from "underscore";
 
 import LabeledRow from "../../components/graph-locked-figures/labeled-row";
@@ -33,9 +27,15 @@ import SegmentCountSelector from "../../components/segment-count-selector";
 import StartCoordsSettings from "../../components/start-coords-settings";
 import {shouldShowStartCoordsUI} from "../../components/util";
 import {parsePointCount} from "../../util/points";
-import {PerseusGraphTypePolygon, PerseusGraphTypeAngle} from "@khanacademy/perseus/src/perseus-types";
-import invariant from "tiny-invariant";
-import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
+
+import type {
+    APIOptionsWithDefaults,
+    LockedFigure,
+    PerseusImageBackground,
+    PerseusInteractiveGraphWidgetOptions,
+    PerseusGraphType,
+} from "@khanacademy/perseus";
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
 const {InfoTip} = components;
 const {containerSizeClass, getInteractiveBoxFromSizeClass} = SizingUtils;
@@ -58,6 +58,8 @@ const POLYGON_SIDES = _.map(_.range(3, 13), function (value) {
 });
 
 type Range = [min: number, max: number];
+type PerseusGraphTypePolygon = Extract<PerseusGraphType, {type: "polygon"}>;
+type PerseusGraphTypeAngle = Extract<PerseusGraphType, {type: "angle"}>;
 
 export type Props = {
     apiOptions: APIOptionsWithDefaults;
@@ -293,7 +295,7 @@ class InteractiveGraphEditor extends React.Component<Props> {
                     let correct = this.props.correct;
                     // TODO(benchristel): can we improve the type of onChange
                     // so this invariant isn't necessary?
-                    invariant(newGraph != null)
+                    invariant(newGraph != null);
                     if (correct.type === newGraph.type) {
                         correct = mergeGraphs(correct, newGraph);
                     } else {
@@ -381,7 +383,9 @@ class InteractiveGraphEditor extends React.Component<Props> {
                                 }
                                 placeholder=""
                                 onChange={(newValue) => {
-                                    invariant(this.props.graph?.type === "polygon")
+                                    invariant(
+                                        this.props.graph?.type === "polygon",
+                                    );
                                     const updates = {
                                         numSides: parsePointCount(newValue),
                                         coords: null,
@@ -392,8 +396,14 @@ class InteractiveGraphEditor extends React.Component<Props> {
                                     } as const;
 
                                     this.props.onChange({
-                                        correct: {...this.props.correct, ...updates},
-                                        graph: {...this.props.graph, ...updates},
+                                        correct: {
+                                            ...this.props.correct,
+                                            ...updates,
+                                        },
+                                        graph: {
+                                            ...this.props.graph,
+                                            ...updates,
+                                        },
                                     });
                                 }}
                                 style={styles.singleSelectShort}
@@ -416,17 +426,29 @@ class InteractiveGraphEditor extends React.Component<Props> {
                                 // Never uses placeholder, always has value
                                 placeholder=""
                                 onChange={(newValue) => {
-                                    invariant(this.props.correct.type === "polygon", `Expected correct answer type to be polygon, but got ${this.props.correct.type}`)
-                                    invariant(this.props.graph?.type === "polygon", `Expected graph type to be polygon, but got ${this.props.graph?.type}`)
+                                    invariant(
+                                        this.props.correct.type === "polygon",
+                                        `Expected correct answer type to be polygon, but got ${this.props.correct.type}`,
+                                    );
+                                    invariant(
+                                        this.props.graph?.type === "polygon",
+                                        `Expected graph type to be polygon, but got ${this.props.graph?.type}`,
+                                    );
 
                                     const updates = {
                                         snapTo: newValue as PerseusGraphTypePolygon["snapTo"],
                                         coords: null,
-                                    } as const
+                                    } as const;
 
                                     this.props.onChange({
-                                        correct: {...this.props.correct, ...updates},
-                                        graph: {...this.props.graph, ...updates},
+                                        correct: {
+                                            ...this.props.correct,
+                                            ...updates,
+                                        },
+                                        graph: {
+                                            ...this.props.graph,
+                                            ...updates,
+                                        },
                                     });
                                 }}
                                 style={styles.singleSelectShort}
@@ -472,7 +494,11 @@ class InteractiveGraphEditor extends React.Component<Props> {
                                 }
                                 onChange={() => {
                                     if (this.props.graph?.type === "polygon") {
-                                        invariant(this.props.correct.type === "polygon", `Expected graph type to be polygon, but got ${this.props.correct.type}`)
+                                        invariant(
+                                            this.props.correct.type ===
+                                                "polygon",
+                                            `Expected graph type to be polygon, but got ${this.props.correct.type}`,
+                                        );
                                         this.props.onChange({
                                             correct: {
                                                 ...this.props.correct,
@@ -504,7 +530,10 @@ class InteractiveGraphEditor extends React.Component<Props> {
                                     !!this.props.correct?.showSides
                                 }
                                 onChange={() => {
-                                    if (this.props.graph?.type === "polygon" && this.props.correct.type === "polygon") {
+                                    if (
+                                        this.props.graph?.type === "polygon" &&
+                                        this.props.correct.type === "polygon"
+                                    ) {
                                         this.props.onChange({
                                             correct: {
                                                 ...this.props.correct,
@@ -579,7 +608,10 @@ class InteractiveGraphEditor extends React.Component<Props> {
                         <SingleSelect
                             selectedValue={this.props.correct.match || "exact"}
                             onChange={(newValue) => {
-                                invariant(this.props.correct.type === "polygon", `Expected graph type to be polygon, but got ${this.props.correct.type}`);
+                                invariant(
+                                    this.props.correct.type === "polygon",
+                                    `Expected graph type to be polygon, but got ${this.props.correct.type}`,
+                                );
                                 const correct = {
                                     ...this.props.correct,
                                     // TODO(benchristel): this cast is necessary
@@ -656,17 +688,19 @@ class InteractiveGraphEditor extends React.Component<Props> {
                         <SingleSelect
                             selectedValue={this.props.correct.match || "exact"}
                             onChange={(newValue) => {
-                                this.props.onChange({correct: {
-                                    ...this.props.correct,
-                                    // TODO(benchristel): this cast is necessary
-                                    // because "exact" is not actually a valid
-                                    // value for `match`; a value of undefined
-                                    // means exact matching. The code happens
-                                    // to work because "exact" falls through
-                                    // to the correct else branch in
-                                    // InteractiveGraph.validate()
-                                    match: newValue as PerseusGraphTypeAngle["match"],
-                                }});
+                                this.props.onChange({
+                                    correct: {
+                                        ...this.props.correct,
+                                        // TODO(benchristel): this cast is necessary
+                                        // because "exact" is not actually a valid
+                                        // value for `match`; a value of undefined
+                                        // means exact matching. The code happens
+                                        // to work because "exact" falls through
+                                        // to the correct else branch in
+                                        // InteractiveGraph.validate()
+                                        match: newValue as PerseusGraphTypeAngle["match"],
+                                    },
+                                });
                             }}
                             // Never uses placeholder, always has value
                             placeholder=""
@@ -720,9 +754,14 @@ class InteractiveGraphEditor extends React.Component<Props> {
 // Merges two graphs that have the same `type`. Properties defined in `b`
 // overwrite properties of the same name in `a`. Throws an exception if the
 // types are different or not recognized.
-function mergeGraphs(a: PerseusGraphType, b: PerseusGraphType): PerseusGraphType {
+function mergeGraphs(
+    a: PerseusGraphType,
+    b: PerseusGraphType,
+): PerseusGraphType {
     if (a.type !== b.type) {
-        throw new Error(`Cannot merge graphs with different types (${a.type} and ${b.type})`)
+        throw new Error(
+            `Cannot merge graphs with different types (${a.type} and ${b.type})`,
+        );
     }
     switch (a.type) {
         case "angle":

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
@@ -168,14 +168,6 @@ class InteractiveGraphEditor extends React.Component<Props> {
         },
     };
 
-    changeMatchType = (newValue) => {
-        const correct = {
-            ...this.props.correct,
-            match: newValue,
-        };
-        this.props.onChange({correct: correct});
-    };
-
     changeStartCoords = (coords) => {
         if (!this.props.graph?.type) {
             return;
@@ -581,7 +573,13 @@ class InteractiveGraphEditor extends React.Component<Props> {
                     <LabeledRow label="Student answer must">
                         <SingleSelect
                             selectedValue={this.props.correct.match || "exact"}
-                            onChange={this.changeMatchType}
+                            onChange={(newValue) => {
+                                const correct = {
+                                    ...this.props.correct,
+                                    match: newValue,
+                                };
+                                this.props.onChange({correct: correct});
+                            }}
                             // Never uses placeholder, always has value
                             placeholder=""
                             style={styles.singleSelectShort}
@@ -644,7 +642,13 @@ class InteractiveGraphEditor extends React.Component<Props> {
                     <LabeledRow label="Student answer must">
                         <SingleSelect
                             selectedValue={this.props.correct.match || "exact"}
-                            onChange={this.changeMatchType}
+                            onChange={(newValue) => {
+                                const correct = {
+                                    ...this.props.correct,
+                                    match: newValue,
+                                };
+                                this.props.onChange({correct: correct});
+                            }}
                             // Never uses placeholder, always has value
                             placeholder=""
                             style={styles.singleSelectShort}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
@@ -124,6 +124,7 @@ export type Props = {
      * on the state of the interactive graph previewed at the bottom of the
      * editor page.
      */
+    // TODO(LEMS-2344): make the type of `correct` more specific
     correct: PerseusGraphType;
     /**
      * The locked figures to display in the graph area.

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -674,6 +674,7 @@ export type PerseusInteractiveGraphWidgetOptions = {
     // The type of graph
     graph: PerseusGraphType;
     // The correct kind of graph, if being used to select function type
+    // TODO(LEMS-2344): make the type of `correct` more specific
     correct: PerseusGraphType;
     // Shapes (points, chords, etc) displayed on the graph that cannot
     // be moved by the user.

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -812,7 +812,7 @@ export type PerseusGraphTypeAngle = {
     // How to match the answer. If missing, defaults to exact matching.
     match?: "congruent";
     // must have 3 coords - ie [Coord, Coord, Coord]
-    coords?: [Coord, Coord, Coord];
+    coords?: [Coord, Coord, Coord] | null;
     // The initial coordinates the graph renders with.
     startCoords?: [Coord, Coord, Coord];
 };
@@ -831,7 +831,7 @@ export type PerseusGraphTypeCircle = {
 export type PerseusGraphTypeLinear = {
     type: "linear";
     // expects 2 coords
-    coords?: CollinearTuple;
+    coords?: CollinearTuple | null;
     // The initial coordinates the graph renders with.
     startCoords?: CollinearTuple;
 } & PerseusGraphTypeCommon;
@@ -839,7 +839,7 @@ export type PerseusGraphTypeLinear = {
 export type PerseusGraphTypeLinearSystem = {
     type: "linear-system";
     // expects 2 sets of 2 coords
-    coords?: CollinearTuple[];
+    coords?: CollinearTuple[] | null;
     // The initial coordinates the graph renders with.
     startCoords?: CollinearTuple[];
 } & PerseusGraphTypeCommon;
@@ -848,7 +848,7 @@ export type PerseusGraphTypePoint = {
     type: "point";
     // The number of points if a "point" type.  default: 1.  "unlimited" if no limit
     numPoints?: number | "unlimited";
-    coords?: ReadonlyArray<Coord>;
+    coords?: ReadonlyArray<Coord> | null;
     // The initial coordinates the graph renders with.
     startCoords?: ReadonlyArray<Coord>;
 } & PerseusGraphTypeCommon;
@@ -865,7 +865,7 @@ export type PerseusGraphTypePolygon = {
     snapTo?: "grid" | "angles" | "sides";
     // How to match the answer. If missing, defaults to exact matching.
     match?: "similar" | "congruent" | "approx";
-    coords?: ReadonlyArray<Coord>;
+    coords?: ReadonlyArray<Coord> | null;
     // The initial coordinates the graph renders with.
     startCoords?: ReadonlyArray<Coord>;
 } & PerseusGraphTypeCommon;
@@ -873,7 +873,7 @@ export type PerseusGraphTypePolygon = {
 export type PerseusGraphTypeQuadratic = {
     type: "quadratic";
     // expects a list of 3 coords
-    coords?: [Coord, Coord, Coord];
+    coords?: [Coord, Coord, Coord] | null;
     // The initial coordinates the graph renders with.
     startCoords?: [Coord, Coord, Coord];
 } & PerseusGraphTypeCommon;
@@ -883,7 +883,7 @@ export type PerseusGraphTypeSegment = {
     // The number of segments if a "segment" type. default: 1.  Max: 6
     numSegments?: number;
     // Expects a list of Coord tuples. Length should match the `numSegments` value.
-    coords?: CollinearTuple[];
+    coords?: CollinearTuple[] | null;
     // The initial coordinates the graph renders with.
     startCoords?: CollinearTuple[];
 } & PerseusGraphTypeCommon;
@@ -891,7 +891,7 @@ export type PerseusGraphTypeSegment = {
 export type PerseusGraphTypeSinusoid = {
     type: "sinusoid";
     // Expects a list of 2 Coords
-    coords?: ReadonlyArray<Coord>;
+    coords?: ReadonlyArray<Coord> | null;
     // The initial coordinates the graph renders with.
     startCoords?: ReadonlyArray<Coord>;
 } & PerseusGraphTypeCommon;
@@ -899,7 +899,7 @@ export type PerseusGraphTypeSinusoid = {
 export type PerseusGraphTypeRay = {
     type: "ray";
     // Expects a list of 2 Coords
-    coords?: CollinearTuple;
+    coords?: CollinearTuple | null;
     // The initial coordinates the graph renders with.
     startCoords?: CollinearTuple;
 } & PerseusGraphTypeCommon;

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -119,6 +119,7 @@ const makeInvalidTypeError = (
 
 type RenderProps = PerseusInteractiveGraphWidgetOptions; // There's no transform function in exports
 export type Rubric = {
+    // TODO(LEMS-2344): make the type of `correct` more specific
     correct: PerseusGraphType;
     graph: PerseusGraphType;
 };

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
@@ -21,6 +21,7 @@ export type StatefulMafsGraphProps = {
     box: [number, number];
     backgroundImage?: InteractiveGraphProps["backgroundImage"];
     graph: PerseusGraphType;
+    // TODO(LEMS-2344): make the type of `correct` more specific
     correct: PerseusGraphType;
     lockedFigures?: InteractiveGraphProps["lockedFigures"];
     range: InteractiveGraphProps["range"];


### PR DESCRIPTION
Previously, `correct` was typed as `any` to suppress an error. TypeScript
complained that the InteractiveGraph component might pass the wrong subtype of
`PerseusGraphType` to its `onChange` callback, causing us to create a
nonsensical chimera graph when we do stuff like `correct = {...correct,
...newGraph};`

This PR adds runtime checks (mostly using `tiny-invariant`) to ensure that
graphs have the type we expect.

In doing this refactoring, I discovered a second problem: the
InteractiveGraphEditor sometimes sets the `coords` of the graph to `null`,
which wasn't allowed by `PerseusGraphType` - only `undefined` was allowed.
This PR fixes that by updating `PerseusGraphType` to allow null coords. The
interactive graph code can (thankfully) already handle null values just fine.

Issue: none

## Test plan:
Edit an interactive graph in the exercise editor.