### PR TITLE
Switch from using useRef() to createRef()

### DIFF
--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
@@ -574,10 +574,7 @@ describe("InteractiveGraphEditor", () => {
 
     test("getSaveWarnings returns an error when the graph is invalid", async () => {
         // Arrange
-        jest.spyOn(React, "useRef").mockReturnValue({
-            current: null,
-        });
-        const ref = React.useRef<InteractiveGraphEditor>(null);
+        const ref = React.createRef<InteractiveGraphEditor>();
 
         // Act
         render(
@@ -611,10 +608,7 @@ describe("InteractiveGraphEditor", () => {
 
     test("getSaveWarnings is empty if there are no errors", async () => {
         // Arrange
-        jest.spyOn(React, "useRef").mockReturnValue({
-            current: null,
-        });
-        const ref = React.useRef<InteractiveGraphEditor>(null);
+        const ref = React.createRef<InteractiveGraphEditor>();
 
         // Act
         render(


### PR DESCRIPTION
## Summary:

I noticed a test that was jumping through hoops with spies in order to manage a ref in tests. Using `React.createRef()` is simpler and avoids needing to mock a hook. 

Issue: "none"

## Test plan:

`yarn test` ✅ 