### PR TITLE
Add a "None"-type interactive graph that only displays locked figures

### DIFF
--- a/.changeset/proud-elephants-camp.md
+++ b/.changeset/proud-elephants-camp.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-editor": minor
+---
+
+Add 'None' graph type, for graphs that should only display locked figures.

--- a/dev/gallery.tsx
+++ b/dev/gallery.tsx
@@ -39,6 +39,7 @@ const questions: [PerseusRenderer, number][] = pairWithIndices([
     interactiveGraph.polygonWithAnglesAndAnglesSnapToQuestion,
     interactiveGraph.rayQuestion,
     interactiveGraph.sinusoidQuestion,
+    interactiveGraph.noneQuestion,
     grapher.absoluteValueQuestion,
     grapher.exponentialQuestion,
     grapher.linearQuestion,

--- a/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
+++ b/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
@@ -12,6 +12,7 @@ export const flags = {
         "linear-system": true,
         ray: true,
         point: true,
+        none: true,
 
         // Locked figures flags
         "interactive-graph-locked-features-labels": true,

--- a/packages/perseus-editor/src/__stories__/interactive-graph-editor.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/interactive-graph-editor.stories.tsx
@@ -7,6 +7,7 @@ import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 import {EditorPage} from "..";
+import {interactiveGraphQuestionBuilder} from "../../../perseus/src/widgets/interactive-graphs/interactive-graph-question-builder";
 import {
     angleWithStartingCoordsQuestion,
     circleWithStartingCoordsQuestion,
@@ -128,6 +129,17 @@ export const InteractiveGraphAngle = (): React.ReactElement => {
     return (
         <EditorPageWithStorybookPreview
             question={angleWithStartingCoordsQuestion}
+        />
+    );
+};
+
+export const InteractiveGraphNone = (): React.ReactElement => {
+    return (
+        <EditorPageWithStorybookPreview
+            question={interactiveGraphQuestionBuilder()
+                .withNoInteractiveFigure()
+                .addLockedFunction("5*sin(x)", {color: "red"})
+                .build()}
         />
     );
 };

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
@@ -871,8 +871,6 @@ describe("InteractiveGraphEditor", () => {
 
         const dropdown = screen.getByRole("button", {name: "Answer type:"});
         await userEvent.click(dropdown);
-        expect(
-            screen.getByRole("option", {name: "None"}),
-        ).toBeInTheDocument();
+        expect(screen.getByRole("option", {name: "None"})).toBeInTheDocument();
     });
 });

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
@@ -819,4 +819,60 @@ describe("InteractiveGraphEditor", () => {
             },
         );
     });
+
+    test("does not display a 'None' answer type option by default", async () => {
+        render(
+            <InteractiveGraphEditor
+                {...{
+                    ...mafsProps,
+                    apiOptions: {
+                        ...mafsProps.apiOptions,
+                        flags: {
+                            ...mafsProps.apiOptions.flags,
+                            mafs: {},
+                        },
+                    },
+                }}
+                graph={{type: "none"}}
+                correct={{type: "none"}}
+            />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
+
+        const dropdown = screen.getByRole("button", {name: "Answer type:"});
+        await userEvent.click(dropdown);
+        expect(
+            screen.queryByRole("option", {name: "None"}),
+        ).not.toBeInTheDocument();
+    });
+
+    test("displays a 'None' answer type option when the feature flag is on", async () => {
+        render(
+            <InteractiveGraphEditor
+                {...{
+                    ...mafsProps,
+                    apiOptions: {
+                        ...mafsProps.apiOptions,
+                        flags: {
+                            ...mafsProps.apiOptions.flags,
+                            mafs: {none: true},
+                        },
+                    },
+                }}
+                graph={{type: "none"}}
+                correct={{type: "none"}}
+            />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
+
+        const dropdown = screen.getByRole("button", {name: "Answer type:"});
+        await userEvent.click(dropdown);
+        expect(
+            screen.getByRole("option", {name: "None"}),
+        ).toBeInTheDocument();
+    });
 });

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
@@ -818,5 +818,5 @@ describe("InteractiveGraphEditor", () => {
                 wrapper: RenderStateRoot,
             },
         );
-    })
+    });
 });

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
@@ -72,7 +72,7 @@ describe("InteractiveGraphEditor", () => {
         );
 
         // Act
-        const dropdown = screen.getByRole("button", {name: "Type of Graph:"});
+        const dropdown = screen.getByRole("button", {name: "Answer type:"});
         await userEvent.click(dropdown);
         await userEvent.click(screen.getByRole("option", {name: "Polygon"}));
 
@@ -806,4 +806,17 @@ describe("InteractiveGraphEditor", () => {
             screen.getByRole("textbox", {name: "Description"}),
         ).toBeInTheDocument();
     });
+
+    test("should render for none-type graphs", () => {
+        render(
+            <InteractiveGraphEditor
+                {...mafsProps}
+                graph={{type: "none"}}
+                correct={{type: "none"}}
+            />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
+    })
 });

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-selector.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-selector.tsx
@@ -12,9 +12,10 @@ const GraphTypeSelector = (props: GraphTypeSelectorProps) => {
         <SingleSelect
             selectedValue={props.graphType}
             onChange={props.onChange}
-            placeholder="Select a graph type"
+            placeholder="Select an answer type"
             style={styles.singleSelectShort}
         >
+            <OptionItem value="none" label="None" />
             <OptionItem value="linear" label="Linear function" />
             <OptionItem value="quadratic" label="Quadratic function" />
             <OptionItem value="sinusoid" label="Sinusoid function" />

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-selector.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-selector.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 type GraphTypeSelectorProps = {
     graphType: string;
     onChange: (newGraphType: string) => void;
+    showNoneOption: boolean;
 };
 
 const GraphTypeSelector = (props: GraphTypeSelectorProps) => {
@@ -15,7 +16,7 @@ const GraphTypeSelector = (props: GraphTypeSelectorProps) => {
             placeholder="Select an answer type"
             style={styles.singleSelectShort}
         >
-            <OptionItem value="none" label="None" />
+            {props.showNoneOption && <OptionItem value="none" label="None" />}
             <OptionItem value="linear" label="Linear function" />
             <OptionItem value="quadratic" label="Quadratic function" />
             <OptionItem value="sinusoid" label="Sinusoid function" />

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
@@ -366,6 +366,9 @@ class InteractiveGraphEditor extends React.Component<Props> {
                                 correct: {type},
                             });
                         }}
+                        showNoneOption={
+                            this.props.apiOptions?.flags?.mafs?.["none"]
+                        }
                     />
                 </LabeledRow>
                 {this.props.graph &&

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
@@ -28,7 +28,7 @@ import SegmentCountSelector from "./components/segment-count-selector";
 import LabeledRow from "./locked-figures/labeled-row";
 import LockedFiguresSection from "./locked-figures/locked-figures-section";
 import StartCoordsSettings from "./start-coords/start-coords-settings";
-import {shouldShowStartCoordsUI} from "./start-coords/util";
+import {getStartCoords, shouldShowStartCoordsUI} from "./start-coords/util";
 
 import type {
     APIOptionsWithDefaults,
@@ -228,15 +228,10 @@ class InteractiveGraphEditor extends React.Component<Props> {
             _.extend(json, {
                 graph: {
                     type: correct.type,
+                    startCoords: this.props.graph && getStartCoords(this.props.graph),
                 },
                 correct: correct,
             });
-
-            if (this.props.graph != null && "startCoords" in this.props.graph) {
-                // FIXME
-                // @ts-expect-error
-                json.graph.startCoords = this.props.graph.startCoords;
-            }
 
             _.each(
                 [

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
@@ -228,7 +228,8 @@ class InteractiveGraphEditor extends React.Component<Props> {
             _.extend(json, {
                 graph: {
                     type: correct.type,
-                    startCoords: this.props.graph && getStartCoords(this.props.graph),
+                    startCoords:
+                        this.props.graph && getStartCoords(this.props.graph),
                 },
                 correct: correct,
             });

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
@@ -228,10 +228,15 @@ class InteractiveGraphEditor extends React.Component<Props> {
             _.extend(json, {
                 graph: {
                     type: correct.type,
-                    startCoords: this.props.graph?.startCoords,
                 },
                 correct: correct,
             });
+
+            if (this.props.graph != null && "startCoords" in this.props.graph) {
+                // FIXME
+                // @ts-expect-error
+                json.graph.startCoords = this.props.graph.startCoords;
+            }
 
             _.each(
                 [
@@ -351,7 +356,7 @@ class InteractiveGraphEditor extends React.Component<Props> {
 
         return (
             <View>
-                <LabeledRow label="Type of Graph:">
+                <LabeledRow label="Answer type:">
                     <GraphTypeSelector
                         graphType={
                             this.props.graph?.type ??
@@ -799,6 +804,9 @@ function mergeGraphs(
             return {...a, ...b};
         case "linear-system":
             invariant(b.type === "linear-system");
+            return {...a, ...b};
+        case "none":
+            invariant(b.type === "none");
             return {...a, ...b};
         case "point":
             invariant(b.type === "point");

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-angle.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-angle.tsx
@@ -13,12 +13,13 @@ import CoordinatePairInput from "../../../components/coordinate-pair-input";
 
 import {getAngleEquation} from "./util";
 
-import type {StartCoords} from "./types";
 import type {Coord} from "@khanacademy/perseus";
 
+type AngleCoords = [Coord, Coord, Coord];
+
 type Props = {
-    startCoords: [Coord, Coord, Coord];
-    onChange: (startCoords: StartCoords) => void;
+    startCoords: AngleCoords;
+    onChange: (startCoords: AngleCoords) => void;
 };
 
 const StartCoordsAngle = (props: Props) => {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-angle.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-angle.tsx
@@ -17,6 +17,8 @@ import type {Coord, PerseusGraphType} from "@khanacademy/perseus";
 
 type Props = {
     startCoords: [Coord, Coord, Coord];
+    // FIXME
+    // @ts-expect-error
     onChange: (startCoords: PerseusGraphType["startCoords"]) => void;
 };
 

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-angle.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-angle.tsx
@@ -13,13 +13,12 @@ import CoordinatePairInput from "../../../components/coordinate-pair-input";
 
 import {getAngleEquation} from "./util";
 
-import type {Coord, PerseusGraphType} from "@khanacademy/perseus";
+import type {Coord} from "@khanacademy/perseus";
+import type {StartCoords} from "./types";
 
 type Props = {
     startCoords: [Coord, Coord, Coord];
-    // FIXME
-    // @ts-expect-error
-    onChange: (startCoords: PerseusGraphType["startCoords"]) => void;
+    onChange: (startCoords: StartCoords) => void;
 };
 
 const StartCoordsAngle = (props: Props) => {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-angle.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-angle.tsx
@@ -13,8 +13,8 @@ import CoordinatePairInput from "../../../components/coordinate-pair-input";
 
 import {getAngleEquation} from "./util";
 
-import type {Coord} from "@khanacademy/perseus";
 import type {StartCoords} from "./types";
+import type {Coord} from "@khanacademy/perseus";
 
 type Props = {
     startCoords: [Coord, Coord, Coord];

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-circle.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-circle.tsx
@@ -8,15 +8,16 @@ import * as React from "react";
 import CoordinatePairInput from "../../../components/coordinate-pair-input";
 import ScrolllessNumberTextField from "../../../components/scrollless-number-text-field";
 
-import type {StartCoords} from "./types";
 import type {Coord} from "@khanacademy/perseus";
 
+type CircleCoords = {
+    center: Coord;
+    radius: number;
+};
+
 type Props = {
-    startCoords: {
-        center: Coord;
-        radius: number;
-    };
-    onChange: (startCoords: StartCoords) => void;
+    startCoords: CircleCoords;
+    onChange: (startCoords: CircleCoords) => void;
 };
 
 const StartCoordsCircle = (props: Props) => {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-circle.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-circle.tsx
@@ -8,16 +8,15 @@ import * as React from "react";
 import CoordinatePairInput from "../../../components/coordinate-pair-input";
 import ScrolllessNumberTextField from "../../../components/scrollless-number-text-field";
 
-import type {Coord, PerseusGraphType} from "@khanacademy/perseus";
+import type {Coord} from "@khanacademy/perseus";
+import type {StartCoords} from "./types";
 
 type Props = {
     startCoords: {
         center: Coord;
         radius: number;
     };
-    // FIXME
-    // @ts-expect-error
-    onChange: (startCoords: PerseusGraphType["startCoords"]) => void;
+    onChange: (startCoords: StartCoords) => void;
 };
 
 const StartCoordsCircle = (props: Props) => {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-circle.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-circle.tsx
@@ -15,6 +15,8 @@ type Props = {
         center: Coord;
         radius: number;
     };
+    // FIXME
+    // @ts-expect-error
     onChange: (startCoords: PerseusGraphType["startCoords"]) => void;
 };
 

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-circle.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-circle.tsx
@@ -8,8 +8,8 @@ import * as React from "react";
 import CoordinatePairInput from "../../../components/coordinate-pair-input";
 import ScrolllessNumberTextField from "../../../components/scrollless-number-text-field";
 
-import type {Coord} from "@khanacademy/perseus";
 import type {StartCoords} from "./types";
+import type {Coord} from "@khanacademy/perseus";
 
 type Props = {
     startCoords: {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-line.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-line.tsx
@@ -7,8 +7,8 @@ import * as React from "react";
 
 import CoordinatePairInput from "../../../components/coordinate-pair-input";
 
-import type {CollinearTuple} from "@khanacademy/perseus";
 import type {StartCoords} from "./types";
+import type {CollinearTuple} from "@khanacademy/perseus";
 
 type Props = {
     startCoords: CollinearTuple;

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-line.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-line.tsx
@@ -7,12 +7,11 @@ import * as React from "react";
 
 import CoordinatePairInput from "../../../components/coordinate-pair-input";
 
-import type {StartCoords} from "./types";
 import type {CollinearTuple} from "@khanacademy/perseus";
 
 type Props = {
     startCoords: CollinearTuple;
-    onChange: (startCoords: StartCoords) => void;
+    onChange: (startCoords: CollinearTuple) => void;
 };
 
 const StartCoordsLine = (props: Props) => {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-line.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-line.tsx
@@ -11,6 +11,8 @@ import type {CollinearTuple, PerseusGraphType} from "@khanacademy/perseus";
 
 type Props = {
     startCoords: CollinearTuple;
+    // FIXME
+    // @ts-expect-error
     onChange: (startCoords: PerseusGraphType["startCoords"]) => void;
 };
 

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-line.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-line.tsx
@@ -7,13 +7,12 @@ import * as React from "react";
 
 import CoordinatePairInput from "../../../components/coordinate-pair-input";
 
-import type {CollinearTuple, PerseusGraphType} from "@khanacademy/perseus";
+import type {CollinearTuple} from "@khanacademy/perseus";
+import type {StartCoords} from "./types";
 
 type Props = {
     startCoords: CollinearTuple;
-    // FIXME
-    // @ts-expect-error
-    onChange: (startCoords: PerseusGraphType["startCoords"]) => void;
+    onChange: (startCoords: StartCoords) => void;
 };
 
 const StartCoordsLine = (props: Props) => {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-multiline.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-multiline.tsx
@@ -8,8 +8,8 @@ import * as React from "react";
 import CoordinatePairInput from "../../../components/coordinate-pair-input";
 import PerseusEditorAccordion from "../../../components/perseus-editor-accordion";
 
-import type {CollinearTuple} from "@khanacademy/perseus";
 import type {StartCoords} from "./types";
+import type {CollinearTuple} from "@khanacademy/perseus";
 
 type Props = {
     type: "linear-system" | "segment";

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-multiline.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-multiline.tsx
@@ -13,6 +13,8 @@ import type {CollinearTuple, PerseusGraphType} from "@khanacademy/perseus";
 type Props = {
     type: "linear-system" | "segment";
     startCoords: CollinearTuple[];
+    // FIXME
+    // @ts-expect-error
     onChange: (startCoords: PerseusGraphType["startCoords"]) => void;
 };
 

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-multiline.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-multiline.tsx
@@ -8,14 +8,13 @@ import * as React from "react";
 import CoordinatePairInput from "../../../components/coordinate-pair-input";
 import PerseusEditorAccordion from "../../../components/perseus-editor-accordion";
 
-import type {CollinearTuple, PerseusGraphType} from "@khanacademy/perseus";
+import type {CollinearTuple} from "@khanacademy/perseus";
+import type {StartCoords} from "./types";
 
 type Props = {
     type: "linear-system" | "segment";
     startCoords: CollinearTuple[];
-    // FIXME
-    // @ts-expect-error
-    onChange: (startCoords: PerseusGraphType["startCoords"]) => void;
+    onChange: (startCoords: StartCoords) => void;
 };
 
 const StartCoordsMultiline = (props: Props) => {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-multiline.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-multiline.tsx
@@ -8,13 +8,12 @@ import * as React from "react";
 import CoordinatePairInput from "../../../components/coordinate-pair-input";
 import PerseusEditorAccordion from "../../../components/perseus-editor-accordion";
 
-import type {StartCoords} from "./types";
 import type {CollinearTuple} from "@khanacademy/perseus";
 
 type Props = {
     type: "linear-system" | "segment";
     startCoords: CollinearTuple[];
-    onChange: (startCoords: StartCoords) => void;
+    onChange: (startCoords: CollinearTuple[]) => void;
 };
 
 const StartCoordsMultiline = (props: Props) => {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-point.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-point.tsx
@@ -7,12 +7,11 @@ import * as React from "react";
 
 import CoordinatePairInput from "../../../components/coordinate-pair-input";
 
-import type {StartCoords} from "./types";
 import type {Coord} from "@khanacademy/perseus";
 
 type Props = {
     startCoords: ReadonlyArray<Coord>;
-    onChange: (startCoords: StartCoords) => void;
+    onChange: (startCoords: ReadonlyArray<Coord>) => void;
 };
 
 const StartCoordsPoint = (props: Props) => {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-point.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-point.tsx
@@ -11,6 +11,8 @@ import type {Coord, PerseusGraphType} from "@khanacademy/perseus";
 
 type Props = {
     startCoords: ReadonlyArray<Coord>;
+    // FIXME
+    // @ts-expect-error
     onChange: (startCoords: PerseusGraphType["startCoords"]) => void;
 };
 

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-point.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-point.tsx
@@ -7,13 +7,12 @@ import * as React from "react";
 
 import CoordinatePairInput from "../../../components/coordinate-pair-input";
 
-import type {Coord, PerseusGraphType} from "@khanacademy/perseus";
+import type {StartCoords} from "./types";
+import type {Coord} from "@khanacademy/perseus";
 
 type Props = {
     startCoords: ReadonlyArray<Coord>;
-    // FIXME
-    // @ts-expect-error
-    onChange: (startCoords: PerseusGraphType["startCoords"]) => void;
+    onChange: (startCoords: StartCoords) => void;
 };
 
 const StartCoordsPoint = (props: Props) => {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-quadratic.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-quadratic.tsx
@@ -13,12 +13,12 @@ import CoordinatePairInput from "../../../components/coordinate-pair-input";
 
 import {getQuadraticEquation} from "./util";
 
-import type {Coord, PerseusGraphType} from "@khanacademy/perseus";
+import type {StartCoords} from "./types";
+import type {Coord} from "@khanacademy/perseus";
 
 type Props = {
     startCoords: [Coord, Coord, Coord];
-    // @ts-expect-error
-    onChange: (startCoords: PerseusGraphType["startCoords"]) => void;
+    onChange: (startCoords: StartCoords) => void;
 };
 
 const StartCoordsQuadratic = (props: Props) => {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-quadratic.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-quadratic.tsx
@@ -13,12 +13,11 @@ import CoordinatePairInput from "../../../components/coordinate-pair-input";
 
 import {getQuadraticEquation} from "./util";
 
-import type {StartCoords} from "./types";
 import type {Coord} from "@khanacademy/perseus";
 
 type Props = {
     startCoords: [Coord, Coord, Coord];
-    onChange: (startCoords: StartCoords) => void;
+    onChange: (startCoords: [Coord, Coord, Coord]) => void;
 };
 
 const StartCoordsQuadratic = (props: Props) => {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-quadratic.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-quadratic.tsx
@@ -17,6 +17,7 @@ import type {Coord, PerseusGraphType} from "@khanacademy/perseus";
 
 type Props = {
     startCoords: [Coord, Coord, Coord];
+    // @ts-expect-error
     onChange: (startCoords: PerseusGraphType["startCoords"]) => void;
 };
 

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.tsx
@@ -28,8 +28,8 @@ import StartCoordsQuadratic from "./start-coords-quadratic";
 import StartCoordsSinusoid from "./start-coords-sinusoid";
 import {getDefaultGraphStartCoords} from "./util";
 
-import type {PerseusGraphType, Range} from "@khanacademy/perseus";
 import type {StartCoords} from "./types";
+import type {PerseusGraphType, Range} from "@khanacademy/perseus";
 
 type Props = PerseusGraphType & {
     range: [x: Range, y: Range];

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.tsx
@@ -33,6 +33,8 @@ import type {PerseusGraphType, Range} from "@khanacademy/perseus";
 type Props = PerseusGraphType & {
     range: [x: Range, y: Range];
     step: [x: number, y: number];
+    // FIXME
+    // @ts-expect-error
     onChange: (startCoords: PerseusGraphType["startCoords"]) => void;
 };
 

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.tsx
@@ -29,13 +29,12 @@ import StartCoordsSinusoid from "./start-coords-sinusoid";
 import {getDefaultGraphStartCoords} from "./util";
 
 import type {PerseusGraphType, Range} from "@khanacademy/perseus";
+import type {StartCoords} from "./types";
 
 type Props = PerseusGraphType & {
     range: [x: Range, y: Range];
     step: [x: number, y: number];
-    // FIXME
-    // @ts-expect-error
-    onChange: (startCoords: PerseusGraphType["startCoords"]) => void;
+    onChange: (startCoords: StartCoords) => void;
 };
 
 const StartCoordsSettingsInner = (props: Props) => {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-sinusoid.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-sinusoid.tsx
@@ -15,7 +15,7 @@ import {getSinusoidEquation} from "./util";
 
 import type {Coord, PerseusGraphType} from "@khanacademy/perseus";
 
-type PerseusGraphTypeSinusoid = Extract<PerseusGraphType, {type: "sinusoid"}>
+type PerseusGraphTypeSinusoid = Extract<PerseusGraphType, {type: "sinusoid"}>;
 
 type Props = {
     startCoords: [Coord, Coord];

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-sinusoid.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-sinusoid.tsx
@@ -15,9 +15,11 @@ import {getSinusoidEquation} from "./util";
 
 import type {Coord, PerseusGraphType} from "@khanacademy/perseus";
 
+type PerseusGraphTypeSinusoid = Extract<PerseusGraphType, {type: "sinusoid"}>
+
 type Props = {
     startCoords: [Coord, Coord];
-    onChange: (startCoords: PerseusGraphType["startCoords"]) => void;
+    onChange: (startCoords: PerseusGraphTypeSinusoid["startCoords"]) => void;
 };
 
 const StartCoordsSinusoid = (props: Props) => {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-sinusoid.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-sinusoid.tsx
@@ -13,13 +13,13 @@ import CoordinatePairInput from "../../../components/coordinate-pair-input";
 
 import {getSinusoidEquation} from "./util";
 
-import type {Coord, PerseusGraphType} from "@khanacademy/perseus";
+import type {Coord} from "@khanacademy/perseus";
 
-type PerseusGraphTypeSinusoid = Extract<PerseusGraphType, {type: "sinusoid"}>;
+type SinusoidCoords = [Coord, Coord];
 
 type Props = {
-    startCoords: [Coord, Coord];
-    onChange: (startCoords: PerseusGraphTypeSinusoid["startCoords"]) => void;
+    startCoords: SinusoidCoords;
+    onChange: (startCoords: SinusoidCoords) => void;
 };
 
 const StartCoordsSinusoid = (props: Props) => {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/types.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/types.ts
@@ -1,0 +1,18 @@
+import {PerseusGraphType} from "@khanacademy/perseus";
+
+type GraphTypesThatHaveStartCoords =
+    | {type: "angle"}
+    | {type: "circle"}
+    | {type: "linear"}
+    | {type: "linear-system"}
+    | {type: "point"}
+    | {type: "polygon"}
+    | {type: "quadratic"}
+    | {type: "ray"}
+    | {type: "segment"}
+    | {type: "sinusoid"}
+
+export type StartCoords = Extract<
+    PerseusGraphType,
+    GraphTypesThatHaveStartCoords
+>["startCoords"];

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/types.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/types.ts
@@ -1,4 +1,4 @@
-import {PerseusGraphType} from "@khanacademy/perseus";
+import type {PerseusGraphType} from "@khanacademy/perseus";
 
 type GraphTypesThatHaveStartCoords =
     | {type: "angle"}
@@ -10,7 +10,7 @@ type GraphTypesThatHaveStartCoords =
     | {type: "quadratic"}
     | {type: "ray"}
     | {type: "segment"}
-    | {type: "sinusoid"}
+    | {type: "sinusoid"};
 
 export type StartCoords = Extract<
     PerseusGraphType,

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/util.test.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/util.test.ts
@@ -420,4 +420,13 @@ describe("shouldShowStartCoordsUI", () => {
 
         expect(shouldShowStartCoordsUI(graph, isStatic)).toBe(false);
     });
+
+    it("returns true for other graph types", () => {
+        const isStatic = false;
+        const graph: PerseusGraphType = {
+            type: "linear",
+        };
+
+        expect(shouldShowStartCoordsUI(graph, isStatic)).toBe(true);
+    });
 });

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/util.test.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/util.test.ts
@@ -3,6 +3,7 @@ import {
     getDefaultGraphStartCoords,
     getQuadraticEquation,
     getSinusoidEquation,
+    shouldShowStartCoordsUI,
 } from "./util";
 
 import type {PerseusGraphType, Range} from "@khanacademy/perseus";
@@ -335,4 +336,88 @@ describe("getAngleEquation", () => {
             expect(equation).toBe(expected);
         },
     );
+});
+
+describe("shouldShowStartCoordsUI", () => {
+    it("returns false for a static graph", () => {
+        const isStatic = true;
+        const graph: PerseusGraphType = {
+            type: "point",
+        };
+
+        expect(shouldShowStartCoordsUI(graph, isStatic)).toBe(false);
+    });
+
+    it("returns false for an unlimited point graph", () => {
+        const isStatic = false;
+        const graph: PerseusGraphType = {
+            type: "point",
+            numPoints: "unlimited",
+        };
+
+        expect(shouldShowStartCoordsUI(graph, isStatic)).toBe(false);
+    });
+
+    it("returns true for a point graph with a fixed number of points", () => {
+        const isStatic = false;
+        const graph: PerseusGraphType = {
+            type: "point",
+            numPoints: 3,
+        };
+
+        expect(shouldShowStartCoordsUI(graph, isStatic)).toBe(true);
+    });
+
+    it("returns false for a polygon graph with unlimited sides", () => {
+        const isStatic = false;
+        const graph: PerseusGraphType = {
+            type: "polygon",
+            numSides: "unlimited",
+            snapTo: "grid",
+        };
+
+        expect(shouldShowStartCoordsUI(graph, isStatic)).toBe(false);
+    });
+
+    it("returns false for a polygon graph with angle snapping", () => {
+        const isStatic = false;
+        const graph: PerseusGraphType = {
+            type: "polygon",
+            numSides: 3,
+            snapTo: "angles",
+        };
+
+        expect(shouldShowStartCoordsUI(graph, isStatic)).toBe(false);
+    });
+
+    it("returns false for a polygon graph with side snapping", () => {
+        const isStatic = false;
+        const graph: PerseusGraphType = {
+            type: "polygon",
+            numSides: 3,
+            snapTo: "sides",
+        };
+
+        expect(shouldShowStartCoordsUI(graph, isStatic)).toBe(false);
+    });
+
+    it("returns true for a polygon graph with grid snapping and a fixed number of sides", () => {
+        const isStatic = false;
+        const graph: PerseusGraphType = {
+            type: "polygon",
+            numSides: 3,
+            snapTo: "grid",
+        };
+
+        expect(shouldShowStartCoordsUI(graph, isStatic)).toBe(true);
+    });
+
+    it("returns false for a none-type graph", () => {
+        const isStatic = false;
+        const graph: PerseusGraphType = {
+            type: "none",
+        };
+
+        expect(shouldShowStartCoordsUI(graph, isStatic)).toBe(false);
+    });
 });

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/util.test.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/util.test.ts
@@ -401,6 +401,17 @@ describe("shouldShowStartCoordsUI", () => {
         expect(shouldShowStartCoordsUI(graph, isStatic)).toBe(false);
     });
 
+    it("returns true for a polygon graph with no snapping behavior specified", () => {
+        // snapTo defaults to "grid"
+        const isStatic = false;
+        const graph: PerseusGraphType = {
+            type: "polygon",
+            numSides: 3,
+        };
+
+        expect(shouldShowStartCoordsUI(graph, isStatic)).toBe(true);
+    });
+
     it("returns true for a polygon graph with grid snapping and a fixed number of sides", () => {
         const isStatic = false;
         const graph: PerseusGraphType = {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/util.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/util.ts
@@ -12,14 +12,20 @@ import {
 } from "@khanacademy/perseus";
 
 import type {Range, PerseusGraphType, Coord} from "@khanacademy/perseus";
+import type {StartCoords} from "./types";
+
+export function getStartCoords(graph: PerseusGraphType): StartCoords {
+    if ("startCoords" in graph) {
+        return graph.startCoords
+    }
+    return undefined;
+}
 
 export function getDefaultGraphStartCoords(
     graph: PerseusGraphType,
     range: [x: Range, y: Range],
     step: [x: number, y: number],
-    // FIXME
-    // @ts-expect-error
-): PerseusGraphType["startCoords"] {
+): StartCoords {
     switch (graph.type) {
         case "linear":
         case "ray":

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/util.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/util.ts
@@ -10,6 +10,7 @@ import {
     getSegmentCoords,
     getSinusoidCoords,
 } from "@khanacademy/perseus";
+import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
 
 import type {StartCoords} from "./types";
 import type {Range, PerseusGraphType, Coord} from "@khanacademy/perseus";
@@ -172,18 +173,23 @@ export const shouldShowStartCoordsUI = (
         return false;
     }
 
-    if (graph.type === "point" && graph.numPoints === "unlimited") {
-        return false;
+    switch (graph.type) {
+        case "point":
+            return graph.numPoints !== "unlimited";
+        case "polygon":
+            return graph.numSides !== "unlimited" && graph.snapTo === "grid";
+        case "none":
+            return false;
+        case "angle":
+        case "circle":
+        case "linear":
+        case "linear-system":
+        case "quadratic":
+        case "ray":
+        case "segment":
+        case "sinusoid":
+            return true;
+        default:
+            throw new UnreachableCaseError(graph);
     }
-
-    if (
-        graph.type === "polygon" &&
-        (graph.numSides === "unlimited" ||
-            graph.snapTo === "angles" ||
-            graph.snapTo === "sides")
-    ) {
-        return false;
-    }
-
-    return true;
 };

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/util.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/util.ts
@@ -177,7 +177,11 @@ export const shouldShowStartCoordsUI = (
         case "point":
             return graph.numPoints !== "unlimited";
         case "polygon":
-            return graph.numSides !== "unlimited" && graph.snapTo === "grid";
+            return (
+                graph.numSides !== "unlimited" &&
+                graph.snapTo !== "angles" &&
+                graph.snapTo !== "sides"
+            );
         case "none":
             return false;
         case "angle":

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/util.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/util.ts
@@ -17,6 +17,8 @@ export function getDefaultGraphStartCoords(
     graph: PerseusGraphType,
     range: [x: Range, y: Range],
     step: [x: number, y: number],
+    // FIXME
+    // @ts-expect-error
 ): PerseusGraphType["startCoords"] {
     switch (graph.type) {
         case "linear":

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/util.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/util.ts
@@ -11,12 +11,12 @@ import {
     getSinusoidCoords,
 } from "@khanacademy/perseus";
 
-import type {Range, PerseusGraphType, Coord} from "@khanacademy/perseus";
 import type {StartCoords} from "./types";
+import type {Range, PerseusGraphType, Coord} from "@khanacademy/perseus";
 
 export function getStartCoords(graph: PerseusGraphType): StartCoords {
     if ("startCoords" in graph) {
-        return graph.startCoords
+        return graph.startCoords;
     }
     return undefined;
 }

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -717,6 +717,8 @@ export type LockedFigure =
     | LockedLabelType;
 export type LockedFigureType = LockedFigure["type"];
 
+export type LockedLineStyle = "solid" | "dashed";
+
 export type LockedPointType = {
     type: "point";
     coord: Coord;
@@ -729,7 +731,7 @@ export type LockedLineType = {
     kind: "line" | "ray" | "segment";
     points: [point1: LockedPointType, point2: LockedPointType];
     color: LockedFigureColor;
-    lineStyle: "solid" | "dashed";
+    lineStyle: LockedLineStyle;
     showPoint1: boolean;
     showPoint2: boolean;
 };
@@ -755,7 +757,7 @@ export type LockedEllipseType = {
     angle: number;
     color: LockedFigureColor;
     fillStyle: LockedFigureFillType;
-    strokeStyle: "solid" | "dashed";
+    strokeStyle: LockedLineStyle;
 };
 
 export type LockedPolygonType = {
@@ -764,13 +766,13 @@ export type LockedPolygonType = {
     color: LockedFigureColor;
     showVertices: boolean;
     fillStyle: LockedFigureFillType;
-    strokeStyle: "solid" | "dashed";
+    strokeStyle: LockedLineStyle;
 };
 
 export type LockedFunctionType = {
     type: "function";
     color: LockedFigureColor;
-    strokeStyle: "solid" | "dashed";
+    strokeStyle: LockedLineStyle;
     equation: string; // This is the user-defined equation (as it was typed)
     directionalAxis: "x" | "y";
     domain?: Interval;

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -791,6 +791,7 @@ export type PerseusGraphType =
     | PerseusGraphTypeCircle
     | PerseusGraphTypeLinear
     | PerseusGraphTypeLinearSystem
+    | PerseusGraphTypeNone
     | PerseusGraphTypePoint
     | PerseusGraphTypePolygon
     | PerseusGraphTypeQuadratic
@@ -848,6 +849,10 @@ export type PerseusGraphTypeLinearSystem = {
     // The initial coordinates the graph renders with.
     startCoords?: CollinearTuple[];
 } & PerseusGraphTypeCommon;
+
+export type PerseusGraphTypeNone = {
+    type: "none"
+}
 
 export type PerseusGraphTypePoint = {
     type: "point";

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -851,8 +851,8 @@ export type PerseusGraphTypeLinearSystem = {
 } & PerseusGraphTypeCommon;
 
 export type PerseusGraphTypeNone = {
-    type: "none"
-}
+    type: "none";
+};
 
 export type PerseusGraphTypePoint = {
     type: "point";

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -144,6 +144,8 @@ export const MafsGraphTypeFlags = [
     "point",
     /** Enable the `unlimited-point` interactive graph type */
     "unlimited-point",
+    /** Enable the `none` interactive graph type for content editors */
+    "none",
 ] as const;
 
 export const InteractiveGraphLockedFeaturesFlags = [

--- a/packages/perseus/src/widgets/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.test.tsx
@@ -9,7 +9,7 @@ import type {
     PerseusGraphTypeLinear,
     PerseusGraphTypePoint,
     PerseusGraphTypePolygon,
-    PerseusGraphType,
+    PerseusGraphType, PerseusGraphTypeNone,
 } from "../perseus-types";
 
 function createRubric(graph: PerseusGraphType): Rubric {
@@ -323,4 +323,13 @@ describe("shouldUseMafs", () => {
 
         expect(shouldUseMafs(mafsFlags, graph)).toBe(true);
     });
+
+    it("is always true for a 'none' graph (no interactive element)", () => {
+        const graph: PerseusGraphTypeNone = {
+            type: "none",
+        };
+        const mafsFlags = {};
+
+        expect(shouldUseMafs(mafsFlags, graph)).toBe(true);
+    })
 });

--- a/packages/perseus/src/widgets/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.test.tsx
@@ -9,7 +9,8 @@ import type {
     PerseusGraphTypeLinear,
     PerseusGraphTypePoint,
     PerseusGraphTypePolygon,
-    PerseusGraphType, PerseusGraphTypeNone,
+    PerseusGraphType,
+    PerseusGraphTypeNone,
 } from "../perseus-types";
 
 function createRubric(graph: PerseusGraphType): Rubric {
@@ -331,5 +332,5 @@ describe("shouldUseMafs", () => {
         const mafsFlags = {};
 
         expect(shouldUseMafs(mafsFlags, graph)).toBe(true);
-    })
+    });
 });

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -2377,7 +2377,7 @@ class InteractiveGraph extends React.Component<Props, State> {
                 earned: 0,
                 total: 0,
                 message: null,
-            }
+            };
         }
 
         // When nothing has moved, there will neither be coords nor the

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -517,6 +517,10 @@ class LegacyInteractiveGraph extends React.Component<Props, State> {
         this.line?.remove();
     };
 
+    addNoneControls: () => void = () => {};
+
+    removeNoneControls: () => void = () => {};
+
     addLinearControls: () => void = () => {
         this.addLine("line");
     };
@@ -2177,6 +2181,10 @@ class InteractiveGraph extends React.Component<Props, State> {
         });
     }
 
+    static getNoneEquationString(): string {
+        return ""
+    }
+
     static getLinearEquationString(props: Props): string {
         const coords = InteractiveGraph.getLineCoords(props.graph, props);
         if (eq(coords[0][0], coords[1][0])) {
@@ -2655,6 +2663,8 @@ export function shouldUseMafs(
     }
 
     switch (graph.type) {
+        case "none":
+            return true;
         case "point":
             if (graph.numPoints === UNLIMITED) {
                 return Boolean(mafsFlags["unlimited-point"]);

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -2182,7 +2182,7 @@ class InteractiveGraph extends React.Component<Props, State> {
     }
 
     static getNoneEquationString(): string {
-        return ""
+        return "";
     }
 
     static getLinearEquationString(props: Props): string {

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -2370,6 +2370,16 @@ class InteractiveGraph extends React.Component<Props, State> {
         rubric: Rubric,
         component: any,
     ): PerseusScore {
+        // None-type graphs are not graded
+        if (userInput.type === "none" && rubric.correct.type === "none") {
+            return {
+                type: "points",
+                earned: 0,
+                total: 0,
+                message: null,
+            }
+        }
+
         // When nothing has moved, there will neither be coords nor the
         // circle's center/radius fields. When those fields are absent, skip
         // all these checks; just go mark the answer as empty.

--- a/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
@@ -1,5 +1,1104 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`interactive-graph widget A none-type graph renders predictably: first render 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <div
+            class="perseus-widget perseus-widget-interactive-graph"
+            style="width: 400px; height: 400px;"
+          >
+            <div
+              class="graphie-container above-scratchpad"
+              style="width: 400px; height: 400px;"
+            >
+              <div
+                class="graphie"
+                style="position: relative; width: 400px; height: 400px;"
+              >
+                <svg
+                  height="400"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
+                  version="1.1"
+                  width="400"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                </svg>
+                <svg
+                  height="400"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  version="1.1"
+                  width="400"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <path
+                    d="M0,400L0,0"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M20,400L20,0"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M40,400L40,0"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M60,400L60,0"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M80,400L80,0"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M100,400L100,0"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M120,400L120,0"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M140,400L140,0"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M160,400L160,0"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M180,400L180,0"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M200,400L200,0"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M220,400L220,0"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M240,400L240,0"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M260,400L260,0"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M280,400L280,0"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M300,400L300,0"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M320,400L320,0"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M340,400L340,0"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M360,400L360,0"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M380,400L380,0"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M400,400L400,0"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M0,400L400,400"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M0,380L400,380"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M0,360L400,360"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M0,340L400,340"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M0,320L400,320"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M0,300L400,300"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M0,280L400,280"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M0,260L400,260"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M0,240L400,240"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M0,220L400,220"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M0,200L400,200"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M0,180L400,180"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M0,160L400,160"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M0,140L400,140"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M0,120L400,120"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M0,100L400,100"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M0,80L400,80"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M0,60L400,60"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M0,40L400,40"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M0,20L400,20"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M0,0L400,0"
+                    fill="none"
+                    opacity="0.1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
+                  />
+                  <path
+                    d="M-3.4499999999999886,205.6C-3.0999999999999885,203.5,0.7500000000000115,200.35,1.8000000000000114,200C0.7500000000000113,199.65,-3.099999999999989,196.5,-3.4499999999999886,194.4"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1; stroke-linejoin: round; stroke-linecap: round;"
+                    transform="rotate(180 1.8000000000000114 200)"
+                  />
+                  <path
+                    d="M200,200C200,200,200,200,1.0500000000000114,200"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
+                  />
+                  <path
+                    d="M394.45,205.6C394.8,203.5,398.65,200.35,399.7,200C398.65,199.65,394.8,196.5,394.45,194.4"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1; stroke-linejoin: round; stroke-linecap: round;"
+                    transform=""
+                  />
+                  <path
+                    d="M200,200C200,200,200,200,398.95,200"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
+                  />
+                  <path
+                    d="M195.5,404.55C195.85,402.45,199.7,399.3,200.75,398.95C199.7,398.59999999999997,195.85,395.45,195.5,393.34999999999997"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1; stroke-linejoin: round; stroke-linecap: round;"
+                    transform="rotate(90 200.75 398.95)"
+                  />
+                  <path
+                    d="M200,200C200,200,200,200,200,398.95"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
+                  />
+                  <path
+                    d="M195.5,6.650000000000011C195.85,4.550000000000011,199.7,1.400000000000011,200.75,1.0500000000000114C199.7,0.7000000000000114,195.85,-2.4499999999999886,195.5,-4.549999999999988"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1; stroke-linejoin: round; stroke-linecap: round;"
+                    transform="rotate(-90 200.75 1.0500000000000114)"
+                  />
+                  <path
+                    d="M200,200C200,200,200,200,200,1.0500000000000114"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
+                  />
+                  <path
+                    d="M220,205L220,195"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M240,205L240,195"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M260,205L260,195"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M280,205L280,195"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M300,205L300,195"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M320,205L320,195"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M340,205L340,195"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M360,205L360,195"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M380,205L380,195"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M180,205L180,195"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M160,205L160,195"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M140,205L140,195"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M120,205L120,195"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M100,205L100,195"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M80,205L80,195"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M60,205L60,195"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M40,205L40,195"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M20,205L20,195"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M195,180L205,180"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M195,160L205,160"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M195,140L205,140"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M195,120L205,120"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M195,100L205,100"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M195,80L205,80"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M195,60L205,60"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M195,40L205,40"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M195,20L205,20"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M195,220L205,220"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M195,240L205,240"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M195,260L205,260"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M195,280L205,280"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M195,300L205,300"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M195,320L205,320"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M195,340L205,340"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M195,360L205,360"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                  <path
+                    d="M195,380L205,380"
+                    fill="none"
+                    opacity="1"
+                    stroke="#000000"
+                    stroke-width="1"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
+                  />
+                </svg>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{1}"
+                  style="position: absolute; padding: 7px; color: black; left: 220px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{2}"
+                  style="position: absolute; padding: 7px; color: black; left: 240px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{3}"
+                  style="position: absolute; padding: 7px; color: black; left: 260px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{4}"
+                  style="position: absolute; padding: 7px; color: black; left: 280px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{5}"
+                  style="position: absolute; padding: 7px; color: black; left: 300px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{6}"
+                  style="position: absolute; padding: 7px; color: black; left: 320px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{7}"
+                  style="position: absolute; padding: 7px; color: black; left: 340px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{8}"
+                  style="position: absolute; padding: 7px; color: black; left: 360px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{9}"
+                  style="position: absolute; padding: 7px; color: black; left: 380px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{\\llap{-}2}"
+                  style="position: absolute; padding: 7px; color: black; left: 160px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{\\llap{-}3}"
+                  style="position: absolute; padding: 7px; color: black; left: 140px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{\\llap{-}4}"
+                  style="position: absolute; padding: 7px; color: black; left: 120px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{\\llap{-}5}"
+                  style="position: absolute; padding: 7px; color: black; left: 100px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{\\llap{-}6}"
+                  style="position: absolute; padding: 7px; color: black; left: 80px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{\\llap{-}7}"
+                  style="position: absolute; padding: 7px; color: black; left: 60px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{\\llap{-}8}"
+                  style="position: absolute; padding: 7px; color: black; left: 40px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{\\llap{-}9}"
+                  style="position: absolute; padding: 7px; color: black; left: 20px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{1}"
+                  style="position: absolute; padding: 7px; color: black; left: 200px; top: 180px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{2}"
+                  style="position: absolute; padding: 7px; color: black; left: 200px; top: 160px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{3}"
+                  style="position: absolute; padding: 7px; color: black; left: 200px; top: 140px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{4}"
+                  style="position: absolute; padding: 7px; color: black; left: 200px; top: 120px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{5}"
+                  style="position: absolute; padding: 7px; color: black; left: 200px; top: 100px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{6}"
+                  style="position: absolute; padding: 7px; color: black; left: 200px; top: 80px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{7}"
+                  style="position: absolute; padding: 7px; color: black; left: 200px; top: 60px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{8}"
+                  style="position: absolute; padding: 7px; color: black; left: 200px; top: 40px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{9}"
+                  style="position: absolute; padding: 7px; color: black; left: 200px; top: 20px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{\\llap{-}2}"
+                  style="position: absolute; padding: 7px; color: black; left: 200px; top: 240px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{\\llap{-}3}"
+                  style="position: absolute; padding: 7px; color: black; left: 200px; top: 260px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{\\llap{-}4}"
+                  style="position: absolute; padding: 7px; color: black; left: 200px; top: 280px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{\\llap{-}5}"
+                  style="position: absolute; padding: 7px; color: black; left: 200px; top: 300px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{\\llap{-}6}"
+                  style="position: absolute; padding: 7px; color: black; left: 200px; top: 320px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{\\llap{-}7}"
+                  style="position: absolute; padding: 7px; color: black; left: 200px; top: 340px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{\\llap{-}8}"
+                  style="position: absolute; padding: 7px; color: black; left: 200px; top: 360px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="\\small{\\llap{-}9}"
+                  style="position: absolute; padding: 7px; color: black; left: 200px; top: 380px; fill: none; stroke: #000000; opacity: 1;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="y"
+                  style="position: absolute; padding: 7px; color: black; left: 200px; top: 0px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="x"
+                  style="position: absolute; padding: 7px; color: black; left: 400px; top: 200px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <div
+                  style="position: absolute; left: 0px; top: 0px;"
+                />
+                <div
+                  style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`interactive-graph widget question Should render predictably: after interaction 1`] = `
 <div>
   <div

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
@@ -223,10 +223,12 @@ describe("InteractiveGraphQuestionBuilder", () => {
             .build();
 
         const graph = question.widgets["interactive-graph 1"];
-        expect(graph.options).toEqual(expect.objectContaining({
-            graph: {type: "none"},
-            correct: {type: "none"},
-        }));
+        expect(graph.options).toEqual(
+            expect.objectContaining({
+                graph: {type: "none"},
+                correct: {type: "none"},
+            }),
+        );
     });
 
     it("creates a linear graph", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
@@ -217,6 +217,18 @@ describe("InteractiveGraphQuestionBuilder", () => {
         );
     });
 
+    it("creates a 'none' type graph", () => {
+        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withNoInteractiveFigure()
+            .build();
+
+        const graph = question.widgets["interactive-graph 1"];
+        expect(graph.options).toEqual(expect.objectContaining({
+            graph: {type: "none"},
+            correct: {type: "none"},
+        }));
+    });
+
     it("creates a linear graph", () => {
         const question: PerseusRenderer = interactiveGraphQuestionBuilder()
             .withLinear()

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -7,6 +7,7 @@ import type {
     LockedFigureFillType,
     LockedFunctionType,
     LockedLabelType,
+    LockedLineStyle,
     LockedLineType,
     LockedPointType,
     LockedPolygonType,
@@ -16,10 +17,12 @@ import type {
 } from "../../perseus-types";
 import type {Interval, vec} from "mafs";
 
-export type LockedFunctionOptions = Omit<
-    Partial<LockedFunctionType>,
-    "type" | "equation"
->;
+export type LockedFunctionOptions = {
+    color?: LockedFigureColor;
+    strokeStyle?: LockedLineStyle;
+    directionalAxis?: "x" | "y";
+    domain?: Interval;
+};
 
 export function interactiveGraphQuestionBuilder(): InteractiveGraphQuestionBuilder {
     return new InteractiveGraphQuestionBuilder();
@@ -296,7 +299,7 @@ class InteractiveGraphQuestionBuilder {
         point2: vec.Vector2,
         options?: {
             kind?: "line" | "ray" | "segment";
-            lineStyle?: "solid" | "dashed";
+            lineStyle?: LockedLineStyle;
             color?: LockedFigureColor;
             filled?: [boolean, boolean];
             showPoint1?: boolean;

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -180,6 +180,11 @@ class InteractiveGraphQuestionBuilder {
         return this;
     }
 
+    withNoInteractiveFigure() {
+        this.interactiveFigureConfig = new NoInteractiveFigureConfig();
+        return this;
+    }
+
     withLinear(options?: {
         coords?: CollinearTuple;
         startCoords?: CollinearTuple;
@@ -480,6 +485,16 @@ class SegmentGraphConfig implements InteractiveFigureConfig {
             numSegments: this.numSegments,
             startCoords: this.startCoords,
         };
+    }
+}
+
+class NoInteractiveFigureConfig implements InteractiveFigureConfig {
+    correct(): PerseusGraphType {
+        return {type: "none"};
+    }
+
+    graph(): PerseusGraphType {
+        return {type: "none"};
     }
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
@@ -55,6 +55,9 @@ import type {PerseusRenderer} from "../../perseus-types";
 import type Renderer from "../../renderer";
 import type {APIOptions} from "../../types";
 import type {UserEvent} from "@testing-library/user-event";
+import {
+    interactiveGraphQuestionBuilder
+} from "./interactive-graph-question-builder";
 
 const updateWidgetState = (renderer: Renderer, widgetId: string, update) => {
     const state = clone(renderer.getSerializedState());
@@ -155,6 +158,26 @@ describe("interactive-graph widget", function () {
             });
         },
     );
+
+    describe("A none-type graph", () => {
+        it("renders predictably", () => {
+            const question = interactiveGraphQuestionBuilder()
+                .withNoInteractiveFigure()
+                .build();
+            const {container} = renderQuestion(question, blankOptions);
+
+            expect(container).toMatchSnapshot("first render");
+        });
+
+        it("treats no interaction as a correct answer", async () => {
+            const question = interactiveGraphQuestionBuilder()
+                .withNoInteractiveFigure()
+                .build();
+            const {renderer} = renderQuestion(question, blankOptions);
+
+            expect(renderer).toHaveBeenAnsweredCorrectly();
+        });
+    })
 });
 
 describe("a mafs graph", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
@@ -14,6 +14,7 @@ import {lockedFigureColors} from "../../perseus-types";
 import {renderQuestion} from "../__testutils__/renderQuestion";
 import {sinusoidQuestion} from "../grapher/grapher.testdata";
 
+import {interactiveGraphQuestionBuilder} from "./interactive-graph-question-builder";
 import {
     angleQuestion,
     angleQuestionWithDefaultCorrect,
@@ -55,9 +56,6 @@ import type {PerseusRenderer} from "../../perseus-types";
 import type Renderer from "../../renderer";
 import type {APIOptions} from "../../types";
 import type {UserEvent} from "@testing-library/user-event";
-import {
-    interactiveGraphQuestionBuilder
-} from "./interactive-graph-question-builder";
 
 const updateWidgetState = (renderer: Renderer, widgetId: string, update) => {
     const state = clone(renderer.getSerializedState());
@@ -177,7 +175,7 @@ describe("interactive-graph widget", function () {
 
             expect(renderer).toHaveBeenAnsweredCorrectly();
         });
-    })
+    });
 });
 
 describe("a mafs graph", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -483,6 +483,14 @@ export const sinusoidQuestion: PerseusRenderer =
         })
         .build();
 
+export const noneQuestion: PerseusRenderer = interactiveGraphQuestionBuilder()
+    .withContent("This graph isn't interactive.\n\n[[☃ interactive-graph 1]]")
+    .withNoInteractiveFigure()
+    .addLockedFunction("5*sin(x)+x^3/20-ln(abs(x))", {color: "green"})
+    .addLockedEllipse([-5, 5], [2, 2], {color: "red", fillStyle: "translucent"})
+    .addLockedEllipse([5, -5], [2, 2], {color: "red", fillStyle: "translucent"})
+    .build();
+
 export const sinusoidQuestionWithDefaultCorrect: PerseusRenderer =
     interactiveGraphQuestionBuilder().withSinusoid().build();
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -407,6 +407,8 @@ const renderGraph = (props: {
             return <QuadraticGraph graphState={state} dispatch={dispatch} />;
         case "sinusoid":
             return <SinusoidGraph graphState={state} dispatch={dispatch} />;
+        case "none":
+            return null;
         default:
             throw new UnreachableCaseError(type);
     }

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
@@ -11,6 +11,7 @@ import type {
     PerseusGraphTypeCircle,
     PerseusGraphTypeLinear,
     PerseusGraphTypeLinearSystem,
+    PerseusGraphTypeNone,
     PerseusGraphTypePoint,
     PerseusGraphTypePolygon,
     PerseusGraphTypeQuadratic,
@@ -107,6 +108,11 @@ export function initializeGraphState(
                 angleOffsetDeg: Number(graph.angleOffsetDeg),
                 allowReflexAngles: Boolean(graph.allowReflexAngles),
                 snapDegrees: Number(graph.snapDegrees),
+            };
+        case "none":
+            return {
+                ...shared,
+                type: "none"
             };
         default:
             throw new UnreachableCaseError(graph);

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
@@ -11,7 +11,6 @@ import type {
     PerseusGraphTypeCircle,
     PerseusGraphTypeLinear,
     PerseusGraphTypeLinearSystem,
-    PerseusGraphTypeNone,
     PerseusGraphTypePoint,
     PerseusGraphTypePolygon,
     PerseusGraphTypeQuadratic,

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
@@ -112,7 +112,7 @@ export function initializeGraphState(
         case "none":
             return {
                 ...shared,
-                type: "none"
+                type: "none",
             };
         default:
             throw new UnreachableCaseError(graph);

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -193,6 +193,7 @@ function doMovePointInFigure(
         }
         case "angle":
         case "circle":
+        case "none":
         case "point":
         case "polygon":
         case "quadratic":

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -193,6 +193,7 @@ function doMovePointInFigure(
         }
         case "angle":
         case "circle":
+            throw new Error("FIXME implement circle reducer");
         case "none":
         case "point":
         case "polygon":

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -102,6 +102,10 @@ export function getGradableGraph(
         };
     }
 
+    if (state.type === "none" && initialGraph.type === "none") {
+        return {type: "none"};
+    }
+
     throw new Error(
         "Mafs is not yet implemented for graph type: " + initialGraph.type,
     );

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
@@ -101,7 +101,6 @@ export const StatefulMafsGraph = React.forwardRef<
         );
     }, [dispatch, xMinRange, xMaxRange, yMinRange, yMaxRange]);
 
-    // FIXME: extract getReinitializationKey(graph)
     // Update the graph whenever any of the following values changes.
     // This is necessary to keep the graph previews in sync with the updated
     // graph settings within the interative graph editor.

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
@@ -101,6 +101,7 @@ export const StatefulMafsGraph = React.forwardRef<
         );
     }, [dispatch, xMinRange, xMaxRange, yMinRange, yMaxRange]);
 
+    // FIXME: extract getReinitializationKey(graph)
     // Update the graph whenever any of the following values changes.
     // This is necessary to keep the graph previews in sync with the updated
     // graph settings within the interative graph editor.
@@ -110,6 +111,7 @@ export const StatefulMafsGraph = React.forwardRef<
     const snapTo = graph.type === "polygon" ? graph.snapTo : null;
     const showAngles = graph.type === "polygon" ? graph.showAngles : null;
     const showSides = graph.type === "polygon" ? graph.showSides : null;
+    const startCoords = "startCoords" in graph ? graph.startCoords : null;
 
     const originalPropsRef = useRef(props);
     const latestPropsRef = useLatestRef(props);
@@ -130,7 +132,7 @@ export const StatefulMafsGraph = React.forwardRef<
         showAngles,
         showSides,
         latestPropsRef,
-        graph.startCoords,
+        startCoords,
     ]);
 
     // If the graph is static, it always displays the correct answer. This is

--- a/packages/perseus/src/widgets/interactive-graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/types.ts
@@ -51,7 +51,7 @@ export interface LinearSystemGraphState extends InteractiveGraphStateCommon {
 }
 
 export interface NoneGraphState extends InteractiveGraphStateCommon {
-    type: "none"
+    type: "none";
 }
 
 export interface PointGraphState extends InteractiveGraphStateCommon {

--- a/packages/perseus/src/widgets/interactive-graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/types.ts
@@ -20,6 +20,7 @@ export type InteractiveGraphState =
     | LinearSystemGraphState
     | LinearGraphState
     | RayGraphState
+    | NoneGraphState
     | PolygonGraphState
     | PointGraphState
     | CircleGraphState
@@ -47,6 +48,10 @@ export interface LinearGraphState extends InteractiveGraphStateCommon {
 export interface LinearSystemGraphState extends InteractiveGraphStateCommon {
     type: "linear-system";
     coords: PairOfPoints[];
+}
+
+export interface NoneGraphState extends InteractiveGraphStateCommon {
+    type: "none"
 }
 
 export interface PointGraphState extends InteractiveGraphStateCommon {


### PR DESCRIPTION
Content creators will now see an "Answer type" dropdown in the interactive graph widget editor, from which they can select "Angle", "Circle", etc... plus a new type, "None".

Graphs of type "None" do not have any interactive elements and cannot be answered. However, they _can_ contain locked figures. Their purpose is to be a more accessible and content-creator-friendly replacement for the static SVG images generated by graphie-to-png.

Issue: LEMS-2030

## Test plan:

Search for "none" in the dev UI gallery (https://localhost:5173). Copy the question into the flipbook (https://localhost:5173/#flipbook) and verify that it is marked correct when you click the "check answer" button.