### PR TITLE
[Interactive Graph Editor] Use Wonder Blocks TextArea in the graph description settings UI

### DIFF
--- a/.changeset/ninety-laws-decide.md
+++ b/.changeset/ninety-laws-decide.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Interactive Graph Editor] Use Wonder Blocks TextArea in the graph description settings UI

--- a/packages/perseus-editor/src/components/__tests__/interactive-graph-description.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/interactive-graph-description.test.tsx
@@ -1,4 +1,5 @@
 import {Dependencies} from "@khanacademy/perseus";
+import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 import {render, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
@@ -33,6 +34,7 @@ describe("InteractiveGraphSettings", () => {
                 ariaDescriptionValue="Graph Description"
                 onChange={jest.fn()}
             />,
+            {wrapper: RenderStateRoot},
         );
 
         // Act
@@ -57,6 +59,7 @@ describe("InteractiveGraphSettings", () => {
                 ariaDescriptionValue=""
                 onChange={onChange}
             />,
+            {wrapper: RenderStateRoot},
         );
 
         // Act
@@ -82,6 +85,7 @@ describe("InteractiveGraphSettings", () => {
                 ariaDescriptionValue=""
                 onChange={onChange}
             />,
+            {wrapper: RenderStateRoot},
         );
 
         // Act

--- a/packages/perseus-editor/src/components/interactive-graph-description.tsx
+++ b/packages/perseus-editor/src/components/interactive-graph-description.tsx
@@ -1,5 +1,5 @@
 import {View} from "@khanacademy/wonder-blocks-core";
-import {TextField} from "@khanacademy/wonder-blocks-form";
+import {TextArea, TextField} from "@khanacademy/wonder-blocks-form";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelLarge, LabelXSmall} from "@khanacademy/wonder-blocks-typography";
@@ -43,28 +43,22 @@ export default function InteractiveGraphDescription(props: Props) {
                             onChange={(newValue) =>
                                 onChange({fullGraphAriaLabel: newValue})
                             }
+                            style={styles.spaceAbove}
                         />
                     </LabelLarge>
-                    <Strut size={spacing.xSmall_8} />
-                    <LabelLarge
-                        tag="label"
-                        // TODO(LEMS-2332): Remove this style prop after
-                        // switching to WB TextArea
-                        style={{
-                            display: "flex",
-                            flexDirection: "column",
-                        }}
-                    >
+                    <Strut size={spacing.small_12} />
+                    <LabelLarge tag="label">
                         Description
-                        {/* TODO(LEMS-2332): Change this to a WB TextArea */}
-                        <textarea
+                        <TextArea
                             rows={8}
+                            resizeType="vertical"
                             value={ariaDescriptionValue}
-                            onChange={(e) =>
+                            onChange={(newValue) =>
                                 onChange({
-                                    fullGraphAriaDescription: e.target.value,
+                                    fullGraphAriaDescription: newValue,
                                 })
                             }
+                            style={styles.spaceAbove}
                         />
                     </LabelLarge>
                 </View>
@@ -78,5 +72,8 @@ const styles = StyleSheet.create({
         color: color.offBlack64,
         paddingTop: spacing.xxSmall_6,
         paddingBottom: spacing.xxSmall_6,
+    },
+    spaceAbove: {
+        marginTop: spacing.xxxSmall_4,
     },
 });


### PR DESCRIPTION
## Summary:
Right now, we are using a native HTML <textarea> element inside the
graph description settings, since there were some issues importing
TextArea from wonder blocks.

It seems those issues have been resolved (or were local the whole
time and therefore nonexistent), so now we can update the element
we're using for the description input.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2332

## Test plan:
`yarn jest packages/perseus-editor/src/components/__tests__/interactive-graph-description.test.tsx`

Storybook
- http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--interactive-graph-with-aria-label
- Confirm that the screenreader reads out the label and description as
  expected in Safari and Firefox.

<img width="383" alt="image" src="https://github.com/user-attachments/assets/bcd21d39-ac1e-4732-9a95-7f323805404b">
