### PR TITLE
[Interactive Graph] Remove the interactive-graph-locked-feature-m2b flag

### DIFF
--- a/.changeset/tame-ways-reply.md
+++ b/.changeset/tame-ways-reply.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+[Interactive Graph] Remove the interactive-graph-locked-feature-m2b flag

--- a/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
+++ b/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
@@ -14,7 +14,6 @@ export const flags = {
         point: true,
 
         // Locked figures flags
-        "interactive-graph-locked-features-m2b": true,
         "interactive-graph-locked-features-labels": true,
 
         // Start coords UI flags

--- a/packages/perseus-editor/src/components/__stories__/locked-figures-section.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/locked-figures-section.stories.tsx
@@ -32,7 +32,6 @@ export const Controlled: StoryComponentType = {
 
         return (
             <LockedFiguresSection
-                showM2bFeatures={true}
                 figures={figures}
                 onChange={handlePropsUpdate}
             />
@@ -54,7 +53,6 @@ export const WithProdWidth: StoryComponentType = {
         return (
             <View style={styles.prodSizeContainer}>
                 <LockedFiguresSection
-                    showM2bFeatures={true}
                     figures={figures}
                     onChange={handlePropsUpdate}
                 />

--- a/packages/perseus-editor/src/components/__tests__/locked-figures-section.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/locked-figures-section.test.tsx
@@ -40,15 +40,9 @@ describe("LockedFiguresSection", () => {
 
     test("renders", () => {
         // Arrange, Act
-        render(
-            <LockedFiguresSection
-                showM2bFeatures={true}
-                onChange={jest.fn()}
-            />,
-            {
-                wrapper: RenderStateRoot,
-            },
-        );
+        render(<LockedFiguresSection onChange={jest.fn()} />, {
+            wrapper: RenderStateRoot,
+        });
 
         // Assert
         expect(screen.getByText("Add locked figure")).toBeInTheDocument();
@@ -56,15 +50,9 @@ describe("LockedFiguresSection", () => {
 
     test("renders no expand/collapse button when there are no figures", () => {
         // Arrange, Act
-        render(
-            <LockedFiguresSection
-                showM2bFeatures={true}
-                onChange={jest.fn()}
-            />,
-            {
-                wrapper: RenderStateRoot,
-            },
-        );
+        render(<LockedFiguresSection onChange={jest.fn()} />, {
+            wrapper: RenderStateRoot,
+        });
 
         // Assert
         expect(screen.queryByRole("button", {name: "Expand all"})).toBeNull();
@@ -76,7 +64,6 @@ describe("LockedFiguresSection", () => {
         render(
             <LockedFiguresSection
                 figures={defaultFigures}
-                showM2bFeatures={true}
                 onChange={jest.fn()}
             />,
             {
@@ -98,7 +85,6 @@ describe("LockedFiguresSection", () => {
         render(
             <LockedFiguresSection
                 figures={defaultFigures}
-                showM2bFeatures={true}
                 onChange={jest.fn()}
             />,
             {
@@ -122,7 +108,6 @@ describe("LockedFiguresSection", () => {
         render(
             <LockedFiguresSection
                 figures={defaultFigures}
-                showM2bFeatures={true}
                 onChange={jest.fn()}
             />,
             {
@@ -152,7 +137,6 @@ describe("LockedFiguresSection", () => {
         render(
             <LockedFiguresSection
                 figures={defaultFigures}
-                showM2bFeatures={true}
                 onChange={jest.fn()}
             />,
             {
@@ -186,7 +170,6 @@ describe("LockedFiguresSection", () => {
         // Arrange
         render(
             <LockedFiguresSection
-                showM2bFeatures={true}
                 figures={defaultFigures}
                 onChange={jest.fn()}
             />,
@@ -212,7 +195,6 @@ describe("LockedFiguresSection", () => {
         // Arrange
         render(
             <LockedFiguresSection
-                showM2bFeatures={true}
                 figures={[
                     getDefaultFigureForType("point"),
                     {...getDefaultFigureForType("point"), coord: [1, 1]},

--- a/packages/perseus-editor/src/components/graph-locked-figures/locked-figure-select.tsx
+++ b/packages/perseus-editor/src/components/graph-locked-figures/locked-figure-select.tsx
@@ -12,8 +12,6 @@ import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 type Props = {
-    // TODO(LEMS-2107): Remove this prop once the M2b flag is fully rolled out.
-    showM2bFeatures: boolean;
     // Whether to show the locked labels in the locked figure settings.
     // TODO(LEMS-2274): Remove this prop once the label flag is
     // sfully rolled out.
@@ -25,10 +23,14 @@ type Props = {
 const LockedFigureSelect = (props: Props) => {
     const {id, onChange} = props;
 
-    const figureTypes = ["point", "line", "vector", "ellipse", "polygon"];
-    if (props.showM2bFeatures) {
-        figureTypes.push("function");
-    }
+    const figureTypes = [
+        "point",
+        "line",
+        "vector",
+        "ellipse",
+        "polygon",
+        "function",
+    ];
     if (props.showLabelsFlag) {
         figureTypes.push("label");
     }

--- a/packages/perseus-editor/src/components/graph-locked-figures/locked-figure-settings.tsx
+++ b/packages/perseus-editor/src/components/graph-locked-figures/locked-figure-settings.tsx
@@ -25,9 +25,6 @@ import type {Props as LockedPolygonProps} from "./locked-polygon-settings";
 import type {Props as LockedVectorProps} from "./locked-vector-settings";
 
 export type LockedFigureSettingsCommonProps = {
-    // Whether to show the M2b features in the locked figure settings.
-    // TODO(LEMS-2107): Remove this prop once the M2b flag is fully rolled out.
-    showM2bFeatures?: boolean;
     // Whether to show the locked labels in the locked figure settings.
     // TODO(LEMS-2274): Remove this prop once the label flag is
     // sfully rolled out.
@@ -79,10 +76,7 @@ const LockedFigureSettings = (props: Props) => {
         case "polygon":
             return <LockedPolygonSettings {...props} />;
         case "function":
-            if (props.showM2bFeatures) {
-                return <LockedFunctionSettings {...props} />;
-            }
-            break;
+            return <LockedFunctionSettings {...props} />;
         case "label":
             if (props.showLabelsFlag) {
                 return <LockedLabelSettings {...props} />;

--- a/packages/perseus-editor/src/components/graph-locked-figures/locked-figures-section.tsx
+++ b/packages/perseus-editor/src/components/graph-locked-figures/locked-figures-section.tsx
@@ -21,9 +21,6 @@ import type {Props as InteractiveGraphEditorProps} from "../../widgets/interacti
 import type {LockedFigure, LockedFigureType} from "@khanacademy/perseus";
 
 type Props = {
-    // Whether to show the M2b features in the locked figure settings.
-    // TODO(LEMS-2107): Remove this prop once the M2b flag is fully rolled out.
-    showM2bFeatures: boolean;
     // Whether to show the locked labels in the locked figure settings.
     // TODO(LEMS-2274): Remove this prop once the label flag is
     // sfully rolled out.
@@ -166,7 +163,6 @@ const LockedFiguresSection = (props: Props) => {
                         return (
                             <LockedFigureSettings
                                 key={`${uniqueId}-locked-${figure}-${index}`}
-                                showM2bFeatures={props.showM2bFeatures}
                                 showLabelsFlag={props.showLabelsFlag}
                                 expanded={expandedStates[index]}
                                 onToggle={(newValue) => {
@@ -187,7 +183,6 @@ const LockedFiguresSection = (props: Props) => {
                     })}
                     <View style={styles.buttonContainer}>
                         <LockedFigureSelect
-                            showM2bFeatures={props.showM2bFeatures}
                             showLabelsFlag={props.showLabelsFlag}
                             id={`${uniqueId}-select`}
                             onChange={addLockedFigure}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
@@ -756,11 +756,6 @@ class InteractiveGraphEditor extends React.Component<Props> {
                             this.props.graph.type
                         ] && (
                             <LockedFiguresSection
-                                showM2bFeatures={
-                                    this.props.apiOptions?.flags?.mafs?.[
-                                        "interactive-graph-locked-features-m2b"
-                                    ]
-                                }
                                 showLabelsFlag={
                                     this.props.apiOptions?.flags?.mafs?.[
                                         "interactive-graph-locked-features-labels"

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -148,11 +148,6 @@ export const MafsGraphTypeFlags = [
 
 export const InteractiveGraphLockedFeaturesFlags = [
     /**
-     * Enables/Disables Milestone 2 phase b locked features in the
-     * new Mafs interactive-graph widget (locked functions).
-     */
-    "interactive-graph-locked-features-m2b",
-    /**
      * Enables/Disables locked features in the new Mafs interactive-graph
      * widget (locked labels).
      */


### PR DESCRIPTION
## Summary:
Now that locked functions have been safely out for a while now, we can
remove the `interactive-graph-locked-features-m2b` flag from Perseus.

Next, we can remove it from webapp Growthbook.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2107

## Test plan:
`yarn jest`
`yarn typecheck`

- In the Perseus repo in your IDE, search for all instances of `m2b` and confirm there are none left.

Storybook
- http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--mafs-with-locked-figures-current
- Confirm that the locked functions are still available in the graph and editor