### PR TITLE
Delete redundant throw statement

### DIFF
--- a/.changeset/tiny-rules-sleep.md
+++ b/.changeset/tiny-rules-sleep.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Delete redundant `throw` statement.

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -192,7 +192,6 @@ function doMovePointInFigure(
         }
         case "angle":
         case "circle":
-            throw new Error("FIXME implement circle reducer");
         case "point":
         case "polygon":
         case "quadratic":


### PR DESCRIPTION
We were throwing an error with the message `"FIXME implement circle reducer"`
when `doMovePointInFigure` was called with a circle graph. The error message
didn't make sense because there's no need to implement `doMovePointInFigure`
for circles. The `throw` statement was redundant because without it, the circle
case just falls through to the `throw` below.

Issue: none

## Test plan:

`yarn test`