### PR TITLE
BUGFIX - Some Graphie Labels Were Misaligned

### DIFF
--- a/.changeset/wicked-spiders-call.md
+++ b/.changeset/wicked-spiders-call.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+BUGFIX - Some Graphie labels were misaligned due to recent code adjustment (LEMS-2022)

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1675,25 +1675,55 @@ const setLabelMargins = function (span: HTMLElement, size: Coord): void {
             marginTop: -height / 2 - y * scale,
         });
     } else {
-        const $container = $span.closest(".svg-image");
+        // We are using jQuery to collect information and calculate a scale
+        //     since we don't have a way to pass it to this function.
+        // We need the width of the container in order to calculate the scale to apply to the label.
+        // Unfortunately, the DOM tree leading to the label is not consistent.
+        // Therefore, we need to check different elements and different style properties to get the width of the container.
+        // Some graphie labels exist within an ".svg-image" container, and others do not.
+        // All graphie labels have a ".graphie" container.
+        // When a label has an ".svg-image" container,
+        //     the width information in the ".graphie" element is expressed as a percentage instead of pixels,
+        //     so we can't use it.
+        // Instead, the ".svg-image" container can be used to get the width information.
+        // The following lines determine which container element to use for the width measurement.
+        const $svgImage = $span.closest(".svg-image");
+        const $graphie = $span.closest(".graphie");
+        // If an ".svg-image" container exists in the DOM tree, then use it, otherwise use the ".graphie" container.
+        const $container = $svgImage.length > 0 ? $svgImage : $graphie;
+
         // Ensuring that the line-height of the text doesn't throw off placement of the text element.
         // Inherited line-height values can really mess up placement.
         $container.css("line-height", "normal");
 
-        // The 'max-width' value is the same as the expected (100% scale) width of the graphie.
-        // We are using jQuery to get this information since we don't have a way to pass it to this function.
-        const expectedWidth = $container.css("max-width") ?? "0px";
+        // The expected width of the graphie is found in the "max-width" property on ".svg-image" containers,
+        //     and is found in the "width" property on ".graphie" containers.
+        const widthValues = $container.css(["max-width", "width"]);
+        const cssWidth =
+            // Verified in Chrome, Firefox, and Safari - all return the same "none" value if the property does not exist.
+            widthValues["max-width"] !== "none"
+                ? widthValues["max-width"]
+                : widthValues["width"];
+        const expectedWidth = cssWidth ?? "0px";
         // We can calculate the true scale of the graphie by taking actual width and dividing by the expected width.
-        // NOTE: Using 'slice' to remove the "px" unit from the end of the expected width value.
-        const scale =
+        // NOTE: Using 'replace' to remove the "px" unit from the end of the expected width value.
+        let scale =
             (($container.width() ?? 0) /
                 parseInt(expectedWidth.replace(/px$/, ""))) *
             100;
+        // If something failed in the calculation, then default to 100% scale.
+        if (isNaN(scale)) {
+            scale = 100;
+        } else if (scale === 0) {
+            scale = 100;
+        }
 
         // Any padding needs to be scaled accordingly.
-        const currentPadding = $span.css("padding") ?? "0px";
+        const padding = $span.css("padding");
+        const currentPadding = padding !== "none" ? padding : "0px";
         const newPadding =
-            Math.round(parseInt(currentPadding.slice(0, -2)) * scale) / 100;
+            Math.round(parseInt(currentPadding.replace(/px$/, "")) * scale) /
+            100;
 
         // "multipliers" basically move the position of the text by using 1, 0, -1
         // 'margin-left' and 'margin-top' are used to position the text.

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1698,13 +1698,15 @@ const setLabelMargins = function (span: HTMLElement, size: Coord): void {
 
         // The expected width of the graphie is found in the "max-width" property on ".svg-image" containers,
         //     and is found in the "width" property on ".graphie" containers.
-        const widthValues = $container.css(["max-width", "width"]);
-        const cssWidth =
+        const widthValues = $container.css(["max-width", "width"]) ?? {
+            // The browser will always return a value, but tests won't, so ensuring something is returned.
+            "max-width": "0px",
+        };
+        const expectedWidth =
             // Verified in Chrome, Firefox, and Safari - all return the same "none" value if the property does not exist.
             widthValues["max-width"] !== "none"
                 ? widthValues["max-width"]
                 : widthValues["width"];
-        const expectedWidth = cssWidth ?? "0px";
         // We can calculate the true scale of the graphie by taking actual width and dividing by the expected width.
         // NOTE: Using 'replace' to remove the "px" unit from the end of the expected width value.
         let scale =
@@ -1719,7 +1721,7 @@ const setLabelMargins = function (span: HTMLElement, size: Coord): void {
         }
 
         // Any padding needs to be scaled accordingly.
-        const padding = $span.css("padding");
+        const padding = $span.css("padding") ?? "0px";
         const currentPadding = padding !== "none" ? padding : "0px";
         const newPadding =
             Math.round(parseInt(currentPadding.replace(/px$/, "")) * scale) /


### PR DESCRIPTION
## Summary:
The work done in LEMS-2022 addressed the scaling problems with graphie labels in one specific use-case. There are actually two use-cases for Graphie. The second use-case didn't include elements that the original solution relied upon. This bugfix accounts for the second use case, and adds in safeguards for any potential other use-case so that a default of 100% scale is used instead of a possible NaN.

Issue: LEMS-2373

## Test plan:
1. Launch Storybook
2. Review the following examples (labels should be in their proper location):
   * Grapher widget (specifically the [Linear Question](http://localhost:6006/?path=/story/perseus-widgets-grapher--linear-question), which doesn't use a background)
   * [Number Line](http://localhost:6006/?path=/story/perseus-widgets-number-line--question-1) widget
   * Plotter widget (though at this time, the Storybook entry doesn't render the widget, so will need to [test in an editor](http://localhost:6006/?path=/story/perseuseditor-editorpage--demo))
   * (Legacy) Interactive Graph widget - this applies to just the [unlimited points](http://localhost:6006/?path=/story/perseus-widgets-interactive-graph--point) and [polygon](http://localhost:6006/?path=/story/perseus-widgets-interactive-graph--polygon)
   * Measurer widget (though at this time, there is no Storybook entry, so will need to [test in an editor](http://localhost:6006/?path=/story/perseuseditor-editorpage--demo))
   * [Interaction](http://localhost:6006/?path=/story/perseus-widgets-interaction--question-1) widget

## Affected behavior
### Grapher
#### Before:
![Grapher - Before](https://github.com/user-attachments/assets/261e58cb-bc77-4120-abfb-ca305f5a124c)

#### After:
![Grapher - After](https://github.com/user-attachments/assets/637add9b-e7a0-4556-8920-836c8c3447f3)

### Number Line
#### Before:
![Number Line - Before](https://github.com/user-attachments/assets/ed3c99a9-da2e-4edc-a878-24ff123f6144)

#### After:
![Number Line - After](https://github.com/user-attachments/assets/b626adb3-9985-4ef3-8913-1aeb54177a17)

### Plotter
#### Before:
![Plotter - Before](https://github.com/user-attachments/assets/bf86584c-f475-446e-919f-3fe0718fe0f6)

#### After:
![Plotter - After](https://github.com/user-attachments/assets/5d9b809c-5fe8-4150-b694-c5a6ef8ed2cd)

### (Legacy) Interactive Graph
#### Before:
![Interactive Graph - Before](https://github.com/user-attachments/assets/f1147894-58fb-49da-815c-cc5e52984f3e)

#### After:
![Interactive Graph - After](https://github.com/user-attachments/assets/1bf107f5-b0a8-439f-a47d-a17ee0cd838d)

### Interaction
#### Before:
![Interaction - Before](https://github.com/user-attachments/assets/204d1b19-63a0-4748-b5be-f4b7dd9b5911)

#### After:
![Interaction - After](https://github.com/user-attachments/assets/3dd46aab-49b3-4411-ba5a-dcc8e1b8155a)

