### PR TITLE
feat(LEMS-2722): Add scientific option to basic keypad

### DIFF
--- a/.changeset/twelve-rockets-taste.md
+++ b/.changeset/twelve-rockets-taste.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/math-input": minor
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-editor": minor
+---
+
+add scientific notation button / toggle to basic keypad

--- a/packages/math-input/src/components/keypad/__tests__/keypad.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/keypad.test.tsx
@@ -329,4 +329,33 @@ describe("keypad", () => {
         // Assert
         expect(screen.getByTestId("period-decimal")).toBeInTheDocument();
     });
+
+    it('shows the exponent button for scientific keypad', () => {
+        //Arrange
+        //Act
+        render(
+            <Keypad
+                onClickKey={() => {}}
+                scientific
+                onAnalyticsEvent={async () => {}}
+            />
+        );
+
+        //Assert
+        expect(screen.getByRole("button", {name: 'Custom exponent'})).toBeInTheDocument();
+    });
+
+    it('does not show the exponent button for non-scientific keypad', () => {
+        //Arrange
+        //Act
+        render(
+            <Keypad
+                onClickKey={() => {}}
+                onAnalyticsEvent={async () => {}}
+            />
+        );
+
+        //Assert
+        expect(screen.queryByRole("button", {name: 'Custom exponent'})).not.toBeInTheDocument();
+    });
 });

--- a/packages/math-input/src/components/keypad/__tests__/keypad.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/keypad.test.tsx
@@ -330,7 +330,7 @@ describe("keypad", () => {
         expect(screen.getByTestId("period-decimal")).toBeInTheDocument();
     });
 
-    it('shows the exponent button for scientific keypad', () => {
+    it("shows the exponent button for scientific keypad", () => {
         //Arrange
         //Act
         render(
@@ -338,24 +338,25 @@ describe("keypad", () => {
                 onClickKey={() => {}}
                 scientific
                 onAnalyticsEvent={async () => {}}
-            />
+            />,
         );
 
         //Assert
-        expect(screen.getByRole("button", {name: 'Custom exponent'})).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Custom exponent"}),
+        ).toBeInTheDocument();
     });
 
-    it('does not show the exponent button for non-scientific keypad', () => {
+    it("does not show the exponent button for non-scientific keypad", () => {
         //Arrange
         //Act
         render(
-            <Keypad
-                onClickKey={() => {}}
-                onAnalyticsEvent={async () => {}}
-            />
+            <Keypad onClickKey={() => {}} onAnalyticsEvent={async () => {}} />,
         );
 
         //Assert
-        expect(screen.queryByRole("button", {name: 'Custom exponent'})).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", {name: "Custom exponent"}),
+        ).not.toBeInTheDocument();
     });
 });

--- a/packages/math-input/src/components/keypad/keypad.tsx
+++ b/packages/math-input/src/components/keypad/keypad.tsx
@@ -34,6 +34,7 @@ export type Props = {
     basicRelations?: boolean;
     advancedRelations?: boolean;
     fractionsOnly?: boolean;
+    scientific?: boolean;
 
     onClickKey: ClickKeyCallback;
     onAnalyticsEvent: AnalyticsEventHandlerFn;
@@ -94,6 +95,7 @@ export default function Keypad(props: Props) {
         logarithms,
         basicRelations,
         advancedRelations,
+        scientific,
         showDismiss,
         onAnalyticsEvent,
         fractionsOnly,
@@ -187,6 +189,7 @@ export default function Keypad(props: Props) {
                                 convertDotToTimes={convertDotToTimes}
                                 divisionKey={divisionKey}
                                 selectedPage={selectedPage}
+                                scientific={scientific}
                             />
                         )}
                     </View>

--- a/packages/math-input/src/components/keypad/mobile-keypad-internals.tsx
+++ b/packages/math-input/src/components/keypad/mobile-keypad-internals.tsx
@@ -220,6 +220,7 @@ class MobileKeypadInternals
                                 containerWidth > expandedViewThreshold
                             }
                             showDismiss
+                            scientific={keypadConfig?.scientific}
                         />
                     ) : null}
                 </AphroditeCssTransitionGroup>

--- a/packages/math-input/src/components/keypad/shared-keys.tsx
+++ b/packages/math-input/src/components/keypad/shared-keys.tsx
@@ -26,7 +26,7 @@ export default function SharedKeys(props: Props) {
         divisionKey,
         convertDotToTimes,
         selectedPage,
-        scientific
+        scientific,
     } = props;
     const {strings, locale} = useMathInputI18n();
     const cursorKeyConfig = getCursorContextConfig(strings, cursorContext);
@@ -58,13 +58,13 @@ export default function SharedKeys(props: Props) {
                 coord={[5, 0]}
                 secondary
             />
-            {scientific &&
-            ( <KeypadButton
-                keyConfig={Keys.EXP}
-                onClickKey={onClickKey}
-                coord={[3, 2]}
-                secondary
-            />
+            {scientific && (
+                <KeypadButton
+                    keyConfig={Keys.EXP}
+                    onClickKey={onClickKey}
+                    coord={[3, 2]}
+                    secondary
+                />
             )}
             {/* Row 2 */}
             <KeypadButton

--- a/packages/math-input/src/components/keypad/shared-keys.tsx
+++ b/packages/math-input/src/components/keypad/shared-keys.tsx
@@ -16,6 +16,7 @@ type Props = {
     cursorContext?: (typeof CursorContext)[keyof typeof CursorContext];
     convertDotToTimes?: boolean;
     divisionKey?: boolean;
+    scientific?: boolean;
 };
 
 export default function SharedKeys(props: Props) {
@@ -25,6 +26,7 @@ export default function SharedKeys(props: Props) {
         divisionKey,
         convertDotToTimes,
         selectedPage,
+        scientific
     } = props;
     const {strings, locale} = useMathInputI18n();
     const cursorKeyConfig = getCursorContextConfig(strings, cursorContext);
@@ -56,7 +58,14 @@ export default function SharedKeys(props: Props) {
                 coord={[5, 0]}
                 secondary
             />
-
+            {scientific &&
+            ( <KeypadButton
+                keyConfig={Keys.EXP}
+                onClickKey={onClickKey}
+                coord={[3, 2]}
+                secondary
+            />
+            )}
             {/* Row 2 */}
             <KeypadButton
                 keyConfig={

--- a/packages/math-input/src/types.ts
+++ b/packages/math-input/src/types.ts
@@ -20,6 +20,7 @@ export type KeypadConfiguration = {
     keypadType: KeypadType;
     extraKeys?: ReadonlyArray<Key>;
     times?: boolean;
+    scientific?: boolean;
 };
 
 export type KeyHandler = (key: Key) => Cursor;

--- a/packages/perseus-editor/src/widgets/__tests__/expression-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/expression-editor.test.tsx
@@ -209,6 +209,23 @@ describe("expression-editor", () => {
         });
     });
 
+    it("should toggle scientific checkbox", async () => {
+        const onChangeMock = jest.fn();
+
+        render(<ExpressionEditor onChange={onChangeMock} />);
+        act(() => jest.runOnlyPendingTimers());
+
+        await userEvent.click(
+            screen.getByRole("checkbox", {
+                name: "scientific",
+            }),
+        );
+
+        expect(onChangeMock).toBeCalledWith({
+            buttonSets: ["basic", "scientific"],
+        });
+    });
+
     it("should be possible to add an answer", async () => {
         const onChangeMock = jest.fn();
 

--- a/packages/perseus-editor/src/widgets/expression-editor.tsx
+++ b/packages/perseus-editor/src/widgets/expression-editor.tsx
@@ -50,6 +50,7 @@ const buttonSetsList: LegacyButtonSets = [
     "basic",
     "trig",
     "prealgebra",
+    "scientific",
     "logarithms",
     "basic relations",
     "advanced relations",

--- a/packages/perseus/src/components/__tests__/math-input.test.tsx
+++ b/packages/perseus/src/components/__tests__/math-input.test.tsx
@@ -4,17 +4,18 @@ import * as React from "react";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
-import MathInput from "../math-input";
+import MathInput, {KeypadButtonSets} from "../math-input";
 
 import type {UserEvent} from "@testing-library/user-event";
 
-const allButtonSets = {
+const allButtonSets: KeypadButtonSets = {
     advancedRelations: true,
     basicRelations: true,
     divisionKey: true,
     logarithms: true,
     preAlgebra: true,
     trigonometry: true,
+    scientific: true,
 };
 
 describe("Perseus' MathInput", () => {
@@ -140,6 +141,33 @@ describe("Perseus' MathInput", () => {
 
         // Assert
         expect(mockOnChange).toHaveBeenLastCalledWith("1+2-3");
+    });
+
+    it("is possible to use the scientific keypad", async () => {
+        // Assemble
+        const mockOnChange = jest.fn();
+        render(
+            <MathInput
+                onChange={mockOnChange}
+                keypadButtonSets={{scientific: true}}
+                analytics={{onAnalyticsEvent: () => Promise.resolve()}}
+                convertDotToTimes={false}
+                value=""
+            />,
+        );
+        act(() => jest.runOnlyPendingTimers());
+
+        // Act
+        await userEvent.click(
+            screen.getByRole("button", {name: /open math keypad/}),
+        );
+        await userEvent.click(screen.getByRole("button", {name: "2"}));
+        await userEvent.click(screen.getByRole("button", {name: "Custom exponent"}));
+        await userEvent.click(screen.getByRole("button", {name: "2"}));
+        act(() => jest.runOnlyPendingTimers());
+
+        // Assert
+        expect(mockOnChange).toHaveBeenLastCalledWith("2^{2}");
     });
 
     it("is possible to use buttons with legacy props", async () => {

--- a/packages/perseus/src/components/__tests__/math-input.test.tsx
+++ b/packages/perseus/src/components/__tests__/math-input.test.tsx
@@ -4,8 +4,9 @@ import * as React from "react";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
-import MathInput, {KeypadButtonSets} from "../math-input";
+import MathInput from "../math-input";
 
+import type {KeypadButtonSets} from "../math-input";
 import type {UserEvent} from "@testing-library/user-event";
 
 const allButtonSets: KeypadButtonSets = {
@@ -162,7 +163,9 @@ describe("Perseus' MathInput", () => {
             screen.getByRole("button", {name: /open math keypad/}),
         );
         await userEvent.click(screen.getByRole("button", {name: "2"}));
-        await userEvent.click(screen.getByRole("button", {name: "Custom exponent"}));
+        await userEvent.click(
+            screen.getByRole("button", {name: "Custom exponent"}),
+        );
         await userEvent.click(screen.getByRole("button", {name: "2"}));
         act(() => jest.runOnlyPendingTimers());
 

--- a/packages/perseus/src/components/__tests__/math-input.test.tsx
+++ b/packages/perseus/src/components/__tests__/math-input.test.tsx
@@ -33,7 +33,7 @@ describe("Perseus' MathInput", () => {
     });
 
     it("renders", () => {
-        // Assemble
+        // Arrange
         render(
             <MathInput
                 onChange={() => {}}
@@ -52,7 +52,7 @@ describe("Perseus' MathInput", () => {
     });
 
     it("provides a default aria label", () => {
-        // Assemble
+        // Arrange
         render(
             <MathInput
                 onChange={() => {}}
@@ -71,7 +71,7 @@ describe("Perseus' MathInput", () => {
     });
 
     it("is possible to overwrite the aria label", () => {
-        // Assemble
+        // Arrange
         render(
             <MathInput
                 onChange={() => {}}
@@ -91,7 +91,7 @@ describe("Perseus' MathInput", () => {
     });
 
     it("is possible to type in the input", async () => {
-        // Assemble
+        // Arrange
         const mockOnChange = jest.fn();
         render(
             <MathInput
@@ -116,7 +116,7 @@ describe("Perseus' MathInput", () => {
     });
 
     it("is possible to use buttons", async () => {
-        // Assemble
+        // Arrange
         const mockOnChange = jest.fn();
         render(
             <MathInput
@@ -145,7 +145,7 @@ describe("Perseus' MathInput", () => {
     });
 
     it("is possible to use the scientific keypad", async () => {
-        // Assemble
+        // Arrange
         const mockOnChange = jest.fn();
         render(
             <MathInput
@@ -174,7 +174,7 @@ describe("Perseus' MathInput", () => {
     });
 
     it("is possible to use buttons with legacy props", async () => {
-        // Assemble
+        // Arrange
         const mockOnChange = jest.fn();
         render(
             <MathInput
@@ -204,7 +204,7 @@ describe("Perseus' MathInput", () => {
     });
 
     it("returns focus to input after button click", async () => {
-        // Assemble
+        // Arrange
         render(
             <MathInput
                 onChange={() => {}}
@@ -228,7 +228,7 @@ describe("Perseus' MathInput", () => {
     });
 
     it("does not return focus to input after button press via keyboard", async () => {
-        // Assemble
+        // Arrange
         render(
             <MathInput
                 onChange={() => {}}
@@ -257,7 +257,7 @@ describe("Perseus' MathInput", () => {
     });
 
     it("does not focus on the keypad button when it is clicked with the mouse", async () => {
-        // Assemble
+        // Arrange
         render(
             <MathInput
                 onChange={() => {}}

--- a/packages/perseus/src/components/math-input.tsx
+++ b/packages/perseus/src/components/math-input.tsx
@@ -39,6 +39,7 @@ type KeypadButtonSets = {
     logarithms?: boolean;
     preAlgebra?: boolean;
     trigonometry?: boolean;
+    scientific?: boolean;
 };
 
 type Props = {
@@ -494,6 +495,9 @@ const mapButtonSets = (buttonSets?: LegacyButtonSets) => {
                 break;
             case "trig":
                 keypadButtonSets.trigonometry = true;
+                break;
+            case "scientific":
+                keypadButtonSets.scientific = true;
                 break;
             case "basic":
             default:

--- a/packages/perseus/src/components/math-input.tsx
+++ b/packages/perseus/src/components/math-input.tsx
@@ -32,7 +32,7 @@ import type {Keys, MathFieldInterface} from "@khanacademy/math-input";
 
 type ButtonsVisibleType = "always" | "never" | "focused";
 
-type KeypadButtonSets = {
+export type KeypadButtonSets = {
     advancedRelations?: boolean;
     basicRelations?: boolean;
     divisionKey?: boolean;

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -425,7 +425,6 @@ export type LegacyButtonSets = ReadonlyArray<
 export type PerseusExpressionWidgetOptions = {
     // The expression forms the answer may come in
     answerForms: ReadonlyArray<PerseusExpressionAnswerForm>;
-    // Different buttons sets that can show in the expression. Options are "basic", "basic+div", "trig", "prealgebra", "scientific", "logarithms", "basic relations", "advanced relations"
     buttonSets: LegacyButtonSets;
     // Variables that can be used as functions.  Default: ["f", "g", "h"]
     functions: ReadonlyArray<string>;

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -415,6 +415,7 @@ export type LegacyButtonSets = ReadonlyArray<
     | "basic"
     | "basic+div"
     | "trig"
+    | "scientific"
     | "prealgebra"
     | "logarithms"
     | "basic relations"
@@ -424,7 +425,7 @@ export type LegacyButtonSets = ReadonlyArray<
 export type PerseusExpressionWidgetOptions = {
     // The expression forms the answer may come in
     answerForms: ReadonlyArray<PerseusExpressionAnswerForm>;
-    // Different buttons sets that can show in the expression. Options are "basic", "basic+div", "trig", "prealgebra", "logarithms", "basic relations", "advanced relations"
+    // Different buttons sets that can show in the expression. Options are "basic", "basic+div", "trig", "prealgebra", "scientific", "logarithms", "basic relations", "advanced relations"
     buttonSets: LegacyButtonSets;
     // Variables that can be used as functions.  Default: ["f", "g", "h"]
     functions: ReadonlyArray<string>;

--- a/packages/perseus/src/widgets/expression/expression.stories.tsx
+++ b/packages/perseus/src/widgets/expression/expression.stories.tsx
@@ -68,7 +68,7 @@ export const DesktopKitchenSink = (args: StoryArgs): React.ReactElement => {
             "logarithms",
             "basic relations",
             "advanced relations",
-            "scientific"
+            "scientific",
         ] as LegacyButtonSets,
     };
 

--- a/packages/perseus/src/widgets/expression/expression.stories.tsx
+++ b/packages/perseus/src/widgets/expression/expression.stories.tsx
@@ -68,6 +68,7 @@ export const DesktopKitchenSink = (args: StoryArgs): React.ReactElement => {
             "logarithms",
             "basic relations",
             "advanced relations",
+            "scientific"
         ] as LegacyButtonSets,
     };
 

--- a/packages/perseus/src/widgets/expression/expression.test.tsx
+++ b/packages/perseus/src/widgets/expression/expression.test.tsx
@@ -10,7 +10,7 @@ import * as Dependencies from "../../dependencies";
 import {mockStrings} from "../../strings";
 import {renderQuestion} from "../__testutils__/renderQuestion";
 
-import {Expression} from "./expression";
+import {Expression, keypadConfigurationForProps} from "./expression";
 import {
     expressionItem2,
     expressionItem3,
@@ -19,9 +19,10 @@ import {
     expressionItemWithLabels,
 } from "./expression.testdata";
 
-import type {PerseusItem} from "../../perseus-types";
+import type {PerseusExpressionWidgetOptions, PerseusItem} from "../../perseus-types";
 import type {APIOptions} from "../../types";
 import type {UserEvent} from "@testing-library/user-event";
+import { KeypadConfiguration, KeypadType } from "@khanacademy/math-input";
 
 const renderAndAnswer = async (
     userEvent: ReturnType<(typeof userEventLib)["setup"]>,
@@ -611,5 +612,92 @@ describe("Expression Widget", function () {
                 screen.queryByText("Sorry, I don't understand that!"),
             ).toBeNull();
         });
+    });
+});
+
+describe("Keypad configuration", () => {
+    it("should handle basic button set", async() => {
+        // Arrange
+        const widgetOptions: PerseusExpressionWidgetOptions = {
+            answerForms: [],
+            buttonSets: ["basic"],
+            times: false,
+            functions:[]
+        };
+
+        const expected: KeypadConfiguration = {
+            keypadType: KeypadType.EXPRESSION,
+            times: false,
+            scientific: false,
+            extraKeys: ["PI"],
+        };
+
+        // Act
+        const result = keypadConfigurationForProps(widgetOptions);
+
+        // Assert
+        expect(result).toEqual(expected);
+    });
+
+    it("should handle basic+div button set", async() => {
+        // Arrange
+        const widgetOptions: PerseusExpressionWidgetOptions = {
+            answerForms: [],
+            buttonSets: ["basic+div"],
+            times: false,
+            functions:[]
+        };
+
+        const expected: KeypadConfiguration = {
+            keypadType: KeypadType.EXPRESSION,
+            times: false,
+            scientific: false,
+            extraKeys: ["PI"],
+        };
+
+        // Act
+        const result = keypadConfigurationForProps(widgetOptions);
+
+        // Assert
+        expect(result).toEqual(expected);
+    });
+
+    it("should return expression keypad configuration by default", async() => {
+        // Arrange
+        const widgetOptions: PerseusExpressionWidgetOptions = {
+            answerForms: [],
+            buttonSets: [],
+            times: false,
+            functions:[]
+        };
+
+        // Act
+        const result = keypadConfigurationForProps(widgetOptions);
+
+        // Assert
+        expect(result.keypadType).toEqual(KeypadType.EXPRESSION);
+    });
+
+    it("should handle scientific button set", async() => {
+        // Arrange
+        const widgetOptions: PerseusExpressionWidgetOptions = {
+            answerForms: [],
+            buttonSets: ["scientific"],
+            times: false,
+            functions:[]
+        };
+
+        const expected: KeypadConfiguration = {
+            keypadType: KeypadType.EXPRESSION,
+            times: false,
+            scientific: true,
+            extraKeys: ["PI"],
+        };
+
+        // Act
+        const result = keypadConfigurationForProps(widgetOptions);
+
+        // Assert
+        expect(result).toEqual(expected);
     });
 });

--- a/packages/perseus/src/widgets/expression/expression.test.tsx
+++ b/packages/perseus/src/widgets/expression/expression.test.tsx
@@ -632,7 +632,6 @@ describe("Keypad configuration", () => {
         const expected: KeypadConfiguration = {
             keypadType: KeypadType.EXPRESSION,
             times: false,
-            scientific: false,
             extraKeys: ["PI"],
         };
 
@@ -645,38 +644,31 @@ describe("Keypad configuration", () => {
 
     it("should handle basic+div button set", async () => {
         // Arrange
-        const widgetOptions: PerseusExpressionWidgetOptions = {
-            answerForms: [],
-            buttonSets: ["basic+div"],
-            times: false,
-            functions: [],
-        };
-
-        const expected: KeypadConfiguration = {
+        // Act
+        // Assert
+        expect(
+            keypadConfigurationForProps({
+                answerForms: [],
+                buttonSets: ["basic+div"],
+                times: false,
+                functions: [],
+            }),
+        ).toEqual({
             keypadType: KeypadType.EXPRESSION,
             times: false,
-            scientific: false,
             extraKeys: ["PI"],
-        };
-
-        // Act
-        const result = keypadConfigurationForProps(widgetOptions);
-
-        // Assert
-        expect(result).toEqual(expected);
+        });
     });
 
     it("should return expression keypad configuration by default", async () => {
         // Arrange
-        const widgetOptions: PerseusExpressionWidgetOptions = {
+        // Act
+        const result = keypadConfigurationForProps({
             answerForms: [],
             buttonSets: [],
             times: false,
             functions: [],
-        };
-
-        // Act
-        const result = keypadConfigurationForProps(widgetOptions);
+        });
 
         // Assert
         expect(result.keypadType).toEqual(KeypadType.EXPRESSION);
@@ -684,24 +676,19 @@ describe("Keypad configuration", () => {
 
     it("should handle scientific button set", async () => {
         // Arrange
-        const widgetOptions: PerseusExpressionWidgetOptions = {
-            answerForms: [],
-            buttonSets: ["scientific"],
-            times: false,
-            functions: [],
-        };
-
-        const expected: KeypadConfiguration = {
+        // Act
+        // Assert
+        expect(
+            keypadConfigurationForProps({
+                answerForms: [],
+                buttonSets: ["scientific"],
+                times: false,
+                functions: [],
+            }),
+        ).toEqual({
             keypadType: KeypadType.EXPRESSION,
             times: false,
-            scientific: true,
             extraKeys: ["PI"],
-        };
-
-        // Act
-        const result = keypadConfigurationForProps(widgetOptions);
-
-        // Assert
-        expect(result).toEqual(expected);
+        });
     });
 });

--- a/packages/perseus/src/widgets/expression/expression.test.tsx
+++ b/packages/perseus/src/widgets/expression/expression.test.tsx
@@ -1,4 +1,5 @@
 import {it, describe, beforeEach} from "@jest/globals";
+import {KeypadType} from "@khanacademy/math-input";
 import {act, screen, waitFor} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 
@@ -19,10 +20,13 @@ import {
     expressionItemWithLabels,
 } from "./expression.testdata";
 
-import type {PerseusExpressionWidgetOptions, PerseusItem} from "../../perseus-types";
+import type {
+    PerseusExpressionWidgetOptions,
+    PerseusItem,
+} from "../../perseus-types";
 import type {APIOptions} from "../../types";
+import type {KeypadConfiguration} from "@khanacademy/math-input";
 import type {UserEvent} from "@testing-library/user-event";
-import { KeypadConfiguration, KeypadType } from "@khanacademy/math-input";
 
 const renderAndAnswer = async (
     userEvent: ReturnType<(typeof userEventLib)["setup"]>,
@@ -616,13 +620,13 @@ describe("Expression Widget", function () {
 });
 
 describe("Keypad configuration", () => {
-    it("should handle basic button set", async() => {
+    it("should handle basic button set", async () => {
         // Arrange
         const widgetOptions: PerseusExpressionWidgetOptions = {
             answerForms: [],
             buttonSets: ["basic"],
             times: false,
-            functions:[]
+            functions: [],
         };
 
         const expected: KeypadConfiguration = {
@@ -639,13 +643,13 @@ describe("Keypad configuration", () => {
         expect(result).toEqual(expected);
     });
 
-    it("should handle basic+div button set", async() => {
+    it("should handle basic+div button set", async () => {
         // Arrange
         const widgetOptions: PerseusExpressionWidgetOptions = {
             answerForms: [],
             buttonSets: ["basic+div"],
             times: false,
-            functions:[]
+            functions: [],
         };
 
         const expected: KeypadConfiguration = {
@@ -662,13 +666,13 @@ describe("Keypad configuration", () => {
         expect(result).toEqual(expected);
     });
 
-    it("should return expression keypad configuration by default", async() => {
+    it("should return expression keypad configuration by default", async () => {
         // Arrange
         const widgetOptions: PerseusExpressionWidgetOptions = {
             answerForms: [],
             buttonSets: [],
             times: false,
-            functions:[]
+            functions: [],
         };
 
         // Act
@@ -678,13 +682,13 @@ describe("Keypad configuration", () => {
         expect(result.keypadType).toEqual(KeypadType.EXPRESSION);
     });
 
-    it("should handle scientific button set", async() => {
+    it("should handle scientific button set", async () => {
         // Arrange
         const widgetOptions: PerseusExpressionWidgetOptions = {
             answerForms: [],
             buttonSets: ["scientific"],
             times: false,
-            functions:[]
+            functions: [],
         };
 
         const expected: KeypadConfiguration = {

--- a/packages/perseus/src/widgets/expression/expression.tsx
+++ b/packages/perseus/src/widgets/expression/expression.tsx
@@ -749,7 +749,7 @@ export const keypadConfigurationForProps = (
         keypadType,
         extraKeys,
         times: widgetOptions.times,
-        scientific: widgetOptions.buttonSets.includes("scientific"),
+        // scientific: widgetOptions.buttonSets.includes("scientific"), // POC note: this line may or may not be needed ~ doesn't seem to impact output
     };
 };
 

--- a/packages/perseus/src/widgets/expression/expression.tsx
+++ b/packages/perseus/src/widgets/expression/expression.tsx
@@ -688,7 +688,7 @@ const styles = StyleSheet.create({
  *       to be included as keys on the keypad. These are scraped from the answer
  *       forms.
  */
-const keypadConfigurationForProps = (
+export const keypadConfigurationForProps = (
     widgetOptions: PerseusExpressionWidgetOptions,
 ): KeypadConfiguration => {
     // Always use the Expression keypad, regardless of the button sets that have

--- a/packages/perseus/src/widgets/expression/expression.tsx
+++ b/packages/perseus/src/widgets/expression/expression.tsx
@@ -806,7 +806,7 @@ export default {
             ariaLabel,
         } = widgetOptions;
         return {
-            keypadConfiguration: keypadConfigurationForProps(widgetOptions), // mobile keypad
+            keypadConfiguration: keypadConfigurationForProps(widgetOptions),
             times,
             functions,
             buttonSets,

--- a/packages/perseus/src/widgets/expression/expression.tsx
+++ b/packages/perseus/src/widgets/expression/expression.tsx
@@ -745,7 +745,12 @@ const keypadConfigurationForProps = (
         extraKeys = ["PI"];
     }
 
-    return {keypadType, extraKeys, times: widgetOptions.times, scientific: widgetOptions.buttonSets.includes("scientific")};
+    return {
+        keypadType,
+        extraKeys,
+        times: widgetOptions.times,
+        scientific: widgetOptions.buttonSets.includes("scientific"),
+    };
 };
 
 const propUpgrades = {

--- a/packages/perseus/src/widgets/expression/expression.tsx
+++ b/packages/perseus/src/widgets/expression/expression.tsx
@@ -745,7 +745,7 @@ const keypadConfigurationForProps = (
         extraKeys = ["PI"];
     }
 
-    return {keypadType, extraKeys, times: widgetOptions.times};
+    return {keypadType, extraKeys, times: widgetOptions.times, scientific: widgetOptions.buttonSets.includes("scientific")};
 };
 
 const propUpgrades = {
@@ -806,7 +806,7 @@ export default {
             ariaLabel,
         } = widgetOptions;
         return {
-            keypadConfiguration: keypadConfigurationForProps(widgetOptions),
+            keypadConfiguration: keypadConfigurationForProps(widgetOptions), // mobile keypad
             times,
             functions,
             buttonSets,


### PR DESCRIPTION
## Summary:
#### Proof of concept: 
Adds scientific notation to basic keypad using toggle on expression editor

Issue: LEMS-2272

## Test plan:
1. [Navigate to expression editor story](https://650db21c3f5d1b2f13c02952-evogyhpohm.chromatic.com/?path=/docs/perseuseditor-widgets-expression-editor--docs)
2. Toggle `scientific` in the editor to see the scientific notation added to the basic keypad.

#### Note
When adding other keypads, if scientific notation is toggled, the scientific notation button will remain visible. This includes when scientific and pre-algebra are toggled simultaneously, causing there to be 2 scientific notation buttons displayed on the screen. 
If we decide to pursue this further - it would be key to identify the use cases when we would display and hide the button, despite the toggle being set to `true` 

## Screenshots

https://github.com/user-attachments/assets/55d7395d-bd93-4aad-8195-b321be71e376
