### PR TITLE
Fix types for 'classnames' package

### DIFF
--- a/.changeset/red-roses-brush.md
+++ b/.changeset/red-roses-brush.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix types for `classnames` package usages

--- a/packages/perseus/package.json
+++ b/packages/perseus/package.json
@@ -48,6 +48,7 @@
         "@khanacademy/perseus-linter": "^1.2.0",
         "@khanacademy/pure-markdown": "^0.3.8",
         "@khanacademy/simple-markdown": "^0.13.1",
+        "@types/classnames": "2.2.0",
         "@use-gesture/react": "^10.2.27",
         "mafs": "0.19.0",
         "uuid": "^10.0.0"

--- a/packages/perseus/src/components/number-input.tsx
+++ b/packages/perseus/src/components/number-input.tsx
@@ -238,7 +238,6 @@ class NumberInput extends React.Component<any, any> {
                 onBlur={this._handleBlur}
                 onKeyPress={this._handleBlur}
                 onKeyDown={this._onKeyDown}
-                // @ts-expect-error - TS2322 - Type '(e: TouchEvent) => void' is not assignable to type 'TouchEventHandler<HTMLInputElement>'.
                 onTouchStart={captureScratchpadTouchStart}
                 defaultValue={toNumericString(
                     this.props.value,

--- a/packages/perseus/src/util.ts
+++ b/packages/perseus/src/util.ts
@@ -9,6 +9,7 @@ import type {Range} from "./perseus-types";
 import type {PerseusStrings} from "./strings";
 import type {Widget, PerseusScore} from "./types";
 import type {KEScore} from "@khanacademy/perseus-core";
+import type * as React from "react";
 
 type WordPosition = {
     start: number;
@@ -791,7 +792,7 @@ const supportsPassiveEvents: () => boolean = () => {
  * Pass this function as the touchstart for an element to
  * avoid sending the touch to the mobile scratchpad
  */
-function captureScratchpadTouchStart(e: TouchEvent) {
+function captureScratchpadTouchStart(e: React.TouchEvent) {
     e.stopPropagation();
 }
 

--- a/packages/perseus/src/widgets/radio/base-radio.tsx
+++ b/packages/perseus/src/widgets/radio/base-radio.tsx
@@ -387,8 +387,8 @@ const BaseRadio = function (props: Props): React.ReactElement {
                             onClick={clickHandler}
                             onTouchStart={
                                 labelWrap
-                                    ? captureScratchpadTouchStart
-                                    : undefined
+                                    ? undefined
+                                    : captureScratchpadTouchStart
                             }
                         >
                             <Element {...elementProps} ref={ref} />

--- a/packages/perseus/src/widgets/radio/base-radio.tsx
+++ b/packages/perseus/src/widgets/radio/base-radio.tsx
@@ -223,7 +223,7 @@ const BaseRadio = function (props: Props): React.ReactElement {
     const firstChoiceHighlighted = choices[0].highlighted;
     const lastChoiceHighlighted = choices[choices.length - 1].highlighted;
 
-    const className: ReadonlyArray<string> = classNames(
+    const className = classNames(
         "perseus-widget-radio",
         !editMode && "perseus-rendered-radio",
         css(
@@ -238,7 +238,7 @@ const BaseRadio = function (props: Props): React.ReactElement {
         ),
     );
 
-    const instructionsClassName: ReadonlyArray<string> = classNames(
+    const instructionsClassName = classNames(
         "instructions",
         css(styles.instructions, isMobile && styles.instructionsMobile),
     );
@@ -255,11 +255,9 @@ const BaseRadio = function (props: Props): React.ReactElement {
             className={`perseus-widget-radio-fieldset ${responsiveClassName}`}
         >
             <legend className="perseus-sr-only">{instructions}</legend>
-            {/* @ts-expect-error - TS2322 - Type 'readonly string[]' is not assignable to type 'string'. */}
             <div className={instructionsClassName} aria-hidden="true">
                 {instructions}
             </div>
-            {/* @ts-expect-error - TS2322 - Type 'readonly string[]' is not assignable to type 'string'. */}
             <ul className={className} style={{listStyle: "none"}}>
                 {choices.map((choice, i) => {
                     let Element = Choice;
@@ -337,7 +335,7 @@ const BaseRadio = function (props: Props): React.ReactElement {
                             ? ApiClassNames.CORRECT
                             : ApiClassNames.INCORRECT;
                     }
-                    const className: ReadonlyArray<string> = classNames(
+                    const className = classNames(
                         aphroditeClassName(choice.checked),
                         // TODO(aria): Make test case for these API
                         // classNames
@@ -351,10 +349,11 @@ const BaseRadio = function (props: Props): React.ReactElement {
                     // (label forces any clicks inside to select the input
                     // element) We have to add some extra behavior to make
                     // sure that we can still check the choice.
-                    let listElem = null;
-                    let clickHandler = null;
+                    let listElem: HTMLLIElement | null = null;
+                    let clickHandler:
+                        | React.MouseEventHandler<HTMLLIElement>
+                        | undefined;
                     if (editMode) {
-                        // @ts-expect-error - TS2322 - Type '(e: any) => void' is not assignable to type 'null'.
                         clickHandler = (e: any) => {
                             // Traverse the parent nodes of the clicked
                             // element.
@@ -383,15 +382,13 @@ const BaseRadio = function (props: Props): React.ReactElement {
                     return (
                         <li
                             key={i}
-                            // @ts-expect-error - TS2322 - Type 'HTMLLIElement | null' is not assignable to type 'null'.
                             ref={(e) => (listElem = e)}
-                            // @ts-expect-error - TS2322 - Type 'readonly string[]' is not assignable to type 'string'.
                             className={className}
-                            // @ts-expect-error - TS2322 - Type 'null' is not assignable to type 'MouseEventHandler<HTMLLIElement> | undefined'.
                             onClick={clickHandler}
-                            // @ts-expect-error - TS2322 - Type '((e: TouchEvent) => void) | null' is not assignable to type 'TouchEventHandler<HTMLLIElement> | undefined'.
                             onTouchStart={
-                                !labelWrap ? null : captureScratchpadTouchStart
+                                labelWrap
+                                    ? captureScratchpadTouchStart
+                                    : undefined
                             }
                         >
                             <Element {...elementProps} ref={ref} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -4328,6 +4328,11 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/classnames@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.0.tgz#f2312039e780bdf89d7d4102a26ec11de5ec58aa"
+  integrity sha512-MFvoUmNDEnETgHkDZlmnLjVSSFcAH/dwDRi+EU1cYc0+wl4J6t1xGSqiGq7oytKSAXZCaHIkclFL0QaKQENDrA==
+
 "@types/classnames@^2.3.1":
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.3.1.tgz#3c2467aa0f1a93f1f021e3b9bcf938bd5dfdc0dd"


### PR DESCRIPTION
## Summary:

We didn't have types for the `classnames` package. That led us to try to define the types for it's return value in-place. That led us to suppress Typescript errors incorrectly. 

I added the version of the types used by webapp for the same version of `classnames` package we're using and voila, fixes.

Issue: "none"

## Test plan:

`yarn tsc`
`yarn test`