### PR TITLE
Beta: Export beta ContentPreview component

### DIFF
--- a/.changeset/lucky-mails-obey.md
+++ b/.changeset/lucky-mails-obey.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+Export beta version of `ContentPreview` component

--- a/packages/perseus-editor/src/content-preview.tsx
+++ b/packages/perseus-editor/src/content-preview.tsx
@@ -19,10 +19,10 @@ import * as React from "react";
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
 
 /**
- * The `ContentPreview` component provides a simple preview system for Perseus
- * Content. Due to how Persus styles are built, the preview styling matches the
- * current device based on the viewport width (using `@media` queries for
- * `min-width` and `max-width`).
+ * BETA!! The `ContentPreview` component provides a simple preview system for
+ * Perseus Content. Due to how Persus styles are built, the preview styling
+ * matches the current device based on the viewport width (using `@media`
+ * queries for `min-width` and `max-width`).
  *
  * The preview will render the mobile variant (styling and layout) when the
  * `previewDevice` is phone or tablet. Note that the styling cannot be matched

--- a/packages/perseus-editor/src/index.ts
+++ b/packages/perseus-editor/src/index.ts
@@ -9,6 +9,7 @@ export {default as StructuredItemDiff} from "./diffs/structured-item-diff";
 export {default as EditorPage} from "./editor-page";
 export {default as Editor} from "./editor";
 export {default as i18n} from "./i18n";
+export {default as ContentPreview} from "./content-preview";
 export {default as IframeContentRenderer} from "./iframe-content-renderer";
 export {default as MultiRendererEditor} from "./multirenderer-editor";
 export {default as StatefulEditorPage} from "./stateful-editor-page";


### PR DESCRIPTION
## Summary:

Export `ContentPreview` component for CP to start adopting in the v2 exercise editor.

Issue: "none"

## Test plan:

none