### PR TITLE
Adding back a nested svg element to fix Interactive Graph regression

### DIFF
--- a/.changeset/perfect-taxis-do.md
+++ b/.changeset/perfect-taxis-do.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Minor regression fix for bounding of interactive elements in the Interactive Graph widget.

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -244,6 +244,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                                 width={width}
                                 height={height}
                             >
+                                {/* Intearctive Elements are nested in an SVG to lock them to graph bounds */}
                                 <svg {...nestedSVGAttributes}>
                                     {/* Protractor */}
                                     {props.showProtractor && <Protractor />}

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -244,13 +244,15 @@ export const MafsGraph = (props: MafsGraphProps) => {
                                 width={width}
                                 height={height}
                             >
-                                {/* Protractor */}
-                                {props.showProtractor && <Protractor />}
-                                {/* Interactive layer */}
-                                {renderGraph({
-                                    state,
-                                    dispatch,
-                                })}
+                                <svg {...nestedSVGAttributes}>
+                                    {/* Protractor */}
+                                    {props.showProtractor && <Protractor />}
+                                    {/* Interactive layer */}
+                                    {renderGraph({
+                                        state,
+                                        dispatch,
+                                    })}
+                                </svg>
                             </Mafs>
                         </View>
                     </View>


### PR DESCRIPTION
## Summary:
While deploying Perseus, it was discovered that there was a regression related to the bounding of the interactive elements and the protractor in the Interactive Graph widget. 

Upon investigation, it seems like the nested svg (which is containing the overlow) was accidentally removed. This PR adds the nested svg back.

Issue: LEMS-2392

## Screenshots:
![Screenshot 2024-09-16 at 4 11 33 PM](https://github.com/user-attachments/assets/35aca7cd-c8fb-44f2-a69f-92f35dfa42c2)

![Screenshot 2024-09-16 at 4 12 21 PM](https://github.com/user-attachments/assets/c1ce695a-79d3-4760-b07b-cf950bee05f3)

## Test plan:
- Manual Testing 