### PR TITLE
Small tweaks to non-interactive validation logic

### DIFF
--- a/.changeset/violet-scissors-punch.md
+++ b/.changeset/violet-scissors-punch.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Small tweak to validation logic for non-interactive widgets

--- a/packages/perseus/src/widgets/definition/definition.tsx
+++ b/packages/perseus/src/widgets/definition/definition.tsx
@@ -12,7 +12,7 @@ import type {
     PerseusRenderer,
     PerseusDefinitionWidgetOptions,
 } from "../../perseus-types";
-import type {PerseusScore, WidgetExports, WidgetProps} from "../../types";
+import type {WidgetExports, WidgetProps} from "../../types";
 
 type RenderProps = PerseusDefinitionWidgetOptions;
 
@@ -38,7 +38,8 @@ class Definition extends React.Component<DefinitionProps> {
         definition: "definition goes here",
     };
 
-    static validate(userInput: UserInput, rubric: Rubric): PerseusScore {
+    // TODO (LEMS-2396): remove validation logic from widgets that don't validate
+    static validate() {
         return noopValidator();
     }
 
@@ -46,9 +47,10 @@ class Definition extends React.Component<DefinitionProps> {
         return {};
     };
 
-    simpleValidate: (arg1: Rubric) => PerseusScore = (rubric) => {
-        return Definition.validate(this.getUserInput(), rubric);
-    };
+    // TODO (LEMS-2396): remove validation logic from widgets that don't validate
+    simpleValidate() {
+        return noopValidator();
+    }
 
     render(): React.ReactNode {
         return (

--- a/packages/perseus/src/widgets/explanation/explanation.test.ts
+++ b/packages/perseus/src/widgets/explanation/explanation.test.ts
@@ -302,10 +302,7 @@ describe("Explanation", function () {
 
     describe("static validate", () => {
         it("should always return 0 points", async () => {
-            const result = ExplanationWidgetExports.widget.validate(
-                {},
-                question1.widgets["explanation 1"].options,
-            );
+            const result = ExplanationWidgetExports.widget.validate();
 
             expect(result).toMatchInlineSnapshot(`
                 {

--- a/packages/perseus/src/widgets/explanation/explanation.tsx
+++ b/packages/perseus/src/widgets/explanation/explanation.tsx
@@ -13,13 +13,9 @@ import Renderer from "../../renderer";
 import noopValidator from "../__shared__/noop-validator";
 
 import type {PerseusExplanationWidgetOptions} from "../../perseus-types";
-import type {PerseusScore, WidgetExports, WidgetProps} from "../../types";
+import type {WidgetExports, WidgetProps} from "../../types";
 
 type RenderProps = PerseusExplanationWidgetOptions; // transform = _.identity
-
-type Rubric = PerseusExplanationWidgetOptions;
-
-type UserInput = Empty;
 
 type Props = WidgetProps<RenderProps, PerseusExplanationWidgetOptions>;
 
@@ -59,7 +55,8 @@ class Explanation extends React.Component<Props, State> {
         linterContext: linterContextDefault,
     };
 
-    static validate(userInput: UserInput, rubric: Rubric): PerseusScore {
+    // TODO (LEMS-2396): remove validation logic from widgets that don't validate
+    static validate() {
         return noopValidator();
     }
 
@@ -86,9 +83,10 @@ class Explanation extends React.Component<Props, State> {
         return {};
     };
 
-    simpleValidate: (arg1: Rubric) => PerseusScore = (rubric) => {
-        return Explanation.validate(this.getUserInput(), rubric);
-    };
+    // TODO (LEMS-2396): remove validation logic from widgets that don't validate
+    simpleValidate() {
+        return noopValidator();
+    }
 
     render(): React.ReactNode {
         const promptText = this.state.expanded

--- a/packages/perseus/src/widgets/image/image.tsx
+++ b/packages/perseus/src/widgets/image/image.tsx
@@ -11,12 +11,7 @@ import Renderer from "../../renderer";
 import noopValidator from "../__shared__/noop-validator";
 
 import type {Range, PerseusImageWidgetOptions} from "../../perseus-types";
-import type {
-    ChangeFn,
-    PerseusScore,
-    WidgetExports,
-    WidgetProps,
-} from "../../types";
+import type {ChangeFn, WidgetExports, WidgetProps} from "../../types";
 
 const defaultBoxSize = 400;
 const defaultRange: Range = [0, 10];
@@ -76,7 +71,8 @@ class ImageWidget extends React.Component<Props> {
         linterContext: linterContextDefault,
     };
 
-    static validate(userInput: UserInput, rubric: Rubric): PerseusScore {
+    // TODO (LEMS-2396): remove validation logic from widgets that don't validate
+    static validate() {
         return noopValidator();
     }
 
@@ -88,9 +84,10 @@ class ImageWidget extends React.Component<Props> {
         return null;
     };
 
-    simpleValidate: (arg1: Rubric) => PerseusScore = (rubric) => {
-        return ImageWidget.validate(this.getUserInput(), rubric);
-    };
+    // TODO (LEMS-2396): remove validation logic from widgets that don't validate
+    simpleValidate() {
+        return noopValidator();
+    }
 
     focus: () => void = () => {}; // no-op
 

--- a/packages/perseus/src/widgets/interaction/interaction.tsx
+++ b/packages/perseus/src/widgets/interaction/interaction.tsx
@@ -15,7 +15,7 @@ import type {
     PerseusInteractionElement,
     PerseusInteractionWidgetOptions,
 } from "../../perseus-types";
-import type {PerseusScore, WidgetExports, WidgetProps} from "../../types";
+import type {WidgetExports, WidgetProps} from "../../types";
 
 // @ts-expect-error - TS2339 - Property 'Label' does not exist on type 'typeof Graphie'.
 const Label = Graphie.Label;
@@ -125,7 +125,8 @@ class Interaction extends React.Component<Props, State> {
         elements: [],
     };
 
-    static validate(state: any, rubric: any): PerseusScore {
+    // TODO (LEMS-2396): remove validation logic from widgets that don't validate
+    static validate() {
         return noopValidator();
     }
 
@@ -258,9 +259,10 @@ class Interaction extends React.Component<Props, State> {
         return {};
     };
 
-    simpleValidate: (arg1: any) => any = (rubric) => {
-        return Interaction.validate(this.getUserInput(), rubric);
-    };
+    // TODO (LEMS-2396): remove validation logic from widgets that don't validate
+    simpleValidate() {
+        return noopValidator();
+    }
 
     render(): React.ReactNode {
         const range = this.props.graph.range;

--- a/packages/perseus/src/widgets/measurer/measurer-validator.test.ts
+++ b/packages/perseus/src/widgets/measurer/measurer-validator.test.ts
@@ -1,0 +1,12 @@
+import measurerValidator from "./measurer-validator";
+
+describe("measurer-validator", () => {
+    it("always gives points for some reason", () => {
+        expect(measurerValidator()).toEqual({
+            type: "points",
+            earned: 1,
+            total: 1,
+            message: null,
+        });
+    });
+});

--- a/packages/perseus/src/widgets/measurer/measurer-validator.ts
+++ b/packages/perseus/src/widgets/measurer/measurer-validator.ts
@@ -1,0 +1,10 @@
+function measurerValidator() {
+    return {
+        type: "points",
+        earned: 1,
+        total: 1,
+        message: null,
+    };
+}
+
+export default measurerValidator;

--- a/packages/perseus/src/widgets/measurer/measurer.tsx
+++ b/packages/perseus/src/widgets/measurer/measurer.tsx
@@ -10,6 +10,8 @@ import SvgImage from "../../components/svg-image";
 import {ApiOptions} from "../../perseus-api";
 import GraphUtils from "../../util/graph-utils";
 
+import measurerValidator from "./measurer-validator";
+
 import type {Coord} from "../../interactive2/types";
 import type {WidgetExports} from "../../types";
 import type {Interval} from "../../util/interval";
@@ -145,9 +147,8 @@ const Measurer: any = createReactClass({
         return {};
     },
 
-    simpleValidate: function (rubric) {
-        // TODO(joel) - I don't understand how this is useful!
-        return Measurer.validate(this.getUserInput(), rubric);
+    simpleValidate: function () {
+        return measurerValidator();
     },
 
     focus: $.noop,
@@ -185,14 +186,7 @@ const Measurer: any = createReactClass({
 });
 
 _.extend(Measurer, {
-    validate: function (state, rubric) {
-        return {
-            type: "points",
-            earned: 1,
-            total: 1,
-            message: null,
-        };
-    },
+    validate: measurerValidator,
 });
 
 const propUpgrades = {

--- a/packages/perseus/src/widgets/molecule/molecule.tsx
+++ b/packages/perseus/src/widgets/molecule/molecule.tsx
@@ -139,20 +139,19 @@ class MoleculeWidget extends React.Component<Props> {
         rotationAngle: 0,
     };
 
-    simpleValidate: (arg1: any) => any = () => {
-        return {type: "points", earned: 0, total: 0, message: null};
-    };
+    // TODO (LEMS-2396): remove validation logic from widgets that don't validate
+    simpleValidate() {
+        return noopValidator();
+    }
 
     getUserInput: () => ReadonlyArray<ReadonlyArray<string>> = () => {
         return [];
     };
 
-    validate: (arg1: any, arg2: any) => any = (state, rubric) => {
-        // TODO(colin): this is here as part of the interface for a component.
-        // Figure out if there is something more appropriate that this should
-        // return.
+    // TODO (LEMS-2396): remove validation logic from widgets that don't validate
+    validate() {
         return noopValidator();
-    };
+    }
 
     render(): React.ReactNode {
         return (

--- a/packages/perseus/src/widgets/passage-ref-target/passage-ref-target.tsx
+++ b/packages/perseus/src/widgets/passage-ref-target/passage-ref-target.tsx
@@ -31,7 +31,8 @@ class PassageRefTarget extends React.Component<Props> {
         linterContext: linterContextDefault,
     };
 
-    static validate(state: any, rubric: any): any {
+    // TODO (LEMS-2396): remove validation logic from widgets that don't validate
+    static validate() {
         return noopValidator();
     }
 
@@ -45,10 +46,10 @@ class PassageRefTarget extends React.Component<Props> {
         return Changeable.change.apply(this, args);
     };
 
-    // TODO passage-ref-target isn't interactive; remove
-    simpleValidate: (arg1: any) => any = (rubric) => {
-        return PassageRefTarget.validate(this.getUserInput(), rubric);
-    };
+    // TODO (LEMS-2396): remove validation logic from widgets that don't validate
+    simpleValidate() {
+        return noopValidator();
+    }
 
     render(): React.ReactNode {
         return (

--- a/packages/perseus/src/widgets/passage-ref/passage-ref.tsx
+++ b/packages/perseus/src/widgets/passage-ref/passage-ref.tsx
@@ -8,12 +8,7 @@ import PerseusMarkdown from "../../perseus-markdown";
 import noopValidator from "../__shared__/noop-validator";
 
 import type {PerseusPassageRefWidgetOptions} from "../../perseus-types";
-import type {
-    ChangeFn,
-    PerseusScore,
-    WidgetExports,
-    WidgetProps,
-} from "../../types";
+import type {ChangeFn, WidgetExports, WidgetProps} from "../../types";
 import type {Passage, Reference} from "../passage";
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
 
@@ -69,7 +64,8 @@ class PassageRef extends React.Component<Props, State> {
         content: null,
     };
 
-    static validate(userInput: UserInput, rubric: Rubric): PerseusScore {
+    // TODO (LEMS-2396): remove validation logic from widgets that don't validate
+    static validate() {
         return noopValidator();
     }
 
@@ -143,9 +139,10 @@ class PassageRef extends React.Component<Props, State> {
         }
     };
 
-    simpleValidate: (arg1: Rubric) => PerseusScore = (rubric) => {
-        return PassageRef.validate(this.getUserInput(), rubric);
-    };
+    // TODO (LEMS-2396): remove validation logic from widgets that don't validate
+    simpleValidate() {
+        return noopValidator();
+    }
 
     render(): React.ReactNode {
         const {strings} = this.context;

--- a/packages/perseus/src/widgets/passage/passage.tsx
+++ b/packages/perseus/src/widgets/passage/passage.tsx
@@ -20,7 +20,7 @@ import type {
     PerseusPassageWidgetOptions,
     PerseusWidget,
 } from "../../perseus-types";
-import type {PerseusScore, WidgetExports, WidgetProps} from "../../types";
+import type {WidgetExports, WidgetProps} from "../../types";
 import type {SingleASTNode} from "@khanacademy/simple-markdown";
 
 // A fake paragraph to measure the line height of the passage,
@@ -126,7 +126,8 @@ export class Passage extends React.Component<PassageProps, PassageState> {
         stylesAreApplied: false,
     };
 
-    static validate(state: UserInput, rubric: Rubric): PerseusScore {
+    // TODO (LEMS-2396): remove validation logic from widgets that don't validate
+    static validate() {
         return noopValidator();
     }
 
@@ -377,8 +378,9 @@ export class Passage extends React.Component<PassageProps, PassageState> {
         return null;
     }
 
-    simpleValidate(rubric: Rubric): PerseusScore {
-        return Passage.validate(this.getUserInput(), rubric);
+    // TODO (LEMS-2396): remove validation logic from widgets that don't validate
+    simpleValidate() {
+        return noopValidator();
     }
 
     /**

--- a/packages/perseus/src/widgets/video/video.tsx
+++ b/packages/perseus/src/widgets/video/video.tsx
@@ -16,7 +16,7 @@ import noopValidator from "../__shared__/noop-validator";
 import VideoTranscriptLink from "./video-transcript-link";
 
 import type {PerseusVideoWidgetOptions} from "../../perseus-types";
-import type {PerseusScore, WidgetExports, WidgetProps} from "../../types";
+import type {WidgetExports, WidgetProps} from "../../types";
 
 // Current default is 720p, based on the typical videos we upload currently
 const DEFAULT_WIDTH = 1280;
@@ -27,7 +27,6 @@ const IS_URL = /^https?:\/\//;
 const IS_KA_SITE = /(khanacademy\.org|localhost)/;
 const IS_VIMEO = /(vimeo\.com)/;
 
-type UserInput = null;
 type Rubric = PerseusVideoWidgetOptions;
 type RenderProps = PerseusVideoWidgetOptions; // exports has no 'transform'
 type Props = WidgetProps<RenderProps, Rubric> & {
@@ -46,7 +45,8 @@ class Video extends React.Component<Props> {
      * Points for videos are tallied by the embedded video itself, in the case
      * of Khan Academy videos.
      */
-    static validate(userInput: UserInput, rubric: Rubric): PerseusScore {
+    // TODO (LEMS-2396): remove validation logic from widgets that don't validate
+    static validate() {
         return noopValidator();
     }
 
@@ -54,9 +54,10 @@ class Video extends React.Component<Props> {
         return null;
     };
 
-    simpleValidate: (arg1: Rubric) => PerseusScore = (rubric) => {
-        return Video.validate(null, rubric);
-    };
+    // TODO (LEMS-2396): remove validation logic from widgets that don't validate
+    simpleValidate() {
+        return noopValidator();
+    }
 
     change: (...args: ReadonlyArray<unknown>) => any = (...args) => {
         // @ts-expect-error - TS2345 - Argument of type 'readonly unknown[]' is not assignable to parameter of type 'any[]'.


### PR DESCRIPTION
## Summary:
- Split out Measurer validation logic
- Go back to other non-interactive widgets and detach `staticValidate` from `validate`

## Test plan:
Nothing should change, just some tweaks