### PR TITLE
Split out validation logic for categorizer

### DIFF
--- a/.changeset/smart-bottles-listen.md
+++ b/.changeset/smart-bottles-listen.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Move validation logic out of the Categorizer widget

--- a/packages/perseus/src/widgets/categorizer/categorizer-validator.test.ts
+++ b/packages/perseus/src/widgets/categorizer/categorizer-validator.test.ts
@@ -4,7 +4,7 @@ import categorizerValidator from "./categorizer-validator";
 
 import type {Rubric} from "./categorizer.types";
 
-describe("validating answers", () => {
+describe("categorizerValidator", () => {
     it("gives points when the answer is correct", () => {
         const rubric: Rubric = {
             items: ["Graph $1$", "Graph $2$"],

--- a/packages/perseus/src/widgets/categorizer/categorizer-validator.test.ts
+++ b/packages/perseus/src/widgets/categorizer/categorizer-validator.test.ts
@@ -1,0 +1,185 @@
+import {screen} from "@testing-library/react";
+import {userEvent as userEventLib} from "@testing-library/user-event";
+
+import {testDependencies} from "../../../../../testing/test-dependencies";
+import * as Dependencies from "../../dependencies";
+import {mockStrings} from "../../strings";
+import {renderQuestion} from "../__testutils__/renderQuestion";
+
+import {Categorizer} from "./categorizer";
+import {question1} from "./categorizer.testdata";
+
+import type {Rubric} from "./categorizer.types";
+import type {APIOptions} from "../../types";
+import type {UserEvent} from "@testing-library/user-event";
+
+describe("categorizer widget", () => {
+    let userEvent: UserEvent;
+    beforeEach(() => {
+        userEvent = userEventLib.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("is incorrect when blank", async () => {
+        // Arrange
+        const apiOptions: APIOptions = {
+            isMobile: false,
+        };
+        const {renderer} = renderQuestion(question1, apiOptions);
+
+        // Act
+        const [_, score] = renderer.guessAndScore();
+
+        // Assert
+        expect(score).toMatchInlineSnapshot(`
+            {
+              "message": "Make sure you select something for every row.",
+              "type": "invalid",
+            }
+        `);
+    });
+
+    it("can be answered incorrectly", async () => {
+        // arrange
+        const {renderer} = renderQuestion(question1);
+
+        const firstItem = screen.getAllByRole("row")[0];
+        await userEvent.click(firstItem);
+
+        // act
+        const [_, score] = renderer.guessAndScore();
+
+        // assert
+        expect(score).toMatchInlineSnapshot(`
+            {
+              "message": "Make sure you select something for every row.",
+              "type": "invalid",
+            }
+        `);
+    });
+
+    it("can be answered correctly", async () => {
+        // arrange
+        const {renderer} = renderQuestion(question1);
+
+        // act
+        await userEvent.click(
+            screen.getAllByRole("button", {name: "No relationship"})[0],
+        );
+        await userEvent.click(
+            screen.getAllByRole("button", {
+                name: "Positive linear relationship",
+            })[0],
+        );
+        await userEvent.click(
+            screen.getAllByRole("button", {
+                name: "Negative linear relationship",
+            })[1],
+        );
+        await userEvent.click(
+            screen.getAllByRole("button", {
+                name: "Nonlinear relationship",
+            })[1],
+        );
+
+        renderer.guessAndScore();
+
+        // assert
+        expect(renderer).toHaveBeenAnsweredCorrectly();
+    });
+});
+
+describe("validating answers", () => {
+    it("gives points when the answer is correct", () => {
+        const rubric: Rubric = {
+            items: ["Graph $1$", "Graph $2$"],
+            values: [1, 3],
+            randomizeItems: false,
+            categories: [
+                "No relationship",
+                "Positive linear relationship",
+                "Negative linear relationship",
+                "Nonlinear relationship",
+            ],
+            highlightLint: false,
+            static: false,
+        };
+
+        const useInput = {
+            values: [1, 3],
+        } as const;
+        const score = Categorizer.validate(useInput, rubric, mockStrings);
+
+        expect(score).toMatchInlineSnapshot(`
+            {
+              "earned": 1,
+              "message": null,
+              "total": 1,
+              "type": "points",
+            }
+        `);
+    });
+
+    it("does not give points when incorrectly answered", () => {
+        const rubric: Rubric = {
+            items: ["Graph $1$", "Graph $2$"],
+            values: [1, 3],
+            randomizeItems: false,
+            categories: [
+                "No relationship",
+                "Positive linear relationship",
+                "Negative linear relationship",
+                "Nonlinear relationship",
+            ],
+            highlightLint: false,
+            static: false,
+        };
+
+        const useInput = {
+            values: [2, 3],
+        } as const;
+        const score = Categorizer.validate(useInput, rubric, mockStrings);
+
+        expect(score).toMatchInlineSnapshot(`
+            {
+              "earned": 0,
+              "message": null,
+              "total": 1,
+              "type": "points",
+            }
+        `);
+    });
+
+    it("tells the learner its not complete if not selected", () => {
+        const rubric: Rubric = {
+            items: ["Graph $1$", "Graph $2$"],
+            values: [1, 3],
+            randomizeItems: false,
+            categories: [
+                "No relationship",
+                "Positive linear relationship",
+                "Negative linear relationship",
+                "Nonlinear relationship",
+            ],
+            highlightLint: false,
+            static: false,
+        };
+
+        const useInput = {
+            values: [2],
+        } as const;
+        const score = Categorizer.validate(useInput, rubric, mockStrings);
+
+        expect(score).toMatchInlineSnapshot(`
+            {
+              "message": "Make sure you select something for every row.",
+              "type": "invalid",
+            }
+        `);
+    });
+});

--- a/packages/perseus/src/widgets/categorizer/categorizer-validator.ts
+++ b/packages/perseus/src/widgets/categorizer/categorizer-validator.ts
@@ -1,6 +1,6 @@
 import type {Rubric, UserInput} from "./categorizer.types";
 import type {PerseusStrings} from "../../strings";
-import type {PerseusScore} from "@khanacademy/perseus";
+import type {PerseusScore} from "../../types";
 
 function categorizerValidator(
     userInput: UserInput,

--- a/packages/perseus/src/widgets/categorizer/categorizer-validator.ts
+++ b/packages/perseus/src/widgets/categorizer/categorizer-validator.ts
@@ -1,0 +1,34 @@
+import type {Rubric, UserInput} from "./categorizer.types";
+import type {PerseusStrings} from "../../strings";
+import type {PerseusScore} from "@khanacademy/perseus";
+
+function categorizerValidator(
+    userInput: UserInput,
+    rubric: Rubric,
+    strings: PerseusStrings,
+): PerseusScore {
+    let completed = true;
+    let allCorrect = true;
+    rubric.values.forEach((value, i) => {
+        if (userInput.values[i] == null) {
+            completed = false;
+        }
+        if (userInput.values[i] !== value) {
+            allCorrect = false;
+        }
+    });
+    if (!completed) {
+        return {
+            type: "invalid",
+            message: strings.invalidSelection,
+        };
+    }
+    return {
+        type: "points",
+        earned: allCorrect ? 1 : 0,
+        total: 1,
+        message: null,
+    };
+}
+
+export default categorizerValidator;

--- a/packages/perseus/src/widgets/categorizer/categorizer.test.ts
+++ b/packages/perseus/src/widgets/categorizer/categorizer.test.ts
@@ -1,25 +1,14 @@
-import {screen} from "@testing-library/react";
-import {userEvent as userEventLib} from "@testing-library/user-event";
-
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
-import {mockStrings} from "../../strings";
 import {renderQuestion} from "../__testutils__/renderQuestion";
 
 import {Categorizer} from "./categorizer";
 import {question1} from "./categorizer.testdata";
 
-import type {Rubric} from "./categorizer";
 import type {APIOptions} from "../../types";
-import type {UserEvent} from "@testing-library/user-event";
 
 describe("categorizer widget", () => {
-    let userEvent: UserEvent;
     beforeEach(() => {
-        userEvent = userEventLib.setup({
-            advanceTimers: jest.advanceTimersByTime,
-        });
-
         jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
             testDependencies,
         );
@@ -51,74 +40,6 @@ describe("categorizer widget", () => {
         expect(container).toMatchSnapshot("first mobile render");
     });
 
-    it("is incorrect when blank", async () => {
-        // Arrange
-        const apiOptions: APIOptions = {
-            isMobile: false,
-        };
-        const {renderer} = renderQuestion(question1, apiOptions);
-
-        // Act
-        const [_, score] = renderer.guessAndScore();
-
-        // Assert
-        expect(score).toMatchInlineSnapshot(`
-            {
-              "message": "Make sure you select something for every row.",
-              "type": "invalid",
-            }
-        `);
-    });
-
-    it("can be answered incorrectly", async () => {
-        // arrange
-        const {renderer} = renderQuestion(question1);
-
-        const firstItem = screen.getAllByRole("row")[0];
-        await userEvent.click(firstItem);
-
-        // act
-        const [_, score] = renderer.guessAndScore();
-
-        // assert
-        expect(score).toMatchInlineSnapshot(`
-            {
-              "message": "Make sure you select something for every row.",
-              "type": "invalid",
-            }
-        `);
-    });
-
-    it("can be answered correctly", async () => {
-        // arrange
-        const {renderer} = renderQuestion(question1);
-
-        // act
-        await userEvent.click(
-            screen.getAllByRole("button", {name: "No relationship"})[0],
-        );
-        await userEvent.click(
-            screen.getAllByRole("button", {
-                name: "Positive linear relationship",
-            })[0],
-        );
-        await userEvent.click(
-            screen.getAllByRole("button", {
-                name: "Negative linear relationship",
-            })[1],
-        );
-        await userEvent.click(
-            screen.getAllByRole("button", {
-                name: "Nonlinear relationship",
-            })[1],
-        );
-
-        renderer.guessAndScore();
-
-        // assert
-        expect(renderer).toHaveBeenAnsweredCorrectly();
-    });
-
     it("can get user input from props", () => {
         // Arrange
         const widgetProps: any = {
@@ -133,95 +54,5 @@ describe("categorizer widget", () => {
 
         // Assert
         expect(userInput).toEqual({values: [1, 0, 0, 0, 1, 1]});
-    });
-});
-
-describe("validating answers", () => {
-    it("gives points when the answer is correct", () => {
-        const rubric: Rubric = {
-            items: ["Graph $1$", "Graph $2$"],
-            values: [1, 3],
-            randomizeItems: false,
-            categories: [
-                "No relationship",
-                "Positive linear relationship",
-                "Negative linear relationship",
-                "Nonlinear relationship",
-            ],
-            highlightLint: false,
-            static: false,
-        };
-
-        const useInput = {
-            values: [1, 3],
-        } as const;
-        const score = Categorizer.validate(useInput, rubric, mockStrings);
-
-        expect(score).toMatchInlineSnapshot(`
-            {
-              "earned": 1,
-              "message": null,
-              "total": 1,
-              "type": "points",
-            }
-        `);
-    });
-
-    it("does not give points when incorrectly answered", () => {
-        const rubric: Rubric = {
-            items: ["Graph $1$", "Graph $2$"],
-            values: [1, 3],
-            randomizeItems: false,
-            categories: [
-                "No relationship",
-                "Positive linear relationship",
-                "Negative linear relationship",
-                "Nonlinear relationship",
-            ],
-            highlightLint: false,
-            static: false,
-        };
-
-        const useInput = {
-            values: [2, 3],
-        } as const;
-        const score = Categorizer.validate(useInput, rubric, mockStrings);
-
-        expect(score).toMatchInlineSnapshot(`
-            {
-              "earned": 0,
-              "message": null,
-              "total": 1,
-              "type": "points",
-            }
-        `);
-    });
-
-    it("tells the learner its not complete if not selected", () => {
-        const rubric: Rubric = {
-            items: ["Graph $1$", "Graph $2$"],
-            values: [1, 3],
-            randomizeItems: false,
-            categories: [
-                "No relationship",
-                "Positive linear relationship",
-                "Negative linear relationship",
-                "Nonlinear relationship",
-            ],
-            highlightLint: false,
-            static: false,
-        };
-
-        const useInput = {
-            values: [2],
-        } as const;
-        const score = Categorizer.validate(useInput, rubric, mockStrings);
-
-        expect(score).toMatchInlineSnapshot(`
-            {
-              "message": "Make sure you select something for every row.",
-              "type": "invalid",
-            }
-        `);
     });
 });

--- a/packages/perseus/src/widgets/categorizer/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.tsx
@@ -15,15 +15,12 @@ import mediaQueries from "../../styles/media-queries";
 import sharedStyles from "../../styles/shared";
 import Util from "../../util";
 
+import categorizerValidator from "./categorizer-validator";
+
+import type {Rubric, UserInput} from "./categorizer.types";
 import type {PerseusCategorizerWidgetOptions} from "../../perseus-types";
 import type {PerseusStrings} from "../../strings";
 import type {PerseusScore, WidgetExports, WidgetProps} from "../../types";
-
-type UserInput = {
-    values: ReadonlyArray<number>;
-};
-
-export type Rubric = PerseusCategorizerWidgetOptions;
 
 type Props = WidgetProps<RenderProps, Rubric> & {
     values: ReadonlyArray<string>;
@@ -60,28 +57,7 @@ export class Categorizer extends React.Component<Props, State> {
         rubric: Rubric,
         strings: PerseusStrings,
     ): PerseusScore {
-        let completed = true;
-        let allCorrect = true;
-        rubric.values.forEach((value, i) => {
-            if (userInput.values[i] == null) {
-                completed = false;
-            }
-            if (userInput.values[i] !== value) {
-                allCorrect = false;
-            }
-        });
-        if (!completed) {
-            return {
-                type: "invalid",
-                message: strings.invalidSelection,
-            };
-        }
-        return {
-            type: "points",
-            earned: allCorrect ? 1 : 0,
-            total: 1,
-            message: null,
-        };
+        return categorizerValidator(userInput, rubric, strings);
     }
 
     static getUserInputFromProps(props: Props): UserInput {
@@ -106,7 +82,7 @@ export class Categorizer extends React.Component<Props, State> {
     }
 
     simpleValidate: (arg1: Rubric) => PerseusScore = (rubric) => {
-        return Categorizer.validate(
+        return categorizerValidator(
             this.getUserInput(),
             rubric,
             this.context.strings,

--- a/packages/perseus/src/widgets/categorizer/categorizer.types.ts
+++ b/packages/perseus/src/widgets/categorizer/categorizer.types.ts
@@ -1,0 +1,7 @@
+import type {PerseusCategorizerWidgetOptions} from "../../perseus-types";
+
+export type UserInput = {
+    values: ReadonlyArray<number>;
+};
+
+export type Rubric = PerseusCategorizerWidgetOptions;


### PR DESCRIPTION
## Summary:
For the servier-side scoring project, we are moving validation logic out of each widget component. This moves the validation logic for the categorizer widget.

Issue: LEMS-2341

## Test plan:
- All tests should pass
- Nothing should chang as code is just being moved into separate files