### PR TITLE
[Locked Figure Labels] View locked line labels

### DIFF
--- a/.changeset/few-moles-obey.md
+++ b/.changeset/few-moles-obey.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-editor": minor
+---
+
+[Locked Figure Labels] View locked line labels

--- a/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
+++ b/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
@@ -17,6 +17,7 @@ export const flags = {
         // Locked figures flags
         "interactive-graph-locked-features-labels": true,
         "locked-point-labels": true,
+        "locked-line-labels": true,
     },
 } satisfies APIOptions["flags"];
 

--- a/packages/perseus-editor/src/__stories__/interactive-graph-editor.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/interactive-graph-editor.stories.tsx
@@ -153,6 +153,8 @@ export const MafsWithLockedFiguresCurrent = (): React.ReactElement => {
                     mafs: {
                         ...flags.mafs,
                         "interactive-graph-locked-features-labels": false,
+                        "locked-point-labels": false,
+                        "locked-line-labels": false,
                     },
                 },
             }}
@@ -178,6 +180,7 @@ export const MafsWithLockedLabelsFlag = (): React.ReactElement => {
                         ...flags.mafs,
                         "interactive-graph-locked-features-labels": true,
                         "locked-point-labels": false,
+                        "locked-line-labels": false,
                     },
                 },
             }}
@@ -196,11 +199,49 @@ MafsWithLockedLabelsFlag.parameters = {
 
 export const MafsWithLockedPointLabelsFlag = (): React.ReactElement => {
     return (
-        <EditorPageWithStorybookPreview question={segmentWithLockedFigures} />
+        <EditorPageWithStorybookPreview
+            apiOptions={{
+                flags: {
+                    mafs: {
+                        ...flags.mafs,
+                        "interactive-graph-locked-features-labels": true,
+                        "locked-point-labels": true,
+                        "locked-line-labels": false,
+                    },
+                },
+            }}
+            question={segmentWithLockedFigures}
+        />
     );
 };
 
 MafsWithLockedPointLabelsFlag.parameters = {
+    chromatic: {
+        // Disabling because this isn't visually testing anything on the
+        // initial load of the editor page.
+        disable: true,
+    },
+};
+
+export const MafsWithLockedLineLabelsFlag = (): React.ReactElement => {
+    return (
+        <EditorPageWithStorybookPreview
+            apiOptions={{
+                flags: {
+                    mafs: {
+                        ...flags.mafs,
+                        "interactive-graph-locked-features-labels": true,
+                        "locked-point-labels": false,
+                        "locked-line-labels": true,
+                    },
+                },
+            }}
+            question={segmentWithLockedFigures}
+        />
+    );
+};
+
+MafsWithLockedLineLabelsFlag.parameters = {
     chromatic: {
         // Disabling because this isn't visually testing anything on the
         // initial load of the editor page.

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.test.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.test.ts
@@ -37,6 +37,7 @@ describe("getDefaultFigureForType", () => {
             lineStyle: "solid",
             showPoint1: false,
             showPoint2: false,
+            labels: [],
         });
     });
 

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.ts
@@ -47,6 +47,7 @@ export function getDefaultFigureForType(type: LockedFigureType): LockedFigure {
                 lineStyle: "solid",
                 showPoint1: false,
                 showPoint2: false,
+                labels: [],
             };
         case "vector":
             return {

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -735,6 +735,7 @@ export type LockedLineType = {
     lineStyle: LockedLineStyle;
     showPoint1: boolean;
     showPoint2: boolean;
+    labels: LockedLabelType[];
 };
 
 export type LockedVectorType = {

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -160,6 +160,11 @@ export const InteractiveGraphLockedFeaturesFlags = [
      * updated Interactive Graph widget.
      */
     "locked-point-labels",
+    /**
+     * Enables/disables the labels associated with locked lines in the
+     * updated Interactive Graph widget.
+     */
+    "locked-line-labels",
 ] as const;
 
 /**

--- a/packages/perseus/src/widgets/interactive-graphs/graph-locked-labels-layer.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graph-locked-labels-layer.tsx
@@ -19,11 +19,14 @@ export default function GraphLockedLabelsLayer(props: Props) {
         }
 
         if (
-            flags?.["mafs"]?.["locked-point-labels"] &&
-            figure.type === "point"
+            // Point flag + point type
+            (flags?.["mafs"]?.["locked-point-labels"] &&
+                figure.type === "point") ||
+            // Line flag + line type
+            (flags?.["mafs"]?.["locked-line-labels"] && figure.type === "line")
         ) {
             return (
-                <React.Fragment key={`point-${i}`}>
+                <React.Fragment key={`locked-figure-${i}`}>
                     {figure.labels.map((label, j) => (
                         <LockedLabel
                             key={`locked-figure-${i}-label-${j}`}

--- a/packages/perseus/src/widgets/interactive-graphs/graph-locked-labels-layer.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graph-locked-labels-layer.tsx
@@ -26,12 +26,9 @@ export default function GraphLockedLabelsLayer(props: Props) {
             (flags?.["mafs"]?.["locked-line-labels"] && figure.type === "line")
         ) {
             return (
-                <React.Fragment key={`locked-figure-${i}`}>
+                <React.Fragment key={i}>
                     {figure.labels.map((label, j) => (
-                        <LockedLabel
-                            key={`locked-figure-${i}-label-${j}`}
-                            {...label}
-                        />
+                        <LockedLabel key={`${i}-label-${j}`} {...label} />
                     ))}
                 </React.Fragment>
             );

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
@@ -856,6 +856,109 @@ describe("InteractiveGraphQuestionBuilder", () => {
                 lineStyle: "solid",
                 showPoint1: false,
                 showPoint2: false,
+                labels: [],
+            },
+        ]);
+    });
+
+    it("adds a locked line with options and minimal label", () => {
+        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .addLockedLine([1, 2], [3, 4], {
+                kind: "segment",
+                lineStyle: "dashed",
+                color: "green",
+                filled: [false, false],
+                showPoint1: true,
+                showPoint2: true,
+                labels: [{text: "a label"}],
+            })
+            .build();
+        const graph = question.widgets["interactive-graph 1"];
+
+        expect(graph.options.lockedFigures).toEqual([
+            {
+                type: "line",
+                kind: "segment",
+                points: [
+                    {
+                        type: "point",
+                        coord: [1, 2],
+                        color: "green",
+                        filled: false,
+                        labels: [],
+                    },
+                    {
+                        type: "point",
+                        coord: [3, 4],
+                        color: "green",
+                        filled: false,
+                        labels: [],
+                    },
+                ],
+                color: "green",
+                lineStyle: "dashed",
+                showPoint1: true,
+                showPoint2: true,
+                labels: [
+                    {
+                        type: "label",
+                        text: "a label",
+                        coord: [2, 3],
+                        color: "green",
+                        size: "medium",
+                    },
+                ],
+            },
+        ]);
+    });
+
+    it("adds a locked line with options and specific label", () => {
+        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .addLockedLine([1, 2], [3, 4], {
+                kind: "segment",
+                lineStyle: "dashed",
+                color: "green",
+                filled: [false, false],
+                showPoint1: true,
+                showPoint2: true,
+                labels: [{text: "a label", coord: [9, 9], size: "small"}],
+            })
+            .build();
+        const graph = question.widgets["interactive-graph 1"];
+
+        expect(graph.options.lockedFigures).toEqual([
+            {
+                type: "line",
+                kind: "segment",
+                points: [
+                    {
+                        type: "point",
+                        coord: [1, 2],
+                        color: "green",
+                        filled: false,
+                        labels: [],
+                    },
+                    {
+                        type: "point",
+                        coord: [3, 4],
+                        color: "green",
+                        filled: false,
+                        labels: [],
+                    },
+                ],
+                color: "green",
+                lineStyle: "dashed",
+                showPoint1: true,
+                showPoint2: true,
+                labels: [
+                    {
+                        type: "label",
+                        text: "a label",
+                        coord: [9, 9],
+                        color: "green",
+                        size: "small",
+                    },
+                ],
             },
         ]);
     });

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -1,3 +1,5 @@
+import {line as kline} from "@khanacademy/kmath";
+
 import type {Coord} from "../../interactive2/types";
 import type {
     CollinearTuple,
@@ -22,6 +24,12 @@ export type LockedFunctionOptions = {
     strokeStyle?: LockedLineStyle;
     directionalAxis?: "x" | "y";
     domain?: Interval;
+};
+
+type LockedFigureLabelOptions = {
+    text: string;
+    coord?: Coord;
+    size?: "small" | "medium" | "large";
 };
 
 export function interactiveGraphQuestionBuilder(): InteractiveGraphQuestionBuilder {
@@ -288,11 +296,7 @@ class InteractiveGraphQuestionBuilder {
         options?: {
             color?: LockedFigureColor;
             filled?: boolean;
-            labels?: {
-                text: string;
-                coord?: Coord;
-                size?: "small" | "medium" | "large";
-            }[];
+            labels?: LockedFigureLabelOptions[];
         },
     ): InteractiveGraphQuestionBuilder {
         this.addLockedFigure(this.createLockedPoint(x, y, options));
@@ -309,6 +313,7 @@ class InteractiveGraphQuestionBuilder {
             filled?: [boolean, boolean];
             showPoint1?: boolean;
             showPoint2?: boolean;
+            labels?: LockedFigureLabelOptions[];
         },
     ): InteractiveGraphQuestionBuilder {
         const line: LockedLineType = {
@@ -318,6 +323,17 @@ class InteractiveGraphQuestionBuilder {
             showPoint2: options?.showPoint2 ?? false,
             color: options?.color ?? "grayH",
             lineStyle: options?.lineStyle ?? "solid",
+            labels: options?.labels
+                ? options.labels.map((label) => ({
+                      type: "label",
+                      coord:
+                          label.coord ??
+                          ([...kline.midpoint([point1, point2])] as Coord),
+                      text: label.text,
+                      color: options.color ?? "grayH",
+                      size: label.size ?? "medium",
+                  }))
+                : [],
             points: [
                 {
                     ...this.createLockedPoint(...point1, {
@@ -440,11 +456,7 @@ class InteractiveGraphQuestionBuilder {
         options?: {
             color?: LockedFigureColor;
             filled?: boolean;
-            labels?: {
-                text: string;
-                coord?: Coord;
-                size?: "small" | "medium" | "large";
-            }[];
+            labels?: LockedFigureLabelOptions[];
         },
     ): LockedPointType {
         return {

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -323,17 +323,15 @@ class InteractiveGraphQuestionBuilder {
             showPoint2: options?.showPoint2 ?? false,
             color: options?.color ?? "grayH",
             lineStyle: options?.lineStyle ?? "solid",
-            labels: options?.labels
-                ? options.labels.map((label) => ({
-                      type: "label",
-                      coord:
-                          label.coord ??
-                          ([...kline.midpoint([point1, point2])] as Coord),
-                      text: label.text,
-                      color: options.color ?? "grayH",
-                      size: label.size ?? "medium",
-                  }))
-                : [],
+            labels: (options?.labels ?? []).map((label) => ({
+                type: "label",
+                coord:
+                    label.coord ??
+                    ([...kline.midpoint([point1, point2])] as Coord),
+                text: label.text,
+                color: options?.color ?? "grayH",
+                size: label.size ?? "medium",
+            })),
             points: [
                 {
                     ...this.createLockedPoint(...point1, {
@@ -464,15 +462,13 @@ class InteractiveGraphQuestionBuilder {
             coord: [x, y],
             color: options?.color ?? "grayH",
             filled: options?.filled ?? true,
-            labels: options?.labels
-                ? options.labels.map((label) => ({
-                      type: "label",
-                      coord: label.coord ?? [x + 0.5, y],
-                      text: label.text,
-                      color: options.color ?? "grayH",
-                      size: label.size ?? "medium",
-                  }))
-                : [],
+            labels: (options?.labels ?? []).map((label) => ({
+                type: "label",
+                coord: label.coord ?? [x + 0.5, y],
+                text: label.text,
+                color: options?.color ?? "grayH",
+                size: label.size ?? "medium",
+            })),
         };
     }
 

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
@@ -20,6 +20,7 @@ import {
     angleQuestionWithDefaultCorrect,
     circleQuestion,
     circleQuestionWithDefaultCorrect,
+    graphWithLabeledLine,
     graphWithLabeledPoint,
     interactiveGraphWithAriaLabel,
     linearQuestion,
@@ -935,7 +936,7 @@ describe("locked layer", () => {
         });
     });
 
-    it("should render a locked label within a locked figure", async () => {
+    it("should render a locked label within a locked point", async () => {
         // Arrange
         const {container} = renderQuestion(graphWithLabeledPoint, {
             flags: {
@@ -960,6 +961,33 @@ describe("locked layer", () => {
             fontSize: "16px",
             left: "210px",
             top: "200px",
+        });
+    });
+
+    it("should render a locked label within a locked line", async () => {
+        const {container} = renderQuestion(graphWithLabeledLine, {
+            flags: {
+                mafs: {
+                    segment: true,
+                    "interactive-graph-locked-features-labels": true,
+                    "locked-line-labels": true,
+                },
+            },
+        });
+
+        // Act
+        // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+        const labels = container.querySelectorAll(".locked-label");
+        const label = labels[0];
+
+        // Assert
+        expect(labels).toHaveLength(1);
+        expect(label).toHaveTextContent("B");
+        expect(label).toHaveStyle({
+            color: lockedFigureColors["grayH"],
+            fontSize: "16px",
+            left: "150px",
+            top: "280px",
         });
     });
 

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -831,7 +831,11 @@ export const segmentWithLockedLabels: PerseusRenderer =
 export const segmentWithLockedFigures: PerseusRenderer =
     interactiveGraphQuestionBuilder()
         .addLockedPointAt(-7, -7, {labels: [{text: "A"}]})
-        .addLockedLine([-7, -5], [2, -3])
+        .addLockedLine([-7, -5], [2, -3], {
+            showPoint1: true,
+            showPoint2: true,
+            labels: [{text: "B"}],
+        })
         .addLockedVector([0, 0], [8, 2], "purple")
         .addLockedEllipse([0, 5], [4, 2], {angle: Math.PI / 4, color: "blue"})
         .addLockedPolygon(
@@ -955,5 +959,12 @@ export const graphWithLabeledPoint: PerseusRenderer =
     interactiveGraphQuestionBuilder()
         .addLockedPointAt(0, 0, {
             labels: [{text: "A"}],
+        })
+        .build();
+
+export const graphWithLabeledLine: PerseusRenderer =
+    interactiveGraphQuestionBuilder()
+        .addLockedLine([-7, -5], [2, -3], {
+            labels: [{text: "B"}],
         })
         .build();


### PR DESCRIPTION
## Summary:
- Add a feature flag for locked line labels
- Add `labels` to LockedLineType
- Update builder
- Updates stories and tests

Issue: https://khanacademy.atlassian.net/browse/LEMS-2347

## Test plan:
- Go to the following story: http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--mafs-with-locked-line-labels-flag
- Confirm there is a label "B" next to the locked line
- Go to the following story: http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--mafs-with-locked-point-labels-flag
- Confirm there is no "B" next to the line (there should be an "A" for the point)
- Go to the following story: http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--mafs-with-locked-labels-flag
- Confirm there is no A or B label next to the point or the line

<img width="495" alt="image" src="https://github.com/user-attachments/assets/3880afa2-7812-46c1-aa4a-cf1d4fb2d203">
