### PR TITLE
Omit extra properties from InteractiveGraph onChange arg

### DIFF
--- a/.changeset/eleven-elephants-trade.md
+++ b/.changeset/eleven-elephants-trade.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Omit unused data from interactive graph onChange callback

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -9,7 +9,6 @@ import type {
 } from "./perseus-types";
 import type {PerseusStrings} from "./strings";
 import type {SizeClass} from "./util/sizing-utils";
-import type {InteractiveGraphState} from "./widgets/interactive-graphs/types";
 import type {KeypadAPI} from "@khanacademy/math-input";
 import type {AnalyticsEventHandlerFn} from "@khanacademy/perseus-core";
 import type {LinterContextProps} from "@khanacademy/perseus-linter";

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -3,6 +3,7 @@ import type {Item} from "./multi-items/item-types";
 import type {
     Hint,
     PerseusAnswerArea,
+    PerseusGraphType,
     PerseusWidget,
     PerseusWidgetsMap,
 } from "./perseus-types";
@@ -90,7 +91,7 @@ export type ChangeHandler = (
         // perseus-all-package/widgets/grapher.jsx
         plot?: any;
         // Interactive Graph callback (see legacy: interactive-graph.tsx)
-        graph?: InteractiveGraphState;
+        graph?: PerseusGraphType;
     },
     callback?: () => unknown | null | undefined,
     silent?: boolean,

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -1656,7 +1656,6 @@ class LegacyInteractiveGraph extends React.Component<Props, State> {
 
         $(this.angle).on("move", () => {
             this.onChange({
-                // @ts-expect-error Type '{ coords: any; type: "angle"; showAngles?: boolean | undefined; allowReflexAngles?: boolean | undefined; angleOffsetDeg?: number | undefined; snapDegrees?: number | undefined; match?: "congruent" | undefined; }' is not assignable to type 'InteractiveGraphState | undefined'.
                 graph: {...graph, coords: this.angle?.getClockwiseCoords()},
             });
         });

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.test.ts
@@ -1,23 +1,29 @@
-import {
-    AngleGraphState,
-    CircleGraphState, InteractiveGraphState, InteractiveGraphStateCommon,
-    LinearGraphState,
-    LinearSystemGraphState, NoneGraphState,
-    PointGraphState,
-    PolygonGraphState, QuadraticGraphState,
-    RayGraphState,
-    SegmentGraphState, SinusoidGraphState
-} from "./types";
 import {mafsStateToInteractiveGraph} from "./mafs-state-to-interactive-graph";
-import {PerseusGraphType} from "../../perseus-types";
-import {Coord} from "@khanacademy/perseus";
-import {Interval, vec} from "mafs";
+
+import type {
+    AngleGraphState,
+    CircleGraphState,
+    InteractiveGraphStateCommon,
+    LinearGraphState,
+    LinearSystemGraphState,
+    NoneGraphState,
+    PointGraphState,
+    PolygonGraphState,
+    QuadraticGraphState,
+    RayGraphState,
+    SegmentGraphState,
+    SinusoidGraphState,
+} from "./types";
+import type {PerseusGraphType} from "../../perseus-types";
 
 const commonGraphState: InteractiveGraphStateCommon = {
     hasBeenInteractedWith: true,
-    range: [[-9, 9], [-9, 9]],
+    range: [
+        [-9, 9],
+        [-9, 9],
+    ],
     snapStep: [9, 9],
-}
+};
 
 describe("mafsStateToInteractiveGraph", () => {
     it("converts the state of an angle graph", () => {
@@ -28,16 +34,24 @@ describe("mafsStateToInteractiveGraph", () => {
             allowReflexAngles: true,
             angleOffsetDeg: 7,
             snapDegrees: 8,
-            coords: [[9, 10], [11, 12], [13, 14]],
-        }
+            coords: [
+                [9, 10],
+                [11, 12],
+                [13, 14],
+            ],
+        };
 
         const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
 
         expect(result).toEqual({
             type: "angle",
-            coords: [[9, 10], [11, 12], [13, 14]],
-        })
-    })
+            coords: [
+                [9, 10],
+                [11, 12],
+                [13, 14],
+            ],
+        });
+    });
 
     it("converts the state of a circle graph", () => {
         const state: CircleGraphState = {
@@ -45,7 +59,10 @@ describe("mafsStateToInteractiveGraph", () => {
             center: [1, 2],
             radiusPoint: [3, 2],
             hasBeenInteractedWith: true,
-            range: [[-9, 9], [-9, 9]],
+            range: [
+                [-9, 9],
+                [-9, 9],
+            ],
             snapStep: [9, 9],
         };
 
@@ -55,68 +72,108 @@ describe("mafsStateToInteractiveGraph", () => {
             type: "circle",
             radius: 2,
             center: [1, 2],
-        })
-    })
+        });
+    });
 
     it("converts the state of a segment graph", () => {
         const state: SegmentGraphState = {
             ...commonGraphState,
             type: "segment",
-            coords: [[[1, 2], [3, 4]]],
+            coords: [
+                [
+                    [1, 2],
+                    [3, 4],
+                ],
+            ],
         };
 
         const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
 
         expect(result).toEqual({
             type: "segment",
-            coords: [[[1, 2], [3, 4]]],
-        })
-    })
+            coords: [
+                [
+                    [1, 2],
+                    [3, 4],
+                ],
+            ],
+        });
+    });
 
     it("converts the state of a linear graph", () => {
         const state: LinearGraphState = {
             ...commonGraphState,
             type: "linear",
-            coords: [[1, 2], [3, 4]],
+            coords: [
+                [1, 2],
+                [3, 4],
+            ],
         };
 
         const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
 
         expect(result).toEqual({
             type: "linear",
-            coords: [[1, 2], [3, 4]],
-        })
-    })
+            coords: [
+                [1, 2],
+                [3, 4],
+            ],
+        });
+    });
 
     it("converts the state of a linear-system graph", () => {
         const state: LinearSystemGraphState = {
             ...commonGraphState,
             type: "linear-system",
-            coords: [[[1, 2], [3, 4]], [[5, 6], [7, 8]]],
+            coords: [
+                [
+                    [1, 2],
+                    [3, 4],
+                ],
+                [
+                    [5, 6],
+                    [7, 8],
+                ],
+            ],
         };
 
         const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
 
         expect(result).toEqual({
             type: "linear-system",
-            coords: [[[1, 2], [3, 4]], [[5, 6], [7, 8]]],
-        })
-    })
+            coords: [
+                [
+                    [1, 2],
+                    [3, 4],
+                ],
+                [
+                    [5, 6],
+                    [7, 8],
+                ],
+            ],
+        });
+    });
 
     it("converts the state of a ray graph", () => {
         const state: RayGraphState = {
             ...commonGraphState,
             type: "ray",
-            coords: [[1, 2], [3, 4]],
+            coords: [
+                [1, 2],
+                [3, 4],
+            ],
         };
 
         const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
 
         expect(result).toEqual({
             type: "ray",
-            coords: [[1, 2], [3, 4]],
-        })
-    })
+            coords: [
+                [1, 2],
+                [3, 4],
+            ],
+        });
+    });
 
     it("converts the state of a polygon graph", () => {
         const state: PolygonGraphState = {
@@ -125,16 +182,24 @@ describe("mafsStateToInteractiveGraph", () => {
             showAngles: true,
             showSides: true,
             snapTo: "sides",
-            coords: [[1, 2], [3, 4], [5, 6]],
+            coords: [
+                [1, 2],
+                [3, 4],
+                [5, 6],
+            ],
         };
 
         const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
 
         expect(result).toEqual({
             type: "polygon",
-            coords: [[1, 2], [3, 4], [5, 6]],
-        })
-    })
+            coords: [
+                [1, 2],
+                [3, 4],
+                [5, 6],
+            ],
+        });
+    });
 
     it("converts the state of a point graph", () => {
         const state: PointGraphState = {
@@ -143,57 +208,79 @@ describe("mafsStateToInteractiveGraph", () => {
             numPoints: "unlimited",
             focusedPointIndex: 99,
             showRemovePointButton: true,
-            coords: [[1, 2], [3, 4], [5, 6]],
+            coords: [
+                [1, 2],
+                [3, 4],
+                [5, 6],
+            ],
         };
 
         const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
 
         expect(result).toEqual({
             type: "point",
-            coords: [[1, 2], [3, 4], [5, 6]],
-        })
-    })
+            coords: [
+                [1, 2],
+                [3, 4],
+                [5, 6],
+            ],
+        });
+    });
 
     it("converts the state of a quadratic graph", () => {
         const state: QuadraticGraphState = {
             ...commonGraphState,
             type: "quadratic",
-            coords: [[1, 2], [3, 4], [5, 6]],
+            coords: [
+                [1, 2],
+                [3, 4],
+                [5, 6],
+            ],
         };
 
         const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
 
         expect(result).toEqual({
             type: "quadratic",
-            coords: [[1, 2], [3, 4], [5, 6]],
-        })
-    })
+            coords: [
+                [1, 2],
+                [3, 4],
+                [5, 6],
+            ],
+        });
+    });
 
     it("converts the state of a sinusoid graph", () => {
         const state: SinusoidGraphState = {
             ...commonGraphState,
             type: "sinusoid",
-            coords: [[1, 2], [3, 4]],
-        }
+            coords: [
+                [1, 2],
+                [3, 4],
+            ],
+        };
 
         const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
 
         expect(result).toEqual({
             type: "sinusoid",
-            coords: [[1, 2], [3, 4]],
-        })
-    })
+            coords: [
+                [1, 2],
+                [3, 4],
+            ],
+        });
+    });
 
     it("converts the state of a none-type graph", () => {
         const state: NoneGraphState = {
             ...commonGraphState,
             type: "none",
-        }
+        };
 
         const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
 
         expect(result).toEqual({
             type: "none",
-        })
-    })
-})
+        });
+    });
+});

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.test.ts
@@ -208,6 +208,8 @@ describe("mafsStateToInteractiveGraph", () => {
             numPoints: "unlimited",
             focusedPointIndex: 99,
             showRemovePointButton: true,
+            showKeyboardInteractionInvitation: true,
+            interactionMode: "mouse",
             coords: [
                 [1, 2],
                 [3, 4],

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.test.ts
@@ -1,0 +1,199 @@
+import {
+    AngleGraphState,
+    CircleGraphState, InteractiveGraphState, InteractiveGraphStateCommon,
+    LinearGraphState,
+    LinearSystemGraphState, NoneGraphState,
+    PointGraphState,
+    PolygonGraphState, QuadraticGraphState,
+    RayGraphState,
+    SegmentGraphState, SinusoidGraphState
+} from "./types";
+import {mafsStateToInteractiveGraph} from "./mafs-state-to-interactive-graph";
+import {PerseusGraphType} from "../../perseus-types";
+import {Coord} from "@khanacademy/perseus";
+import {Interval, vec} from "mafs";
+
+const commonGraphState: InteractiveGraphStateCommon = {
+    hasBeenInteractedWith: true,
+    range: [[-9, 9], [-9, 9]],
+    snapStep: [9, 9],
+}
+
+describe("mafsStateToInteractiveGraph", () => {
+    it("converts the state of an angle graph", () => {
+        const state: AngleGraphState = {
+            ...commonGraphState,
+            type: "angle",
+            showAngles: true,
+            allowReflexAngles: true,
+            angleOffsetDeg: 7,
+            snapDegrees: 8,
+            coords: [[9, 10], [11, 12], [13, 14]],
+        }
+
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+
+        expect(result).toEqual({
+            type: "angle",
+            coords: [[9, 10], [11, 12], [13, 14]],
+        })
+    })
+
+    it("converts the state of a circle graph", () => {
+        const state: CircleGraphState = {
+            type: "circle",
+            center: [1, 2],
+            radiusPoint: [3, 2],
+            hasBeenInteractedWith: true,
+            range: [[-9, 9], [-9, 9]],
+            snapStep: [9, 9],
+        };
+
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+
+        expect(result).toEqual({
+            type: "circle",
+            radius: 2,
+            center: [1, 2],
+        })
+    })
+
+    it("converts the state of a segment graph", () => {
+        const state: SegmentGraphState = {
+            ...commonGraphState,
+            type: "segment",
+            coords: [[[1, 2], [3, 4]]],
+        };
+
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+
+        expect(result).toEqual({
+            type: "segment",
+            coords: [[[1, 2], [3, 4]]],
+        })
+    })
+
+    it("converts the state of a linear graph", () => {
+        const state: LinearGraphState = {
+            ...commonGraphState,
+            type: "linear",
+            coords: [[1, 2], [3, 4]],
+        };
+
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+
+        expect(result).toEqual({
+            type: "linear",
+            coords: [[1, 2], [3, 4]],
+        })
+    })
+
+    it("converts the state of a linear-system graph", () => {
+        const state: LinearSystemGraphState = {
+            ...commonGraphState,
+            type: "linear-system",
+            coords: [[[1, 2], [3, 4]], [[5, 6], [7, 8]]],
+        };
+
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+
+        expect(result).toEqual({
+            type: "linear-system",
+            coords: [[[1, 2], [3, 4]], [[5, 6], [7, 8]]],
+        })
+    })
+
+    it("converts the state of a ray graph", () => {
+        const state: RayGraphState = {
+            ...commonGraphState,
+            type: "ray",
+            coords: [[1, 2], [3, 4]],
+        };
+
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+
+        expect(result).toEqual({
+            type: "ray",
+            coords: [[1, 2], [3, 4]],
+        })
+    })
+
+    it("converts the state of a polygon graph", () => {
+        const state: PolygonGraphState = {
+            ...commonGraphState,
+            type: "polygon",
+            showAngles: true,
+            showSides: true,
+            snapTo: "sides",
+            coords: [[1, 2], [3, 4], [5, 6]],
+        };
+
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+
+        expect(result).toEqual({
+            type: "polygon",
+            coords: [[1, 2], [3, 4], [5, 6]],
+        })
+    })
+
+    it("converts the state of a point graph", () => {
+        const state: PointGraphState = {
+            ...commonGraphState,
+            type: "point",
+            numPoints: "unlimited",
+            focusedPointIndex: 99,
+            showRemovePointButton: true,
+            coords: [[1, 2], [3, 4], [5, 6]],
+        };
+
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+
+        expect(result).toEqual({
+            type: "point",
+            coords: [[1, 2], [3, 4], [5, 6]],
+        })
+    })
+
+    it("converts the state of a quadratic graph", () => {
+        const state: QuadraticGraphState = {
+            ...commonGraphState,
+            type: "quadratic",
+            coords: [[1, 2], [3, 4], [5, 6]],
+        };
+
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+
+        expect(result).toEqual({
+            type: "quadratic",
+            coords: [[1, 2], [3, 4], [5, 6]],
+        })
+    })
+
+    it("converts the state of a sinusoid graph", () => {
+        const state: SinusoidGraphState = {
+            ...commonGraphState,
+            type: "sinusoid",
+            coords: [[1, 2], [3, 4]],
+        }
+
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+
+        expect(result).toEqual({
+            type: "sinusoid",
+            coords: [[1, 2], [3, 4]],
+        })
+    })
+
+    it("converts the state of a none-type graph", () => {
+        const state: NoneGraphState = {
+            ...commonGraphState,
+            type: "none",
+        }
+
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+
+        expect(result).toEqual({
+            type: "none",
+        })
+    })
+})

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.ts
@@ -1,0 +1,55 @@
+import {getRadius} from "./reducer/interactive-graph-state";
+
+import type {InteractiveGraphState} from "./types";
+import type {PerseusGraphType} from "@khanacademy/perseus";
+import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
+
+// Converts the state of a StatefulMafsGraph back to the format used to
+// represent graph state in the widget JSON.
+//
+// Rather than be tightly bound to how data was structured in
+// the legacy interactive graph, this lets us store state
+// however we want and we just transform it before handing it off
+// the the parent InteractiveGraph.
+//
+// The transformed state is used in the interactive graph widget editor, to
+// set the `correct` field of the graph options.
+export function mafsStateToInteractiveGraph(state: InteractiveGraphState): PerseusGraphType {
+    switch (state.type) {
+        case "angle":
+        case "quadratic":
+            return {
+                type: state.type,
+                coords: state.coords,
+            }
+        case "circle":
+            return {
+                type: "circle",
+                center: state.center,
+                radius: getRadius(state),
+            }
+        case "linear":
+        case "ray":
+        case "sinusoid":
+            return {
+                type: state.type,
+                coords: state.coords,
+            }
+        case "segment":
+        case "linear-system":
+            return {
+                type: state.type,
+                coords: state.coords,
+            }
+        case "polygon":
+        case "point":
+            return {
+                type: state.type,
+                coords: state.coords,
+            }
+        case "none":
+            return {type: "none"}
+        default:
+            throw new UnreachableCaseError(state)
+    }
+}

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.ts
@@ -13,8 +13,10 @@ import type {PerseusGraphType} from "@khanacademy/perseus";
 // however we want and we just transform it before handing it off
 // the the parent InteractiveGraph.
 //
-// The transformed state is used in the interactive graph widget editor, to
-// set the `correct` field of the graph options.
+// The transformed data is used in the interactive graph widget editor, to
+// set the `correct` field of the graph options. In the learner-facing UI, the
+// data is also stored by the Renderer, and passed back down to the graph
+// widget via the `graph` prop.
 export function mafsStateToInteractiveGraph(
     state: InteractiveGraphState,
 ): PerseusGraphType {

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.ts
@@ -1,8 +1,9 @@
+import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
+
 import {getRadius} from "./reducer/interactive-graph-state";
 
 import type {InteractiveGraphState} from "./types";
 import type {PerseusGraphType} from "@khanacademy/perseus";
-import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
 
 // Converts the state of a StatefulMafsGraph back to the format used to
 // represent graph state in the widget JSON.
@@ -14,42 +15,44 @@ import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
 //
 // The transformed state is used in the interactive graph widget editor, to
 // set the `correct` field of the graph options.
-export function mafsStateToInteractiveGraph(state: InteractiveGraphState): PerseusGraphType {
+export function mafsStateToInteractiveGraph(
+    state: InteractiveGraphState,
+): PerseusGraphType {
     switch (state.type) {
         case "angle":
         case "quadratic":
             return {
                 type: state.type,
                 coords: state.coords,
-            }
+            };
         case "circle":
             return {
                 type: "circle",
                 center: state.center,
                 radius: getRadius(state),
-            }
+            };
         case "linear":
         case "ray":
         case "sinusoid":
             return {
                 type: state.type,
                 coords: state.coords,
-            }
+            };
         case "segment":
         case "linear-system":
             return {
                 type: state.type,
                 coords: state.coords,
-            }
+            };
         case "polygon":
         case "point":
             return {
                 type: state.type,
                 coords: state.coords,
-            }
+            };
         case "none":
-            return {type: "none"}
+            return {type: "none"};
         default:
-            throw new UnreachableCaseError(state)
+            throw new UnreachableCaseError(state);
     }
 }

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
@@ -16,6 +16,7 @@ import type {InteractiveGraphProps, InteractiveGraphState} from "./types";
 import type {PerseusGraphType} from "../../perseus-types";
 import type {Widget} from "../../renderer";
 import type {APIOptions} from "../../types";
+import {mafsStateToInteractiveGraph} from "./mafs-state-to-interactive-graph";
 
 export type StatefulMafsGraphProps = {
     flags?: APIOptions["flags"];
@@ -40,22 +41,6 @@ export type StatefulMafsGraphProps = {
     readOnly: boolean;
     static: InteractiveGraphProps["static"];
 };
-
-// Rather than be tightly bound to how data was structured in
-// the legacy interactive graph, this lets us store state
-// however we want and we just transform it before handing it off
-// the the parent InteractiveGraph
-function mafsStateToInteractiveGraph(state: InteractiveGraphState): PerseusGraphType {
-    if (state.type === "circle") {
-        return {
-            ...state,
-            radius: getRadius(state),
-        };
-    }
-    return {
-        ...state,
-    };
-}
 
 export const StatefulMafsGraph = React.forwardRef<
     Partial<Widget>,

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import {useEffect, useImperativeHandle, useRef} from "react";
 
 import {MafsGraph} from "./mafs-graph";
+import {mafsStateToInteractiveGraph} from "./mafs-state-to-interactive-graph";
 import {initializeGraphState} from "./reducer/initialize-graph-state";
 import {
     changeRange,
@@ -10,13 +11,12 @@ import {
     reinitialize,
 } from "./reducer/interactive-graph-action";
 import {interactiveGraphReducer} from "./reducer/interactive-graph-reducer";
-import {getGradableGraph, getRadius} from "./reducer/interactive-graph-state";
+import {getGradableGraph} from "./reducer/interactive-graph-state";
 
 import type {InteractiveGraphProps, InteractiveGraphState} from "./types";
 import type {PerseusGraphType} from "../../perseus-types";
 import type {Widget} from "../../renderer";
 import type {APIOptions} from "../../types";
-import {mafsStateToInteractiveGraph} from "./mafs-state-to-interactive-graph";
 
 export type StatefulMafsGraphProps = {
     flags?: APIOptions["flags"];

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
@@ -45,14 +45,11 @@ export type StatefulMafsGraphProps = {
 // the legacy interactive graph, this lets us store state
 // however we want and we just transform it before handing it off
 // the the parent InteractiveGraph
-function mafsStateToInteractiveGraph(state: {graph: InteractiveGraphState}) {
-    if (state.graph.type === "circle") {
+function mafsStateToInteractiveGraph(state: InteractiveGraphState): PerseusGraphType {
+    if (state.type === "circle") {
         return {
             ...state,
-            graph: {
-                ...state.graph,
-                radius: getRadius(state.graph),
-            },
+            radius: getRadius(state),
         };
     }
     return {
@@ -80,7 +77,7 @@ export const StatefulMafsGraph = React.forwardRef<
 
     useEffect(() => {
         if (prevState.current !== state) {
-            onChange(mafsStateToInteractiveGraph({graph: state}));
+            onChange({graph: mafsStateToInteractiveGraph(state)});
         }
         prevState.current = state;
     }, [onChange, state]);


### PR DESCRIPTION
Previously, we were passing the entire Mafs graph state to onChange.  Since
the onChange callback data is used by the Interactive Graph widget editor to
set the correct answer for the graph, a bunch of extra data like
`"hasBeenInteractedWith": true` was getting saved in the `correct` field of
the Widget data.

This extra data is not used, so its presence in datastore is potentially
confusing to future maintainers trying to understand the data. It might
also cause bugs in the future - e.g. if some code merges it into another
object in which those properties _are_ meaningful.

This PR ensures that we only save relevant data in the `correct` field of
interactive graph widgets.

Issue: none

## Test plan:

Edit, save and publish an interactive graph widget in an exercise. As a
learner, you should be able to complete the exercise successfully.