### PR TITLE
Delete outdated comment about static widgets being banned from questions

### DIFF
--- a/.changeset/nine-dingos-appear.md
+++ b/.changeset/nine-dingos-appear.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: delete an outdated comment

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -562,8 +562,6 @@ export type WidgetProps<
     // provided by renderer.jsx#getWidgetProps()
     widgetId: string;
     alignment: string | null | undefined;
-    // When determining if a widget is static, we verify that the widget is not an
-    // exercise question by verifying that it has no problem number.
     static: boolean | null | undefined;
     problemNum: number | null | undefined;
     apiOptions: APIOptionsWithDefaults;


### PR DESCRIPTION
## Summary:
Static widgets can now appear in question stems. This behavior was
changed here:

https://github.com/Khan/perseus/pull/1503/files#diff-2630b3a01f66b4e66fb891ac29f5676d40759b290607f4f0e628701f37bf665dR658

The rationale for the change is explained in the [description of another PR](https://github.com/Khan/perseus/pull/1511)

Issue: none

Test plan:

CI should pass.