### PR TITLE
Reimplement mafsStateToInteractiveGraph

### DIFF
--- a/.changeset/eleven-elephants-trade.md
+++ b/.changeset/eleven-elephants-trade.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Omit unused data from interactive graph onChange callback

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -3,12 +3,12 @@ import type {Item} from "./multi-items/item-types";
 import type {
     Hint,
     PerseusAnswerArea,
+    PerseusGraphType,
     PerseusWidget,
     PerseusWidgetsMap,
 } from "./perseus-types";
 import type {PerseusStrings} from "./strings";
 import type {SizeClass} from "./util/sizing-utils";
-import type {InteractiveGraphState} from "./widgets/interactive-graphs/types";
 import type {KeypadAPI} from "@khanacademy/math-input";
 import type {AnalyticsEventHandlerFn} from "@khanacademy/perseus-core";
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
@@ -90,7 +90,7 @@ export type ChangeHandler = (
         // perseus-all-package/widgets/grapher.jsx
         plot?: any;
         // Interactive Graph callback (see legacy: interactive-graph.tsx)
-        graph?: InteractiveGraphState;
+        graph?: PerseusGraphType;
     },
     callback?: () => unknown | null | undefined,
     silent?: boolean,

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -1655,7 +1655,6 @@ class LegacyInteractiveGraph extends React.Component<Props, State> {
 
         $(this.angle).on("move", () => {
             this.onChange({
-                // @ts-expect-error Type '{ coords: any; type: "angle"; showAngles?: boolean | undefined; allowReflexAngles?: boolean | undefined; angleOffsetDeg?: number | undefined; snapDegrees?: number | undefined; match?: "congruent" | undefined; }' is not assignable to type 'InteractiveGraphState | undefined'.
                 graph: {...graph, coords: this.angle?.getClockwiseCoords()},
             });
         });

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.test.ts
@@ -1,0 +1,288 @@
+import {mafsStateToInteractiveGraph} from "./mafs-state-to-interactive-graph";
+
+import type {
+    AngleGraphState,
+    CircleGraphState,
+    InteractiveGraphStateCommon,
+    LinearGraphState,
+    LinearSystemGraphState,
+    NoneGraphState,
+    PointGraphState,
+    PolygonGraphState,
+    QuadraticGraphState,
+    RayGraphState,
+    SegmentGraphState,
+    SinusoidGraphState,
+} from "./types";
+import type {PerseusGraphType} from "../../perseus-types";
+
+const commonGraphState: InteractiveGraphStateCommon = {
+    hasBeenInteractedWith: true,
+    range: [
+        [-9, 9],
+        [-9, 9],
+    ],
+    snapStep: [9, 9],
+};
+
+describe("mafsStateToInteractiveGraph", () => {
+    it("converts the state of an angle graph", () => {
+        const state: AngleGraphState = {
+            ...commonGraphState,
+            type: "angle",
+            showAngles: true,
+            allowReflexAngles: true,
+            angleOffsetDeg: 7,
+            snapDegrees: 8,
+            coords: [
+                [9, 10],
+                [11, 12],
+                [13, 14],
+            ],
+        };
+
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+
+        expect(result).toEqual({
+            type: "angle",
+            coords: [
+                [9, 10],
+                [11, 12],
+                [13, 14],
+            ],
+        });
+    });
+
+    it("converts the state of a circle graph", () => {
+        const state: CircleGraphState = {
+            type: "circle",
+            center: [1, 2],
+            radiusPoint: [3, 2],
+            hasBeenInteractedWith: true,
+            range: [
+                [-9, 9],
+                [-9, 9],
+            ],
+            snapStep: [9, 9],
+        };
+
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+
+        expect(result).toEqual({
+            type: "circle",
+            radius: 2,
+            center: [1, 2],
+        });
+    });
+
+    it("converts the state of a segment graph", () => {
+        const state: SegmentGraphState = {
+            ...commonGraphState,
+            type: "segment",
+            coords: [
+                [
+                    [1, 2],
+                    [3, 4],
+                ],
+            ],
+        };
+
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+
+        expect(result).toEqual({
+            type: "segment",
+            coords: [
+                [
+                    [1, 2],
+                    [3, 4],
+                ],
+            ],
+        });
+    });
+
+    it("converts the state of a linear graph", () => {
+        const state: LinearGraphState = {
+            ...commonGraphState,
+            type: "linear",
+            coords: [
+                [1, 2],
+                [3, 4],
+            ],
+        };
+
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+
+        expect(result).toEqual({
+            type: "linear",
+            coords: [
+                [1, 2],
+                [3, 4],
+            ],
+        });
+    });
+
+    it("converts the state of a linear-system graph", () => {
+        const state: LinearSystemGraphState = {
+            ...commonGraphState,
+            type: "linear-system",
+            coords: [
+                [
+                    [1, 2],
+                    [3, 4],
+                ],
+                [
+                    [5, 6],
+                    [7, 8],
+                ],
+            ],
+        };
+
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+
+        expect(result).toEqual({
+            type: "linear-system",
+            coords: [
+                [
+                    [1, 2],
+                    [3, 4],
+                ],
+                [
+                    [5, 6],
+                    [7, 8],
+                ],
+            ],
+        });
+    });
+
+    it("converts the state of a ray graph", () => {
+        const state: RayGraphState = {
+            ...commonGraphState,
+            type: "ray",
+            coords: [
+                [1, 2],
+                [3, 4],
+            ],
+        };
+
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+
+        expect(result).toEqual({
+            type: "ray",
+            coords: [
+                [1, 2],
+                [3, 4],
+            ],
+        });
+    });
+
+    it("converts the state of a polygon graph", () => {
+        const state: PolygonGraphState = {
+            ...commonGraphState,
+            type: "polygon",
+            showAngles: true,
+            showSides: true,
+            snapTo: "sides",
+            coords: [
+                [1, 2],
+                [3, 4],
+                [5, 6],
+            ],
+        };
+
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+
+        expect(result).toEqual({
+            type: "polygon",
+            coords: [
+                [1, 2],
+                [3, 4],
+                [5, 6],
+            ],
+        });
+    });
+
+    it("converts the state of a point graph", () => {
+        const state: PointGraphState = {
+            ...commonGraphState,
+            type: "point",
+            numPoints: "unlimited",
+            focusedPointIndex: 99,
+            showRemovePointButton: true,
+            showKeyboardInteractionInvitation: true,
+            interactionMode: "mouse",
+            coords: [
+                [1, 2],
+                [3, 4],
+                [5, 6],
+            ],
+        };
+
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+
+        expect(result).toEqual({
+            type: "point",
+            coords: [
+                [1, 2],
+                [3, 4],
+                [5, 6],
+            ],
+        });
+    });
+
+    it("converts the state of a quadratic graph", () => {
+        const state: QuadraticGraphState = {
+            ...commonGraphState,
+            type: "quadratic",
+            coords: [
+                [1, 2],
+                [3, 4],
+                [5, 6],
+            ],
+        };
+
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+
+        expect(result).toEqual({
+            type: "quadratic",
+            coords: [
+                [1, 2],
+                [3, 4],
+                [5, 6],
+            ],
+        });
+    });
+
+    it("converts the state of a sinusoid graph", () => {
+        const state: SinusoidGraphState = {
+            ...commonGraphState,
+            type: "sinusoid",
+            coords: [
+                [1, 2],
+                [3, 4],
+            ],
+        };
+
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+
+        expect(result).toEqual({
+            type: "sinusoid",
+            coords: [
+                [1, 2],
+                [3, 4],
+            ],
+        });
+    });
+
+    it("converts the state of a none-type graph", () => {
+        const state: NoneGraphState = {
+            ...commonGraphState,
+            type: "none",
+        };
+
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+
+        expect(result).toEqual({
+            type: "none",
+        });
+    });
+});

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.test.ts
@@ -27,6 +27,10 @@ const commonGraphState: InteractiveGraphStateCommon = {
 
 describe("mafsStateToInteractiveGraph", () => {
     it("converts the state of an angle graph", () => {
+        const graph: PerseusGraphType = {
+            type: "angle",
+            match: "congruent",
+        }
         const state: AngleGraphState = {
             ...commonGraphState,
             type: "angle",
@@ -41,10 +45,11 @@ describe("mafsStateToInteractiveGraph", () => {
             ],
         };
 
-        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state, graph);
 
         expect(result).toEqual({
             type: "angle",
+            match: "congruent",
             coords: [
                 [9, 10],
                 [11, 12],
@@ -54,6 +59,13 @@ describe("mafsStateToInteractiveGraph", () => {
     });
 
     it("converts the state of a circle graph", () => {
+        const graph: PerseusGraphType = {
+            type: "circle",
+            startCoords: {
+                radius: 3,
+                center: [4, 5],
+            }
+        }
         const state: CircleGraphState = {
             type: "circle",
             center: [1, 2],
@@ -66,16 +78,24 @@ describe("mafsStateToInteractiveGraph", () => {
             snapStep: [9, 9],
         };
 
-        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state, graph);
 
         expect(result).toEqual({
             type: "circle",
             radius: 2,
             center: [1, 2],
+            startCoords: {
+                radius: 3,
+                center: [4, 5],
+            }
         });
     });
 
     it("converts the state of a segment graph", () => {
+        const graph: PerseusGraphType = {
+            type: "segment",
+            numSegments: 7,
+        }
         const state: SegmentGraphState = {
             ...commonGraphState,
             type: "segment",
@@ -87,10 +107,11 @@ describe("mafsStateToInteractiveGraph", () => {
             ],
         };
 
-        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state, graph);
 
         expect(result).toEqual({
             type: "segment",
+            numSegments: 7,
             coords: [
                 [
                     [1, 2],
@@ -101,6 +122,13 @@ describe("mafsStateToInteractiveGraph", () => {
     });
 
     it("converts the state of a linear graph", () => {
+        const graph: PerseusGraphType = {
+            type: "linear",
+            startCoords: [
+                [5, 6],
+                [7, 8],
+            ]
+        }
         const state: LinearGraphState = {
             ...commonGraphState,
             type: "linear",
@@ -110,7 +138,7 @@ describe("mafsStateToInteractiveGraph", () => {
             ],
         };
 
-        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state, graph);
 
         expect(result).toEqual({
             type: "linear",
@@ -118,10 +146,23 @@ describe("mafsStateToInteractiveGraph", () => {
                 [1, 2],
                 [3, 4],
             ],
+            startCoords: [
+                [5, 6],
+                [7, 8],
+            ]
         });
     });
 
     it("converts the state of a linear-system graph", () => {
+        const graph: PerseusGraphType = {
+            type: "linear-system",
+            startCoords: [
+                [
+                    [9, 10],
+                    [11, 12],
+                ]
+            ]
+        }
         const state: LinearSystemGraphState = {
             ...commonGraphState,
             type: "linear-system",
@@ -137,7 +178,7 @@ describe("mafsStateToInteractiveGraph", () => {
             ],
         };
 
-        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state, graph);
 
         expect(result).toEqual({
             type: "linear-system",
@@ -151,10 +192,23 @@ describe("mafsStateToInteractiveGraph", () => {
                     [7, 8],
                 ],
             ],
+            startCoords: [
+                [
+                    [9, 10],
+                    [11, 12],
+                ]
+            ]
         });
     });
 
     it("converts the state of a ray graph", () => {
+        const graph: PerseusGraphType = {
+            type: "ray",
+            startCoords: [
+                [5, 6],
+                [7, 8],
+            ]
+        }
         const state: RayGraphState = {
             ...commonGraphState,
             type: "ray",
@@ -164,7 +218,7 @@ describe("mafsStateToInteractiveGraph", () => {
             ],
         };
 
-        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state, graph);
 
         expect(result).toEqual({
             type: "ray",
@@ -172,10 +226,18 @@ describe("mafsStateToInteractiveGraph", () => {
                 [1, 2],
                 [3, 4],
             ],
+            startCoords: [
+                [5, 6],
+                [7, 8]
+            ]
         });
     });
 
     it("converts the state of a polygon graph", () => {
+        const graph: PerseusGraphType = {
+            type: "polygon",
+            match: "approx",
+        }
         const state: PolygonGraphState = {
             ...commonGraphState,
             type: "polygon",
@@ -189,10 +251,11 @@ describe("mafsStateToInteractiveGraph", () => {
             ],
         };
 
-        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state, graph);
 
         expect(result).toEqual({
             type: "polygon",
+            match: "approx",
             coords: [
                 [1, 2],
                 [3, 4],
@@ -202,6 +265,13 @@ describe("mafsStateToInteractiveGraph", () => {
     });
 
     it("converts the state of a point graph", () => {
+        const graph: PerseusGraphType = {
+            type: "point",
+            numPoints: "unlimited",
+            startCoords: [
+                [7, 8],
+            ],
+        }
         const state: PointGraphState = {
             ...commonGraphState,
             type: "point",
@@ -217,19 +287,31 @@ describe("mafsStateToInteractiveGraph", () => {
             ],
         };
 
-        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state, graph);
 
         expect(result).toEqual({
             type: "point",
+            numPoints: "unlimited",
             coords: [
                 [1, 2],
                 [3, 4],
                 [5, 6],
             ],
+            startCoords: [
+                [7, 8],
+            ]
         });
     });
 
     it("converts the state of a quadratic graph", () => {
+        const graph: PerseusGraphType = {
+            type: "quadratic",
+            startCoords: [
+                [7, 8],
+                [9, 10],
+                [11, 12],
+            ]
+        }
         const state: QuadraticGraphState = {
             ...commonGraphState,
             type: "quadratic",
@@ -240,7 +322,7 @@ describe("mafsStateToInteractiveGraph", () => {
             ],
         };
 
-        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state, graph);
 
         expect(result).toEqual({
             type: "quadratic",
@@ -249,10 +331,22 @@ describe("mafsStateToInteractiveGraph", () => {
                 [3, 4],
                 [5, 6],
             ],
+            startCoords: [
+                [7, 8],
+                [9, 10],
+                [11, 12],
+            ]
         });
     });
 
     it("converts the state of a sinusoid graph", () => {
+        const graph: PerseusGraphType = {
+            type: "sinusoid",
+            startCoords: [
+                [5, 6],
+                [7, 8],
+            ],
+        }
         const state: SinusoidGraphState = {
             ...commonGraphState,
             type: "sinusoid",
@@ -262,7 +356,7 @@ describe("mafsStateToInteractiveGraph", () => {
             ],
         };
 
-        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state, graph);
 
         expect(result).toEqual({
             type: "sinusoid",
@@ -270,16 +364,23 @@ describe("mafsStateToInteractiveGraph", () => {
                 [1, 2],
                 [3, 4],
             ],
+            startCoords: [
+                [5, 6],
+                [7, 8],
+            ],
         });
     });
 
     it("converts the state of a none-type graph", () => {
+        const graph: PerseusGraphType = {
+            type: "none",
+        }
         const state: NoneGraphState = {
             ...commonGraphState,
             type: "none",
         };
 
-        const result: PerseusGraphType = mafsStateToInteractiveGraph(state);
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(state, graph);
 
         expect(result).toEqual({
             type: "none",

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.test.ts
@@ -30,7 +30,7 @@ describe("mafsStateToInteractiveGraph", () => {
         const graph: PerseusGraphType = {
             type: "angle",
             match: "congruent",
-        }
+        };
         const state: AngleGraphState = {
             ...commonGraphState,
             type: "angle",
@@ -45,7 +45,10 @@ describe("mafsStateToInteractiveGraph", () => {
             ],
         };
 
-        const result: PerseusGraphType = mafsStateToInteractiveGraph(state, graph);
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(
+            state,
+            graph,
+        );
 
         expect(result).toEqual({
             type: "angle",
@@ -64,8 +67,8 @@ describe("mafsStateToInteractiveGraph", () => {
             startCoords: {
                 radius: 3,
                 center: [4, 5],
-            }
-        }
+            },
+        };
         const state: CircleGraphState = {
             type: "circle",
             center: [1, 2],
@@ -78,7 +81,10 @@ describe("mafsStateToInteractiveGraph", () => {
             snapStep: [9, 9],
         };
 
-        const result: PerseusGraphType = mafsStateToInteractiveGraph(state, graph);
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(
+            state,
+            graph,
+        );
 
         expect(result).toEqual({
             type: "circle",
@@ -87,7 +93,7 @@ describe("mafsStateToInteractiveGraph", () => {
             startCoords: {
                 radius: 3,
                 center: [4, 5],
-            }
+            },
         });
     });
 
@@ -95,7 +101,7 @@ describe("mafsStateToInteractiveGraph", () => {
         const graph: PerseusGraphType = {
             type: "segment",
             numSegments: 7,
-        }
+        };
         const state: SegmentGraphState = {
             ...commonGraphState,
             type: "segment",
@@ -107,7 +113,10 @@ describe("mafsStateToInteractiveGraph", () => {
             ],
         };
 
-        const result: PerseusGraphType = mafsStateToInteractiveGraph(state, graph);
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(
+            state,
+            graph,
+        );
 
         expect(result).toEqual({
             type: "segment",
@@ -127,8 +136,8 @@ describe("mafsStateToInteractiveGraph", () => {
             startCoords: [
                 [5, 6],
                 [7, 8],
-            ]
-        }
+            ],
+        };
         const state: LinearGraphState = {
             ...commonGraphState,
             type: "linear",
@@ -138,7 +147,10 @@ describe("mafsStateToInteractiveGraph", () => {
             ],
         };
 
-        const result: PerseusGraphType = mafsStateToInteractiveGraph(state, graph);
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(
+            state,
+            graph,
+        );
 
         expect(result).toEqual({
             type: "linear",
@@ -149,7 +161,7 @@ describe("mafsStateToInteractiveGraph", () => {
             startCoords: [
                 [5, 6],
                 [7, 8],
-            ]
+            ],
         });
     });
 
@@ -160,9 +172,9 @@ describe("mafsStateToInteractiveGraph", () => {
                 [
                     [9, 10],
                     [11, 12],
-                ]
-            ]
-        }
+                ],
+            ],
+        };
         const state: LinearSystemGraphState = {
             ...commonGraphState,
             type: "linear-system",
@@ -178,7 +190,10 @@ describe("mafsStateToInteractiveGraph", () => {
             ],
         };
 
-        const result: PerseusGraphType = mafsStateToInteractiveGraph(state, graph);
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(
+            state,
+            graph,
+        );
 
         expect(result).toEqual({
             type: "linear-system",
@@ -196,8 +211,8 @@ describe("mafsStateToInteractiveGraph", () => {
                 [
                     [9, 10],
                     [11, 12],
-                ]
-            ]
+                ],
+            ],
         });
     });
 
@@ -207,8 +222,8 @@ describe("mafsStateToInteractiveGraph", () => {
             startCoords: [
                 [5, 6],
                 [7, 8],
-            ]
-        }
+            ],
+        };
         const state: RayGraphState = {
             ...commonGraphState,
             type: "ray",
@@ -218,7 +233,10 @@ describe("mafsStateToInteractiveGraph", () => {
             ],
         };
 
-        const result: PerseusGraphType = mafsStateToInteractiveGraph(state, graph);
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(
+            state,
+            graph,
+        );
 
         expect(result).toEqual({
             type: "ray",
@@ -228,8 +246,8 @@ describe("mafsStateToInteractiveGraph", () => {
             ],
             startCoords: [
                 [5, 6],
-                [7, 8]
-            ]
+                [7, 8],
+            ],
         });
     });
 
@@ -237,7 +255,7 @@ describe("mafsStateToInteractiveGraph", () => {
         const graph: PerseusGraphType = {
             type: "polygon",
             match: "approx",
-        }
+        };
         const state: PolygonGraphState = {
             ...commonGraphState,
             type: "polygon",
@@ -251,7 +269,10 @@ describe("mafsStateToInteractiveGraph", () => {
             ],
         };
 
-        const result: PerseusGraphType = mafsStateToInteractiveGraph(state, graph);
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(
+            state,
+            graph,
+        );
 
         expect(result).toEqual({
             type: "polygon",
@@ -268,10 +289,8 @@ describe("mafsStateToInteractiveGraph", () => {
         const graph: PerseusGraphType = {
             type: "point",
             numPoints: "unlimited",
-            startCoords: [
-                [7, 8],
-            ],
-        }
+            startCoords: [[7, 8]],
+        };
         const state: PointGraphState = {
             ...commonGraphState,
             type: "point",
@@ -287,7 +306,10 @@ describe("mafsStateToInteractiveGraph", () => {
             ],
         };
 
-        const result: PerseusGraphType = mafsStateToInteractiveGraph(state, graph);
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(
+            state,
+            graph,
+        );
 
         expect(result).toEqual({
             type: "point",
@@ -297,9 +319,7 @@ describe("mafsStateToInteractiveGraph", () => {
                 [3, 4],
                 [5, 6],
             ],
-            startCoords: [
-                [7, 8],
-            ]
+            startCoords: [[7, 8]],
         });
     });
 
@@ -310,8 +330,8 @@ describe("mafsStateToInteractiveGraph", () => {
                 [7, 8],
                 [9, 10],
                 [11, 12],
-            ]
-        }
+            ],
+        };
         const state: QuadraticGraphState = {
             ...commonGraphState,
             type: "quadratic",
@@ -322,7 +342,10 @@ describe("mafsStateToInteractiveGraph", () => {
             ],
         };
 
-        const result: PerseusGraphType = mafsStateToInteractiveGraph(state, graph);
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(
+            state,
+            graph,
+        );
 
         expect(result).toEqual({
             type: "quadratic",
@@ -335,7 +358,7 @@ describe("mafsStateToInteractiveGraph", () => {
                 [7, 8],
                 [9, 10],
                 [11, 12],
-            ]
+            ],
         });
     });
 
@@ -346,7 +369,7 @@ describe("mafsStateToInteractiveGraph", () => {
                 [5, 6],
                 [7, 8],
             ],
-        }
+        };
         const state: SinusoidGraphState = {
             ...commonGraphState,
             type: "sinusoid",
@@ -356,7 +379,10 @@ describe("mafsStateToInteractiveGraph", () => {
             ],
         };
 
-        const result: PerseusGraphType = mafsStateToInteractiveGraph(state, graph);
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(
+            state,
+            graph,
+        );
 
         expect(result).toEqual({
             type: "sinusoid",
@@ -374,13 +400,16 @@ describe("mafsStateToInteractiveGraph", () => {
     it("converts the state of a none-type graph", () => {
         const graph: PerseusGraphType = {
             type: "none",
-        }
+        };
         const state: NoneGraphState = {
             ...commonGraphState,
             type: "none",
         };
 
-        const result: PerseusGraphType = mafsStateToInteractiveGraph(state, graph);
+        const result: PerseusGraphType = mafsStateToInteractiveGraph(
+            state,
+            graph,
+        );
 
         expect(result).toEqual({
             type: "none",

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.ts
@@ -1,10 +1,10 @@
 import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
+import invariant from "tiny-invariant";
 
 import {getRadius} from "./reducer/interactive-graph-state";
 
 import type {InteractiveGraphState} from "./types";
 import type {PerseusGraphType} from "@khanacademy/perseus";
-import invariant from "tiny-invariant";
 
 // Converts the state of a StatefulMafsGraph back to the format used to
 // represent graph state in the widget JSON.
@@ -28,68 +28,68 @@ export function mafsStateToInteractiveGraph(
 ): PerseusGraphType {
     switch (state.type) {
         case "angle":
-            invariant(originalGraph.type === "angle")
+            invariant(originalGraph.type === "angle");
             return {
                 ...originalGraph,
                 coords: state.coords,
             };
         case "quadratic":
-            invariant(originalGraph.type === "quadratic")
+            invariant(originalGraph.type === "quadratic");
             return {
                 ...originalGraph,
                 coords: state.coords,
             };
         case "circle":
-            invariant(originalGraph.type === "circle")
+            invariant(originalGraph.type === "circle");
             return {
                 ...originalGraph,
                 center: state.center,
                 radius: getRadius(state),
             };
         case "linear":
-            invariant(originalGraph.type === "linear")
+            invariant(originalGraph.type === "linear");
             return {
                 ...originalGraph,
                 coords: state.coords,
-            }
+            };
         case "ray":
-            invariant(originalGraph.type === "ray")
+            invariant(originalGraph.type === "ray");
             return {
                 ...originalGraph,
                 coords: state.coords,
-            }
+            };
         case "sinusoid":
-            invariant(originalGraph.type === "sinusoid")
+            invariant(originalGraph.type === "sinusoid");
             return {
                 ...originalGraph,
                 coords: state.coords,
             };
         case "segment":
-            invariant(originalGraph.type === "segment")
+            invariant(originalGraph.type === "segment");
             return {
                 ...originalGraph,
                 coords: state.coords,
             };
         case "linear-system":
-            invariant(originalGraph.type === "linear-system")
+            invariant(originalGraph.type === "linear-system");
             return {
                 ...originalGraph,
                 coords: state.coords,
             };
         case "polygon":
-            invariant(originalGraph.type === "polygon")
+            invariant(originalGraph.type === "polygon");
             return {
                 ...originalGraph,
                 coords: state.coords,
-            }
+            };
         case "point":
-            invariant(originalGraph.type === "point")
+            invariant(originalGraph.type === "point");
             return {
                 ...originalGraph,
                 coords: state.coords,
             };
         case "none":
-            invariant(originalGraph.type === "none")
+            invariant(originalGraph.type === "none");
             return {...originalGraph};
         default:
             throw new UnreachableCaseError(state);

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.ts
@@ -1,0 +1,60 @@
+import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
+
+import {getRadius} from "./reducer/interactive-graph-state";
+
+import type {InteractiveGraphState} from "./types";
+import type {PerseusGraphType} from "@khanacademy/perseus";
+
+// Converts the state of a StatefulMafsGraph back to the format used to
+// represent graph state in the widget JSON.
+//
+// Rather than be tightly bound to how data was structured in
+// the legacy interactive graph, this lets us store state
+// however we want and we just transform it before handing it off
+// the the parent InteractiveGraph.
+//
+// The transformed data is used in the interactive graph widget editor, to
+// set the `correct` field of the graph options. In the learner-facing UI, the
+// data is also stored by the Renderer, and passed back down to the graph
+// widget via the `graph` prop.
+export function mafsStateToInteractiveGraph(
+    state: InteractiveGraphState,
+): PerseusGraphType {
+    switch (state.type) {
+        case "angle":
+        case "quadratic":
+            return {
+                type: state.type,
+                coords: state.coords,
+            };
+        case "circle":
+            return {
+                type: "circle",
+                center: state.center,
+                radius: getRadius(state),
+            };
+        case "linear":
+        case "ray":
+        case "sinusoid":
+            return {
+                type: state.type,
+                coords: state.coords,
+            };
+        case "segment":
+        case "linear-system":
+            return {
+                type: state.type,
+                coords: state.coords,
+            };
+        case "polygon":
+        case "point":
+            return {
+                type: state.type,
+                coords: state.coords,
+            };
+        case "none":
+            return {type: "none"};
+        default:
+            throw new UnreachableCaseError(state);
+    }
+}

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.ts
@@ -4,6 +4,7 @@ import {getRadius} from "./reducer/interactive-graph-state";
 
 import type {InteractiveGraphState} from "./types";
 import type {PerseusGraphType} from "@khanacademy/perseus";
+import invariant from "tiny-invariant";
 
 // Converts the state of a StatefulMafsGraph back to the format used to
 // represent graph state in the widget JSON.
@@ -16,44 +17,80 @@ import type {PerseusGraphType} from "@khanacademy/perseus";
 // The transformed data is used in the interactive graph widget editor, to
 // set the `correct` field of the graph options. In the learner-facing UI, the
 // data is also stored by the Renderer, and passed back down to the graph
-// widget via the `graph` prop.
+// widget via the `graph` prop. Because the data returned by this function
+// completely replaces the Renderer's representation of the widget, rather than
+// being merged into it, we take it upon ourselves to merge in the original
+// widget data here. If we didn't do this merging, the graph's configuration
+// would reset to the defaults when the learner interacted with it.
 export function mafsStateToInteractiveGraph(
     state: InteractiveGraphState,
+    originalGraph: PerseusGraphType,
 ): PerseusGraphType {
     switch (state.type) {
         case "angle":
-        case "quadratic":
+            invariant(originalGraph.type === "angle")
             return {
-                type: state.type,
+                ...originalGraph,
+                coords: state.coords,
+            };
+        case "quadratic":
+            invariant(originalGraph.type === "quadratic")
+            return {
+                ...originalGraph,
                 coords: state.coords,
             };
         case "circle":
+            invariant(originalGraph.type === "circle")
             return {
-                type: "circle",
+                ...originalGraph,
                 center: state.center,
                 radius: getRadius(state),
             };
         case "linear":
-        case "ray":
-        case "sinusoid":
+            invariant(originalGraph.type === "linear")
             return {
-                type: state.type,
+                ...originalGraph,
+                coords: state.coords,
+            }
+        case "ray":
+            invariant(originalGraph.type === "ray")
+            return {
+                ...originalGraph,
+                coords: state.coords,
+            }
+        case "sinusoid":
+            invariant(originalGraph.type === "sinusoid")
+            return {
+                ...originalGraph,
                 coords: state.coords,
             };
         case "segment":
-        case "linear-system":
+            invariant(originalGraph.type === "segment")
             return {
-                type: state.type,
+                ...originalGraph,
+                coords: state.coords,
+            };
+        case "linear-system":
+            invariant(originalGraph.type === "linear-system")
+            return {
+                ...originalGraph,
                 coords: state.coords,
             };
         case "polygon":
-        case "point":
+            invariant(originalGraph.type === "polygon")
             return {
-                type: state.type,
+                ...originalGraph,
+                coords: state.coords,
+            }
+        case "point":
+            invariant(originalGraph.type === "point")
+            return {
+                ...originalGraph,
                 coords: state.coords,
             };
         case "none":
-            return {type: "none"};
+            invariant(originalGraph.type === "none")
+            return {...originalGraph};
         default:
             throw new UnreachableCaseError(state);
     }

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
@@ -69,7 +69,7 @@ export const StatefulMafsGraph = React.forwardRef<
             onChange({graph: mafsStateToInteractiveGraph(state, graph)});
         }
         prevState.current = state;
-    }, [onChange, state]);
+    }, [onChange, state, graph]);
 
     // Destructuring first to keep useEffect from making excess calls
     const [xSnap, ySnap] = props.snapStep;

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import {useEffect, useImperativeHandle, useRef} from "react";
 
 import {MafsGraph} from "./mafs-graph";
+import {mafsStateToInteractiveGraph} from "./mafs-state-to-interactive-graph";
 import {initializeGraphState} from "./reducer/initialize-graph-state";
 import {
     changeRange,
@@ -10,7 +11,7 @@ import {
     reinitialize,
 } from "./reducer/interactive-graph-action";
 import {interactiveGraphReducer} from "./reducer/interactive-graph-reducer";
-import {getGradableGraph, getRadius} from "./reducer/interactive-graph-state";
+import {getGradableGraph} from "./reducer/interactive-graph-state";
 
 import type {InteractiveGraphProps, InteractiveGraphState} from "./types";
 import type {PerseusGraphType} from "../../perseus-types";
@@ -45,25 +46,6 @@ export type StatefulMafsGraphType = {
     getUserInput: () => PerseusInteractiveGraphUserInput;
 };
 
-// Rather than be tightly bound to how data was structured in
-// the legacy interactive graph, this lets us store state
-// however we want and we just transform it before handing it off
-// the the parent InteractiveGraph
-function mafsStateToInteractiveGraph(state: {graph: InteractiveGraphState}) {
-    if (state.graph.type === "circle") {
-        return {
-            ...state,
-            graph: {
-                ...state.graph,
-                radius: getRadius(state.graph),
-            },
-        };
-    }
-    return {
-        ...state,
-    };
-}
-
 export const StatefulMafsGraph = React.forwardRef<
     StatefulMafsGraphType,
     StatefulMafsGraphProps
@@ -84,7 +66,7 @@ export const StatefulMafsGraph = React.forwardRef<
 
     useEffect(() => {
         if (prevState.current !== state) {
-            onChange(mafsStateToInteractiveGraph({graph: state}));
+            onChange({graph: mafsStateToInteractiveGraph(state)});
         }
         prevState.current = state;
     }, [onChange, state]);

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
@@ -66,7 +66,7 @@ export const StatefulMafsGraph = React.forwardRef<
 
     useEffect(() => {
         if (prevState.current !== state) {
-            onChange({graph: mafsStateToInteractiveGraph(state)});
+            onChange({graph: mafsStateToInteractiveGraph(state, graph)});
         }
         prevState.current = state;
     }, [onChange, state]);


### PR DESCRIPTION
This change was previously implemented in PR #1654, then reverted in #1663 due
to a bug. This PR reimplements the change without the bug. The original PR
summary follows.

---

Previously, we were passing the entire Mafs graph state to onChange. Since
the onChange callback data is used by the Interactive Graph widget editor to
set the correct answer for the graph, a bunch of extra data like
"hasBeenInteractedWith": true was getting saved in the correct field of
the Widget data.

This extra data is not used, so its presence in datastore is potentially
confusing to future maintainers trying to understand the data. It might
also cause bugs in the future - e.g. if some code merges it into another
object in which those properties are meaningful.

This PR ensures that we only save relevant data in the correct field of
interactive graph widgets.

Issue: none

## Test plan:

`yarn dev; open http://localhost:5173`

Play around with the graphs on the dev UI gallery page. In particular:

- Unlimited point
- Polygons with angle and side labels
- Polygons with side snapping

You should not observe any issues.

Edit, save and publish an interactive graph widget in an exercise. As a
learner, you should be able to complete the exercise successfully.