### PR TITLE
Updating protractor to default position.

### DIFF
--- a/.changeset/breezy-rockets-greet.md
+++ b/.changeset/breezy-rockets-greet.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Updating protractor's default position within a graph.

--- a/packages/perseus/src/widgets/interactive-graphs/protractor.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/protractor.tsx
@@ -39,7 +39,7 @@ export function Protractor() {
     // 95% of the way to the bottom of the graph (vertically).
     const initialCenter: vec.Vector2 = [
         lerp(xMin, xMax, 0.5),
-        lerp(yMin, yMax, 0.05),
+        lerp(yMin, yMax, 0.25),
     ];
     const [center, setCenter] = useState<vec.Vector2>(initialCenter);
     const [rotationHandleOffset, setRotationHandleOffset] =


### PR DESCRIPTION
## Summary:
We're updating the protractor's default position from 5% above the bottom of the graph to 25%. This is necessary because with the new angle Mafs implementation, the angle graph cannot reach the bottom of the graph, due to saving room for multiple angle options. To improve this we can simply position the graph slightly higher to make it accessible for keyboard users, while still preserving the need for students to properly position the graph and protractor.

Before: (default position of protractor.)
![image](https://github.com/user-attachments/assets/b1854d09-420e-4770-8602-d652ef1bc6f1)

After:
![image](https://github.com/user-attachments/assets/780ba604-2129-4914-b55a-117d96bdbc8c)

Issue: LEMS-2372

## Test plan:

1. Go to http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph-editor--with-mafs
2. Select `Answer type: Angle` and check `Show protractor`
3. See that the protractor is higher (25% from the bottom of the graph) and you can use your keyboard to position the angle over the protractor without having to move the protractor.