### PR TITLE
[Locked Figures Labels] Make labels optional to increase type safety

### DIFF
--- a/.changeset/yellow-poets-poke.md
+++ b/.changeset/yellow-poets-poke.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+[Locked Figures Labels] Make labels optional to increase type safety

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-ellipse-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-ellipse-settings.tsx
@@ -65,7 +65,7 @@ const LockedEllipseSettings = (props: Props) => {
         };
 
         // Update the coord by the same amount as the point for all labels
-        newProps.labels = labels.map((label) => ({
+        newProps.labels = labels?.map((label) => ({
             ...label,
             coord: [label.coord[0] + xOffset, label.coord[1] + yOffset],
         }));
@@ -79,7 +79,7 @@ const LockedEllipseSettings = (props: Props) => {
         };
 
         // Update the color of the all labels to match the point
-        newProps.labels = labels.map((label) => ({
+        newProps.labels = labels?.map((label) => ({
             ...label,
             color: newValue,
         }));
@@ -91,6 +91,10 @@ const LockedEllipseSettings = (props: Props) => {
         updatedLabel: LockedLabelType,
         labelIndex: number,
     ) {
+        if (!labels) {
+            return;
+        }
+
         const updatedLabels = [...labels];
         updatedLabels[labelIndex] = {
             ...labels[labelIndex],
@@ -101,6 +105,10 @@ const LockedEllipseSettings = (props: Props) => {
     }
 
     function handleLabelRemove(labelIndex: number) {
+        if (!labels) {
+            return;
+        }
+
         const updatedLabels = labels.filter((_, index) => index !== labelIndex);
 
         onChangeProps({labels: updatedLabels});
@@ -200,7 +208,7 @@ const LockedEllipseSettings = (props: Props) => {
             {/* Visible Labels */}
             {flags?.["mafs"]?.["locked-ellipse-labels"] && (
                 <>
-                    {labels.map((label, labelIndex) => (
+                    {labels?.map((label, labelIndex) => (
                         <LockedLabelSettings
                             {...label}
                             expanded={true}
@@ -224,14 +232,14 @@ const LockedEllipseSettings = (props: Props) => {
                                     center[0],
                                     // Additional vertical offset for each
                                     // label so they don't overlap.
-                                    center[1] - labels.length,
+                                    center[1] - (labels?.length ?? 0),
                                 ],
                                 // Default to the same color as the ellipse
                                 color: color,
                             } satisfies LockedLabelType;
 
                             onChangeProps({
-                                labels: [...labels, newLabel],
+                                labels: [...(labels ?? []), newLabel],
                             });
                         }}
                         style={styles.addButton}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.test.tsx
@@ -191,7 +191,6 @@ describe("Locked Function Settings", () => {
             // Assert
             expect(onChangeProps).toHaveBeenCalledWith({
                 color: "green",
-                labels: [],
             });
         });
 

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.tsx
@@ -123,7 +123,7 @@ const LockedFunctionSettings = (props: Props) => {
         };
 
         // Update the color of the all labels to match the point
-        newProps.labels = labels.map((label) => ({
+        newProps.labels = labels?.map((label) => ({
             ...label,
             color: newValue,
         }));
@@ -135,6 +135,10 @@ const LockedFunctionSettings = (props: Props) => {
         updatedLabel: LockedLabelType,
         labelIndex: number,
     ) {
+        if (!labels) {
+            return;
+        }
+
         const updatedLabels = [...labels];
         updatedLabels[labelIndex] = {
             ...labels[labelIndex],
@@ -145,6 +149,10 @@ const LockedFunctionSettings = (props: Props) => {
     }
 
     function handleLabelRemove(labelIndex: number) {
+        if (!labels) {
+            return;
+        }
+
         const updatedLabels = labels.filter((_, index) => index !== labelIndex);
 
         onChangeProps({labels: updatedLabels});
@@ -292,7 +300,7 @@ const LockedFunctionSettings = (props: Props) => {
                 <>
                     <View style={styles.horizontalRule} />
 
-                    {labels.map((label, labelIndex) => (
+                    {labels?.map((label, labelIndex) => (
                         <LockedLabelSettings
                             {...label}
                             expanded={true}
@@ -314,13 +322,13 @@ const LockedFunctionSettings = (props: Props) => {
                                 ...getDefaultFigureForType("label"),
                                 // Vertical offset for each label so they
                                 // don't overlap.
-                                coord: [0, -labels.length],
+                                coord: [0, -(labels?.length ?? 0)],
                                 // Default to the same color as the function
                                 color: lineColor,
                             } satisfies LockedLabelType;
 
                             onChangeProps({
-                                labels: [...labels, newLabel],
+                                labels: [...(labels ?? []), newLabel],
                             });
                         }}
                         style={styles.addButton}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-line-settings.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-line-settings.test.tsx
@@ -162,7 +162,6 @@ describe("LockedLineSettings", () => {
                 },
                 defaultProps.points[1],
             ],
-            labels: [],
         });
     });
 
@@ -254,7 +253,6 @@ describe("LockedLineSettings", () => {
                 },
                 defaultProps.points[1],
             ],
-            labels: [],
         });
     });
 

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-line-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-line-settings.tsx
@@ -90,7 +90,7 @@ const LockedLineSettings = (props: Props) => {
             newMidpoint[0] - oldMidpoint[0],
             newMidpoint[1] - oldMidpoint[1],
         ];
-        const newLabels = labels.map((label, labelIndex) => ({
+        const newLabels = labels?.map((label, labelIndex) => ({
             ...label,
             coord: [
                 label.coord[0] + offset[0],
@@ -105,7 +105,7 @@ const LockedLineSettings = (props: Props) => {
     }
 
     function handleColorChange(newColor: LockedFigureColor) {
-        const newLabels = labels.map((label) => ({
+        const newLabels = labels?.map((label) => ({
             ...label,
             color: newColor,
         }));
@@ -117,7 +117,7 @@ const LockedLineSettings = (props: Props) => {
                 {
                     ...point1,
                     color: newColor,
-                    labels: point1.labels.map((label) => ({
+                    labels: point1.labels?.map((label) => ({
                         ...label,
                         color: newColor,
                     })),
@@ -125,7 +125,7 @@ const LockedLineSettings = (props: Props) => {
                 {
                     ...point2,
                     color: newColor,
-                    labels: point2.labels.map((label) => ({
+                    labels: point2.labels?.map((label) => ({
                         ...label,
                         color: newColor,
                     })),
@@ -140,6 +140,10 @@ const LockedLineSettings = (props: Props) => {
         updatedLabel: LockedLabelType,
         labelIndex: number,
     ) {
+        if (!labels) {
+            return;
+        }
+
         const updatedLabels = [...labels];
         updatedLabels[labelIndex] = {
             ...labels[labelIndex],
@@ -150,6 +154,10 @@ const LockedLineSettings = (props: Props) => {
     }
 
     function handleLabelRemove(labelIndex: number) {
+        if (!labels) {
+            return;
+        }
+
         const updatedLabels = labels.filter((_, index) => index !== labelIndex);
 
         onChangeProps({labels: updatedLabels});
@@ -239,7 +247,7 @@ const LockedLineSettings = (props: Props) => {
                 <>
                     <View style={styles.horizontalRule} />
 
-                    {labels.map((label, labelIndex) => (
+                    {labels?.map((label, labelIndex) => (
                         <LockedLabelSettings
                             {...label}
                             expanded={true}
@@ -261,7 +269,7 @@ const LockedLineSettings = (props: Props) => {
                             // they don't overlap.
                             const offsetPerLabel: vec.Vector2 = [0, -1];
                             const labelLocation = vec.add(
-                                vec.scale(offsetPerLabel, labels.length),
+                                vec.scale(offsetPerLabel, labels?.length ?? 0),
                                 vec.midpoint(points[0].coord, points[1].coord),
                             );
 
@@ -273,7 +281,7 @@ const LockedLineSettings = (props: Props) => {
                             } satisfies LockedLabelType;
 
                             onChangeProps({
-                                labels: [...labels, newLabel],
+                                labels: [...(labels ?? []), newLabel],
                             });
                         }}
                         style={styles.addButton}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-point-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-point-settings.tsx
@@ -105,10 +105,12 @@ const LockedPointSettings = (props: Props) => {
         };
 
         // Update the color of the all labels to match the point
-        newProps.labels = labels.map((label) => ({
-            ...label,
-            color: newValue,
-        }));
+        if (labels) {
+            newProps.labels = labels.map((label) => ({
+                ...label,
+                color: newValue,
+            }));
+        }
 
         onChangeProps(newProps);
     }
@@ -122,10 +124,12 @@ const LockedPointSettings = (props: Props) => {
         };
 
         // Update the coord by the same amount as the point for all labels
-        newProps.labels = labels.map((label) => ({
-            ...label,
-            coord: [label.coord[0] + xOffset, label.coord[1] + yOffset],
-        }));
+        if (labels) {
+            newProps.labels = labels.map((label) => ({
+                ...label,
+                coord: [label.coord[0] + xOffset, label.coord[1] + yOffset],
+            }));
+        }
 
         onChangeProps(newProps);
     }
@@ -134,6 +138,10 @@ const LockedPointSettings = (props: Props) => {
         updatedLabel: LockedLabelType,
         labelIndex: number,
     ) {
+        if (!labels) {
+            return;
+        }
+
         const updatedLabels = [...labels];
         updatedLabels[labelIndex] = {
             ...labels[labelIndex],
@@ -144,6 +152,10 @@ const LockedPointSettings = (props: Props) => {
     }
 
     function handleLabelRemove(labelIndex: number) {
+        if (!labels) {
+            return;
+        }
+
         const updatedLabels = labels.filter((_, index) => index !== labelIndex);
 
         onChangeProps({labels: updatedLabels});
@@ -204,7 +216,7 @@ const LockedPointSettings = (props: Props) => {
                 (isDefiningPoint &&
                     flags?.["mafs"]?.["locked-line-labels"])) && (
                 <>
-                    {labels.map((label, labelIndex) => (
+                    {labels?.map((label, labelIndex) => (
                         <LockedLabelSettings
                             {...label}
                             containerStyle={
@@ -233,14 +245,14 @@ const LockedPointSettings = (props: Props) => {
                                     coord[0] + 0.5,
                                     // Additional offset for each label so
                                     // they don't overlap.
-                                    coord[1] - 1 * labels?.length,
+                                    coord[1] - 1 * (labels?.length ?? 0),
                                 ],
                                 // Default to the same color as the point
                                 color: pointColor,
                             } satisfies LockedLabelType;
 
                             onChangeProps({
-                                labels: [...labels, newLabel],
+                                labels: [...(labels ?? []), newLabel],
                             });
                         }}
                         style={styles.addButton}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-vector-settings.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-vector-settings.test.tsx
@@ -117,7 +117,6 @@ describe("Locked Vector Settings", () => {
             // Assert
             expect(onChangeProps).toHaveBeenCalledWith({
                 color: "green",
-                labels: [],
             });
         });
 

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-vector-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-vector-settings.tsx
@@ -68,7 +68,7 @@ const LockedVectorSettings = (props: Props) => {
             const oldMidpoint = vec.midpoint(tail, tip);
             const newMidpoint = vec.midpoint(newPoints[0], newPoints[1]);
             const offset = vec.sub(newMidpoint, oldMidpoint);
-            const newLabels = labels.map((label) => ({
+            const newLabels = labels?.map((label) => ({
                 ...label,
                 coord: vec.add(label.coord, offset),
             }));
@@ -86,7 +86,7 @@ const LockedVectorSettings = (props: Props) => {
         };
 
         // Update the color of the all labels to match the point
-        newProps.labels = labels.map((label) => ({
+        newProps.labels = labels?.map((label) => ({
             ...label,
             color: newColor,
         }));
@@ -98,6 +98,10 @@ const LockedVectorSettings = (props: Props) => {
         updatedLabel: LockedLabelType,
         labelIndex: number,
     ) {
+        if (!labels) {
+            return;
+        }
+
         const updatedLabels = [...labels];
         updatedLabels[labelIndex] = {
             ...labels[labelIndex],
@@ -108,6 +112,10 @@ const LockedVectorSettings = (props: Props) => {
     }
 
     function handleLabelRemove(labelIndex: number) {
+        if (!labels) {
+            return;
+        }
+
         const updatedLabels = labels.filter((_, index) => index !== labelIndex);
 
         onChangeProps({labels: updatedLabels});
@@ -183,7 +191,7 @@ const LockedVectorSettings = (props: Props) => {
                 <>
                     <View style={styles.horizontalRule} />
 
-                    {labels.map((label, labelIndex) => (
+                    {labels?.map((label, labelIndex) => (
                         <LockedLabelSettings
                             {...label}
                             expanded={true}
@@ -205,7 +213,7 @@ const LockedVectorSettings = (props: Props) => {
                             // they don't overlap.
                             const offsetPerLabel: vec.Vector2 = [0, -1];
                             const labelLocation = vec.add(
-                                vec.scale(offsetPerLabel, labels.length),
+                                vec.scale(offsetPerLabel, labels?.length ?? 0),
                                 vec.midpoint(tail, tip),
                             );
 
@@ -217,7 +225,7 @@ const LockedVectorSettings = (props: Props) => {
                             } satisfies LockedLabelType;
 
                             onChangeProps({
-                                labels: [...labels, newLabel],
+                                labels: [...(labels ?? []), newLabel],
                             });
                         }}
                         style={styles.addButton}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.test.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.test.ts
@@ -8,7 +8,6 @@ describe("getDefaultFigureForType", () => {
             coord: [0, 0],
             color: "grayH",
             filled: true,
-            labels: [],
         });
     });
 
@@ -23,21 +22,18 @@ describe("getDefaultFigureForType", () => {
                     coord: [0, 0],
                     color: "grayH",
                     filled: true,
-                    labels: [],
                 },
                 {
                     type: "point",
                     coord: [2, 2],
                     color: "grayH",
                     filled: true,
-                    labels: [],
                 },
             ],
             color: "grayH",
             lineStyle: "solid",
             showPoint1: false,
             showPoint2: false,
-            labels: [],
         });
     });
 
@@ -50,7 +46,6 @@ describe("getDefaultFigureForType", () => {
                 [2, 2],
             ],
             color: "grayH",
-            labels: [],
         });
     });
 
@@ -64,7 +59,6 @@ describe("getDefaultFigureForType", () => {
             color: "grayH",
             fillStyle: "none",
             strokeStyle: "solid",
-            labels: [],
         });
     });
 
@@ -92,7 +86,6 @@ describe("getDefaultFigureForType", () => {
             strokeStyle: "solid",
             equation: "x^2",
             directionalAxis: "x",
-            labels: [],
         });
     });
 

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.ts
@@ -30,7 +30,6 @@ export function getDefaultFigureForType(type: LockedFigureType): LockedFigure {
                 coord: [0, 0],
                 color: DEFAULT_COLOR,
                 filled: true,
-                labels: [],
             };
         case "line":
             return {
@@ -47,7 +46,6 @@ export function getDefaultFigureForType(type: LockedFigureType): LockedFigure {
                 lineStyle: "solid",
                 showPoint1: false,
                 showPoint2: false,
-                labels: [],
             };
         case "vector":
             return {
@@ -57,7 +55,6 @@ export function getDefaultFigureForType(type: LockedFigureType): LockedFigure {
                     [2, 2],
                 ],
                 color: DEFAULT_COLOR,
-                labels: [],
             };
         case "ellipse":
             return {
@@ -68,7 +65,6 @@ export function getDefaultFigureForType(type: LockedFigureType): LockedFigure {
                 color: DEFAULT_COLOR,
                 fillStyle: "none",
                 strokeStyle: "solid",
-                labels: [],
             };
         case "polygon":
             return {
@@ -90,7 +86,6 @@ export function getDefaultFigureForType(type: LockedFigureType): LockedFigure {
                 strokeStyle: "solid",
                 equation: "x^2",
                 directionalAxis: "x",
-                labels: [],
             };
         case "label":
             return {

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -706,7 +706,7 @@ export type LockedPointType = {
     coord: Coord;
     color: LockedFigureColor;
     filled: boolean;
-    labels: LockedLabelType[];
+    labels?: LockedLabelType[];
 };
 
 export type LockedLineType = {
@@ -717,14 +717,14 @@ export type LockedLineType = {
     lineStyle: LockedLineStyle;
     showPoint1: boolean;
     showPoint2: boolean;
-    labels: LockedLabelType[];
+    labels?: LockedLabelType[];
 };
 
 export type LockedVectorType = {
     type: "vector";
     points: [tail: Coord, tip: Coord];
     color: LockedFigureColor;
-    labels: LockedLabelType[];
+    labels?: LockedLabelType[];
 };
 
 export type LockedFigureFillType = "none" | "white" | "translucent" | "solid";
@@ -743,7 +743,7 @@ export type LockedEllipseType = {
     color: LockedFigureColor;
     fillStyle: LockedFigureFillType;
     strokeStyle: LockedLineStyle;
-    labels: LockedLabelType[];
+    labels?: LockedLabelType[];
 };
 
 export type LockedPolygonType = {
@@ -762,7 +762,7 @@ export type LockedFunctionType = {
     equation: string; // This is the user-defined equation (as it was typed)
     directionalAxis: "x" | "y";
     domain?: Interval;
-    labels: LockedLabelType[];
+    labels?: LockedLabelType[];
 };
 
 // Not associated with a specific figure

--- a/packages/perseus/src/widgets/interactive-graphs/graph-locked-labels-layer.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graph-locked-labels-layer.tsx
@@ -45,14 +45,14 @@ export default function GraphLockedLabelsLayer(props: Props) {
                     {figure.type === "line" && (
                         <>
                             {/* Point 1 labels */}
-                            {(figure.points[0].labels ?? []).map((label, k) => (
+                            {figure.points[0].labels?.map((label, k) => (
                                 <LockedLabel
                                     key={`locked-figure-${i}-point-1-label-${k}`}
                                     {...label}
                                 />
                             ))}
                             {/* Point 2 labels */}
-                            {(figure.points[1].labels ?? []).map((label, k) => (
+                            {figure.points[1].labels?.map((label, k) => (
                                 <LockedLabel
                                     key={`locked-figure-${i}-point-2-label-${k}`}
                                     {...label}

--- a/packages/perseus/src/widgets/interactive-graphs/graph-locked-labels-layer.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graph-locked-labels-layer.tsx
@@ -37,7 +37,7 @@ export default function GraphLockedLabelsLayer(props: Props) {
         ) {
             return (
                 <React.Fragment key={i}>
-                    {figure.labels.map((label, j) => (
+                    {(figure.labels ?? []).map((label, j) => (
                         <LockedLabel key={`${i}-label-${j}`} {...label} />
                     ))}
 
@@ -45,14 +45,14 @@ export default function GraphLockedLabelsLayer(props: Props) {
                     {figure.type === "line" && (
                         <>
                             {/* Point 1 labels */}
-                            {figure.points[0].labels.map((label, k) => (
+                            {(figure.points[0].labels ?? []).map((label, k) => (
                                 <LockedLabel
                                     key={`locked-figure-${i}-point-1-label-${k}`}
                                     {...label}
                                 />
                             ))}
                             {/* Point 2 labels */}
-                            {figure.points[1].labels.map((label, k) => (
+                            {(figure.points[1].labels ?? []).map((label, k) => (
                                 <LockedLabel
                                     key={`locked-figure-${i}-point-2-label-${k}`}
                                     {...label}

--- a/packages/perseus/src/widgets/interactive-graphs/graph-locked-labels-layer.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graph-locked-labels-layer.tsx
@@ -37,7 +37,7 @@ export default function GraphLockedLabelsLayer(props: Props) {
         ) {
             return (
                 <React.Fragment key={i}>
-                    {(figure.labels ?? []).map((label, j) => (
+                    {figure.labels?.map((label, j) => (
                         <LockedLabel key={`${i}-label-${j}`} {...label} />
                     ))}
 

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
@@ -738,7 +738,6 @@ describe("InteractiveGraphQuestionBuilder", () => {
                 coord: [3, 5],
                 color: "grayH",
                 filled: true,
-                labels: [],
             },
         ]);
     });
@@ -756,14 +755,12 @@ describe("InteractiveGraphQuestionBuilder", () => {
                 coord: [3, 5],
                 color: "grayH",
                 filled: true,
-                labels: [],
             },
             {
                 type: "point",
                 coord: [6, 7],
                 color: "grayH",
                 filled: true,
-                labels: [],
             },
         ]);
     });
@@ -842,21 +839,18 @@ describe("InteractiveGraphQuestionBuilder", () => {
                         coord: [1, 2],
                         color: "grayH",
                         filled: true,
-                        labels: [],
                     },
                     {
                         type: "point",
                         coord: [3, 4],
                         color: "grayH",
                         filled: true,
-                        labels: [],
                     },
                 ],
                 color: "grayH",
                 lineStyle: "solid",
                 showPoint1: false,
                 showPoint2: false,
-                labels: [],
             },
         ]);
     });
@@ -885,14 +879,12 @@ describe("InteractiveGraphQuestionBuilder", () => {
                         coord: [1, 2],
                         color: "green",
                         filled: false,
-                        labels: [],
                     },
                     {
                         type: "point",
                         coord: [3, 4],
                         color: "green",
                         filled: false,
-                        labels: [],
                     },
                 ],
                 color: "green",
@@ -936,14 +928,12 @@ describe("InteractiveGraphQuestionBuilder", () => {
                         coord: [1, 2],
                         color: "green",
                         filled: false,
-                        labels: [],
                     },
                     {
                         type: "point",
                         coord: [3, 4],
                         color: "green",
                         filled: false,
-                        labels: [],
                     },
                 ],
                 color: "green",
@@ -977,7 +967,6 @@ describe("InteractiveGraphQuestionBuilder", () => {
                     [3, 4],
                 ],
                 color: "grayH",
-                labels: [],
             },
         ]);
     });
@@ -1057,7 +1046,6 @@ describe("InteractiveGraphQuestionBuilder", () => {
                 color: "grayH",
                 fillStyle: "none",
                 strokeStyle: "solid",
-                labels: [],
             },
         ]);
     });
@@ -1199,7 +1187,6 @@ describe("InteractiveGraphQuestionBuilder", () => {
                 color: "grayH",
                 strokeStyle: "solid",
                 directionalAxis: "x",
-                labels: [],
             },
         ]);
     });

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -324,13 +324,15 @@ class InteractiveGraphQuestionBuilder {
             showPoint2: options?.showPoint2 ?? false,
             color: options?.color ?? "grayH",
             lineStyle: options?.lineStyle ?? "solid",
-            labels: (options?.labels ?? []).map((label) => ({
-                type: "label",
-                coord: label.coord ?? vec.midpoint(point1, point2),
-                text: label.text,
-                color: options?.color ?? "grayH",
-                size: label.size ?? "medium",
-            })),
+            labels: options?.labels
+                ? options.labels.map((label) => ({
+                      type: "label",
+                      coord: label.coord ?? vec.midpoint(point1, point2),
+                      text: label.text,
+                      color: options?.color ?? "grayH",
+                      size: label.size ?? "medium",
+                  }))
+                : undefined,
             points: [
                 {
                     ...this.createLockedPoint(...point1, {
@@ -362,13 +364,15 @@ class InteractiveGraphQuestionBuilder {
             type: "vector",
             color: options?.color ?? "grayH",
             points: [tail, tip],
-            labels: (options?.labels ?? []).map((label) => ({
-                type: "label",
-                coord: label.coord ?? vec.midpoint(tail, tip),
-                text: label.text,
-                color: options?.color ?? "grayH",
-                size: label.size ?? "medium",
-            })),
+            labels: options?.labels
+                ? (options?.labels ?? []).map((label) => ({
+                      type: "label",
+                      coord: label.coord ?? vec.midpoint(tail, tip),
+                      text: label.text,
+                      color: options?.color ?? "grayH",
+                      size: label.size ?? "medium",
+                  }))
+                : undefined,
         };
         this.addLockedFigure(vector);
         return this;
@@ -394,13 +398,15 @@ class InteractiveGraphQuestionBuilder {
             fillStyle: "none",
             strokeStyle: "solid",
             ...options,
-            labels: (options?.labels ?? []).map((label) => ({
-                type: "label",
-                coord: label.coord ?? center,
-                text: label.text,
-                color: options?.color ?? "grayH",
-                size: label.size ?? "medium",
-            })),
+            labels: options?.labels
+                ? (options?.labels ?? []).map((label) => ({
+                      type: "label",
+                      coord: label.coord ?? center,
+                      text: label.text,
+                      color: options?.color ?? "grayH",
+                      size: label.size ?? "medium",
+                  }))
+                : undefined,
         };
 
         this.addLockedFigure(ellipse);
@@ -438,17 +444,18 @@ class InteractiveGraphQuestionBuilder {
             strokeStyle: "solid",
             directionalAxis: "x",
             ...options,
-            labels:
-                options?.labels?.map(
-                    (label) =>
-                        ({
-                            type: "label",
-                            coord: label.coord ?? [0, 0],
-                            text: label.text,
-                            color: options?.color ?? "grayH",
-                            size: label.size ?? "medium",
-                        }) satisfies LockedLabelType,
-                ) ?? [],
+            labels: options?.labels
+                ? options?.labels?.map(
+                      (label) =>
+                          ({
+                              type: "label",
+                              coord: label.coord ?? [0, 0],
+                              text: label.text,
+                              color: options?.color ?? "grayH",
+                              size: label.size ?? "medium",
+                          }) satisfies LockedLabelType,
+                  )
+                : undefined,
         };
 
         this.addLockedFigure(lockedFunction);
@@ -490,13 +497,15 @@ class InteractiveGraphQuestionBuilder {
             coord: [x, y],
             color: options?.color ?? "grayH",
             filled: options?.filled ?? true,
-            labels: (options?.labels ?? []).map((label) => ({
-                type: "label",
-                coord: label.coord ?? [x + 0.5, y],
-                text: label.text,
-                color: options?.color ?? "grayH",
-                size: label.size ?? "medium",
-            })),
+            labels: options?.labels
+                ? (options?.labels ?? []).map((label) => ({
+                      type: "label",
+                      coord: label.coord ?? [x + 0.5, y],
+                      text: label.text,
+                      color: options?.color ?? "grayH",
+                      size: label.size ?? "medium",
+                  }))
+                : undefined,
         };
     }
 

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -362,15 +362,13 @@ class InteractiveGraphQuestionBuilder {
             type: "vector",
             color: options?.color ?? "grayH",
             points: [tail, tip],
-            labels: options?.labels
-                ? options?.labels?.map((label) => ({
-                      type: "label",
-                      coord: label.coord ?? vec.midpoint(tail, tip),
-                      text: label.text,
-                      color: options?.color ?? "grayH",
-                      size: label.size ?? "medium",
-                  }))
-                : undefined,
+            labels: options?.labels?.map((label) => ({
+                type: "label",
+                coord: label.coord ?? vec.midpoint(tail, tip),
+                text: label.text,
+                color: options?.color ?? "grayH",
+                size: label.size ?? "medium",
+            })),
         };
         this.addLockedFigure(vector);
         return this;
@@ -440,18 +438,16 @@ class InteractiveGraphQuestionBuilder {
             strokeStyle: "solid",
             directionalAxis: "x",
             ...options,
-            labels: options?.labels
-                ? options?.labels?.map(
-                      (label) =>
-                          ({
-                              type: "label",
-                              coord: label.coord ?? [0, 0],
-                              text: label.text,
-                              color: options?.color ?? "grayH",
-                              size: label.size ?? "medium",
-                          }) satisfies LockedLabelType,
-                  )
-                : undefined,
+            labels: options?.labels?.map(
+                (label) =>
+                    ({
+                        type: "label",
+                        coord: label.coord ?? [0, 0],
+                        text: label.text,
+                        color: options?.color ?? "grayH",
+                        size: label.size ?? "medium",
+                    }) satisfies LockedLabelType,
+            ),
         };
 
         this.addLockedFigure(lockedFunction);

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -324,15 +324,13 @@ class InteractiveGraphQuestionBuilder {
             showPoint2: options?.showPoint2 ?? false,
             color: options?.color ?? "grayH",
             lineStyle: options?.lineStyle ?? "solid",
-            labels: options?.labels
-                ? options.labels.map((label) => ({
-                      type: "label",
-                      coord: label.coord ?? vec.midpoint(point1, point2),
-                      text: label.text,
-                      color: options?.color ?? "grayH",
-                      size: label.size ?? "medium",
-                  }))
-                : undefined,
+            labels: options?.labels?.map((label) => ({
+                type: "label",
+                coord: label.coord ?? vec.midpoint(point1, point2),
+                text: label.text,
+                color: options?.color ?? "grayH",
+                size: label.size ?? "medium",
+            })),
             points: [
                 {
                     ...this.createLockedPoint(...point1, {
@@ -365,7 +363,7 @@ class InteractiveGraphQuestionBuilder {
             color: options?.color ?? "grayH",
             points: [tail, tip],
             labels: options?.labels
-                ? (options?.labels ?? []).map((label) => ({
+                ? options?.labels?.map((label) => ({
                       type: "label",
                       coord: label.coord ?? vec.midpoint(tail, tip),
                       text: label.text,
@@ -398,15 +396,13 @@ class InteractiveGraphQuestionBuilder {
             fillStyle: "none",
             strokeStyle: "solid",
             ...options,
-            labels: options?.labels
-                ? (options?.labels ?? []).map((label) => ({
-                      type: "label",
-                      coord: label.coord ?? center,
-                      text: label.text,
-                      color: options?.color ?? "grayH",
-                      size: label.size ?? "medium",
-                  }))
-                : undefined,
+            labels: options?.labels?.map((label) => ({
+                type: "label",
+                coord: label.coord ?? center,
+                text: label.text,
+                color: options?.color ?? "grayH",
+                size: label.size ?? "medium",
+            })),
         };
 
         this.addLockedFigure(ellipse);
@@ -497,15 +493,13 @@ class InteractiveGraphQuestionBuilder {
             coord: [x, y],
             color: options?.color ?? "grayH",
             filled: options?.filled ?? true,
-            labels: options?.labels
-                ? (options?.labels ?? []).map((label) => ({
-                      type: "label",
-                      coord: label.coord ?? [x + 0.5, y],
-                      text: label.text,
-                      color: options?.color ?? "grayH",
-                      size: label.size ?? "medium",
-                  }))
-                : undefined,
+            labels: options?.labels?.map((label) => ({
+                type: "label",
+                coord: label.coord ?? [x + 0.5, y],
+                text: label.text,
+                color: options?.color ?? "grayH",
+                size: label.size ?? "medium",
+            })),
         };
     }
 


### PR DESCRIPTION
## Summary:
Since the `labels` field was added to the interactive graph
locked figures after they were released and used by content
authors, there are already exercises saved with locked figures
that don't have a `labels` field.

If we make this a required field, this can lead to issues with
the existing exercises in the future. To increase type safety,
I'm making `labels` optional. We should also do this with
new types added in the future. (Labels haven't been released
for use yet, so we can still fix this now without issue.)

Issue: none

## Test plan:
`yarn jest`
`yarn typecheck`