### PR TITLE
[Interactive Graph Editor] Save empty full graph aria label/description as undefined

### DIFF
--- a/.changeset/violet-icons-breathe.md
+++ b/.changeset/violet-icons-breathe.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Interactive Graph Editor] Save empty full graph aria label/description as undefined

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-description.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-description.test.tsx
@@ -104,4 +104,48 @@ describe("InteractiveGraphSettings", () => {
             [{fullGraphAriaDescription: "t"}],
         ]);
     });
+
+    test("saves undefined when the title is cleared", async () => {
+        // Arrange
+        const onChange = jest.fn();
+        render(
+            <InteractiveGraphDescription
+                ariaLabelValue="Graph Title"
+                ariaDescriptionValue=""
+                onChange={onChange}
+            />,
+            {wrapper: RenderStateRoot},
+        );
+
+        // Act
+        const titleInput = screen.getByRole("textbox", {name: "Title"});
+        await userEvent.clear(titleInput);
+
+        // Assert
+        expect(onChange).toHaveBeenCalledWith({fullGraphAriaLabel: undefined});
+    });
+
+    test("saves undefined when the description is cleared", async () => {
+        // Arrange
+        const onChange = jest.fn();
+        render(
+            <InteractiveGraphDescription
+                ariaLabelValue=""
+                ariaDescriptionValue="Graph Description"
+                onChange={onChange}
+            />,
+            {wrapper: RenderStateRoot},
+        );
+
+        // Act
+        const descriptionInput = screen.getByRole("textbox", {
+            name: "Description",
+        });
+        await userEvent.clear(descriptionInput);
+
+        // Assert
+        expect(onChange).toHaveBeenCalledWith({
+            fullGraphAriaDescription: undefined,
+        });
+    });
 });

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-description.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-description.tsx
@@ -41,7 +41,12 @@ export default function InteractiveGraphDescription(props: Props) {
                         <TextField
                             value={ariaLabelValue}
                             onChange={(newValue) =>
-                                onChange({fullGraphAriaLabel: newValue})
+                                onChange({
+                                    fullGraphAriaLabel:
+                                        // Save as undefined if the new value
+                                        // is an empty string.
+                                        newValue || undefined,
+                                })
                             }
                             style={styles.spaceAbove}
                         />
@@ -55,7 +60,10 @@ export default function InteractiveGraphDescription(props: Props) {
                             value={ariaDescriptionValue}
                             onChange={(newValue) =>
                                 onChange({
-                                    fullGraphAriaDescription: newValue,
+                                    fullGraphAriaDescription:
+                                        // Save as undefined if the new value
+                                        // is an empty string.
+                                        newValue || undefined,
                                 })
                             }
                             style={styles.spaceAbove}


### PR DESCRIPTION
## Summary:
For consistency's sake, I'm updating the fullGraphAriaLabel and
fullGraphAriaDescription to save as `undefined` instead of
`""` when they're cleared. This will be consistent with their
values when they haven't been edited yet.

Issue: none

Test plan:
`yarn jest packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-description.test.tsx`

- Go to http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--mafs-with-locked-figure-labels-all-flags
- Confirm that the title and description can still be
  updated and cleared without any errors.