### PR TITLE
Delete unused component param of InteractiveGraph.validate()

### DIFF
--- a/.changeset/honest-games-do.md
+++ b/.changeset/honest-games-do.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: remove dead code from InteractiveGraph.validate()

--- a/packages/perseus/src/widgets/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.test.tsx
@@ -256,12 +256,7 @@ describe("InteractiveGraph.validate on a point question", () => {
 
         const result = InteractiveGraph.widget.validate(guess, rubric);
 
-        expect(result).toEqual({
-            type: "points",
-            earned: 1,
-            total: 1,
-            message: null,
-        });
+        expect(result).toHaveBeenAnsweredCorrectly();
     });
 
     it("does not modify the `guess` data", () => {

--- a/packages/perseus/src/widgets/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.test.tsx
@@ -215,12 +215,7 @@ describe("InteractiveGraph.validate on a point question", () => {
 
         const result = InteractiveGraph.widget.validate(guess, rubric);
 
-        expect(result).toEqual({
-            type: "points",
-            earned: 0,
-            total: 1,
-            message: null,
-        });
+        expect(result).toHaveBeenAnsweredIncorrectly();
     });
 
     it("awards points if guess.coords is right", () => {

--- a/packages/perseus/src/widgets/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.test.tsx
@@ -184,10 +184,7 @@ describe("InteractiveGraph.validate on a point question", () => {
 
         const result = InteractiveGraph.widget.validate(guess, rubric);
 
-        expect(result).toEqual({
-            type: "invalid",
-            message: null,
-        });
+        expect(result).toHaveInvalidInput();
     });
 
     it("throws an exception if correct.coords is missing", () => {

--- a/packages/perseus/src/widgets/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.test.tsx
@@ -1,5 +1,7 @@
 import invariant from "tiny-invariant";
 
+import {clone} from "../../../../testing/object-utils";
+
 import InteractiveGraph, {shouldUseMafs} from "./interactive-graph";
 
 import type {
@@ -28,7 +30,7 @@ describe("InteractiveGraph.validate on a segment question", () => {
             ],
         });
 
-        const result = InteractiveGraph.widget.validate(guess, rubric, null);
+        const result = InteractiveGraph.widget.validate(guess, rubric);
 
         expect(result).toHaveInvalidInput();
     });
@@ -53,7 +55,7 @@ describe("InteractiveGraph.validate on a segment question", () => {
             ],
         });
 
-        const result = InteractiveGraph.widget.validate(guess, rubric, null);
+        const result = InteractiveGraph.widget.validate(guess, rubric);
 
         expect(result).toHaveBeenAnsweredIncorrectly();
     });
@@ -78,7 +80,7 @@ describe("InteractiveGraph.validate on a segment question", () => {
             ],
         });
 
-        const result = InteractiveGraph.widget.validate(guess, rubric, null);
+        const result = InteractiveGraph.widget.validate(guess, rubric);
 
         expect(result).toHaveBeenAnsweredCorrectly();
     });
@@ -103,7 +105,7 @@ describe("InteractiveGraph.validate on a segment question", () => {
             ],
         });
 
-        const result = InteractiveGraph.widget.validate(guess, rubric, null);
+        const result = InteractiveGraph.widget.validate(guess, rubric);
 
         expect(result).toHaveBeenAnsweredCorrectly();
     });
@@ -128,7 +130,7 @@ describe("InteractiveGraph.validate on a segment question", () => {
             ],
         });
 
-        InteractiveGraph.widget.validate(guess, rubric, null);
+        InteractiveGraph.widget.validate(guess, rubric);
 
         expect(guess.coords).toEqual([
             [
@@ -158,7 +160,7 @@ describe("InteractiveGraph.validate on a segment question", () => {
             ],
         });
 
-        InteractiveGraph.widget.validate(guess, rubric, null);
+        InteractiveGraph.widget.validate(guess, rubric);
 
         // Narrow the type of `rubric.correct` to segment graph; otherwise TS
         // thinks it might not have a `coords` property.
@@ -169,6 +171,151 @@ describe("InteractiveGraph.validate on a segment question", () => {
                 [0, 0],
             ],
         ]);
+    });
+});
+
+describe("InteractiveGraph.validate on a point question", () => {
+    it("marks the answer invalid if guess.coords is missing", () => {
+        const guess: PerseusGraphType = {type: "point"};
+        const rubric: PerseusInteractiveGraphRubric = createRubric({
+            type: "point",
+            coords: [[0, 0]],
+        });
+
+        const result = InteractiveGraph.widget.validate(guess, rubric);
+
+        expect(result).toEqual({
+            type: "invalid",
+            message: null,
+        });
+    });
+
+    it("throws an exception if correct.coords is missing", () => {
+        // Characterization test: this might not be desirable behavior, but
+        // it's the current behavior as of 2024-09-25.
+        const guess: PerseusGraphType = {
+            type: "point",
+            coords: [[0, 0]],
+        };
+        const rubric: PerseusInteractiveGraphRubric = createRubric({
+            type: "point",
+        });
+
+        expect(() =>
+            InteractiveGraph.widget.validate(guess, rubric),
+        ).toThrowError();
+    });
+
+    it("does not award points if guess.coords is wrong", () => {
+        const guess: PerseusGraphType = {
+            type: "point",
+            coords: [[9, 9]],
+        };
+        const rubric: PerseusInteractiveGraphRubric = createRubric({
+            type: "point",
+            coords: [[0, 0]],
+        });
+
+        const result = InteractiveGraph.widget.validate(guess, rubric);
+
+        expect(result).toEqual({
+            type: "points",
+            earned: 0,
+            total: 1,
+            message: null,
+        });
+    });
+
+    it("awards points if guess.coords is right", () => {
+        const guess: PerseusGraphType = {
+            type: "point",
+            coords: [[7, 8]],
+        };
+        const rubric: PerseusInteractiveGraphRubric = createRubric({
+            type: "point",
+            coords: [[7, 8]],
+        });
+
+        const result = InteractiveGraph.widget.validate(guess, rubric);
+
+        expect(result).toEqual({
+            type: "points",
+            earned: 1,
+            total: 1,
+            message: null,
+        });
+    });
+
+    it("allows points to be specified in any order", () => {
+        const guess: PerseusGraphType = {
+            type: "point",
+            coords: [
+                [7, 8],
+                [5, 6],
+            ],
+        };
+        const rubric: PerseusInteractiveGraphRubric = createRubric({
+            type: "point",
+            coords: [
+                [5, 6],
+                [7, 8],
+            ],
+        });
+
+        const result = InteractiveGraph.widget.validate(guess, rubric);
+
+        expect(result).toEqual({
+            type: "points",
+            earned: 1,
+            total: 1,
+            message: null,
+        });
+    });
+
+    it("does not modify the `guess` data", () => {
+        const guess: PerseusGraphType = {
+            type: "point",
+            coords: [
+                [7, 8],
+                [5, 6],
+            ],
+        };
+        const rubric: PerseusInteractiveGraphRubric = createRubric({
+            type: "point",
+            coords: [
+                [5, 6],
+                [7, 8],
+            ],
+        });
+
+        const guessClone = clone(guess);
+
+        InteractiveGraph.widget.validate(guess, rubric);
+
+        expect(guess).toEqual(guessClone);
+    });
+
+    it("does not modify the `rubric` data", () => {
+        const guess: PerseusGraphType = {
+            type: "point",
+            coords: [
+                [7, 8],
+                [5, 6],
+            ],
+        };
+        const rubric: PerseusInteractiveGraphRubric = createRubric({
+            type: "point",
+            coords: [
+                [5, 6],
+                [7, 8],
+            ],
+        });
+
+        const rubricClone = clone(rubric);
+
+        InteractiveGraph.widget.validate(guess, rubric);
+
+        expect(rubric).toEqual(rubricClone);
     });
 });
 

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -1681,7 +1681,7 @@ class LegacyInteractiveGraph extends React.Component<Props, State> {
     }
 
     simpleValidate(rubric: PerseusInteractiveGraphRubric) {
-        return InteractiveGraph.validate(this.getUserInput(), rubric, this);
+        return InteractiveGraph.validate(this.getUserInput(), rubric);
     }
 
     focus: () => void = $.noop;
@@ -1791,7 +1791,7 @@ class InteractiveGraph extends React.Component<Props, State> {
     }
 
     simpleValidate(rubric: PerseusInteractiveGraphRubric) {
-        return InteractiveGraph.validate(this.getUserInput(), rubric, this);
+        return InteractiveGraph.validate(this.getUserInput(), rubric);
     }
 
     render() {
@@ -2363,7 +2363,6 @@ class InteractiveGraph extends React.Component<Props, State> {
     static validate(
         userInput: PerseusGraphType,
         rubric: PerseusInteractiveGraphRubric,
-        component: any,
     ): PerseusScore {
         // None-type graphs are not graded
         if (userInput.type === "none" && rubric.correct.type === "none") {
@@ -2503,10 +2502,10 @@ class InteractiveGraph extends React.Component<Props, State> {
                 rubric.correct.type === "point" &&
                 userInput.coords != null
             ) {
-                let correct = InteractiveGraph.getPointCoords(
-                    rubric.correct,
-                    component,
-                );
+                let correct = rubric.correct.coords;
+                if (correct == null) {
+                    throw new Error("Point graph rubric has null coords");
+                }
                 const guess = userInput.coords.slice();
                 correct = correct.slice();
                 // Everything's already rounded so we shouldn't need to do an


### PR DESCRIPTION
This parameter appeared to be used to score point graphs. It was passed to
`getPointCoords()`. However, on closer inspection, there was no way this code
could have worked: `getPointCoords` takes the interactive graph props as an
argument, but we were passing it the entire component. This props param was
only being used if the rubric contained no coords. Maybe that's a realistic
case, or maybe it's not, but either way, it was throwing an error trying to
access `props.range[0]`.

Long story short, we lose nothing by deleting the `component` param and
explicitly throwing an error if the rubric has no coords.

Issue: LEMS-2448

## Test plan:

Run this script to copy point graph data to your clipboard:

```
grep -rl '"type":"point"' data/questions/ | xargs cat | pbcopy
```

Paste it into `http://localhost:5173#flipbook`. Solve some point graph
questions.