### PR TITLE
[Locked Figure Aria] Implement locked point aria label behavior on graph

### DIFF
--- a/.changeset/hot-geese-look.md
+++ b/.changeset/hot-geese-look.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-editor": minor
+---
+
+[Locked Figure Aria] Implement locked point aria label behavior on graph

--- a/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
+++ b/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
@@ -16,6 +16,7 @@ export const flags = {
 
         // Locked figures flags
         "interactive-graph-locked-features-labels": true,
+        "locked-figures-aria": true,
         "locked-point-labels": true,
         "locked-line-labels": true,
         "locked-vector-labels": true,

--- a/packages/perseus-editor/src/__stories__/interactive-graph-editor.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/interactive-graph-editor.stories.tsx
@@ -153,6 +153,7 @@ export const MafsWithLockedFiguresCurrent = (): React.ReactElement => {
                     mafs: {
                         ...flags.mafs,
                         "interactive-graph-locked-features-labels": false,
+                        "locked-figures-aria": false,
                         "locked-point-labels": false,
                         "locked-line-labels": false,
                         "locked-vector-labels": false,

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -707,6 +707,7 @@ export type LockedPointType = {
     color: LockedFigureColor;
     filled: boolean;
     labels?: LockedLabelType[];
+    ariaLabel?: string;
 };
 
 export type LockedLineType = {

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -154,6 +154,11 @@ export const InteractiveGraphLockedFeaturesFlags = [
      * widget (locked labels).
      */
     "interactive-graph-locked-features-labels",
+    /**
+     * Enables/disables the aria labels associated with specific locked
+     * figures in the updated Interactive Graph widget.
+     */
+    "locked-figures-aria",
 
     /**
      * Enables/disables the labels associated with locked points in the

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.tsx
@@ -48,7 +48,7 @@ const YGridTick = ({y, range}: {y: number; range: [Interval, Interval]}) => {
     const showLabel = shouldShowLabel(y, range);
 
     return (
-        <g className="tick">
+        <g className="tick" aria-hidden={true}>
             <line x1={x1} y1={y1} x2={x2} y2={y2} className="axis-tick" />
             {showLabel && (
                 <text
@@ -106,7 +106,7 @@ const XGridTick = ({x, range}: {x: number; range: [Interval, Interval]}) => {
     const yPositionText = yPosition + yAdjustment;
 
     return (
-        <g className="tick">
+        <g className="tick" aria-hidden={true}>
             <line x1={x1} y1={y1} x2={x2} y2={y2} className="axis-tick" />
             {
                 <text

--- a/packages/perseus/src/widgets/interactive-graphs/graph-locked-layer.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graph-locked-layer.tsx
@@ -9,22 +9,28 @@ import LockedPolygon from "./locked-figures/locked-polygon";
 import LockedVector from "./locked-figures/locked-vector";
 
 import type {LockedFigure} from "../../perseus-types";
+import type {APIOptions} from "../../types";
 import type {Interval} from "mafs";
 
 type Props = {
+    flags?: APIOptions["flags"];
     lockedFigures: ReadonlyArray<LockedFigure>;
     range: [x: Interval, y: Interval];
 };
 
 const GraphLockedLayer = (props: Props) => {
-    const {lockedFigures} = props;
+    const {flags, lockedFigures} = props;
     return (
         <>
             {lockedFigures.map((figure, index) => {
                 switch (figure.type) {
                     case "point":
                         return (
-                            <LockedPoint key={`point-${index}`} {...figure} />
+                            <LockedPoint
+                                key={`point-${index}`}
+                                {...figure}
+                                flags={flags}
+                            />
                         );
                     case "line":
                         return (

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
@@ -771,6 +771,7 @@ describe("InteractiveGraphQuestionBuilder", () => {
                 color: "green",
                 filled: false,
                 labels: [{text: "a label"}],
+                ariaLabel: "an aria label",
             })
             .build();
         const graph = question.widgets["interactive-graph 1"];
@@ -790,6 +791,7 @@ describe("InteractiveGraphQuestionBuilder", () => {
                         size: "medium",
                     },
                 ],
+                ariaLabel: "an aria label",
             },
         ]);
     });

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -298,6 +298,7 @@ class InteractiveGraphQuestionBuilder {
             color?: LockedFigureColor;
             filled?: boolean;
             labels?: LockedFigureLabelOptions[];
+            ariaLabel?: string;
         },
     ): InteractiveGraphQuestionBuilder {
         this.addLockedFigure(this.createLockedPoint(x, y, options));
@@ -482,6 +483,7 @@ class InteractiveGraphQuestionBuilder {
             color?: LockedFigureColor;
             filled?: boolean;
             labels?: LockedFigureLabelOptions[];
+            ariaLabel?: string;
         },
     ): LockedPointType {
         return {
@@ -496,6 +498,7 @@ class InteractiveGraphQuestionBuilder {
                 color: options?.color ?? "grayH",
                 size: label.size ?? "medium",
             })),
+            ariaLabel: options?.ariaLabel,
         };
     }
 

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
@@ -542,6 +542,52 @@ describe("locked layer", () => {
         });
     });
 
+    it("should render locked point with aria label when one is provided", () => {
+        // Arrange
+        const lockedPointWithAriaLabelQuestion =
+            interactiveGraphQuestionBuilder()
+                .addLockedPointAt(0, 0, {
+                    ariaLabel: "Point A",
+                })
+                .build();
+        const {container} = renderQuestion(lockedPointWithAriaLabelQuestion, {
+            flags: {
+                mafs: {
+                    segment: true,
+                    "locked-figures-aria": true,
+                },
+            },
+        });
+
+        // Act
+        // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+        const point = container.querySelector(".locked-point");
+
+        // Assert
+        expect(point).toHaveAttribute("aria-label", "Point A");
+    });
+
+    it("should render locked points without aria label by default", () => {
+        // Arrange
+        const simpleLockedPointQuestion = interactiveGraphQuestionBuilder()
+            .addLockedPointAt(0, 0)
+            .build();
+        const {container} = renderQuestion(simpleLockedPointQuestion, {
+            flags: {
+                mafs: {
+                    segment: true,
+                },
+            },
+        });
+
+        // Act
+        // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+        const point = container.querySelector(".locked-point");
+
+        // Assert
+        expect(point).not.toHaveAttribute("aria-label");
+    });
+
     it("should render locked lines", () => {
         // Arrange
         const {container} = renderQuestion(segmentWithLockedLineQuestion, {

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -830,7 +830,7 @@ export const segmentWithLockedLabels: PerseusRenderer =
 
 export const segmentWithLockedFigures: PerseusRenderer =
     interactiveGraphQuestionBuilder()
-        .addLockedPointAt(-7, -7, {labels: [{text: "A"}]})
+        .addLockedPointAt(-7, -7, {labels: [{text: "A"}], ariaLabel: "Point A"})
         .addLockedLine([-7, -5], [2, -3], {
             showPoint1: true,
             showPoint2: true,

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-label.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-label.tsx
@@ -25,6 +25,7 @@ export default function LockedLabel(props: LockedLabelType) {
                 fontSize: font.size[size],
                 backgroundColor: "rgba(255, 255, 255, 0.8)",
             }}
+            aria-hidden={true}
         >
             <TeX>{text}</TeX>
         </span>

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-point.tsx
@@ -21,11 +21,6 @@ const LockedPoint = (props: Props) => {
             className="locked-point"
             aria-label={hasAria ? ariaLabel : undefined}
             aria-hidden={!hasAria}
-            style={{
-                // Outline styles on focus.
-                outlineOffset: spacing.xxxSmall_4,
-                borderRadius: "50%",
-            }}
         >
             <Point
                 x={x}

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-point.tsx
@@ -4,21 +4,43 @@ import * as React from "react";
 
 import {lockedFigureColors, type LockedPointType} from "../../../perseus-types";
 
-const LockedPoint = (props: LockedPointType) => {
-    const {color, coord, filled} = props;
+import type {APIOptions} from "../../../types";
+
+type Props = LockedPointType & {
+    flags?: APIOptions["flags"];
+};
+
+const LockedPoint = (props: Props) => {
+    const {flags, color, coord, filled, ariaLabel} = props;
     const [x, y] = coord;
+
+    const hasAria = ariaLabel && flags?.["mafs"]?.["locked-figures-aria"];
+
     return (
-        <Point
-            x={x}
-            y={y}
-            svgCircleProps={{
-                style: {
-                    fill: filled ? lockedFigureColors[color] : wbColor.white,
-                    stroke: lockedFigureColors[color],
-                    strokeWidth: spacing.xxxxSmall_2,
-                },
+        <g
+            className="locked-point"
+            aria-label={hasAria ? ariaLabel : undefined}
+            aria-hidden={!hasAria}
+            style={{
+                // Outline styles on focus.
+                outlineOffset: spacing.xxxSmall_4,
+                borderRadius: "50%",
             }}
-        />
+        >
+            <Point
+                x={x}
+                y={y}
+                svgCircleProps={{
+                    style: {
+                        fill: filled
+                            ? lockedFigureColors[color]
+                            : wbColor.white,
+                        stroke: lockedFigureColors[color],
+                        strokeWidth: spacing.xxxxSmall_2,
+                    },
+                }}
+            />
+        </g>
     );
 };
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -230,6 +230,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                                 {/* Locked figures layer */}
                                 {props.lockedFigures && (
                                     <GraphLockedLayer
+                                        flags={props.flags}
                                         lockedFigures={props.lockedFigures}
                                         range={state.range}
                                     />


### PR DESCRIPTION
## Summary:
- Add `locked-figures-aria` flag
- Add `ariaLabel` field to LockedPointType
- Add the aria label behavior to the LockedPoint on the mafs graph
- Minor updates to the screen reader behvaior

Issue: https://khanacademy.atlassian.net/browse/LEMS-2375

## Test plan:
`yarn jest packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx`

Storybook
- Go to http://localhost:6006/iframe.html?args=&id=perseuseditor-widgets-interactive-graph--mafs-with-locked-figure-labels-all-flags&viewMode=story
- Use a screen reader to navigate through the preview graph
- Using tab should _only_ navigate to the interactive elements, NOT the locked point
- Using the screenreader controls (VO + arrow keys) should be able to navigate to
  the locked point. It should read out as "Point A".

https://github.com/user-attachments/assets/939ae929-8569-410b-a25b-8b09e16ec97b

