### PR TITLE
Port tests to custom matcher

### DIFF
--- a/.changeset/great-lions-switch.md
+++ b/.changeset/great-lions-switch.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Port some tests to new custom matcher

--- a/packages/perseus/src/widgets/definition/definition.test.ts
+++ b/packages/perseus/src/widgets/definition/definition.test.ts
@@ -128,11 +128,6 @@ describe("Definition widget", () => {
         const result = renderer.scoreWidgets();
 
         // Assert
-        expect(result["definition 1"]).toMatchObject({
-            type: "points",
-            earned: 0,
-            total: 0,
-            message: null,
-        });
+        expect(result["definition 1"]).toHaveBeenAnsweredCorrectly();
     });
 });

--- a/packages/perseus/src/widgets/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.test.tsx
@@ -30,10 +30,7 @@ describe("InteractiveGraph.validate on a segment question", () => {
 
         const result = InteractiveGraph.widget.validate(guess, rubric, null);
 
-        expect(result).toEqual({
-            type: "invalid",
-            message: null,
-        });
+        expect(result).toHaveInvalidInput();
     });
 
     it("does not award points if guess.coords is wrong", () => {
@@ -58,12 +55,7 @@ describe("InteractiveGraph.validate on a segment question", () => {
 
         const result = InteractiveGraph.widget.validate(guess, rubric, null);
 
-        expect(result).toEqual({
-            type: "points",
-            earned: 0,
-            total: 1,
-            message: null,
-        });
+        expect(result).toHaveBeenAnsweredIncorrectly();
     });
 
     it("awards points if guess.coords is right", () => {
@@ -88,12 +80,7 @@ describe("InteractiveGraph.validate on a segment question", () => {
 
         const result = InteractiveGraph.widget.validate(guess, rubric, null);
 
-        expect(result).toEqual({
-            type: "points",
-            earned: 1,
-            total: 1,
-            message: null,
-        });
+        expect(result).toHaveBeenAnsweredCorrectly();
     });
 
     it("allows points of a segment to be specified in reverse order", () => {
@@ -118,12 +105,7 @@ describe("InteractiveGraph.validate on a segment question", () => {
 
         const result = InteractiveGraph.widget.validate(guess, rubric, null);
 
-        expect(result).toEqual({
-            type: "points",
-            earned: 1,
-            total: 1,
-            message: null,
-        });
+        expect(result).toHaveBeenAnsweredCorrectly();
     });
 
     it("does not modify the `guess` data", () => {


### PR DESCRIPTION
## Summary:
We made a custom matcher to make score tests easier to grok. This ports some existing tests over to that.