### PR TITLE
[Bug fix] - Ensuring decimal axis tick labels display with the same level of granularity as the tick step. 

### DIFF
--- a/.changeset/heavy-steaks-count.md
+++ b/.changeset/heavy-steaks-count.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Bug fix for Axis Tick Labels in Interactive Graph to handle floating point issues when working with decimals.

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.test.ts
@@ -1,4 +1,8 @@
-import {generateTickLocations, shouldShowLabel} from "./axis-ticks";
+import {
+    generateTickLocations,
+    shouldShowLabel,
+    countSignificantDecimals,
+} from "./axis-ticks";
 
 describe("generateTickLocations", () => {
     it("should generate ticks from the origin", () => {
@@ -48,4 +52,22 @@ describe("shouldShowLabel", () => {
             ]),
         ).toBe(true);
     });
+});
+describe("countSignificantDecimals", () => {
+    test.each`
+        tickStep   | expected
+        ${0.3}     | ${1}
+        ${0.03}    | ${2}
+        ${0.003}   | ${3}
+        ${0.0003}  | ${4}
+        ${0.00003} | ${5}
+    `(
+        "should correctly calculate the number of decimal places for $tickStep",
+        ({tickStep, expected}) => {
+            // Act
+            const decimalPlaces = countSignificantDecimals(tickStep);
+
+            expect(decimalPlaces).toBe(expected);
+        },
+    );
 });

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.tsx
@@ -147,10 +147,16 @@ export function generateTickLocations(
 ): number[] {
     const ticks: number[] = [];
 
+    // Calculate the number of significant decimals in the tick step so
+    // that we can match the desired precision when generating ticks.
+    const decimalSigFigs: number = countSignificantDecimals(tickStep);
+
     // Add ticks in the positive direction
     const start = Math.max(min, 0);
     for (let i = start + tickStep; i < max; i += tickStep) {
-        ticks.push(i);
+        // Match to the same number of decimal places as the tick step
+        // to avoid floating point errors when working with small numbers
+        ticks.push(parseFloat(i.toFixed(decimalSigFigs)));
     }
 
     // Add ticks in the negative direction
@@ -161,6 +167,15 @@ export function generateTickLocations(
     }
     return ticks;
 }
+
+// Count the number of significant digits after the decimal point
+const countSignificantDecimals = (number: number): number => {
+    const numStr = number.toString();
+    if (!numStr.includes(".")) {
+        return 0;
+    }
+    return numStr.split(".")[1].length;
+};
 
 export const AxisTicks = () => {
     const {tickStep, range} = useGraphConfig();

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.tsx
@@ -169,7 +169,7 @@ export function generateTickLocations(
 }
 
 // Count the number of significant digits after the decimal point
-const countSignificantDecimals = (number: number): number => {
+export const countSignificantDecimals = (number: number): number => {
     const numStr = number.toString();
     if (!numStr.includes(".")) {
         return 0;


### PR DESCRIPTION
## Summary:
A bug with the axis tick labels was discovered when using decimal-based tickSteps in an interactive graph. In order to help alleviate this floating point issue, I've added a new function that counts the number of significant figures after the decimal point in the tickStep, so that we can generate tickSteps with the same level of specificity.

**Note:**
While investigating this issue, I discovered we have several floating point issues when dealing with very small decimals that seem to actually be stemming from the Content Editor experience itself. I'll start a separate discussion on that, but I believe it to be low priority as I don't expect content creators to be working with numbers smaller than 3-4 sig figs after the decimal. If you try to enter small numbers into the grid/snap/tick steps, you'll notice that editing one might result in floating point issues in another input. 

Issue: LEMS-2405

## Test plan:
- manual testing 
- New micro tests for decimal counter 