### PR TITLE
[Bug Fix] Update shouldShowLabel logic to better handle decimal tickSteps 

### DIFF
--- a/.changeset/tall-scissors-pay.md
+++ b/.changeset/tall-scissors-pay.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Bug fix for Axis Tick Labels in Interactive Graph to hide the first negative tick step on the yAxis if it is within the graph

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.test.ts
@@ -24,28 +24,40 @@ describe("generateTickLocations", () => {
 describe("shouldShowLabel", () => {
     it("should show label when y-axis is not at -1", () => {
         expect(
-            shouldShowLabel(0, [
-                [-10, 10],
-                [-10, 10],
-            ]),
+            shouldShowLabel(
+                0,
+                [
+                    [-10, 10],
+                    [-10, 10],
+                ],
+                1,
+            ),
         ).toBe(true);
     });
 
-    it("should hide label when y-axis is at -1 and within the graph bounds", () => {
+    it("should hide label when y-axis is at -tickStep and exists within the graph bounds", () => {
         expect(
-            shouldShowLabel(-1, [
-                [-10, 10],
-                [-10, 10],
-            ]),
+            shouldShowLabel(
+                -0.5,
+                [
+                    [-3, 3],
+                    [-3, 3],
+                ],
+                0.5,
+            ),
         ).toBe(false);
     });
 
     it("should show label when y-axis is not at -1 and exists outside of the graph bounds", () => {
         expect(
-            shouldShowLabel(-1, [
-                [1, 10],
-                [-10, 10],
-            ]),
+            shouldShowLabel(
+                -1,
+                [
+                    [1, 10],
+                    [-10, 10],
+                ],
+                1,
+            ),
         ).toBe(true);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.test.ts
@@ -1,5 +1,7 @@
 import {generateTickLocations, shouldShowLabel} from "./axis-ticks";
 
+import type {Interval} from "mafs";
+
 describe("generateTickLocations", () => {
     it("should generate ticks from the origin", () => {
         expect(generateTickLocations(10, 0, 100)).toEqual([
@@ -22,42 +24,33 @@ describe("generateTickLocations", () => {
 });
 
 describe("shouldShowLabel", () => {
-    it("should show label when y-axis is not at -1", () => {
-        expect(
-            shouldShowLabel(
-                0,
-                [
-                    [-10, 10],
-                    [-10, 10],
-                ],
-                1,
-            ),
-        ).toBe(true);
+    it("should show label when y-axis is not at -tickStep", () => {
+        const currentTick = 1;
+        const range: [Interval, Interval] = [
+            [-10, 10],
+            [-10, 10],
+        ];
+        const tickStep = 1;
+        expect(shouldShowLabel(currentTick, range, tickStep)).toBe(true);
     });
 
-    it("should hide label when y-axis is at -tickStep and exists within the graph bounds", () => {
-        expect(
-            shouldShowLabel(
-                -0.5,
-                [
-                    [-3, 3],
-                    [-3, 3],
-                ],
-                0.5,
-            ),
-        ).toBe(false);
+    it("should hide label when currentTick equals -tickStep and the y-axis is within the graph bounds", () => {
+        const currentTick = -0.5;
+        const range: [Interval, Interval] = [
+            [-3, 3],
+            [-3, 3],
+        ];
+        const tickStep = 0.5;
+        expect(shouldShowLabel(currentTick, range, tickStep)).toBe(false);
     });
 
-    it("should show label when y-axis is not at -1 and exists outside of the graph bounds", () => {
-        expect(
-            shouldShowLabel(
-                -1,
-                [
-                    [1, 10],
-                    [-10, 10],
-                ],
-                1,
-            ),
-        ).toBe(true);
+    it("should show label when currentTick equals -tickStep but y-axis is outside of the graph bounds", () => {
+        const currentTick = 1;
+        const range: [Interval, Interval] = [
+            [1, 10],
+            [-10, 10],
+        ];
+        const tickStep = 1;
+        expect(shouldShowLabel(currentTick, range, tickStep)).toBe(true);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.tsx
@@ -10,7 +10,15 @@ import type {Interval, vec} from "mafs";
 const tickSize = 10;
 const tickLabelSize = 14;
 
-const YGridTick = ({y, range}: {y: number; range: [Interval, Interval]}) => {
+const YGridTick = ({
+    y,
+    range,
+    tickStep,
+}: {
+    y: number;
+    range: [Interval, Interval];
+    tickStep: number;
+}) => {
     // If the graph requires out-of-bounds labels, we want to make sure to set the
     // coordinates to the edge of the visible range of the graph. Otherwise,
     // the ticks and labels would render outside of the clipping-mask.
@@ -45,7 +53,7 @@ const YGridTick = ({y, range}: {y: number; range: [Interval, Interval]}) => {
 
     // If the graph displays both the y and x axis lines within the graph, we want
     // to hide the label at -1 on the y-axis to prevent overlap with the x-axis label
-    const showLabel = shouldShowLabel(y, range);
+    const showLabel = shouldShowLabel(y, range, tickStep);
 
     return (
         <g className="tick">
@@ -124,16 +132,21 @@ const XGridTick = ({x, range}: {x: number; range: [Interval, Interval]}) => {
 };
 
 // Determines whether to show the label for the given tick
-// Currently, the only condition is to hide the label at -1
-// on the y-axis when the x-axis is within the graph
+// Currently, the only condition is to hide the label at -tickStep
+// on the y-axis when the y-axis is within the graph bounds
 export const shouldShowLabel = (
-    number: number,
+    currentTick: number,
     range: [Interval, Interval],
+    tickStep: number,
 ) => {
     let showLabel = true;
 
-    // If the x-axis is within the graph and the y-axis is at -1, hide the label
-    if (range[X][MIN] < -1 && range[X][MAX] > 0 && number === -1) {
+    // If the y-axis is within the graph and currentTick equals -tickStep, hide the label
+    if (
+        range[X][MIN] < -tickStep &&
+        range[X][MAX] > 0 &&
+        currentTick === -tickStep
+    ) {
         showLabel = false;
     }
 
@@ -180,6 +193,7 @@ export const AxisTicks = () => {
                             y={y}
                             key={`y-grid-tick-${y}`}
                             range={range}
+                            tickStep={tickStep[Y]}
                         />
                     );
                 })}


### PR DESCRIPTION
## Summary:
Decimal labels for the Axis Ticks in the Interactive Graph Widget are experiencing a bug in relation to the shouldShowLabel logic, where the -1 is being hidden when it should not be. Additionally, decimal tick steps would often result in overlapping labels. 

This PR updates the shouldShowLabel logic to always hide the negative tickStep on the y-axis if it is within the graph bounds. This should solve both of the issues above, and result in a cleaner graph experience. 

Issue: LEMS-2406

## Test plan:
- yarn jest
- Updated test to test the edge case 