### PR TITLE
Refine Expression Rubric type (#1698)

### DIFF
--- a/.changeset/hot-carrots-eat.md
+++ b/.changeset/hot-carrots-eat.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Refine Expression's Rubric type

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -5,7 +5,7 @@ import type {
     PerseusDefinitionWidgetOptions,
     PerseusDropdownWidgetOptions,
     PerseusExplanationWidgetOptions,
-    PerseusExpressionWidgetOptions,
+    PerseusExpressionAnswerForm,
     PerseusGradedGroupSetWidgetOptions,
     PerseusGradedGroupWidgetOptions,
     PerseusGrapherWidgetOptions,
@@ -64,7 +64,10 @@ export type PerseusExplanationRubric = PerseusExplanationWidgetOptions;
 // TODO (LEMS-2396): remove validation logic from widgets that don't validate
 export type PerseusExplanationUserInput = Empty;
 
-export type PerseusExpressionRubric = PerseusExpressionWidgetOptions;
+export type PerseusExpressionRubric = {
+    answerForms: ReadonlyArray<PerseusExpressionAnswerForm>;
+    functions: ReadonlyArray<string>;
+};
 
 export type PerseusExpressionUserInput = string;
 

--- a/packages/perseus/src/widgets/expression/expression-validator.ts
+++ b/packages/perseus/src/widgets/expression/expression-validator.ts
@@ -34,6 +34,7 @@ import type {
  *   show the user an error. TODO(joel) - what error?
  * - Otherwise, pass through the resulting points and message.
  */
+
 function expressionValidator(
     userInput: PerseusExpressionUserInput,
     rubric: PerseusExpressionRubric,

--- a/packages/perseus/src/widgets/expression/expression-validator.ts
+++ b/packages/perseus/src/widgets/expression/expression-validator.ts
@@ -34,7 +34,6 @@ import type {
  *   show the user an error. TODO(joel) - what error?
  * - Otherwise, pass through the resulting points and message.
  */
-
 function expressionValidator(
     userInput: PerseusExpressionUserInput,
     rubric: PerseusExpressionRubric,


### PR DESCRIPTION
## Summary:
We're trying to make the Rubric type only include the things it needs for scoring. This is Expression.

Issue: LEMS-2462

## Test plan:
Nothing should change, just a type tweak.

Author: handeyeco

Reviewers: Myranae

Required Reviewers:

Approved By: Myranae

Checks: ✅ Publish npm snapshot (ubuntu-latest, 20.x), ✅ Check builds for changes in size (ubuntu-latest, 20.x), ✅ Lint, Typecheck, Format, and Test (ubuntu-latest, 20.x), ✅ Check for .changeset entries for all changed files (ubuntu-latest, 20.x), ✅ Cypress (ubuntu-latest, 20.x), ✅ gerald, 🚫 Publish npm snapshot (ubuntu-latest, 20.x), 🚫 Cypress (ubuntu-latest, 20.x), 🚫 Check for .changeset entries for all changed files (ubuntu-latest, 20.x), 🚫 Lint, Typecheck, Format, and Test (ubuntu-latest, 20.x), 🚫 Check builds for changes in size (ubuntu-latest, 20.x), ✅ Publish Storybook to Chromatic (ubuntu-latest, 20.x), ✅ gerald

Pull Request URL: https://github.com/Khan/perseus/pull/1698