### PR TITLE
Add renderer level tests for shuffled scoring

### DIFF
--- a/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
@@ -5,16 +5,20 @@ import {userEvent as userEventLib} from "@testing-library/user-event";
 import {clone} from "../../../../../../testing/object-utils";
 import {testDependencies} from "../../../../../../testing/test-dependencies";
 import * as Dependencies from "../../../dependencies";
+import {mockStrings} from "../../../strings";
 import {renderQuestion} from "../../__testutils__/renderQuestion";
 import PassageWidget from "../../passage";
+import radioValidator from "../radio-validator";
 
 import {
     questionAndAnswer,
     multiChoiceQuestionAndAnswer,
+    shuffledQuestion,
 } from "./radio.testdata";
 
 import type {PerseusRenderer} from "../../../perseus-types";
 import type {APIOptions} from "../../../types";
+import type {PerseusRadioUserInput} from "../../../validation.types";
 import type {UserEvent} from "@testing-library/user-event";
 
 const selectOption = async (
@@ -873,4 +877,63 @@ describe("multi-choice question", () => {
             expect(renderer).toHaveInvalidInput();
         },
     );
+});
+
+describe("scoring", () => {
+    let userEvent: UserEvent;
+    beforeEach(() => {
+        userEvent = userEventLib.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    /**
+     * (LEMS-2435) We want to be sure that we're able to score shuffled
+     * Radio widgets outside of the component which means `getUserInput`
+     * should return the same order that the rubric provides
+     */
+    it("can be scored correctly when shuffled", async () => {
+        // Arrange
+        const {renderer} = renderQuestion(shuffledQuestion);
+
+        // Act
+        await userEvent.click(
+            screen.getByRole("radio", {name: /Correct Choice$/}),
+        );
+
+        const userInput = renderer.getUserInput()[0] as PerseusRadioUserInput;
+        const rubric = shuffledQuestion.widgets["radio 1"].options;
+        const score = radioValidator(userInput, rubric, mockStrings);
+
+        // Assert
+        expect(score).toHaveBeenAnsweredCorrectly();
+        expect(renderer).toHaveBeenAnsweredCorrectly();
+    });
+
+    /**
+     * (LEMS-2435) We want to be sure that we're able to score shuffled
+     * Radio widgets outside of the component which means `getUserInput`
+     * should return the same order that the rubric provides
+     */
+    it("can be scored incorrectly when shuffled", async () => {
+        // Arrange
+        const {renderer} = renderQuestion(shuffledQuestion);
+
+        // Act
+        await userEvent.click(
+            screen.getByRole("radio", {name: /Incorrect Choice 1$/}),
+        );
+
+        const userInput = renderer.getUserInput()[0] as PerseusRadioUserInput;
+        const rubric = shuffledQuestion.widgets["radio 1"].options;
+        const score = radioValidator(userInput, rubric, mockStrings);
+
+        // Assert
+        expect(score).toHaveBeenAnsweredIncorrectly();
+        expect(renderer).toHaveBeenAnsweredIncorrectly();
+    });
 });

--- a/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
@@ -14,6 +14,7 @@ import {
     questionAndAnswer,
     multiChoiceQuestionAndAnswer,
     shuffledQuestion,
+    shuffledNoneQuestion,
 } from "./radio.testdata";
 
 import type {PerseusRenderer} from "../../../perseus-types";
@@ -930,6 +931,52 @@ describe("scoring", () => {
 
         const userInput = renderer.getUserInput()[0] as PerseusRadioUserInput;
         const rubric = shuffledQuestion.widgets["radio 1"].options;
+        const score = radioValidator(userInput, rubric, mockStrings);
+
+        // Assert
+        expect(score).toHaveBeenAnsweredIncorrectly();
+        expect(renderer).toHaveBeenAnsweredIncorrectly();
+    });
+
+    /**
+     * (LEMS-2435) We want to be sure that we're able to score shuffled
+     * Radio widgets outside of the component which means `getUserInput`
+     * should return the same order that the rubric provides
+     */
+    it("can be scored correctly when shuffled with none of the above", async () => {
+        // Arrange
+        const {renderer} = renderQuestion(shuffledNoneQuestion);
+
+        // Act
+        await userEvent.click(
+            screen.getByRole("radio", {name: /None of the above$/}),
+        );
+
+        const userInput = renderer.getUserInput()[0] as PerseusRadioUserInput;
+        const rubric = shuffledNoneQuestion.widgets["radio 1"].options;
+        const score = radioValidator(userInput, rubric, mockStrings);
+
+        // Assert
+        expect(score).toHaveBeenAnsweredCorrectly();
+        expect(renderer).toHaveBeenAnsweredCorrectly();
+    });
+
+    /**
+     * (LEMS-2435) We want to be sure that we're able to score shuffled
+     * Radio widgets outside of the component which means `getUserInput`
+     * should return the same order that the rubric provides
+     */
+    it("can be scored incorrectly when shuffled with none of the above", async () => {
+        // Arrange
+        const {renderer} = renderQuestion(shuffledNoneQuestion);
+
+        // Act
+        await userEvent.click(
+            screen.getByRole("radio", {name: /Incorrect Choice 1$/}),
+        );
+
+        const userInput = renderer.getUserInput()[0] as PerseusRadioUserInput;
+        const rubric = shuffledNoneQuestion.widgets["radio 1"].options;
         const score = radioValidator(userInput, rubric, mockStrings);
 
         // Assert

--- a/packages/perseus/src/widgets/radio/__tests__/radio.testdata.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/radio.testdata.ts
@@ -323,3 +323,47 @@ export const multiChoiceQuestionAndAnswer: [
         [0, 1, 2, 3],
     ],
 ];
+
+export const shuffledQuestion: PerseusRenderer = {
+    content: "[[\u2603 radio 1]]",
+    images: {},
+    widgets: {
+        "radio 1": {
+            graded: true,
+            version: {
+                major: 1,
+                minor: 0,
+            },
+            static: false,
+            type: "radio",
+            options: {
+                displayCount: null,
+                onePerLine: false,
+                choices: [
+                    {
+                        content: "Incorrect Choice 1",
+                        correct: false,
+                    },
+                    {
+                        content: "Incorrect Choice 2",
+                        correct: false,
+                    },
+                    {
+                        content: "Correct Choice",
+                        correct: true,
+                    },
+                    {
+                        content: "Incorrect Choice 3",
+                        correct: false,
+                    },
+                ],
+                countChoices: false,
+                hasNoneOfTheAbove: false,
+                multipleSelect: false,
+                randomize: true,
+                deselectEnabled: false,
+            },
+            alignment: "default",
+        } as RadioWidget,
+    },
+};

--- a/packages/perseus/src/widgets/radio/__tests__/radio.testdata.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/radio.testdata.ts
@@ -367,3 +367,52 @@ export const shuffledQuestion: PerseusRenderer = {
         } as RadioWidget,
     },
 };
+
+export const shuffledNoneQuestion: PerseusRenderer = {
+    content: "[[\u2603 radio 1]]",
+    images: {},
+    widgets: {
+        "radio 1": {
+            graded: true,
+            version: {
+                major: 1,
+                minor: 0,
+            },
+            static: false,
+            type: "radio",
+            options: {
+                displayCount: null,
+                onePerLine: false,
+                choices: [
+                    {
+                        content: "Incorrect Choice 1",
+                        correct: false,
+                    },
+                    {
+                        content: "Incorrect Choice 2",
+                        correct: false,
+                    },
+                    {
+                        content: "Incorrect Choice 3",
+                        correct: false,
+                    },
+                    {
+                        content: "Incorrect Choice 4",
+                        correct: false,
+                    },
+                    {
+                        content: "None of the above",
+                        correct: true,
+                        isNoneOfTheAbove: true,
+                    },
+                ],
+                countChoices: false,
+                hasNoneOfTheAbove: true,
+                multipleSelect: false,
+                randomize: true,
+                deselectEnabled: false,
+            },
+            alignment: "default",
+        } as RadioWidget,
+    },
+};


### PR DESCRIPTION
## Summary:
We were worried about SSS and shuffling, but it seems Radio's `getUserInput` is smart about un-shuffling answers before scoring.

Issue: LEMS-2435

## Test plan:
This PR is just tests