### PR TITLE
Remove inaccurate WidgetDict type and bespoke typings for `widgets` key

### DIFF
--- a/.changeset/green-pants-hear.md
+++ b/.changeset/green-pants-hear.md
@@ -1,5 +1,5 @@
 ---
-"@khanacademy/perseus": patch
+"@khanacademy/perseus": major
 "@khanacademy/perseus-editor": patch
 ---
 

--- a/.changeset/green-pants-hear.md
+++ b/.changeset/green-pants-hear.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Remove duplicate WidgetDict type and bespoke typings of `widgets` in favour of `PerseusWidgetsMap` type.

--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -28,6 +28,7 @@ import type {
     ChangeHandler,
     ImageUploader,
     PerseusWidget,
+    PerseusWidgetsMap,
 } from "@khanacademy/perseus";
 
 // like [[snowman input-number 1]]
@@ -116,9 +117,7 @@ type Props = Readonly<{
     content: string;
     replace?: any;
     placeholder: string;
-    widgets: {
-        [name: string]: PerseusWidget;
-    };
+    widgets: PerseusWidgetsMap;
     images: any;
     disabled: boolean;
     widgetEnabled: boolean;
@@ -458,7 +457,7 @@ class Editor extends React.Component<Props, State> {
             if (matches != null) {
                 const text = matches[1];
                 const widgets = Widgets.getAllWidgetTypes();
-                const matchingWidgets = _.filter(widgets, (name) => {
+                const matchingWidgets = widgets.filter((name) => {
                     return name.substring(0, text.length) === text;
                 });
 
@@ -642,7 +641,7 @@ class Editor extends React.Component<Props, State> {
     ) => void = (
         oldContent: string,
         cursorRange: ReadonlyArray<number>,
-        widgetType: string,
+        widgetType: PerseusWidget["type"],
     ) => {
         // Note: we have to use _.map here instead of Array::map
         // because the results of a .match might be null if no
@@ -687,8 +686,7 @@ class Editor extends React.Component<Props, State> {
 
         const newContent = newPrelude + widgetContent + newPostlude;
 
-        const newWidgets = _.clone(this.props.widgets);
-        // @ts-expect-error TS(2345) Type '"categorizer" | undefined' is not assignable to type '"deprecated-standin"'.
+        const newWidgets = {...this.props.widgets};
         newWidgets[id] = {
             options: Widgets.getEditor(widgetType)?.defaultProps,
             type: widgetType as PerseusWidget["type"],

--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -689,7 +689,7 @@ class Editor extends React.Component<Props, State> {
         const newWidgets = {...this.props.widgets};
         newWidgets[id] = {
             options: Widgets.getEditor(widgetType)?.defaultProps,
-            type: widgetType as PerseusWidget["type"],
+            type: widgetType,
             // Track widget version on creation, so that a widget editor
             // without a valid version prop can only possibly refer to a
             // pre-versioning creation time.

--- a/packages/perseus-editor/src/hint-editor.tsx
+++ b/packages/perseus-editor/src/hint-editor.tsx
@@ -14,12 +14,12 @@ import IframeContentRenderer from "./iframe-content-renderer";
 
 import type {
     APIOptions,
-    WidgetDict,
     ImageDict,
     Hint,
     ChangeHandler,
     DeviceType,
     ImageUploader,
+    PerseusWidgetsMap,
 } from "@khanacademy/perseus";
 
 const {InfoTip, InlineIcon} = components;
@@ -35,7 +35,7 @@ type HintEditorProps = {
     showTitle?: boolean;
     content?: string | null | undefined;
     replace?: boolean | null | undefined;
-    widgets?: WidgetDict | null | undefined;
+    widgets?: PerseusWidgetsMap | null | undefined;
     images?: ImageDict | null | undefined;
     isLast: boolean;
     isFirst: boolean;

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -163,7 +163,6 @@ export type {
     Version,
     VideoData,
     VideoKind,
-    WidgetDict,
     WidgetExports,
     SharedRendererProps,
 } from "./types";

--- a/packages/perseus/src/multi-items/item-types.ts
+++ b/packages/perseus/src/multi-items/item-types.ts
@@ -9,7 +9,8 @@
  * - And the various types of nodes that compose a tree.
  */
 import type {Tree, ArrayNode, ObjectNode} from "./tree-types";
-import type {WidgetDict, ImageDict} from "../types";
+import type {PerseusWidgetsMap} from "../perseus-types";
+import type {ImageDict} from "../types";
 
 export type ContentNode = {
     // TODO(mdr): When we first drafted the multi-item feature, we named
@@ -25,14 +26,14 @@ export type ContentNode = {
     // Perseus has default values for these fields, so they're all optional.
     content?: string | null | undefined;
     images?: ImageDict | null | undefined;
-    widgets?: WidgetDict | null | undefined;
+    widgets?: PerseusWidgetsMap | null | undefined;
 };
 export type HintNode = {
     __type: "hint";
     // Perseus has default values for these fields, so they're all optional.
     content?: string | null | undefined;
     images?: ImageDict | null | undefined;
-    widgets?: WidgetDict | null | undefined;
+    widgets?: PerseusWidgetsMap | null | undefined;
     replace?: boolean | null | undefined;
 };
 export type TagsNode = ReadonlyArray<string>;

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -92,9 +92,6 @@ export interface Widget {
     examples?: () => ReadonlyArray<string>;
 }
 
-export type WidgetDict = {
-    [name: string]: PerseusWidget;
-};
 export type ImageDict = {
     [url: string]: Dimensions;
 };
@@ -134,7 +131,7 @@ export type ChangeHandler = (
         hints?: ReadonlyArray<Hint>;
         replace?: boolean;
         content?: string;
-        widgets?: WidgetDict;
+        widgets?: PerseusWidgetsMap;
         images?: ImageDict;
         // used only in EditorPage
         question?: any;

--- a/packages/perseus/src/widgets/orderer/orderer.tsx
+++ b/packages/perseus/src/widgets/orderer/orderer.tsx
@@ -433,7 +433,7 @@ class Orderer
             }
 
             this.props.onChange({
-                // @ts-expect-error - TS2345 - Argument of type '{ current: any[]; }' is not assignable to parameter of type '{ hints?: readonly Hint[] | undefined; replace?: boolean | undefined; content?: string | undefined; widgets?: WidgetDict | undefined; images?: ImageDict | undefined; ... 13 more ...; plot?: any; }'.
+                // @ts-expect-error - TS2345 - Argument of type '{ current: any[]; }' is not assignable to parameter of type '{ hints?: readonly Hint[] | undefined; replace?: boolean | undefined; content?: string | undefined; widgets?: PerseusWidgetsMap | undefined; images?: ImageDict | undefined; ... 13 more ...; plot?: any; }'.
                 current: list,
             });
             this.setState({
@@ -625,7 +625,7 @@ class Orderer
             return {content: value};
         });
         this.props.onChange({
-            // @ts-expect-error - TS2345 - Argument of type '{ current: { content: string; }[]; }' is not assignable to parameter of type '{ hints?: readonly Hint[] | undefined; replace?: boolean | undefined; content?: string | undefined; widgets?: WidgetDict | undefined; images?: ImageDict | undefined; ... 13 more ...; plot?: any; }'.
+            // @ts-expect-error - TS2345 - Argument of type '{ current: { content: string; }[]; }' is not assignable to parameter of type '{ hints?: readonly Hint[] | undefined; replace?: boolean | undefined; content?: string | undefined; widgets?: PerseusWidgetsMap | undefined; images?: ImageDict | undefined; ... 13 more ...; plot?: any; }'.
             current: list,
         });
 


### PR DESCRIPTION
## Summary:

After releasing the PR to migrate the `Widget` type to an interface, I noticed that we have several different ways of typing the `widgets` key in our main Perseus render type (`PerseusRenderer`) and throughout the codebase. 

Today, we have the really useful `PerseusWidgetsMap` type which maintains the correct widget options type for each widget. So this PR removes the less-specific `WidgetDict` type and other bespoke typings (such as `{[key: string]: Widget}`) in favour of the `PerseusWidgetsMap`.

Issue: "none"

## Test plan:

`yarn tsc`