### PR TITLE
Refine CS-Program Rubric type

### DIFF
--- a/.changeset/calm-eggs-speak.md
+++ b/.changeset/calm-eggs-speak.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Refine CS-Program's Rubric type

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -1,7 +1,6 @@
 import type {Coord} from "./interactive2/types";
 import type {
     PerseusCategorizerWidgetOptions,
-    PerseusCSProgramWidgetOptions,
     PerseusDefinitionWidgetOptions,
     PerseusDropdownWidgetOptions,
     PerseusExplanationWidgetOptions,
@@ -45,7 +44,10 @@ export type PerseusCategorizerUserInput = {
     values: ReadonlyArray<number>;
 };
 
-export type PerseusCSProgramRubric = PerseusCSProgramWidgetOptions;
+// TODO(LEMS-2440): Can possibly be removed during 2440?
+// This is not used for grading at all. The only place it is used is to define
+// Props type in cs-program.tsx, but RenderProps already contains WidgetOptions
+export type PerseusCSProgramRubric = Empty;
 
 export type PerseusCSProgramUserInput = {
     status: UserInputStatus;

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -47,6 +47,7 @@ export type PerseusCategorizerUserInput = {
 // TODO(LEMS-2440): Can possibly be removed during 2440?
 // This is not used for grading at all. The only place it is used is to define
 // Props type in cs-program.tsx, but RenderProps already contains WidgetOptions
+// and is already included in the Props type.
 export type PerseusCSProgramRubric = Empty;
 
 export type PerseusCSProgramUserInput = {

--- a/packages/perseus/src/widgets/cs-program/cs-program.tsx
+++ b/packages/perseus/src/widgets/cs-program/cs-program.tsx
@@ -26,15 +26,11 @@ import type {
 import type {
     PerseusCSProgramRubric,
     PerseusCSProgramUserInput,
-    UserInputStatus,
 } from "../../validation.types";
 
 const {updateQueryString} = Util;
 
-type RenderProps = PerseusCSProgramWidgetOptions & {
-    status: UserInputStatus;
-    message: string | null;
-};
+type RenderProps = PerseusCSProgramWidgetOptions & PerseusCSProgramUserInput;
 
 type Props = WidgetProps<RenderProps, PerseusCSProgramRubric>;
 


### PR DESCRIPTION
## Summary:
As part of the Server Side Scoring project, this refactors the CS-Program Rubric type to show it is not particularly needed and could most likely be removed. Adds a comment to come back to it with LEMS-2440.

Issue: LEMS-2464

## Test plan:
- Confirm tests pass
- Confirm CS-Program widgets still work locally or via znd if locally doesn't work