### PR TITLE
[EXPERIMENT] Create a recursive descent version of KAS' parser

### DIFF
--- a/packages/kas/src/__tests__/__snapshots__/lexer.test.ts.snap
+++ b/packages/kas/src/__tests__/__snapshots__/lexer.test.ts.snap
@@ -38,6 +38,9 @@ exports[`lexer should lex LaTeX tokens 1`] = `
   {
     "kind": ")",
   },
+  {
+    "kind": "EOF",
+  },
 ]
 `;
 
@@ -64,6 +67,9 @@ exports[`lexer should lex different numbers 1`] = `
     "kind": "FLOAT",
     "value": "3.14",
   },
+  {
+    "kind": "EOF",
+  },
 ]
 `;
 
@@ -87,6 +93,9 @@ exports[`lexer should lex simple tokens 1`] = `
   {
     "kind": "VAR",
     "value": "y",
+  },
+  {
+    "kind": "EOF",
   },
 ]
 `;
@@ -121,6 +130,9 @@ exports[`lexer should lex with options 1`] = `
   {
     "kind": "VAR",
     "value": "x",
+  },
+  {
+    "kind": "EOF",
   },
 ]
 `;

--- a/packages/kas/src/__tests__/__snapshots__/lexer.test.ts.snap
+++ b/packages/kas/src/__tests__/__snapshots__/lexer.test.ts.snap
@@ -1,0 +1,126 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`lexer should lex LaTeX tokens 1`] = `
+[
+  {
+    "kind": "(",
+  },
+  {
+    "kind": "FRAC",
+  },
+  {
+    "kind": "{",
+  },
+  {
+    "kind": "INT",
+    "value": "1",
+  },
+  {
+    "kind": "}",
+  },
+  {
+    "kind": "{",
+  },
+  {
+    "kind": "VAR",
+    "value": "x",
+  },
+  {
+    "kind": "}",
+  },
+  {
+    "kind": "-",
+  },
+  {
+    "kind": "INT",
+    "value": "1",
+  },
+  {
+    "kind": ")",
+  },
+]
+`;
+
+exports[`lexer should lex different numbers 1`] = `
+[
+  {
+    "kind": "INT",
+    "value": "1",
+  },
+  {
+    "kind": "+",
+  },
+  {
+    "kind": "-",
+  },
+  {
+    "kind": "INT",
+    "value": "2",
+  },
+  {
+    "kind": "+",
+  },
+  {
+    "kind": "FLOAT",
+    "value": "3.14",
+  },
+]
+`;
+
+exports[`lexer should lex simple tokens 1`] = `
+[
+  {
+    "kind": "INT",
+    "value": "1",
+  },
+  {
+    "kind": "+",
+  },
+  {
+    "kind": "INT",
+    "value": "2",
+  },
+  {
+    "kind": "VAR",
+    "value": "x",
+  },
+  {
+    "kind": "VAR",
+    "value": "y",
+  },
+]
+`;
+
+exports[`lexer should lex with options 1`] = `
+[
+  {
+    "kind": "FUNC",
+    "value": "f",
+  },
+  {
+    "kind": "(",
+  },
+  {
+    "kind": "VAR",
+    "value": "x",
+  },
+  {
+    "kind": ")",
+  },
+  {
+    "kind": "SIGN",
+    "value": "=",
+  },
+  {
+    "kind": "CONST",
+    "value": "e",
+  },
+  {
+    "kind": "^",
+  },
+  {
+    "kind": "VAR",
+    "value": "x",
+  },
+]
+`;

--- a/packages/kas/src/__tests__/lexer.test.ts
+++ b/packages/kas/src/__tests__/lexer.test.ts
@@ -1,0 +1,27 @@
+import {lex} from "../lexer";
+
+describe("lexer", () => {
+    it("should lex simple tokens", () => {
+        const tokens = lex("1+2xy");
+
+        expect(tokens).toMatchSnapshot();
+    });
+
+    it("should lex LaTeX tokens", () => {
+        const tokens = lex("\\left(\\frac{1}{x}\u22121\\right)");
+
+        expect(tokens).toMatchSnapshot();
+    });
+
+    it("should lex different numbers", () => {
+        const tokens = lex("1+-2+3.14");
+
+        expect(tokens).toMatchSnapshot();
+    });
+
+    it("should lex with options", () => {
+        const tokens = lex("f(x)=e^x", {functions: ["f"]});
+
+        expect(tokens).toMatchSnapshot();
+    });
+});

--- a/packages/kas/src/__tests__/parser.test.ts
+++ b/packages/kas/src/__tests__/parser.test.ts
@@ -1,0 +1,513 @@
+import _ from "underscore";
+
+import {parse} from "../parser";
+
+expect.extend({
+    toParseAs(
+        input: string,
+        expected: string,
+        options?: any,
+    ): jest.CustomMatcherResult {
+        const result = parse(input, options);
+        if (!result.parsed) {
+            return {
+                pass: false,
+                message: () => `error: ${result.error}`,
+            };
+        }
+        const actual = result.expr.print();
+
+        if (actual !== expected) {
+            return {
+                pass: false,
+                message: () =>
+                    `input: ${input}\nexpected:${expected}\nactual: ${actual}`,
+            };
+        }
+
+        return {
+            pass: !this.isNot,
+            message: () => "",
+        };
+    },
+    toParseWithStructure(
+        input: string,
+        expected: string,
+        options?: any,
+    ): jest.CustomMatcherResult {
+        const result = parse(input, options);
+        if (!result.parsed) {
+            return {
+                pass: false,
+                message: () => `error: ${result.error}`,
+            };
+        }
+        const actual = result.expr.repr();
+
+        if (actual !== expected) {
+            return {
+                pass: false,
+                message: () => `${input} parses as ${expected}`,
+            };
+        }
+
+        return {
+            pass: !this.isNot,
+            message: () => "",
+        };
+    },
+});
+
+describe("Parser", () => {
+    test("empty", () => {
+        expect("").toParseAs("");
+    });
+
+    test("positive and negative primitives", () => {
+        expect("0").toParseAs("0");
+        expect("1.").toParseAs("1");
+        expect("3.14").toParseAs("3.14");
+        expect(".14").toParseAs("0.14");
+        expect("pi").toParseAs("pi");
+        expect("e").toParseAs("e");
+        expect("x").toParseAs("x");
+        expect("theta").toParseAs("theta");
+
+        expect("-0").toParseAs("-1*0");
+        expect("-1.").toParseAs("-1");
+        expect("-3.14").toParseAs("-3.14");
+        expect("-.14").toParseAs("-0.14");
+        expect("-pi").toParseAs("-1*pi");
+        expect("-e").toParseAs("-1*e");
+        expect("-theta").toParseAs("-1*theta");
+    });
+
+    test("LaTeX constants", () => {
+        expect("\\theta").toParseAs("theta");
+        expect("\\pi").toParseAs("pi");
+        expect("\\phi").toParseAs("phi");
+    });
+
+    test("ignore TeX spaces", () => {
+        expect("a\\space b").toParseAs("a*b");
+        expect("a\\ b").toParseAs("a*b");
+    });
+
+    test("positive and negative rationals", () => {
+        expect("1/2").toParseAs("1/2");
+        expect("-1/2").toParseAs("-1/2");
+        expect("1/-2").toParseAs("-1/2");
+        expect("-1/-2").toParseAs("-1*-1/2");
+        expect("42/42").toParseAs("42/42");
+        expect("42/1").toParseAs("42/1");
+        expect("0/42").toParseAs("0/42");
+
+        expect("2 (1/2)").toParseAs("2*1/2");
+        expect("1/2 1/2").toParseAs("1/2*1/2");
+        expect("-1/2").toParseAs("-1/2");
+        expect("1/2 2").toParseAs("1/2*2");
+    });
+
+    test("rationals using \\frac", () => {
+        expect("\\frac{1}{2}").toParseAs("1/2");
+        expect("\\frac{-1}{2}").toParseAs("-1/2");
+        expect("\\frac{1}{-2}").toParseAs("-1/2");
+        expect("\\frac{-1}{-2}").toParseAs("-1*-1/2");
+        expect("\\frac{42}{42}").toParseAs("42/42");
+        expect("\\frac{42}{1}").toParseAs("42/1");
+        expect("\\frac{0}{42}").toParseAs("0/42");
+
+        // TODO (LEMS-2198): this should actually be:
+        // expect("2\\frac{1}{2}").toParseAs("2+1/2");
+        expect("2\\frac{1}{2}").toParseAs("2*1/2");
+        expect("\\frac{1}{2}\\frac{1}{2}").toParseAs("1/2*1/2");
+        expect("-\\frac{1}{2}").toParseAs("-1/2");
+        expect("\\frac{1}{2}2").toParseAs("1/2*2");
+    });
+
+    test("rationals using \\dfrac", () => {
+        expect("\\dfrac{1}{2}").toParseAs("1/2");
+        expect("\\dfrac{-1}{2}").toParseAs("-1/2");
+        expect("\\dfrac{1}{-2}").toParseAs("-1/2");
+        expect("\\dfrac{-1}{-2}").toParseAs("-1*-1/2");
+        expect("\\dfrac{42}{42}").toParseAs("42/42");
+        expect("\\dfrac{42}{1}").toParseAs("42/1");
+        expect("\\dfrac{0}{42}").toParseAs("0/42");
+
+        // TODO (LEMS-2198): this should actually be:
+        // expect("2\\dfrac{1}{2}").toParseAs("2+1/2");
+        expect("2\\dfrac{1}{2}").toParseAs("2*1/2");
+        expect("\\dfrac{1}{2}\\dfrac{1}{2}").toParseAs("1/2*1/2");
+        expect("-\\dfrac{1}{2}").toParseAs("-1/2");
+        expect("\\dfrac{1}{2}2").toParseAs("1/2*2");
+    });
+
+    test("parens", () => {
+        expect("(0)").toParseAs("0");
+        expect("(ab)").toParseAs("a*b");
+        expect("(a/b)").toParseAs("a*b^(-1)");
+        expect("(a^b)").toParseAs("a^(b)");
+        expect("(ab)c").toParseAs("a*b*c");
+        expect("a(bc)").toParseAs("a*b*c");
+        expect("a+(b+c)").toParseAs("a+b+c");
+        expect("(a+b)+c").toParseAs("a+b+c");
+        expect("a(b+c)").toParseAs("a*(b+c)");
+        expect("(a+b)^c").toParseAs("(a+b)^(c)");
+        expect("(ab)^c").toParseAs("(a*b)^(c)");
+    });
+
+    test("subscripts", () => {
+        expect("a").toParseAs("a");
+        expect("a_0").toParseAs("a_(0)");
+        expect("a_i").toParseAs("a_(i)");
+        expect("a_n").toParseAs("a_(n)");
+        expect("a_n+1").toParseAs("a_(n)+1");
+        expect("a_(n+1)").toParseAs("a_(n+1)");
+        expect("a_{n+1}").toParseAs("a_(n+1)");
+    });
+
+    test("negation", () => {
+        expect("-x").toParseAs("-1*x");
+        expect("--x").toParseAs("-1*-1*x");
+        expect("---x").toParseAs("-1*-1*-1*x");
+        expect("-1").toParseAs("-1");
+        expect("--1").toParseAs("-1*-1");
+        expect("---1").toParseAs("-1*-1*-1");
+        expect("-3x").toParseAs("-3*x");
+        expect("--3x").toParseAs("-1*-3*x");
+        expect("-x*3").toParseAs("x*-3");
+        expect("--x*3").toParseAs("-1*x*-3");
+        expect("\u2212x").toParseAs("-1*x");
+    });
+
+    test("addition and subtraction", () => {
+        expect("a+b").toParseAs("a+b");
+        expect("a-b").toParseAs("a+-1*b");
+        expect("a--b").toParseAs("a+-1*-1*b");
+        expect("a---b").toParseAs("a+-1*-1*-1*b");
+        expect("2-4").toParseAs("2+-4");
+        expect("2--4").toParseAs("2+-1*-4");
+        expect("2---4").toParseAs("2+-1*-1*-4");
+        expect("2-x*4").toParseAs("2+x*-4");
+        expect("1-2+a-b+pi-e").toParseAs("1+-2+a+-1*b+pi+-1*e");
+        expect("x+1").toParseAs("x+1");
+        expect("x-1").toParseAs("x+-1");
+        expect("(x-1)").toParseAs("x+-1");
+        expect("a(x-1)").toParseAs("a*(x+-1)");
+        expect("a\u2212b").toParseAs("a+-1*b");
+    });
+
+    test("multiplication", () => {
+        expect("a*b").toParseAs("a*b");
+        expect("-a*b").toParseAs("-1*a*b");
+        expect("a*-b").toParseAs("a*-1*b");
+        expect("-ab").toParseAs("-1*a*b");
+        expect("-a*b").toParseAs("-1*a*b");
+        expect("-(ab)").toParseAs("-1*a*b");
+        expect("a\u00b7b").toParseAs("a*b");
+        expect("a\u00d7b").toParseAs("a*b");
+        expect("a\\cdotb").toParseAs("a*b");
+        expect("a\\timesb").toParseAs("a*b");
+        expect("a\\astb").toParseAs("a*b");
+    });
+
+    test("division", () => {
+        expect("a/b").toParseAs("a*b^(-1)");
+        expect("a/bc").toParseAs("a*b^(-1)*c");
+        expect("(ab)/c").toParseAs("a*b*c^(-1)");
+        expect("ab/c").toParseAs("a*b*c^(-1)");
+        expect("ab/cd").toParseAs("a*b*c^(-1)*d");
+        expect("a\\divb").toParseAs("a*b^(-1)");
+        expect("a\u00F7b").toParseAs("a*b^(-1)");
+    });
+
+    test("exponentiation", () => {
+        expect("x^y").toParseAs("x^(y)");
+        expect("x^y^z").toParseAs("x^(y^(z))");
+        expect("x^yz").toParseAs("x^(y)*z");
+        expect("-x^2").toParseAs("-1*x^(2)");
+        expect("-(x^2)").toParseAs("-1*x^(2)");
+        expect("0-x^2").toParseAs("0+-1*x^(2)");
+        expect("x^-y").toParseAs("x^(-1*y)");
+        expect("x^(-y)").toParseAs("x^(-1*y)");
+        expect("x^-(y)").toParseAs("x^(-1*y)");
+        expect("x^-(-y)").toParseAs("x^(-1*-1*y)");
+        expect("x^--y").toParseAs("x^(-1*-1*y)");
+        expect("x^-yz").toParseAs("x^(-1*y)*z");
+        expect("x^-y^z").toParseAs("x^(-1*y^(z))");
+        expect("x**y").toParseAs("x^(y)");
+
+        expect("x^{a}").toParseAs("x^(a)");
+        expect("x^{ab}").toParseAs("x^(a*b)");
+    });
+
+    test("square root", () => {
+        expect("sqrt(x)").toParseAs("x^(1/2)");
+        expect("sqrt(x)y").toParseAs("x^(1/2)*y");
+        expect("1/sqrt(x)").toParseAs("x^(-1/2)");
+        expect("1/sqrt(x)y").toParseAs("x^(-1/2)*y");
+
+        expect("sqrt(2)/2").toParseAs("2^(1/2)*1/2");
+        expect("sqrt(2)^2").toParseAs("(2^(1/2))^(2)");
+
+        expect("\\sqrt(x)").toParseAs("x^(1/2)");
+        expect("\\sqrt(x)y").toParseAs("x^(1/2)*y");
+        expect("1/\\sqrt(x)").toParseAs("x^(-1/2)");
+        expect("1/\\sqrt(x)y").toParseAs("x^(-1/2)*y");
+
+        expect("\\sqrt(2)/2").toParseAs("2^(1/2)*1/2");
+        expect("\\sqrt(2)^2").toParseAs("(2^(1/2))^(2)");
+
+        expect("\\sqrt{2}").toParseAs("2^(1/2)");
+        expect("\\sqrt{2+2}").toParseAs("(2+2)^(1/2)");
+    });
+
+    test("nth root", () => {
+        expect("sqrt[3]{x}").toParseAs("x^(1/3)");
+        expect("sqrt[4]{x}y").toParseAs("x^(1/4)*y");
+        expect("1/sqrt[5]{x}").toParseAs("x^(-1/5)");
+        expect("1/sqrt[7]{x}y").toParseAs("x^(-1/7)*y");
+
+        expect("sqrt[3]{2}/2").toParseAs("2^(1/3)*1/2");
+        expect("sqrt[3]{2}^2").toParseAs("(2^(1/3))^(2)");
+
+        expect("\\sqrt[4]{x}").toParseAs("x^(1/4)");
+        expect("\\sqrt[4]{x}y").toParseAs("x^(1/4)*y");
+        expect("1/\\sqrt[4]{x}").toParseAs("x^(-1/4)");
+        expect("1/\\sqrt[4]{x}y").toParseAs("x^(-1/4)*y");
+
+        expect("\\sqrt[5]{2}/2").toParseAs("2^(1/5)*1/2");
+        expect("\\sqrt[5]{2}^2").toParseAs("(2^(1/5))^(2)");
+
+        expect("\\sqrt[6]{2}").toParseAs("2^(1/6)");
+        expect("\\sqrt[6]{2+2}").toParseAs("(2+2)^(1/6)");
+
+        expect("\\sqrt[2]{2}").toParseAs("2^(1/2)");
+        expect("\\sqrt[2]{2+2}").toParseAs("(2+2)^(1/2)");
+    });
+
+    test("absolute value", () => {
+        expect("abs(x)").toParseAs("abs(x)");
+        expect("abs(abs(x))").toParseAs("abs(abs(x))");
+        expect("abs(x)abs(y)").toParseAs("abs(x)*abs(y)");
+
+        expect("|x|").toParseAs("abs(x)");
+        expect("||x||").toParseAs("abs(abs(x))");
+        // TODO(alex): fix the below so it doesn't require an *
+        // may require own lexer/preprocessor
+        expect("|x|*|y|").toParseAs("abs(x)*abs(y)");
+
+        expect("\\abs(x)").toParseAs("abs(x)");
+        expect("\\abs(\\abs(x))").toParseAs("abs(abs(x))");
+        expect("\\abs(x)\\abs(y)").toParseAs("abs(x)*abs(y)");
+
+        expect("\\left|x\\right|").toParseAs("abs(x)");
+        expect("\\left|\\left|x\\right|\\right|").toParseAs("abs(abs(x))");
+        expect("\\left|x\\right|\\left|y\\right|").toParseAs("abs(x)*abs(y)");
+    });
+
+    test("logarithms", () => {
+        expect("lnx").toParseAs("ln(x)");
+        expect("ln x").toParseAs("ln(x)");
+        expect("ln x^y").toParseAs("ln(x^(y))");
+        expect("ln xy").toParseAs("ln(x*y)");
+        expect("ln x/y").toParseAs("ln(x*y^(-1))");
+        expect("ln x+y").toParseAs("ln(x)+y");
+        expect("ln x-y").toParseAs("ln(x)+-1*y");
+
+        expect("ln xyz").toParseAs("ln(x*y*z)");
+        expect("ln xy/z").toParseAs("ln(x*y*z^(-1))");
+        expect("ln xy/z+1").toParseAs("ln(x*y*z^(-1))+1");
+
+        expect("ln x(y)").toParseAs("ln(x)*y");
+
+        expect("logx").toParseAs("log_(10) (x)");
+        expect("log x").toParseAs("log_(10) (x)");
+        expect("log_2x").toParseAs("log_(2) (x)");
+        expect("log _ 2 x").toParseAs("log_(2) (x)");
+        expect("log_bx_0").toParseAs("log_(b) (x_(0))");
+        expect("log_x_0b").toParseAs("log_(x_(0)) (b)");
+
+        expect("log_2.5x").toParseAs("log_(2.5) (x)");
+
+        expect("ln ln x").toParseAs("ln(ln(x))");
+        expect("ln x ln y").toParseAs("ln(x)*ln(y)");
+        expect("ln x/ln y").toParseAs("ln(x)*ln(y)^(-1)");
+
+        expect("\\lnx").toParseAs("ln(x)");
+        expect("\\ln x").toParseAs("ln(x)");
+        expect("\\ln x^y").toParseAs("ln(x^(y))");
+        expect("\\ln xy").toParseAs("ln(x*y)");
+        expect("\\ln x/y").toParseAs("ln(x*y^(-1))");
+        expect("\\ln x+y").toParseAs("ln(x)+y");
+        expect("\\ln x-y").toParseAs("ln(x)+-1*y");
+
+        expect("\\logx").toParseAs("log_(10) (x)");
+        expect("\\log x").toParseAs("log_(10) (x)");
+        expect("\\log_2x").toParseAs("log_(2) (x)");
+        expect("\\log _ 2 x").toParseAs("log_(2) (x)");
+        expect("\\log_bx_0").toParseAs("log_(b) (x_(0))");
+        expect("\\log_x_0b").toParseAs("log_(x_(0)) (b)");
+
+        expect("\\log_2.5x").toParseAs("log_(2.5) (x)");
+
+        expect("\\frac{\\logx}{y}").toParseAs("log_(10) (x)*y^(-1)");
+        expect("\\frac{\\log x}{y}").toParseAs("log_(10) (x)*y^(-1)");
+    });
+
+    test("trig functions", () => {
+        const functions = ["sin", "cos", "tan", "csc", "sec", "cot"];
+
+        const inverses = _.map(functions, function (func) {
+            return "arc" + func;
+        });
+
+        _.each(functions.concat(inverses), function (func) {
+            expect(func + "x").toParseAs(func + "(x)");
+            expect("\\" + func + "x").toParseAs(func + "(x)");
+        });
+
+        expect("sin^-1 x").toParseAs("arcsin(x)");
+        expect("\\sin^-1 x").toParseAs("arcsin(x)");
+
+        expect("(sinx)^2").toParseAs("sin(x)^(2)");
+        expect("sin^2x").toParseAs("sin(x)^(2)");
+        expect("sin^2(x)").toParseAs("sin(x)^(2)");
+        expect("sin^2 x").toParseAs("sin(x)^(2)");
+        expect("(sin^2x)").toParseAs("sin(x)^(2)");
+
+        expect("sin xy").toParseAs("sin(x*y)");
+        expect("sin x(y)").toParseAs("sin(x)*y");
+        expect("sin x/y").toParseAs("sin(x*y^(-1))");
+        expect("(sin x)/y").toParseAs("sin(x)*y^(-1)");
+
+        expect("sin sin x").toParseAs("sin(sin(x))");
+        expect("sin x sin y").toParseAs("sin(x)*sin(y)");
+        expect("sin x/sin y").toParseAs("sin(x)*sin(y)^(-1)");
+
+        expect("1/(sinx)^2").toParseAs("sin(x)^(-2)");
+        expect("1/sin^2x").toParseAs("sin(x)^(-2)");
+        expect("1/sin^2(x)").toParseAs("sin(x)^(-2)");
+        expect("1/(sin^2x)").toParseAs("sin(x)^(-2)");
+
+        expect("sin(theta)").toParseAs("sin(theta)");
+        expect("\\sin(\\theta)").toParseAs("sin(theta)");
+    });
+
+    test("hyperbolic functions", () => {
+        expect("sinh xy").toParseAs("sinh(x*y)");
+        expect("1/(sinhx)^2").toParseAs("sinh(x)^(-2)");
+        expect("\\sinh(\\theta)").toParseAs("sinh(theta)");
+    });
+
+    test("formulas", () => {
+        expect("mx+b").toParseAs("m*x+b");
+        expect("v^2/r").toParseAs("v^(2)*r^(-1)");
+        expect("4/3pir^3").toParseAs("4/3*pi*r^(3)");
+        expect("4/3\u03C0r^3").toParseAs("4/3*pi*r^(3)");
+        expect("sin^2 x + cos^2 x = 1").toParseAs("sin(x)^(2)+cos(x)^(2)=1");
+    });
+
+    test("factors", () => {
+        expect("(6x+1)(x-1)").toParseAs("(6*x+1)*(x+-1)");
+    });
+
+    test("whitespace", () => {
+        expect("12/3").toParseAs("12/3");
+        expect("12 /3").toParseAs("12/3");
+        expect("12/ 3").toParseAs("12/3");
+        expect("xy").toParseAs("x*y");
+        expect("x y").toParseAs("x*y");
+    });
+
+    test("equations", () => {
+        expect("y=x").toParseAs("y=x");
+        expect("y=x^2").toParseAs("y=x^(2)");
+        expect("1<2").toParseAs("1<2");
+        expect("1<=2").toParseAs("1<=2");
+        expect("1\\le2").toParseAs("1<=2");
+        expect("2>1").toParseAs("2>1");
+        expect("2>=1").toParseAs("2>=1");
+        expect("2\\ge1").toParseAs("2>=1");
+        expect("1<>2").toParseAs("1<>2");
+        expect("1=/=2").toParseAs("1<>2");
+        expect("1\\ne2").toParseAs("1<>2");
+        expect("1\\neq2").toParseAs("1<>2");
+        expect("a\u2260b").toParseAs("a<>b");
+        expect("a\u2264b").toParseAs("a<=b");
+        expect("a\u2265b").toParseAs("a>=b");
+
+        expect("y \\le x").toParseAs("y<=x");
+        expect("y \\leq x").toParseAs("y<=x");
+        expect("y \\ge x").toParseAs("y>=x");
+        expect("y \\geq x").toParseAs("y>=x");
+    });
+
+    test("function variables", () => {
+        expect("f(x)").toParseAs("f*x");
+        expect("f(x)").toParseAs("f(x)", {functions: ["f"]});
+        expect("f(x+y)").toParseAs("f(x+y)", {functions: ["f"]});
+        expect("f(x)g(x)").toParseAs("f(x)*g(x)", {functions: ["f", "g"]});
+        expect("f(g(h(x)))").toParseAs("f(g(h(x)))", {
+            functions: ["f", "g", "h"],
+        });
+
+        expect("f\\left(x\\right)").toParseAs("f*x");
+        expect("f\\left(x\\right)").toParseAs("f(x)", {functions: ["f"]});
+        expect("f\\left(x+y\\right)").toParseAs("f(x+y)", {
+            functions: ["f"],
+        });
+        expect("f\\left(x\\right)g\\left(x\\right)").toParseAs("f(x)*g(x)", {
+            functions: ["f", "g"],
+        });
+        expect("f\\left(g\\left(h\\left(x\\right)\\right)\\right)").toParseAs(
+            "f(g(h(x)))",
+            {functions: ["f", "g", "h"]},
+        );
+    });
+
+    test("structure", () => {
+        expect("").toParseWithStructure("Add()");
+        expect("1.").toParseWithStructure("1");
+        expect("1/2").toParseWithStructure("1/2");
+        expect("1/-2").toParseWithStructure("-1/2");
+        expect("x/-2").toParseWithStructure("Mul(Var(x),-1/2)");
+        expect("a+b").toParseWithStructure("Add(Var(a),Var(b))");
+        expect("a+b+c").toParseWithStructure("Add(Var(a),Var(b),Var(c))");
+        expect("a-b").toParseWithStructure("Add(Var(a),Mul(-1,Var(b)))");
+        expect("a-b+c").toParseWithStructure(
+            "Add(Var(a),Mul(-1,Var(b)),Var(c))",
+        );
+        expect("abc").toParseWithStructure("Mul(Var(a),Var(b),Var(c))");
+        expect("a/bc").toParseWithStructure(
+            "Mul(Var(a),Pow(Var(b),-1),Var(c))",
+        );
+        expect("a*(b+c)").toParseWithStructure(
+            "Mul(Var(a),Add(Var(b),Var(c)))",
+        );
+        expect("x--y").toParseWithStructure("Add(Var(x),Mul(-1,-1,Var(y)))");
+        expect("--y").toParseWithStructure("Mul(-1,-1,Var(y))");
+        expect("e").toParseWithStructure("Const(e)");
+        expect("2e").toParseWithStructure("Mul(2,Const(e))");
+        expect("2e^x").toParseWithStructure("Mul(2,Pow(Const(e),Var(x)))");
+        expect("cdef").toParseWithStructure(
+            "Mul(Var(c),Var(d),Const(e),Var(f))",
+        );
+        expect("pi").toParseWithStructure("Const(pi)");
+        expect("pi^2").toParseWithStructure("Pow(Const(pi),2)");
+        expect("pir").toParseWithStructure("Mul(Const(pi),Var(r))");
+        expect("pir^2").toParseWithStructure("Mul(Const(pi),Pow(Var(r),2))");
+        expect("y=x^2").toParseWithStructure("Eq(Var(y),=,Pow(Var(x),2))");
+        expect("log_2x").toParseWithStructure("Log(2,Var(x))");
+        expect("f(x+y)").toParseWithStructure("Mul(Var(f),Add(Var(x),Var(y)))");
+        expect("f(x+y)").toParseWithStructure("Func(f,Add(Var(x),Var(y)))", {
+            functions: ["f"],
+        });
+        expect("sin(theta)").toParseWithStructure("Trig(sin,Var(theta))");
+        expect("tanh(theta)").toParseWithStructure("Trig(tanh,Var(theta))");
+
+        // verify that negative signs get folded into numbers
+        expect("-x*3").toParseWithStructure("Mul(Var(x),-3)");
+        expect("sin -x*3").toParseWithStructure("Trig(sin,Mul(Var(x),-3))");
+    });
+});

--- a/packages/kas/src/lexer.ts
+++ b/packages/kas/src/lexer.ts
@@ -129,11 +129,6 @@ const preparedRules: PreparedRule[] = rules.map((rule) => {
     return [regex, rule[1]];
 });
 
-// TODO:
-// - try each of the rules in order
-// - pick the longest one and return token
-// - update the input string so that we match the next token
-
 const next = (
     input: string,
     preparedRules: PreparedRule[],

--- a/packages/kas/src/lexer.ts
+++ b/packages/kas/src/lexer.ts
@@ -20,10 +20,10 @@ export type Token =
     | {kind: "RIGHT|"}
     | {kind: "SIGN"; value: string} // (in)equality
     | {kind: "FRAC"}
-    | {kind: "sqrt"}
-    | {kind: "abs"}
-    | {kind: "ln"}
-    | {kind: "log"}
+    | {kind: "SQRT"}
+    | {kind: "ABS"}
+    | {kind: "LN"}
+    | {kind: "LOG"}
     | {kind: "TRIG"; value: string}
     | {kind: "TRIGINV"; value: string}
     | {kind: "CONST"; value: string}
@@ -81,10 +81,10 @@ const rules: Rule[] = [
     ["\u2265", {kind: "SIGN", value: ">="}], // ge
     ["\\\\frac", {kind: "FRAC"}],
     ["\\\\dfrac", {kind: "FRAC"}],
-    ["sqrt|\\\\sqrt", {kind: "sqrt"}],
-    ["abs|\\\\abs", {kind: "abs"}],
-    ["ln|\\\\ln", {kind: "ln"}],
-    ["log|\\\\log", {kind: "log"}],
+    ["sqrt|\\\\sqrt", {kind: "SQRT"}],
+    ["abs|\\\\abs", {kind: "ABS"}],
+    ["ln|\\\\ln", {kind: "LN"}],
+    ["log|\\\\log", {kind: "LOG"}],
     ["sin|cos|tan", (value) => ({kind: "TRIG", value})],
     ["csc|sec|cot", (value) => ({kind: "TRIG", value})],
     ["sinh|cosh|tanh", (value) => ({kind: "TRIG", value})],

--- a/packages/kas/src/lexer.ts
+++ b/packages/kas/src/lexer.ts
@@ -1,0 +1,192 @@
+export type Token =
+    | {kind: "WHITESPACE"}
+    | {kind: "INT"; value: string}
+    | {kind: "FLOAT"; value: string}
+    | {kind: "^"}
+    | {kind: "*"}
+    | {kind: "/"}
+    | {kind: "-"}
+    | {kind: "+"}
+    | {kind: "("}
+    | {kind: ")"}
+    | {kind: "["}
+    | {kind: "]"}
+    | {kind: "{"}
+    | {kind: "}"}
+    | {kind: "|"}
+    | {kind: "!"} // unused
+    | {kind: "_"}
+    | {kind: "LEFT|"}
+    | {kind: "RIGHT|"}
+    | {kind: "SIGN"; value: string} // (in)equality
+    | {kind: "FRAC"}
+    | {kind: "sqrt"}
+    | {kind: "abs"}
+    | {kind: "ln"}
+    | {kind: "log"}
+    | {kind: "TRIG"; value: string}
+    | {kind: "TRIGINV"; value: string}
+    | {kind: "CONST"; value: string}
+    | {kind: "VAR"; value: string} // identifier
+    | {kind: "FUNC"; value: string}
+    | {kind: "EOF"}
+    | {kind: "INVALID"};
+
+// Most tokens don't have any additional data.  For those that
+// do, we use a thunk to get the token based on the match string.
+type Rule = [string, Token | ((match: string) => Token)];
+
+const rules: Rule[] = [
+    ["\\s+", {kind: "WHITESPACE"}],
+    ["\\\\space", {kind: "WHITESPACE"}],
+    ["\\\\ ", () => ({kind: "WHITESPACE"})],
+    ["[0-9]+\\.?", (value) => ({kind: "INT", value})],
+    ["([0-9]+)?\\.[0-9]+", (value) => ({kind: "FLOAT", value})],
+    ["\\*\\*", {kind: "^"}],
+    ["\\*", {kind: "*"}],
+    ["\\\\cdot|\u00b7", {kind: "*"}],
+    ["\\\\times|\u00d7", {kind: "*"}],
+    ["\\\\ast", {kind: "*"}],
+    ["\\/", {kind: "/"}],
+    ["\\\\div|\u00F7", {kind: "/"}],
+    ["-", {kind: "-"}],
+    ["\u2212", {kind: "-"}], // minus
+    ["\\+", {kind: "+"}],
+    ["\\^", {kind: "^"}],
+    ["\\(", {kind: "("}],
+    ["\\)", {kind: ")"}],
+    ["\\\\left\\(", {kind: "("}],
+    ["\\\\right\\)", {kind: ")"}],
+    ["\\[", {kind: "["}],
+    ["\\]", {kind: "]"}],
+    ["\\{", {kind: "{"}],
+    ["\\}", {kind: "}"}],
+    ["\\\\left\\{", {kind: "{"}],
+    ["\\\\right\\}", {kind: "}"}],
+    ["_", {kind: "_"}],
+    ["\\|", {kind: "|"}],
+    ["\\\\left\\|", {kind: "LEFT|"}],
+    ["\\\\right\\|", {kind: "RIGHT|"}],
+    ["\\!", {kind: "!"}], // not yet interpreted
+    ["<=|>=|<>|<|>|=", (value) => ({kind: "SIGN", value})],
+    ["\\\\le", {kind: "SIGN", value: "<="}],
+    ["\\\\ge", {kind: "SIGN", value: ">="}],
+    ["\\\\leq", {kind: "SIGN", value: "<="}],
+    ["\\\\geq", {kind: "SIGN", value: ">="}],
+    ["=\\/=", {kind: "SIGN", value: "<>"}],
+    ["\\\\ne", {kind: "SIGN", value: "<>"}],
+    ["\\\\neq", {kind: "SIGN", value: "<>"}],
+    ["\u2260", {kind: "SIGN", value: "<>"}], // ne
+    ["\u2264", {kind: "SIGN", value: "<="}], // le
+    ["\u2265", {kind: "SIGN", value: ">="}], // ge
+    ["\\\\frac", {kind: "FRAC"}],
+    ["\\\\dfrac", {kind: "FRAC"}],
+    ["sqrt|\\\\sqrt", {kind: "sqrt"}],
+    ["abs|\\\\abs", {kind: "abs"}],
+    ["ln|\\\\ln", {kind: "ln"}],
+    ["log|\\\\log", {kind: "log"}],
+    ["sin|cos|tan", (value) => ({kind: "TRIG", value})],
+    ["csc|sec|cot", (value) => ({kind: "TRIG", value})],
+    ["sinh|cosh|tanh", (value) => ({kind: "TRIG", value})],
+    ["csch|sech|coth", (value) => ({kind: "TRIG", value})],
+    ["\\\\sin", {kind: "TRIG", value: "sin"}],
+    ["\\\\cos", {kind: "TRIG", value: "cos"}],
+    ["\\\\tan", {kind: "TRIG", value: "tan"}],
+    ["\\\\csc", {kind: "TRIG", value: "csc"}],
+    ["\\\\sec", {kind: "TRIG", value: "sec"}],
+    ["\\\\cot", {kind: "TRIG", value: "cot"}],
+    ["\\\\arcsin", {kind: "TRIG", value: "arcsin"}], // should this be TRIGINV
+    ["\\\\arccos", {kind: "TRIG", value: "arccos"}], // should this be TRIGINV
+    ["\\\\arctan", {kind: "TRIG", value: "arctan"}], // should this be TRIGINV
+    ["\\\\arccsc", {kind: "TRIG", value: "arccsc"}], // should this be TRIGINV
+    ["\\\\arcsec", {kind: "TRIG", value: "arcsec"}], // should this be TRIGINV
+    ["\\\\arccot", {kind: "TRIG", value: "arccot"}], // should this be TRIGINV
+    ["arcsin|arccos|arctan", (value) => ({kind: "TRIGINV", value})],
+    ["arccsc|arcsec|arccot", (value) => ({kind: "TRIGINV", value})],
+    ["\\\\sinh", {kind: "TRIG", value: "sinh"}],
+    ["\\\\cosh", {kind: "TRIG", value: "cosh"}],
+    ["\\\\tanh", {kind: "TRIG", value: "tanh"}],
+    ["\\\\csch", {kind: "TRIG", value: "csch"}],
+    ["\\\\sech", {kind: "TRIG", value: "sech"}],
+    ["\\\\coth", {kind: "TRIG", value: "coth"}],
+    ["pi", {kind: "CONST", value: "pi"}],
+    ["\u03C0", {kind: "CONST", value: "pi"}], // pi
+    ["\\\\pi", {kind: "CONST", value: "pi"}],
+    ["theta", {kind: "VAR", value: "theta"}],
+    ["\u03B8", {kind: "VAR", value: "theta"}], // theta
+    ["\\\\theta", {kind: "VAR", value: "theta"}],
+    ["phi", {kind: "VAR", value: "phi"}],
+    ["\u03C6", {kind: "VAR", value: "phi"}], // phi
+    ["\\\\phi", {kind: "VAR", value: "phi"}],
+    ["[a-zA-Z]", (value) => ({kind: "VAR", value})], // TODO: post-process
+    [".", {kind: "INVALID"}],
+];
+
+type PreparedRule = [RegExp, Token | ((match: string) => Token)];
+
+const preparedRules: PreparedRule[] = rules.map((rule) => {
+    const regex = new RegExp("^(?:" + rule[0] + ")");
+    return [regex, rule[1]];
+});
+
+// TODO:
+// - try each of the rules in order
+// - pick the longest one and return token
+// - update the input string so that we match the next token
+
+const next = (
+    input: string,
+    preparedRules: PreparedRule[],
+): [Token, string] => {
+    let currentMatch: string = "";
+    let token: Token = {kind: "INVALID"};
+
+    for (const rule of preparedRules) {
+        const match = input.match(rule[0]);
+        if (match && match[0].length > currentMatch.length) {
+            currentMatch = match[0];
+            if (typeof rule[1] === "function") {
+                token = rule[1](currentMatch);
+            } else {
+                token = rule[1];
+            }
+        }
+    }
+
+    if (currentMatch === "") {
+        throw new Error(`No match for ${input}`);
+    }
+
+    return [token, input.slice(currentMatch.length)];
+};
+
+export type Options = {
+    functions?: string[];
+};
+
+export const lex = (input: string, options?: Options): Token[] => {
+    const tokens: Token[] = [];
+    const constants = ["e"];
+    const functions = options?.functions
+        ? options.functions.filter((fn) => fn !== "i")
+        : [];
+    while (input.length > 0) {
+        const [token, remainingInput] = next(input, preparedRules);
+        if (token.kind === "VAR") {
+            if (constants.includes(token.value)) {
+                tokens.push({kind: "CONST", value: token.value});
+            } else if (functions.includes(token.value)) {
+                tokens.push({kind: "FUNC", value: token.value});
+            } else {
+                tokens.push(token);
+            }
+        } else if (token.kind === "WHITESPACE") {
+            // Ignore whitespace
+        } else {
+            tokens.push(token);
+        }
+        input = remainingInput;
+    }
+    tokens.push({kind: "EOF"});
+    return tokens;
+};

--- a/packages/kas/src/nodes.ts
+++ b/packages/kas/src/nodes.ts
@@ -112,7 +112,7 @@ type Options = {
 };
 
 /* abstract base expression node */
-abstract class Expr {
+export abstract class Expr {
     hints: Hints;
 
     constructor() {
@@ -2969,9 +2969,9 @@ export class Func extends Sym {
 /* variable */
 export class Var extends Sym {
     symbol: string;
-    subscript: Expr;
+    subscript?: Expr;
 
-    constructor(symbol: string, subscript: Expr) {
+    constructor(symbol: string, subscript?: Expr) {
         super();
         this.symbol = symbol;
         this.subscript = subscript;
@@ -2980,7 +2980,9 @@ export class Var extends Sym {
     func = Var;
 
     args() {
-        return [this.symbol, this.subscript];
+        return this.subscript
+            ? [this.symbol, this.subscript]
+            : [this.symbol];
     }
 
     exprArgs() {

--- a/packages/kas/src/parser.ts
+++ b/packages/kas/src/parser.ts
@@ -265,12 +265,12 @@ export class Parser {
         const next = this.peek();
         switch (next.kind) {
             case "LN":
-                this.consume(); // ln
+                this.consume(); // LN
                 return Log.natural();
             case "LOG":
-                this.consume(); // log
+                this.consume(); // LOG
                 if (this.peek().kind === "_") {
-                    this.consume();
+                    this.consume(); // _
                     return this.subscriptable();
                 } else {
                     return Log.common();
@@ -329,13 +329,13 @@ export class Parser {
             const next = this.peek();
             switch (next.kind) {
                 case "CONST":
-                    this.consume();
+                    this.consume(); // CONST
                     return new Const(next.value.toLocaleLowerCase());
                 case "INT":
-                    this.consume();
+                    this.consume(); // INT
                     return Int.create(parseInt(next.value, 10));
                 case "FLOAT":
-                    this.consume();
+                    this.consume(); // FLOAT
                     return Float.create(parseFloat(next.value));
                 case "{": {
                     const node = this.additiveBetween("{", "}");
@@ -358,7 +358,7 @@ export class Parser {
         const next = this.peek();
         switch (next.kind) {
             case "SQRT": {
-                this.consume();
+                this.consume(); // SQRT
                 const next = this.peek();
                 switch (next.kind) {
                     case "(": {
@@ -381,7 +381,7 @@ export class Parser {
                 }
             }
             case "ABS": {
-                this.consume(); // abs
+                this.consume(); // ABS
                 const arg = this.additiveBetween("(", ")");
                 return new Abs(arg);
             }

--- a/packages/kas/src/parser.ts
+++ b/packages/kas/src/parser.ts
@@ -1,0 +1,383 @@
+import {type Token, type Options, lex} from "./lexer";
+import {
+    Abs,
+    Add,
+    Const,
+    Eq,
+    Float,
+    Func,
+    Int,
+    Log,
+    Mul,
+    Pow,
+    Trig,
+    Var,
+} from "./nodes";
+
+type Expr = any;
+
+export class Parser {
+    tokens: Token[];
+    index: number;
+
+    constructor(tokens: Token[]) {
+        this.tokens = tokens;
+        this.index = 0;
+    }
+
+    peek() {
+        const next = this.tokens[this.index];
+        return next;
+    }
+
+    consume() {
+        this.index++;
+    }
+
+    expect(tokenKind: string) {
+        const next = this.peek();
+        if (next.kind !== tokenKind) {
+            throw new Error(`Expected ${tokenKind} but got ${next.kind}`);
+        }
+        this.consume();
+    }
+
+    parse() {
+        return this.equation();
+    }
+
+    equation(): Expr {
+        if (this.peek().kind === "EOF") {
+            return new Add([]);
+        }
+        const left = this.expression();
+        const next = this.peek();
+        if (next.kind === "EOF") {
+            return left;
+        }
+        if (next.kind === "SIGN") {
+            this.consume(); // equality operator
+            const right = this.expression();
+            return new Eq(left, next.value, right);
+        }
+        throw new Error(`Expected SIGN token but got ${next.kind}`);
+    }
+
+    expression(): Add | Mul {
+        return this.additive();
+    }
+
+    additive(): Add | Mul {
+        let left = this.multiplicative();
+
+        let op = this.peek();
+        while (op.kind === "+" || op.kind === "-") {
+            this.consume(); // op
+            const right = this.multiplicative();
+            switch (op.kind) {
+                case "+":
+                    left = Add.createOrAppend(left, right); // left associative
+                    break;
+                case "-":
+                    left = Add.createOrAppend(
+                        left,
+                        Mul.handleNegative(right, "subtract"),
+                    ); // left associative
+                    break;
+            }
+            op = this.peek();
+        }
+
+        return left;
+    }
+
+    multiplicative(): Mul {
+        let left = this.negative();
+
+        while (this.index < this.tokens.length) {
+            const index = this.index; // save state
+            try {
+                const right = this.triglog();
+                left = Mul.fold(Mul.createOrAppend(left, right)); // left associative
+            } catch (e) {
+                this.index = index; // restore state
+                const op = this.peek();
+                if (op.kind === "*" || op.kind === "/") {
+                    this.consume(); // op
+                    const right = this.negative();
+                    switch (op.kind) {
+                        case "*":
+                            left = Mul.fold(Mul.createOrAppend(left, right)); // left associative
+                            break;
+                        case "/":
+                            left = Mul.fold(Mul.handleDivide(left, right)); // left associative
+                            break;
+                    }
+                } else {
+                    break;
+                }
+            }
+        }
+
+        return left;
+    }
+
+    negative() {
+        if (this.peek().kind === "-") {
+            this.consume(); // -
+            return Mul.handleNegative(this.negative());
+        } else {
+            return this.triglog();
+        }
+    }
+
+    trig(): [string] {
+        const next = this.peek();
+        if (next.kind === "TRIG") {
+            this.consume(); // trig
+            return [next.value];
+        } else {
+            throw new Error(`Expected TRIG token but tog ${next.kind}`);
+        }
+    }
+
+    trigfunc(): [string] | [string, Expr] {
+        const next = this.peek();
+        // NOTE(kevin): We're able to reorder the rules for `trigfunc()`
+        // so that "TRIGINV" is first only because there's no overlap
+        // with what `trig()` matches.
+        if (next.kind === "TRIGINV") {
+            this.consume(); // triginv
+            return [next.value];
+        } else {
+            const left = this.trig();
+            const op = this.peek();
+            if (op.kind === "^") {
+                this.consume(); // ^
+                const right = this.negative();
+                return [left[0], right];
+            } else {
+                return left;
+            }
+        }
+    }
+
+    logbase() {
+        const next = this.peek();
+        this.consume();
+        switch (next.kind) {
+            case "ln":
+                return Log.natural();
+            case "log":
+                if (this.peek().kind === "_") {
+                    this.consume();
+                    return this.subscriptable();
+                } else {
+                    return Log.common();
+                }
+            default:
+                throw new Error(
+                    `Expected either ln or log but got ${next.kind}`,
+                );
+        }
+    }
+
+    triglog() {
+        const index = this.index; // save state
+        try {
+            const left = this.trigfunc();
+            const right = this.negative();
+            return Trig.create(left, right);
+        } catch {
+            this.index = index; // restore state
+            try {
+                const left = this.logbase();
+                const right = this.negative();
+                return Log.create(left, right);
+            } catch {
+                this.index = index; // restore state
+                return this.power();
+            }
+        }
+    }
+
+    power() {
+        const left = this.primitive();
+        const op = this.peek();
+        if (op.kind === "^") {
+            this.consume(); // ^
+            const right = this.negative();
+            return new Pow(left, right);
+        } else {
+            return left;
+        }
+    }
+
+    variable(): string {
+        const next = this.peek();
+        if (next.kind === "VAR") {
+            this.consume();
+            return next.value;
+        } else {
+            throw new Error(`Expected VAR token but got ${next.kind}`);
+        }
+    }
+
+    subscriptable() {
+        const index = this.index; // save state
+        try {
+            const left = this.variable();
+            if (this.peek().kind === "_") {
+                this.consume();
+                const right = this.subscriptable();
+                return new Var(left, right);
+            } else {
+                return new Var(left);
+            }
+        } catch (e) {
+            this.index = index; // restore state
+            const next = this.peek();
+            this.consume();
+            switch (next.kind) {
+                case "CONST":
+                    return new Const(next.value.toLocaleLowerCase());
+                case "INT":
+                    // Why are we using the `Number` constructor instead of `parseInt`?
+                    return Int.create(Number(next.value));
+                case "FLOAT":
+                    // Why are we using the `Number` constructor instead of `parseFlat`?
+                    return Float.create(Number(next.value));
+                case "{": {
+                    const node = this.additive().completeParse(); // post-process Trig ndoes with exponents
+                    this.expect("}");
+                    return node;
+                }
+                case "(": {
+                    const node = this.additive()
+                        .completeParse() // post-process Trig ndoes with exponents
+                        .addHint("parens"); // this probably shouldn't be a hint...
+                    this.expect(")");
+                    return node;
+                }
+                default:
+                    throw new Error(
+                        `Expected either CONST, INT, FLOAT, {, or ( but got ${next.kind}`,
+                    );
+            }
+        }
+    }
+
+    function() {
+        const next = this.peek();
+        if (next.kind === "FUNC") {
+            this.consume();
+            return next.value;
+        } else {
+            throw new Error(`Expected FUNC token but got ${next.kind}`);
+        }
+    }
+
+    invocation() {
+        const next = this.peek();
+        this.consume();
+        switch (next.kind) {
+            case "sqrt": {
+                const next = this.peek();
+                this.consume();
+                switch (next.kind) {
+                    case "(": {
+                        const arg = this.additive();
+                        this.expect(")");
+                        return Pow.sqrt(arg);
+                    }
+                    case "{": {
+                        const arg = this.additive();
+                        this.expect("}");
+                        return Pow.sqrt(arg);
+                    }
+                    case "[": {
+                        const index = this.additive();
+                        this.expect("]");
+                        this.expect("{");
+                        const arg = this.additive();
+                        this.expect("}");
+                        return Pow.nthroot(arg, index);
+                    }
+                    default:
+                        throw new Error(
+                            `Expected (, {, or [ but got ${next.kind}`,
+                        );
+                }
+            }
+            case "abs": {
+                this.expect("(");
+                const arg = this.additive();
+                this.expect(")");
+                return new Abs(arg);
+            }
+            case "|": {
+                const arg = this.additive();
+                this.expect("|");
+                return new Abs(arg);
+            }
+            case "LEFT|": {
+                const arg = this.additive();
+                this.expect("RIGHT|");
+                return new Abs(arg);
+            }
+            case "FUNC": {
+                this.expect("(");
+                const arg = this.additive();
+                this.expect(")");
+                return new Func(next.value, arg);
+            }
+            default:
+                throw new Error(
+                    `Expected sqrt, abs, |, LEFT|, or FUNC but got ${next.kind}`,
+                );
+        }
+    }
+
+    primitive() {
+        const index = this.index; // save state
+        try {
+            return this.subscriptable();
+        } catch (e) {
+            this.index = index; // restore state
+            try {
+                return this.invocation();
+            } catch (e) {
+                this.index = index; // restore state
+                this.expect("FRAC");
+                this.expect("{");
+                const left = this.additive();
+                this.expect("}");
+                this.expect("{");
+                const right = this.additive();
+                this.expect("}");
+                return Mul.handleDivide(left, right);
+            }
+        }
+    }
+}
+
+type ParseResult =
+    | {
+          parsed: true;
+          expr: Expr;
+      }
+    | {
+          parsed: false;
+          error: string;
+      };
+
+export function parse(input: string, options?: Options): ParseResult {
+    try {
+        const tokens = lex(input, options);
+        const parser = new Parser(tokens);
+        const expr = parser.parse().completeParse();
+        return {parsed: true, expr};
+    } catch (e) {
+        return {parsed: false, error: (e as Error).message};
+    }
+}

--- a/packages/kas/src/parser.ts
+++ b/packages/kas/src/parser.ts
@@ -14,8 +14,7 @@ import {
     Var,
 } from "./nodes";
 
-// TODO(kevinb): Replace with a real type once #1748 is landed.
-type Expr = any;
+import type {Expr} from "./nodes";
 
 // Parser implements a recursive descent parser that can parse a simple
 // subset of LaTeX.  See lexer.ts for a list of the commands it supports.
@@ -165,7 +164,7 @@ export class Parser {
         throw new Error(`Expected SIGN token but got ${next.kind}`);
     }
 
-    additive(): Add | Mul {
+    additive(): Expr {
         let left = this.multiplicative();
 
         let op = this.peek();
@@ -196,7 +195,7 @@ export class Parser {
         return node;
     }
 
-    multiplicative(): Mul {
+    multiplicative(): Expr {
         let left = this.negative();
 
         while (this.index < this.tokens.length) {
@@ -228,7 +227,7 @@ export class Parser {
         return left;
     }
 
-    negative() {
+    negative(): Expr {
         if (this.peek().kind === "-") {
             this.consume(); // -
             return Mul.handleNegative(this.negative());
@@ -261,7 +260,7 @@ export class Parser {
         }
     }
 
-    logbase() {
+    logbase(): Expr {
         const next = this.peek();
         switch (next.kind) {
             case "LN":
@@ -282,7 +281,7 @@ export class Parser {
         }
     }
 
-    triglog() {
+    triglog(): Expr {
         const index = this.index; // save state
         try {
             const func = this.trigfunc();
@@ -301,7 +300,7 @@ export class Parser {
         }
     }
 
-    power() {
+    power(): Expr {
         const base = this.primitive();
         const op = this.peek();
         if (op.kind === "^") {
@@ -313,7 +312,7 @@ export class Parser {
         }
     }
 
-    subscriptable() {
+    subscriptable(): Expr {
         const index = this.index; // save state
         try {
             const left = this.expectValue("VAR");
@@ -354,7 +353,7 @@ export class Parser {
         }
     }
 
-    invocation() {
+    invocation(): Expr {
         const next = this.peek();
         switch (next.kind) {
             case "SQRT": {
@@ -405,7 +404,7 @@ export class Parser {
         }
     }
 
-    primitive() {
+    primitive(): Expr {
         const index = this.index; // save state
         try {
             return this.subscriptable();

--- a/packages/kas/src/parser.ts
+++ b/packages/kas/src/parser.ts
@@ -59,10 +59,8 @@ type Expr = any;
 //      power
 // power:
 //      primative ("^" negative)
-// variable:
-//      VAR
 // subscriptable:
-//      variable ("_" subscriptable)?
+//      VAR ("_" subscriptable)?
 //      CONST
 //      INT
 //      FLOAT


### PR DESCRIPTION
## Summary:
The reason for creating this alternate version of the KAS parse is that I want to create a parser that outputs a MathBlocks AST for my hackathon project.  This project is heavily based on MathBlocks which is a suite of node modules I've developed as a side project to facilitate the development of interact math applications on the web.   I thought that it would be easier to create the parser for my hackathon project if I first had a recursive descent parser (as opposed to the current JISON-based parser).  It's much hard to see what's going on with the JISON parser because parts of code the make up the parser are in different files.  Also, the JISON parser doesn't produce type-safe code.

In the future, we may want replace KAS' current parser with this one.  I think it'll make maintenance a bit easier since it uses plain old TypeScript code which means that maintainers don't have to understand JISON.  The parser is implemented as a recursive descent parser which is one of the simplest types of parsers to write.  Because it uses TypeScript it's also typesafe which also makes it easier to work on.  The parser itself is also fewer lines 577 (shipped) vs 814 (shipped) + 214 (dev-only).

If we do want to adopt this parser we'll likely also want to convert the unit parser to be a recursive descent parser as well.  This would allow us to remove JISON from the code base completely (JISON is a dev dependency so this wouldn't have too much impact on bundle size).  Additionally, converting nodes.js to TypeScript and all of the node types to be ES6 classes would also help with maintainability, but would not be a requirement for adopting the new parser(s).

Issue: None

TODO:
- [ ] handle custom decimal separator

## Test plan:
- yarn test packages/kas/src