### PR TITLE
Refine InputNumber's Rubric type

### DIFF
--- a/.changeset/long-baboons-hide.md
+++ b/.changeset/long-baboons-hide.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Refine InputNumber's rubric type

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -94,7 +94,21 @@ export type PerseusIFrameUserInput = {
 // TODO (LEMS-2396): remove validation logic from widgets that don't validate
 export type PerseusImageRubric = PerseusImageWidgetOptions;
 
-export type PerseusInputNumberRubric = PerseusInputNumberWidgetOptions;
+export type PerseusInputNumberRubric = {
+    answerType?:
+        | "number"
+        | "decimal"
+        | "integer"
+        | "rational"
+        | "improper"
+        | "mixed"
+        | "percent"
+        | "pi";
+    inexact?: boolean;
+    maxError?: number | string;
+    simplify: "required" | "optional" | "enforced";
+    value: string | number;
+};
 
 export type PerseusInputNumberUserInput = {
     currentValue: string;

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -10,7 +10,6 @@ import type {
     PerseusGroupWidgetOptions,
     PerseusIFrameWidgetOptions,
     PerseusImageWidgetOptions,
-    PerseusInputNumberWidgetOptions,
     PerseusInteractionWidgetOptions,
     PerseusLabelImageWidgetOptions,
     PerseusMatcherWidgetOptions,

--- a/packages/perseus/src/widgets/input-number/input-number-validator.test.ts
+++ b/packages/perseus/src/widgets/input-number/input-number-validator.test.ts
@@ -12,7 +12,6 @@ describe("inputNumberValidator", () => {
             value: 1,
             simplify: "optional",
             answerType: "percent",
-            size: "small",
         };
 
         const useInput = {
@@ -31,7 +30,6 @@ describe("inputNumberValidator", () => {
             value: 1,
             simplify: "optional",
             answerType: "percent",
-            size: "small",
         };
 
         const useInput = {
@@ -50,7 +48,6 @@ describe("inputNumberValidator", () => {
             value: 1,
             simplify: "optional",
             answerType: "percent",
-            size: "small",
         };
 
         const useInput = {
@@ -76,7 +73,6 @@ describe("inputNumberValidator", () => {
             inexact: false,
             value: 241.90263432641407,
             simplify: "required",
-            size: "normal",
         };
 
         const userInput = {
@@ -105,7 +101,6 @@ describe("inputNumberValidator", () => {
             value: 241.90263432641407,
             simplify: "required",
             answerType: "pi",
-            size: "normal",
         };
 
         const userInput = {

--- a/packages/perseus/src/widgets/input-number/input-number-validator.ts
+++ b/packages/perseus/src/widgets/input-number/input-number-validator.ts
@@ -2,7 +2,10 @@ import TexWrangler from "../../tex-wrangler";
 import KhanAnswerTypes from "../../util/answer-types";
 
 import type {PerseusStrings} from "../../strings";
-import type {PerseusInputNumberRubric} from "../../validation.types";
+import type {
+    PerseusInputNumberRubric,
+    PerseusInputNumberUserInput,
+} from "../../validation.types";
 import type {PerseusScore} from "@khanacademy/perseus";
 
 const ParseTex = TexWrangler.parseTex;
@@ -43,9 +46,7 @@ export const answerTypes = {
 } as const;
 
 function inputNumberValidator(
-    state: {
-        currentValue: string;
-    },
+    userInput: PerseusInputNumberUserInput,
     rubric: PerseusInputNumberRubric,
     strings: PerseusStrings,
 ): PerseusScore {
@@ -70,7 +71,7 @@ function inputNumberValidator(
 
     // We may have received TeX; try to parse it before grading.
     // If `currentValue` is not TeX, this should be a no-op.
-    const currentValue = ParseTex(state.currentValue);
+    const currentValue = ParseTex(userInput.currentValue);
 
     const result = val(currentValue);
 


### PR DESCRIPTION
## Summary:
As part of the Server Side Scoring project, this refactors InputNumber's Rubric type to contain only what is needed for scoring. Also adds the UserInput type to the validator as it was defined already but not referenced.

Issue: LEMS-2467

## Test plan:
- Confirm all tests pass
- Confirm InputNumber still works as expected via Storybook