### PR TITLE
BUGFIX: [Number Line] - Tick labels not showing in some exercises

### DIFF
--- a/.changeset/violet-bulldogs-shout.md
+++ b/.changeset/violet-bulldogs-shout.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+BUGFIX - [Number Line] - Tick labels not showing in some exercises

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1698,9 +1698,6 @@ const setLabelMargins = function (span: HTMLElement, size: Coord): void {
         // Inherited line-height values can really mess up placement.
         $container.css("line-height", "normal");
 
-        // TODO: Verify that this change doesn't impact other graphies
-        //       Check the full list of consuming widgets.
-
         // If the change in line-height affected the height of the element,
         //     then the height used for calculations should be updated.
         // This can happen when the first label in the container calls this method,

--- a/packages/perseus/src/widgets/number-line/__snapshots__/number-line.test.ts.snap
+++ b/packages/perseus/src/widgets/number-line/__snapshots__/number-line.test.ts.snap
@@ -1,6 +1,2910 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`number-line widget should snapshot on mobile: first mobile render 1`] = `
+exports[`number-line widget snapshots all tick labels show when "Style" is "decimal ticks" (deprecated option): show decimal ticks 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph perseus-paragraph-centered"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="perseus-block-math"
+      >
+        <div
+          class="perseus-block-math-inner"
+          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+        >
+          <span
+            class="mock-TeX"
+          >
+            E=2.5
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
+      <div
+        class="paragraph"
+      >
+        <strong>
+          Move the dot to 
+          <span
+            style="white-space: nowrap;"
+          >
+            <span />
+            <span
+              class="mock-TeX"
+            >
+              -E
+            </span>
+            <span />
+          </span>
+           on the number line.
+        </strong>
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <div
+            class="perseus-widget perseus-widget-interactive-number-line"
+          >
+            <div
+              class="graphie-container"
+            >
+              <div
+                class="graphie"
+                style="position: relative; width: 460px; height: 80px;"
+              >
+                <svg
+                  height="80"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
+                  version="1.1"
+                  width="460"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <rect
+                    fill="#000000"
+                    height="80"
+                    opacity="0"
+                    r="0"
+                    rx="0"
+                    ry="0"
+                    stroke="#000"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0;"
+                    width="460"
+                    x="0"
+                    y="0"
+                  />
+                </svg>
+                <svg
+                  height="80"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  version="1.1"
+                  width="460"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <path
+                    d="M454.45,45.6C454.8,43.5,458.65,40.35,459.7,40C458.65,39.65,454.8,36.5,454.45,34.4"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; stroke-linejoin: round; stroke-linecap: round;"
+                    transform=""
+                  />
+                  <path
+                    d="M230,40C230,40,230,40,458.95,40"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M-3.4499999999999886,45.6C-3.0999999999999885,43.5,0.7500000000000115,40.35,1.8000000000000114,40C0.7500000000000113,39.65,-3.099999999999989,36.5,-3.4499999999999886,34.4"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; stroke-linejoin: round; stroke-linecap: round;"
+                    transform="rotate(180 1.8000000000000114 40)"
+                  />
+                  <path
+                    d="M230,40C230,40,230,40,1.0500000000000114,40"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M30,48L30,32"
+                    fill="none"
+                    stroke="#1865f2"
+                    stroke-width="3.5"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 3.5;"
+                  />
+                  <path
+                    d="M50,48L50,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M70,48L70,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M90,48L90,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M110,48L110,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M130,48L130,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M150,48L150,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M170,48L170,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M190,48L190,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M210,48L210,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M230,48L230,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M250,48L250,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M270,48L270,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M290,48L290,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M310,48L310,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M330,48L330,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M350,48L350,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M370,48L370,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M390,48L390,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M410,48L410,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M430,48L430,32"
+                    fill="none"
+                    stroke="#1865f2"
+                    stroke-width="3.5"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 3.5;"
+                  />
+                </svg>
+                <div
+                  style="position: absolute; left: 0px; top: 0px;"
+                >
+                  <div
+                    style="position: absolute; width: 34px; height: 34px; left: 13px; top: 23px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="34"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="34"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#00a60e"
+                        r="NaN"
+                        rx="6"
+                        ry="6"
+                        stroke="#00a60e"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
+                        transform=""
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                >
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 6px; top: 16px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-10"
+                  style="position: absolute; padding: 7px; color: rgb(24, 101, 242); left: 30px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-9"
+                  style="position: absolute; padding: 7px; color: black; left: 50px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-8"
+                  style="position: absolute; padding: 7px; color: black; left: 70px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-7"
+                  style="position: absolute; padding: 7px; color: black; left: 90px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-6"
+                  style="position: absolute; padding: 7px; color: black; left: 110px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-5"
+                  style="position: absolute; padding: 7px; color: black; left: 130px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-4"
+                  style="position: absolute; padding: 7px; color: black; left: 150px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-3"
+                  style="position: absolute; padding: 7px; color: black; left: 170px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-2"
+                  style="position: absolute; padding: 7px; color: black; left: 190px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-1"
+                  style="position: absolute; padding: 7px; color: black; left: 210px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="0"
+                  style="position: absolute; padding: 7px; color: black; left: 230px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="1"
+                  style="position: absolute; padding: 7px; color: black; left: 250px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="2"
+                  style="position: absolute; padding: 7px; color: black; left: 270px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="3"
+                  style="position: absolute; padding: 7px; color: black; left: 290px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="4"
+                  style="position: absolute; padding: 7px; color: black; left: 310px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="5"
+                  style="position: absolute; padding: 7px; color: black; left: 330px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="6"
+                  style="position: absolute; padding: 7px; color: black; left: 350px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="7"
+                  style="position: absolute; padding: 7px; color: black; left: 370px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="8"
+                  style="position: absolute; padding: 7px; color: black; left: 390px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="9"
+                  style="position: absolute; padding: 7px; color: black; left: 410px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="10"
+                  style="position: absolute; padding: 7px; color: rgb(24, 101, 242); left: 430px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`number-line widget snapshots default: first render 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph perseus-paragraph-centered"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="perseus-block-math"
+      >
+        <div
+          class="perseus-block-math-inner"
+          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+        >
+          <span
+            class="mock-TeX"
+          >
+            E=2.5
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
+      <div
+        class="paragraph"
+      >
+        <strong>
+          Move the dot to 
+          <span
+            style="white-space: nowrap;"
+          >
+            <span />
+            <span
+              class="mock-TeX"
+            >
+              -E
+            </span>
+            <span />
+          </span>
+           on the number line.
+        </strong>
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <div
+            class="perseus-widget perseus-widget-interactive-number-line"
+          >
+            <div
+              class="graphie-container"
+            >
+              <div
+                class="graphie"
+                style="position: relative; width: 459.99999999999994px; height: 80px;"
+              >
+                <svg
+                  height="80"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
+                  version="1.1"
+                  width="460"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <rect
+                    fill="#000000"
+                    height="80"
+                    opacity="0"
+                    r="0"
+                    rx="0"
+                    ry="0"
+                    stroke="#000"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0;"
+                    width="460"
+                    x="0"
+                    y="0"
+                  />
+                </svg>
+                <svg
+                  height="80"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  version="1.1"
+                  width="459.99999999999994"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <path
+                    d="M454.44999999999993,45.6C454.79999999999995,43.5,458.6499999999999,40.35,459.69999999999993,40C458.6499999999999,39.65,454.79999999999995,36.5,454.44999999999993,34.4"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; stroke-linejoin: round; stroke-linecap: round;"
+                    transform=""
+                  />
+                  <path
+                    d="M229.99999999999997,40C229.99999999999997,40,229.99999999999997,40,458.94999999999993,40"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M-3.4499999999999886,45.6C-3.0999999999999885,43.5,0.7500000000000115,40.35,1.8000000000000114,40C0.7500000000000113,39.65,-3.099999999999989,36.5,-3.4499999999999886,34.4"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; stroke-linejoin: round; stroke-linecap: round;"
+                    transform="rotate(180 1.8000000000000114 40)"
+                  />
+                  <path
+                    d="M229.99999999999997,40C229.99999999999997,40,229.99999999999997,40,1.0500000000000114,40"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M29.999999999999982,48L29.999999999999982,32"
+                    fill="none"
+                    stroke="#1865f2"
+                    stroke-width="3.5"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 3.5;"
+                  />
+                  <path
+                    d="M79.99999999999999,48L79.99999999999999,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M129.99999999999997,48L129.99999999999997,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M179.99999999999997,48L179.99999999999997,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M229.99999999999997,48L229.99999999999997,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M280,48L280,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M330,48L330,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M380,48L380,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M430,48L430,32"
+                    fill="none"
+                    stroke="#1865f2"
+                    stroke-width="3.5"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 3.5;"
+                  />
+                </svg>
+                <div
+                  style="position: absolute; left: 0px; top: 0px;"
+                >
+                  <div
+                    style="position: absolute; width: 34px; height: 34px; left: 12.999999999999982px; top: 23px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="34"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="34"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#00a60e"
+                        r="NaN"
+                        rx="6"
+                        ry="6"
+                        stroke="#00a60e"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
+                        transform=""
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                >
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 5.999999999999982px; top: 16px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-4"
+                  style="position: absolute; padding: 7px; color: rgb(24, 101, 242); left: 29.999999999999982px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-3"
+                  style="position: absolute; padding: 7px; color: black; left: 79.99999999999999px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-2"
+                  style="position: absolute; padding: 7px; color: black; left: 129.99999999999997px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-1"
+                  style="position: absolute; padding: 7px; color: black; left: 179.99999999999997px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="0"
+                  style="position: absolute; padding: 7px; color: black; left: 229.99999999999997px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="1"
+                  style="position: absolute; padding: 7px; color: black; left: 280px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="2"
+                  style="position: absolute; padding: 7px; color: black; left: 330px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="3"
+                  style="position: absolute; padding: 7px; color: black; left: 380px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="4"
+                  style="position: absolute; padding: 7px; color: rgb(24, 101, 242); left: 430px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`number-line widget snapshots endpoints are highlighted when labels are NOT indicated: left endpoint highlighted 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph perseus-paragraph-centered"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="perseus-block-math"
+      >
+        <div
+          class="perseus-block-math-inner"
+          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+        >
+          <span
+            class="mock-TeX"
+          >
+            E=2.5
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
+      <div
+        class="paragraph"
+      >
+        <strong>
+          Move the dot to 
+          <span
+            style="white-space: nowrap;"
+          >
+            <span />
+            <span
+              class="mock-TeX"
+            >
+              -E
+            </span>
+            <span />
+          </span>
+           on the number line.
+        </strong>
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <div
+            class="perseus-widget perseus-widget-interactive-number-line"
+          >
+            <div
+              class="graphie-container"
+            >
+              <div
+                class="graphie"
+                style="position: relative; width: 460px; height: 80px;"
+              >
+                <svg
+                  height="80"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
+                  version="1.1"
+                  width="460"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <rect
+                    fill="#000000"
+                    height="80"
+                    opacity="0"
+                    r="0"
+                    rx="0"
+                    ry="0"
+                    stroke="#000"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0;"
+                    width="460"
+                    x="0"
+                    y="0"
+                  />
+                </svg>
+                <svg
+                  height="80"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  version="1.1"
+                  width="460"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <path
+                    d="M454.45,45.6C454.8,43.5,458.65,40.35,459.7,40C458.65,39.65,454.8,36.5,454.45,34.4"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; stroke-linejoin: round; stroke-linecap: round;"
+                    transform=""
+                  />
+                  <path
+                    d="M230,40C230,40,230,40,458.95,40"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M-3.4499999999999886,45.6C-3.0999999999999885,43.5,0.7500000000000115,40.35,1.8000000000000114,40C0.7500000000000113,39.65,-3.099999999999989,36.5,-3.4499999999999886,34.4"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; stroke-linejoin: round; stroke-linecap: round;"
+                    transform="rotate(180 1.8000000000000114 40)"
+                  />
+                  <path
+                    d="M230,40C230,40,230,40,1.0500000000000114,40"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M30,48L30,32"
+                    fill="none"
+                    stroke="#1865f2"
+                    stroke-width="3.5"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 3.5;"
+                  />
+                  <path
+                    d="M50,48L50,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M70,48L70,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M90,48L90,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M110,48L110,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M130,48L130,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M150,48L150,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M170,48L170,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M190,48L190,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M210,48L210,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M230,48L230,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M250,48L250,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M270,48L270,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M290,48L290,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M310,48L310,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M330,48L330,32"
+                    fill="none"
+                    stroke="#1865f2"
+                    stroke-width="3.5"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 3.5;"
+                  />
+                  <path
+                    d="M350,48L350,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M370,48L370,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M390,48L390,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M410,48L410,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M430,48L430,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                </svg>
+                <div
+                  style="position: absolute; left: 0px; top: 0px;"
+                >
+                  <div
+                    style="position: absolute; width: 34px; height: 34px; left: 13px; top: 23px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="34"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="34"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#00a60e"
+                        r="NaN"
+                        rx="6"
+                        ry="6"
+                        stroke="#00a60e"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
+                        transform=""
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                >
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 6px; top: 16px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-10"
+                  style="position: absolute; padding: 7px; color: rgb(24, 101, 242); left: 30px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-9"
+                  style="position: absolute; padding: 7px; color: black; left: 50px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-8"
+                  style="position: absolute; padding: 7px; color: black; left: 70px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-7"
+                  style="position: absolute; padding: 7px; color: black; left: 90px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-6"
+                  style="position: absolute; padding: 7px; color: black; left: 110px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-5"
+                  style="position: absolute; padding: 7px; color: black; left: 130px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-4"
+                  style="position: absolute; padding: 7px; color: black; left: 150px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-3"
+                  style="position: absolute; padding: 7px; color: black; left: 170px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-2"
+                  style="position: absolute; padding: 7px; color: black; left: 190px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-1"
+                  style="position: absolute; padding: 7px; color: black; left: 210px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="0"
+                  style="position: absolute; padding: 7px; color: black; left: 230px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="1"
+                  style="position: absolute; padding: 7px; color: black; left: 250px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="2"
+                  style="position: absolute; padding: 7px; color: black; left: 270px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="3"
+                  style="position: absolute; padding: 7px; color: black; left: 290px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="4"
+                  style="position: absolute; padding: 7px; color: black; left: 310px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="5"
+                  style="position: absolute; padding: 7px; color: rgb(24, 101, 242); left: 330px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="6"
+                  style="position: absolute; padding: 7px; color: black; left: 350px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="7"
+                  style="position: absolute; padding: 7px; color: black; left: 370px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="8"
+                  style="position: absolute; padding: 7px; color: black; left: 390px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="9"
+                  style="position: absolute; padding: 7px; color: black; left: 410px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="10"
+                  style="position: absolute; padding: 7px; color: black; left: 430px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`number-line widget snapshots endpoints are highlighted when labels are NOT indicated: right endpoint highlighted 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph perseus-paragraph-centered"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="perseus-block-math"
+      >
+        <div
+          class="perseus-block-math-inner"
+          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+        >
+          <span
+            class="mock-TeX"
+          >
+            E=2.5
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
+      <div
+        class="paragraph"
+      >
+        <strong>
+          Move the dot to 
+          <span
+            style="white-space: nowrap;"
+          >
+            <span />
+            <span
+              class="mock-TeX"
+            >
+              -E
+            </span>
+            <span />
+          </span>
+           on the number line.
+        </strong>
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <div
+            class="perseus-widget perseus-widget-interactive-number-line"
+          >
+            <div
+              class="graphie-container"
+            >
+              <div
+                class="graphie"
+                style="position: relative; width: 460px; height: 80px;"
+              >
+                <svg
+                  height="80"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
+                  version="1.1"
+                  width="460"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <rect
+                    fill="#000000"
+                    height="80"
+                    opacity="0"
+                    r="0"
+                    rx="0"
+                    ry="0"
+                    stroke="#000"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0;"
+                    width="460"
+                    x="0"
+                    y="0"
+                  />
+                </svg>
+                <svg
+                  height="80"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  version="1.1"
+                  width="460"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <path
+                    d="M454.45,45.6C454.8,43.5,458.65,40.35,459.7,40C458.65,39.65,454.8,36.5,454.45,34.4"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; stroke-linejoin: round; stroke-linecap: round;"
+                    transform=""
+                  />
+                  <path
+                    d="M230,40C230,40,230,40,458.95,40"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M-3.4499999999999886,45.6C-3.0999999999999885,43.5,0.7500000000000115,40.35,1.8000000000000114,40C0.7500000000000113,39.65,-3.099999999999989,36.5,-3.4499999999999886,34.4"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; stroke-linejoin: round; stroke-linecap: round;"
+                    transform="rotate(180 1.8000000000000114 40)"
+                  />
+                  <path
+                    d="M230,40C230,40,230,40,1.0500000000000114,40"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M30,48L30,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M50,48L50,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M70,48L70,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M90,48L90,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M110,48L110,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M130,48L130,32"
+                    fill="none"
+                    stroke="#1865f2"
+                    stroke-width="3.5"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 3.5;"
+                  />
+                  <path
+                    d="M150,48L150,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M170,48L170,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M190,48L190,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M210,48L210,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M230,48L230,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M250,48L250,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M270,48L270,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M290,48L290,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M310,48L310,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M330,48L330,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M350,48L350,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M370,48L370,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M390,48L390,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M410,48L410,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M430,48L430,32"
+                    fill="none"
+                    stroke="#1865f2"
+                    stroke-width="3.5"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 3.5;"
+                  />
+                </svg>
+                <div
+                  style="position: absolute; left: 0px; top: 0px;"
+                >
+                  <div
+                    style="position: absolute; width: 34px; height: 34px; left: 13px; top: 23px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="34"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="34"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#00a60e"
+                        r="NaN"
+                        rx="6"
+                        ry="6"
+                        stroke="#00a60e"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
+                        transform=""
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                >
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 6px; top: 16px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-10"
+                  style="position: absolute; padding: 7px; color: black; left: 30px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-9"
+                  style="position: absolute; padding: 7px; color: black; left: 50px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-8"
+                  style="position: absolute; padding: 7px; color: black; left: 70px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-7"
+                  style="position: absolute; padding: 7px; color: black; left: 90px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-6"
+                  style="position: absolute; padding: 7px; color: black; left: 110px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-5"
+                  style="position: absolute; padding: 7px; color: rgb(24, 101, 242); left: 130px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-4"
+                  style="position: absolute; padding: 7px; color: black; left: 150px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-3"
+                  style="position: absolute; padding: 7px; color: black; left: 170px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-2"
+                  style="position: absolute; padding: 7px; color: black; left: 190px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-1"
+                  style="position: absolute; padding: 7px; color: black; left: 210px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="0"
+                  style="position: absolute; padding: 7px; color: black; left: 230px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="1"
+                  style="position: absolute; padding: 7px; color: black; left: 250px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="2"
+                  style="position: absolute; padding: 7px; color: black; left: 270px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="3"
+                  style="position: absolute; padding: 7px; color: black; left: 290px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="4"
+                  style="position: absolute; padding: 7px; color: black; left: 310px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="5"
+                  style="position: absolute; padding: 7px; color: black; left: 330px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="6"
+                  style="position: absolute; padding: 7px; color: black; left: 350px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="7"
+                  style="position: absolute; padding: 7px; color: black; left: 370px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="8"
+                  style="position: absolute; padding: 7px; color: black; left: 390px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="9"
+                  style="position: absolute; padding: 7px; color: black; left: 410px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="10"
+                  style="position: absolute; padding: 7px; color: rgb(24, 101, 242); left: 430px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`number-line widget snapshots labels are highlighted when part of the tick step: show highlighted labels 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph perseus-paragraph-centered"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="perseus-block-math"
+      >
+        <div
+          class="perseus-block-math-inner"
+          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+        >
+          <span
+            class="mock-TeX"
+          >
+            E=2.5
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
+      <div
+        class="paragraph"
+      >
+        <strong>
+          Move the dot to 
+          <span
+            style="white-space: nowrap;"
+          >
+            <span />
+            <span
+              class="mock-TeX"
+            >
+              -E
+            </span>
+            <span />
+          </span>
+           on the number line.
+        </strong>
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <div
+            class="perseus-widget perseus-widget-interactive-number-line"
+          >
+            <div
+              class="graphie-container"
+            >
+              <div
+                class="graphie"
+                style="position: relative; width: 460px; height: 80px;"
+              >
+                <svg
+                  height="80"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
+                  version="1.1"
+                  width="460"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <rect
+                    fill="#000000"
+                    height="80"
+                    opacity="0"
+                    r="0"
+                    rx="0"
+                    ry="0"
+                    stroke="#000"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0;"
+                    width="460"
+                    x="0"
+                    y="0"
+                  />
+                </svg>
+                <svg
+                  height="80"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  version="1.1"
+                  width="460"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <path
+                    d="M454.45,45.6C454.8,43.5,458.65,40.35,459.7,40C458.65,39.65,454.8,36.5,454.45,34.4"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; stroke-linejoin: round; stroke-linecap: round;"
+                    transform=""
+                  />
+                  <path
+                    d="M230,40C230,40,230,40,458.95,40"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M-3.4499999999999886,45.6C-3.0999999999999885,43.5,0.7500000000000115,40.35,1.8000000000000114,40C0.7500000000000113,39.65,-3.099999999999989,36.5,-3.4499999999999886,34.4"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; stroke-linejoin: round; stroke-linecap: round;"
+                    transform="rotate(180 1.8000000000000114 40)"
+                  />
+                  <path
+                    d="M230,40C230,40,230,40,1.0500000000000114,40"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M30,48L30,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M70,48L70,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M110,48L110,32"
+                    fill="none"
+                    stroke="#1865f2"
+                    stroke-width="3.5"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 3.5;"
+                  />
+                  <path
+                    d="M150,48L150,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M190,48L190,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M230,48L230,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M270,48L270,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M310,48L310,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M350,48L350,32"
+                    fill="none"
+                    stroke="#1865f2"
+                    stroke-width="3.5"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 3.5;"
+                  />
+                  <path
+                    d="M390,48L390,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M430,48L430,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                </svg>
+                <div
+                  style="position: absolute; left: 0px; top: 0px;"
+                >
+                  <div
+                    style="position: absolute; width: 34px; height: 34px; left: 13px; top: 23px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="34"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="34"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#00a60e"
+                        r="NaN"
+                        rx="6"
+                        ry="6"
+                        stroke="#00a60e"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
+                        transform=""
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                >
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 6px; top: 16px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-10"
+                  style="position: absolute; padding: 7px; color: black; left: 30px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-8"
+                  style="position: absolute; padding: 7px; color: black; left: 70px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-6"
+                  style="position: absolute; padding: 7px; color: rgb(24, 101, 242); left: 110px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-4"
+                  style="position: absolute; padding: 7px; color: black; left: 150px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-2"
+                  style="position: absolute; padding: 7px; color: black; left: 190px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="0"
+                  style="position: absolute; padding: 7px; color: black; left: 230px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="2"
+                  style="position: absolute; padding: 7px; color: black; left: 270px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="4"
+                  style="position: absolute; padding: 7px; color: black; left: 310px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="6"
+                  style="position: absolute; padding: 7px; color: rgb(24, 101, 242); left: 350px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="8"
+                  style="position: absolute; padding: 7px; color: black; left: 390px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="10"
+                  style="position: absolute; padding: 7px; color: black; left: 430px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`number-line widget snapshots labels are inserted when NOT part of the tick step: show inserted labels 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph perseus-paragraph-centered"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="perseus-block-math"
+      >
+        <div
+          class="perseus-block-math-inner"
+          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+        >
+          <span
+            class="mock-TeX"
+          >
+            E=2.5
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
+      <div
+        class="paragraph"
+      >
+        <strong>
+          Move the dot to 
+          <span
+            style="white-space: nowrap;"
+          >
+            <span />
+            <span
+              class="mock-TeX"
+            >
+              -E
+            </span>
+            <span />
+          </span>
+           on the number line.
+        </strong>
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <div
+            class="perseus-widget perseus-widget-interactive-number-line"
+          >
+            <div
+              class="graphie-container"
+            >
+              <div
+                class="graphie"
+                style="position: relative; width: 460px; height: 80px;"
+              >
+                <svg
+                  height="80"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
+                  version="1.1"
+                  width="460"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <rect
+                    fill="#000000"
+                    height="80"
+                    opacity="0"
+                    r="0"
+                    rx="0"
+                    ry="0"
+                    stroke="#000"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0;"
+                    width="460"
+                    x="0"
+                    y="0"
+                  />
+                </svg>
+                <svg
+                  height="80"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  version="1.1"
+                  width="460"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <path
+                    d="M454.45,45.6C454.8,43.5,458.65,40.35,459.7,40C458.65,39.65,454.8,36.5,454.45,34.4"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; stroke-linejoin: round; stroke-linecap: round;"
+                    transform=""
+                  />
+                  <path
+                    d="M230,40C230,40,230,40,458.95,40"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M-3.4499999999999886,45.6C-3.0999999999999885,43.5,0.7500000000000115,40.35,1.8000000000000114,40C0.7500000000000113,39.65,-3.099999999999989,36.5,-3.4499999999999886,34.4"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; stroke-linejoin: round; stroke-linecap: round;"
+                    transform="rotate(180 1.8000000000000114 40)"
+                  />
+                  <path
+                    d="M230,40C230,40,230,40,1.0500000000000114,40"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M30,48L30,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M70,48L70,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M110,48L110,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M130,48L130,32"
+                    fill="none"
+                    stroke="#1865f2"
+                    stroke-width="3.5"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 3.5;"
+                  />
+                  <path
+                    d="M150,48L150,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M190,48L190,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M230,48L230,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M270,48L270,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M310,48L310,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M330,48L330,32"
+                    fill="none"
+                    stroke="#1865f2"
+                    stroke-width="3.5"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 3.5;"
+                  />
+                  <path
+                    d="M350,48L350,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M390,48L390,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M430,48L430,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                </svg>
+                <div
+                  style="position: absolute; left: 0px; top: 0px;"
+                >
+                  <div
+                    style="position: absolute; width: 34px; height: 34px; left: 13px; top: 23px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="34"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="34"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#00a60e"
+                        r="NaN"
+                        rx="6"
+                        ry="6"
+                        stroke="#00a60e"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
+                        transform=""
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                >
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 6px; top: 16px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-10"
+                  style="position: absolute; padding: 7px; color: black; left: 30px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-8"
+                  style="position: absolute; padding: 7px; color: black; left: 70px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-6"
+                  style="position: absolute; padding: 7px; color: black; left: 110px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-5"
+                  style="position: absolute; padding: 7px; color: rgb(24, 101, 242); left: 130px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-4"
+                  style="position: absolute; padding: 7px; color: black; left: 150px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-2"
+                  style="position: absolute; padding: 7px; color: black; left: 190px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="0"
+                  style="position: absolute; padding: 7px; color: black; left: 230px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="2"
+                  style="position: absolute; padding: 7px; color: black; left: 270px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="4"
+                  style="position: absolute; padding: 7px; color: black; left: 310px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="5"
+                  style="position: absolute; padding: 7px; color: rgb(24, 101, 242); left: 330px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="6"
+                  style="position: absolute; padding: 7px; color: black; left: 350px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="8"
+                  style="position: absolute; padding: 7px; color: black; left: 390px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="10"
+                  style="position: absolute; padding: 7px; color: black; left: 430px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`number-line widget snapshots mobile: first mobile render 1`] = `
 <div>
   <div
     class="perseus-renderer perseus-renderer-responsive"
@@ -377,7 +3281,7 @@ exports[`number-line widget should snapshot on mobile: first mobile render 1`] =
 </div>
 `;
 
-exports[`number-line widget should snapshot: first render 1`] = `
+exports[`number-line widget snapshots only endpoints/labels show when "Show label ticks" is off: show label ticks off (endpoints) 1`] = `
 <div>
   <div
     class="perseus-renderer perseus-renderer-responsive"
@@ -443,7 +3347,7 @@ exports[`number-line widget should snapshot: first render 1`] = `
             >
               <div
                 class="graphie"
-                style="position: relative; width: 459.99999999999994px; height: 80px;"
+                style="position: relative; width: 460px; height: 80px;"
               >
                 <svg
                   height="80"
@@ -478,7 +3382,7 @@ exports[`number-line widget should snapshot: first render 1`] = `
                   height="80"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
                   version="1.1"
-                  width="459.99999999999994"
+                  width="460"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <desc
@@ -490,7 +3394,7 @@ exports[`number-line widget should snapshot: first render 1`] = `
                     style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
                   />
                   <path
-                    d="M454.44999999999993,45.6C454.79999999999995,43.5,458.6499999999999,40.35,459.69999999999993,40C458.6499999999999,39.65,454.79999999999995,36.5,454.44999999999993,34.4"
+                    d="M454.45,45.6C454.8,43.5,458.65,40.35,459.7,40C458.65,39.65,454.8,36.5,454.45,34.4"
                     fill="none"
                     stroke="#000000"
                     stroke-linecap="round"
@@ -500,7 +3404,7 @@ exports[`number-line widget should snapshot: first render 1`] = `
                     transform=""
                   />
                   <path
-                    d="M229.99999999999997,40C229.99999999999997,40,229.99999999999997,40,458.94999999999993,40"
+                    d="M230,40C230,40,230,40,458.95,40"
                     fill="none"
                     stroke="#000000"
                     stroke-width="2"
@@ -517,49 +3421,112 @@ exports[`number-line widget should snapshot: first render 1`] = `
                     transform="rotate(180 1.8000000000000114 40)"
                   />
                   <path
-                    d="M229.99999999999997,40C229.99999999999997,40,229.99999999999997,40,1.0500000000000114,40"
+                    d="M230,40C230,40,230,40,1.0500000000000114,40"
                     fill="none"
                     stroke="#000000"
                     stroke-width="2"
                     style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
                   />
                   <path
-                    d="M29.999999999999982,48L29.999999999999982,32"
+                    d="M30,48L30,32"
                     fill="none"
                     stroke="#1865f2"
                     stroke-width="3.5"
                     style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 3.5;"
                   />
                   <path
-                    d="M79.99999999999999,48L79.99999999999999,32"
+                    d="M50,48L50,32"
                     fill="none"
                     stroke="#000000"
                     stroke-width="2"
                     style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
                   />
                   <path
-                    d="M129.99999999999997,48L129.99999999999997,32"
+                    d="M70,48L70,32"
                     fill="none"
                     stroke="#000000"
                     stroke-width="2"
                     style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
                   />
                   <path
-                    d="M179.99999999999997,48L179.99999999999997,32"
+                    d="M90,48L90,32"
                     fill="none"
                     stroke="#000000"
                     stroke-width="2"
                     style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
                   />
                   <path
-                    d="M229.99999999999997,48L229.99999999999997,32"
+                    d="M110,48L110,32"
                     fill="none"
                     stroke="#000000"
                     stroke-width="2"
                     style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
                   />
                   <path
-                    d="M280,48L280,32"
+                    d="M130,48L130,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M150,48L150,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M170,48L170,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M190,48L190,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M210,48L210,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M230,48L230,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M250,48L250,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M270,48L270,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M290,48L290,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M310,48L310,32"
                     fill="none"
                     stroke="#000000"
                     stroke-width="2"
@@ -573,7 +3540,28 @@ exports[`number-line widget should snapshot: first render 1`] = `
                     style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
                   />
                   <path
-                    d="M380,48L380,32"
+                    d="M350,48L350,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M370,48L370,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M390,48L390,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M410,48L410,32"
                     fill="none"
                     stroke="#000000"
                     stroke-width="2"
@@ -591,7 +3579,7 @@ exports[`number-line widget should snapshot: first render 1`] = `
                   style="position: absolute; left: 0px; top: 0px;"
                 >
                   <div
-                    style="position: absolute; width: 34px; height: 34px; left: 12.999999999999982px; top: 23px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                    style="position: absolute; width: 34px; height: 34px; left: 13px; top: 23px; transform: translateX(0px) translateY(0px) translateZ(0);"
                   >
                     <svg
                       height="34"
@@ -628,7 +3616,400 @@ exports[`number-line widget should snapshot: first render 1`] = `
                 >
                   <div
                     data-interactive-kind-for-testing="movable-point"
-                    style="position: absolute; width: 48px; height: 48px; left: 5.999999999999982px; top: 16px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                    style="position: absolute; width: 48px; height: 48px; left: 6px; top: 16px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="48"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="48"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="24"
+                        cy="24"
+                        fill="#000000"
+                        opacity="0"
+                        rx="24"
+                        ry="24"
+                        stroke="#000"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0; cursor: move;"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <span
+                  class="graphie-label"
+                  data-math-formula="-10"
+                  style="position: absolute; padding: 7px; color: rgb(24, 101, 242); left: 30px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+                <span
+                  class="graphie-label"
+                  data-math-formula="10"
+                  style="position: absolute; padding: 7px; color: rgb(24, 101, 242); left: 430px; top: 61.2px; fill: none;"
+                >
+                  <span
+                    class="tex-holder"
+                  />
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`number-line widget snapshots only endpoints/labels show when "Show label ticks" is off: show label ticks off (labels) 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph perseus-paragraph-centered"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="perseus-block-math"
+      >
+        <div
+          class="perseus-block-math-inner"
+          style="overflow-x: auto; overflow-y: hidden; padding-top: 10px; padding-bottom: 10px; margin-top: -10px; margin-bottom: -10px;"
+        >
+          <span
+            class="mock-TeX"
+          >
+            E=2.5
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="1"
+    >
+      <div
+        class="paragraph"
+      >
+        <strong>
+          Move the dot to 
+          <span
+            style="white-space: nowrap;"
+          >
+            <span />
+            <span
+              class="mock-TeX"
+            >
+              -E
+            </span>
+            <span />
+          </span>
+           on the number line.
+        </strong>
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="2"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <div
+            class="perseus-widget perseus-widget-interactive-number-line"
+          >
+            <div
+              class="graphie-container"
+            >
+              <div
+                class="graphie"
+                style="position: relative; width: 460px; height: 80px;"
+              >
+                <svg
+                  height="80"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); z-index: 2;"
+                  version="1.1"
+                  width="460"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <rect
+                    fill="#000000"
+                    height="80"
+                    opacity="0"
+                    r="0"
+                    rx="0"
+                    ry="0"
+                    stroke="#000"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); opacity: 0;"
+                    width="460"
+                    x="0"
+                    y="0"
+                  />
+                </svg>
+                <svg
+                  height="80"
+                  style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  version="1.1"
+                  width="460"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <desc
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  >
+                    Created with Raphaël
+                  </desc>
+                  <defs
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                  />
+                  <path
+                    d="M454.45,45.6C454.8,43.5,458.65,40.35,459.7,40C458.65,39.65,454.8,36.5,454.45,34.4"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; stroke-linejoin: round; stroke-linecap: round;"
+                    transform=""
+                  />
+                  <path
+                    d="M230,40C230,40,230,40,458.95,40"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M-3.4499999999999886,45.6C-3.0999999999999885,43.5,0.7500000000000115,40.35,1.8000000000000114,40C0.7500000000000113,39.65,-3.099999999999989,36.5,-3.4499999999999886,34.4"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; stroke-linejoin: round; stroke-linecap: round;"
+                    transform="rotate(180 1.8000000000000114 40)"
+                  />
+                  <path
+                    d="M230,40C230,40,230,40,1.0500000000000114,40"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M30,48L30,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M50,48L50,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M70,48L70,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M90,48L90,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M110,48L110,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M130,48L130,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M150,48L150,32"
+                    fill="none"
+                    stroke="#1865f2"
+                    stroke-width="3.5"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 3.5;"
+                  />
+                  <path
+                    d="M170,48L170,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M190,48L190,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M210,48L210,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M230,48L230,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M250,48L250,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M270,48L270,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M290,48L290,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M310,48L310,32"
+                    fill="none"
+                    stroke="#1865f2"
+                    stroke-width="3.5"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 3.5;"
+                  />
+                  <path
+                    d="M330,48L330,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M350,48L350,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M370,48L370,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M390,48L390,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M410,48L410,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                  <path
+                    d="M430,48L430,32"
+                    fill="none"
+                    stroke="#000000"
+                    stroke-width="2"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                  />
+                </svg>
+                <div
+                  style="position: absolute; left: 0px; top: 0px;"
+                >
+                  <div
+                    style="position: absolute; width: 34px; height: 34px; left: 13px; top: 23px; transform: translateX(0px) translateY(0px) translateZ(0);"
+                  >
+                    <svg
+                      height="34"
+                      style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      version="1.1"
+                      width="34"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <desc
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      >
+                        Created with Raphaël
+                      </desc>
+                      <defs
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0);"
+                      />
+                      <ellipse
+                        cx="NaN"
+                        cy="NaN"
+                        fill="#00a60e"
+                        r="NaN"
+                        rx="6"
+                        ry="6"
+                        stroke="#00a60e"
+                        stroke-width="1"
+                        style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1;"
+                        transform=""
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  style="position: absolute; left: 0px; top: 0px; z-index: 2;"
+                >
+                  <div
+                    data-interactive-kind-for-testing="movable-point"
+                    style="position: absolute; width: 48px; height: 48px; left: 6px; top: 16px; transform: translateX(0px) translateY(0px) translateZ(0);"
                   >
                     <svg
                       height="48"
@@ -661,70 +4042,7 @@ exports[`number-line widget should snapshot: first render 1`] = `
                 <span
                   class="graphie-label"
                   data-math-formula="-4"
-                  style="position: absolute; padding: 7px; color: rgb(24, 101, 242); left: 29.999999999999982px; top: 61.2px; fill: none;"
-                >
-                  <span
-                    class="tex-holder"
-                  />
-                </span>
-                <span
-                  class="graphie-label"
-                  data-math-formula="-3"
-                  style="position: absolute; padding: 7px; color: black; left: 79.99999999999999px; top: 61.2px; fill: none;"
-                >
-                  <span
-                    class="tex-holder"
-                  />
-                </span>
-                <span
-                  class="graphie-label"
-                  data-math-formula="-2"
-                  style="position: absolute; padding: 7px; color: black; left: 129.99999999999997px; top: 61.2px; fill: none;"
-                >
-                  <span
-                    class="tex-holder"
-                  />
-                </span>
-                <span
-                  class="graphie-label"
-                  data-math-formula="-1"
-                  style="position: absolute; padding: 7px; color: black; left: 179.99999999999997px; top: 61.2px; fill: none;"
-                >
-                  <span
-                    class="tex-holder"
-                  />
-                </span>
-                <span
-                  class="graphie-label"
-                  data-math-formula="0"
-                  style="position: absolute; padding: 7px; color: black; left: 229.99999999999997px; top: 61.2px; fill: none;"
-                >
-                  <span
-                    class="tex-holder"
-                  />
-                </span>
-                <span
-                  class="graphie-label"
-                  data-math-formula="1"
-                  style="position: absolute; padding: 7px; color: black; left: 280px; top: 61.2px; fill: none;"
-                >
-                  <span
-                    class="tex-holder"
-                  />
-                </span>
-                <span
-                  class="graphie-label"
-                  data-math-formula="2"
-                  style="position: absolute; padding: 7px; color: black; left: 330px; top: 61.2px; fill: none;"
-                >
-                  <span
-                    class="tex-holder"
-                  />
-                </span>
-                <span
-                  class="graphie-label"
-                  data-math-formula="3"
-                  style="position: absolute; padding: 7px; color: black; left: 380px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; color: rgb(24, 101, 242); left: 150px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -733,7 +4051,7 @@ exports[`number-line widget should snapshot: first render 1`] = `
                 <span
                   class="graphie-label"
                   data-math-formula="4"
-                  style="position: absolute; padding: 7px; color: rgb(24, 101, 242); left: 430px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; color: rgb(24, 101, 242); left: 310px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"

--- a/packages/perseus/src/widgets/number-line/__snapshots__/number-line.test.ts.snap
+++ b/packages/perseus/src/widgets/number-line/__snapshots__/number-line.test.ts.snap
@@ -154,9 +154,9 @@ exports[`number-line widget should snapshot on mobile: first mobile render 1`] =
                   <path
                     d="M29.999999999999993,48L29.999999999999993,32"
                     fill="none"
-                    stroke="#000000"
-                    stroke-width="2"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 2;"
+                    stroke="#1865f2"
+                    stroke-width="3.5"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 3.5;"
                   />
                   <path
                     d="M58.49999999999999,48L58.49999999999999,32"
@@ -206,20 +206,6 @@ exports[`number-line widget should snapshot on mobile: first mobile render 1`] =
                     stroke="#000000"
                     stroke-width="2"
                     style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 2;"
-                  />
-                  <path
-                    d="M258,48L258,32"
-                    fill="none"
-                    stroke="#000000"
-                    stroke-width="2"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 2;"
-                  />
-                  <path
-                    d="M29.999999999999993,48L29.999999999999993,32"
-                    fill="none"
-                    stroke="#1865f2"
-                    stroke-width="3.5"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); shape-rendering: crispEdges; stroke-width: 3.5;"
                   />
                   <path
                     d="M258,48L258,32"
@@ -540,9 +526,9 @@ exports[`number-line widget should snapshot: first render 1`] = `
                   <path
                     d="M29.999999999999982,48L29.999999999999982,32"
                     fill="none"
-                    stroke="#000000"
-                    stroke-width="2"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
+                    stroke="#1865f2"
+                    stroke-width="3.5"
+                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 3.5;"
                   />
                   <path
                     d="M79.99999999999999,48L79.99999999999999,32"
@@ -592,20 +578,6 @@ exports[`number-line widget should snapshot: first render 1`] = `
                     stroke="#000000"
                     stroke-width="2"
                     style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
-                  />
-                  <path
-                    d="M430,48L430,32"
-                    fill="none"
-                    stroke="#000000"
-                    stroke-width="2"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2;"
-                  />
-                  <path
-                    d="M29.999999999999982,48L29.999999999999982,32"
-                    fill="none"
-                    stroke="#1865f2"
-                    stroke-width="3.5"
-                    style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 3.5;"
                   />
                   <path
                     d="M430,48L430,32"

--- a/packages/perseus/src/widgets/number-line/number-line.test.ts
+++ b/packages/perseus/src/widgets/number-line/number-line.test.ts
@@ -4,7 +4,7 @@ import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
 import {renderQuestion} from "../__testutils__/renderQuestion";
 
-import {question1, snapshots} from "./number-line.testdata";
+import {question1} from "./number-line.testdata";
 
 import type {APIOptions} from "../../types";
 
@@ -21,18 +21,28 @@ describe("number-line widget", () => {
     });
 
     describe("snapshots", () => {
-        let originalOptions;
         let apiOptions: APIOptions;
+        const createNumberLineQuestionWithOptions = (widgetOptions) => {
+            return {
+                ...question1,
+                widgets: {
+                    ...question1.widgets,
+                    "number-line 1": {
+                        ...question1.widgets["number-line 1"],
+                        options: {
+                            ...question1.widgets["number-line 1"].options,
+                            range: [-10, 10],
+                            ...widgetOptions,
+                        },
+                    },
+                },
+            };
+        };
 
         beforeAll(() => {
-            originalOptions = snapshots.widgets["number-line 1"].options;
             apiOptions = {
                 isMobile: false,
             };
-        });
-
-        afterAll(() => {
-            snapshots.widgets["number-line 1"].options = originalOptions;
         });
 
         it("default", () => {
@@ -60,11 +70,12 @@ describe("number-line widget", () => {
 
         it(`only endpoints/labels show when "Show label ticks" is off`, () => {
             // Arrange - endpoints
-            let widgetOptions = {...originalOptions, labelTicks: false};
-            snapshots.widgets["number-line 1"].options = widgetOptions;
+            let question = createNumberLineQuestionWithOptions({
+                labelTicks: false,
+            });
 
             // Act
-            let {container} = renderQuestion(snapshots, apiOptions);
+            let {container} = renderQuestion(question, apiOptions);
 
             // Assert
             expect(container).toMatchSnapshot(
@@ -72,11 +83,13 @@ describe("number-line widget", () => {
             );
 
             // Arrange - labels
-            widgetOptions = {...widgetOptions, labelRange: [-4, 4]};
-            snapshots.widgets["number-line 1"].options = widgetOptions;
+            question = createNumberLineQuestionWithOptions({
+                labelTicks: false,
+                labelRange: [-4, 4],
+            });
 
             // Act
-            container = renderQuestion(snapshots, apiOptions).container;
+            container = renderQuestion(question, apiOptions).container;
 
             // Assert
             expect(container).toMatchSnapshot("show label ticks off (labels)");
@@ -84,15 +97,13 @@ describe("number-line widget", () => {
 
         it(`labels are highlighted when part of the tick step`, () => {
             // Arrange
-            const widgetOptions = {
-                ...originalOptions,
+            const question = createNumberLineQuestionWithOptions({
                 tickStep: 2,
                 labelRange: [-6, 6],
-            };
-            snapshots.widgets["number-line 1"].options = widgetOptions;
+            });
 
             // Act
-            const {container} = renderQuestion(snapshots, apiOptions);
+            const {container} = renderQuestion(question, apiOptions);
 
             // Assert
             expect(container).toMatchSnapshot("show highlighted labels");
@@ -100,15 +111,13 @@ describe("number-line widget", () => {
 
         it(`labels are inserted when NOT part of the tick step`, () => {
             // Arrange
-            const widgetOptions = {
-                ...originalOptions,
+            const question = createNumberLineQuestionWithOptions({
                 tickStep: 2,
                 labelRange: [-5, 5],
-            };
-            snapshots.widgets["number-line 1"].options = widgetOptions;
+            });
 
             // Act
-            const {container} = renderQuestion(snapshots, apiOptions);
+            const {container} = renderQuestion(question, apiOptions);
 
             // Assert
             expect(container).toMatchSnapshot("show inserted labels");
@@ -116,21 +125,23 @@ describe("number-line widget", () => {
 
         it(`endpoints are highlighted when labels are NOT indicated`, () => {
             // Arrange - right endpoint should highlight
-            let widgetOptions = {...originalOptions, labelRange: [-5, null]};
-            snapshots.widgets["number-line 1"].options = widgetOptions;
+            let question = createNumberLineQuestionWithOptions({
+                labelRange: [-5, null],
+            });
 
             // Act
-            let {container} = renderQuestion(snapshots, apiOptions);
+            let {container} = renderQuestion(question, apiOptions);
 
             // Assert
             expect(container).toMatchSnapshot("right endpoint highlighted");
 
             // Arrange - left endpoint should highlight
-            widgetOptions = {...originalOptions, labelRange: [null, 5]};
-            snapshots.widgets["number-line 1"].options = widgetOptions;
+            question = createNumberLineQuestionWithOptions({
+                labelRange: [null, 5],
+            });
 
             // Act
-            container = renderQuestion(snapshots, apiOptions).container;
+            container = renderQuestion(question, apiOptions).container;
 
             // Assert
             expect(container).toMatchSnapshot("left endpoint highlighted");
@@ -138,15 +149,13 @@ describe("number-line widget", () => {
 
         it(`all tick labels show when "Style" is "decimal ticks" (deprecated option)`, () => {
             // Arrange
-            const widgetOptions = {
-                ...originalOptions,
+            const question = createNumberLineQuestionWithOptions({
                 labelTicks: false,
                 labelStyle: "decimal ticks",
-            };
-            snapshots.widgets["number-line 1"].options = widgetOptions;
+            });
 
             // Act
-            const {container} = renderQuestion(snapshots, apiOptions);
+            const {container} = renderQuestion(question, apiOptions);
 
             // Assert
             expect(container).toMatchSnapshot("show decimal ticks");

--- a/packages/perseus/src/widgets/number-line/number-line.test.ts
+++ b/packages/perseus/src/widgets/number-line/number-line.test.ts
@@ -4,7 +4,7 @@ import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
 import {renderQuestion} from "../__testutils__/renderQuestion";
 
-import {question1} from "./number-line.testdata";
+import {question1, snapshots} from "./number-line.testdata";
 
 import type {APIOptions} from "../../types";
 
@@ -20,32 +20,137 @@ describe("number-line widget", () => {
         );
     });
 
-    it("should snapshot", () => {
-        // Arrange
-        const apiOptions: APIOptions = {
-            isMobile: false,
-        };
+    describe("snapshots", () => {
+        let originalOptions;
+        let apiOptions: APIOptions;
 
-        // Act
-        const {container} = renderQuestion(question1, apiOptions);
+        beforeAll(() => {
+            originalOptions = snapshots.widgets["number-line 1"].options;
+            apiOptions = {
+                isMobile: false,
+            };
+        });
 
-        // Assert
-        expect(container).toMatchSnapshot("first render");
-    });
+        afterAll(() => {
+            snapshots.widgets["number-line 1"].options = originalOptions;
+        });
 
-    it("should snapshot on mobile", () => {
-        // Arrange
-        jest.useRealTimers();
+        it("default", () => {
+            // Act
+            const {container} = renderQuestion(question1, apiOptions);
 
-        const apiOptions: APIOptions = {
-            isMobile: true,
-        };
+            // Assert
+            expect(container).toMatchSnapshot("first render");
+        });
 
-        // Act
-        const {container} = renderQuestion(question1, apiOptions);
+        it("mobile", () => {
+            // Arrange
+            jest.useRealTimers();
 
-        // Assert
-        expect(container).toMatchSnapshot("first mobile render");
+            const mobileApiOptions: APIOptions = {
+                isMobile: true,
+            };
+
+            // Act
+            const {container} = renderQuestion(question1, mobileApiOptions);
+
+            // Assert
+            expect(container).toMatchSnapshot("first mobile render");
+        });
+
+        it(`only endpoints/labels show when "Show label ticks" is off`, () => {
+            // Arrange - endpoints
+            let widgetOptions = {...originalOptions, labelTicks: false};
+            snapshots.widgets["number-line 1"].options = widgetOptions;
+
+            // Act
+            let {container} = renderQuestion(snapshots, apiOptions);
+
+            // Assert
+            expect(container).toMatchSnapshot(
+                "show label ticks off (endpoints)",
+            );
+
+            // Arrange - labels
+            widgetOptions = {...widgetOptions, labelRange: [-4, 4]};
+            snapshots.widgets["number-line 1"].options = widgetOptions;
+
+            // Act
+            container = renderQuestion(snapshots, apiOptions).container;
+
+            // Assert
+            expect(container).toMatchSnapshot("show label ticks off (labels)");
+        });
+
+        it(`labels are highlighted when part of the tick step`, () => {
+            // Arrange
+            const widgetOptions = {
+                ...originalOptions,
+                tickStep: 2,
+                labelRange: [-6, 6],
+            };
+            snapshots.widgets["number-line 1"].options = widgetOptions;
+
+            // Act
+            const {container} = renderQuestion(snapshots, apiOptions);
+
+            // Assert
+            expect(container).toMatchSnapshot("show highlighted labels");
+        });
+
+        it(`labels are inserted when NOT part of the tick step`, () => {
+            // Arrange
+            const widgetOptions = {
+                ...originalOptions,
+                tickStep: 2,
+                labelRange: [-5, 5],
+            };
+            snapshots.widgets["number-line 1"].options = widgetOptions;
+
+            // Act
+            const {container} = renderQuestion(snapshots, apiOptions);
+
+            // Assert
+            expect(container).toMatchSnapshot("show inserted labels");
+        });
+
+        it(`endpoints are highlighted when labels are NOT indicated`, () => {
+            // Arrange - right endpoint should highlight
+            let widgetOptions = {...originalOptions, labelRange: [-5, null]};
+            snapshots.widgets["number-line 1"].options = widgetOptions;
+
+            // Act
+            let {container} = renderQuestion(snapshots, apiOptions);
+
+            // Assert
+            expect(container).toMatchSnapshot("right endpoint highlighted");
+
+            // Arrange - left endpoint should highlight
+            widgetOptions = {...originalOptions, labelRange: [null, 5]};
+            snapshots.widgets["number-line 1"].options = widgetOptions;
+
+            // Act
+            container = renderQuestion(snapshots, apiOptions).container;
+
+            // Assert
+            expect(container).toMatchSnapshot("left endpoint highlighted");
+        });
+
+        it(`all tick labels show when "Style" is "decimal ticks" (deprecated option)`, () => {
+            // Arrange
+            const widgetOptions = {
+                ...originalOptions,
+                labelTicks: false,
+                labelStyle: "decimal ticks",
+            };
+            snapshots.widgets["number-line 1"].options = widgetOptions;
+
+            // Act
+            const {container} = renderQuestion(snapshots, apiOptions);
+
+            // Assert
+            expect(container).toMatchSnapshot("show decimal ticks");
+        });
     });
 
     it("can be answered correctly", () => {

--- a/packages/perseus/src/widgets/number-line/number-line.testdata.ts
+++ b/packages/perseus/src/widgets/number-line/number-line.testdata.ts
@@ -58,32 +58,3 @@ export const question2: PerseusRenderer = {
         },
     },
 };
-
-export const snapshots: PerseusRenderer = {
-    content:
-        "$E=2.5$\n\n**Move the dot to $-E$ on the number line.**\n\n\n[[\u2603 number-line 1]]",
-    images: {},
-    widgets: {
-        "number-line 1": {
-            graded: true,
-            version: {major: 0, minor: 0},
-            static: false,
-            type: "number-line",
-            options: {
-                labelRange: [null, null],
-                initialX: null,
-                tickStep: 1,
-                labelStyle: "decimal",
-                labelTicks: true,
-                snapDivisions: 2,
-                range: [-10, 10],
-                static: false,
-                correctRel: "eq",
-                numDivisions: null,
-                divisionRange: [1, 10],
-                correctX: -2.5,
-            },
-            alignment: "default",
-        },
-    },
-};

--- a/packages/perseus/src/widgets/number-line/number-line.testdata.ts
+++ b/packages/perseus/src/widgets/number-line/number-line.testdata.ts
@@ -58,3 +58,32 @@ export const question2: PerseusRenderer = {
         },
     },
 };
+
+export const snapshots: PerseusRenderer = {
+    content:
+        "$E=2.5$\n\n**Move the dot to $-E$ on the number line.**\n\n\n[[\u2603 number-line 1]]",
+    images: {},
+    widgets: {
+        "number-line 1": {
+            graded: true,
+            version: {major: 0, minor: 0},
+            static: false,
+            type: "number-line",
+            options: {
+                labelRange: [null, null],
+                initialX: null,
+                tickStep: 1,
+                labelStyle: "decimal",
+                labelTicks: true,
+                snapDivisions: 2,
+                range: [-10, 10],
+                static: false,
+                correctRel: "eq",
+                numDivisions: null,
+                divisionRange: [1, 10],
+                correctX: -2.5,
+            },
+            alignment: "default",
+        },
+    },
+};

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -124,7 +124,8 @@ const TickMarks: any = Graphie.createSimpleClass((graphie, props) => {
     const results: Array<any> = [];
 
     // For convenience, extract some props into separate variables
-    const {range, labelRange, labelStyle, labelTicks, tickStep} = props;
+    const {range, labelRange, labelStyle, labelTicks, tickStep, numDivisions} =
+        props;
     const leftLabel = labelRange[0] == null ? range[0] : labelRange[0];
     const rightLabel = labelRange[1] == null ? range[1] : labelRange[1];
 
@@ -132,7 +133,7 @@ const TickMarks: any = Graphie.createSimpleClass((graphie, props) => {
     let base;
     if (labelStyle === "non-reduced") {
         const fractions = [leftLabel, rightLabel];
-        for (let i = 0; i <= props.numDivisions; i++) {
+        for (let i = 0; i <= numDivisions; i++) {
             const x = range[0] + i * tickStep;
             fractions.push(x);
         }
@@ -143,34 +144,38 @@ const TickMarks: any = Graphie.createSimpleClass((graphie, props) => {
         base = undefined;
     }
 
-    const endpointLineStyle = {
+    const highlightedLineStyle = {
         stroke: KhanColors.BLUE,
         strokeWidth: 3.5,
     };
-    const endpointTextStyle = {color: KhanColors.BLUE};
+    const highlightedTextStyle = {color: KhanColors.BLUE};
 
     // Generate an array of tick numbers:
     //    `Array(props.numDivisions)` makes an array of null values - one for every division marker
     //    `.keys()` gets the index values for each marker placeholder
     //    `.map()` converts the index values into actual tick numbers
-    const initialTicks: number[] = [...Array(props.numDivisions).keys()].map(
+    const initialTicks: number[] = [...Array(numDivisions).keys()].map(
         (index) => range[0] + index * tickStep,
     );
+
+    // .sort() comparator
+    const byNumericAscending = (a: number, b: number) => a - b;
+
     // Ensure that any label markers and range endpoints are included in the array
     // Using `Set()` prevents duplication of tick numbers (and is quite performant)
     const allTicks: number[] = [
         ...new Set([...initialTicks, leftLabel, rightLabel, ...range]),
-    ].sort((current, next) => current - next);
+    ].sort(byNumericAscending);
 
     // Cycle through each tick number and add a tick line, and a label (if needed)
     allTicks.forEach((tick) => {
-        const tickHasLabel = tick === leftLabel || tick === rightLabel;
-        const lineStyle = tickHasLabel ? endpointLineStyle : null;
-        const textStyle = tickHasLabel ? endpointTextStyle : null;
+        const tickIsHighlighted = tick === leftLabel || tick === rightLabel;
+        const lineStyle = tickIsHighlighted ? highlightedLineStyle : null;
+        const textStyle = tickIsHighlighted ? highlightedTextStyle : null;
         graphie.style(lineStyle, () => {
             results.push(graphie.line([tick, -0.2], [tick, 0.2]));
         });
-        if (labelTicks || tickHasLabel || labelStyle === "decimal ticks") {
+        if (labelTicks || tickIsHighlighted || labelStyle === "decimal ticks") {
             graphie.style(textStyle, () => {
                 results.push(_label(graphie, labelStyle, tick, tick, base));
             });

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -124,17 +124,16 @@ const TickMarks: any = Graphie.createSimpleClass((graphie, props) => {
     const results: Array<any> = [];
 
     // For convenience, extract some props into separate variables
-    const range = props.range;
-    const labelRange = props.labelRange;
+    const {range, labelRange, labelStyle, labelTicks, tickStep} = props;
     const leftLabel = labelRange[0] == null ? range[0] : labelRange[0];
     const rightLabel = labelRange[1] == null ? range[1] : labelRange[1];
 
     // Find base via GCD for non-reduced fractions
     let base;
-    if (props.labelStyle === "non-reduced") {
+    if (labelStyle === "non-reduced") {
         const fractions = [leftLabel, rightLabel];
         for (let i = 0; i <= props.numDivisions; i++) {
-            const x = range[0] + i * props.tickStep;
+            const x = range[0] + i * tickStep;
             fractions.push(x);
         }
         const getDenom = (x: any) => knumber.toFraction(x)[1];
@@ -144,36 +143,39 @@ const TickMarks: any = Graphie.createSimpleClass((graphie, props) => {
         base = undefined;
     }
 
-    // Draw and save the tick marks and tick labels
-    for (let i = 0; i <= props.numDivisions; i++) {
-        const x = range[0] + i * props.tickStep;
-        results.push(graphie.line([x, -0.2], [x, 0.2]));
+    const endpointLineStyle = {
+        stroke: KhanColors.BLUE,
+        strokeWidth: 3.5,
+    };
+    const endpointTextStyle = {color: KhanColors.BLUE};
 
-        const labelTicks = props.labelTicks;
-        if (labelTicks || props.labelStyle === "decimal ticks") {
-            if (x === leftLabel || x === rightLabel) {
-                results.push(
-                    graphie.style({color: KhanColors.BLUE}, () =>
-                        _label(graphie, props.labelStyle, x, x, base),
-                    ),
-                );
-            } else {
-                results.push(_label(graphie, props.labelStyle, x, x, base));
-            }
-        }
-    }
-
-    // Render the labels' lines
-    graphie.style(
-        {
-            stroke: KhanColors.BLUE,
-            strokeWidth: 3.5,
-        },
-        () => {
-            results.push(graphie.line([leftLabel, -0.2], [leftLabel, 0.2]));
-            results.push(graphie.line([rightLabel, -0.2], [rightLabel, 0.2]));
-        },
+    // Generate an array of tick numbers:
+    //    `Array(props.numDivisions)` makes an array of null values - one for every division marker
+    //    `.keys()` gets the index values for each marker placeholder
+    //    `.map()` converts the index values into actual tick numbers
+    const initialTicks: number[] = [...Array(props.numDivisions).keys()].map(
+        (index) => range[0] + index * tickStep,
     );
+    // Ensure that any label markers and range endpoints are included in the array
+    // Using `Set()` prevents duplication of tick numbers (and is quite performant)
+    const allTicks: number[] = [
+        ...new Set([...initialTicks, leftLabel, rightLabel, ...range]),
+    ];
+
+    // Cycle through each tick number and add a tick line, and a label (if needed)
+    allTicks.forEach((tick) => {
+        const tickIsEndpoint = tick === leftLabel || tick === rightLabel;
+        const lineStyle = tickIsEndpoint ? endpointLineStyle : null;
+        const textStyle = tickIsEndpoint ? endpointTextStyle : null;
+        graphie.style(lineStyle, () => {
+            results.push(graphie.line([tick, -0.2], [tick, 0.2]));
+        });
+        if (labelTicks || tickIsEndpoint || labelStyle === "decimal ticks") {
+            graphie.style(textStyle, () => {
+                results.push(_label(graphie, labelStyle, tick, tick, base));
+            });
+        }
+    });
 
     return results;
 });

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -160,7 +160,7 @@ const TickMarks: any = Graphie.createSimpleClass((graphie, props) => {
     // Using `Set()` prevents duplication of tick numbers (and is quite performant)
     const allTicks: number[] = [
         ...new Set([...initialTicks, leftLabel, rightLabel, ...range]),
-    ];
+    ].sort((current, next) => current - next);
 
     // Cycle through each tick number and add a tick line, and a label (if needed)
     allTicks.forEach((tick) => {

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -164,13 +164,13 @@ const TickMarks: any = Graphie.createSimpleClass((graphie, props) => {
 
     // Cycle through each tick number and add a tick line, and a label (if needed)
     allTicks.forEach((tick) => {
-        const tickIsEndpoint = tick === leftLabel || tick === rightLabel;
-        const lineStyle = tickIsEndpoint ? endpointLineStyle : null;
-        const textStyle = tickIsEndpoint ? endpointTextStyle : null;
+        const tickHasLabel = tick === leftLabel || tick === rightLabel;
+        const lineStyle = tickHasLabel ? endpointLineStyle : null;
+        const textStyle = tickHasLabel ? endpointTextStyle : null;
         graphie.style(lineStyle, () => {
             results.push(graphie.line([tick, -0.2], [tick, 0.2]));
         });
-        if (labelTicks || tickIsEndpoint || labelStyle === "decimal ticks") {
+        if (labelTicks || tickHasLabel || labelStyle === "decimal ticks") {
             graphie.style(textStyle, () => {
                 results.push(_label(graphie, labelStyle, tick, tick, base));
             });


### PR DESCRIPTION
## Summary:
A regression was introduced during the last bugfix ([PR 1695](https://github.com/Khan/perseus/pull/1695)) that caused the tick labels to not show for endpoints when the "Show label ticks" options is deselected. This PR fixes that regression by refactoring how the ticks and their labels are generated.

Issue: LEMS-2532

## Test plan:

1. Launch Storybook
1. Review the [Editor Demo](http://localhost:6006/?path=/story/perseuseditor-editorpage--demo) page
1. Add a Number line widget
   * A number line should show with the default 0 - 10 scale
   * Tick marks and labels are provided in steps of 2 (i.e. 0, 2, 4...)
1. Toggle the "Show label ticks" checkbox off
   * All the labels should now be removed except for the endpoints of zero (0) and ten (10)
1. Enter label values that are different than the endpoints
   * For instance, adding one (1) and seven (7)
   * The endpoint labels are now no longer showing
   * Instead, the newly specified labelled points are showing, along with their associated ticks

## Affected behavior:
### No labels specified
#### Before
![Endpoints - Before](https://github.com/user-attachments/assets/1e51c01a-b764-48dc-8f8d-143dcd8adddd)

#### After
![Endpoints - After](https://github.com/user-attachments/assets/47cbe1b7-834f-4a25-aa85-7375aaed75ae)

### Labels specified
#### Before
![Labels - Before](https://github.com/user-attachments/assets/05461418-4e0a-4fe9-b196-98582358b181)

#### After
![Labels - After](https://github.com/user-attachments/assets/59a676c0-ea05-4716-aa82-edbc25bb59bb)
