### PR TITLE
Refine Label Image Rubric type

### DIFF
--- a/.changeset/red-points-call.md
+++ b/.changeset/red-points-call.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Refine LabelImage's Rubric type

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -12,7 +12,6 @@ import type {
     PerseusImageWidgetOptions,
     PerseusInputNumberWidgetOptions,
     PerseusInteractionWidgetOptions,
-    PerseusLabelImageWidgetOptions,
     PerseusMatcherWidgetOptions,
     PerseusMatrixWidgetOptions,
     PerseusNumberLineWidgetOptions,
@@ -111,7 +110,9 @@ export type PerseusInteractiveGraphRubric = {
 
 export type PerseusInteractiveGraphUserInput = PerseusGraphType;
 
-export type PerseusLabelImageRubric = PerseusLabelImageWidgetOptions;
+/* TODO(LEMS-2440): Should be removed or refactored. Grading info may need
+    to be moved to the rubric from userInput (mark. */
+export type PerseusLabelImageRubric = Empty;
 
 export type PerseusLabelImageUserInput = {
     markers: ReadonlyArray<InteractiveMarkerType>;

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -124,7 +124,7 @@ export type PerseusInteractiveGraphRubric = {
 export type PerseusInteractiveGraphUserInput = PerseusGraphType;
 
 /* TODO(LEMS-2440): Should be removed or refactored. Grading info may need
-    to be moved to the rubric from userInput (mark. */
+    to be moved to the rubric from userInput. */
 export type PerseusLabelImageRubric = Empty;
 
 export type PerseusLabelImageUserInput = {

--- a/packages/perseus/src/widgets/label-image/label-image-validator.ts
+++ b/packages/perseus/src/widgets/label-image/label-image-validator.ts
@@ -43,7 +43,7 @@ export function scoreMarker(
     return score;
 }
 
-// TODO(LEMS-2440): Can possibly remove rubric parameter during 2440?
+// TODO(LEMS-2440): May need to pull answers out of PerseusLabelImageWidgetOptions[markers] for the rubric
 function labelImageValidator(
     userInput: PerseusLabelImageUserInput,
     rubric?: PerseusLabelImageRubric,

--- a/packages/perseus/src/widgets/label-image/label-image-validator.ts
+++ b/packages/perseus/src/widgets/label-image/label-image-validator.ts
@@ -43,14 +43,15 @@ export function scoreMarker(
     return score;
 }
 
+// TODO(LEMS-2440): Can possibly remove rubric parameter during 2440?
 function labelImageValidator(
-    state: PerseusLabelImageUserInput,
+    userInput: PerseusLabelImageUserInput,
     rubric?: PerseusLabelImageRubric,
 ): PerseusScore {
     let numAnswered = 0;
     let numCorrect = 0;
 
-    for (const marker of state.markers) {
+    for (const marker of userInput.markers) {
         const score = scoreMarker(marker);
 
         if (score.hasAnswers) {
@@ -63,7 +64,7 @@ function labelImageValidator(
     }
 
     // We expect all question markers to be answered before grading.
-    if (numAnswered !== state.markers.length) {
+    if (numAnswered !== userInput.markers.length) {
         return {
             type: "invalid",
             message: null,
@@ -74,7 +75,7 @@ function labelImageValidator(
         type: "points",
         // Markers with no expected answers are graded as correct if user
         // makes no answer selection.
-        earned: numCorrect === state.markers.length ? 1 : 0,
+        earned: numCorrect === userInput.markers.length ? 1 : 0,
         total: 1,
         message: null,
     };

--- a/packages/perseus/src/widgets/label-image/label-image.tsx
+++ b/packages/perseus/src/widgets/label-image/label-image.tsx
@@ -320,7 +320,7 @@ export class LabelImage
         return {markers};
     }
 
-    // TODO(LEMS-2440): Can possibly remove rubric parameter during 2440? Or refactor
+    // TODO(LEMS-2544): Investigate impact on scoring; possibly pull out &/or remove rubric parameter.
     showRationalesForCurrentlySelectedChoices(rubric: PerseusLabelImageRubric) {
         const {markers} = this.props;
         const {onChange} = this.props;

--- a/packages/perseus/src/widgets/label-image/label-image.tsx
+++ b/packages/perseus/src/widgets/label-image/label-image.tsx
@@ -30,7 +30,10 @@ import type {InteractiveMarkerType} from "./types";
 import type {DependencyProps} from "../../dependencies";
 import type {ChangeableProps} from "../../mixins/changeable";
 import type {APIOptions, Widget, WidgetExports} from "../../types";
-import type {PerseusLabelImageUserInput} from "../../validation.types";
+import type {
+    PerseusLabelImageRubric,
+    PerseusLabelImageUserInput,
+} from "../../validation.types";
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 import type {CSSProperties} from "aphrodite";
 
@@ -317,7 +320,8 @@ export class LabelImage
         return {markers};
     }
 
-    showRationalesForCurrentlySelectedChoices(rubric: LabelImageProps) {
+    // TODO(LEMS-2440): Can possibly remove rubric parameter during 2440? Or refactor
+    showRationalesForCurrentlySelectedChoices(rubric: PerseusLabelImageRubric) {
         const {markers} = this.props;
         const {onChange} = this.props;
 


### PR DESCRIPTION
## Summary:
As part of the Server Side Scoring project, this refactors Label Image's Rubric type based on current usage. It is not currently used in this widget. As we plan to review the use of rubric during LEMS-2440, the Rubric type was left in but changed to `Empty`. It was also added in one place where rubric was listed as a parameter (but was not in use).

Issue: LEMS-2468

## Test plan:
- Confirm all tests pass
- Confirm the label image widget still works in Storybook