### PR TITLE
Knip 5: consolidate Mathquill Field types

### DIFF
--- a/.changeset/tricky-wasps-hug.md
+++ b/.changeset/tricky-wasps-hug.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Consolidate MathFieldActionTypes

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -21,6 +21,8 @@ const config: KnipConfig = {
         // dev tools
         "wallaby.js",
         "data/find-questions.ts",
+        // there seems to be a bug with the knip Jest plugin?
+        "jest.config.js",
     ],
 };
 

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,5 +1,11 @@
 import type {KnipConfig} from "knip";
 
+/**
+ * knip is a tool for discovering dead code:
+ * https://knip.dev/
+ *
+ * To use: `yarn knip`
+ */
 const config: KnipConfig = {
     entry: [
         "{index,main,cli}.{js,cjs,mjs,jsx,ts,cts,mts,tsx}",
@@ -25,6 +31,9 @@ const config: KnipConfig = {
         "data/find-questions.ts",
         // there seems to be a bug with the knip Jest plugin?
         "jest.config.js",
+        // this file causes side-effects by importing it
+        // so it's not "used" in the conventional sense
+        "packages/perseus/src/util/interactive.ts",
     ],
 };
 

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,21 +1,11 @@
 import type {KnipConfig} from "knip";
 
-const base: KnipConfig = {
-    entry: [
-        "{index,main,cli}.{js,cjs,mjs,jsx,ts,cts,mts,tsx}",
-        "src/{index,main,cli}.{js,cjs,mjs,jsx,ts,cts,mts,tsx}",
-    ],
-    project: ["**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}"],
-};
-
 const config: KnipConfig = {
     entry: [
-        // default
         "{index,main,cli}.{js,cjs,mjs,jsx,ts,cts,mts,tsx}",
         "src/{index,main,cli}.{js,cjs,mjs,jsx,ts,cts,mts,tsx}",
     ],
     project: [
-        // default
         "**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}",
         // dev tools
         "!utils/**",
@@ -34,5 +24,4 @@ const config: KnipConfig = {
     ],
 };
 
-// export default config;
-export default base;
+export default config;

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -9,6 +9,8 @@ const config: KnipConfig = {
         "**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}",
         // dev tools
         "!utils/**",
+        // there seems to be a bug with the knip Jest plugin?
+        "!config/test/**",
     ],
     ignore: [
         // symlinked type defs for third-party libs

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,0 +1,38 @@
+import type {KnipConfig} from "knip";
+
+const base: KnipConfig = {
+    entry: [
+        "{index,main,cli}.{js,cjs,mjs,jsx,ts,cts,mts,tsx}",
+        "src/{index,main,cli}.{js,cjs,mjs,jsx,ts,cts,mts,tsx}",
+    ],
+    project: ["**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}"],
+};
+
+const config: KnipConfig = {
+    entry: [
+        // default
+        "{index,main,cli}.{js,cjs,mjs,jsx,ts,cts,mts,tsx}",
+        "src/{index,main,cli}.{js,cjs,mjs,jsx,ts,cts,mts,tsx}",
+    ],
+    project: [
+        // default
+        "**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}",
+        // dev tools
+        "!utils/**",
+    ],
+    ignore: [
+        // symlinked type defs for third-party libs
+        "**/aphrodite.d.ts",
+        "**/assets.d.ts",
+        "**/hubble.d.ts",
+        "**/jsdiff.d.ts",
+        "**/raphael.d.ts",
+        "**/utility.d.ts",
+        // dev tools
+        "wallaby.js",
+        "data/find-questions.ts",
+    ],
+};
+
+// export default config;
+export default base;

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
         "jest-environment-jsdom": "^29.7.0",
         "jest-serializer-html": "^7.1.0",
         "jest-specific-snapshot": "^5.0.0",
+        "knip": "^5.33.3",
         "less": "^4.2.0",
         "less-loader": "^11.1.3",
         "nyc": "^15.1.0",
@@ -146,7 +147,8 @@
         "cypress": "cypress open --component",
         "cypress:ci": "cross-env cypress run --component",
         "format": "prettier --write .",
-        "typecheck": "tsc"
+        "typecheck": "tsc",
+        "knip": "knip --config knip.config.ts"
     },
     "nyc": {
         "report-dir": "coverage/cypress/"

--- a/packages/math-input/src/components/input/mathquill-helpers.ts
+++ b/packages/math-input/src/components/input/mathquill-helpers.ts
@@ -1,6 +1,7 @@
+import {MathFieldActionType} from "../../types";
+
 import {CursorContext} from "./cursor-contexts";
 import {mathQuillInstance} from "./mathquill-instance";
-import {MathFieldActionType} from "./mathquill-types";
 
 import type {MathFieldInterface} from "./mathquill-types";
 

--- a/packages/math-input/src/components/input/mathquill-types.ts
+++ b/packages/math-input/src/components/input/mathquill-types.ts
@@ -15,13 +15,6 @@ export type MathFieldInterface = MathQuill.v3.EditableMathQuill & {
     controller: () => MathQuill.Controller;
 };
 
-export enum MathFieldActionType {
-    WRITE = "write",
-    CMD = "cmd",
-    KEYSTROKE = "keystroke",
-    MQ_END = 0,
-}
-
 export type MathFieldUpdaterCallback = (
     mathField: MathFieldInterface,
     key: Key,

--- a/packages/math-input/src/components/key-handlers/handle-arrow.ts
+++ b/packages/math-input/src/components/key-handlers/handle-arrow.ts
@@ -1,9 +1,9 @@
+import {MathFieldActionType} from "../../types";
 import {
     maybeFindCommand,
     maybeFindCommandBeforeParens,
 } from "../input/mathquill-helpers";
 import {mathQuillInstance} from "../input/mathquill-instance";
-import {MathFieldActionType} from "../input/mathquill-types";
 
 import type Key from "../../data/keys";
 import type {MathFieldInterface} from "../input/mathquill-types";

--- a/packages/math-input/src/components/key-handlers/handle-backspace.ts
+++ b/packages/math-input/src/components/key-handlers/handle-backspace.ts
@@ -1,3 +1,4 @@
+import {MathFieldActionType} from "../../types";
 import {
     isFraction,
     isSquareRoot,
@@ -9,7 +10,6 @@ import {
     maybeFindCommandBeforeParens,
 } from "../input/mathquill-helpers";
 import {mathQuillInstance} from "../input/mathquill-instance";
-import {MathFieldActionType} from "../input/mathquill-types";
 
 import type {MathFieldInterface} from "../input/mathquill-types";
 import type MathQuill from "mathquill";

--- a/packages/math-input/src/components/key-handlers/handle-exponent.ts
+++ b/packages/math-input/src/components/key-handlers/handle-exponent.ts
@@ -1,5 +1,5 @@
+import {MathFieldActionType} from "../../types";
 import {mathQuillInstance} from "../input/mathquill-instance";
-import {MathFieldActionType} from "../input/mathquill-types";
 
 import type Key from "../../data/keys";
 import type {MathFieldInterface} from "../input/mathquill-types";

--- a/packages/math-input/src/components/key-handlers/handle-jump-out.ts
+++ b/packages/math-input/src/components/key-handlers/handle-jump-out.ts
@@ -1,3 +1,4 @@
+import {MathFieldActionType} from "../../types";
 import {CursorContext} from "../input/cursor-contexts";
 import {
     isFraction,
@@ -5,7 +6,6 @@ import {
     getCursorContext,
 } from "../input/mathquill-helpers";
 import {mathQuillInstance} from "../input/mathquill-instance";
-import {MathFieldActionType} from "../input/mathquill-types";
 
 import type Key from "../../data/keys";
 import type {MathFieldInterface} from "../input/mathquill-types";

--- a/packages/math-input/src/components/key-handlers/key-translator.ts
+++ b/packages/math-input/src/components/key-handlers/key-translator.ts
@@ -1,3 +1,4 @@
+import {MathFieldActionType} from "../../types";
 import {getDecimalSeparator} from "../../utils";
 import {mathQuillInstance} from "../input/mathquill-instance";
 
@@ -11,28 +12,21 @@ import type {
     MathFieldUpdaterCallback,
 } from "../input/mathquill-types";
 
-enum ActionType {
-    WRITE = "write",
-    CMD = "cmd",
-    KEYSTROKE = "keystroke",
-    MQ_END = 0,
-}
-
 function buildGenericCallback(
     str: string,
-    type: ActionType = ActionType.WRITE,
+    type: MathFieldActionType = MathFieldActionType.WRITE,
 ): MathFieldUpdaterCallback {
     return function (mathQuill: MathFieldInterface) {
         switch (type) {
-            case ActionType.WRITE: {
+            case MathFieldActionType.WRITE: {
                 mathQuill.write(str);
                 return;
             }
-            case ActionType.CMD: {
+            case MathFieldActionType.CMD: {
                 mathQuill.cmd(str);
                 return;
             }
-            case ActionType.KEYSTROKE: {
+            case MathFieldActionType.KEYSTROKE: {
                 mathQuill.keystroke(str);
                 return;
             }
@@ -120,18 +114,18 @@ export const getKeyTranslator = (
 
     // The `FRAC_EXCLUSIVE` variant is handled manually, since we may need to do
     // some additional navigation depending on the cursor position.
-    FRAC_INCLUSIVE: buildGenericCallback("/", ActionType.CMD),
-    FRAC: buildGenericCallback("\\frac", ActionType.CMD),
-    LEFT_PAREN: buildGenericCallback("(", ActionType.CMD),
-    RIGHT_PAREN: buildGenericCallback(")", ActionType.CMD),
-    SQRT: buildGenericCallback("sqrt", ActionType.CMD),
-    PI: buildGenericCallback("pi", ActionType.CMD),
-    THETA: buildGenericCallback("theta", ActionType.CMD),
-    RADICAL: buildGenericCallback("nthroot", ActionType.CMD),
+    FRAC_INCLUSIVE: buildGenericCallback("/", MathFieldActionType.CMD),
+    FRAC: buildGenericCallback("\\frac", MathFieldActionType.CMD),
+    LEFT_PAREN: buildGenericCallback("(", MathFieldActionType.CMD),
+    RIGHT_PAREN: buildGenericCallback(")", MathFieldActionType.CMD),
+    SQRT: buildGenericCallback("sqrt", MathFieldActionType.CMD),
+    PI: buildGenericCallback("pi", MathFieldActionType.CMD),
+    THETA: buildGenericCallback("theta", MathFieldActionType.CMD),
+    RADICAL: buildGenericCallback("nthroot", MathFieldActionType.CMD),
 
-    BACKSPACE: buildGenericCallback("Backspace", ActionType.KEYSTROKE),
-    UP: buildGenericCallback("Up", ActionType.KEYSTROKE),
-    DOWN: buildGenericCallback("Down", ActionType.KEYSTROKE),
+    BACKSPACE: buildGenericCallback("Backspace", MathFieldActionType.KEYSTROKE),
+    UP: buildGenericCallback("Up", MathFieldActionType.KEYSTROKE),
+    DOWN: buildGenericCallback("Down", MathFieldActionType.KEYSTROKE),
 
     CUBE_ROOT: (mathQuill) => {
         mathQuill.write("\\sqrt[3]{}");
@@ -143,7 +137,7 @@ export const getKeyTranslator = (
         // If there's nothing to the left of the cursor, then we want to
         // leave the cursor to the left of the fraction after creating it.
         const shouldNavigateLeft =
-            cursor[mathQuillInstance.L] === ActionType.MQ_END;
+            cursor[mathQuillInstance.L] === MathFieldActionType.MQ_END;
         mathQuill.cmd("\\frac");
         if (shouldNavigateLeft) {
             mathQuill.keystroke("Left");

--- a/packages/math-input/src/types.ts
+++ b/packages/math-input/src/types.ts
@@ -5,6 +5,13 @@ import type {KeypadContextRendererInterface} from "@khanacademy/perseus-core";
 import type * as React from "react";
 import type ReactDOM from "react-dom";
 
+export enum MathFieldActionType {
+    WRITE = "write",
+    CMD = "cmd",
+    KEYSTROKE = "keystroke",
+    MQ_END = 0,
+}
+
 export type IconConfig = {
     data: string;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2935,7 +2935,7 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
 
-"@nodelib/fs.walk@^1.2.3", "@nodelib/fs.walk@^1.2.8":
+"@nodelib/fs.walk@1.2.8", "@nodelib/fs.walk@^1.2.3", "@nodelib/fs.walk@^1.2.8":
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
   integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
@@ -3488,6 +3488,15 @@
   integrity sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==
   dependencies:
     "@sinonjs/commons" "^2.0.0"
+
+"@snyk/github-codeowners@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@snyk/github-codeowners/-/github-codeowners-1.1.0.tgz#45b99732c3c38b5f5b47e43d2b0c9db67a6d2bcc"
+  integrity sha512-lGFf08pbkEac0NYgVf4hdANpAgApRjNByLXB+WBip3qj1iendOIyAwP2GKkKbQMNVy2r1xxDf0ssfWscoiC+Vw==
+  dependencies:
+    commander "^4.1.1"
+    ignore "^5.1.8"
+    p-map "^4.0.0"
 
 "@stardust-ui/react-component-event-listener@~0.38.0":
   version "0.38.0"
@@ -6481,7 +6490,7 @@ commander@^2.19.0, commander@^2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^4.0.1:
+commander@^4.0.1, commander@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
@@ -7442,6 +7451,15 @@ eastasianwidth@^0.2.0:
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
+easy-table@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/easy-table/-/easy-table-1.2.0.tgz#ba9225d7138fee307bfd4f0b5bc3c04bdc7c54eb"
+  integrity sha512-OFzVOv03YpvtcWGe5AayU5G2hgybsg3iqA6drU8UaoZyB9jLGMTrz9+asnLp/E+6qPh88yEI1gvyZFZ41dmgww==
+  dependencies:
+    ansi-regex "^5.0.1"
+  optionalDependencies:
+    wcwidth "^1.0.1"
+
 ebnf-parser@0.1.10:
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/ebnf-parser/-/ebnf-parser-0.1.10.tgz#cd1f6ba477c5638c40c97ed9b572db5bab5d8331"
@@ -7525,6 +7543,14 @@ enhanced-resolve@^5.12.0:
   version "5.15.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz#1af946c7d93603eb88e9896cee4904dc012e9c35"
   integrity sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
+
+enhanced-resolve@^5.17.1:
+  version "5.17.1"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz#67bfbbcc2f81d511be77d686a90267ef7f898a15"
+  integrity sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
@@ -8625,7 +8651,7 @@ fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-glob@^3.3.1:
+fast-glob@^3.3.1, fast-glob@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
   integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
@@ -9728,6 +9754,11 @@ ignore@^5.0.5:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
+
+ignore@^5.1.8:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
+  integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
 ignore@^5.2.0:
   version "5.2.4"
@@ -11099,6 +11130,11 @@ jison@0.4.15:
     lex-parser "~0.1.3"
     nomnom "1.5.2"
 
+jiti@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.3.3.tgz#39c66fc77476b92a694e65dfe04b294070e2e096"
+  integrity sha512-EX4oNDwcXSivPrw2qKH2LB5PoFxEvgtv2JgwW0bU858HoLQ+kutSvjLMUqBd0PeJYEinLWhoI9Ol0eYMqj/wNQ==
+
 jquery@^2.1.1:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.2.4.tgz#2c89d6889b5eac522a7eea32c14521559c6cbf02"
@@ -11380,6 +11416,28 @@ kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
+
+knip@^5.33.3:
+  version "5.33.3"
+  resolved "https://registry.yarnpkg.com/knip/-/knip-5.33.3.tgz#0a007e9927117958acf2ccfaca0f76f3fed801e2"
+  integrity sha512-saUxedVDCa/8p3w445at66vLmYKretzYsX7+elMJ5ROWGzU+1aTRm3EmKELTaho1ue7BlwJB5BxLJROy43+LtQ==
+  dependencies:
+    "@nodelib/fs.walk" "1.2.8"
+    "@snyk/github-codeowners" "1.1.0"
+    easy-table "1.2.0"
+    enhanced-resolve "^5.17.1"
+    fast-glob "^3.3.2"
+    jiti "^2.3.3"
+    js-yaml "^4.1.0"
+    minimist "^1.2.8"
+    picocolors "^1.0.0"
+    picomatch "^4.0.1"
+    pretty-ms "^9.0.0"
+    smol-toml "^1.3.0"
+    strip-json-comments "5.0.1"
+    summary "2.1.0"
+    zod "^3.22.4"
+    zod-validation-error "^3.0.3"
 
 kuler@^2.0.0:
   version "2.0.0"
@@ -12837,6 +12895,11 @@ parse-json@^5.0.0, parse-json@^5.2.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parse-ms@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-4.0.0.tgz#c0c058edd47c2a590151a718990533fd62803df4"
+  integrity sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==
+
 parse-node-version@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parse-node-version/-/parse-node-version-1.0.1.tgz#e2b5dbede00e7fa9bc363607f53327e8b073189b"
@@ -12974,6 +13037,11 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.2.3, picomatc
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+picomatch@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
+  integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
 
 pify@^2.2.0:
   version "2.3.0"
@@ -13414,6 +13482,13 @@ pretty-hrtime@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==
+
+pretty-ms@^9.0.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-9.1.0.tgz#0ad44de6086454f48a168e5abb3c26f8db1b3253"
+  integrity sha512-o1piW0n3tgKIKCwk2vpM/vOV13zjJzvP37Ioze54YlTHE06m4tjEbzg9WsKkvTuyYln2DHjo5pY4qrZGI0otpw==
+  dependencies:
+    parse-ms "^4.0.0"
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -14781,6 +14856,11 @@ smartwrap@^1.2.3:
     wcwidth "^1.0.1"
     yargs "^15.1.0"
 
+smol-toml@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/smol-toml/-/smol-toml-1.3.0.tgz#5200e251fffadbb72570c84e9776d2a3eca48143"
+  integrity sha512-tWpi2TsODPScmi48b/OQZGi2lgUmBCHy6SZrhi/FdnnHiU1GwebbCfuQuxsC3nHaLwtYeJGPrDZDIeodDOc4pA==
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -15078,7 +15158,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -15095,15 +15175,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -15189,7 +15260,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15202,13 +15273,6 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -15251,6 +15315,11 @@ strip-indent@^4.0.0:
   dependencies:
     min-indent "^1.0.1"
 
+strip-json-comments@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-5.0.1.tgz#0d8b7d01b23848ed7dbdf4baaaa31a8250d8cfa0"
+  integrity sha512-0fk9zBqO67Nq5M/m45qHCJxylV/DhBlIOVExqgOMiCCrzrhU6tCibRXNqE3jwJLftzE9SNuZtYbpzcO+i9FiKw==
+
 strip-json-comments@^3.0.1, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
@@ -15268,6 +15337,11 @@ stylehacks@^5.1.0:
   dependencies:
     browserslist "^4.16.6"
     postcss-selector-parser "^6.0.4"
+
+summary@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/summary/-/summary-2.1.0.tgz#be8a49a0aa34eb6ceea56042cae88f8add4b0885"
+  integrity sha512-nMIjMrd5Z2nuB2RZCKJfFMjgS3fygbeyGk9PxPPaJR1RIcyN9yn4A63Isovzm3ZtQuEkLBVgMdPup8UeLH7aQw==
 
 supports-color@^5.3.0:
   version "5.5.0"
@@ -16428,7 +16502,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -16441,15 +16515,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -16623,3 +16688,13 @@ yocto-queue@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
+
+zod-validation-error@^3.0.3:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/zod-validation-error/-/zod-validation-error-3.4.0.tgz#3a8a1f55c65579822d7faa190b51336c61bee2a6"
+  integrity sha512-ZOPR9SVY6Pb2qqO5XHt+MkkTRxGXb4EVtnjc9JpXUOtUB1T9Ru7mZOT361AN3MsetVe7R0a1KZshJDZdgp9miQ==
+
+zod@^3.22.4:
+  version "3.23.8"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.8.tgz#e37b957b5d52079769fb8097099b592f0ef4067d"
+  integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==


### PR DESCRIPTION
## Summary:
Knip detected some of these unused enums, which helped me realize there was a duplicate type declaration; so I was able to consolidate them into one type.