### PR TITLE
Check if process exists before accessing it

### DIFF
--- a/.changeset/polite-pigs-look.md
+++ b/.changeset/polite-pigs-look.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/math-input": patch
+"@khanacademy/perseus": patch
+---
+
+Check for process before accessing properties on it

--- a/packages/math-input/src/components/i18n-context.tsx
+++ b/packages/math-input/src/components/i18n-context.tsx
@@ -15,14 +15,11 @@ type I18nContextType = {
     locale: string;
 };
 
-const shouldMockStrings: boolean = Boolean(
-    process?.env?.NODE_ENV === "test" || process?.env?.STORYBOOK,
-);
-
 // @ts-expect-error - TS2322 - Type 'Context<{ strings: {}; locale: string; }>' is not assignable to type 'Context<I18nContextType>'.
 export const MathInputI18nContext: React.Context<I18nContextType> =
     React.createContext(
-        shouldMockStrings
+        typeof process !== "undefined" &&
+            (process.env.NODE_ENV === "test" || process.env.STORYBOOK)
             ? {
                   strings: mockStrings,
                   locale: "en",

--- a/packages/math-input/src/components/i18n-context.tsx
+++ b/packages/math-input/src/components/i18n-context.tsx
@@ -15,10 +15,14 @@ type I18nContextType = {
     locale: string;
 };
 
+const shouldMockStrings: boolean = Boolean(
+    process?.env?.NODE_ENV === "test" || process?.env?.STORYBOOK,
+);
+
 // @ts-expect-error - TS2322 - Type 'Context<{ strings: {}; locale: string; }>' is not assignable to type 'Context<I18nContextType>'.
 export const MathInputI18nContext: React.Context<I18nContextType> =
     React.createContext(
-        process?.env?.NODE_ENV === "test" || process?.env?.STORYBOOK
+        shouldMockStrings
             ? {
                   strings: mockStrings,
                   locale: "en",

--- a/packages/math-input/src/components/i18n-context.tsx
+++ b/packages/math-input/src/components/i18n-context.tsx
@@ -18,7 +18,7 @@ type I18nContextType = {
 // @ts-expect-error - TS2322 - Type 'Context<{ strings: {}; locale: string; }>' is not assignable to type 'Context<I18nContextType>'.
 export const MathInputI18nContext: React.Context<I18nContextType> =
     React.createContext(
-        process.env.NODE_ENV === "test" || process.env.STORYBOOK
+        process?.env?.NODE_ENV === "test" || process?.env?.STORYBOOK
             ? {
                   strings: mockStrings,
                   locale: "en",

--- a/packages/perseus/src/components/i18n-context.tsx
+++ b/packages/perseus/src/components/i18n-context.tsx
@@ -18,7 +18,7 @@ type I18nContextType = {
 // @ts-expect-error - TS2322 - Type 'Context<{ strings: {}; locale: string; }>' is not assignable to type 'Context<I18nContextType>'.
 export const PerseusI18nContext: React.Context<I18nContextType> =
     React.createContext(
-        process.env.NODE_ENV === "test" || process.env.STORYBOOK
+        process?.env?.NODE_ENV === "test" || process?.env?.STORYBOOK
             ? {
                   strings: mockStrings,
                   locale: "en",

--- a/packages/perseus/src/components/i18n-context.tsx
+++ b/packages/perseus/src/components/i18n-context.tsx
@@ -15,14 +15,11 @@ type I18nContextType = {
     locale: string;
 };
 
-const shouldMockStrings: boolean = Boolean(
-    process?.env?.NODE_ENV === "test" || process?.env?.STORYBOOK,
-);
-
 // @ts-expect-error - TS2322 - Type 'Context<{ strings: {}; locale: string; }>' is not assignable to type 'Context<I18nContextType>'.
 export const PerseusI18nContext: React.Context<I18nContextType> =
     React.createContext(
-        shouldMockStrings
+        typeof process !== "undefined" &&
+            (process.env.NODE_ENV === "test" || process.env.STORYBOOK)
             ? {
                   strings: mockStrings,
                   locale: "en",

--- a/packages/perseus/src/components/i18n-context.tsx
+++ b/packages/perseus/src/components/i18n-context.tsx
@@ -15,10 +15,14 @@ type I18nContextType = {
     locale: string;
 };
 
+const shouldMockStrings: boolean = Boolean(
+    process?.env?.NODE_ENV === "test" || process?.env?.STORYBOOK,
+);
+
 // @ts-expect-error - TS2322 - Type 'Context<{ strings: {}; locale: string; }>' is not assignable to type 'Context<I18nContextType>'.
 export const PerseusI18nContext: React.Context<I18nContextType> =
     React.createContext(
-        process?.env?.NODE_ENV === "test" || process?.env?.STORYBOOK
+        shouldMockStrings
             ? {
                   strings: mockStrings,
                   locale: "en",


### PR DESCRIPTION
## Summary:
`process` is a NodeJS thing, so it's not guaranteed to be on the FE. This checks that it exists before accessing it.