### PR TITLE
Remove isMobile from Dependencies

### DIFF
--- a/.changeset/smart-phones-rush.md
+++ b/.changeset/smart-phones-rush.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Remove isMobile from Dependencies since it's now on APIOptions

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -498,7 +498,6 @@ export type PerseusDependencies = {
     // RequestInfo
     isDevServer: boolean;
     kaLocale: string;
-    isMobile: boolean;
 };
 
 /**

--- a/testing/test-dependencies.tsx
+++ b/testing/test-dependencies.tsx
@@ -103,7 +103,6 @@ export const testDependencies: PerseusDependencies = {
 
     isDevServer: false,
     kaLocale: "en",
-    isMobile: false,
 
     Log: LogForTesting,
 };


### PR DESCRIPTION
## Summary:
Remove isMobile from Dependencies since it's now on APIOptions