### PR TITLE
Add types to no-extraneous-dependencies check

### DIFF
--- a/.changeset/swift-trees-flash.md
+++ b/.changeset/swift-trees-flash.md
@@ -1,0 +1,14 @@
+---
+"@khanacademy/kas": patch
+"@khanacademy/keypad-context": patch
+"@khanacademy/kmath": patch
+"@khanacademy/math-input": patch
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-core": patch
+"@khanacademy/perseus-editor": patch
+"@khanacademy/perseus-linter": patch
+"@khanacademy/pure-markdown": patch
+"@khanacademy/simple-markdown": patch
+---
+
+Check types for import/no-extraneous-dependencies eslint check

--- a/packages/kas/.eslintrc.js
+++ b/packages/kas/.eslintrc.js
@@ -6,7 +6,10 @@ module.exports = {
     rules: {
         "import/no-extraneous-dependencies": [
             "error",
-            {packageDir: [__dirname, path.join(__dirname, "../../")]},
+            {
+                packageDir: [__dirname, path.join(__dirname, "../../")],
+                includeTypes: true,
+            },
         ],
     },
 };

--- a/packages/keypad-context/.eslintrc.js
+++ b/packages/keypad-context/.eslintrc.js
@@ -6,7 +6,10 @@ module.exports = {
     rules: {
         "import/no-extraneous-dependencies": [
             "error",
-            {packageDir: [__dirname, path.join(__dirname, "../../")]},
+            {
+                packageDir: [__dirname, path.join(__dirname, "../../")],
+                includeTypes: true,
+            },
         ],
     },
 };

--- a/packages/kmath/.eslintrc.js
+++ b/packages/kmath/.eslintrc.js
@@ -6,7 +6,10 @@ module.exports = {
     rules: {
         "import/no-extraneous-dependencies": [
             "error",
-            {packageDir: [__dirname, path.join(__dirname, "../../")]},
+            {
+                packageDir: [__dirname, path.join(__dirname, "../../")],
+                includeTypes: true,
+            },
         ],
     },
 };

--- a/packages/math-input/.eslintrc.js
+++ b/packages/math-input/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
                 // it's right so I made a ticket to circle back to it
                 // https://khanacademy.atlassian.net/browse/LC-864
                 devDependencies: ["**/*.stories.tsx", "**/*.test.tsx"],
+                includeTypes: true,
             },
         ],
     },

--- a/packages/perseus-core/.eslintrc.js
+++ b/packages/perseus-core/.eslintrc.js
@@ -6,7 +6,10 @@ module.exports = {
     rules: {
         "import/no-extraneous-dependencies": [
             "error",
-            {packageDir: [__dirname, path.join(__dirname, "../../")]},
+            {
+                packageDir: [__dirname, path.join(__dirname, "../../")],
+                includeTypes: true,
+            },
         ],
     },
 };

--- a/packages/perseus-core/package.json
+++ b/packages/perseus-core/package.json
@@ -25,7 +25,9 @@
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
     },
     "dependencies": {},
-    "devDependencies": {},
+    "devDependencies": {
+        "@khanacademy/wonder-stuff-core": "1.5.2"
+    },
     "peerDependencies": {},
     "keywords": []
 }

--- a/packages/perseus-editor/.eslintrc.js
+++ b/packages/perseus-editor/.eslintrc.js
@@ -6,7 +6,10 @@ module.exports = {
     rules: {
         "import/no-extraneous-dependencies": [
             "error",
-            {packageDir: [__dirname, path.join(__dirname, "../../")]},
+            {
+                packageDir: [__dirname, path.join(__dirname, "../../")],
+                includeTypes: true,
+            },
         ],
     },
 };

--- a/packages/perseus-editor/package.json
+++ b/packages/perseus-editor/package.json
@@ -43,6 +43,7 @@
         "mafs": "^0.19.0"
     },
     "devDependencies": {
+        "@khanacademy/perseus-linter": "^1.2.2",
         "@khanacademy/wonder-blocks-accordion": "1.3.6",
         "@khanacademy/wonder-blocks-banner": "3.1.7",
         "@khanacademy/wonder-blocks-button": "6.3.8",

--- a/packages/perseus-linter/.eslintrc.js
+++ b/packages/perseus-linter/.eslintrc.js
@@ -6,7 +6,10 @@ module.exports = {
     rules: {
         "import/no-extraneous-dependencies": [
             "error",
-            {packageDir: [__dirname, path.join(__dirname, "../../")]},
+            {
+                packageDir: [__dirname, path.join(__dirname, "../../")],
+                includeTypes: true,
+            },
         ],
     },
 };

--- a/packages/perseus/.eslintrc.js
+++ b/packages/perseus/.eslintrc.js
@@ -6,7 +6,10 @@ module.exports = {
     rules: {
         "import/no-extraneous-dependencies": [
             "error",
-            {packageDir: [__dirname, path.join(__dirname, "../../")]},
+            {
+                packageDir: [__dirname, path.join(__dirname, "../../")],
+                includeTypes: true,
+            },
         ],
     },
 };

--- a/packages/perseus/package.json
+++ b/packages/perseus/package.json
@@ -78,6 +78,7 @@
         "aphrodite": "^1.2.5",
         "classnames": "1.1.4",
         "create-react-class": "15.6.3",
+        "csstype": "^3.1.3",
         "intersection-observer": "^0.12.0",
         "jquery": "^2.1.1",
         "lodash.debounce": "^4.0.8",

--- a/packages/perseus/src/multi-items/multi-renderer.tsx
+++ b/packages/perseus/src/multi-items/multi-renderer.tsx
@@ -37,8 +37,9 @@
  *   </MultiRenderer>
  */
 import {Errors} from "@khanacademy/perseus-core";
-import {StyleSheet, css} from "aphrodite"; // eslint-disable-line import/no-extraneous-dependencies
-import lens from "hubble"; // eslint-disable-line import/no-extraneous-dependencies
+import {StyleSheet, css} from "aphrodite";
+// eslint-disable-next-line import/no-extraneous-dependencies
+import lens from "hubble";
 import * as React from "react";
 
 import {PerseusI18nContext} from "../components/i18n-context";

--- a/packages/perseus/src/util/graphie.test.ts
+++ b/packages/perseus/src/util/graphie.test.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import $ from "jquery";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import Raphael from "raphael";

--- a/packages/pure-markdown/.eslintrc.js
+++ b/packages/pure-markdown/.eslintrc.js
@@ -6,7 +6,10 @@ module.exports = {
     rules: {
         "import/no-extraneous-dependencies": [
             "error",
-            {packageDir: [__dirname, path.join(__dirname, "../../")]},
+            {
+                packageDir: [__dirname, path.join(__dirname, "../../")],
+                includeTypes: true,
+            },
         ],
     },
 };

--- a/packages/simple-markdown/.eslintrc.js
+++ b/packages/simple-markdown/.eslintrc.js
@@ -6,7 +6,10 @@ module.exports = {
     rules: {
         "import/no-extraneous-dependencies": [
             "error",
-            {packageDir: [__dirname, path.join(__dirname, "../../")]},
+            {
+                packageDir: [__dirname, path.join(__dirname, "../../")],
+                includeTypes: true,
+            },
         ],
     },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6883,6 +6883,11 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
   integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
 
+csstype@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
+  integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
+
 csv-generate@^3.4.3:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/csv-generate/-/csv-generate-3.4.3.tgz#bc42d943b45aea52afa896874291da4b9108ffff"


### PR DESCRIPTION
## Summary:
Check types for import/no-extraneous-dependencies eslint check

Found by Knip and after talking with Jeremy we think this is the way to go.