### PR TITLE
Remove unused optionRenderer prop on dropdown's Option component

### DIFF
--- a/.changeset/perfect-guests-raise.md
+++ b/.changeset/perfect-guests-raise.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Remove unused prop, optionRenderer, from dropdown-option component

--- a/packages/perseus-editor/src/components/dropdown-option.tsx
+++ b/packages/perseus-editor/src/components/dropdown-option.tsx
@@ -5,48 +5,48 @@
  * OptionGroup which is an internal component used in the dropdowns to house
  * a list of options.
  **/
-import {components, globalStyles} from "@khanacademy/perseus";
-import {css, StyleSheet} from "aphrodite";
+import { components, globalStyles } from "@khanacademy/perseus";
+import { css, StyleSheet } from "aphrodite";
 import * as React from "react";
 import ReactDOM from "react-dom";
 
-import {focusWithChromeStickyFocusBugWorkaround} from "./util";
+import { focusWithChromeStickyFocusBugWorkaround } from "./util";
 
-const {Icon} = components;
-const {colors} = globalStyles;
+const { Icon } = components;
+const { colors } = globalStyles;
 
 const findAndFocusElement = (component?: Element | null) => {
-    const DOMNode: Element | Text | null | undefined =
-        ReactDOM.findDOMNode(component);
-    const button = DOMNode as HTMLInputElement;
-    // @ts-expect-error - TS2774 - This condition will always return true since this function is always defined. Did you mean to call it instead?
-    if (button.focus) {
-        focusWithChromeStickyFocusBugWorkaround(button);
-    }
+	const DOMNode: Element | Text | null | undefined =
+		ReactDOM.findDOMNode(component);
+	const button = DOMNode as HTMLInputElement;
+	// @ts-expect-error - TS2774 - This condition will always return true since this function is always defined. Did you mean to call it instead?
+	if (button.focus) {
+		focusWithChromeStickyFocusBugWorkaround(button);
+	}
 };
 
 type Props = {
-    // The value to use when the option is selected
-    value: string;
-    // The display of the option
-    children?: React.ReactNode;
-    // Is the current option selected?
-    selected?: boolean;
-    // Is the current option disabled?
-    disabled?: boolean;
-    // An event when an option is clicked
-    onClick?: () => void;
-    // An optional function to call when the dropdown should close
-    // Only relevant if the Option is inside of a dropdown menu
-    onDropdownClose?: () => void;
-    // An optional value to override the focus styling of an option.
-    // Use caution when using this - keyboard users need to know what they're
-    // focused on in order to interact with the product!
-    hideFocusState?: boolean;
-    // An optional test id that can be used to identify this Option in automated tests.
-    testId?: string;
-    // Text to provide for assistive tech users
-    ariaLabel?: string;
+	// The value to use when the option is selected
+	value: string;
+	// The display of the option
+	children?: React.ReactNode;
+	// Is the current option selected?
+	selected?: boolean;
+	// Is the current option disabled?
+	disabled?: boolean;
+	// An event when an option is clicked
+	onClick?: () => void;
+	// An optional function to call when the dropdown should close
+	// Only relevant if the Option is inside of a dropdown menu
+	onDropdownClose?: () => void;
+	// An optional value to override the focus styling of an option.
+	// Use caution when using this - keyboard users need to know what they're
+	// focused on in order to interact with the product!
+	hideFocusState?: boolean;
+	// An optional test id that can be used to identify this Option in automated tests.
+	testId?: string;
+	// Text to provide for assistive tech users
+	ariaLabel?: string;
 };
 
 const check = `M10,3.8C10,4,9.9,4.2,9.8,4.3L5.1,8.9L4.3,9.8C4.2,9.9,4,10,3.8,10
@@ -58,92 +58,89 @@ const check = `M10,3.8C10,4,9.9,4.2,9.8,4.3L5.1,8.9L4.3,9.8C4.2,9.9,4,10,3.8,10
 const optionHeight = 30;
 
 class Option extends React.Component<Props> {
-    // @ts-expect-error - TS2564 - Property 'node' has no initializer and is not definitely assigned in the constructor.
-    node: HTMLDivElement;
+	// @ts-expect-error - TS2564 - Property 'node' has no initializer and is not definitely assigned in the constructor.
+	node: HTMLDivElement;
 
-    handleKeyDown(event: any): void {
-        const {onDropdownClose} = this.props;
-        const pressedKey = event.key;
-        const focusedElement = event.target;
+	handleKeyDown(event: any): void {
+		const { onDropdownClose } = this.props;
+		const pressedKey = event.key;
+		const focusedElement = event.target;
 
-        if (pressedKey === "ArrowDown" && focusedElement.nextSibling) {
-            event.preventDefault();
-            focusedElement.nextSibling.focus();
-        }
-        if (pressedKey === "ArrowUp" && focusedElement.previousSibling) {
-            event.preventDefault();
-            focusedElement.previousSibling.focus();
-        }
-        if (
-            pressedKey === "ArrowUp" &&
-            !focusedElement.previousSibling &&
-            onDropdownClose
-        ) {
-            event.preventDefault();
-            onDropdownClose();
-        }
-        if (
-            (pressedKey === "Escape" || pressedKey === "Tab") &&
-            onDropdownClose
-        ) {
-            onDropdownClose();
-        }
-    }
+		if (pressedKey === "ArrowDown" && focusedElement.nextSibling) {
+			event.preventDefault();
+			focusedElement.nextSibling.focus();
+		}
+		if (pressedKey === "ArrowUp" && focusedElement.previousSibling) {
+			event.preventDefault();
+			focusedElement.previousSibling.focus();
+		}
+		if (
+			pressedKey === "ArrowUp" &&
+			!focusedElement.previousSibling &&
+			onDropdownClose
+		) {
+			event.preventDefault();
+			onDropdownClose();
+		}
+		if ((pressedKey === "Escape" || pressedKey === "Tab") && onDropdownClose) {
+			onDropdownClose();
+		}
+	}
 
-    render(): React.ReactNode {
-        const {
-            selected,
-            value,
-            onClick,
-            children,
-            disabled,
-            hideFocusState,
-            testId,
-            ariaLabel,
-        } = this.props;
+	render(): React.ReactNode {
+		const {
+			selected,
+			value,
+			onClick,
+			children,
+			disabled,
+			hideFocusState,
+			testId,
+			ariaLabel,
+		} = this.props;
 
-        return (
-            <button
-                // @ts-expect-error - TS2322 - Type 'HTMLButtonElement | null' is not assignable to type 'HTMLDivElement'.
-                ref={(node) => (this.node = node)}
-                value={value}
-                role="menuitemradio"
-                aria-checked={selected}
-                className={css(
-                    styles.notAButton,
-                    disabled && styles.cursorDefault,
-                    hideFocusState && styles.noFocus,
-                )}
-                // @ts-expect-error - TS2322 - Type '(value: string) => void' is not assignable to type 'MouseEventHandler<HTMLButtonElement>'.
-                onClick={(value: string) => {
-                    if (!disabled && onClick) {
-                        // @ts-expect-error - TS2554 - Expected 0 arguments, but got 1.
-                        onClick(value);
-                    }
-                }}
-                // @ts-expect-error - TS2322 - Type '(event: KeyboardEvent) => void' is not assignable to type 'KeyboardEventHandler<HTMLButtonElement>'.
-                onKeyDown={(event: KeyboardEvent) => this.handleKeyDown(event)}
-                aria-disabled={disabled}
-                aria-label={ariaLabel}
-                data-testid={testId}
-            >
-                <span
-                    className={css(
-                        styles.option,
-                        selected && styles.optionSelected,
-                        disabled && styles.optionDisabled,
-                    )}
-                >
-                    {children}
-                    {selected && (
-                        <span className={css(styles.check)}>
-                            <Icon icon={check} />
-                        </span>
-                    )}
-                </span>
-            </button>
-        );
-    }
+		return (
+			<button
+				// @ts-expect-error - TS2322 - Type 'HTMLButtonElement | null' is not assignable to type 'HTMLDivElement'.
+				ref={(node) => (this.node = node)}
+				value={value}
+				role="menuitemradio"
+				aria-checked={selected}
+				className={css(
+					styles.notAButton,
+					disabled && styles.cursorDefault,
+					hideFocusState && styles.noFocus,
+				)}
+				// @ts-expect-error - TS2322 - Type '(value: string) => void' is not assignable to type 'MouseEventHandler<HTMLButtonElement>'.
+				onClick={(value: string) => {
+					if (!disabled && onClick) {
+						// @ts-expect-error - TS2554 - Expected 0 arguments, but got 1.
+						onClick(value);
+					}
+				}}
+				// @ts-expect-error - TS2322 - Type '(event: KeyboardEvent) => void' is not assignable to type 'KeyboardEventHandler<HTMLButtonElement>'.
+				onKeyDown={(event: KeyboardEvent) => this.handleKeyDown(event)}
+				aria-disabled={disabled}
+				aria-label={ariaLabel}
+				data-testid={testId}
+			>
+				<span
+					className={css(
+						styles.option,
+						selected && styles.optionSelected,
+						disabled && styles.optionDisabled,
+					)}
+				>
+					{children}
+					{selected && (
+						<span className={css(styles.check)}>
+							<Icon icon={check} />
+						</span>
+					)}
+				</span>
+			</button>
+		);
+	}
 }
 
 // TODO(kevinb):
@@ -151,136 +148,132 @@ class Option extends React.Component<Props> {
 // - do we really want to dismiss this on scroll
 // - how does the drop down interact with tooltips?  what's the z-index order?
 class OptionGroup extends React.Component<{
-    // An event when an option is selected
-    onSelected: (value: string) => void;
-    // The list of options to display
-    children?: Array<React.ReactElement<React.ComponentProps<typeof Option>>>;
-    // The currently selected options
-    selectedValues: Array<string>;
-    // An optional rendering function to render the details of the options
-    optionRenderer?: OptionRenderer;
-    // An override to skip the bit of top/bottom spacing around the group
-    noMargin?: boolean;
-    // An optional function to call when the dropdown should close
-    onDropdownClose?: () => void;
-    // An optional value to override the focus styling of an option.
-    // Use caution when using this - keyboard users need to know what
-    // they're focused on in order to interact with the product!
-    hideFocusState?: boolean;
+	// An event when an option is selected
+	onSelected: (value: string) => void;
+	// The list of options to display
+	children?: Array<React.ReactElement<React.ComponentProps<typeof Option>>>;
+	// The currently selected options
+	selectedValues: Array<string>;
+	// An override to skip the bit of top/bottom spacing around the group
+	noMargin?: boolean;
+	// An optional function to call when the dropdown should close
+	onDropdownClose?: () => void;
+	// An optional value to override the focus styling of an option.
+	// Use caution when using this - keyboard users need to know what
+	// they're focused on in order to interact with the product!
+	hideFocusState?: boolean;
 }> {
-    // @ts-expect-error - TS2564 - Property 'focusedElement' has no initializer and is not definitely assigned in the constructor.
-    focusedElement: Element;
+	// @ts-expect-error - TS2564 - Property 'focusedElement' has no initializer and is not definitely assigned in the constructor.
+	focusedElement: Element;
 
-    componentDidMount() {
-        if (this.focusedElement) {
-            findAndFocusElement(this.focusedElement);
-        }
-    }
+	componentDidMount() {
+		if (this.focusedElement) {
+			findAndFocusElement(this.focusedElement);
+		}
+	}
 
-    render(): React.ReactNode {
-        const {
-            children,
-            onSelected,
-            selectedValues,
-            optionRenderer,
-            noMargin,
-            onDropdownClose,
-            hideFocusState,
-        } = this.props;
+	render(): React.ReactNode {
+		const {
+			children,
+			onSelected,
+			selectedValues,
+			noMargin,
+			onDropdownClose,
+			hideFocusState,
+		} = this.props;
 
-        return (
-            <div
-                // @ts-expect-error - TS2322 - Type 'Window | null' is not assignable to type 'Top<string | number> | undefined'.
-                style={{top}}
-                className={css(
-                    styles.optionGroup,
-                    noMargin && styles.optionGroupNoMargin,
-                )}
-            >
-                {React.Children.map(children, (child, index) => {
-                    // @ts-expect-error - TS2532 - Object is possibly 'undefined'.
-                    const selected = selectedValues.includes(child.props.value);
+		return (
+			<div
+				// @ts-expect-error - TS2322 - Type 'Window | null' is not assignable to type 'Top<string | number> | undefined'.
+				style={{ top }}
+				className={css(
+					styles.optionGroup,
+					noMargin && styles.optionGroupNoMargin,
+				)}
+			>
+				{React.Children.map(children, (child, index) => {
+					// @ts-expect-error - TS2532 - Object is possibly 'undefined'.
+					const selected = selectedValues.includes(child.props.value);
 
-                    const reference =
-                        selected || index === 0
-                            ? (node: Element) => (this.focusedElement = node)
-                            : null;
+					const reference =
+						selected || index === 0
+							? (node: Element) => (this.focusedElement = node)
+							: null;
 
-                    // @ts-expect-error - TS2769 - No overload matches this call.
-                    return React.cloneElement(child, {
-                        // @ts-expect-error - TS2532 - Object is possibly 'undefined'.
-                        ...child.props,
-                        key: index,
-                        selected: selected,
-                        // @ts-expect-error - TS2532 - Object is possibly 'undefined'.
-                        onClick: () => onSelected(child.props.value),
-                        optionRenderer: optionRenderer,
-                        ref: reference,
-                        onDropdownClose: onDropdownClose,
-                        hideFocusState: hideFocusState,
-                    });
-                })}
-            </div>
-        );
-    }
+					// @ts-expect-error - TS2769 - No overload matches this call.
+					return React.cloneElement(child, {
+						// @ts-expect-error - TS2532 - Object is possibly 'undefined'.
+						...child.props,
+						key: index,
+						selected: selected,
+						// @ts-expect-error - TS2532 - Object is possibly 'undefined'.
+						onClick: () => onSelected(child.props.value),
+						ref: reference,
+						onDropdownClose: onDropdownClose,
+						hideFocusState: hideFocusState,
+					});
+				})}
+			</div>
+		);
+	}
 }
 
 const styles = StyleSheet.create({
-    optionGroup: {
-        margin: "4px 0",
-    },
-    optionGroupNoMargin: {
-        margin: 0,
-    },
-    option: {
-        display: "flex",
-        flexDirection: "row",
-        alignItems: "center",
-        paddingLeft: 32,
-        paddingRight: 32,
-        height: optionHeight,
-        whiteSpace: "nowrap",
-        overflow: "hidden",
-        textOverflow: "ellipsis",
-        color: colors.gray17,
-        userSelect: "none",
+	optionGroup: {
+		margin: "4px 0",
+	},
+	optionGroupNoMargin: {
+		margin: 0,
+	},
+	option: {
+		display: "flex",
+		flexDirection: "row",
+		alignItems: "center",
+		paddingLeft: 32,
+		paddingRight: 32,
+		height: optionHeight,
+		whiteSpace: "nowrap",
+		overflow: "hidden",
+		textOverflow: "ellipsis",
+		color: colors.gray17,
+		userSelect: "none",
 
-        ":hover": {
-            backgroundColor: colors.gray95,
-        },
-    },
-    optionSelected: {
-        backgroundColor: colors.gray95,
-        color: "#11ACCD",
-    },
-    optionDisabled: {
-        color: colors.gray76,
-        ":hover": {
-            backgroundColor: "transparent",
-        },
-    },
-    check: {
-        position: "absolute",
-        left: 11,
-    },
-    notAButton: {
-        backgroundColor: "transparent",
-        border: "none",
-        display: "block",
-        padding: 0,
-        margin: 0,
-        width: "100%",
-        // <button> uses user agent stylesheet over inherit so we need to set
-        // it explicitly.
-        font: "inherit",
-    },
-    noFocus: {
-        outline: "none",
-    },
-    cursorDefault: {
-        cursor: "default",
-    },
+		":hover": {
+			backgroundColor: colors.gray95,
+		},
+	},
+	optionSelected: {
+		backgroundColor: colors.gray95,
+		color: "#11ACCD",
+	},
+	optionDisabled: {
+		color: colors.gray76,
+		":hover": {
+			backgroundColor: "transparent",
+		},
+	},
+	check: {
+		position: "absolute",
+		left: 11,
+	},
+	notAButton: {
+		backgroundColor: "transparent",
+		border: "none",
+		display: "block",
+		padding: 0,
+		margin: 0,
+		width: "100%",
+		// <button> uses user agent stylesheet over inherit so we need to set
+		// it explicitly.
+		font: "inherit",
+	},
+	noFocus: {
+		outline: "none",
+	},
+	cursorDefault: {
+		cursor: "default",
+	},
 });
 
-export {OptionGroup};
+export { OptionGroup };
 export default Option;

--- a/packages/perseus-editor/src/components/dropdown-option.tsx
+++ b/packages/perseus-editor/src/components/dropdown-option.tsx
@@ -5,48 +5,48 @@
  * OptionGroup which is an internal component used in the dropdowns to house
  * a list of options.
  **/
-import { components, globalStyles } from "@khanacademy/perseus";
-import { css, StyleSheet } from "aphrodite";
+import {components, globalStyles} from "@khanacademy/perseus";
+import {css, StyleSheet} from "aphrodite";
 import * as React from "react";
 import ReactDOM from "react-dom";
 
-import { focusWithChromeStickyFocusBugWorkaround } from "./util";
+import {focusWithChromeStickyFocusBugWorkaround} from "./util";
 
-const { Icon } = components;
-const { colors } = globalStyles;
+const {Icon} = components;
+const {colors} = globalStyles;
 
 const findAndFocusElement = (component?: Element | null) => {
-	const DOMNode: Element | Text | null | undefined =
-		ReactDOM.findDOMNode(component);
-	const button = DOMNode as HTMLInputElement;
-	// @ts-expect-error - TS2774 - This condition will always return true since this function is always defined. Did you mean to call it instead?
-	if (button.focus) {
-		focusWithChromeStickyFocusBugWorkaround(button);
-	}
+    const DOMNode: Element | Text | null | undefined =
+        ReactDOM.findDOMNode(component);
+    const button = DOMNode as HTMLInputElement;
+    // @ts-expect-error - TS2774 - This condition will always return true since this function is always defined. Did you mean to call it instead?
+    if (button.focus) {
+        focusWithChromeStickyFocusBugWorkaround(button);
+    }
 };
 
 type Props = {
-	// The value to use when the option is selected
-	value: string;
-	// The display of the option
-	children?: React.ReactNode;
-	// Is the current option selected?
-	selected?: boolean;
-	// Is the current option disabled?
-	disabled?: boolean;
-	// An event when an option is clicked
-	onClick?: () => void;
-	// An optional function to call when the dropdown should close
-	// Only relevant if the Option is inside of a dropdown menu
-	onDropdownClose?: () => void;
-	// An optional value to override the focus styling of an option.
-	// Use caution when using this - keyboard users need to know what they're
-	// focused on in order to interact with the product!
-	hideFocusState?: boolean;
-	// An optional test id that can be used to identify this Option in automated tests.
-	testId?: string;
-	// Text to provide for assistive tech users
-	ariaLabel?: string;
+    // The value to use when the option is selected
+    value: string;
+    // The display of the option
+    children?: React.ReactNode;
+    // Is the current option selected?
+    selected?: boolean;
+    // Is the current option disabled?
+    disabled?: boolean;
+    // An event when an option is clicked
+    onClick?: () => void;
+    // An optional function to call when the dropdown should close
+    // Only relevant if the Option is inside of a dropdown menu
+    onDropdownClose?: () => void;
+    // An optional value to override the focus styling of an option.
+    // Use caution when using this - keyboard users need to know what they're
+    // focused on in order to interact with the product!
+    hideFocusState?: boolean;
+    // An optional test id that can be used to identify this Option in automated tests.
+    testId?: string;
+    // Text to provide for assistive tech users
+    ariaLabel?: string;
 };
 
 const check = `M10,3.8C10,4,9.9,4.2,9.8,4.3L5.1,8.9L4.3,9.8C4.2,9.9,4,10,3.8,10
@@ -58,89 +58,92 @@ const check = `M10,3.8C10,4,9.9,4.2,9.8,4.3L5.1,8.9L4.3,9.8C4.2,9.9,4,10,3.8,10
 const optionHeight = 30;
 
 class Option extends React.Component<Props> {
-	// @ts-expect-error - TS2564 - Property 'node' has no initializer and is not definitely assigned in the constructor.
-	node: HTMLDivElement;
+    // @ts-expect-error - TS2564 - Property 'node' has no initializer and is not definitely assigned in the constructor.
+    node: HTMLDivElement;
 
-	handleKeyDown(event: any): void {
-		const { onDropdownClose } = this.props;
-		const pressedKey = event.key;
-		const focusedElement = event.target;
+    handleKeyDown(event: any): void {
+        const {onDropdownClose} = this.props;
+        const pressedKey = event.key;
+        const focusedElement = event.target;
 
-		if (pressedKey === "ArrowDown" && focusedElement.nextSibling) {
-			event.preventDefault();
-			focusedElement.nextSibling.focus();
-		}
-		if (pressedKey === "ArrowUp" && focusedElement.previousSibling) {
-			event.preventDefault();
-			focusedElement.previousSibling.focus();
-		}
-		if (
-			pressedKey === "ArrowUp" &&
-			!focusedElement.previousSibling &&
-			onDropdownClose
-		) {
-			event.preventDefault();
-			onDropdownClose();
-		}
-		if ((pressedKey === "Escape" || pressedKey === "Tab") && onDropdownClose) {
-			onDropdownClose();
-		}
-	}
+        if (pressedKey === "ArrowDown" && focusedElement.nextSibling) {
+            event.preventDefault();
+            focusedElement.nextSibling.focus();
+        }
+        if (pressedKey === "ArrowUp" && focusedElement.previousSibling) {
+            event.preventDefault();
+            focusedElement.previousSibling.focus();
+        }
+        if (
+            pressedKey === "ArrowUp" &&
+            !focusedElement.previousSibling &&
+            onDropdownClose
+        ) {
+            event.preventDefault();
+            onDropdownClose();
+        }
+        if (
+            (pressedKey === "Escape" || pressedKey === "Tab") &&
+            onDropdownClose
+        ) {
+            onDropdownClose();
+        }
+    }
 
-	render(): React.ReactNode {
-		const {
-			selected,
-			value,
-			onClick,
-			children,
-			disabled,
-			hideFocusState,
-			testId,
-			ariaLabel,
-		} = this.props;
+    render(): React.ReactNode {
+        const {
+            selected,
+            value,
+            onClick,
+            children,
+            disabled,
+            hideFocusState,
+            testId,
+            ariaLabel,
+        } = this.props;
 
-		return (
-			<button
-				// @ts-expect-error - TS2322 - Type 'HTMLButtonElement | null' is not assignable to type 'HTMLDivElement'.
-				ref={(node) => (this.node = node)}
-				value={value}
-				role="menuitemradio"
-				aria-checked={selected}
-				className={css(
-					styles.notAButton,
-					disabled && styles.cursorDefault,
-					hideFocusState && styles.noFocus,
-				)}
-				// @ts-expect-error - TS2322 - Type '(value: string) => void' is not assignable to type 'MouseEventHandler<HTMLButtonElement>'.
-				onClick={(value: string) => {
-					if (!disabled && onClick) {
-						// @ts-expect-error - TS2554 - Expected 0 arguments, but got 1.
-						onClick(value);
-					}
-				}}
-				// @ts-expect-error - TS2322 - Type '(event: KeyboardEvent) => void' is not assignable to type 'KeyboardEventHandler<HTMLButtonElement>'.
-				onKeyDown={(event: KeyboardEvent) => this.handleKeyDown(event)}
-				aria-disabled={disabled}
-				aria-label={ariaLabel}
-				data-testid={testId}
-			>
-				<span
-					className={css(
-						styles.option,
-						selected && styles.optionSelected,
-						disabled && styles.optionDisabled,
-					)}
-				>
-					{children}
-					{selected && (
-						<span className={css(styles.check)}>
-							<Icon icon={check} />
-						</span>
-					)}
-				</span>
-			</button>
-		);
-	}
+        return (
+            <button
+                // @ts-expect-error - TS2322 - Type 'HTMLButtonElement | null' is not assignable to type 'HTMLDivElement'.
+                ref={(node) => (this.node = node)}
+                value={value}
+                role="menuitemradio"
+                aria-checked={selected}
+                className={css(
+                    styles.notAButton,
+                    disabled && styles.cursorDefault,
+                    hideFocusState && styles.noFocus,
+                )}
+                // @ts-expect-error - TS2322 - Type '(value: string) => void' is not assignable to type 'MouseEventHandler<HTMLButtonElement>'.
+                onClick={(value: string) => {
+                    if (!disabled && onClick) {
+                        // @ts-expect-error - TS2554 - Expected 0 arguments, but got 1.
+                        onClick(value);
+                    }
+                }}
+                // @ts-expect-error - TS2322 - Type '(event: KeyboardEvent) => void' is not assignable to type 'KeyboardEventHandler<HTMLButtonElement>'.
+                onKeyDown={(event: KeyboardEvent) => this.handleKeyDown(event)}
+                aria-disabled={disabled}
+                aria-label={ariaLabel}
+                data-testid={testId}
+            >
+                <span
+                    className={css(
+                        styles.option,
+                        selected && styles.optionSelected,
+                        disabled && styles.optionDisabled,
+                    )}
+                >
+                    {children}
+                    {selected && (
+                        <span className={css(styles.check)}>
+                            <Icon icon={check} />
+                        </span>
+                    )}
+                </span>
+            </button>
+        );
+    }
 }
 
 // TODO(kevinb):
@@ -148,132 +151,132 @@ class Option extends React.Component<Props> {
 // - do we really want to dismiss this on scroll
 // - how does the drop down interact with tooltips?  what's the z-index order?
 class OptionGroup extends React.Component<{
-	// An event when an option is selected
-	onSelected: (value: string) => void;
-	// The list of options to display
-	children?: Array<React.ReactElement<React.ComponentProps<typeof Option>>>;
-	// The currently selected options
-	selectedValues: Array<string>;
-	// An override to skip the bit of top/bottom spacing around the group
-	noMargin?: boolean;
-	// An optional function to call when the dropdown should close
-	onDropdownClose?: () => void;
-	// An optional value to override the focus styling of an option.
-	// Use caution when using this - keyboard users need to know what
-	// they're focused on in order to interact with the product!
-	hideFocusState?: boolean;
+    // An event when an option is selected
+    onSelected: (value: string) => void;
+    // The list of options to display
+    children?: Array<React.ReactElement<React.ComponentProps<typeof Option>>>;
+    // The currently selected options
+    selectedValues: Array<string>;
+    // An override to skip the bit of top/bottom spacing around the group
+    noMargin?: boolean;
+    // An optional function to call when the dropdown should close
+    onDropdownClose?: () => void;
+    // An optional value to override the focus styling of an option.
+    // Use caution when using this - keyboard users need to know what
+    // they're focused on in order to interact with the product!
+    hideFocusState?: boolean;
 }> {
-	// @ts-expect-error - TS2564 - Property 'focusedElement' has no initializer and is not definitely assigned in the constructor.
-	focusedElement: Element;
+    // @ts-expect-error - TS2564 - Property 'focusedElement' has no initializer and is not definitely assigned in the constructor.
+    focusedElement: Element;
 
-	componentDidMount() {
-		if (this.focusedElement) {
-			findAndFocusElement(this.focusedElement);
-		}
-	}
+    componentDidMount() {
+        if (this.focusedElement) {
+            findAndFocusElement(this.focusedElement);
+        }
+    }
 
-	render(): React.ReactNode {
-		const {
-			children,
-			onSelected,
-			selectedValues,
-			noMargin,
-			onDropdownClose,
-			hideFocusState,
-		} = this.props;
+    render(): React.ReactNode {
+        const {
+            children,
+            onSelected,
+            selectedValues,
+            noMargin,
+            onDropdownClose,
+            hideFocusState,
+        } = this.props;
 
-		return (
-			<div
-				// @ts-expect-error - TS2322 - Type 'Window | null' is not assignable to type 'Top<string | number> | undefined'.
-				style={{ top }}
-				className={css(
-					styles.optionGroup,
-					noMargin && styles.optionGroupNoMargin,
-				)}
-			>
-				{React.Children.map(children, (child, index) => {
-					// @ts-expect-error - TS2532 - Object is possibly 'undefined'.
-					const selected = selectedValues.includes(child.props.value);
+        return (
+            <div
+                // @ts-expect-error - TS2322 - Type 'Window | null' is not assignable to type 'Top<string | number> | undefined'.
+                style={{top}}
+                className={css(
+                    styles.optionGroup,
+                    noMargin && styles.optionGroupNoMargin,
+                )}
+            >
+                {React.Children.map(children, (child, index) => {
+                    // @ts-expect-error - TS2532 - Object is possibly 'undefined'.
+                    const selected = selectedValues.includes(child.props.value);
 
-					const reference =
-						selected || index === 0
-							? (node: Element) => (this.focusedElement = node)
-							: null;
+                    const reference =
+                        selected || index === 0
+                            ? (node: Element) => (this.focusedElement = node)
+                            : null;
 
-					// @ts-expect-error - TS2769 - No overload matches this call.
-					return React.cloneElement(child, {
-						// @ts-expect-error - TS2532 - Object is possibly 'undefined'.
-						...child.props,
-						key: index,
-						selected: selected,
-						// @ts-expect-error - TS2532 - Object is possibly 'undefined'.
-						onClick: () => onSelected(child.props.value),
-						ref: reference,
-						onDropdownClose: onDropdownClose,
-						hideFocusState: hideFocusState,
-					});
-				})}
-			</div>
-		);
-	}
+                    // @ts-expect-error - TS2769 - No overload matches this call.
+                    return React.cloneElement(child, {
+                        // @ts-expect-error - TS2532 - Object is possibly 'undefined'.
+                        ...child.props,
+                        key: index,
+                        selected: selected,
+                        // @ts-expect-error - TS2532 - Object is possibly 'undefined'.
+                        onClick: () => onSelected(child.props.value),
+                        ref: reference,
+                        onDropdownClose: onDropdownClose,
+                        hideFocusState: hideFocusState,
+                    });
+                })}
+            </div>
+        );
+    }
 }
 
 const styles = StyleSheet.create({
-	optionGroup: {
-		margin: "4px 0",
-	},
-	optionGroupNoMargin: {
-		margin: 0,
-	},
-	option: {
-		display: "flex",
-		flexDirection: "row",
-		alignItems: "center",
-		paddingLeft: 32,
-		paddingRight: 32,
-		height: optionHeight,
-		whiteSpace: "nowrap",
-		overflow: "hidden",
-		textOverflow: "ellipsis",
-		color: colors.gray17,
-		userSelect: "none",
+    optionGroup: {
+        margin: "4px 0",
+    },
+    optionGroupNoMargin: {
+        margin: 0,
+    },
+    option: {
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        paddingLeft: 32,
+        paddingRight: 32,
+        height: optionHeight,
+        whiteSpace: "nowrap",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        color: colors.gray17,
+        userSelect: "none",
 
-		":hover": {
-			backgroundColor: colors.gray95,
-		},
-	},
-	optionSelected: {
-		backgroundColor: colors.gray95,
-		color: "#11ACCD",
-	},
-	optionDisabled: {
-		color: colors.gray76,
-		":hover": {
-			backgroundColor: "transparent",
-		},
-	},
-	check: {
-		position: "absolute",
-		left: 11,
-	},
-	notAButton: {
-		backgroundColor: "transparent",
-		border: "none",
-		display: "block",
-		padding: 0,
-		margin: 0,
-		width: "100%",
-		// <button> uses user agent stylesheet over inherit so we need to set
-		// it explicitly.
-		font: "inherit",
-	},
-	noFocus: {
-		outline: "none",
-	},
-	cursorDefault: {
-		cursor: "default",
-	},
+        ":hover": {
+            backgroundColor: colors.gray95,
+        },
+    },
+    optionSelected: {
+        backgroundColor: colors.gray95,
+        color: "#11ACCD",
+    },
+    optionDisabled: {
+        color: colors.gray76,
+        ":hover": {
+            backgroundColor: "transparent",
+        },
+    },
+    check: {
+        position: "absolute",
+        left: 11,
+    },
+    notAButton: {
+        backgroundColor: "transparent",
+        border: "none",
+        display: "block",
+        padding: 0,
+        margin: 0,
+        width: "100%",
+        // <button> uses user agent stylesheet over inherit so we need to set
+        // it explicitly.
+        font: "inherit",
+    },
+    noFocus: {
+        outline: "none",
+    },
+    cursorDefault: {
+        cursor: "default",
+    },
 });
 
-export { OptionGroup };
+export {OptionGroup};
 export default Option;

--- a/packages/perseus-editor/src/components/dropdown-option.tsx
+++ b/packages/perseus-editor/src/components/dropdown-option.tsx
@@ -12,13 +12,6 @@ import ReactDOM from "react-dom";
 
 import {focusWithChromeStickyFocusBugWorkaround} from "./util";
 
-type OptionRenderer = (
-    children: React.ReactElement<any> | null | undefined,
-    value: string,
-    selected: boolean,
-    disabled?: boolean,
-) => React.ReactElement<any>;
-
 const {Icon} = components;
 const {colors} = globalStyles;
 
@@ -43,8 +36,6 @@ type Props = {
     disabled?: boolean;
     // An event when an option is clicked
     onClick?: () => void;
-    // An optional rendering function to render the details of the option
-    optionRenderer?: OptionRenderer;
     // An optional function to call when the dropdown should close
     // Only relevant if the Option is inside of a dropdown menu
     onDropdownClose?: () => void;
@@ -105,7 +96,6 @@ class Option extends React.Component<Props> {
             value,
             onClick,
             children,
-            optionRenderer,
             disabled,
             hideFocusState,
             testId,
@@ -137,35 +127,20 @@ class Option extends React.Component<Props> {
                 aria-label={ariaLabel}
                 data-testid={testId}
             >
-                {optionRenderer &&
-                    optionRenderer(
-                        /**
-                         * This expects a `React.Element<>` but `children` is a
-                         * `React.Node`. We can convert a `React.Node` to a
-                         * `React.Element<>` by wrapping it in a fragment.
-                         */
-                        <>{children}</>,
-                        value || "",
-                        selected || false,
-                        disabled,
+                <span
+                    className={css(
+                        styles.option,
+                        selected && styles.optionSelected,
+                        disabled && styles.optionDisabled,
                     )}
-
-                {!optionRenderer && (
-                    <span
-                        className={css(
-                            styles.option,
-                            selected && styles.optionSelected,
-                            disabled && styles.optionDisabled,
-                        )}
-                    >
-                        {children}
-                        {selected && (
-                            <span className={css(styles.check)}>
-                                <Icon icon={check} />
-                            </span>
-                        )}
-                    </span>
-                )}
+                >
+                    {children}
+                    {selected && (
+                        <span className={css(styles.check)}>
+                            <Icon icon={check} />
+                        </span>
+                    )}
+                </span>
             </button>
         );
     }


### PR DESCRIPTION
## Summary:

As I was working in the code I noticed that the `optionRenderer` prop is never passed to the Option nor OptionGroup components. So I'm removing it. 

Issue: "none"

## Test plan:

`yarn typecheck`
`yarn test`
`rg optionRenderer` (in hosting applications - webapp, mobile)