### PR TITLE
Make `MovablePoint` use `useControlPoint`

### DIFF
--- a/.changeset/tame-insects-return.md
+++ b/.changeset/tame-insects-return.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Refactor MovablePoint to useControlPoint

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/__snapshots__/movable-line.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/__snapshots__/movable-line.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`Rendering Does NOT render extensions of line when option is disabled 1`
         tabindex="0"
       />
       <g
-        class="movable-point  "
+        class="movable-point"
         data-testid="movable-point"
         style="--movable-point-color: #1865f2;"
       >
@@ -96,7 +96,7 @@ exports[`Rendering Does NOT render extensions of line when option is disabled 1`
         />
       </g>
       <g
-        class="movable-point  "
+        class="movable-point"
         data-testid="movable-point"
         style="--movable-point-color: #1865f2;"
       >
@@ -196,7 +196,7 @@ exports[`Rendering Does NOT render extensions of line when option is not provide
         tabindex="0"
       />
       <g
-        class="movable-point  "
+        class="movable-point"
         data-testid="movable-point"
         style="--movable-point-color: #1865f2;"
       >
@@ -230,7 +230,7 @@ exports[`Rendering Does NOT render extensions of line when option is not provide
         />
       </g>
       <g
-        class="movable-point  "
+        class="movable-point"
         data-testid="movable-point"
         style="--movable-point-color: #1865f2;"
       >
@@ -384,7 +384,7 @@ exports[`Rendering Does render extensions of line when option is enabled 1`] = `
         tabindex="0"
       />
       <g
-        class="movable-point  "
+        class="movable-point"
         data-testid="movable-point"
         style="--movable-point-color: #1865f2;"
       >
@@ -418,7 +418,7 @@ exports[`Rendering Does render extensions of line when option is enabled 1`] = `
         />
       </g>
       <g
-        class="movable-point  "
+        class="movable-point"
         data-testid="movable-point"
         style="--movable-point-color: #1865f2;"
       >

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -48,9 +48,17 @@ export const MovableLine = (props: Props) => {
     //   setting tabindex > 0. But that bumps elements to the front of the
     //   tab order for the entire page, which is not what we want.
     const {visiblePoint: visiblePoint1, focusableHandle: focusableHandle1} =
-        useControlPoint(start, color, (p) => onMovePoint(0, p));
+        useControlPoint({
+            point: start,
+            color,
+            onMove: (p) => onMovePoint(0, p),
+        });
     const {visiblePoint: visiblePoint2, focusableHandle: focusableHandle2} =
-        useControlPoint(end, color, (p) => onMovePoint(1, p));
+        useControlPoint({
+            point: end,
+            color,
+            onMove: (p) => onMovePoint(1, p),
+        });
 
     const line = (
         <Line

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -1,5 +1,5 @@
 import {vec} from "mafs";
-import {useRef, useState} from "react";
+import {useRef} from "react";
 import * as React from "react";
 
 import {inset, snap, size} from "../../math";
@@ -9,8 +9,8 @@ import {useDraggable} from "../use-draggable";
 import {useTransformVectorsToPixels} from "../use-transform";
 import {getIntersectionOfRayWithBox} from "../utils";
 
-import {MovablePointView} from "./movable-point-view";
 import {SVGLine} from "./svg-line";
+import {useControlPoint} from "./use-control-point";
 import {Vector} from "./vector";
 
 import type {Interval} from "mafs";
@@ -72,55 +72,6 @@ export const MovableLine = (props: Props) => {
         </>
     );
 };
-
-function useControlPoint(
-    point: vec.Vector2,
-    color: string | undefined,
-    onMovePoint: (newPoint: vec.Vector2) => unknown,
-) {
-    const {snapStep, disableKeyboardInteraction} = useGraphConfig();
-    const [focused, setFocused] = useState(false);
-    const keyboardHandleRef = useRef<SVGGElement>(null);
-    useDraggable({
-        gestureTarget: keyboardHandleRef,
-        point,
-        onMove: onMovePoint,
-        constrainKeyboardMovement: (p) => snap(snapStep, p),
-    });
-
-    const visiblePointRef = useRef<SVGGElement>(null);
-    const {dragging} = useDraggable({
-        gestureTarget: visiblePointRef,
-        point,
-        onMove: onMovePoint,
-        constrainKeyboardMovement: (p) => snap(snapStep, p),
-    });
-
-    const focusableHandle = (
-        <g
-            data-testid="movable-point__focusable-handle"
-            className="movable-point__focusable-handle"
-            tabIndex={disableKeyboardInteraction ? -1 : 0}
-            ref={keyboardHandleRef}
-            onFocus={() => setFocused(true)}
-            onBlur={() => setFocused(false)}
-        />
-    );
-    const visiblePoint = (
-        <MovablePointView
-            point={point}
-            dragging={dragging}
-            color={color}
-            ref={visiblePointRef}
-            focusBehavior={{type: "controlled", showFocusRing: focused}}
-        />
-    );
-
-    return {
-        focusableHandle,
-        visiblePoint,
-    };
-}
 
 const defaultStroke = "var(--movable-line-stroke-color)";
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
@@ -130,6 +130,8 @@ export const MovablePointView = forwardRef(
 
 // TODO(benchristel): Move this to a more central location if it's reused.
 // Or install the library.
-function classNames(...names: Array<string | false | null | undefined>): string {
-    return names.filter(Boolean).join(" ")
+function classNames(
+    ...names: Array<string | false | null | undefined>
+): string {
+    return names.filter(Boolean).join(" ");
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
@@ -22,6 +22,7 @@ type Props = {
 
 type FocusBehaviorConfig = ControlledFocusBehavior | UncontrolledFocusBehavior;
 
+// FIXME: remove uncontrolled focus behavior
 type ControlledFocusBehavior = {type: "controlled"; showFocusRing: boolean};
 type UncontrolledFocusBehavior = {
     type: "uncontrolled";

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.test.tsx
@@ -157,10 +157,7 @@ describe("MovablePoint", () => {
             );
 
             // eslint-disable-next-line testing-library/no-container,testing-library/no-node-access
-            const svgGroups = container.querySelectorAll("svg > g");
-            expect(svgGroups).toHaveLength(2);
-            // eslint-disable-next-line testing-library/no-container,testing-library/no-node-access
-            const hairLines = svgGroups[0].querySelectorAll("line");
+            const hairLines = container.querySelectorAll("svg line");
             expect(hairLines).toHaveLength(2);
         });
 
@@ -173,8 +170,8 @@ describe("MovablePoint", () => {
             );
 
             // eslint-disable-next-line testing-library/no-container,testing-library/no-node-access
-            const svgGroups = container.querySelectorAll("svg > g");
-            expect(svgGroups).toHaveLength(1);
+            const hairLines = container.querySelectorAll("svg line");
+            expect(hairLines).toHaveLength(0);
         });
 
         it("Hairlines do NOT show when 'markings' are set to 'none'", () => {
@@ -189,59 +186,56 @@ describe("MovablePoint", () => {
             );
 
             // eslint-disable-next-line testing-library/no-container,testing-library/no-node-access
-            const svgGroups = container.querySelectorAll("svg > g");
-            expect(svgGroups).toHaveLength(1);
+            const hairLines = container.querySelectorAll("svg line");
+            expect(hairLines).toHaveLength(0);
         });
     });
 
-    it("calls onFocusChange(true) when you tab to it", async () => {
-        const focusChangeSpy = jest.fn();
+    it("calls onFocus() when you tab to it", async () => {
+        const focusSpy = jest.fn();
         render(
             <Mafs width={200} height={200}>
-                <MovablePoint point={[0, 0]} onFocusChange={focusChangeSpy} />,
+                <MovablePoint point={[0, 0]} onFocus={focusSpy} />,
             </Mafs>,
         );
 
-        expect(focusChangeSpy).not.toHaveBeenCalled();
+        expect(focusSpy).not.toHaveBeenCalled();
 
         await userEvent.tab(); // tab to the graph
         await userEvent.tab(); // tab to the point
 
-        expect(focusChangeSpy.mock.calls[0][1]).toEqual(true);
+        expect(focusSpy).toHaveBeenCalledTimes(1);
     });
 
-    it("calls onFocusChange(false) when you tab away from it", async () => {
-        const focusChangeSpy = jest.fn();
+    it("calls onBlur() when you tab away from it", async () => {
+        const blurSpy = jest.fn();
         render(
             <Mafs width={200} height={200}>
-                <MovablePoint point={[0, 0]} onFocusChange={focusChangeSpy} />,
+                <MovablePoint point={[0, 0]} onBlur={blurSpy} />,
             </Mafs>,
         );
 
-        expect(focusChangeSpy).not.toHaveBeenCalled();
+        expect(blurSpy).not.toHaveBeenCalled();
 
         await userEvent.tab(); // tab to the graph
         await userEvent.tab(); // tab to the point
         await userEvent.tab(); // tab away
 
-        expect(focusChangeSpy.mock.calls.length).toBe(2);
-
-        expect(focusChangeSpy.mock.calls[0][1]).toEqual(true);
-        expect(focusChangeSpy.mock.calls[1][1]).toEqual(false);
+        expect(blurSpy).toHaveBeenCalledTimes(1);
     });
 
     it("calls onFocusChange(true) when you click it", async () => {
-        const focusChangeSpy = jest.fn();
+        const focusSpy = jest.fn();
         render(
             <Mafs width={200} height={200}>
-                <MovablePoint point={[0, 0]} onFocusChange={focusChangeSpy} />,
+                <MovablePoint point={[0, 0]} onFocus={focusSpy} />,
             </Mafs>,
         );
 
-        expect(focusChangeSpy).not.toHaveBeenCalled();
+        expect(focusSpy).not.toHaveBeenCalled();
 
         await userEvent.click(screen.getByTestId("movable-point"));
 
-        expect(focusChangeSpy.mock.calls[0][1]).toEqual(true);
+        expect(focusSpy).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
@@ -13,7 +13,8 @@ type Props = {
     color?: string;
     cursor?: CSSCursor | undefined;
     constrain?: KeyboardMovementConstraint;
-    onFocusChange?: (event: React.FocusEvent, isFocused: boolean) => unknown;
+    onFocus?: ((event: React.FocusEvent) => unknown) | undefined;
+    onBlur?: ((event: React.FocusEvent) => unknown) | undefined;
 };
 
 export const MovablePoint = React.forwardRef(

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
@@ -1,12 +1,6 @@
-import {color as WBColor} from "@khanacademy/wonder-blocks-tokens";
 import * as React from "react";
-import {useRef} from "react";
 
-import {snap} from "../../math";
-import useGraphConfig from "../../reducer/use-graph-config";
-import {useDraggable} from "../use-draggable";
-
-import {MovablePointView} from "./movable-point-view";
+import {useControlPoint} from "./use-control-point";
 
 import type {CSSCursor} from "./css-cursor";
 import type {KeyboardMovementConstraint} from "../use-draggable";
@@ -24,55 +18,15 @@ type Props = {
 
 export const MovablePoint = React.forwardRef(
     (props: Props, pointRef: React.ForwardedRef<SVGGElement | null>) => {
-        const {snapStep} = useGraphConfig();
-        const elementRef = useRef<SVGGElement | null>(null);
-        const {
-            point,
-            onMove = () => {},
-            onFocusChange = () => {},
-            onClick = () => {},
-            cursor,
-            color = WBColor.blue,
-            constrain = (p) => snap(snapStep, p),
-        } = props;
-        const {dragging} = useDraggable({
-            gestureTarget: elementRef,
-            point,
-            onMove,
-            constrainKeyboardMovement: constrain,
+        const {visiblePoint, focusableHandle} = useControlPoint({
+            ...props,
+            forwardedRef: pointRef,
         });
-
         return (
-            <MovablePointView
-                ref={(ref) => {
-                    // Note: This handles the case where pointRef is either a
-                    // function or a MutableRefObject. Mostly this is to satisfy
-                    // the type system, the function branch seems to be the only
-                    // one that occurs
-                    if (typeof pointRef === "function") {
-                        pointRef(ref);
-                    } else if (pointRef !== null) {
-                        pointRef.current = ref;
-                    }
-
-                    // This ref is for the useDraggable and is not passed up the
-                    // chain
-                    elementRef.current = ref;
-                }}
-                point={point}
-                color={color}
-                dragging={dragging}
-                focusBehavior={{
-                    type: "uncontrolled",
-                    tabIndex: 0,
-                    onFocusChange,
-                }}
-                onClick={() => {
-                    onClick && onClick();
-                    elementRef.current?.focus();
-                }}
-                cursor={cursor}
-            />
+            <>
+                {focusableHandle}
+                {visiblePoint}
+            </>
         );
     },
 );

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -18,9 +18,8 @@ type Params = {
     constrain?: KeyboardMovementConstraint;
     onMove?: ((newPoint: vec.Vector2) => unknown) | undefined;
     onClick?: (() => unknown) | undefined;
-    // TODO(benchristel): Replace onFocusChange with onFocus and onBlur,
-    // since all callers handle focus and blur separately.
-    onFocusChange?: (event: React.FocusEvent, isFocused: boolean) => unknown;
+    onFocus?: ((event: React.FocusEvent) => unknown) | undefined;
+    onBlur?: ((event: React.FocusEvent) => unknown) | undefined;
     // The focusableHandle element is assigned to the forwarded ref
     forwardedRef?: React.ForwardedRef<SVGGElement | null> | undefined;
 };
@@ -41,7 +40,8 @@ export function useControlPoint(params: Params): Return {
         constrain = (p) => snap(snapStep, p),
         onMove = noop,
         onClick = noop,
-        onFocusChange = noop,
+        onFocus = noop,
+        onBlur = noop,
         forwardedRef = noop,
     } = params;
 
@@ -73,11 +73,11 @@ export function useControlPoint(params: Params): Return {
             tabIndex={disableKeyboardInteraction ? -1 : 0}
             ref={focusableHandleRef}
             onFocus={(event) => {
-                onFocusChange(event, true);
+                onFocus(event);
                 setFocused(true);
             }}
             onBlur={(event) => {
-                onFocusChange(event, false);
+                onBlur(event);
                 setFocused(false);
             }}
         />

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -9,18 +9,20 @@ import {MovablePointView} from "./movable-point-view";
 
 import type {vec} from "mafs";
 
-export function useControlPoint(
-    point: vec.Vector2,
-    color: string | undefined,
-    onMovePoint: (newPoint: vec.Vector2) => unknown,
-) {
+type Params = {
+    point: vec.Vector2;
+    color?: string | undefined;
+    onMove?: (newPoint: vec.Vector2) => unknown;
+};
+
+export function useControlPoint({point, color, onMove = () => {}}: Params) {
     const {snapStep, disableKeyboardInteraction} = useGraphConfig();
     const [focused, setFocused] = useState(false);
     const keyboardHandleRef = useRef<SVGGElement>(null);
     useDraggable({
         gestureTarget: keyboardHandleRef,
         point,
-        onMove: onMovePoint,
+        onMove,
         constrainKeyboardMovement: (p) => snap(snapStep, p),
     });
 
@@ -28,7 +30,7 @@ export function useControlPoint(
     const {dragging} = useDraggable({
         gestureTarget: visiblePointRef,
         point,
-        onMove: onMovePoint,
+        onMove,
         constrainKeyboardMovement: (p) => snap(snapStep, p),
     });
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -93,7 +93,7 @@ export function useControlPoint(params: Params): Return {
             dragging={dragging}
             color={color}
             ref={visiblePointRef}
-            focusBehavior={{type: "controlled", showFocusRing: focused}}
+            showFocusRing={focused}
         />
     );
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+import {useState, useRef} from "react";
+
+import {snap} from "../../math";
+import useGraphConfig from "../../reducer/use-graph-config";
+import {useDraggable} from "../use-draggable";
+
+import {MovablePointView} from "./movable-point-view";
+
+import type {vec} from "mafs";
+
+export function useControlPoint(
+    point: vec.Vector2,
+    color: string | undefined,
+    onMovePoint: (newPoint: vec.Vector2) => unknown,
+) {
+    const {snapStep, disableKeyboardInteraction} = useGraphConfig();
+    const [focused, setFocused] = useState(false);
+    const keyboardHandleRef = useRef<SVGGElement>(null);
+    useDraggable({
+        gestureTarget: keyboardHandleRef,
+        point,
+        onMove: onMovePoint,
+        constrainKeyboardMovement: (p) => snap(snapStep, p),
+    });
+
+    const visiblePointRef = useRef<SVGGElement>(null);
+    const {dragging} = useDraggable({
+        gestureTarget: visiblePointRef,
+        point,
+        onMove: onMovePoint,
+        constrainKeyboardMovement: (p) => snap(snapStep, p),
+    });
+
+    const focusableHandle = (
+        <g
+            data-testid="movable-point__focusable-handle"
+            className="movable-point__focusable-handle"
+            tabIndex={disableKeyboardInteraction ? -1 : 0}
+            ref={keyboardHandleRef}
+            onFocus={() => setFocused(true)}
+            onBlur={() => setFocused(false)}
+        />
+    );
+    const visiblePoint = (
+        <MovablePointView
+            point={point}
+            dragging={dragging}
+            color={color}
+            ref={visiblePointRef}
+            focusBehavior={{type: "controlled", showFocusRing: focused}}
+        />
+    );
+
+    return {
+        focusableHandle,
+        visiblePoint,
+    };
+}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -20,7 +20,7 @@ type Params = {
     onClick?: (() => unknown) | undefined;
     onFocus?: ((event: React.FocusEvent) => unknown) | undefined;
     onBlur?: ((event: React.FocusEvent) => unknown) | undefined;
-    // The focusableHandle element is assigned to the forwarded ref
+    // The focusableHandle element is assigned to the forwarded ref.
     forwardedRef?: React.ForwardedRef<SVGGElement | null> | undefined;
 };
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
@@ -93,27 +93,26 @@ function UnlimitedPointGraph(props: PointGraphProps) {
                     ref={(ref) => {
                         itemsRef.current[i] = ref;
                     }}
-                    onFocusChange={(event, isFocused) => {
-                        if (isFocused) {
-                            dispatch(actions.pointGraph.focusPoint(i));
-                        } else {
-                            if (event.relatedTarget?.id === REMOVE_BUTTON_ID) {
-                                return;
-                                // This is an optimization: If the next target
-                                // is a point then don't blur because it casues
-                                // the remove button to get taken off the page
-                                // and then put back on The new point will
-                                // receive focus and set the correct state in
-                                // the reducer
-                            } else if (
-                                event.relatedTarget?.classList.contains(
-                                    "movable-point",
-                                )
-                            ) {
-                                return;
-                            }
-                            dispatch(actions.pointGraph.blurPoint());
+                    onFocus={() => {
+                        dispatch(actions.pointGraph.focusPoint(i));
+                    }}
+                    onBlur={(event) => {
+                        if (event.relatedTarget?.id === REMOVE_BUTTON_ID) {
+                            return;
+                            // This is an optimization: If the next target
+                            // is a point then don't blur because it casues
+                            // the remove button to get taken off the page
+                            // and then put back on The new point will
+                            // receive focus and set the correct state in
+                            // the reducer
+                        } else if (
+                            event.relatedTarget?.classList.contains(
+                                "movable-point",
+                            )
+                        ) {
+                            return;
                         }
+                        dispatch(actions.pointGraph.blurPoint());
                     }}
                     onClick={() => {
                         dispatch(actions.pointGraph.clickPoint(i));

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
@@ -96,24 +96,6 @@ function UnlimitedPointGraph(props: PointGraphProps) {
                     onFocus={() => {
                         dispatch(actions.pointGraph.focusPoint(i));
                     }}
-                    onBlur={(event) => {
-                        if (event.relatedTarget?.id === REMOVE_BUTTON_ID) {
-                            return;
-                            // This is an optimization: If the next target
-                            // is a point then don't blur because it casues
-                            // the remove button to get taken off the page
-                            // and then put back on The new point will
-                            // receive focus and set the correct state in
-                            // the reducer
-                        } else if (
-                            event.relatedTarget?.classList.contains(
-                                "movable-point",
-                            )
-                        ) {
-                            return;
-                        }
-                        dispatch(actions.pointGraph.blurPoint());
-                    }}
                     onClick={() => {
                         dispatch(actions.pointGraph.clickPoint(i));
                     }}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
@@ -35,10 +35,10 @@ function LimitedPointGraph(props: PointGraphProps) {
 
 function UnlimitedPointGraph(props: PointGraphProps) {
     const {dispatch} = props;
-    const graphState = useGraphConfig();
+    const graphConfig = useGraphConfig();
     const {
         range: [[minX, maxX], [minY, maxY]],
-    } = graphState;
+    } = graphConfig;
     const width = maxX - minX;
     const height = maxY - minY;
     const [[widthPx, heightPx]] = useTransformDimensionsToPixels([
@@ -78,7 +78,7 @@ function UnlimitedPointGraph(props: PointGraphProps) {
 
                     const graphCoordinates = pixelsToVectors(
                         [[x, y]],
-                        graphState,
+                        graphConfig,
                     );
                     dispatch(actions.pointGraph.addPoint(graphCoordinates[0]));
                 }}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 
-import {REMOVE_BUTTON_ID} from "../mafs-graph";
 import {actions} from "../reducer/interactive-graph-action";
 import useGraphConfig from "../reducer/use-graph-config";
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -162,7 +162,7 @@ describe("MafsGraph", () => {
             />,
         );
 
-        const group = screen.getByTestId("movable-point");
+        const group = screen.getByTestId("movable-point__focusable-handle");
         group.focus();
         await userEvent.keyboard("[ArrowRight]");
         const action = actions.pointGraph.movePoint(0, [4, 2]);

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -441,7 +441,11 @@ function handleKeyboardEvent(
             // while the whole graph is focused. Instead of doing this, we
             // should move the keyboard event handler to the movable point
             // handle element.
-            if (document.activeElement?.classList.contains("movable-point__focusable-handle")) {
+            if (
+                document.activeElement?.classList.contains(
+                    "movable-point__focusable-handle",
+                )
+            ) {
                 dispatch(actions.global.deleteIntent());
             }
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -436,7 +436,14 @@ function handleKeyboardEvent(
 ) {
     if (state.type === "point" && state.numPoints === "unlimited") {
         if (event.key === "Backspace") {
-            dispatch(actions.global.deleteIntent());
+            // TODO(benchristel): Checking classList here is a hack to prevent
+            // points from being deleted if the user presses the backspace key
+            // while the whole graph is focused. Instead of doing this, we
+            // should move the keyboard event handler to the movable point
+            // handle element.
+            if (document.activeElement?.classList.contains("movable-point__focusable-handle")) {
+                dispatch(actions.global.deleteIntent());
+            }
 
             // After removing a point blur
             // It would be nice if this could focus on the graph but doing so

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -128,9 +128,8 @@ function doDeleteIntent(
 ): InteractiveGraphState {
     // For unlimited point graphs
     if (state.type === "point" && state.numPoints === "unlimited") {
-        // if there's a focused point
+        // Remove the last point that was focused, if any
         if (state.focusedPointIndex !== null) {
-            // Remove the focused focus
             return doRemovePoint(
                 state,
                 actions.pointGraph.removePoint(state.focusedPointIndex),


### PR DESCRIPTION
Note to reviewers: it will probably be easiest to review this PR one commit at
a time.

When I started to add aria labels to movable points, I hit a snag: some of
our graph types make the movable point SVG itself tab-focusable, while other
graph types (e.g. segment) add a focusable dummy element so the visual
render order of the points can be different from the tabindex order. This
means that we'd want aria labels in different locations for each of these
graph types. Sometimes, the aria label would need to be on the movable point
itself, and sometimes it would need to be on the dummy element.

The solution implemented in this PR is to use the dummy element for all movable
points. That way we will only need to add accessible stuff to the dummy
element.

This PR is just refactoring; it doesn't add any features.

Issue: none

## Test plan:

`yarn dev`

Play with the graph types on `localhost:5173`. You should be able to control
each graph using either the mouse or the keyboard. A ring should always appear
on the focused point (whether it received focus from a mouse or keyboard
interaction).