### PR TITLE
Hackathon 2024 - Biome 1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,9 @@
 # https://editorconfig.org/#file-format-details
 
+# top-most EditorConfig file
 root = true
 
+[*]
 indent_style = space
 indent_size = 4
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,15 @@
 {
     "editor.renderWhitespace": "boundary",
+
+    "editor.defaultFormatter": "biomejs.biome",
+    "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-        "source.fixAll": "explicit"
+        "quickfix.biome": "explicit"
     },
-    "eslint.codeActionsOnSave.mode": "all",
     "files.trimTrailingWhitespace": true,
-    "todo-tree.filtering.excludeGlobs": [
-        "**/dist/**",
-    ],
-    "typescript.format.enable": false,
+
+    "todo-tree.filtering.excludeGlobs": ["**/dist/**"],
+
     "typescript.validate.enable": true,
     "typescript.tsdk": "node_modules/typescript/lib",
     "typescript.tsserver.experimental.enableProjectDiagnostics": true,
@@ -26,5 +27,5 @@
     "typescript.inlayHints.parameterNames.enabled": "all",
     "typescript.inlayHints.parameterTypes.enabled": true,
     "typescript.inlayHints.propertyDeclarationTypes.enabled": true,
-    "typescript.inlayHints.variableTypes.enabled": true,
+    "typescript.inlayHints.variableTypes.enabled": true
 }

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,0 +1,30 @@
+{
+	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+	"vcs": {
+		"enabled": false,
+		"clientKind": "git",
+		"useIgnoreFile": false
+	},
+	"files": {
+		"ignoreUnknown": false,
+		"ignore": []
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab"
+	},
+	"organizeImports": {
+		"enabled": true
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double"
+		}
+	}
+}

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -2,7 +2,17 @@
     "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
     "files": {
         "ignoreUnknown": false,
-        "ignore": ["data/questions/", "__genfiles__/", "vendor/**/*.js"]
+        "ignore": [
+            "data/questions/",
+            "__genfiles__/",
+            "vendor/**/*.js",
+            "storybook-static/",
+            "styles/khan-exercise.css"
+        ]
+    },
+    "vcs": {
+        "clientKind": "git",
+        "useIgnoreFile": true
     },
     "formatter": {
         "enabled": true,

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -2,7 +2,7 @@
     "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
     "files": {
         "ignoreUnknown": false,
-        "ignore": ["data/questions/", "__genfiles__/"]
+        "ignore": ["data/questions/", "__genfiles__/", "vendor/**/*.js"]
     },
     "formatter": {
         "enabled": true,

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,30 +1,26 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
-	"vcs": {
-		"enabled": false,
-		"clientKind": "git",
-		"useIgnoreFile": false
-	},
-	"files": {
-		"ignoreUnknown": false,
-		"ignore": []
-	},
-	"formatter": {
-		"enabled": true,
-		"indentStyle": "tab"
-	},
-	"organizeImports": {
-		"enabled": true
-	},
-	"linter": {
-		"enabled": true,
-		"rules": {
-			"recommended": true
-		}
-	},
-	"javascript": {
-		"formatter": {
-			"quoteStyle": "double"
-		}
-	}
+    "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+    "files": {
+        "ignoreUnknown": false,
+        "ignore": []
+    },
+    "formatter": {
+        "useEditorconfig": true,
+        "enabled": true
+    },
+    "organizeImports": {
+        "enabled": true
+    },
+    "linter": {
+        "enabled": true,
+        "rules": {
+            "recommended": true
+        }
+    },
+    "javascript": {
+        "formatter": {
+            "quoteStyle": "double",
+            "trailingCommas": "all"
+        }
+    }
 }

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -5,14 +5,14 @@
         "ignore": []
     },
     "formatter": {
-        "useEditorconfig": true,
-        "enabled": true
+        "enabled": true,
+        "useEditorconfig": true
     },
     "organizeImports": {
         "enabled": false
     },
     "linter": {
-        "enabled": true,
+        "enabled": false,
         "rules": {
             "recommended": true
         }

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -2,7 +2,7 @@
     "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
     "files": {
         "ignoreUnknown": false,
-        "ignore": []
+        "ignore": ["data/questions/"]
     },
     "formatter": {
         "enabled": true,

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -20,7 +20,9 @@
     "javascript": {
         "formatter": {
             "quoteStyle": "double",
-            "trailingCommas": "all"
+            "trailingCommas": "all",
+
+            "bracketSpacing": false
         }
     }
 }

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -9,7 +9,7 @@
         "enabled": true
     },
     "organizeImports": {
-        "enabled": true
+        "enabled": false
     },
     "linter": {
         "enabled": true,

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -35,5 +35,24 @@
 
             "bracketSpacing": false
         }
-    }
+    },
+    "overrides": [
+        {
+            "include": [
+                "tsconfig-build.json",
+                "tsconfig-common.json",
+                "tsconfig-shared.json",
+                "tsconfig.json"
+            ],
+            "json": {
+                "formatter": {
+                    "trailingCommas": "all"
+                },
+                "parser": {
+                    "allowTrailingCommas": true,
+                    "allowComments": true
+                }
+            }
+        }
+    ]
 }

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -5,7 +5,8 @@
         "ignore": [
             "data/questions/",
             "__genfiles__/",
-            "vendor/**/*.js",
+            "dist/",
+            "vendor/",
             "storybook-static/",
             "styles/khan-exercise.css"
         ]

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -2,7 +2,7 @@
     "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
     "files": {
         "ignoreUnknown": false,
-        "ignore": ["data/questions/"]
+        "ignore": ["data/questions/", "__genfiles__/"]
     },
     "formatter": {
         "enabled": true,

--- a/config/test/log-on-fail-reporter.js
+++ b/config/test/log-on-fail-reporter.js
@@ -22,7 +22,7 @@ class LogOnFailedTestReporter extends DefaultReporter {
         const testFailed = result.numFailingTests > 0;
 
         if (testFailed && consoleBuffer && consoleBuffer.length) {
-            // prettier-ignore
+            // biome-ignore format: keep these on the same line
             this.log(
          `  ${TITLE_BULLET}Console\n\n${getConsoleOutput(
            consoleBuffer,

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "@babel/preset-env": "^7.23.2",
         "@babel/preset-react": "^7.22.12",
         "@babel/preset-typescript": "^7.23.2",
+        "@biomejs/biome": "2.0.0-beta.1",
         "@changesets/changelog-github": "^0.4.8",
         "@changesets/cli": "^2.22.0",
         "@cypress/code-coverage": "^3.12.24",

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -326,73 +326,73 @@ export type WidgetOptions<Type extends string, Options> = {
     version?: Version;
 };
 
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type CategorizerWidget = WidgetOptions<'categorizer', PerseusCategorizerWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type CSProgramWidget = WidgetOptions<'cs-program', PerseusCSProgramWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type DefinitionWidget = WidgetOptions<'definition', PerseusDefinitionWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type DropdownWidget = WidgetOptions<'dropdown', PerseusDropdownWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type ExplanationWidget = WidgetOptions<'explanation', PerseusExplanationWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type ExpressionWidget = WidgetOptions<'expression', PerseusExpressionWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type GradedGroupSetWidget = WidgetOptions<'graded-group-set', PerseusGradedGroupSetWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type GradedGroupWidget = WidgetOptions<'graded-group', PerseusGradedGroupWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type GrapherWidget = WidgetOptions<'grapher', PerseusGrapherWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type GroupWidget = WidgetOptions<'group', PerseusGroupWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type IFrameWidget = WidgetOptions<'iframe', PerseusIFrameWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type ImageWidget = WidgetOptions<'image', PerseusImageWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type InteractionWidget = WidgetOptions<'interaction', PerseusInteractionWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type InteractiveGraphWidget = WidgetOptions<'interactive-graph', PerseusInteractiveGraphWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type LabelImageWidget = WidgetOptions<'label-image', PerseusLabelImageWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type MatcherWidget = WidgetOptions<'matcher', PerseusMatcherWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type MatrixWidget = WidgetOptions<'matrix', PerseusMatrixWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type MeasurerWidget = WidgetOptions<'measurer', PerseusMeasurerWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type NumberLineWidget = WidgetOptions<'number-line', PerseusNumberLineWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type NumericInputWidget = WidgetOptions<'numeric-input', PerseusNumericInputWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type OrdererWidget = WidgetOptions<'orderer', PerseusOrdererWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type PassageRefWidget = WidgetOptions<'passage-ref', PerseusPassageRefWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type PassageWidget = WidgetOptions<'passage', PerseusPassageWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type PhetSimulationWidget = WidgetOptions<'phet-simulation', PerseusPhetSimulationWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type PlotterWidget = WidgetOptions<'plotter', PerseusPlotterWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type PythonProgramWidget = WidgetOptions<'python-program', PerseusPythonProgramWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type RadioWidget = WidgetOptions<'radio', PerseusRadioWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type SorterWidget = WidgetOptions<'sorter', PerseusSorterWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type TableWidget = WidgetOptions<'table', PerseusTableWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type InputNumberWidget = WidgetOptions<'input-number', PerseusInputNumberWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type MoleculeRendererWidget = WidgetOptions<'molecule-renderer', PerseusMoleculeRendererWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type RefTargetWidget = WidgetOptions<'passage-ref-target', PerseusPassageRefTargetWidgetOptions>;
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 export type VideoWidget = WidgetOptions<'video', PerseusVideoWidgetOptions>;
-//prettier-ignore
+// biome-ignore format: keep these on the same line
 export type DeprecatedStandinWidget = WidgetOptions<'deprecated-standin', object>;
 
 /**

--- a/packages/perseus-core/src/utils/grapher-util.ts
+++ b/packages/perseus-core/src/utils/grapher-util.ts
@@ -627,7 +627,7 @@ export const allTypes: any = _.keys(functionTypeMapping);
 export type FunctionTypeMappingKeys = keyof typeof functionTypeMapping;
 
 type ConditionalGraderType<T extends FunctionTypeMappingKeys> =
-    // prettier-ignore
+    // biome-ignore
     T extends "linear" ? LinearType
     : T extends "quadratic" ? QuadraticType
     : T extends "sinusoid" ? SinusoidType

--- a/packages/perseus-linter/src/rule.ts
+++ b/packages/perseus-linter/src/rule.ts
@@ -164,7 +164,7 @@ type RuleCheckReturnType =
 // This is the return type of the lint detection function passed as the 4th
 // argument to the Rule() constructor. It can return null or a string or an
 // object containing a string and two numbers.
-// prettier-ignore
+// biome-ignore format: keep these on the same line
 // (prettier formats this in a way that ka-lint does not like)
 type LintTesterReturnType = string | {
     message: string,

--- a/packages/perseus/src/widgets/grapher/util.tsx
+++ b/packages/perseus/src/widgets/grapher/util.tsx
@@ -1,189 +1,187 @@
-import {point as kpoint} from "@khanacademy/kmath";
-import {GrapherUtil} from "@khanacademy/perseus-core";
+import { point as kpoint } from "@khanacademy/kmath";
+import { GrapherUtil } from "@khanacademy/perseus-core";
 import * as React from "react";
 import _ from "underscore";
 
 import Graphie from "../../components/graphie";
-import {getDependencies} from "../../dependencies";
+import { getDependencies } from "../../dependencies";
 import Util from "../../util";
 
-import type {Coord} from "../../interactive2/types";
-import type {FunctionTypeMappingKeys} from "@khanacademy/perseus-core";
+import type { Coord } from "../../interactive2/types";
+import type { FunctionTypeMappingKeys } from "@khanacademy/perseus-core";
 
 type MovableMap = {
-    [K in keyof typeof GrapherUtil.MOVABLES]: any;
+	[K in keyof typeof GrapherUtil.MOVABLES]: any;
 };
 export const movableTypeToComponent: MovableMap = {
-    // @ts-expect-error - TS2339 - Property 'Plot' does not exist on type 'typeof Graphie'.
-    PLOT: Graphie.Plot,
-    // @ts-expect-error - TS2339 - Property 'Parabola' does not exist on type 'typeof Graphie'.
-    PARABOLA: Graphie.Parabola,
-    // @ts-expect-error - TS2339 - Property 'Sinusoid' does not exist on type 'typeof Graphie'.
-    SINUSOID: Graphie.Sinusoid,
+	// @ts-expect-error - TS2339 - Property 'Plot' does not exist on type 'typeof Graphie'.
+	PLOT: Graphie.Plot,
+	// @ts-expect-error - TS2339 - Property 'Parabola' does not exist on type 'typeof Graphie'.
+	PARABOLA: Graphie.Parabola,
+	// @ts-expect-error - TS2339 - Property 'Sinusoid' does not exist on type 'typeof Graphie'.
+	SINUSOID: Graphie.Sinusoid,
 };
 
 const DEFAULT_BACKGROUND_IMAGE = {
-    url: null,
+	url: null,
 } as const;
 
 export const getEquationString = (props: any): string => {
-    const plot = props.plot;
-    if (plot.type && plot.coords) {
-        const handler = GrapherUtil.functionForType(plot.type);
-        const result = handler.getEquationString(plot.coords, plot.asymptote);
-        return result || "";
-    }
-    return "";
+	const plot = props.plot;
+	if (plot.type && plot.coords) {
+		const handler = GrapherUtil.functionForType(plot.type);
+		const result = handler.getEquationString(plot.coords, plot.asymptote);
+		return result || "";
+	}
+	return "";
 };
 
 const pointsFromNormalized = (
-    coordsList: ReadonlyArray<Coord>,
-    range: [Coord, Coord],
-    step: [number, number],
-    snapStep: [number, number],
+	coordsList: ReadonlyArray<Coord>,
+	range: [Coord, Coord],
+	step: [number, number],
+	snapStep: [number, number],
 ): ReadonlyArray<Coord> => {
-    const numSteps = function (range: Coord, step: number) {
-        return Math.floor((range[1] - range[0]) / step);
-    };
+	const numSteps = (range: Coord, step: number) =>
+		Math.floor((range[1] - range[0]) / step);
 
-    // @ts-expect-error - TS2322 - Type 'number[][]' is not assignable to type 'readonly Coord[]'.
-    return coordsList.map((coords) => {
-        const unsnappedPoint = coords.map((coord, i) => {
-            const currRange = range[i];
-            const currStep = step[i];
-            const nSteps = numSteps(currRange, currStep);
-            const tick = Math.round(coord * nSteps);
-            return currRange[0] + currStep * tick;
-        });
-        // In some graphing widgets, e.g. interactive-graph, you can rely
-        // on the Graphie to handle snapping. Here, we need the points
-        // returned to already be snapped so that the plot that goes
-        // through them is correct.
-        return kpoint.roundTo(unsnappedPoint, snapStep);
-    });
+	// @ts-expect-error - TS2322 - Type 'number[][]' is not assignable to type 'readonly Coord[]'.
+	return coordsList.map((coords) => {
+		const unsnappedPoint = coords.map((coord, i) => {
+			const currRange = range[i];
+			const currStep = step[i];
+			const nSteps = numSteps(currRange, currStep);
+			const tick = Math.round(coord * nSteps);
+			return currRange[0] + currStep * tick;
+		});
+		// In some graphing widgets, e.g. interactive-graph, you can rely
+		// on the Graphie to handle snapping. Here, we need the points
+		// returned to already be snapped so that the plot that goes
+		// through them is correct.
+		return kpoint.roundTo(unsnappedPoint, snapStep);
+	});
 };
 
 export const maybePointsFromNormalized = (
-    coordsList: ReadonlyArray<Coord> | null | undefined,
-    range: [Coord, Coord],
-    step: [number, number],
-    snapStep: [number, number],
+	coordsList: ReadonlyArray<Coord> | null | undefined,
+	range: [Coord, Coord],
+	step: [number, number],
+	snapStep: [number, number],
 ): ReadonlyArray<Coord> | null | undefined => {
-    if (coordsList) {
-        return pointsFromNormalized(coordsList, range, step, snapStep);
-    }
-    return coordsList;
+	if (coordsList) {
+		return pointsFromNormalized(coordsList, range, step, snapStep);
+	}
+	return coordsList;
 };
 
 /* Given a plot type, return the appropriate default value for a grapher
  * widget's plot props: type, default coords, default asymptote. */
 export const defaultPlotProps = (
-    type: FunctionTypeMappingKeys,
-    graph: any,
+	type: FunctionTypeMappingKeys,
+	graph: any,
 ): any => {
-    // The coords are null by default, to indicate that the user has not
-    // moved them from the default position, and that this widget should
-    // therefore be considered empty and ineligible for grading. The user
-    // *can* move the coords from the default position and then back if
-    // they really want to submit the default coords as their answer, but
-    // we currently don't write questions that require this.
-    //
-    // We *do* write questions in which the asymptote should be left in
-    // the default position. For this reason, we fill in the default
-    // asymptote rather than leaving it null; if the user moves the coords
-    // but not the asymptote, the widget is non-empty and eligible for
-    // grading.
-    //
-    // TODO(mattdr): Consider an updated scoring function that marks the
-    // default coords as empty *unless* they're the correct coords. This
-    // would remove this default-coords-are-always-wrong constraints on
-    // the questions we write, while still maintaining our kind behavior
-    // when users forget to update a widget... but we'd also be revealing
-    // extra information. It would be valid to always submit the default
-    // widget before even reading the question; you can't lose, but you
-    // might get a free win.
-    const model = GrapherUtil.functionForType(type);
-    const defaultAsymptote =
-        "defaultAsymptote" in model ? model.defaultAsymptote : null;
-    const gridStep = [1, 1];
-    // @ts-expect-error - TS2345 - Argument of type 'number[]' is not assignable to parameter of type '[number, number]'.
-    const snapStep = Util.snapStepFromGridStep(gridStep);
-    return {
-        type,
-        asymptote: maybePointsFromNormalized(
-            defaultAsymptote,
-            graph.range,
-            graph.step,
-            snapStep,
-        ),
-        coords: null,
-    };
+	// The coords are null by default, to indicate that the user has not
+	// moved them from the default position, and that this widget should
+	// therefore be considered empty and ineligible for grading. The user
+	// *can* move the coords from the default position and then back if
+	// they really want to submit the default coords as their answer, but
+	// we currently don't write questions that require this.
+	//
+	// We *do* write questions in which the asymptote should be left in
+	// the default position. For this reason, we fill in the default
+	// asymptote rather than leaving it null; if the user moves the coords
+	// but not the asymptote, the widget is non-empty and eligible for
+	// grading.
+	//
+	// TODO(mattdr): Consider an updated scoring function that marks the
+	// default coords as empty *unless* they're the correct coords. This
+	// would remove this default-coords-are-always-wrong constraints on
+	// the questions we write, while still maintaining our kind behavior
+	// when users forget to update a widget... but we'd also be revealing
+	// extra information. It would be valid to always submit the default
+	// widget before even reading the question; you can't lose, but you
+	// might get a free win.
+	const model = GrapherUtil.functionForType(type);
+	const defaultAsymptote =
+		"defaultAsymptote" in model ? model.defaultAsymptote : null;
+	const gridStep = [1, 1];
+	// @ts-expect-error - TS2345 - Argument of type 'number[]' is not assignable to parameter of type '[number, number]'.
+	const snapStep = Util.snapStepFromGridStep(gridStep);
+	return {
+		type,
+		asymptote: maybePointsFromNormalized(
+			defaultAsymptote,
+			graph.range,
+			graph.step,
+			snapStep,
+		),
+		coords: null,
+	};
 };
 
 /* Given a list of available types, choose which to use. */
 export const chooseType: <T>(list: ReadonlyArray<T>) => T | undefined = _.first;
 
 export const getGridAndSnapSteps = (
-    options: any,
-    boxSize: number,
+	options: any,
+	boxSize: number,
 ): {
-    gridStep: [number, number];
-    snapStep: [number, number];
+	gridStep: [number, number];
+	snapStep: [number, number];
 } => {
-    const gridStep =
-        options.gridStep ||
-        Util.getGridStep(options.range, options.step, boxSize);
-    const snapStep = options.snapStep || Util.snapStepFromGridStep(gridStep);
-    return {
-        gridStep: gridStep,
-        snapStep: snapStep,
-    };
+	const gridStep =
+		options.gridStep || Util.getGridStep(options.range, options.step, boxSize);
+	const snapStep = options.snapStep || Util.snapStepFromGridStep(gridStep);
+	return {
+		gridStep: gridStep,
+		snapStep: snapStep,
+	};
 };
 
 const defaultGraph: {
-    labels: ReadonlyArray<string>;
-    range: [Coord, Coord];
-    step: [number, number];
-    backgroundImage: any;
-    markings: string;
-    rulerLabel: string;
-    rulerTicks: number;
-    valid: boolean;
-    showTooltips: boolean;
+	labels: ReadonlyArray<string>;
+	range: [Coord, Coord];
+	step: [number, number];
+	backgroundImage: any;
+	markings: string;
+	rulerLabel: string;
+	rulerTicks: number;
+	valid: boolean;
+	showTooltips: boolean;
 } = {
-    labels: ["x", "y"],
-    range: [
-        [-10, 10],
-        [-10, 10],
-    ],
-    step: [1, 1],
-    backgroundImage: DEFAULT_BACKGROUND_IMAGE,
-    markings: "graph",
-    rulerLabel: "",
-    rulerTicks: 10,
-    valid: true,
-    showTooltips: false,
+	labels: ["x", "y"],
+	range: [
+		[-10, 10],
+		[-10, 10],
+	],
+	step: [1, 1],
+	backgroundImage: DEFAULT_BACKGROUND_IMAGE,
+	markings: "graph",
+	rulerLabel: "",
+	rulerTicks: 10,
+	valid: true,
+	showTooltips: false,
 };
 const defaultPlot = defaultPlotProps("linear", defaultGraph);
 
 export const DEFAULT_GRAPHER_PROPS: any = {
-    graph: defaultGraph,
-    plot: defaultPlot,
-    availableTypes: [defaultPlot.type],
+	graph: defaultGraph,
+	plot: defaultPlot,
+	availableTypes: [defaultPlot.type],
 };
 
 export const typeToButton = (type: FunctionTypeMappingKeys): any => {
-    const capitalized = type.charAt(0).toUpperCase() + type.substring(1);
-    const staticUrl = getDependencies().staticUrl;
+	const capitalized = type.charAt(0).toUpperCase() + type.substring(1);
+	const staticUrl = getDependencies().staticUrl;
 
-    return {
-        value: type,
-        title: capitalized,
-        content: (
-            <img
-                src={staticUrl(GrapherUtil.functionForType(type).url)}
-                alt={capitalized}
-            />
-        ),
-    };
+	return {
+		value: type,
+		title: capitalized,
+		content: (
+			<img
+				src={staticUrl(GrapherUtil.functionForType(type).url)}
+				alt={capitalized}
+			/>
+		),
+	};
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       '@babel/preset-typescript':
         specifier: ^7.23.2
         version: 7.23.2(@babel/core@7.26.0)
+      '@biomejs/biome':
+        specifier: 2.0.0-beta.1
+        version: 2.0.0-beta.1
       '@changesets/changelog-github':
         specifier: ^0.4.8
         version: 0.4.8(encoding@0.1.13)
@@ -1700,6 +1703,59 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@biomejs/biome@2.0.0-beta.1':
+    resolution: {integrity: sha512-MqRoy9CbTkrS45zW+S4u8p4kQUIFx0mGUWi789W1R3b1kXYIudEqsTKgXKtTGsI0kWOlvnjuKqwTrabjaGchhQ==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.0.0-beta.1':
+    resolution: {integrity: sha512-RaGmpNLl5NFooXaoCwvgvcuU6Am/rMZ3R48pQeCVxjrCcz1BIlKLTai5UosiedazW7JbXAvgXdSNizYG7ITlAQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.0.0-beta.1':
+    resolution: {integrity: sha512-sTzSshkne7HKZFNfiIhmAji7gjtCBXvkTujZELCZWIZC7oj1Tjw/gvAzbdFj2UyHd5/i90pND4ybFOLQZm9gpg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.0.0-beta.1':
+    resolution: {integrity: sha512-0MPUKzz9uBBxAYSJ+OlFi4+yGwiRcZeFqq39H0MxXCQ9MMpKJFH2Ek72fw8sXwG7Prn7EsW/3u1b7najyn1XGQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-arm64@2.0.0-beta.1':
+    resolution: {integrity: sha512-bxce2O4nooBmp20Ey0+IFIZyy/b0RVnciIQk9euCfAi9evq7SvFtMBYo3YUZej0KIvrau5H7tJk5OqmRJk2l+g==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64-musl@2.0.0-beta.1':
+    resolution: {integrity: sha512-dFvisnP1hFpVILNw0PZfs8piBwe8+aykO04Tb/4AJDVVzKkGgJfwSefwo4jqzO/Wk/Zruvhcp1nKbjgRXM+vDg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64@2.0.0-beta.1':
+    resolution: {integrity: sha512-6P/AtJv4hOH8mu8ez0c4UInUpiet9NEoF25+O7OPyb4w6ZHJMp2qzvayJS7TKrTQzE5KUvSiNsACGRz34DzUkg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-win32-arm64@2.0.0-beta.1':
+    resolution: {integrity: sha512-0C9YSqWHf2cJGnjKDbLi49xv6H9IfqbDsFav7X557PqwY64O6IKWqcmZzi/PkDFHjQM9opU6uhKapeGKGDxziQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.0.0-beta.1':
+    resolution: {integrity: sha512-o8W6+DX0YRjt1kS8Y3ismq6EkjwiVDv7X0TEpfnFywoVG8HoJ7G7/m9r8LM1yE46WI3maPH2A0MoVpQ1ZNG++A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@changesets/apply-release-plan@6.0.0':
     resolution: {integrity: sha512-gp6nIdVdfYdwKww2+f8whckKmvfE4JEm4jJgBhTmooi0uzHWhnxvk6JIzQi89qEAMINN0SeVNnXiAtbFY0Mj3w==}
@@ -9631,6 +9687,41 @@ snapshots:
       '@babel/helper-validator-identifier': 7.25.9
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@biomejs/biome@2.0.0-beta.1':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.0.0-beta.1
+      '@biomejs/cli-darwin-x64': 2.0.0-beta.1
+      '@biomejs/cli-linux-arm64': 2.0.0-beta.1
+      '@biomejs/cli-linux-arm64-musl': 2.0.0-beta.1
+      '@biomejs/cli-linux-x64': 2.0.0-beta.1
+      '@biomejs/cli-linux-x64-musl': 2.0.0-beta.1
+      '@biomejs/cli-win32-arm64': 2.0.0-beta.1
+      '@biomejs/cli-win32-x64': 2.0.0-beta.1
+
+  '@biomejs/cli-darwin-arm64@2.0.0-beta.1':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.0.0-beta.1':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.0.0-beta.1':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.0.0-beta.1':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.0.0-beta.1':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.0.0-beta.1':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.0.0-beta.1':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.0.0-beta.1':
+    optional: true
 
   '@changesets/apply-release-plan@6.0.0':
     dependencies:


### PR DESCRIPTION
## Summary:

This PR introduces a new tool for code formatting and linting (all-in-one) called [Biome](http://biomejs.dev). It is written in Rust and is significantly faster than ESLint and Prettier. It is a "batteries included" type of tool (with many built-in rules). 

I'm going to build a chain of PRs on the `feature/hackathon-biome` to check everything out. 

### PRs
  * This PR --> https://github.com/Khan/perseus/pull/1796
  * https://github.com/Khan/perseus/pull/1797
  * https://github.com/Khan/perseus/pull/1798

The specific pieces of this PR are: 
  * `yarn add --dev --exact --workspace @biomejs/biome`
  * `yarn biome init --jsonc`
  * Fix error in `.editorconfig`
  * Initial working `biome.jsonc`
  * Update repo vscode settings for Biome
  * Change `bracketSpacing` to match prettier config
  * Turn off `organizeImports` to start
  * Disable linter to start
  * Ignore `data/questions` data files
  * Ignore `genfiles`
  * Ignore source files in `vendor/`
  * Ignore `dist/` directories
  * Configure Biome to handle the various JSONC `tsconfig.json` files
  * Migrate from `// prettier-ignore` to `// biome-ignore`

Issue: --hackathon-2024--

## Test plan:

`yarn`
`yarn biome check` (there will be errors, but check out the formatting of the errors, etc).