### PR TITLE
Hackathon 2024 - Biome 2 - Apply formatting

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,13 +1,13 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@1.7.0/schema.json",
-  "changelog": ["@changesets/changelog-github", {"repo": "Khan/perseus"}],
-  "commit": false,
-  "linked": [],
-  "access": "public",
-  "baseBranch": "main",
-  "updateInternalDependencies": "patch",
-  "ignore": [],
-  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
-    "updateInternalDependents": "always"
-  }
+    "$schema": "https://unpkg.com/@changesets/config@1.7.0/schema.json",
+    "changelog": ["@changesets/changelog-github", { "repo": "Khan/perseus" }],
+    "commit": false,
+    "linked": [],
+    "access": "public",
+    "baseBranch": "main",
+    "updateInternalDependencies": "patch",
+    "ignore": [],
+    "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+        "updateInternalDependents": "always"
+    }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,22 +1,22 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
 {
-	"name": "Node.js & TypeScript",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/typescript-node:16",
+    "name": "Node.js & TypeScript",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:16",
 
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    // "features": {},
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [6006],
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    "forwardPorts": [6006],
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "yarn install"
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": "yarn install"
 
-	// Configure tool-specific properties.
-	// "customizations": {},
+    // Configure tool-specific properties.
+    // "customizations": {},
 
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
 }

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -6,9 +6,5 @@
         "packages/*/src/**/*.ts",
         "packages/*/src/**/*.tsx"
     ],
-    "exclude": [
-        "**/*.stories.tsx",
-        "**/*.test.ts",
-        "**/*.test.tsx"
-    ]
+    "exclude": ["**/*.stories.tsx", "**/*.test.ts", "**/*.test.tsx"]
 }

--- a/config/cypress/tsconfig.json
+++ b/config/cypress/tsconfig.json
@@ -5,7 +5,7 @@
         "esModuleInterop": true,
         // be explicit about types included
         // to avoid clashing with Jest types
-        "types": ["cypress", "node", "cypress-real-events"]
+        "types": ["cypress", "node", "cypress-real-events"],
     },
-    "include": ["**/*.ts", "**/*.tsx"]
+    "include": ["**/*.ts", "**/*.tsx"],
 }

--- a/package.json
+++ b/package.json
@@ -5,11 +5,7 @@
     "repository": "git@github.com:Khan/perseus.git",
     "license": "MIT",
     "private": true,
-    "workspaces": [
-        "dev",
-        "packages/*",
-        "config/build"
-    ],
+    "workspaces": ["dev", "packages/*", "config/build"],
     "engines": {
         "node": ">=20"
     },

--- a/packages/kas/package.json
+++ b/packages/kas/package.json
@@ -18,9 +18,7 @@
     "module": "dist/es/index.js",
     "main": "dist/index.js",
     "source": "src/index.js",
-    "files": [
-        "dist"
-    ],
+    "files": ["dist"],
     "scripts": {
         "gen:parsers": "node src/parser-generator.ts",
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
@@ -36,11 +34,5 @@
     "peerDependencies": {
         "underscore": "1.4.4"
     },
-    "keywords": [
-        "parsing",
-        "equation",
-        "expression",
-        "algebra",
-        "symbolic"
-    ]
+    "keywords": ["parsing", "equation", "expression", "algebra", "symbolic"]
 }

--- a/packages/kas/tsconfig-build.json
+++ b/packages/kas/tsconfig-build.json
@@ -2,9 +2,7 @@
     "extends": "../tsconfig-shared.json",
     "compilerOptions": {
         "outDir": "./dist",
-        "rootDir": "src"
+        "rootDir": "src",
     },
-    "references": [
-        {"path": "../perseus-core/tsconfig-build.json"}
-    ]
+    "references": [{ "path": "../perseus-core/tsconfig-build.json" }],
 }

--- a/packages/keypad-context/package.json
+++ b/packages/keypad-context/package.json
@@ -18,9 +18,7 @@
     "module": "dist/es/index.js",
     "main": "dist/index.js",
     "source": "src/index.ts",
-    "files": [
-        "dist"
-    ],
+    "files": ["dist"],
     "scripts": {
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
     },

--- a/packages/keypad-context/tsconfig-build.json
+++ b/packages/keypad-context/tsconfig-build.json
@@ -4,7 +4,5 @@
         "outDir": "./dist",
         "rootDir": "src",
     },
-    "references": [
-        {"path": "../perseus-core/tsconfig-build.json"}
-    ]
+    "references": [{ "path": "../perseus-core/tsconfig-build.json" }],
 }

--- a/packages/kmath/package.json
+++ b/packages/kmath/package.json
@@ -17,9 +17,7 @@
     "module": "dist/es/index.js",
     "main": "dist/index.js",
     "source": "src/index.ts",
-    "files": [
-        "dist"
-    ],
+    "files": ["dist"],
     "scripts": {
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
     },

--- a/packages/kmath/src/__tests__/vector.test.ts
+++ b/packages/kmath/src/__tests__/vector.test.ts
@@ -115,23 +115,17 @@ describe("kvector", function () {
         expect(result).toBe(false);
     });
 
-    it(
-        "vector.collinear should return true on two collinear vectors of " +
-            "the same magnitude but different direction",
-        function () {
-            const result = vector.collinear([3, 3], [-3, -3]);
-            expect(result).toBe(true);
-        },
-    );
+    it("vector.collinear should return true on two collinear vectors of " +
+        "the same magnitude but different direction", function () {
+        const result = vector.collinear([3, 3], [-3, -3]);
+        expect(result).toBe(true);
+    });
 
-    it(
-        "vector.collinear should return true on two collinear vectors of " +
-            "different magnitudes",
-        function () {
-            const result = vector.collinear([2, 1], [6, 3]);
-            expect(result).toBe(true);
-        },
-    );
+    it("vector.collinear should return true on two collinear vectors of " +
+        "different magnitudes", function () {
+        const result = vector.collinear([2, 1], [6, 3]);
+        expect(result).toBe(true);
+    });
 
     it("vector.collinear should return false on non-collinear vectors", function () {
         const result = vector.collinear([1, 2], [-1, 2]);

--- a/packages/kmath/tsconfig-build.json
+++ b/packages/kmath/tsconfig-build.json
@@ -4,7 +4,5 @@
         "outDir": "./dist",
         "rootDir": "src",
     },
-    "references": [
-        {"path": "../perseus-core/tsconfig-build.json"}
-    ]
+    "references": [{ "path": "../perseus-core/tsconfig-build.json" }],
 }

--- a/packages/math-input/package.json
+++ b/packages/math-input/package.json
@@ -33,9 +33,7 @@
         },
         "./styles.css": "./dist/index.css"
     },
-    "files": [
-        "dist"
-    ],
+    "files": ["dist"],
     "scripts": {},
     "dependencies": {
         "@khanacademy/keypad-context": "^1.0.3",

--- a/packages/math-input/tsconfig-build.json
+++ b/packages/math-input/tsconfig-build.json
@@ -5,7 +5,7 @@
         "rootDir": "src",
     },
     "references": [
-        {"path": "../perseus-core/tsconfig-build.json"},
-        {"path": "../keypad-context/tsconfig-build.json"},
-    ]
+        { "path": "../perseus-core/tsconfig-build.json" },
+        { "path": "../keypad-context/tsconfig-build.json" },
+    ],
 }

--- a/packages/perseus-core/package.json
+++ b/packages/perseus-core/package.json
@@ -18,9 +18,7 @@
     "module": "dist/es/index.js",
     "main": "dist/index.js",
     "source": "src/index.ts",
-    "files": [
-        "dist"
-    ],
+    "files": ["dist"],
     "scripts": {
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
     },

--- a/packages/perseus-core/tsconfig-build.json
+++ b/packages/perseus-core/tsconfig-build.json
@@ -6,14 +6,12 @@
         "paths": {
             // NOTE(kevinb): We have to repeat this here because TS doesn't do
             // intelligent merge of tsconfig.json files when using `extends`.
-            "@khanacademy/*": [
-                "../*/src"
-            ]
-        }
+            "@khanacademy/*": ["../*/src"],
+        },
     },
     "references": [
         /* Add in-repo pacakge references here, like this:
            {"path": "../path/to/package/tsconfig-build.json"}
         */
-    ]
+    ],
 }

--- a/packages/perseus-editor/package.json
+++ b/packages/perseus-editor/package.json
@@ -27,9 +27,7 @@
         },
         "./styles.css": "./dist/index.css"
     },
-    "files": [
-        "dist"
-    ],
+    "files": ["dist"],
     "scripts": {
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
     },

--- a/packages/perseus-editor/src/__tests__/traversal.test.ts
+++ b/packages/perseus-editor/src/__tests__/traversal.test.ts
@@ -311,9 +311,7 @@ describe("Traversal", () => {
                 content: `${options.content}\n\nnew content!`,
             });
         });
-        expect(newOptions.content).toBe(
-            "[[☃ input-number 1]]\n\nnew content!",
-        );
+        expect(newOptions.content).toBe("[[☃ input-number 1]]\n\nnew content!");
         expect(newOptions.widgets).toEqual(sampleOptions.widgets);
         assertNonMutative();
     });

--- a/packages/perseus-editor/src/multirenderer-editor.tsx
+++ b/packages/perseus-editor/src/multirenderer-editor.tsx
@@ -27,7 +27,6 @@ import type {
     APIOptions,
     ChangeHandler,
     EditorMode,
-
     // Multi-item item types
     Item,
     // ItemTree is used below, the linter is confused.
@@ -37,7 +36,6 @@ import type {
     ContentNode,
     HintNode,
     TagsNode,
-
     // Multi-item shape types
     Shape,
     ArrayShape,

--- a/packages/perseus-editor/tsconfig-build.json
+++ b/packages/perseus-editor/tsconfig-build.json
@@ -8,15 +8,13 @@
             "hubble": ["../../vendor/hubble/hubble.js"],
             // NOTE(kevinb): We have to repeat this here because TS doesn't do
             // intelligent merge of tsconfig.json files when using `extends`.
-            "@khanacademy/*": [
-                "../*/src"
-            ]
-        }
+            "@khanacademy/*": ["../*/src"],
+        },
     },
     "references": [
-        {"path": "../kas/tsconfig-build.json"},
-        {"path": "../kmath/tsconfig-build.json"},
-        {"path": "../perseus/tsconfig-build.json"},
-        {"path": "../perseus-core/tsconfig-build.json"},
-    ]
+        { "path": "../kas/tsconfig-build.json" },
+        { "path": "../kmath/tsconfig-build.json" },
+        { "path": "../perseus/tsconfig-build.json" },
+        { "path": "../perseus-core/tsconfig-build.json" },
+    ],
 }

--- a/packages/perseus-linter/package.json
+++ b/packages/perseus-linter/package.json
@@ -18,9 +18,7 @@
     "module": "dist/es/index.js",
     "main": "dist/index.js",
     "source": "src/index.ts",
-    "files": [
-        "dist"
-    ],
+    "files": ["dist"],
     "scripts": {
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
     },

--- a/packages/perseus-linter/src/__tests__/rules.test.ts
+++ b/packages/perseus-linter/src/__tests__/rules.test.ts
@@ -654,87 +654,67 @@ describe("Individual lint rules tests", () => {
     ]);
 
     test("Rule static-widget-in-question-stem allows static widgets in hints", () => {
-        const problems = testRule(
-            StaticWidgetInQuestionStem,
-            "[[☃ radio 1]]",
-            {
-                contentType: "exercise",
-                stack: ["hint"],
-                widgets: {
-                    "radio 1": {
-                        static: true,
-                    },
+        const problems = testRule(StaticWidgetInQuestionStem, "[[☃ radio 1]]", {
+            contentType: "exercise",
+            stack: ["hint"],
+            widgets: {
+                "radio 1": {
+                    static: true,
                 },
             },
-        );
+        });
 
         expect(problems).toBe(null);
     });
 
     test("Rule static-widget-in-question-stem allows static widgets in articles", () => {
-        const problems = testRule(
-            StaticWidgetInQuestionStem,
-            "[[☃ radio 1]]",
-            {
-                contentType: "article",
-                stack: [],
-                widgets: {
-                    "radio 1": {
-                        static: true,
-                    },
+        const problems = testRule(StaticWidgetInQuestionStem, "[[☃ radio 1]]", {
+            contentType: "article",
+            stack: [],
+            widgets: {
+                "radio 1": {
+                    static: true,
                 },
             },
-        );
+        });
 
         expect(problems).toBe(null);
     });
 
     test("Rule static-widget-in-question-stem allows non-static widgets in question stems", () => {
-        const problems = testRule(
-            StaticWidgetInQuestionStem,
-            "[[☃ radio 1]]",
-            {
-                contentType: "exercise",
-                stack: [],
-                widgets: {
-                    "radio 1": {
-                        static: false,
-                    },
+        const problems = testRule(StaticWidgetInQuestionStem, "[[☃ radio 1]]", {
+            contentType: "exercise",
+            stack: [],
+            widgets: {
+                "radio 1": {
+                    static: false,
                 },
             },
-        );
+        });
 
         expect(problems).toBe(null);
     });
 
     test("Rule static-widget-in-question-stem tolerates widget with no definition", () => {
-        const problems = testRule(
-            StaticWidgetInQuestionStem,
-            "[[☃ radio 1]]",
-            {
-                contentType: "exercise",
-                stack: [],
-                widgets: {},
-            },
-        );
+        const problems = testRule(StaticWidgetInQuestionStem, "[[☃ radio 1]]", {
+            contentType: "exercise",
+            stack: [],
+            widgets: {},
+        });
 
         expect(problems).toBe(null);
     });
 
     test("Rule static-widget-in-question-stem allows warns about static widgets in question stems", () => {
-        const problems = testRule(
-            StaticWidgetInQuestionStem,
-            "[[☃ radio 1]]",
-            {
-                contentType: "exercise",
-                stack: [],
-                widgets: {
-                    "radio 1": {
-                        static: true,
-                    },
+        const problems = testRule(StaticWidgetInQuestionStem, "[[☃ radio 1]]", {
+            contentType: "exercise",
+            stack: [],
+            widgets: {
+                "radio 1": {
+                    static: true,
                 },
             },
-        );
+        });
 
         expect(problems?.length).toBe(1);
         expect(problems?.[0]?.message).toBe(

--- a/packages/perseus-linter/src/__tests__/tree-transformer.test.ts
+++ b/packages/perseus-linter/src/__tests__/tree-transformer.test.ts
@@ -62,22 +62,20 @@ describe("PerseusLinter tree transformer", () => {
     }
 
     trees.forEach((tree: any, treenum: number) => {
-        it(
-            "does post-order traversal of each node in the tree " + treenum,
-            () => {
-                const tt = new TreeTransformer(tree);
-                const ids: Array<any> = [];
+        it("does post-order traversal of each node in the tree " +
+            treenum, () => {
+            const tt = new TreeTransformer(tree);
+            const ids: Array<any> = [];
 
-                tt.traverse((n: any) => {
-                    nodes[n.id] = n; // Remember the nodes by id for later tests
-                    ids.push(n.id);
-                });
+            tt.traverse((n: any) => {
+                nodes[n.id] = n; // Remember the nodes by id for later tests
+                ids.push(n.id);
+            });
 
-                // Post-order traversal means we visit the nodes on the way
-                // back up, not on the way down.
-                expect(ids).toEqual(postOrderTraversalOrder);
-            },
-        );
+            // Post-order traversal means we visit the nodes on the way
+            // back up, not on the way down.
+            expect(ids).toEqual(postOrderTraversalOrder);
+        });
 
         it("tracks the current node " + treenum, () => {
             new TreeTransformer(tree).traverse((n, state) => {

--- a/packages/perseus-linter/tsconfig-build.json
+++ b/packages/perseus-linter/tsconfig-build.json
@@ -5,7 +5,7 @@
         "rootDir": "src",
     },
     "references": [
-        {"path": "../perseus-core/tsconfig-build.json"},
-        {"path": "../pure-markdown/tsconfig-build.json"},
-    ]
+        { "path": "../perseus-core/tsconfig-build.json" },
+        { "path": "../pure-markdown/tsconfig-build.json" },
+    ],
 }

--- a/packages/perseus/package.json
+++ b/packages/perseus/package.json
@@ -33,9 +33,7 @@
         },
         "./styles.css": "./dist/index.css"
     },
-    "files": [
-        "dist"
-    ],
+    "files": ["dist"],
     "scripts": {
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
     },

--- a/packages/perseus/src/multi-items/__stories__/multi-renderer.stories.tsx
+++ b/packages/perseus/src/multi-items/__stories__/multi-renderer.stories.tsx
@@ -46,8 +46,10 @@ export const SingleItem = (args: StoryArgs): React.ReactElement => {
                                 Hints
                             </HeadingSmall>
                             <View style={styles.hints}>
-                                {// @ts-expect-error [FEI-5003] - TS2339 - Property 'firstN' does not exist on type 'readonly ReactNode[]'.
-                                hints?.firstN(2)}
+                                {
+                                    // @ts-expect-error [FEI-5003] - TS2339 - Property 'firstN' does not exist on type 'readonly ReactNode[]'.
+                                    hints?.firstN(2)
+                                }
                             </View>
                         </View>
                     </View>

--- a/packages/perseus/src/question-paragraph.tsx
+++ b/packages/perseus/src/question-paragraph.tsx
@@ -19,7 +19,7 @@ class QuestionParagraph extends React.Component<Props> {
             <div
                 className={
                     this.props.inline
-                        ? this.props.className ?? undefined
+                        ? (this.props.className ?? undefined)
                         : className
                 }
                 data-perseus-component-index={this.props.translationIndex}

--- a/packages/perseus/src/widgets/expression/expression.test.tsx
+++ b/packages/perseus/src/widgets/expression/expression.test.tsx
@@ -121,13 +121,10 @@ describe("Expression Widget", function () {
 
         // This isn't necessarily the ideal behavior; it's just what was the
         // easiest to implement
-        it(
-            "should not grade answers that have the wrong variable case, " +
-                "even if the answer has got other errors",
-            async function () {
-                await assertInvalid(userEvent, expressionItem2, "123+X");
-            },
-        );
+        it("should not grade answers that have the wrong variable case, " +
+            "even if the answer has got other errors", async function () {
+            await assertInvalid(userEvent, expressionItem2, "123+X");
+        });
 
         it.each(["123-y", "123-Y"])(
             "should not not grade answers that use the wrong variable",

--- a/packages/perseus/src/widgets/graded-group/graded-group-answer-bar.tsx
+++ b/packages/perseus/src/widgets/graded-group/graded-group-answer-bar.tsx
@@ -12,7 +12,8 @@ import {phoneMargin, negativePhoneMargin} from "../../styles/constants";
 
 import type {APIOptions} from "../../types";
 
-export type ANSWER_BAR_STATES = // Initial state before the question is answerable.  The user must complete
+export type ANSWER_BAR_STATES =
+    // Initial state before the question is answerable.  The user must complete
     // each of the widgets before the answer bar becomes visible.
     // The 'Check' button is active whenever the question is answerable or any
     // of the input widgets have been modified after getting the answer wrong.

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -89,9 +89,7 @@
         .movable-point-halo,
         .movable-point-focus-outline
     ) {
-    transition:
-        r 0.15s ease-out,
-        opacity 0.15s ease-out;
+    transition: r 0.15s ease-out, opacity 0.15s ease-out;
 }
 
 .MafsView .movable-point-center {
@@ -113,19 +111,21 @@
 .MafsView .movable-point:hover .movable-point-center {
     r: calc(
         var(--movable-point-hover-expansion) +
-            var(--movable-point-center-radius)
+        var(--movable-point-center-radius)
     );
 }
 
 .MafsView .movable-point:hover .movable-point-ring {
     r: calc(
-        var(--movable-point-hover-expansion) + var(--movable-point-ring-radius)
+        var(--movable-point-hover-expansion) +
+        var(--movable-point-ring-radius)
     );
 }
 
 .MafsView .movable-point:hover .movable-point-halo {
     r: calc(
-        var(--movable-point-hover-expansion) + var(--movable-point-halo-radius)
+        var(--movable-point-hover-expansion) +
+        var(--movable-point-halo-radius)
     );
 }
 
@@ -133,7 +133,7 @@
     visibility: hidden;
     r: calc(
         var(--movable-point-halo-radius) +
-            var(--movable-point-focus-ring-offset)
+        var(--movable-point-focus-ring-offset)
     );
     stroke-width: 2px;
     fill: none;
@@ -142,8 +142,9 @@
 
 .MafsView .movable-point:hover .movable-point-focus-outline {
     r: calc(
-        var(--movable-point-hover-expansion) + var(--movable-point-halo-radius) +
-            var(--movable-point-focus-ring-offset)
+        var(--movable-point-hover-expansion) +
+        var(--movable-point-halo-radius) +
+        var(--movable-point-focus-ring-offset)
     );
 }
 

--- a/packages/perseus/tsconfig-build.json
+++ b/packages/perseus/tsconfig-build.json
@@ -8,19 +8,17 @@
             "raphael": ["../../vendor/raphael/raphael.js"],
             // NOTE(kevinb): We have to repeat this here because TS doesn't do
             // intelligent merge of tsconfig.json files when using `extends`.
-            "@khanacademy/*": [
-                "../*/src"
-            ]
-        }
+            "@khanacademy/*": ["../*/src"],
+        },
     },
     "references": [
-        {"path": "../kas/tsconfig-build.json"},
-        {"path": "../kmath/tsconfig-build.json"},
-        {"path": "../math-input/tsconfig-build.json"},
-        {"path": "../perseus-core/tsconfig-build.json"},
-        {"path": "../keypad-context/tsconfig-build.json"},
-        {"path": "../perseus-linter/tsconfig-build.json"},
-        {"path": "../pure-markdown/tsconfig-build.json"},
-        {"path": "../simple-markdown/tsconfig-build.json"},
-    ]
+        { "path": "../kas/tsconfig-build.json" },
+        { "path": "../kmath/tsconfig-build.json" },
+        { "path": "../math-input/tsconfig-build.json" },
+        { "path": "../perseus-core/tsconfig-build.json" },
+        { "path": "../keypad-context/tsconfig-build.json" },
+        { "path": "../perseus-linter/tsconfig-build.json" },
+        { "path": "../pure-markdown/tsconfig-build.json" },
+        { "path": "../simple-markdown/tsconfig-build.json" },
+    ],
 }

--- a/packages/pure-markdown/package.json
+++ b/packages/pure-markdown/package.json
@@ -18,9 +18,7 @@
     "module": "dist/es/index.js",
     "main": "dist/index.js",
     "source": "src/index.ts",
-    "files": [
-        "dist"
-    ],
+    "files": ["dist"],
     "scripts": {
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
     },

--- a/packages/pure-markdown/tsconfig-build.json
+++ b/packages/pure-markdown/tsconfig-build.json
@@ -5,7 +5,7 @@
         "rootDir": "src",
     },
     "references": [
-        {"path": "../perseus-core/tsconfig-build.json"},
-        {"path": "../simple-markdown/tsconfig-build.json"},
-    ]
+        { "path": "../perseus-core/tsconfig-build.json" },
+        { "path": "../simple-markdown/tsconfig-build.json" },
+    ],
 }

--- a/packages/simple-markdown/package.json
+++ b/packages/simple-markdown/package.json
@@ -18,9 +18,7 @@
     "module": "dist/es/index.js",
     "main": "dist/index.js",
     "source": "src/index.ts",
-    "files": [
-        "dist"
-    ],
+    "files": ["dist"],
     "scripts": {
         "test": "bash -c 'yarn --silent --cwd \"../..\" test ${@:0} $($([[ ${@: -1} = -* ]] || [[ ${@: -1} = bash ]]) && echo $PWD)'"
     },
@@ -34,7 +32,5 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
     },
-    "keywords": [
-        "markdown"
-    ]
+    "keywords": ["markdown"]
 }

--- a/packages/simple-markdown/tsconfig-build.json
+++ b/packages/simple-markdown/tsconfig-build.json
@@ -1,10 +1,8 @@
 {
-  "extends": "../tsconfig-shared.json",
-  "compilerOptions": {
-      "outDir": "./dist",
-      "rootDir": "src",
-  },
-  "references": [
-    {"path": "../perseus-core/tsconfig-build.json"},
-  ]
+    "extends": "../tsconfig-shared.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "src",
+    },
+    "references": [{ "path": "../perseus-core/tsconfig-build.json" }],
 }

--- a/packages/tsconfig-shared.json
+++ b/packages/tsconfig-shared.json
@@ -10,7 +10,7 @@
         "**/__testutils__/**",
         "**/*.stories.*",
         "**/__stories__/**",
-        "**/*.cypress.*"
+        "**/*.cypress.*",
     ],
     "extends": "../tsconfig-common.json",
     "compilerOptions": {
@@ -23,9 +23,7 @@
         "emitDeclarationOnly": true,
 
         "paths": {
-            "@khanacademy/*": [
-                "./*/src"
-            ]
+            "@khanacademy/*": ["./*/src"],
         },
     },
 }

--- a/static/lato.css
+++ b/static/lato.css
@@ -5,9 +5,7 @@
     font-family: "Lato";
     font-style: italic;
     font-weight: 400;
-    src:
-        local("Lato Italic"),
-        local("Lato-Italic"),
+    src: local("Lato Italic"), local("Lato-Italic"),
         url(fonts/lato/Lato-Italic.woff2) format("woff2");
     unicode-range: U+0400-04FF, U+0500-052F, U+2DE0-2DFF, U+A640-A69F,
         U+1D00-1D7F;
@@ -17,9 +15,7 @@
     font-family: "Lato";
     font-style: normal;
     font-weight: 400;
-    src:
-        local("Lato Regular"),
-        local("Lato-Regular"),
+    src: local("Lato Regular"), local("Lato-Regular"),
         url(fonts/lato/Lato-Regular.woff2) format("woff2");
     unicode-range: U+0400-04FF, U+0500-052F, U+2DE0-2DFF, U+A640-A69F,
         U+1D00-1D7F;
@@ -29,10 +25,8 @@
     font-family: "Lato";
     font-style: normal;
     font-weight: 700;
-    src:
-        local("Lato Bold"),
-        local("Lato-Bold"),
-        url(fonts/lato/Lato-Bold.woff2) format("woff2");
+    src: local("Lato Bold"), local("Lato-Bold"), url(fonts/lato/Lato-Bold.woff2)
+        format("woff2");
     unicode-range: U+0400-04FF, U+0500-052F, U+2DE0-2DFF, U+A640-A69F,
         U+1D00-1D7F;
 }
@@ -41,9 +35,7 @@
     font-family: "Lato";
     font-style: normal;
     font-weight: 900;
-    src:
-        local("Lato Black"),
-        local("Lato-Black"),
+    src: local("Lato Black"), local("Lato-Black"),
         url(fonts/lato/Lato-Black.woff2) format("woff2");
     unicode-range: U+0400-04FF, U+0500-052F, U+2DE0-2DFF, U+A640-A69F,
         U+1D00-1D7F;
@@ -54,9 +46,7 @@
     font-family: "Lato";
     font-style: italic;
     font-weight: 400;
-    src:
-        local("Lato Italic"),
-        local("Lato-Italic"),
+    src: local("Lato Italic"), local("Lato-Italic"),
         url(fonts/lato/LatoLatin-Italic.woff2) format("woff2");
 }
 
@@ -64,9 +54,7 @@
     font-family: "Lato";
     font-style: normal;
     font-weight: 400;
-    src:
-        local("Lato Regular"),
-        local("Lato-Regular"),
+    src: local("Lato Regular"), local("Lato-Regular"),
         url(fonts/lato/LatoLatin-Regular.woff2) format("woff2");
 }
 
@@ -74,9 +62,7 @@
     font-family: "Lato";
     font-style: normal;
     font-weight: 700;
-    src:
-        local("Lato Bold"),
-        local("Lato-Bold"),
+    src: local("Lato Bold"), local("Lato-Bold"),
         url(fonts/lato/LatoLatin-Bold.woff2) format("woff2");
 }
 
@@ -84,9 +70,7 @@
     font-family: "Lato";
     font-style: normal;
     font-weight: 900;
-    src:
-        local("Lato Black"),
-        local("Lato-Black"),
+    src: local("Lato Black"), local("Lato-Black"),
         url(fonts/lato/LatoLatin-Black.woff2) format("woff2");
 }
 
@@ -95,9 +79,7 @@
     font-family: "Lato";
     font-style: italic;
     font-weight: 400;
-    src:
-        local("Lato Italic"),
-        local("Lato-Italic"),
+    src: local("Lato Italic"), local("Lato-Italic"),
         url(fonts/lato/LatoLatinExtended-Italic.woff2) format("woff2");
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
         U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;

--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -5,15 +5,15 @@
     // in each package directory.
     "files": [],
     "references": [
-        {"path": "./packages/kas/tsconfig-build.json"},
-        {"path": "./packages/kmath/tsconfig-build.json"},
-        {"path": "./packages/math-input/tsconfig-build.json"},
-        {"path": "./packages/keypad-context/tsconfig-build.json"},
-        {"path": "./packages/perseus/tsconfig-build.json"},
-        {"path": "./packages/perseus-core/tsconfig-build.json"},
-        {"path": "./packages/perseus-editor/tsconfig-build.json"},
-        {"path": "./packages/perseus-linter/tsconfig-build.json"},
-        {"path": "./packages/pure-markdown/tsconfig-build.json"},
-        {"path": "./packages/simple-markdown/tsconfig-build.json"},
-    ]
+        { "path": "./packages/kas/tsconfig-build.json" },
+        { "path": "./packages/kmath/tsconfig-build.json" },
+        { "path": "./packages/math-input/tsconfig-build.json" },
+        { "path": "./packages/keypad-context/tsconfig-build.json" },
+        { "path": "./packages/perseus/tsconfig-build.json" },
+        { "path": "./packages/perseus-core/tsconfig-build.json" },
+        { "path": "./packages/perseus-editor/tsconfig-build.json" },
+        { "path": "./packages/perseus-linter/tsconfig-build.json" },
+        { "path": "./packages/pure-markdown/tsconfig-build.json" },
+        { "path": "./packages/simple-markdown/tsconfig-build.json" },
+    ],
 }

--- a/tsconfig-common.json
+++ b/tsconfig-common.json
@@ -24,5 +24,5 @@
         /* Completeness */
         "skipDefaultLibCheck": true, // it's safe to assume that built-in .d.ts files are correct
         "skipLibCheck": true, // there are conflicts between some of the globals in various third-party packages
-    }
+    },
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
         "cypress.config.ts",
         "config/cypress/**",
         "**/*.cypress.ts",
-        "**/*.cypress.tsx"
+        "**/*.cypress.tsx",
     ],
     "extends": "./tsconfig-common.json",
     "compilerOptions": {
@@ -21,17 +21,19 @@
             "@khanacademy/kmath": ["./packages/kmath/src"],
             "@khanacademy/keypad-context": ["./packages/keypad-context/src"],
             "@khanacademy/math-input": ["./packages/math-input/src"],
-            "@khanacademy/math-input/strings": ["./packages/math-input/src/strings"],
+            "@khanacademy/math-input/strings": [
+                "./packages/math-input/src/strings",
+            ],
             "@khanacademy/perseus": ["./packages/perseus/src"],
             "@khanacademy/perseus/strings": ["./packages/perseus/src/strings"],
             "@khanacademy/perseus-*": ["./packages/perseus-*/src"],
             "@khanacademy/pure-markdown": ["./packages/pure-markdown/src"],
-            "@khanacademy/simple-markdown": ["./packages/simple-markdown/src"]
+            "@khanacademy/simple-markdown": ["./packages/simple-markdown/src"],
         },
 
         /* Preference */
         // If this is disabled, TS will sometimes just delete dead code, which
         // can be confusing!
-        "allowUnreachableCode": true
-    }
+        "allowUnreachableCode": true,
+    },
 }


### PR DESCRIPTION
## Summary:

This is the second PR of setting up Biome. It formats all files using Biome's formatting rules (I've kept the rules as close to Prettier as possible to avoid too much disruption). 

The biggest changes are inlining some arrays that were split across multiple lines and adding trailing commas to some TSConfig files (we were inconsistent with trailing commas within these files... so I just picked one way and made them consistent). 
    
Issue: --hackathon-2024--

## Test plan:

`yarn biome --check`