### PR TITLE
Remove deprecated defaultProps

### DIFF
--- a/.changeset/forty-otters-check.md
+++ b/.changeset/forty-otters-check.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/math-input": patch
+"@khanacademy/perseus": patch
+---
+
+Change functional components to use default parameters instead of deprecated 'defaultProps'

--- a/packages/math-input/src/components/keypad/keypad.tsx
+++ b/packages/math-input/src/components/keypad/keypad.tsx
@@ -21,7 +21,7 @@ import type {CursorContext} from "../input/cursor-contexts";
 import type {AnalyticsEventHandlerFn} from "@khanacademy/perseus-core";
 
 export type Props = {
-    extraKeys: ReadonlyArray<Key>;
+    extraKeys?: ReadonlyArray<Key>;
     cursorContext?: (typeof CursorContext)[keyof typeof CursorContext];
     showDismiss?: boolean;
     expandedView?: boolean;
@@ -37,10 +37,6 @@ export type Props = {
 
     onClickKey: ClickKeyCallback;
     onAnalyticsEvent: AnalyticsEventHandlerFn;
-};
-
-const defaultProps = {
-    extraKeys: [],
 };
 
 function getAvailableTabs(props: Props): ReadonlyArray<KeypadPageType> {
@@ -73,7 +69,7 @@ function getAvailableTabs(props: Props): ReadonlyArray<KeypadPageType> {
 
 // The main (v2) Keypad. Use this component to present an accessible, onscreen
 // keypad to learners for entering math expressions.
-export default function Keypad(props: Props) {
+export default function Keypad({extraKeys = [], ...props}: Props) {
     // If we're using the Fractions keypad, we want to default select that page
     // Otherwise, we want to default to the Numbers page
     const defaultSelectedPage = props.fractionsOnly ? "Fractions" : "Numbers";
@@ -82,12 +78,11 @@ export default function Keypad(props: Props) {
     const [isMounted, setIsMounted] = React.useState<boolean>(false);
 
     // We don't want any tabs available on mobile fractions keypad
-    const availableTabs = getAvailableTabs(props);
+    const availableTabs = getAvailableTabs({...props, extraKeys});
 
     const {
         onClickKey,
         cursorContext,
-        extraKeys,
         convertDotToTimes,
         divisionKey,
         preAlgebra,
@@ -196,8 +191,6 @@ export default function Keypad(props: Props) {
         </View>
     );
 }
-
-Keypad.defaultProps = defaultProps;
 
 const styles = StyleSheet.create({
     keypadOuterContainer: {

--- a/packages/perseus/src/components/tooltip.tsx
+++ b/packages/perseus/src/components/tooltip.tsx
@@ -143,7 +143,7 @@ const TooltipArrow = ({
                 position: position,
                 visibility: visibility,
                 left: left,
-                top: props["top"],
+                top: top,
                 width: props.width + 2,
                 height: props.height + 1,
                 marginTop: -1,

--- a/packages/perseus/src/components/tooltip.tsx
+++ b/packages/perseus/src/components/tooltip.tsx
@@ -107,10 +107,10 @@ const Triangle = (props: TriangleProps) => {
 };
 
 type TooltipArrowProps = {
-    position: Property.Position;
-    visibility: Property.Visibility;
-    left: number;
-    top: number;
+    position?: Property.Position;
+    visibility?: Property.Visibility;
+    left?: number;
+    top?: number;
     color: string; // a css color
     border: string; // a css color
     width: number;
@@ -120,7 +120,13 @@ type TooltipArrowProps = {
     zIndex?: number;
 };
 
-const TooltipArrow = (props: TooltipArrowProps) => {
+const TooltipArrow = ({
+    position = "relative",
+    visibility = "visible",
+    left = 100,
+    top = 0,
+    ...props
+}: TooltipArrowProps) => {
     // TODO(aria): Think about adding a box-shadow to the triangle here
     // See http://css-tricks.com/triangle-with-shadow/
 
@@ -134,9 +140,9 @@ const TooltipArrow = (props: TooltipArrowProps) => {
         <div
             style={{
                 display: "block",
-                position: props.position,
-                visibility: props.visibility,
-                left: props.left,
+                position: position,
+                visibility: visibility,
+                left: left,
                 top: props["top"],
                 width: props.width + 2,
                 height: props.height + 1,
@@ -169,13 +175,6 @@ const TooltipArrow = (props: TooltipArrowProps) => {
             />
         </div>
     );
-};
-
-TooltipArrow.defaultProps = {
-    position: "relative",
-    visibility: "visible",
-    left: 0,
-    top: 0,
 };
 
 const VERTICAL_CORNERS = {

--- a/packages/perseus/src/widgets/label-image/__stories__/answer-choices.stories.tsx
+++ b/packages/perseus/src/widgets/label-image/__stories__/answer-choices.stories.tsx
@@ -44,7 +44,7 @@ const defaultChoices = [
     },
 ];
 
-const WithState = ({multipleSelect}) => {
+const WithState = ({multipleSelect = false}) => {
     const [choices, setChoices] = React.useState([...defaultChoices]);
     const [isOpened, setIsOpened] = React.useState(false);
 
@@ -76,10 +76,6 @@ const WithState = ({multipleSelect}) => {
             </>
         </>
     );
-};
-
-WithState.defaultProps = {
-    multipleSelect: false,
 };
 
 export const SingleSelect = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus/src/widgets/radio/base-radio.tsx
+++ b/packages/perseus/src/widgets/radio/base-radio.tsx
@@ -49,11 +49,11 @@ type Props = {
     apiOptions: APIOptions;
     choices: ReadonlyArray<ChoiceType>;
     deselectEnabled?: boolean;
-    editMode: boolean;
+    editMode?: boolean;
     labelWrap: boolean;
     countChoices: boolean | null | undefined;
     numCorrect: number;
-    multipleSelect: boolean;
+    multipleSelect?: boolean;
     // the logic checks whether this exists,
     // so it must be optional
     reviewModeRubric?: PerseusRadioWidgetOptions | null;
@@ -90,21 +90,20 @@ function getInstructionsText(
     return strings.chooseOneAnswer;
 }
 
-const BaseRadio = function (props: Props): React.ReactElement {
-    const {
-        apiOptions,
-        reviewModeRubric,
-        reviewMode,
-        choices,
-        editMode,
-        multipleSelect,
-        labelWrap,
-        countChoices,
-        numCorrect,
-        isLastUsedWidget,
-        registerFocusFunction,
-    } = props;
-
+const BaseRadio = function ({
+    apiOptions,
+    reviewModeRubric,
+    reviewMode,
+    choices,
+    editMode = false,
+    multipleSelect = false,
+    labelWrap,
+    countChoices,
+    numCorrect,
+    isLastUsedWidget,
+    onChange,
+    registerFocusFunction,
+}: Props): React.ReactElement {
     const {strings} = usePerseusI18n();
 
     // useEffect doesn't have previous props
@@ -174,8 +173,6 @@ const BaseRadio = function (props: Props): React.ReactElement {
             crossedOut: boolean;
         }>,
     ): void {
-        const {multipleSelect, choices, onChange} = props;
-
         // Get the baseline `checked` values. If we're checking a new answer
         // and multiple-select is not on, we should clear all choices to be
         // unchecked. Otherwise, we should copy the old checked values.
@@ -403,11 +400,6 @@ const BaseRadio = function (props: Props): React.ReactElement {
     // Allow for horizontal scrolling if content is too wide, which may be
     // an issue especially on phones.
     return <div className={css(styles.responsiveContainer)}>{fieldset}</div>;
-};
-
-BaseRadio.defaultProps = {
-    editMode: false,
-    multipleSelect: false,
 };
 
 const styles: StyleDeclaration = StyleSheet.create({

--- a/packages/perseus/src/widgets/radio/choice-none-above.tsx
+++ b/packages/perseus/src/widgets/radio/choice-none-above.tsx
@@ -17,11 +17,12 @@ type WithForwardRef = {
 
 type PropsWithForwardRef = Props & WithForwardRef;
 
-const ChoiceNoneAbove = function (
-    props: PropsWithForwardRef,
-): React.ReactElement {
-    const {showContent, content, forwardedRef, ...rest} = props;
-
+const ChoiceNoneAbove = function ({
+    content,
+    forwardedRef,
+    showContent = true,
+    ...rest
+}: PropsWithForwardRef): React.ReactElement {
     const {strings} = usePerseusI18n();
 
     const choiceProps = {
@@ -48,10 +49,6 @@ const ChoiceNoneAbove = function (
     } as const;
 
     return <Choice {...choiceProps} ref={forwardedRef} />;
-};
-
-ChoiceNoneAbove.defaultProps = {
-    showContent: true,
 };
 
 export default React.forwardRef<HTMLButtonElement, Props>((props, ref) => (

--- a/packages/perseus/src/widgets/radio/focus-ring.tsx
+++ b/packages/perseus/src/widgets/radio/focus-ring.tsx
@@ -11,16 +11,19 @@ type Props = {
     children?: React.ReactNode;
     // Whether the focus ring is visible. Allows for positioning
     // the child identically regardless of whether the ring is visible.
-    visible: boolean;
+    visible?: boolean;
     // Color of the focus ring
-    color: string;
+    color?: string;
     // Whether a user can select multiple options or not
-    multipleSelect: boolean;
+    multipleSelect?: boolean;
 };
 
-const FocusRing = function (props: Props): React.ReactElement {
-    const {visible, color, children, multipleSelect} = props;
-
+const FocusRing = function ({
+    visible = true,
+    color = styleConstants.kaGreen,
+    multipleSelect = false,
+    children,
+}: Props): React.ReactElement {
     const borderColor = visible ? color : "transparent";
     const borderRadius = multipleSelect ? 5 : "50%";
     const style = {
@@ -36,12 +39,6 @@ const FocusRing = function (props: Props): React.ReactElement {
             {children}
         </span>
     );
-};
-
-FocusRing.defaultProps = {
-    visible: true,
-    color: styleConstants.kaGreen,
-    multipleSelect: false,
 };
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
## Summary:

While working in Storybook this week, I kept seeing warnings about components using `defaultProps` and it would be removed in the next version of React. 

The migration is straightforward to use default parameters so I've made those changes in this PR. 

Issue: "none"

## Test plan:

`yarn typecheck`
`yarn start` -> I visted each story for the affected component