### PR TITLE
Modernize Perseus' components folder stories

### DIFF
--- a/.changeset/old-lamps-wonder.md
+++ b/.changeset/old-lamps-wonder.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/math-input": patch
+"@khanacademy/perseus": patch
+---
+
+Improve prop types for various components

--- a/packages/perseus-editor/src/__stories__/interactive-graph-editor.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/interactive-graph-editor.stories.tsx
@@ -172,7 +172,7 @@ MafsWithLockedFiguresCurrent.parameters = {
     chromatic: {
         // Disabling because this isn't visually testing anything on the
         // initial load of the editor page.
-        disable: true,
+        disableSnapshot: true,
     },
 };
 
@@ -413,7 +413,7 @@ WithSaveWarnings.parameters = {
         // Disabling because this isn't testing anything visually on the
         // editor page. It's testing the error message, which don't
         // even show up on the initial load.
-        disable: true,
+        disableSnapshot: true,
     },
 };
 

--- a/packages/perseus-editor/src/components/__stories__/scrollless-number-text-field.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/scrollless-number-text-field.stories.tsx
@@ -45,7 +45,7 @@ Controlled.parameters = {
     chromatic: {
         // Disable the snapshot for this story because it's testing
         // behavior, not visuals.
-        disable: true,
+        disableSnapshot: true,
     },
 };
 
@@ -77,6 +77,6 @@ LongPageScroll.parameters = {
     chromatic: {
         // Disable the snapshot for this story because it's testing
         // behavior, not visuals.
-        disable: true,
+        disableSnapshot: true,
     },
 };

--- a/packages/perseus/src/components/__stories__/graph.stories.tsx
+++ b/packages/perseus/src/components/__stories__/graph.stories.tsx
@@ -1,27 +1,22 @@
-import * as React from "react";
-
 import Graph from "../graph";
 
 import type {StoryObj, Meta} from "@storybook/react";
 
-type StoryArgs = StoryObj<Graph>;
-
-type Story = Meta<Graph>;
+type Story = StoryObj<typeof Graph>;
 
 const size = 200;
 
-export default {
+const meta: Meta = {
     title: "Perseus/Components/Graph",
-} as Story;
-
-export const SquareBoxSizeAndOtherwiseEmpty = (
-    args: StoryArgs,
-): React.ReactElement => {
-    return <Graph box={[size, size]} />;
+    component: Graph,
+    args: {
+        box: [size, size],
+    },
 };
+export default meta;
 
-export const LabeledSquaredBox = (args: StoryArgs): React.ReactElement => {
-    return (
-        <Graph box={[size, size]} labels={["First label", "Second label"]} />
-    );
+export const SquareBoxSizeAndOtherwiseEmpty: Story = {};
+
+export const LabeledSquaredBox: Story = {
+    args: {labels: ["First label", "Second label"]},
 };

--- a/packages/perseus/src/components/__stories__/graphie.stories.tsx
+++ b/packages/perseus/src/components/__stories__/graphie.stories.tsx
@@ -23,6 +23,10 @@ export default meta;
 
 export const SquareBoxSizeAndOtherwiseEmpty: Story = {};
 
+/**
+ * A demonstration of a Graphie rendered using the Perseus `Renderer` complete
+ * with overlaid labels and an image caption below.
+ */
 export const PieChartGraphieLabels = () => {
     return <ServerItemRendererWithDebugUI item={itemWithPieChart} />;
 };

--- a/packages/perseus/src/components/__stories__/graphie.stories.tsx
+++ b/packages/perseus/src/components/__stories__/graphie.stories.tsx
@@ -6,28 +6,23 @@ import Graphie from "../graphie";
 
 import type {StoryObj, Meta} from "@storybook/react";
 
-type StoryArgs = StoryObj<Graphie>;
-
-type Story = Meta<Graphie>;
+type Story = StoryObj<typeof Graphie>;
 
 const size = 200;
 
-export default {
+const meta: Meta = {
     title: "Perseus/Components/Graphie",
-} as Story;
-
-export const SquareBoxSizeAndOtherwiseEmpty = (
-    args: StoryArgs,
-): React.ReactElement => {
-    return (
-        <Graphie
-            box={[size, size]}
-            setDrawingAreaAvailable={() => {}}
-            setup={() => {}}
-        />
-    );
+    component: Graphie,
+    args: {
+        box: [size, size],
+        setup: () => {},
+        setDrawingAreaAvailable: () => {},
+    },
 };
+export default meta;
 
-export const PieChartGraphieLabels = (args: StoryArgs): React.ReactElement => {
+export const SquareBoxSizeAndOtherwiseEmpty: Story = {};
+
+export const PieChartGraphieLabels = () => {
     return <ServerItemRendererWithDebugUI item={itemWithPieChart} />;
 };

--- a/packages/perseus/src/components/__stories__/hud.stories.tsx
+++ b/packages/perseus/src/components/__stories__/hud.stories.tsx
@@ -1,35 +1,21 @@
-import * as React from "react";
+import {action} from "@storybook/addon-actions";
 
 import Hud from "../hud";
 
 import type {StoryObj, Meta} from "@storybook/react";
 
-type StoryArgs = StoryObj<typeof Hud>;
+type Story = StoryObj<typeof Hud>;
 
-type Story = Meta<typeof Hud>;
-
-export default {
+const meta: Meta = {
     title: "Perseus/Components/HUD",
-} as Story;
-
-export const TestMessageDisabled = (args: StoryArgs): React.ReactElement => {
-    return (
-        <Hud
-            fixedPosition={false}
-            message="Test message"
-            enabled={false}
-            onClick={() => {}}
-        />
-    );
+    component: Hud,
+    args: {
+        enabled: true,
+        fixedPosition: false,
+        message: "Test message",
+        onClick: action("onClick"),
+    },
 };
+export default meta;
 
-export const TestMessageEnabled = (args: StoryArgs): React.ReactElement => {
-    return (
-        <Hud
-            fixedPosition={false}
-            message="Test message"
-            enabled={true}
-            onClick={() => {}}
-        />
-    );
-};
+export const Default: Story = {};

--- a/packages/perseus/src/components/__stories__/icon.stories.tsx
+++ b/packages/perseus/src/components/__stories__/icon.stories.tsx
@@ -1,16 +1,13 @@
-import * as React from "react";
-
 import * as IconPaths from "../../icon-paths";
 import IconComponent from "../icon";
 
 import type {StoryObj, Meta} from "@storybook/react";
 
-type StoryArgs = StoryObj<IconComponent>;
+type Story = StoryObj<typeof IconComponent>;
 
-type Story = Meta<IconComponent>;
-
-export default {
-    title: "Perseus/Components",
+const meta: Meta = {
+    title: "Perseus/Components/Icon",
+    component: IconComponent,
     args: {
         color: "#808",
         size: 25,
@@ -27,12 +24,12 @@ export default {
             control: "select",
         },
     },
-} as Story;
+};
+export default meta;
 
-export const Icon = (args: StoryArgs): React.ReactElement => (
-    <IconComponent
-        style={{display: "block"}}
-        icon={IconPaths.iconCheck}
-        {...args}
-    />
-);
+export const Icon: Story = {
+    args: {
+        style: {display: "block"},
+        icon: IconPaths.iconCheck,
+    },
+};

--- a/packages/perseus/src/components/__stories__/image-loader.stories.tsx
+++ b/packages/perseus/src/components/__stories__/image-loader.stories.tsx
@@ -17,6 +17,14 @@ const meta: Meta = {
         },
         onUpdate: () => {},
     },
+    parameters: {
+        chromatic: {
+            // This component only deals with loading images and providing a
+            // fallback if it fails. This is not very useful to snapshot so
+            // we're disabling it.
+            disableSnapshot: true,
+        },
+    },
 };
 export default meta;
 

--- a/packages/perseus/src/components/__stories__/image-loader.stories.tsx
+++ b/packages/perseus/src/components/__stories__/image-loader.stories.tsx
@@ -1,60 +1,40 @@
-/* eslint-disable @khanacademy/ts-no-error-suppressions */
 import * as React from "react";
 
-type StoryArgs = Record<any, any>;
-
-type Story = {
-    title: string;
-};
-
 import ImageLoader from "../image-loader";
+
+import type {Meta, StoryObj} from "@storybook/react";
 
 const svgUrl = "http://www.khanacademy.org/images/ohnoes-concerned.svg";
 const imgUrl = "https://www.khanacademy.org/images/hand-tree.new.png";
 
-export default {
+const meta: Meta = {
     title: "Perseus/Components/Image Loader",
-} as Story;
+    component: ImageLoader,
+    args: {
+        preloader: null,
+        imgProps: {
+            alt: "ALT",
+        },
+        onUpdate: () => {},
+    },
+};
+export default meta;
 
-export const SvgImage = (args: StoryArgs): React.ReactElement => {
-    return (
-        <ImageLoader
-            src={svgUrl}
-            preloader={null}
-            imgProps={{
-                alt: "ALT",
-            }}
-            onUpdate={() => {}}
-        />
-    );
+type Story = StoryObj<typeof ImageLoader>;
+
+export const SvgImage: Story = {
+    args: {
+        src: svgUrl,
+    },
 };
 
-export const PngImage = (args: StoryArgs): React.ReactElement => {
-    return (
-        <ImageLoader
-            src={imgUrl}
-            preloader={null}
-            imgProps={{
-                alt: "ALT",
-            }}
-            onUpdate={() => {}}
-        />
-    );
+export const PngImage: Story = {
+    args: {src: imgUrl},
 };
 
-export const InvalidImageWithChildrenForFailedLoading = (
-    args: StoryArgs,
-): React.ReactElement => {
-    return (
-        <ImageLoader
-            src="http://abcdefiahofshiaof.noway.badimage.com"
-            preloader={null}
-            imgProps={{
-                alt: "ALT",
-            }}
-            onUpdate={() => {}}
-        >
-            <span>You can see me! The image failed to load.</span>
-        </ImageLoader>
-    );
+export const InvalidImageWithChildrenForFailedLoading: Story = {
+    args: {
+        src: "http://abcdefiahofshiaof.noway.badimage.com",
+        children: <span>You can see me! The image failed to load.</span>,
+    },
 };

--- a/packages/perseus/src/components/__stories__/info-tip.stories.tsx
+++ b/packages/perseus/src/components/__stories__/info-tip.stories.tsx
@@ -2,34 +2,40 @@ import * as React from "react";
 
 import InfoTip from "../info-tip";
 
-type StoryArgs = Record<any, any>;
+import type {Meta, StoryObj} from "@storybook/react";
 
-type Story = {
-    title: string;
-};
-
-export default {
+const meta: Meta = {
     title: "Perseus/Components/Info Tip",
-} as Story;
+    component: InfoTip,
+};
+export default meta;
 
-export const TextOnMouseover = (args: StoryArgs): React.ReactElement => {
-    return <InfoTip>Sample text</InfoTip>;
+type Story = StoryObj<typeof InfoTip>;
+
+export const TextOnMouseover: Story = {
+    args: {
+        children: "Sample text",
+    },
 };
 
-export const CodeInText = (args: StoryArgs): React.ReactElement => {
-    return (
-        <InfoTip>
-            Settings that you add here are available to the program as an object
-            returned by <code>Program.settings()</code>
-        </InfoTip>
-    );
+export const CodeInText: Story = {
+    args: {
+        children: (
+            <>
+                Settings that you add here are available to the program as an
+                object returned by <code>Program.settings()</code>
+            </>
+        ),
+    },
 };
 
-export const MultipleElements = (args: StoryArgs): React.ReactElement => {
-    return (
-        <InfoTip>
-            <p>First paragraph</p>
-            <p>Second paragraph</p>
-        </InfoTip>
-    );
+export const MultipleElements: Story = {
+    args: {
+        children: (
+            <>
+                <p>First paragraph</p>
+                <p>Second paragraph</p>
+            </>
+        ),
+    },
 };

--- a/packages/perseus/src/components/__stories__/inline-icon.stories.tsx
+++ b/packages/perseus/src/components/__stories__/inline-icon.stories.tsx
@@ -1,40 +1,30 @@
-import * as React from "react";
-
 import InlineIcon from "../inline-icon";
 
-type StoryArgs = Record<any, any>;
+import type {Meta, StoryObj} from "@storybook/react";
 
-type Story = {
-    title: string;
-};
-
-const defaultPath = {
-    path: "M62.808 49.728q0 3.36-2.352 5.88l-41.72 41.664q-2.352 2.408-5.768 2.408t-5.768-2.408l-4.872-4.76q-2.352-2.52-2.352-5.88t2.352-5.712l31.08-31.136-31.08-31.024q-2.352-2.52-2.352-5.88t2.352-5.712l4.872-4.76q2.296-2.408 5.768-2.408t5.768 2.408l41.72 41.664q2.352 2.296 2.352 5.656z",
-    height: 100,
-    width: 64,
-} as const;
-
-export default {
+const meta: Meta = {
     title: "Perseus/Components/Inline Icon",
-} as Story;
+    component: InlineIcon,
+    args: {
+        path: "M62.808 49.728q0 3.36-2.352 5.88l-41.72 41.664q-2.352 2.408-5.768 2.408t-5.768-2.408l-4.872-4.76q-2.352-2.52-2.352-5.88t2.352-5.712l31.08-31.136-31.08-31.024q-2.352-2.52-2.352-5.88t2.352-5.712l4.872-4.76q2.296-2.408 5.768-2.408t5.768 2.408l41.72 41.664q2.352 2.296 2.352 5.656z",
+        height: 100,
+        width: 64,
+    },
+};
+export default meta;
 
-export const BasicIconPathAndSizing = (args: StoryArgs): React.ReactElement => {
-    return <InlineIcon {...defaultPath} />;
+type Story = StoryObj<typeof InlineIcon>;
+
+export const BasicIconPathAndSizing: Story = {};
+
+export const BasicIconWithAdditionalStyling: Story = {
+    args: {
+        style: {color: "red"},
+    },
 };
 
-export const BasicIconWithAdditionalStyling = (
-    args: StoryArgs,
-): React.ReactElement => {
-    return (
-        <InlineIcon
-            {...defaultPath}
-            style={{
-                color: "red",
-            }}
-        />
-    );
-};
-
-export const BasicIconWithAriaTitle = (args: StoryArgs): React.ReactElement => {
-    return <InlineIcon {...defaultPath} title="Sample ARIA title" />;
+export const BasicIconWithAriaTitle: Story = {
+    args: {
+        title: "Sample ARIA title",
+    },
 };

--- a/packages/perseus/src/components/__stories__/input-with-examples.stories.tsx
+++ b/packages/perseus/src/components/__stories__/input-with-examples.stories.tsx
@@ -1,4 +1,4 @@
-import {actions} from "@storybook/addon-actions";
+import {action} from "@storybook/addon-actions";
 
 import InputWithExamples from "../input-with-examples";
 
@@ -10,7 +10,7 @@ const meta: Meta = {
     args: {
         examples: [],
         id: "",
-        onChange: actions("onChange"),
+        onChange: action("onChange"),
         value: "",
     },
     argTypes: {

--- a/packages/perseus/src/components/__stories__/input-with-examples.stories.tsx
+++ b/packages/perseus/src/components/__stories__/input-with-examples.stories.tsx
@@ -15,7 +15,7 @@ const meta: Meta = {
     },
     argTypes: {
         onChange: {
-            table: {disable: true},
+            control: {type: null},
         },
     },
 };

--- a/packages/perseus/src/components/__stories__/input-with-examples.stories.tsx
+++ b/packages/perseus/src/components/__stories__/input-with-examples.stories.tsx
@@ -40,7 +40,7 @@ export const AriaLabelTextWithListOfExamples: Story = {
     },
 };
 
-export const DisabledInput = {
+export const DisabledInput: Story = {
     args: {
         disabled: true,
         examples: testExamples,

--- a/packages/perseus/src/components/__stories__/input-with-examples.stories.tsx
+++ b/packages/perseus/src/components/__stories__/input-with-examples.stories.tsx
@@ -1,53 +1,48 @@
-import * as React from "react";
+import {actions} from "@storybook/addon-actions";
 
 import InputWithExamples from "../input-with-examples";
 
-type StoryArgs = Record<any, any>;
+import type {Meta, StoryObj} from "@storybook/react";
 
-type Story = {
-    title: string;
-};
-
-export default {
+const meta: Meta = {
     title: "Perseus/Components/Input with Examples",
-} as Story;
+    component: InputWithExamples,
+    args: {
+        examples: [],
+        id: "",
+        onChange: actions("onChange"),
+        value: "",
+    },
+    argTypes: {
+        onChange: {
+            table: {disable: true},
+        },
+    },
+};
+export default meta;
 
-const defaultObject = {
-    examples: [],
-    id: "",
-    onChange: () => {},
-    value: "",
-} as const;
+type Story = StoryObj<typeof InputWithExamples>;
+
 const testExamples = ["Sample 1", "Sample 2", "Sample 3"];
 
-export const DefaultAndMostlyEmptyProps = (
-    args: StoryArgs,
-): React.ReactElement => {
-    return <InputWithExamples {...defaultObject} />;
+export const DefaultAndMostlyEmptyProps: Story = {};
+
+export const ListOfExamples: Story = {
+    args: {
+        examples: testExamples,
+    },
 };
 
-export const ListOfExamples = (args: StoryArgs): React.ReactElement => {
-    return <InputWithExamples {...defaultObject} examples={testExamples} />;
+export const AriaLabelTextWithListOfExamples: Story = {
+    args: {
+        examples: testExamples,
+        labelText: "Test label",
+    },
 };
 
-export const AriaLabelTextWithListOfExamples = (
-    args: StoryArgs,
-): React.ReactElement => {
-    return (
-        <InputWithExamples
-            {...defaultObject}
-            examples={testExamples}
-            labelText="Test label"
-        />
-    );
-};
-
-export const DisabledInput = (args: StoryArgs): React.ReactElement => {
-    return (
-        <InputWithExamples
-            {...defaultObject}
-            disabled={true}
-            examples={testExamples}
-        />
-    );
+export const DisabledInput = {
+    args: {
+        disabled: true,
+        examples: testExamples,
+    },
 };

--- a/packages/perseus/src/components/__stories__/lint.stories.tsx
+++ b/packages/perseus/src/components/__stories__/lint.stories.tsx
@@ -31,7 +31,7 @@ const meta: Meta = {
         ruleName: "Test rule",
     },
     argTypes: {
-        children: {table: {disable: true}},
+        children: {control: {type: null}},
         severity: {
             type: "number",
             control: {

--- a/packages/perseus/src/components/__stories__/lint.stories.tsx
+++ b/packages/perseus/src/components/__stories__/lint.stories.tsx
@@ -2,24 +2,9 @@ import * as React from "react";
 
 import Lint from "../lint";
 
-import type {Meta} from "@storybook/react";
+import type {Meta, StoryObj} from "@storybook/react";
 
-const meta: Meta<typeof Lint> = {
-    title: "Perseus/Components/Lint",
-};
-
-export default meta;
-
-type StoryArgs = Record<any, any>;
-
-const defaultObject = {
-    children: <div>This is the sample lint child</div>,
-    insideTable: false,
-    message: "Test message",
-    ruleName: "Test rule",
-} as const;
-
-const Container = ({children}: {children: React.ReactNode}) => {
+const Container = (Story) => {
     return (
         <div
             style={{
@@ -29,58 +14,47 @@ const Container = ({children}: {children: React.ReactNode}) => {
                 border: "solid 1px grey",
             }}
         >
-            {children}
+            <Story />
         </div>
     );
 };
 
-export const DefaultLintContainerAndMessage = (
-    args: StoryArgs,
-): React.ReactElement => {
-    return (
-        <Container>
-            <Lint {...defaultObject} />
-        </Container>
-    );
+const meta: Meta = {
+    title: "Perseus/Components/Lint",
+    component: Lint,
+    decorators: [Container],
+    args: {
+        children: <div>This is the sample lint child</div>,
+        insideTable: false,
+        severity: 1,
+        message: "Test message",
+        ruleName: "Test rule",
+    },
+    argTypes: {
+        children: {table: {disable: true}},
+        severity: {
+            type: "number",
+            control: {
+                type: "range",
+                min: 1,
+                max: 4,
+            },
+        },
+    },
 };
-export const LintSeverity1Error = (args: StoryArgs): React.ReactElement => {
-    return (
-        <Container>
-            <Lint {...defaultObject} severity={1} />
-        </Container>
-    );
-};
-export const LintSeverity2Warning = (args: StoryArgs): React.ReactElement => {
-    return (
-        <Container>
-            <Lint {...defaultObject} severity={2} />
-        </Container>
-    );
-};
-export const LintSeverity3Recommendation = (
-    args: StoryArgs,
-): React.ReactElement => {
-    return (
-        <Container>
-            <Lint {...defaultObject} severity={3} />
-        </Container>
-    );
-};
-export const LintSeverity4OfflineReportingOnly = (
-    args: StoryArgs,
-): React.ReactElement => {
-    return (
-        <Container>
-            <Lint {...defaultObject} severity={4} />
-        </Container>
-    );
-};
-export const InlineLintContainerAndMessage = (
-    args: StoryArgs,
-): React.ReactElement => {
-    return (
-        <Container>
-            <Lint {...defaultObject} inline={true} />
-        </Container>
-    );
+
+export default meta;
+
+type Story = StoryObj<typeof Lint>;
+
+export const DefaultLintContainerAndMessage: Story = {};
+
+export const LintSeverity1Error: Story = {args: {severity: 1}};
+export const LintSeverity2Warning: Story = {args: {severity: 2}};
+export const LintSeverity3Recommendation: Story = {args: {severity: 3}};
+export const LintSeverity4OfflineReportingOnly: Story = {args: {severity: 4}};
+export const InlineLintContainerAndMessage: Story = {
+    args: {
+        inline: true,
+    },
 };

--- a/packages/perseus/src/components/__stories__/math-input.stories.tsx
+++ b/packages/perseus/src/components/__stories__/math-input.stories.tsx
@@ -1,4 +1,4 @@
-import {actions} from "@storybook/addon-actions";
+import {action} from "@storybook/addon-actions";
 
 import MathInput from "../math-input";
 
@@ -18,7 +18,7 @@ const meta: Meta = {
         },
         convertDotToTimes: false,
         value: "",
-        onChange: actions("onChange"),
+        onChange: action("onChange"),
         analytics: {onAnalyticsEvent: () => Promise.resolve()},
         labelText: "Math input",
     },

--- a/packages/perseus/src/components/__stories__/math-input.stories.tsx
+++ b/packages/perseus/src/components/__stories__/math-input.stories.tsx
@@ -1,46 +1,53 @@
-import * as React from "react";
+import {actions} from "@storybook/addon-actions";
 
 import MathInput from "../math-input";
 
-type StoryArgs = Record<any, any>;
+import type {Meta, StoryObj} from "@storybook/react";
 
-type Story = {
-    title: string;
-};
-
-export default {
+const meta: Meta = {
     title: "Perseus/Components/Math Input",
-} as Story;
-
-const defaultObject = {
-    keypadButtonSets: {
-        advancedRelations: true,
-        basicRelations: true,
-        divisionKey: true,
-        logarithms: true,
-        preAlgebra: true,
-        trigonometry: true,
+    component: MathInput,
+    args: {
+        keypadButtonSets: {
+            advancedRelations: true,
+            basicRelations: true,
+            divisionKey: true,
+            logarithms: true,
+            preAlgebra: true,
+            trigonometry: true,
+        },
+        convertDotToTimes: false,
+        value: "",
+        onChange: actions("onChange"),
+        analytics: {onAnalyticsEvent: () => Promise.resolve()},
+        labelText: "Math input",
     },
-    convertDotToTimes: false,
-    value: "",
-    onChange: () => {},
-    analytics: {onAnalyticsEvent: () => Promise.resolve()},
-    labelText: "Math input",
-} as const;
-
-export const DefaultWithBasicButtonSet = (
-    args: StoryArgs,
-): React.ReactElement => {
-    return <MathInput {...defaultObject} />;
+    argTypes: {
+        onChange: {
+            table: {disable: true},
+        },
+        analytics: {
+            table: {disable: true},
+        },
+    },
+    parameters: {
+        controls: {exclude: ["onChange", "analytics"]},
+    },
 };
-export const DefaultWithAriaLabel = (args: StoryArgs): React.ReactElement => {
-    return <MathInput {...defaultObject} ariaLabel="Sample label" />;
+export default meta;
+
+type Story = StoryObj<typeof MathInput>;
+
+export const DefaultWithBasicButtonSet: Story = {};
+
+export const DefaultWithAriaLabel: Story = {
+    args: {ariaLabel: "Sample label"},
 };
 
-export const KeypadOpenByDefault = (args: StoryArgs): React.ReactElement => {
-    return <MathInput {...defaultObject} buttonsVisible="always" />;
+export const KeypadOpenByDefault: Story = {
+    args: {buttonsVisible: "always"},
 };
 
-export const KeypadNeverVisible = (args: StoryArgs): React.ReactElement => {
-    return <MathInput {...defaultObject} buttonsVisible="never" />;
+export const KeypadNeverVisible: Story = {
+    args: {buttonsVisible: "never"},
 };

--- a/packages/perseus/src/components/__stories__/math-input.stories.tsx
+++ b/packages/perseus/src/components/__stories__/math-input.stories.tsx
@@ -24,10 +24,10 @@ const meta: Meta = {
     },
     argTypes: {
         onChange: {
-            table: {disable: true},
+            control: {type: null},
         },
         analytics: {
-            table: {disable: true},
+            control: {type: null},
         },
     },
     parameters: {

--- a/packages/perseus/src/components/__stories__/multi-button-group.stories.tsx
+++ b/packages/perseus/src/components/__stories__/multi-button-group.stories.tsx
@@ -2,65 +2,47 @@ import * as React from "react";
 
 import MultiButtonGroup from "../multi-button-group";
 
-type StoryArgs = {
-    allowEmpty: boolean;
-};
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
+import type {Meta, StoryObj} from "@storybook/react";
 
-type Story = {
-    title: string;
-    args: StoryArgs;
-};
-
-export default {
+const meta: Meta = {
     title: "Perseus/Components/Muli-Button Group",
+    component: MultiButtonGroup,
     args: {
         allowEmpty: true,
+        buttons: [],
     },
-} as Story;
+    render: function WithState(props: PropsFor<typeof MultiButtonGroup>) {
+        const [values, updateValues] = React.useState(props.values);
+        return (
+            <MultiButtonGroup
+                {...props}
+                values={values}
+                onChange={updateValues}
+            />
+        );
+    },
+};
+export default meta;
 
-const HarnassedButtonGroup = (
-    props: Pick<
-        React.ComponentProps<typeof MultiButtonGroup>,
-        "buttons" | "allowEmpty"
-    >,
-) => {
-    const [values, updateValues] = React.useState(
-        null as ReadonlyArray<string> | null | undefined,
-    );
+type Story = StoryObj<typeof MultiButtonGroup>;
 
-    return (
-        <MultiButtonGroup
-            {...props}
-            values={values}
-            onChange={(newValues) => {
-                updateValues(newValues);
-            }}
-        />
-    );
+export const ButtonsWithNoTitles: Story = {
+    args: {
+        buttons: [
+            {value: "One", content: "Item #1"},
+            {value: "Two", content: "Item #2"},
+            {value: "Three", content: "Item #3"},
+        ],
+    },
 };
 
-export const ButtonsWithNoTitles = (args: StoryArgs): React.ReactElement => {
-    return (
-        <HarnassedButtonGroup
-            {...args}
-            buttons={[
-                {value: "One", content: "Item #1"},
-                {value: "Two", content: "Item #2"},
-                {value: "Three", content: "Item #3"},
-            ]}
-        />
-    );
-};
-
-export const ButtonsWithTitles = (args: StoryArgs): React.ReactElement => {
-    return (
-        <HarnassedButtonGroup
-            {...args}
-            buttons={[
-                {value: "One", content: "Item #1", title: "The first item"},
-                {value: "Two", content: "Item #2", title: "The second item"},
-                {value: "Three", content: "Item #3", title: "The third item"},
-            ]}
-        />
-    );
+export const ButtonsWithTitles: Story = {
+    args: {
+        buttons: [
+            {value: "One", content: "Item #1", title: "The first item"},
+            {value: "Two", content: "Item #2", title: "The second item"},
+            {value: "Three", content: "Item #3", title: "The third item"},
+        ],
+    },
 };

--- a/packages/perseus/src/components/__stories__/multi-button-group.stories.tsx
+++ b/packages/perseus/src/components/__stories__/multi-button-group.stories.tsx
@@ -37,6 +37,9 @@ export const ButtonsWithNoTitles: Story = {
     },
 };
 
+/**
+ * Hover over the buttons to see their titles.
+ */
 export const ButtonsWithTitles: Story = {
     args: {
         buttons: [

--- a/packages/perseus/src/components/__stories__/number-input.stories.tsx
+++ b/packages/perseus/src/components/__stories__/number-input.stories.tsx
@@ -1,41 +1,54 @@
-import * as React from "react";
+import {action} from "@storybook/addon-actions";
 
 import NumberInput from "../number-input";
 
-type StoryArgs = Record<any, any>;
+import type {Meta, StoryObj} from "@storybook/react";
 
-type Story = {
-    title: string;
-};
-
-const defaultObject = {
-    onChange: () => {},
-} as const;
-
-export default {
+const meta: Meta = {
     title: "Perseus/Components/Number Input",
-} as Story;
+    component: NumberInput,
+    args: {
+        onChange: action("onChange"),
+        onFormatChange: action("onFormatChange"),
+    },
+    argTypes: {
+        onChange: {table: {disable: true}},
+        onFormatChange: {table: {disable: true}},
+    },
+};
+export default meta;
 
-export const EmptyPropsObject = (args: StoryArgs): React.ReactElement => {
-    return <NumberInput {...defaultObject} />;
+type Story = StoryObj<typeof NumberInput>;
+
+export const EmptyPropsObject: Story = {};
+
+export const SampleValue: Story = {
+    args: {value: 1234567890},
 };
 
-export const SampleValue = (args: StoryArgs): React.ReactElement => {
-    return <NumberInput {...defaultObject} value={1234567890} />;
+export const Placeholder: Story = {
+    args: {
+        placeholder: "Sample placeholder",
+    },
 };
 
-export const Placeholder = (args: StoryArgs): React.ReactElement => {
-    return <NumberInput {...defaultObject} placeholder="Sample placeholder" />;
+export const SizeMini: Story = {
+    args: {
+        size: "mini",
+        placeholder: "Sample placeholder",
+    },
 };
 
-export const SizeMini = (args: StoryArgs): React.ReactElement => {
-    return <NumberInput {...defaultObject} placeholder="Sample placeholder" />;
+export const SizeSmall: Story = {
+    args: {
+        size: "small",
+        placeholder: "Sample placeholder",
+    },
 };
 
-export const SizeSmall = (args: StoryArgs): React.ReactElement => {
-    return <NumberInput {...defaultObject} size="small" />;
-};
-
-export const SizeNormal = (args: StoryArgs): React.ReactElement => {
-    return <NumberInput {...defaultObject} size="normal" />;
+export const SizeNormal: Story = {
+    args: {
+        size: "normal",
+        placeholder: "Sample placeholder",
+    },
 };

--- a/packages/perseus/src/components/__stories__/number-input.stories.tsx
+++ b/packages/perseus/src/components/__stories__/number-input.stories.tsx
@@ -12,8 +12,8 @@ const meta: Meta = {
         onFormatChange: action("onFormatChange"),
     },
     argTypes: {
-        onChange: {table: {disable: true}},
-        onFormatChange: {table: {disable: true}},
+        onChange: {control: {type: null}},
+        onFormatChange: {control: {type: null}},
     },
 };
 export default meta;

--- a/packages/perseus/src/components/__stories__/range-input.stories.tsx
+++ b/packages/perseus/src/components/__stories__/range-input.stories.tsx
@@ -1,29 +1,34 @@
-import * as React from "react";
+import {action} from "@storybook/addon-actions";
 
 import RangeInput from "../range-input";
 
-type StoryArgs = Record<any, any>;
+import type {Meta, StoryObj} from "@storybook/react";
 
-type Story = {
-    title: string;
-};
-
-export default {
+const meta: Meta = {
     title: "Perseus/Components/Range Input",
-} as Story;
+    component: RangeInput,
+    args: {
+        value: [],
+        onChange: action("onChange"),
+    },
+    argTypes: {
+        onChange: {table: {disable: true}},
+    },
+};
+export default meta;
 
-export const EmptyValueArray = (args: StoryArgs): React.ReactElement => {
-    return <RangeInput onChange={() => {}} value={[]} />;
+type Story = StoryObj<typeof RangeInput>;
+
+export const EmptyValueArray: Story = {};
+
+export const SimpleWithSmallValueRanges: Story = {
+    args: {
+        value: [-10, 10],
+    },
 };
 
-export const SimpleWithSmallValueRanges = (
-    args: StoryArgs,
-): React.ReactElement => {
-    return <RangeInput onChange={() => {}} value={[-10, 10]} />;
-};
-
-export const Placeholders = (args: StoryArgs): React.ReactElement => {
-    return (
-        <RangeInput onChange={() => {}} placeholder={["?", "!"]} value={[]} />
-    );
+export const Placeholders: Story = {
+    args: {
+        placeholder: ["?", "!"],
+    },
 };

--- a/packages/perseus/src/components/__stories__/range-input.stories.tsx
+++ b/packages/perseus/src/components/__stories__/range-input.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta = {
         onChange: action("onChange"),
     },
     argTypes: {
-        onChange: {table: {disable: true}},
+        onChange: {control: {type: null}},
     },
 };
 export default meta;

--- a/packages/perseus/src/components/__stories__/simple-keypad-input.stories.tsx
+++ b/packages/perseus/src/components/__stories__/simple-keypad-input.stories.tsx
@@ -1,27 +1,24 @@
-import * as React from "react";
+import {action} from "@storybook/addon-actions";
 
 import SimpleKeypadInput from "../simple-keypad-input";
 
-type StoryArgs = Record<any, any>;
+import type {Meta, StoryObj} from "@storybook/react";
 
-type Story = {
-    title: string;
-};
-
-const defaultObject = {
-    onChange: () => {},
-    onFocus: () => {},
-    onBlur: () => {},
-} as const;
-
-export default {
+const meta: Meta = {
     title: "Perseus/Components/Simple Keypad Input",
-} as Story;
-
-export const EmptyPropsObject = (args: StoryArgs): React.ReactElement => {
-    return <SimpleKeypadInput {...defaultObject} />;
+    component: SimpleKeypadInput,
+    args: {
+        onChange: action("onChange"),
+        onFocus: action("onFocus"),
+        onBlur: action("onBlur"),
+    },
 };
+export default meta;
 
-export const CustomValue = (args: StoryArgs): React.ReactElement => {
-    return <SimpleKeypadInput {...defaultObject} value="Test value" />;
+type Story = StoryObj<typeof SimpleKeypadInput>;
+
+export const EmptyPropsObject: Story = {};
+
+export const CustomValue: Story = {
+    args: {value: "Test value"},
 };

--- a/packages/perseus/src/components/__stories__/sortable.stories.tsx
+++ b/packages/perseus/src/components/__stories__/sortable.stories.tsx
@@ -1,77 +1,53 @@
-import * as React from "react";
-
 import Sortable from "../sortable";
 
-type StoryArgs = Record<any, any>;
+import type {Meta, StoryObj} from "@storybook/react";
 
-type Story = {
-    title: string;
-};
-
-const defaultOptions = ["Option 1", "Option 2", "Option 3"];
-
-export default {
+const meta: Meta = {
     title: "Perseus/Components/Sortable",
-} as Story;
+    component: Sortable,
+    args: {
+        options: ["Option 1", "Option 2", "Option 3"],
+    },
+};
+export default meta;
 
-export const SortableHorizontalExample = (
-    args: StoryArgs,
-): React.ReactElement => {
-    return (
-        <Sortable
-            layout={"horizontal"}
-            options={["a", "b", "c"]}
-            waitForTexRendererToLoad={false}
-        />
-    );
+type Story = StoryObj<typeof Sortable>;
+
+export const SortableHorizontalExample: Story = {
+    args: {
+        layout: "horizontal",
+        options: ["a", "b", "c"],
+        waitForTexRendererToLoad: false,
+    },
 };
 
-export const SortableVerticalExample = (
-    args: StoryArgs,
-): React.ReactElement => {
-    return (
-        <Sortable
-            layout={"vertical"}
-            options={["a", "b", "c"]}
-            waitForTexRendererToLoad={false}
-        />
-    );
+export const SortableVerticalExample: Story = {
+    args: {
+        layout: "vertical",
+        options: ["a", "b", "c"],
+        waitForTexRendererToLoad: false,
+    },
 };
 
-export const BasicSortableOptionsTest = (
-    args: StoryArgs,
-): React.ReactElement => {
-    return <Sortable options={defaultOptions} />;
+export const BasicSortableOptionsTest: Story = {};
+
+export const BasicSortableOptionsTestWithNoPadding: Story = {
+    args: {padding: false},
 };
 
-export const BasicSortableOptionsTestWithNoPadding = (
-    args: StoryArgs,
-): React.ReactElement => {
-    return <Sortable options={defaultOptions} padding={false} />;
+export const BasicSortableOptionsTestWithLargeMargin: Story = {
+    args: {margin: 64},
 };
 
-export const BasicSortableOptionsTestWithLargeMargin = (
-    args: StoryArgs,
-): React.ReactElement => {
-    return <Sortable options={defaultOptions} margin={64} />;
+export const BasicSortableOptionsTestDisabled: Story = {
+    args: {disabled: true},
 };
 
-export const BasicSortableOptionsTestDisabled = (
-    args: StoryArgs,
-): React.ReactElement => {
-    return <Sortable options={defaultOptions} disabled={true} />;
-};
-
-export const BasicSortableOptionsTestWithWidthAndHeightConstraints = (
-    args: StoryArgs,
-): React.ReactElement => {
-    return (
-        <Sortable
-            options={defaultOptions}
-            constraints={{
-                height: 128,
-                width: 256,
-            }}
-        />
-    );
+export const BasicSortableOptionsTestWithWidthAndHeightConstraints: Story = {
+    args: {
+        constraints: {
+            height: 128,
+            width: 256,
+        },
+    },
 };

--- a/packages/perseus/src/components/__stories__/stub-tag-editor.stories.tsx
+++ b/packages/perseus/src/components/__stories__/stub-tag-editor.stories.tsx
@@ -1,4 +1,4 @@
-import {actions} from "@storybook/addon-actions";
+import {action} from "@storybook/addon-actions";
 
 import StubTagEditor from "../stub-tag-editor";
 
@@ -9,7 +9,7 @@ const meta: Meta = {
     component: StubTagEditor,
     args: {
         value: [],
-        onChange: actions("onChange"),
+        onChange: action("onChange"),
     },
     argTypes: {
         onChange: {

--- a/packages/perseus/src/components/__stories__/stub-tag-editor.stories.tsx
+++ b/packages/perseus/src/components/__stories__/stub-tag-editor.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta = {
     },
     argTypes: {
         onChange: {
-            table: {disable: true},
+            control: {type: null},
         },
     },
 };

--- a/packages/perseus/src/components/__stories__/stub-tag-editor.stories.tsx
+++ b/packages/perseus/src/components/__stories__/stub-tag-editor.stories.tsx
@@ -1,45 +1,47 @@
-import * as React from "react";
+import {actions} from "@storybook/addon-actions";
 
 import StubTagEditor from "../stub-tag-editor";
 
-type StoryArgs = Record<any, any>;
+import type {Meta, StoryObj} from "@storybook/react";
 
-type Story = {
-    title: string;
+const meta: Meta = {
+    title: "Perseus/Components/Stub Tag Editor",
+    component: StubTagEditor,
+    args: {
+        value: [],
+        onChange: actions("onChange"),
+    },
+    argTypes: {
+        onChange: {
+            table: {disable: true},
+        },
+    },
 };
 
-export default {
-    title: "Perseus/Components/name",
-} as Story;
+export default meta;
+
+type Story = StoryObj<typeof StubTagEditor>;
 
 const defaultValues = ["Test value 1", "Test value 2", "Test value 3"];
 
-export const ShowingTitle = (args: StoryArgs): React.ReactElement => {
-    return <StubTagEditor onChange={() => {}} showTitle={true} />;
+export const ShowingTitle: Story = {
+    args: {showTitle: true},
 };
 
-export const NotShowingTitle = (args: StoryArgs): React.ReactElement => {
-    return <StubTagEditor onChange={() => {}} showTitle={false} />;
+export const NotShowingTitle: Story = {
+    args: {showTitle: false},
 };
 
-export const ShowingTitleWithValue = (args: StoryArgs): React.ReactElement => {
-    return (
-        <StubTagEditor
-            onChange={() => {}}
-            showTitle={true}
-            value={defaultValues}
-        />
-    );
+export const ShowingTitleWithValue: Story = {
+    args: {
+        showTitle: true,
+        value: defaultValues,
+    },
 };
 
-export const NotShowingTitleWithValue = (
-    args: StoryArgs,
-): React.ReactElement => {
-    return (
-        <StubTagEditor
-            onChange={() => {}}
-            showTitle={false}
-            value={defaultValues}
-        />
-    );
+export const NotShowingTitleWithValue: Story = {
+    args: {
+        showTitle: false,
+        value: defaultValues,
+    },
 };

--- a/packages/perseus/src/components/__stories__/svg-image.stories.tsx
+++ b/packages/perseus/src/components/__stories__/svg-image.stories.tsx
@@ -6,12 +6,6 @@ const meta: Meta = {
     title: "Perseus/Components/SVG Image",
     component: SvgImage,
     args: {alt: "ALT"},
-    parameters: {
-        chromatic: {
-            // The Svg
-            disable: 100,
-        },
-    },
 };
 export default meta;
 

--- a/packages/perseus/src/components/__stories__/svg-image.stories.tsx
+++ b/packages/perseus/src/components/__stories__/svg-image.stories.tsx
@@ -16,17 +16,24 @@ const imgUrl = "https://www.khanacademy.org/images/hand-tree.new.png";
 const graphieUrl =
     "web+graphie://ka-perseus-graphie.s3.amazonaws.com/1e06f6d4071f30cee2cc3ccb7435b3a66a62fe3f";
 
-/**
- * Demostrates an `SvgImage` that doesn't have a `src` defined, and as such
- * never loads (infinite spinner)
- */
-export const Default: Story = {};
+export const Default: Story = {
+    parameters: {
+        /** This story doesn't provide a src url and so just shows a spinner.
+         * Perhaps not useful, but for now we'll just disable snapshots. */
+        chromatic: {disableSnapshot: true},
+    },
+};
 
 export const SvgImageThatDoesntLoad: Story = {
     args: {
         height: 100,
         width: 500,
         src: "http://httpstat.us/200?sleep=1000000",
+    },
+    parameters: {
+        /** This story never loads and so just shows a spinner. Perhaps not
+         * useful, but for now we'll just disable snapshots. */
+        chromatic: {disableSnapshot: true},
     },
 };
 

--- a/packages/perseus/src/components/__stories__/svg-image.stories.tsx
+++ b/packages/perseus/src/components/__stories__/svg-image.stories.tsx
@@ -8,10 +8,8 @@ const meta: Meta = {
     args: {alt: "ALT"},
     parameters: {
         chromatic: {
-            // This component loads images from remote sources. We need to tell
-            // Chromatic to wait a bit before taking a snapshot otherwise we
-            // get only empty snapshots.
-            delay: 100,
+            // The Svg
+            disable: 100,
         },
     },
 };

--- a/packages/perseus/src/components/__stories__/svg-image.stories.tsx
+++ b/packages/perseus/src/components/__stories__/svg-image.stories.tsx
@@ -1,74 +1,61 @@
-import * as React from "react";
-
 import SvgImage from "../svg-image";
 
-type StoryArgs = Record<any, any>;
+import type {Meta, StoryObj} from "@storybook/react";
 
-type Story = {
-    title: string;
-};
-
-export default {
+const meta: Meta = {
     title: "Perseus/Components/SVG Image",
-} as Story;
+    component: SvgImage,
+    args: {alt: "ALT"},
+};
+export default meta;
+
+type Story = StoryObj<typeof SvgImage>;
 
 const svgUrl = "http://www.khanacademy.org/images/ohnoes-concerned.svg";
 const imgUrl = "https://www.khanacademy.org/images/hand-tree.new.png";
 const graphieUrl =
     "web+graphie://ka-perseus-graphie.s3.amazonaws.com/1e06f6d4071f30cee2cc3ccb7435b3a66a62fe3f";
 
-export const MostlyEmptyPropsObject = (args: StoryArgs): React.ReactElement => {
-    return <SvgImage alt="ALT" />;
+export const Default: Story = {};
+
+export const SvgImageThatDoesntLoad: Story = {
+    args: {
+        height: 100,
+        width: 500,
+        src: "http://httpstat.us/200?sleep=1000000",
+    },
 };
 
-export const SvgImageThatDoesntLoad = (args: StoryArgs): React.ReactElement => {
-    return (
-        <SvgImage
-            alt="ALT"
-            height={100}
-            width={500}
-            src={"http://httpstat.us/200?sleep=1000000"}
-        />
-    );
+export const SvgImageBasic: Story = {
+    args: {src: svgUrl},
 };
 
-export const SvgImageBasic = (args: StoryArgs): React.ReactElement => {
-    return <SvgImage src={svgUrl} alt="ALT" />;
+export const SvgImageWithFixedHeight: Story = {
+    args: {height: 50, src: svgUrl},
 };
 
-export const SvgImageWithFixedHeight = (
-    args: StoryArgs,
-): React.ReactElement => {
-    return <SvgImage height={50} src={svgUrl} alt="ALT" />;
+export const SvgImageWithFixedWidth: Story = {
+    args: {src: svgUrl, width: 50},
 };
 
-export const SvgImageWithFixedWidth = (args: StoryArgs): React.ReactElement => {
-    return <SvgImage src={svgUrl} width={50} alt="ALT" />;
+export const SvgImageWithExtraGraphieProps: Story = {
+    args: {
+        extraGraphie: {
+            box: [200, 200],
+            range: [
+                [0, 10],
+                [0, 10],
+            ],
+            labels: ["ok"],
+        },
+        src: svgUrl,
+    },
 };
 
-export const SvgImageWithExtraGraphieProps = (
-    args: StoryArgs,
-): React.ReactElement => {
-    return (
-        <SvgImage
-            extraGraphie={{
-                box: [200, 200],
-                range: [
-                    [0, 10],
-                    [0, 10],
-                ],
-                labels: ["ok"],
-            }}
-            src={svgUrl}
-            alt="ALT"
-        />
-    );
+export const PngImage: Story = {
+    args: {src: imgUrl},
 };
 
-export const PngImage = (args: StoryArgs): React.ReactElement => {
-    return <SvgImage src={imgUrl} alt="ALT" />;
-};
-
-export const GraphieImage = (args: StoryArgs): React.ReactElement => {
-    return <SvgImage src={graphieUrl} alt="ALT" />;
+export const GraphieImage: Story = {
+    args: {src: graphieUrl},
 };

--- a/packages/perseus/src/components/__stories__/svg-image.stories.tsx
+++ b/packages/perseus/src/components/__stories__/svg-image.stories.tsx
@@ -6,6 +6,14 @@ const meta: Meta = {
     title: "Perseus/Components/SVG Image",
     component: SvgImage,
     args: {alt: "ALT"},
+    parameters: {
+        chromatic: {
+            // This component loads images from remote sources. We need to tell
+            // Chromatic to wait a bit before taking a snapshot otherwise we
+            // get only empty snapshots.
+            delay: 100,
+        },
+    },
 };
 export default meta;
 
@@ -16,6 +24,10 @@ const imgUrl = "https://www.khanacademy.org/images/hand-tree.new.png";
 const graphieUrl =
     "web+graphie://ka-perseus-graphie.s3.amazonaws.com/1e06f6d4071f30cee2cc3ccb7435b3a66a62fe3f";
 
+/**
+ * Demostrates an `SvgImage` that doesn't have a `src` defined, and as such
+ * never loads (infinite spinner)
+ */
 export const Default: Story = {};
 
 export const SvgImageThatDoesntLoad: Story = {

--- a/packages/perseus/src/components/__stories__/tex.stories.tsx
+++ b/packages/perseus/src/components/__stories__/tex.stories.tsx
@@ -1,23 +1,16 @@
-import * as React from "react";
-
 import TeX from "../tex";
 
-type StoryArgs = {
-    equation: string;
-};
+import type {Meta, StoryObj} from "@storybook/react";
 
-type Story = {
-    title: string;
-    args: StoryArgs;
-};
-
-export default {
+const meta: Meta = {
     title: "Perseus/Components/Tex",
+    component: TeX,
     args: {
-        equation: "f(x) = x + 1",
+        children: "f(x) = x + 1",
     },
-} as Story;
-
-export const BasicOperation = (args: StoryArgs): React.ReactElement => {
-    return <TeX setAssetStatus={() => {}} children={args.equation} />;
 };
+export default meta;
+
+type Story = StoryObj<typeof TeX>;
+
+export const BasicOperation: Story = {};

--- a/packages/perseus/src/components/__stories__/text-input.stories.tsx
+++ b/packages/perseus/src/components/__stories__/text-input.stories.tsx
@@ -13,9 +13,9 @@ const meta: Meta = {
         onFocus: action("onFocus"),
     },
     argTypes: {
-        onChange: {table: {disable: true}},
-        onBlur: {table: {disable: true}},
-        onFocus: {table: {disable: true}},
+        onChange: {control: {type: null}},
+        onBlur: {control: {type: null}},
+        onFocus: {control: {type: null}},
     },
 };
 export default meta;

--- a/packages/perseus/src/components/__stories__/text-input.stories.tsx
+++ b/packages/perseus/src/components/__stories__/text-input.stories.tsx
@@ -1,4 +1,4 @@
-import {actions} from "@storybook/addon-actions";
+import {action} from "@storybook/addon-actions";
 
 import TextInput from "../text-input";
 
@@ -8,9 +8,9 @@ const meta: Meta = {
     title: "Perseus/Components/Text Input",
     component: TextInput,
     args: {
-        onChange: actions("onChange"),
-        onBlur: actions("onBlur"),
-        onFocus: actions("onFocus"),
+        onChange: action("onChange"),
+        onBlur: action("onBlur"),
+        onFocus: action("onFocus"),
     },
     argTypes: {
         onChange: {table: {disable: true}},

--- a/packages/perseus/src/components/__stories__/text-input.stories.tsx
+++ b/packages/perseus/src/components/__stories__/text-input.stories.tsx
@@ -1,33 +1,37 @@
-import * as React from "react";
+import {actions} from "@storybook/addon-actions";
 
 import TextInput from "../text-input";
 
-type StoryArgs = Record<any, any>;
+import type {Meta, StoryObj} from "@storybook/react";
 
-type Story = {
-    title: string;
-};
-
-export default {
+const meta: Meta = {
     title: "Perseus/Components/Text Input",
-} as Story;
+    component: TextInput,
+    args: {
+        onChange: actions("onChange"),
+        onBlur: actions("onBlur"),
+        onFocus: actions("onFocus"),
+    },
+    argTypes: {
+        onChange: {table: {disable: true}},
+        onBlur: {table: {disable: true}},
+        onFocus: {table: {disable: true}},
+    },
+};
+export default meta;
 
-const defaultObject = {
-    onChange: () => {},
-} as const;
+type Story = StoryObj<typeof TextInput>;
 
-export const EmptyPropsObject = (args: StoryArgs): React.ReactElement => {
-    return <TextInput {...defaultObject} />;
+export const EmptyPropsObject: Story = {};
+
+export const TestValueProvided: Story = {
+    args: {value: "Test value"},
 };
 
-export const TestValueProvided = (args: StoryArgs): React.ReactElement => {
-    return <TextInput {...defaultObject} value="Test value" />;
+export const AriaLabelTextProvided: Story = {
+    args: {labelText: "Test label"},
 };
 
-export const AriaLabelTextProvided = (args: StoryArgs): React.ReactElement => {
-    return <TextInput {...defaultObject} labelText="Test label" />;
-};
-
-export const Disabled = (args: StoryArgs): React.ReactElement => {
-    return <TextInput {...defaultObject} disabled={true} />;
+export const Disabled: Story = {
+    args: {disabled: true},
 };

--- a/packages/perseus/src/components/__stories__/text-list-editor.stories.tsx
+++ b/packages/perseus/src/components/__stories__/text-list-editor.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta = {
         onChange: action("onChange"),
     },
     argTypes: {
-        onChange: {table: {disable: true}},
+        onChange: {control: {type: null}},
     },
     decorators: [
         (Story) => (

--- a/packages/perseus/src/components/__stories__/text-list-editor.stories.tsx
+++ b/packages/perseus/src/components/__stories__/text-list-editor.stories.tsx
@@ -1,4 +1,4 @@
-import {actions} from "@storybook/addon-actions";
+import {action} from "@storybook/addon-actions";
 import * as React from "react";
 
 import TextListEditor from "../text-list-editor";
@@ -10,7 +10,7 @@ const meta: Meta = {
     component: TextListEditor,
     args: {
         options: ["Test option 1", "Test option 2", "Test option 3"],
-        onChange: actions("onChange"),
+        onChange: action("onChange"),
     },
     argTypes: {
         onChange: {table: {disable: true}},

--- a/packages/perseus/src/components/__stories__/text-list-editor.stories.tsx
+++ b/packages/perseus/src/components/__stories__/text-list-editor.stories.tsx
@@ -1,32 +1,30 @@
-import {action} from "@storybook/addon-actions";
+import {actions} from "@storybook/addon-actions";
 import * as React from "react";
 
 import TextListEditor from "../text-list-editor";
 
-type StoryArgs = Record<any, any>;
+import type {Meta, StoryObj} from "@storybook/react";
 
-type Story = {
-    title: string;
-};
-
-export default {
+const meta: Meta = {
     title: "Perseus/Components/Text List Editor",
-} as Story;
-
-const defaultObject = {
-    onChange: (...args) => {
-        action("onChange")(...args);
+    component: TextListEditor,
+    args: {
+        options: ["Test option 1", "Test option 2", "Test option 3"],
+        onChange: actions("onChange"),
     },
-    options: ["Test option 1", "Test option 2", "Test option 3"],
-} as const;
-
-const ClassName = "framework-perseus orderer";
-
-export const SimpleListOfOptions = (args: StoryArgs): React.ReactElement => {
-    return (
-        // @ts-expect-error [FEI-5003] - TS2322 - Type '{ children: Element; class: string; }' is not assignable to type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>'.
-        <div class={ClassName}>
-            <TextListEditor {...defaultObject} />
-        </div>
-    );
+    argTypes: {
+        onChange: {table: {disable: true}},
+    },
+    decorators: [
+        (Story) => (
+            <div className={"framework-perseus orderer"}>
+                <Story />
+            </div>
+        ),
+    ],
 };
+export default meta;
+
+type Story = StoryObj<typeof TextListEditor>;
+
+export const SimpleListOfOptions: Story = {};

--- a/packages/perseus/src/components/__stories__/tooltip.stories.tsx
+++ b/packages/perseus/src/components/__stories__/tooltip.stories.tsx
@@ -3,50 +3,39 @@ import * as React from "react";
 
 import Tooltip, {HorizontalDirection, VerticalDirection} from "../tooltip";
 
-import type {Meta} from "@storybook/react";
+import type {Meta, StoryObj} from "@storybook/react";
 
-const meta: Meta<typeof Tooltip> = {
+const meta: Meta = {
     title: "Perseus/Components/Tooltip",
+    component: Tooltip,
+    render(props) {
+        return (
+            <View style={{margin: "20px"}}>
+                Hover over{" "}
+                <Tooltip
+                    show={props.show}
+                    horizontalPosition={HorizontalDirection.Left}
+                    horizontalAlign={HorizontalDirection.Left}
+                    verticalPosition={VerticalDirection.Bottom}
+                >
+                    <span>this</span>
+                    <View style={{backgroundColor: "white"}}>
+                        You can read so much more if you want...
+                    </View>
+                </Tooltip>{" "}
+                to see more information
+            </View>
+        );
+    },
 };
-
-export const Shown = () => {
-    return (
-        <View style={{margin: "20px"}}>
-            Hover over{" "}
-            <Tooltip
-                show={true}
-                horizontalPosition={HorizontalDirection.Left}
-                horizontalAlign={HorizontalDirection.Left}
-                verticalPosition={VerticalDirection.Bottom}
-            >
-                <span>this</span>
-                <View style={{backgroundColor: "white"}}>
-                    You can read so much more if you want...
-                </View>
-            </Tooltip>{" "}
-            to see more information
-        </View>
-    );
-};
-
-export const Hidden = () => {
-    return (
-        <View style={{margin: "20px"}}>
-            Hover over{" "}
-            <Tooltip
-                show={false}
-                horizontalPosition={HorizontalDirection.Left}
-                horizontalAlign={HorizontalDirection.Left}
-                verticalPosition={VerticalDirection.Bottom}
-            >
-                <span>this</span>
-                <View style={{backgroundColor: "white"}}>
-                    You can read so much more if you want...
-                </View>
-            </Tooltip>{" "}
-            to see more information
-        </View>
-    );
-};
-
 export default meta;
+
+type Story = StoryObj<typeof Tooltip>;
+
+export const Shown: Story = {
+    args: {show: true},
+};
+
+export const Hidden: Story = {
+    args: {show: false},
+};

--- a/packages/perseus/src/components/__stories__/zoomable-tex.stories.tsx
+++ b/packages/perseus/src/components/__stories__/zoomable-tex.stories.tsx
@@ -2,40 +2,34 @@ import * as React from "react";
 
 import ZoomableTex from "../zoomable-tex";
 
-type StoryArgs = Record<any, any>;
+import type {Meta, StoryObj} from "@storybook/react";
 
-type Story = {
-    title: string;
-};
-
-export default {
+const meta: Meta = {
     title: "Perseus/Components/Zoomable Tex",
-} as Story;
+    component: ZoomableTex,
+    decorators: [
+        function ForceZoomWrapper(Story) {
+            return (
+                <>
+                    <h1>Click on equation to zoom/unzoom</h1>
+                    <div style={{width: "80px"}}>
+                        <Story />
+                    </div>
+                </>
+            );
+        },
+    ],
+};
+export default meta;
 
-type Props = {
-    children: React.ReactNode;
+type Story = StoryObj<typeof ZoomableTex>;
+
+export const Tex: Story = {
+    args: {children: "\\sum_{i=1}^\\infty\\frac{1}{n^2} = \\frac{\\pi^2}{6}"},
 };
 
-const ForceZoomWrapper = ({children}: Props): React.ReactElement => (
-    <>
-        <h1>Click on equation to zoom/unzoom</h1>
-        <div style={{width: "50px"}}>{children}</div>
-    </>
-);
-
-export const Tex = (args: StoryArgs): React.ReactElement => {
-    return (
-        <ForceZoomWrapper>
-            <ZoomableTex children="\sum_{i=1}^\infty\frac{1}{n^2} =\frac{\pi^2}{6}" />
-        </ForceZoomWrapper>
-    );
-};
-
-export const ComplexTex = (args: StoryArgs): React.ReactElement => {
-    return (
-        <ForceZoomWrapper>
-            {" "}
-            <ZoomableTex children="\begin{aligned}h\blueE{v_1} \left(\dfrac{\partial f}{\partial x}(x_0, y_0) \right) + h\greenE{v_2}\left( \dfrac{\partial f}{\partial y}(x_0 \redD{+ h\blueE{v_1}}, y_0)\right)\end{aligned}" />
-        </ForceZoomWrapper>
-    );
+export const ComplexTex: Story = {
+    args: {
+        children: `\\begin{aligned}h\\blueE{v_1} \\left(\\dfrac{\\partial f}{\\partial x}(x_0, y_0) \\right) + h\\greenE{v_2}\\left( \\dfrac{\\partial f}{\\partial y}(x_0 \\redD{+ h\\blueE{v_1}}, y_0)\\right)\\end{aligned}`,
+    },
 };

--- a/packages/perseus/src/components/__stories__/zoomable.stories.tsx
+++ b/packages/perseus/src/components/__stories__/zoomable.stories.tsx
@@ -2,20 +2,7 @@ import * as React from "react";
 
 import Zoomable from "../zoomable";
 
-type StoryArgs = Record<any, any>;
-
-type Story = {
-    title: string;
-};
-
-export default {
-    title: "Perseus/Components/Zoomable",
-    argTypes: {
-        disableEntranceAnimation: {
-            control: {type: "boolean"},
-        },
-    },
-} as Story;
+import type {Meta, StoryObj} from "@storybook/react";
 
 type Bounds = {
     width: number;
@@ -32,18 +19,29 @@ const computeChildBounds = (
     };
 };
 
-export const ZoomableExample = (args: StoryArgs): React.ReactElement => {
-    return (
-        <Zoomable
-            computeChildBounds={computeChildBounds}
-            disableEntranceAnimation={!!args.disableEntranceAnimation}
-        >
+const meta: Meta = {
+    title: "Perseus/Components/Zoomable",
+    component: Zoomable,
+    args: {
+        computeChildBounds,
+    },
+    argTypes: {
+        children: {table: {disable: true}},
+    },
+};
+export default meta;
+
+type Story = StoryObj<typeof Zoomable>;
+
+export const ZoomableExample: Story = {
+    args: {
+        children: (
             <span>
                 Here's some zoomed-out content.
                 <br />
                 <br />
                 Click on the content to zoom/unzoom.
             </span>
-        </Zoomable>
-    );
+        ),
+    },
 };

--- a/packages/perseus/src/components/__stories__/zoomable.stories.tsx
+++ b/packages/perseus/src/components/__stories__/zoomable.stories.tsx
@@ -26,7 +26,14 @@ const meta: Meta = {
         computeChildBounds,
     },
     argTypes: {
-        children: {table: {disable: true}},
+        children: {control: {type: null}},
+    },
+    parameters: {
+        chromatic: {
+            // Disable the snapshot for this story because it's testing
+            // behavior, not visuals.
+            disableSnapshot: true,
+        },
     },
 };
 export default meta;

--- a/packages/perseus/src/components/__tests__/math-input.test.tsx
+++ b/packages/perseus/src/components/__tests__/math-input.test.tsx
@@ -36,7 +36,7 @@ describe("Perseus' MathInput", () => {
             <MathInput
                 onChange={() => {}}
                 keypadButtonSets={allButtonSets}
-                analytics={{onAnalyticsEvent: () => Promise.resolve()}}
+                onAnalyticsEvent={() => Promise.resolve()}
                 convertDotToTimes={false}
                 value=""
             />,
@@ -55,7 +55,7 @@ describe("Perseus' MathInput", () => {
             <MathInput
                 onChange={() => {}}
                 keypadButtonSets={allButtonSets}
-                analytics={{onAnalyticsEvent: () => Promise.resolve()}}
+                onAnalyticsEvent={() => Promise.resolve()}
                 convertDotToTimes={false}
                 value=""
             />,
@@ -74,7 +74,7 @@ describe("Perseus' MathInput", () => {
             <MathInput
                 onChange={() => {}}
                 keypadButtonSets={allButtonSets}
-                analytics={{onAnalyticsEvent: () => Promise.resolve()}}
+                onAnalyticsEvent={() => Promise.resolve()}
                 convertDotToTimes={false}
                 value=""
                 ariaLabel="Hello world"
@@ -95,7 +95,7 @@ describe("Perseus' MathInput", () => {
             <MathInput
                 onChange={mockOnChange}
                 keypadButtonSets={allButtonSets}
-                analytics={{onAnalyticsEvent: () => Promise.resolve()}}
+                onAnalyticsEvent={() => Promise.resolve()}
                 convertDotToTimes={false}
                 value=""
             />,
@@ -120,7 +120,7 @@ describe("Perseus' MathInput", () => {
             <MathInput
                 onChange={mockOnChange}
                 keypadButtonSets={allButtonSets}
-                analytics={{onAnalyticsEvent: () => Promise.resolve()}}
+                onAnalyticsEvent={() => Promise.resolve()}
                 convertDotToTimes={false}
                 value=""
             />,
@@ -149,7 +149,7 @@ describe("Perseus' MathInput", () => {
             <MathInput
                 onChange={mockOnChange}
                 buttonSets={["basic+div"]}
-                analytics={{onAnalyticsEvent: () => Promise.resolve()}}
+                onAnalyticsEvent={() => Promise.resolve()}
                 convertDotToTimes={false}
                 value=""
             />,
@@ -178,7 +178,7 @@ describe("Perseus' MathInput", () => {
             <MathInput
                 onChange={() => {}}
                 keypadButtonSets={allButtonSets}
-                analytics={{onAnalyticsEvent: () => Promise.resolve()}}
+                onAnalyticsEvent={() => Promise.resolve()}
                 convertDotToTimes={false}
                 value=""
             />,
@@ -202,7 +202,7 @@ describe("Perseus' MathInput", () => {
             <MathInput
                 onChange={() => {}}
                 keypadButtonSets={allButtonSets}
-                analytics={{onAnalyticsEvent: () => Promise.resolve()}}
+                onAnalyticsEvent={() => Promise.resolve()}
                 convertDotToTimes={false}
                 value=""
             />,
@@ -231,7 +231,7 @@ describe("Perseus' MathInput", () => {
             <MathInput
                 onChange={() => {}}
                 buttonsVisible="always"
-                analytics={{onAnalyticsEvent: () => Promise.resolve()}}
+                onAnalyticsEvent={() => Promise.resolve()}
                 convertDotToTimes={false}
                 value=""
             />,

--- a/packages/perseus/src/components/graph.tsx
+++ b/packages/perseus/src/components/graph.tsx
@@ -3,6 +3,7 @@
 import {vector as kvector} from "@khanacademy/kmath";
 import $ from "jquery";
 import * as React from "react";
+import ReactDOM from "react-dom";
 import _ from "underscore";
 
 import AssetContext from "../asset-context";
@@ -85,9 +86,10 @@ class Graph extends React.Component<Props> {
     protractor: any;
     ruler: any;
     _graphie: any;
-    _hasSetupGraphieThisUpdate = false;
-    _shouldSetupGraphie = true;
-    graphieDiv = React.createRef<HTMLDivElement>();
+    // @ts-expect-error - TS2564 - Property '_hasSetupGraphieThisUpdate' has no initializer and is not definitely assigned in the constructor.
+    _hasSetupGraphieThisUpdate: boolean;
+    // @ts-expect-error - TS2564 - Property '_shouldSetupGraphie' has no initializer and is not definitely assigned in the constructor.
+    _shouldSetupGraphie: boolean;
 
     static defaultProps: DefaultProps = {
         labels: ["x", "y"],
@@ -184,11 +186,11 @@ class Graph extends React.Component<Props> {
         if (this._hasSetupGraphieThisUpdate) {
             return;
         }
-        if (this.graphieDiv.current == null) {
-            return;
-        }
 
-        $(this.graphieDiv.current).empty();
+        // eslint-disable-next-line react/no-string-refs
+        const graphieDiv = ReactDOM.findDOMNode(this.refs.graphieDiv);
+        // @ts-expect-error - TS2769 - No overload matches this call. | TS2339 - Property 'empty' does not exist on type 'JQueryStatic'.
+        $(graphieDiv).empty();
 
         // Content creators may need to explicitly add the dollar signs so the
         // strings are picked up by our translation tools. However, these math
@@ -200,9 +202,8 @@ class Graph extends React.Component<Props> {
             Util.unescapeMathMode(label),
         );
         const range = this.props.range;
-        const graphie = (this._graphie = GraphUtils.createGraphie(
-            this.graphieDiv.current,
-        ));
+        // @ts-expect-error - TS2345: Argument of type 'Element | Text | null' is not assignable to parameter of type 'HTMLElement'.
+        const graphie = (this._graphie = GraphUtils.createGraphie(graphieDiv));
 
         const gridConfig: [GridDimensions, GridDimensions] =
             this._getGridConfig();
@@ -270,7 +271,8 @@ class Graph extends React.Component<Props> {
             });
 
             $instructionsWrapper.append($instructions);
-            $(this.graphieDiv.current).append($instructionsWrapper);
+            // @ts-expect-error - TS2769 - No overload matches this call. | TS2339 - Property 'append' does not exist on type 'JQueryStatic'.
+            $(graphieDiv).append($instructionsWrapper);
         } else {
             $instructionsWrapper = undefined;
         }
@@ -429,7 +431,8 @@ class Graph extends React.Component<Props> {
                 onClick={this.onClick}
             >
                 {image}
-                <div className="graphie" ref={this.graphieDiv} />
+                {/* eslint-disable-next-line react/no-string-refs */}
+                <div className="graphie" ref="graphieDiv" />
             </div>
         );
     }

--- a/packages/perseus/src/components/graph.tsx
+++ b/packages/perseus/src/components/graph.tsx
@@ -3,7 +3,6 @@
 import {vector as kvector} from "@khanacademy/kmath";
 import $ from "jquery";
 import * as React from "react";
-import ReactDOM from "react-dom";
 import _ from "underscore";
 
 import AssetContext from "../asset-context";
@@ -86,10 +85,9 @@ class Graph extends React.Component<Props> {
     protractor: any;
     ruler: any;
     _graphie: any;
-    // @ts-expect-error - TS2564 - Property '_hasSetupGraphieThisUpdate' has no initializer and is not definitely assigned in the constructor.
-    _hasSetupGraphieThisUpdate: boolean;
-    // @ts-expect-error - TS2564 - Property '_shouldSetupGraphie' has no initializer and is not definitely assigned in the constructor.
-    _shouldSetupGraphie: boolean;
+    _hasSetupGraphieThisUpdate = false;
+    _shouldSetupGraphie = true;
+    graphieDiv = React.createRef<HTMLDivElement>();
 
     static defaultProps: DefaultProps = {
         labels: ["x", "y"],
@@ -186,11 +184,11 @@ class Graph extends React.Component<Props> {
         if (this._hasSetupGraphieThisUpdate) {
             return;
         }
+        if (this.graphieDiv.current == null) {
+            return;
+        }
 
-        // eslint-disable-next-line react/no-string-refs
-        const graphieDiv = ReactDOM.findDOMNode(this.refs.graphieDiv);
-        // @ts-expect-error - TS2769 - No overload matches this call. | TS2339 - Property 'empty' does not exist on type 'JQueryStatic'.
-        $(graphieDiv).empty();
+        $(this.graphieDiv.current).empty();
 
         // Content creators may need to explicitly add the dollar signs so the
         // strings are picked up by our translation tools. However, these math
@@ -202,8 +200,9 @@ class Graph extends React.Component<Props> {
             Util.unescapeMathMode(label),
         );
         const range = this.props.range;
-        // @ts-expect-error - TS2345: Argument of type 'Element | Text | null' is not assignable to parameter of type 'HTMLElement'.
-        const graphie = (this._graphie = GraphUtils.createGraphie(graphieDiv));
+        const graphie = (this._graphie = GraphUtils.createGraphie(
+            this.graphieDiv.current,
+        ));
 
         const gridConfig: [GridDimensions, GridDimensions] =
             this._getGridConfig();
@@ -271,8 +270,7 @@ class Graph extends React.Component<Props> {
             });
 
             $instructionsWrapper.append($instructions);
-            // @ts-expect-error - TS2769 - No overload matches this call. | TS2339 - Property 'append' does not exist on type 'JQueryStatic'.
-            $(graphieDiv).append($instructionsWrapper);
+            $(this.graphieDiv.current).append($instructionsWrapper);
         } else {
             $instructionsWrapper = undefined;
         }
@@ -431,8 +429,7 @@ class Graph extends React.Component<Props> {
                 onClick={this.onClick}
             >
                 {image}
-                {/* eslint-disable-next-line react/no-string-refs */}
-                <div className="graphie" ref="graphieDiv" />
+                <div className="graphie" ref={this.graphieDiv} />
             </div>
         );
     }

--- a/packages/perseus/src/components/hud.tsx
+++ b/packages/perseus/src/components/hud.tsx
@@ -84,6 +84,10 @@ type Props = {
     fixedPosition?: boolean;
 };
 
+/**
+ * A "heads-up display" (HUD) indicator that includes a short message (usually
+ * used for linting errors). The indicator can be disabled.
+ */
 const HUD = ({message, enabled, onClick, fixedPosition = true}: Props) => {
     let state;
     let icon;

--- a/packages/perseus/src/components/icon.tsx
+++ b/packages/perseus/src/components/icon.tsx
@@ -1,34 +1,4 @@
 /* eslint-disable @khanacademy/ts-no-error-suppressions */
-/**
- * SVG Icon React Component
- *
- * This component is designed to take in SVG paths and render icons based upon
- * them. If you are looking for an icon that we've used before you should look
- * in `icon-paths.js` which is a reference file for all the SVG paths that
- * we've used. You'll need to copy the object from that file into whichever
- * file you're using the icon and explicitly pass it in to the <Icon/> React
- * component.
- *
- * Sample usage:
- *
- *   const dropdownIcon = `M5,6L0,0L10,0`;
- *   <Icon icon={dropdownIcon} />
- *
- * Or:
- *
- *   const dropdownIcon = {
- *       path: `M5,6L0,0L10,0`,
- *       height: 10,
- *       width: 10,
- *   };
- *   <Icon icon={dropdownIcon} size={20} />
- *
- * A full list of all the existing icons can be seen here:
- * http://localhost:8080/react-sandbox/shared-styles-package/icon.jsx.fixture.js
- *
- * If you want to add an entirely new icon please read the note inside
- * the `icon-paths.js` file.
- */
 
 import * as React from "react";
 
@@ -78,6 +48,37 @@ type Props = {
     alt?: string;
 };
 
+/**
+ * An SVG Icon
+ *
+ * This component is designed to take in SVG paths and render icons based upon
+ * them. If you are looking for an icon that we've used before you should look
+ * in `icon-paths.js` which is a reference file for all the SVG paths that
+ * we've used. You'll need to copy the object from that file into whichever
+ * file you're using the icon and explicitly pass it in to the <Icon/> React
+ * component.
+ *
+ * Sample usage:
+ *
+ * ```
+ * const dropdownIcon = `M5,6L0,0L10,0`;
+ * <Icon icon={dropdownIcon} />
+ * ```
+ *
+ * Or:
+ *
+ * ```
+ *   const dropdownIcon = {
+ *       path: `M5,6L0,0L10,0`,
+ *       height: 10,
+ *       width: 10,
+ *   };
+ *   <Icon icon={dropdownIcon} size={20} />
+ * ```
+ *
+ * If you want to add an entirely new icon please read the note inside
+ * the `icon-paths.ts` file.
+ */
 class Icon extends React.Component<Props> {
     static defaultProps: {
         color: string;

--- a/packages/perseus/src/components/image-loader.tsx
+++ b/packages/perseus/src/components/image-loader.tsx
@@ -1,15 +1,6 @@
 /* eslint-disable @khanacademy/ts-no-error-suppressions */
 /* eslint-disable jsx-a11y/alt-text, react/no-unsafe */
 // TODO(scottgrant): Enable the alt-text eslint rule above.
-/**
- * Component to display an image (or other React components) while the desired
- * image is loading.
- *
- * Derived from
- * https://github.com/hzdg/react-imageloader/blob/master/src/index.js
- * to better suit our environment/build tools. Additionally, this one does
- * not introduce a wrapper element, which makes styling easier.
- */
 
 import * as React from "react";
 
@@ -49,6 +40,15 @@ type State = {
     status: (typeof Status)[keyof typeof Status];
 };
 
+/**
+ * Component to display an image (or other React components) while the desired
+ * image is loading.
+ *
+ * Derived from
+ * https://github.com/hzdg/react-imageloader/blob/master/src/index.js
+ * to better suit our environment/build tools. Additionally, this one does
+ * not introduce a wrapper element, which makes styling easier.
+ */
 class ImageLoader extends React.Component<Props, State> {
     img: HTMLImageElement | null | undefined;
 

--- a/packages/perseus/src/components/inline-icon.tsx
+++ b/packages/perseus/src/components/inline-icon.tsx
@@ -17,11 +17,7 @@ type InlineIconProps = {
  * A stripped version of Icon.jsx from webapp. Takes an SVG icon and renders it
  * inline like Font Awesome did.
  *
- * If you are looking for an icon that we've used before you should look in
- * webapp's `icon-paths.js` which is a reference file for all the SVG paths
- * that we've used. You'll need to copy the object from that file into
- * whichever file you're using the icon and explicitly pass it in to the
- * <InlineIcon/> React component.
+ * You can refer to `icon-paths.ts` for all available SVG icons.
  *
  * We assume that the viewBox is cropped and aligned to (0, 0), but icons can
  * be defined differently. At some point we might want to add these attributes
@@ -29,13 +25,14 @@ type InlineIconProps = {
  *
  * Sample usage:
  *
- *   const editIcon = {
+ * ```
+ * const editIcon = {
  *      path: "M41.209 53.753l5.39 0l0 5.39l3.136 0l6.468-6.517-8.477-8.526-6.517 6.517l0 3.136zm33.173-34.937q-.882-.882-1.862.049l-19.6 19.6q-.931.98-.049 1.862t1.862-.049l19.6-19.6q.931-.98.049-1.862zm-38.563 45.668l0-16.121l37.632-37.632 16.17 16.121-37.632 37.632l-16.17 0zm43.022-12.397l0 10.633q-.049 6.713-4.753 11.417t-11.368 4.704l-46.599 0q-6.713 0-11.417-4.753t-4.704-11.368l0-46.599q0-6.664 4.753-11.417t11.368-4.704l46.599 0q3.528 0 6.566 1.372.833.392.98 1.323t-.49 1.617l-2.744 2.744q-.784.784-1.96.441t-2.352-.343l-46.599 0q-3.675 0-6.321 2.646t-2.646 6.321l0 46.599q0 3.675 2.646 6.321t6.321 2.646l46.599 0q3.675 0 6.321-2.646t2.646-6.321l0-7.056q0-.735.49-1.225l3.577-3.577q.833-.833 1.96-.392t1.127 1.617zm7.203-51.646q2.254 0 3.773 1.568l8.526 8.526q1.568 1.568 1.568 3.822t-1.568 3.773l-5.145 5.145-16.121-16.121 5.145-5.145q1.568-1.568 3.822-1.568z",
  *      width: 100,
  *      height: 78.912,
- *   };
- *   <InlineIcon {...editIcon} />
- *
+ * };
+ * <InlineIcon {...editIcon} />
+ * ```
  */
 const InlineIcon = ({
     path,

--- a/packages/perseus/src/components/input-with-examples.tsx
+++ b/packages/perseus/src/components/input-with-examples.tsx
@@ -155,8 +155,6 @@ class InputWithExamples extends React.Component<Props, State> {
 
         return (
             <Tooltip
-                // eslint-disable-next-line react/no-string-refs
-                ref="tooltip"
                 className="perseus-formats-tooltip preview-measure"
                 horizontalPosition={HorizontalDirection.Left}
                 horizontalAlign={HorizontalDirection.Left}

--- a/packages/perseus/src/components/lint.tsx
+++ b/packages/perseus/src/components/lint.tsx
@@ -20,21 +20,25 @@ enum Severity {
 }
 
 type Props = {
-    // The children are the linty content we're highlighting
+    /** The children are the linty content we're highlighting */
     children: React.ReactNode;
-    // Inline lint is highlighted differently than block lint.
+    /** Inline lint is highlighted differently than block lint. */
     inline?: boolean;
-    // This is the text that appears in the tooltip
+    /** This is the text that appears in the tooltip */
     message: string;
-    // This is used as the fragment id (hash) in the URL of the link
+    /** This is used as the fragment id (hash) in the URL of the link */
     ruleName: string;
-    // Lint warnings inside tables are handled specially
+    /** Lint warnings inside tables are handled specially */
     insideTable: boolean;
-    // Should lint highlighting be rendered as a block to the left of
-    // the lint instead of on the right gutter?
+    /**
+     * Should lint highlighting be rendered as a block to the left of
+     * the lint instead of on the right gutter?
+     */
     blockHighlight?: boolean;
-    // How important this lint message is for the editor. Severity goes
-    // from 1 (indicating an error) to 4 (offline reporting only)
+    /**
+     * How important this lint message is for the editor. Severity goes
+     * from 1 (indicating an error) to 4 (offline reporting only)
+     */
     severity?: Severity;
 };
 

--- a/packages/perseus/src/components/math-input.tsx
+++ b/packages/perseus/src/components/math-input.tsx
@@ -29,6 +29,7 @@ import {PerseusI18nContext} from "./i18n-context";
 import type {LegacyButtonSets} from "../perseus-types";
 import type {PerseusDependenciesV2} from "../types";
 import type {Keys, MathFieldInterface} from "@khanacademy/math-input";
+import type {AnalyticsEventHandlerFn} from "@khanacademy/perseus-core";
 
 type ButtonsVisibleType = "always" | "never" | "focused";
 
@@ -68,7 +69,7 @@ type Props = {
      * - `never` means that the keypad is **never shown**.
      */
     buttonsVisible?: ButtonsVisibleType;
-    analytics: PerseusDependenciesV2["analytics"];
+    onAnalyticsEvent: AnalyticsEventHandlerFn;
 };
 
 type InnerProps = Props & {
@@ -352,8 +353,7 @@ class InnerMathInput extends React.Component<InnerProps, State> {
                                 >
                                     <DesktopKeypad
                                         onAnalyticsEvent={
-                                            this.props.analytics
-                                                .onAnalyticsEvent
+                                            this.props.onAnalyticsEvent
                                         }
                                         extraKeys={this.props.extraKeys}
                                         onClickKey={this.handleKeypadPress}

--- a/packages/perseus/src/components/math-input.tsx
+++ b/packages/perseus/src/components/math-input.tsx
@@ -27,7 +27,6 @@ import {debounce} from "../util/debounce";
 import {PerseusI18nContext} from "./i18n-context";
 
 import type {LegacyButtonSets} from "../perseus-types";
-import type {PerseusDependenciesV2} from "../types";
 import type {Keys, MathFieldInterface} from "@khanacademy/math-input";
 import type {AnalyticsEventHandlerFn} from "@khanacademy/perseus-core";
 

--- a/packages/perseus/src/components/multi-button-group.tsx
+++ b/packages/perseus/src/components/multi-button-group.tsx
@@ -68,6 +68,7 @@ class MultiButtonGroup extends React.Component<Props> {
     };
 
     render(): React.ReactNode {
+        console.log(this.props.values, this.props.buttons);
         const values = this.props.values || [];
         const buttons = this.props.buttons.map((button, i) => {
             const selected = values.indexOf(button.value) >= 0;

--- a/packages/perseus/src/components/multi-button-group.tsx
+++ b/packages/perseus/src/components/multi-button-group.tsx
@@ -3,23 +3,39 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 
 type Props = {
-    // the initial values of the buttons selected, defaults to null (no
-    // selection).
+    /**
+     * The initial values of the buttons selected, defaults to null (no
+     * selection).
+     */
     values: ReadonlyArray<any> | null | undefined;
+    /**
+     * The set of buttons to display in this MultiButtonGroup.
+     */
     buttons: ReadonlyArray<{
-        // the value returned when the button is selected
+        /**
+         * the value returned when the button is selected
+         */
         value: any;
-        // the content shown within the button, typically a string that gets
-        // rendered as the button's display text
+        /**
+         * The content shown within the button, typically a string that gets
+         * rendered as the button's display text.
+         */
         content: React.ReactNode;
-        // the title-text shown on hover
+        /**
+         * The title-text shown on hover
+         */
         title?: string;
     }>;
-    // a function that is provided with the updated set of selected value
-    // (which it then is responsible for updating)
+    /**
+     * A function that is provided with the updated set of selected value
+     * (which it then is responsible for updating)
+     */
     onChange: (values?: any) => unknown;
-    // if false, at least one button must be selected at all times.
-    // defaults to true
+    /**
+     * If false, at least one button must be selected at all times.
+     *
+     * Defaults to `true`
+     */
     allowEmpty?: boolean;
 };
 

--- a/packages/perseus/src/components/multi-button-group.tsx
+++ b/packages/perseus/src/components/multi-button-group.tsx
@@ -68,7 +68,6 @@ class MultiButtonGroup extends React.Component<Props> {
     };
 
     render(): React.ReactNode {
-        console.log(this.props.values, this.props.buttons);
         const values = this.props.values || [];
         const buttons = this.props.buttons.map((button, i) => {
             const selected = values.indexOf(button.value) >= 0;

--- a/packages/perseus/src/components/number-input.tsx
+++ b/packages/perseus/src/components/number-input.tsx
@@ -42,7 +42,7 @@ class NumberInput extends React.Component<any, any> {
         onChange: PropTypes.func.isRequired,
         onFormatChange: PropTypes.func,
         checkValidity: PropTypes.func,
-        size: PropTypes.string,
+        size: PropTypes.oneOf(["mini", "small", "normal"]),
         label: PropTypes.oneOf(["put your labels outside your inputs!"]),
     };
 

--- a/packages/perseus/src/components/number-input.tsx
+++ b/packages/perseus/src/components/number-input.tsx
@@ -18,18 +18,24 @@ const {firstNumericalParse, captureScratchpadTouchStart} = Util;
 const toNumericString = KhanMath.toNumericString;
 const getNumericFormat = KhanMath.getNumericFormat;
 
-/* An input box that accepts only numeric strings
+/**
+ * An input box that accepts only numeric strings
  *
- * Calls onChange(value, format) for valid numbers.
- * Reverts to the current value onBlur or on [ENTER],
+ * Calls `onChange(value, format)` for valid numbers.
+ *
+ * Reverts to the current value `onBlur` or on [ENTER],
  *   but maintains the format (i.e. 3/2, 1 1/2, 150%)
- * Accepts empty input and sends it to onChange as null
- *   if no numeric placeholder is set.
- * If given a checkValidity function, will turn
- *   the background/outline red when invalid
- * If useArrowKeys is set to true, up/down arrows will
- *   increment/decrement integers
- * Optionally takes a size ("mini", "small", "normal")
+ *
+ * Accepts empty input and sends it to `onChange` as `null` if no numeric
+ * placeholder is set.
+ *
+ * If given a `checkValidity` function, will turn the background/outline red
+ * when invalid.
+ *
+ * If `useArrowKeys` is set to `true`, up/down arrows will increment/decrement
+ * integers.
+ *
+ * Optionally takes a `size` (`"mini"`, `"small"`,` `"normal"`)
  */
 class NumberInput extends React.Component<any, any> {
     static contextType = PerseusI18nContext;

--- a/packages/perseus/src/components/range-input.tsx
+++ b/packages/perseus/src/components/range-input.tsx
@@ -6,8 +6,8 @@ import NumberInput from "./number-input";
 
 const truth = () => true;
 
-/* A minor abstraction on top of NumberInput for ranges
- *
+/**
+ * A minor abstraction on top of `NumberInput` for ranges
  */
 class RangeInput extends React.Component<any> {
     static propTypes = {

--- a/packages/perseus/src/components/range-input.tsx
+++ b/packages/perseus/src/components/range-input.tsx
@@ -1,26 +1,33 @@
+/* eslint-disable react/forbid-prop-types */
+import PropTypes from "prop-types";
 import * as React from "react";
 
 import NumberInput from "./number-input";
 
 const truth = () => true;
 
-type Props = {
-    value: [number, number];
-    placeholder: [string, string];
-    onChange: (start: number, end: number) => void;
-    checkValidity: (vals: [number, number]) => boolean;
-};
-
-type DefaultProps = {
-    placeholder: Props["placeholder"] | [null, null];
-};
-
-/**
- * A minor abstraction on top of NumberInput for ranges.
+/* A minor abstraction on top of NumberInput for ranges
+ *
  */
-class RangeInput extends React.Component<Props> {
-    static defaultProps: DefaultProps = {
+class RangeInput extends React.Component<any> {
+    static propTypes = {
+        value: PropTypes.array.isRequired,
+        onChange: PropTypes.func.isRequired,
+        placeholder: PropTypes.array,
+        checkValidity: PropTypes.func,
+    };
+
+    static defaultProps: any = {
         placeholder: [null, null],
+    };
+
+    onChange: (arg1: number, arg2: string) => void = (i, newVal) => {
+        const value = this.props.value;
+        if (i === 0) {
+            this.props.onChange([newVal, value[1]]);
+        } else {
+            this.props.onChange([value[0], newVal]);
+        }
     };
 
     render(): React.ReactNode {
@@ -33,14 +40,16 @@ class RangeInput extends React.Component<Props> {
                     {...this.props}
                     value={value[0]}
                     checkValidity={(val) => checkValidity([val, value[1]])}
-                    onChange={(val) => this.props.onChange(val, value[1])}
+                    // eslint-disable-next-line react/jsx-no-bind
+                    onChange={this.onChange.bind(this, 0)}
                     placeholder={this.props.placeholder[0]}
                 />
                 <NumberInput
                     {...this.props}
                     value={value[1]}
                     checkValidity={(val) => checkValidity([value[0], val])}
-                    onChange={(val: any) => this.props.onChange(value[0], val)}
+                    // eslint-disable-next-line react/jsx-no-bind
+                    onChange={this.onChange.bind(this, 1)}
                     placeholder={this.props.placeholder[1]}
                 />
             </div>

--- a/packages/perseus/src/components/range-input.tsx
+++ b/packages/perseus/src/components/range-input.tsx
@@ -1,33 +1,26 @@
-/* eslint-disable react/forbid-prop-types */
-import PropTypes from "prop-types";
 import * as React from "react";
 
 import NumberInput from "./number-input";
 
 const truth = () => true;
 
-/* A minor abstraction on top of NumberInput for ranges
- *
+type Props = {
+    value: [number, number];
+    placeholder: [string, string];
+    onChange: (start: number, end: number) => void;
+    checkValidity: (vals: [number, number]) => boolean;
+};
+
+type DefaultProps = {
+    placeholder: Props["placeholder"] | [null, null];
+};
+
+/**
+ * A minor abstraction on top of NumberInput for ranges.
  */
-class RangeInput extends React.Component<any> {
-    static propTypes = {
-        value: PropTypes.array.isRequired,
-        onChange: PropTypes.func.isRequired,
-        placeholder: PropTypes.array,
-        checkValidity: PropTypes.func,
-    };
-
-    static defaultProps: any = {
+class RangeInput extends React.Component<Props> {
+    static defaultProps: DefaultProps = {
         placeholder: [null, null],
-    };
-
-    onChange: (arg1: number, arg2: string) => void = (i, newVal) => {
-        const value = this.props.value;
-        if (i === 0) {
-            this.props.onChange([newVal, value[1]]);
-        } else {
-            this.props.onChange([value[0], newVal]);
-        }
     };
 
     render(): React.ReactNode {
@@ -40,16 +33,14 @@ class RangeInput extends React.Component<any> {
                     {...this.props}
                     value={value[0]}
                     checkValidity={(val) => checkValidity([val, value[1]])}
-                    // eslint-disable-next-line react/jsx-no-bind
-                    onChange={this.onChange.bind(this, 0)}
+                    onChange={(val) => this.props.onChange(val, value[1])}
                     placeholder={this.props.placeholder[0]}
                 />
                 <NumberInput
                     {...this.props}
                     value={value[1]}
                     checkValidity={(val) => checkValidity([value[0], val])}
-                    // eslint-disable-next-line react/jsx-no-bind
-                    onChange={this.onChange.bind(this, 1)}
+                    onChange={(val: any) => this.props.onChange(value[0], val)}
                     placeholder={this.props.placeholder[1]}
                 />
             </div>

--- a/packages/perseus/src/components/simple-keypad-input.tsx
+++ b/packages/perseus/src/components/simple-keypad-input.tsx
@@ -1,24 +1,22 @@
-import {KeypadInput, KeypadType} from "@khanacademy/math-input";
-import * as React from "react";
-
-import type {KeypadAPI} from "@khanacademy/math-input";
-
-type Props = {
-    keypadElement: KeypadAPI;
-    onFocus: () => void;
-    value: string | number;
-};
-
 /**
  * A version of the `math-input` subrepo's KeypadInput component that adheres to
- * the same API as Perseus's `MathOuput` and `NumberInput`, allowing it to be
+ * the same API as Perseus's  MathOuput and NumberInput, allowing it to be
  * dropped in as a replacement for those components without any modifications.
  *
  * TODO(charlie): Once the keypad API has stabilized, move this into the
  * `math-input` subrepo and use it everywhere as a simpler, keypad-coupled
  * interface to `math-input`'s MathInput component.
  */
-export default class SimpleKeypadInput extends React.Component<Props> {
+
+import {
+    KeypadInput,
+    KeypadType,
+    keypadElementPropType,
+} from "@khanacademy/math-input";
+import PropTypes from "prop-types";
+import * as React from "react";
+
+export default class SimpleKeypadInput extends React.Component<any> {
     _isMounted = false;
 
     componentDidMount() {
@@ -86,3 +84,10 @@ export default class SimpleKeypadInput extends React.Component<Props> {
         );
     }
 }
+
+// @ts-expect-error - TS2339 - Property 'propTypes' does not exist on type 'typeof SimpleKeypadInput'.
+SimpleKeypadInput.propTypes = {
+    keypadElement: keypadElementPropType,
+    onFocus: PropTypes.func,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};

--- a/packages/perseus/src/components/simple-keypad-input.tsx
+++ b/packages/perseus/src/components/simple-keypad-input.tsx
@@ -1,22 +1,24 @@
+import {KeypadInput, KeypadType} from "@khanacademy/math-input";
+import * as React from "react";
+
+import type {KeypadAPI} from "@khanacademy/math-input";
+
+type Props = {
+    keypadElement: KeypadAPI;
+    onFocus: () => void;
+    value: string | number;
+};
+
 /**
  * A version of the `math-input` subrepo's KeypadInput component that adheres to
- * the same API as Perseus's  MathOuput and NumberInput, allowing it to be
+ * the same API as Perseus's `MathOuput` and `NumberInput`, allowing it to be
  * dropped in as a replacement for those components without any modifications.
  *
  * TODO(charlie): Once the keypad API has stabilized, move this into the
  * `math-input` subrepo and use it everywhere as a simpler, keypad-coupled
  * interface to `math-input`'s MathInput component.
  */
-
-import {
-    KeypadInput,
-    KeypadType,
-    keypadElementPropType,
-} from "@khanacademy/math-input";
-import PropTypes from "prop-types";
-import * as React from "react";
-
-export default class SimpleKeypadInput extends React.Component<any> {
+export default class SimpleKeypadInput extends React.Component<Props> {
     _isMounted = false;
 
     componentDidMount() {
@@ -84,10 +86,3 @@ export default class SimpleKeypadInput extends React.Component<any> {
         );
     }
 }
-
-// @ts-expect-error - TS2339 - Property 'propTypes' does not exist on type 'typeof SimpleKeypadInput'.
-SimpleKeypadInput.propTypes = {
-    keypadElement: keypadElementPropType,
-    onFocus: PropTypes.func,
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-};

--- a/packages/perseus/src/components/stub-tag-editor.tsx
+++ b/packages/perseus/src/components/stub-tag-editor.tsx
@@ -1,3 +1,10 @@
+import PropTypes from "prop-types";
+import * as React from "react";
+
+import TextListEditor from "./text-list-editor";
+
+const EMPTY_ARRAY = [];
+
 /**
  * Stub Tag Editor.
  *
@@ -11,13 +18,6 @@
  * It also gives a nicer interface for the group metadata editor
  * in local demo mode.
  */
-import PropTypes from "prop-types";
-import * as React from "react";
-
-import TextListEditor from "./text-list-editor";
-
-const EMPTY_ARRAY = [];
-
 class StubTagEditor extends React.Component<any> {
     static propTypes = {
         value: PropTypes.arrayOf(PropTypes.string),

--- a/packages/perseus/src/components/svg-image.tsx
+++ b/packages/perseus/src/components/svg-image.tsx
@@ -149,34 +149,46 @@ type Props = {
         labels: ReadonlyArray<any>;
     };
     height?: number;
-    // When the DOM updates to replace the preloader with the image, or
-    // vice-versa, we trigger this callback.
+    /**
+     * When the DOM updates to replace the preloader with the image, or
+     * vice-versa, we trigger this callback.
+     */
     onUpdate: () => void;
-    // If alt is provided, DO NOT set aria-hidden=true unless this override flag
-    // is set.
+    /**
+     * If alt is provided, DO NOT set aria-hidden=true unless this override flag
+     * is set.
+     */
     overrideAriaHidden?: boolean;
     preloader?: (dimensions: Dimensions) => React.ReactNode;
-    // By default, this component attempts to be responsive whenever
-    // possible (specifically, when width and height are passed in).
-    // You can expliclty force unresponsive behavior by *either*
-    // not passing in width/height *or* setting this prop to false.
-    // The difference is that forcing via this prop will result in
-    // explicit width and height styles being set on the rendered
-    // component.
+    /**
+     * By default, this component attempts to be responsive whenever
+     * possible (specifically, when width and height are passed in).
+     *
+     * You can expliclty force unresponsive behavior by *either*
+     * not passing in width/height *or* setting this prop to false.
+     *
+     * The difference is that forcing via this prop will result in
+     * explicit width and height styles being set on the rendered
+     * component.
+     */
     responsive: boolean;
     scale: number;
     src: string;
     title?: string;
     trackInteraction?: () => void;
     width?: number;
-    // Whether clicking this image will allow it to be fully zoomed in to
-    // its original size on click, and allow the user to scroll in that
-    // state. This also does some hacky viewport meta tag changing to
-    // ensure this works on mobile devices, so I (david@) don't recommend
-    // enabling this on desktop yet.
+    /**
+     * Whether clicking this image will allow it to be fully zoomed in to
+     * its original size on click, and allow the user to scroll in that
+     * state. This also does some hacky viewport meta tag changing to
+     * ensure this works on mobile devices, so I (david@) don't recommend
+     * enabling this on desktop yet.
+     */
     zoomToFullSizeOnMobile?: boolean;
-    // If provided, use AssetContext.Consumer, see renderer.jsx.
-    // If not, it defaults to a no-op.
+    /**
+     * If provided, use AssetContext.Consumer, see renderer.jsx.
+     * If not, it defaults to a no-op.
+     */
     setAssetStatus: (assetKey: string, loaded: boolean) => void;
 };
 

--- a/packages/perseus/src/components/text-list-editor.tsx
+++ b/packages/perseus/src/components/text-list-editor.tsx
@@ -21,7 +21,7 @@ function getTextWidth(text: any) {
 class TextListEditor extends React.Component<any, any> {
     static propTypes = {
         options: PropTypes.array,
-        layout: PropTypes.string,
+        layout: PropTypes.oneOf(["horizontal", "vertical"]),
         onChange: PropTypes.func.isRequired,
     };
 

--- a/packages/perseus/src/components/tooltip.tsx
+++ b/packages/perseus/src/components/tooltip.tsx
@@ -58,7 +58,7 @@ const Triangle = (props: TriangleProps) => {
                 width: 0,
                 position: "absolute",
                 left: props.left,
-                top: props["top"],
+                top: props.top,
                 borderLeft: borderLeft,
                 borderRight: borderRight,
                 borderTop: borderTop,

--- a/packages/perseus/src/components/tooltip.tsx
+++ b/packages/perseus/src/components/tooltip.tsx
@@ -1,42 +1,4 @@
 /* eslint-disable react/no-unsafe */
-/**
- * A generic tooltip library for React.js
- *
- * This should eventually end up in react-components
- *
- * Interface: ({a, b} means one of a or b)
- * import Tooltip from "./tooltip";
- * <Tooltip
- *     className="class-for-tooltip-contents"
- *     horizontalPosition={HoriziontalDirection.Left}
- *     horizontalAlign={HoriziontalDirection.Left}
- *     verticalPosition={VerticalDirection.Top}
- *     arrowSize={10} // arrow size in pixels
- *     borderColor="#ccc" // color of the border for the tooltip
- *     show={true} // whether the tooltip should currently be visible
- *     targetContainerStyle={targetContainerStyle}
- * >
- *     <TargetElementOfTheTooltip />
- *     <TooltipContents1 />
- *     <TooltipContents2 />
- * </Tooltip>
- *
- * To show/hide the tooltip, the parent component should call the
- * .show() and .hide() methods of the tooltip when appropriate.
- * (These are usually set up as handlers of events on the target element.)
- *
- * Notes:
- *     className should not specify a border; that is handled by borderColor
- *     so that the arrow and tooltip match
- */
-
-//          __,,--``\\
-//  _,,-''``         \\     ,
-// '----------_.------'-.___|\__
-//    _.--''``    `)__   )__   @\__
-//   (  .. ''---/___,,E/__,E'------`
-//    `-''`''
-// Here be dragons.
 
 // TODO(joel/aria) fix z-index issues https://s3.amazonaws.com/uploads.hipchat.com/6574/29028/yOApjwmgiMhEZYJ/Screen%20Shot%202014-05-30%20at%203.34.18%20PM.png
 // z-index: 3 on perseus-formats-tooltip seemed to work
@@ -233,6 +195,47 @@ type State = {
     height: number | null;
 };
 
+/**
+ * DEPRECATED! Use Wonder Blocks tooltip instead.
+ *
+ * A generic tooltip library for React.js
+ *
+ * ```
+ * import Tooltip from "./tooltip";
+ * <Tooltip
+ *     className="class-for-tooltip-contents"
+ *     horizontalPosition={HoriziontalDirection.Left}
+ *     horizontalAlign={HoriziontalDirection.Left}
+ *     verticalPosition={VerticalDirection.Top}
+ *     arrowSize={10} // arrow size in pixels
+ *     borderColor="#ccc" // color of the border for the tooltip
+ *     show={true} // whether the tooltip should currently be visible
+ *     targetContainerStyle={targetContainerStyle}
+ * >
+ *     <TargetElementOfTheTooltip />
+ *     <TooltipContents1 />
+ *     <TooltipContents2 />
+ * </Tooltip>
+ * ```
+ *
+ * To show/hide the tooltip, the parent component should call the
+ * `.show()` and `.hide()` methods of the tooltip when appropriate.
+ * (These are usually set up as handlers of events on the target element.)
+ *
+ * Notes:
+ *     `className` should not specify a border; that is handled by `borderColor`
+ *     so that the arrow and tooltip match
+ *
+ * ```
+ *          __,,--``\\
+ *  _,,-''``         \\     ,
+ * '----------_.------'-.___|\__
+ *    _.--''``    `)__   )__   @\__
+ *   (  .. ''---/___,,E/__,E'------`
+ *    `-''`''
+ * Here be dragons.
+ * ```
+ */
 class Tooltip extends React.Component<Props, State> {
     static defaultProps: DefaultProps = {
         className: "",

--- a/packages/perseus/src/icon-paths.ts
+++ b/packages/perseus/src/icon-paths.ts
@@ -1,9 +1,5 @@
 /**
- * Icon paths to be used with `inline-icon.jsx`.
- *
- * These paths are taken directly from webapp's `icon-paths.js`. Unlike the
- * webapp equivalent, these can be directly required within Perseus files since
- * this is all bundled together anyway.
+ * Icon paths to be used with `inline-icon.tsx` and `icon.tsx`.
  */
 
 export const iconCheck = {

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -506,9 +506,9 @@ export type PerseusDependencies = {
  *
  * Prefer using this type over `PerseusDependencies` when possible.
  */
-export type PerseusDependenciesV2 = {
+export interface PerseusDependenciesV2 {
     analytics: {onAnalyticsEvent: AnalyticsEventHandlerFn};
-};
+}
 
 /**
  * APIOptionsWithDefaults represents the type that is provided to all widgets.

--- a/packages/perseus/src/widgets/expression/expression.tsx
+++ b/packages/perseus/src/widgets/expression/expression.tsx
@@ -382,10 +382,9 @@ export class Expression
                             extraKeys={
                                 this.props.keypadConfiguration?.extraKeys
                             }
-                            analytics={
-                                this.props.analytics ?? {
-                                    onAnalyticsEvent: async () => {},
-                                }
+                            onAnalyticsEvent={
+                                this.props.analytics?.onAnalyticsEvent ??
+                                (async () => {})
                             }
                         />
                     </Tooltip>

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -41,11 +41,11 @@ import {SvgDefs} from "./graphs/components/text-label";
 import {PointGraph} from "./graphs/point";
 import {MIN, X, Y} from "./math";
 import {Protractor} from "./protractor";
-import {type InteractiveGraphAction} from "./reducer/interactive-graph-action";
 import {actions} from "./reducer/interactive-graph-action";
 import {GraphConfigContext} from "./reducer/use-graph-config";
 import {isUnlimitedGraphState, REMOVE_BUTTON_ID} from "./utils";
 
+import type {InteractiveGraphAction} from "./reducer/interactive-graph-action";
 import type {
     InteractiveGraphState,
     InteractiveGraphProps,


### PR DESCRIPTION
## Summary:

I spent some of Hackathon 2024 looking into a Storybook upgrade (unfinished). During this time, I read up on how Storybook [recommends](https://storybook.js.org/docs/get-started/whats-a-story) writing stories. The new format ([CSF](https://storybook.js.org/docs/api/csf)) makes Typescript understand the stories much better. 

So, it turns out, with a few changes, the Storybook tooling becomes a bunch more helpful and reduces how much code we need to write in our stories. I'll outline the types of changes this PR contains so that it's easy to follow if you want to adjust other stories in this repo. 

Here is what a very, simple, modern Storybook file looks like: 

```ts
import MyComponent from "./my-component";

import type {Meta, StoryObj> from "@storybook/react";

const meta: Meta = {
    title: "Perseus/Components/MyComponent",
    component: MyComponent,
}
export default meta; 

type Story = StoryObj<typeof MyComponent>;

export const Default: Story = {};
```

1. Always define the default export as: 

   ```
   const meta: Meta = {
       title: "..path where this component should show up in storybook", 
       component: MyComponent
   }
   export default meta; 
   ```

   Two things are important here: 

     1. The default export is typed as `Meta` (from `@storybook/react`). This enables Storybook to infer the props this component has and enables "intellisense" on the different parameters to `meta`.
     1. We _do not_ use `as Meta` on this object definition. I'm unclear why, but that doesn't seem to work as well as the example above. 

1. Always define a type in the file as `type Story = StoryObj<typeof MyComponent>`. (again, the `StoryObj<T>` type comes from `@storybook/react`. 

3. Define stories as `export const MyStory: Story = {}`. By defining stories as simple data objects we get better type checking on the args we provide and reduce alot of boilerplate that our stories typically had. 

4. Use [`render`](https://github.com/Khan/perseus/pull/1802/files#diff-f821d3794fd8ed90901679eb1306920bc224c9b028b4f5bc8eae31f9b2e1fc62R15) and/or [`decorators`](https://github.com/Khan/perseus/pull/1802/files#diff-096ad8bf05853f7a13ab3a8d0ec4f50e7799d835babcf1275730e6571f8e0c7cR25) to reduce duplication. Often times we need to wrap our component in order for it to behave properly or to look better in Storybook. Instead of writing each story with this wrapper, move the common wrapping code into the `meta` object's `render` key. (note: I'm not 100% clear when to use the `render` key and when to use the `decorators`. I was able to accomplish similar things with both. I _suspect_ `decorators` is more useful if you have multiple things you want to adorn the component with but do not want to merge them together into a single `render` function.

Issue: "none"

## Test plan:

Review the stories in `Perseus/components` (`yarn start; open http://localhost:6006/?path=/docs/perseus-components-button-group--docs`)