### PR TITLE
Refine sizing-utils exports

### DIFF
--- a/.changeset/spicy-grapes-bathe.md
+++ b/.changeset/spicy-grapes-bathe.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": major
+"@khanacademy/perseus-editor": patch
+---
+
+Scope sizing-utils exports to the essentials

--- a/packages/perseus-editor/src/widgets/grapher-editor.tsx
+++ b/packages/perseus-editor/src/widgets/grapher-editor.tsx
@@ -4,7 +4,8 @@ import {
     Changeable,
     GrapherUtil,
     GrapherWidget,
-    SizingUtils,
+    containerSizeClass,
+    getInteractiveBoxFromSizeClass,
 } from "@khanacademy/perseus";
 import * as React from "react";
 import _ from "underscore";
@@ -12,7 +13,6 @@ import _ from "underscore";
 import GraphSettings from "../components/graph-settings";
 
 const {InfoTip, MultiButtonGroup} = components;
-const {containerSizeClass, getInteractiveBoxFromSizeClass} = SizingUtils;
 const Grapher = GrapherWidget.widget;
 const {
     DEFAULT_GRAPHER_PROPS,

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
@@ -1,9 +1,10 @@
 import {vector as kvector} from "@khanacademy/kmath";
 import {
     components,
+    containerSizeClass,
+    getInteractiveBoxFromSizeClass,
     InteractiveGraphWidget,
     interactiveSizes,
-    SizingUtils,
     Util,
 } from "@khanacademy/perseus";
 import {View} from "@khanacademy/wonder-blocks-core";
@@ -40,7 +41,6 @@ import type {
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
 const {InfoTip} = components;
-const {containerSizeClass, getInteractiveBoxFromSizeClass} = SizingUtils;
 const InteractiveGraph = InteractiveGraphWidget.widget;
 
 type InteractiveGraphProps = PropsFor<typeof InteractiveGraph>;

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -82,7 +82,10 @@ export {default as Util} from "./util";
 export {default as KhanColors} from "./util/colors";
 export {default as preprocessTex} from "./util/tex-preprocess";
 export {registerAllWidgetsForTesting} from "./util/register-all-widgets-for-testing";
-export * as SizingUtils from "./util/sizing-utils";
+export {
+    containerSizeClass,
+    getInteractiveBoxFromSizeClass,
+} from "./util/sizing-utils";
 export {
     getAnswersFromWidgets,
     injectWidgets,


### PR DESCRIPTION
## Summary:
Some things from `sizing-utils` were getting exported from `perseus` when they didn't need to be.

## Test plan:
Nothing should change