### PR TITLE
Fix types in test for perseus-linter

### DIFF
--- a/.changeset/clever-crews-fly.md
+++ b/.changeset/clever-crews-fly.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-linter": patch
+---
+
+Internal: fix types in test for Perseus linter

--- a/packages/perseus-linter/src/__tests__/rule.test.ts
+++ b/packages/perseus-linter/src/__tests__/rule.test.ts
@@ -56,11 +56,6 @@ the previous heading was level ${previousHeading.level}`;
         return PureMarkdown.parse(markdown);
     }
 
-    it("makeRules() factory method", () => {
-        const rules: Rule[] = ruleDescriptions.map((r) => Rule.makeRule(r));
-        expect(rules).toHaveLength(ruleDescriptions.length);
-    });
-
     it("check() method", () => {
         const rules = ruleDescriptions.map((r) => Rule.makeRule(r));
         const tree = parseTree();

--- a/packages/perseus-linter/src/__tests__/rule.test.ts
+++ b/packages/perseus-linter/src/__tests__/rule.test.ts
@@ -52,19 +52,17 @@ the previous heading was level ${previousHeading.level}`;
         },
     ];
 
-    let rules: Array<never> | Array<Rule | any> = [];
-
     function parseTree() {
         return PureMarkdown.parse(markdown);
     }
 
     it("makeRules() factory method", () => {
-        rules = ruleDescriptions.map((r) => Rule.makeRule(r));
+        const rules: Rule[] = ruleDescriptions.map((r) => Rule.makeRule(r));
         expect(rules).toHaveLength(ruleDescriptions.length);
-        rules.forEach((r) => expect(r instanceof Rule).toBeTruthy());
     });
 
     it("check() method", () => {
+        const rules = ruleDescriptions.map((r) => Rule.makeRule(r));
         const tree = parseTree();
         const tt = new TreeTransformer(tree);
         const warnings: Array<
@@ -80,7 +78,7 @@ the previous heading was level ${previousHeading.level}`;
 
         tt.traverse((node, state, content) => {
             rules.forEach((r) => {
-                const lint = r.check(node, state, content);
+                const lint = r.check(node, state, content, undefined);
                 if (lint) {
                     warnings.push(lint);
                 }


### PR DESCRIPTION
While working on something else, I saw TypeScript errors coming from this file.
The error was:

```
packages/perseus-linter/src/__tests__/rule.test.ts:83:32 - error TS2339: Property 'check' does not exist on type 'never'.

83                 const lint = r.check(node, state, content);
```

I'm not sure why this just started erroring, but the types are definitely *weird*, so I'm
taking the opportunity to fix them.

There was also a test that depended on a previous test having been run. I fixed
that too.

Issue: none

## Test plan:

`yarn test`