### PR TITLE
Add aria-label to movable points

### DIFF
--- a/.changeset/wise-keys-explode.md
+++ b/.changeset/wise-keys-explode.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Add a screenreader-accessible label to movable points on interactive graphs

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -133,6 +133,7 @@ export type PerseusStrings = {
     addPoint: string;
     removePoint: string;
     graphKeyboardPrompt: string;
+    srPointAtCoordinates: ({x, y}: {x: string; y: string}) => string;
 };
 
 /**
@@ -308,6 +309,10 @@ export const strings: {
     addPoint: "Add Point",
     removePoint: "Remove Point",
     graphKeyboardPrompt: "Press Shift + Enter to interact with the graph",
+    srPointAtCoordinates: {
+        context: "Screenreader-accessible description of a point on a graph",
+        message: "Point at %(x)s comma %(y)s",
+    },
 };
 
 /**
@@ -467,4 +472,5 @@ export const mockStrings: PerseusStrings = {
     addPoint: "Add Point",
     removePoint: "Remove Point",
     graphKeyboardPrompt: "Press Shift + Enter to interact with the graph",
+    srPointAtCoordinates: ({x, y}) => `Point at ${x} comma ${y}`,
 };

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/__snapshots__/movable-line.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/__snapshots__/movable-line.test.tsx.snap
@@ -15,8 +15,11 @@ exports[`Rendering Does NOT render extensions of line when option is disabled 1`
       width="200"
     >
       <g
+        aria-label="Point at -1 comma -1"
+        aria-live="assertive"
         class="movable-point__focusable-handle"
         data-testid="movable-point__focusable-handle"
+        role="button"
         tabindex="0"
       />
       <g
@@ -57,8 +60,11 @@ exports[`Rendering Does NOT render extensions of line when option is disabled 1`
         />
       </g>
       <g
+        aria-label="Point at 1 comma 1"
+        aria-live="assertive"
         class="movable-point__focusable-handle"
         data-testid="movable-point__focusable-handle"
+        role="button"
         tabindex="0"
       />
       <g
@@ -149,8 +155,11 @@ exports[`Rendering Does NOT render extensions of line when option is not provide
       width="200"
     >
       <g
+        aria-label="Point at -1 comma -1"
+        aria-live="assertive"
         class="movable-point__focusable-handle"
         data-testid="movable-point__focusable-handle"
+        role="button"
         tabindex="0"
       />
       <g
@@ -191,8 +200,11 @@ exports[`Rendering Does NOT render extensions of line when option is not provide
         />
       </g>
       <g
+        aria-label="Point at 1 comma 1"
+        aria-live="assertive"
         class="movable-point__focusable-handle"
         data-testid="movable-point__focusable-handle"
+        role="button"
         tabindex="0"
       />
       <g
@@ -283,8 +295,11 @@ exports[`Rendering Does render extensions of line when option is enabled 1`] = `
       width="200"
     >
       <g
+        aria-label="Point at -1 comma -1"
+        aria-live="assertive"
         class="movable-point__focusable-handle"
         data-testid="movable-point__focusable-handle"
+        role="button"
         tabindex="0"
       />
       <g
@@ -379,8 +394,11 @@ exports[`Rendering Does render extensions of line when option is enabled 1`] = `
         </g>
       </g>
       <g
+        aria-label="Point at 1 comma 1"
+        aria-live="assertive"
         class="movable-point__focusable-handle"
         data-testid="movable-point__focusable-handle"
+        role="button"
         tabindex="0"
       />
       <g

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import {useState, useRef, useLayoutEffect} from "react";
 
 import {usePerseusI18n} from "../../../../components/i18n-context";
-
 import {snap, X, Y} from "../../math";
 import useGraphConfig from "../../reducer/use-graph-config";
 import {useDraggable} from "../use-draggable";

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {useState, useRef, useLayoutEffect} from "react";
 
-import {usePerseusI18n} from "@khanacademy/perseus";
+import {usePerseusI18n} from "../../../../components/i18n-context";
 
 import {snap, X, Y} from "../../math";
 import useGraphConfig from "../../reducer/use-graph-config";

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -80,6 +80,8 @@ export function useControlPoint(params: Params): Return {
                 x: String(point[X]),
                 y: String(point[Y]),
             })}
+            // aria-live="assertive" causes the new location of the point to be
+            // announced immediately on move.
             aria-live="assertive"
             onFocus={(event) => {
                 onFocus(event);

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -1,7 +1,9 @@
 import * as React from "react";
 import {useState, useRef, useLayoutEffect} from "react";
 
-import {snap} from "../../math";
+import {usePerseusI18n} from "@khanacademy/perseus";
+
+import {snap, X, Y} from "../../math";
 import useGraphConfig from "../../reducer/use-graph-config";
 import {useDraggable} from "../use-draggable";
 
@@ -45,6 +47,8 @@ export function useControlPoint(params: Params): Return {
         forwardedRef = noop,
     } = params;
 
+    const {strings} = usePerseusI18n();
+
     const [focused, setFocused] = useState(false);
     const focusableHandleRef = useRef<SVGGElement>(null);
     useDraggable({
@@ -72,6 +76,12 @@ export function useControlPoint(params: Params): Return {
             className="movable-point__focusable-handle"
             tabIndex={disableKeyboardInteraction ? -1 : 0}
             ref={focusableHandleRef}
+            role="button"
+            aria-label={strings.srPointAtCoordinates({
+                x: String(point[X]),
+                y: String(point[Y]),
+            })}
+            aria-live="assertive"
             onFocus={(event) => {
                 onFocus(event);
                 setFocused(true);

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -129,7 +129,6 @@ describe("MafsGraph", () => {
     });
 
     it("renders ARIA labels for each point", () => {
-        const mockDispatch = jest.fn();
         const state: InteractiveGraphState = {
             type: "segment",
             hasBeenInteractedWith: true,
@@ -146,13 +145,11 @@ describe("MafsGraph", () => {
             ],
         };
 
-        const baseMafsGraphProps = getBaseMafsGraphProps();
-
         render(
             <MafsGraph
-                {...baseMafsGraphProps}
+                {...getBaseMafsGraphProps()}
                 state={state}
-                dispatch={mockDispatch}
+                dispatch={() => {}}
             />,
         );
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -128,6 +128,40 @@ describe("MafsGraph", () => {
         expect(line.getAttribute("y2")).toBe(-expectedY2 + "");
     });
 
+    it("renders ARIA labels for each point", () => {
+        const mockDispatch = jest.fn();
+        const state: InteractiveGraphState = {
+            type: "segment",
+            hasBeenInteractedWith: true,
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            snapStep: [0.5, 0.5],
+            coords: [
+                [
+                    [0, 0],
+                    [-7, 0.5],
+                ],
+            ],
+        };
+
+        const baseMafsGraphProps = getBaseMafsGraphProps();
+
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={state}
+                dispatch={mockDispatch}
+            />,
+        );
+
+        expect(screen.getByLabelText("Point at 0 comma 0")).toBeInTheDocument();
+        expect(
+            screen.getByLabelText("Point at -7 comma 0.5"),
+        ).toBeInTheDocument();
+    });
+
     /**
      * regression LEMS-1885
      * Important parts of this test:


### PR DESCRIPTION
This is step one toward implementing screenreader interactions
for the Interactive Graph widget.

This PR does *not* implement everything described in LEMS-1725.  Notably
missing is the description of the entire graph (listing all points).
I will open another PR for that.

Issue: https://khanacademy.atlassian.net/browse/LEMS-1725

## Test plan:

- Use VoiceOver
- `yarn dev`
- `open https://localhost:5173`

Navigate to the Point graph and tab to focus the movable point.  VoiceOver
should read the coordinates.

Move the point with the arrow keys. VoiceOver should play a sound effect and
read the new coordinates with each keypress.