### PR TITLE
Wrap text node to reduce Google Translate bug

### DIFF
--- a/.changeset/rude-spies-doubt.md
+++ b/.changeset/rude-spies-doubt.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Wraps a text node in a `span` to reduce bugs caused by Google Translate

--- a/packages/perseus/src/multi-items/__tests__/__snapshots__/multi-renderer.test.tsx.snap
+++ b/packages/perseus/src/multi-items/__tests__/__snapshots__/multi-renderer.test.tsx.snap
@@ -223,7 +223,9 @@ exports[`multi-item renderer should snapshot: initial render 1`] = `
                                     <div
                                       class="innerWrapper_177sg8x"
                                     >
-                                      A
+                                      <span>
+                                        A
+                                      </span>
                                     </div>
                                   </div>
                                 </span>
@@ -387,7 +389,9 @@ exports[`multi-item renderer should snapshot: initial render 1`] = `
                                     <div
                                       class="innerWrapper_177sg8x"
                                     >
-                                      B
+                                      <span>
+                                        B
+                                      </span>
                                     </div>
                                   </div>
                                 </span>
@@ -551,7 +555,9 @@ exports[`multi-item renderer should snapshot: initial render 1`] = `
                                     <div
                                       class="innerWrapper_177sg8x"
                                     >
-                                      C
+                                      <span>
+                                        C
+                                      </span>
                                     </div>
                                   </div>
                                 </span>
@@ -715,7 +721,9 @@ exports[`multi-item renderer should snapshot: initial render 1`] = `
                                     <div
                                       class="innerWrapper_177sg8x"
                                     >
-                                      D
+                                      <span>
+                                        D
+                                      </span>
                                     </div>
                                   </div>
                                 </span>
@@ -879,7 +887,9 @@ exports[`multi-item renderer should snapshot: initial render 1`] = `
                                     <div
                                       class="innerWrapper_177sg8x"
                                     >
-                                      E
+                                      <span>
+                                        E
+                                      </span>
                                     </div>
                                   </div>
                                 </span>

--- a/packages/perseus/src/widgets/group/__snapshots__/group.test.tsx.snap
+++ b/packages/perseus/src/widgets/group/__snapshots__/group.test.tsx.snap
@@ -197,7 +197,9 @@ exports[`group widget should snapshot: initial render 1`] = `
                                                 <div
                                                   class="innerWrapper_177sg8x"
                                                 >
-                                                  A
+                                                  <span>
+                                                    A
+                                                  </span>
                                                 </div>
                                               </div>
                                             </span>
@@ -309,7 +311,9 @@ exports[`group widget should snapshot: initial render 1`] = `
                                                 <div
                                                   class="innerWrapper_177sg8x"
                                                 >
-                                                  B
+                                                  <span>
+                                                    B
+                                                  </span>
                                                 </div>
                                               </div>
                                             </span>
@@ -421,7 +425,9 @@ exports[`group widget should snapshot: initial render 1`] = `
                                                 <div
                                                   class="innerWrapper_177sg8x"
                                                 >
-                                                  C
+                                                  <span>
+                                                    C
+                                                  </span>
                                                 </div>
                                               </div>
                                             </span>
@@ -533,7 +539,9 @@ exports[`group widget should snapshot: initial render 1`] = `
                                                 <div
                                                   class="innerWrapper_177sg8x"
                                                 >
-                                                  D
+                                                  <span>
+                                                    D
+                                                  </span>
                                                 </div>
                                               </div>
                                             </span>
@@ -645,7 +653,9 @@ exports[`group widget should snapshot: initial render 1`] = `
                                                 <div
                                                   class="innerWrapper_177sg8x"
                                                 >
-                                                  E
+                                                  <span>
+                                                    E
+                                                  </span>
                                                 </div>
                                               </div>
                                             </span>

--- a/packages/perseus/src/widgets/radio/__tests__/__snapshots__/radio.test.ts.snap
+++ b/packages/perseus/src/widgets/radio/__tests__/__snapshots__/radio.test.ts.snap
@@ -132,7 +132,9 @@ exports[`multi-choice question should snapshot the same when invalid: invalid st
                                 <div
                                   class="innerWrapper_177sg8x"
                                 >
-                                  A
+                                  <span>
+                                    A
+                                  </span>
                                 </div>
                               </div>
                             </span>
@@ -244,7 +246,9 @@ exports[`multi-choice question should snapshot the same when invalid: invalid st
                                 <div
                                   class="innerWrapper_177sg8x"
                                 >
-                                  B
+                                  <span>
+                                    B
+                                  </span>
                                 </div>
                               </div>
                             </span>
@@ -356,7 +360,9 @@ exports[`multi-choice question should snapshot the same when invalid: invalid st
                                 <div
                                   class="innerWrapper_177sg8x"
                                 >
-                                  C
+                                  <span>
+                                    C
+                                  </span>
                                 </div>
                               </div>
                             </span>
@@ -459,7 +465,9 @@ exports[`multi-choice question should snapshot the same when invalid: invalid st
                                 <div
                                   class="innerWrapper_177sg8x"
                                 >
-                                  D
+                                  <span>
+                                    D
+                                  </span>
                                 </div>
                               </div>
                             </span>
@@ -693,7 +701,9 @@ exports[`single-choice question reviewMode: false should snapshot the same with 
                                 <div
                                   class="innerWrapper_177sg8x"
                                 >
-                                  A
+                                  <span>
+                                    A
+                                  </span>
                                 </div>
                               </div>
                             </span>
@@ -818,7 +828,9 @@ exports[`single-choice question reviewMode: false should snapshot the same with 
                                 <div
                                   class="innerWrapper_177sg8x"
                                 >
-                                  B
+                                  <span>
+                                    B
+                                  </span>
                                 </div>
                               </div>
                             </span>
@@ -930,7 +942,9 @@ exports[`single-choice question reviewMode: false should snapshot the same with 
                                 <div
                                   class="innerWrapper_177sg8x"
                                 >
-                                  C
+                                  <span>
+                                    C
+                                  </span>
                                 </div>
                               </div>
                             </span>
@@ -1045,7 +1059,9 @@ exports[`single-choice question reviewMode: false should snapshot the same with 
                                 <div
                                   class="innerWrapper_177sg8x"
                                 >
-                                  D
+                                  <span>
+                                    D
+                                  </span>
                                 </div>
                               </div>
                             </span>
@@ -1253,7 +1269,9 @@ exports[`single-choice question reviewMode: false should snapshot the same with 
                                 <div
                                   class="innerWrapper_177sg8x"
                                 >
-                                  A
+                                  <span>
+                                    A
+                                  </span>
                                 </div>
                               </div>
                             </span>
@@ -1378,7 +1396,9 @@ exports[`single-choice question reviewMode: false should snapshot the same with 
                                 <div
                                   class="innerWrapper_177sg8x"
                                 >
-                                  B
+                                  <span>
+                                    B
+                                  </span>
                                 </div>
                               </div>
                             </span>
@@ -1490,7 +1510,9 @@ exports[`single-choice question reviewMode: false should snapshot the same with 
                                 <div
                                   class="innerWrapper_177sg8x"
                                 >
-                                  C
+                                  <span>
+                                    C
+                                  </span>
                                 </div>
                               </div>
                             </span>
@@ -1605,7 +1627,9 @@ exports[`single-choice question reviewMode: false should snapshot the same with 
                                 <div
                                   class="innerWrapper_177sg8x"
                                 >
-                                  D
+                                  <span>
+                                    D
+                                  </span>
                                 </div>
                               </div>
                             </span>
@@ -1813,7 +1837,9 @@ exports[`single-choice question reviewMode: false should snapshot the same: firs
                                 <div
                                   class="innerWrapper_177sg8x"
                                 >
-                                  A
+                                  <span>
+                                    A
+                                  </span>
                                 </div>
                               </div>
                             </span>
@@ -1938,7 +1964,9 @@ exports[`single-choice question reviewMode: false should snapshot the same: firs
                                 <div
                                   class="innerWrapper_177sg8x"
                                 >
-                                  B
+                                  <span>
+                                    B
+                                  </span>
                                 </div>
                               </div>
                             </span>
@@ -2050,7 +2078,9 @@ exports[`single-choice question reviewMode: false should snapshot the same: firs
                                 <div
                                   class="innerWrapper_177sg8x"
                                 >
-                                  C
+                                  <span>
+                                    C
+                                  </span>
                                 </div>
                               </div>
                             </span>
@@ -2165,7 +2195,9 @@ exports[`single-choice question reviewMode: false should snapshot the same: firs
                                 <div
                                   class="innerWrapper_177sg8x"
                                 >
-                                  D
+                                  <span>
+                                    D
+                                  </span>
                                 </div>
                               </div>
                             </span>
@@ -2373,7 +2405,9 @@ exports[`single-choice question reviewMode: true should snapshot the same with c
                                 <div
                                   class="innerWrapper_177sg8x"
                                 >
-                                  A
+                                  <span>
+                                    A
+                                  </span>
                                 </div>
                               </div>
                             </span>
@@ -2498,7 +2532,9 @@ exports[`single-choice question reviewMode: true should snapshot the same with c
                                 <div
                                   class="innerWrapper_177sg8x"
                                 >
-                                  B
+                                  <span>
+                                    B
+                                  </span>
                                 </div>
                               </div>
                             </span>
@@ -2610,7 +2646,9 @@ exports[`single-choice question reviewMode: true should snapshot the same with c
                                 <div
                                   class="innerWrapper_177sg8x"
                                 >
-                                  C
+                                  <span>
+                                    C
+                                  </span>
                                 </div>
                               </div>
                             </span>
@@ -2725,7 +2763,9 @@ exports[`single-choice question reviewMode: true should snapshot the same with c
                                 <div
                                   class="innerWrapper_177sg8x"
                                 >
-                                  D
+                                  <span>
+                                    D
+                                  </span>
                                 </div>
                               </div>
                             </span>
@@ -2933,7 +2973,9 @@ exports[`single-choice question reviewMode: true should snapshot the same with i
                                 <div
                                   class="innerWrapper_177sg8x"
                                 >
-                                  A
+                                  <span>
+                                    A
+                                  </span>
                                 </div>
                               </div>
                             </span>
@@ -3058,7 +3100,9 @@ exports[`single-choice question reviewMode: true should snapshot the same with i
                                 <div
                                   class="innerWrapper_177sg8x"
                                 >
-                                  B
+                                  <span>
+                                    B
+                                  </span>
                                 </div>
                               </div>
                             </span>
@@ -3170,7 +3214,9 @@ exports[`single-choice question reviewMode: true should snapshot the same with i
                                 <div
                                   class="innerWrapper_177sg8x"
                                 >
-                                  C
+                                  <span>
+                                    C
+                                  </span>
                                 </div>
                               </div>
                             </span>
@@ -3285,7 +3331,9 @@ exports[`single-choice question reviewMode: true should snapshot the same with i
                                 <div
                                   class="innerWrapper_177sg8x"
                                 >
-                                  D
+                                  <span>
+                                    D
+                                  </span>
                                 </div>
                               </div>
                             </span>

--- a/packages/perseus/src/widgets/radio/choice-icon/choice-icon.tsx
+++ b/packages/perseus/src/widgets/radio/choice-icon/choice-icon.tsx
@@ -41,7 +41,7 @@ function ChoiceInner(props: ChoiceInnerProps) {
     const letter = getChoiceLetter(pos, strings);
 
     if (!showCorrectness) {
-        return letter;
+        return <span>{letter}</span>;
     }
     if (correct) {
         return (
@@ -68,14 +68,14 @@ function getDynamicStyles(
     multipleSelect: boolean,
     correct?: boolean | null,
 ): {
-    backgroundColor: string | null | undefined;
+    backgroundColor: string | undefined;
     borderColor: string;
     color: string;
     borderRadius: number;
 } {
-    let backgroundColor;
-    let borderColor;
-    let color;
+    let backgroundColor: string | undefined;
+    let borderColor: string;
+    let color: string;
     if (!showCorrectness && pressed) {
         borderColor = WBColor.blue;
         color = WBColor.blue;
@@ -131,7 +131,6 @@ const ChoiceIcon = function (props: ChoiceIconProps): React.ReactElement {
                 multipleSelect={multipleSelect}
             >
                 <div
-                    // @ts-expect-error - TS2322 - Type '{ backgroundColor: string | null | undefined; borderColor: string; color: string; borderRadius: number; }' is not assignable to type 'Properties<string | number, string & {}>'.
                     style={dynamicStyles}
                     data-testid="choice-icon__library-choice-icon"
                     className={css(


### PR DESCRIPTION
[It looks like Google Translate doesn't play nicely with React.](https://martijnhols.nl/gists/everything-about-google-translate-crashing-react)
There is [a known issue that Google plans to address](https://issues.chromium.org/issues/41407169)... one day, maybe.
In the short term, it looks like if we wrap text nodes in elements, we should be good to go.

Issue: LEMS-2574

Testing:
Use Google Translate on any radio widget exercise and do something that causes the radio widgets to change state to render a text node (the easiest way was showing rationales). The red bar of doom doesn't show.