### PR TITLE
Add screenreader description for point graph elements

### DIFF
--- a/.changeset/real-suns-fail.md
+++ b/.changeset/real-suns-fail.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Add screenreader description for the interactive elements of point graphs

--- a/packages/perseus/src/components/i18n-context.tsx
+++ b/packages/perseus/src/components/i18n-context.tsx
@@ -15,14 +15,16 @@ type I18nContextType = {
     locale: string;
 };
 
+export const mockPerseusI18nContext = {
+    strings: mockStrings,
+    locale: "en",
+};
+
 // @ts-expect-error - TS2322 - Type 'Context<{ strings: {}; locale: string; }>' is not assignable to type 'Context<I18nContextType>'.
 export const PerseusI18nContext: React.Context<I18nContextType> =
     React.createContext(
         process.env.NODE_ENV === "test" || process.env.STORYBOOK
-            ? {
-                  strings: mockStrings,
-                  locale: "en",
-              }
+            ? mockPerseusI18nContext
             : // We want to return null here, not an empty object, so that we
               // are will throw an error when attempting to access the
               // undefined locale or strings, making it easier to debug.

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -134,6 +134,8 @@ export type PerseusStrings = {
     removePoint: string;
     graphKeyboardPrompt: string;
     srPointAtCoordinates: ({x, y}: {x: string; y: string}) => string;
+    srInteractiveElements: ({elements}: {elements: string}) => string;
+    srNoInteractiveElements: string;
 };
 
 /**
@@ -313,6 +315,8 @@ export const strings: {
         context: "Screenreader-accessible description of a point on a graph",
         message: "Point at %(x)s comma %(y)s",
     },
+    srInteractiveElements: "Interactive elements: %(elements)s",
+    srNoInteractiveElements: "No interactive elements",
 };
 
 /**
@@ -473,4 +477,6 @@ export const mockStrings: PerseusStrings = {
     removePoint: "Remove Point",
     graphKeyboardPrompt: "Press Shift + Enter to interact with the graph",
     srPointAtCoordinates: ({x, y}) => `Point at ${x} comma ${y}`,
+    srInteractiveElements: ({elements}) => `Interactive elements: ${elements}`,
+    srNoInteractiveElements: "No interactive elements",
 };

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/angle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/angle.tsx
@@ -31,7 +31,7 @@ export function renderAngleGraph(
 ): InteractiveGraphElementSuite {
     return {
         graph: <AngleGraph graphState={state} dispatch={dispatch} />,
-        screenreaderDescription: null,
+        interactiveElementsDescription: null,
     };
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -27,7 +27,7 @@ export function renderCircleGraph(
 ): InteractiveGraphElementSuite {
     return {
         graph: <CircleGraph graphState={state} dispatch={dispatch} />,
-        screenreaderDescription: null,
+        interactiveElementsDescription: null,
     };
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -47,7 +47,7 @@ export function useControlPoint(params: Params): Return {
         forwardedRef = noop,
     } = params;
 
-    const {strings} = usePerseusI18n();
+    const {strings, locale} = usePerseusI18n();
 
     const [focused, setFocused] = useState(false);
     const focusableHandleRef = useRef<SVGGElement>(null);
@@ -78,8 +78,8 @@ export function useControlPoint(params: Params): Return {
             ref={focusableHandleRef}
             role="button"
             aria-label={strings.srPointAtCoordinates({
-                x: srFormatNumber(point[X]),
-                y: srFormatNumber(point[Y]),
+                x: srFormatNumber(point[X], locale),
+                y: srFormatNumber(point[Y], locale),
             })}
             // aria-live="assertive" causes the new location of the point to be
             // announced immediately on move.

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -4,6 +4,7 @@ import {useState, useRef, useLayoutEffect} from "react";
 import {usePerseusI18n} from "../../../../components/i18n-context";
 import {snap, X, Y} from "../../math";
 import useGraphConfig from "../../reducer/use-graph-config";
+import {srFormatNumber} from "../screenreader-text";
 import {useDraggable} from "../use-draggable";
 
 import {MovablePointView} from "./movable-point-view";
@@ -77,8 +78,8 @@ export function useControlPoint(params: Params): Return {
             ref={focusableHandleRef}
             role="button"
             aria-label={strings.srPointAtCoordinates({
-                x: String(point[X]),
-                y: String(point[Y]),
+                x: srFormatNumber(point[X]),
+                y: srFormatNumber(point[Y]),
             })}
             // aria-live="assertive" causes the new location of the point to be
             // announced immediately on move.

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.tsx
@@ -18,7 +18,7 @@ export function renderLinearSystemGraph(
 ): InteractiveGraphElementSuite {
     return {
         graph: <LinearSystemGraph graphState={state} dispatch={dispatch} />,
-        screenreaderDescription: null,
+        interactiveElementsDescription: null,
     };
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
@@ -18,7 +18,7 @@ export function renderLinearGraph(
 ): InteractiveGraphElementSuite {
     return {
         graph: <LinearGraph graphState={state} dispatch={dispatch} />,
-        screenreaderDescription: null,
+        interactiveElementsDescription: null,
     };
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.test.ts
@@ -1,9 +1,8 @@
-import {mockStrings} from "../../../strings";
+import {mockPerseusI18nContext} from "../../../components/i18n-context";
 
 import {describePointGraph} from "./point";
 
 import type {PointGraphState} from "../types";
-import {mockPerseusI18nContext} from "../../../components/i18n-context";
 
 describe("describePointGraph", () => {
     const baseState: PointGraphState = {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.test.ts
@@ -1,0 +1,59 @@
+import {mockStrings} from "../../../strings";
+
+import {describePointGraph} from "./point";
+
+import type {PointGraphState} from "../types";
+
+describe("describePointGraph", () => {
+    const baseState: PointGraphState = {
+        type: "point",
+        coords: [],
+        focusedPointIndex: null,
+        hasBeenInteractedWith: false,
+        interactionMode: "keyboard",
+        range: [
+            [0, 0],
+            [0, 0],
+        ] as const,
+        showKeyboardInteractionInvitation: false,
+        showRemovePointButton: false,
+        snapStep: [0, 0] as const,
+    };
+
+    it(`returns "No interactive elements" for a graph with no points`, () => {
+        const state: PointGraphState = {...baseState, coords: []};
+        expect(describePointGraph(state, mockStrings)).toBe(
+            "No interactive elements",
+        );
+    });
+
+    it("describes one point", () => {
+        const state: PointGraphState = {...baseState, coords: [[3, 5]]};
+        expect(describePointGraph(state, mockStrings)).toBe(
+            "Interactive elements: Point at 3 comma 5",
+        );
+    });
+
+    it("separates multiple point descriptions by commas", () => {
+        const state: PointGraphState = {
+            ...baseState,
+            coords: [
+                [3, 5],
+                [2, 4],
+            ],
+        };
+        expect(describePointGraph(state, mockStrings)).toBe(
+            "Interactive elements: Point at 3 comma 5, Point at 2 comma 4",
+        );
+    });
+
+    it("rounds to 3 decimal places", () => {
+        const state: PointGraphState = {
+            ...baseState,
+            coords: [[-1.1234, 3.5678]],
+        };
+        expect(describePointGraph(state, mockStrings)).toBe(
+            "Interactive elements: Point at -1.123 comma 3.568",
+        );
+    });
+});

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.test.ts
@@ -3,6 +3,7 @@ import {mockStrings} from "../../../strings";
 import {describePointGraph} from "./point";
 
 import type {PointGraphState} from "../types";
+import {mockPerseusI18nContext} from "../../../components/i18n-context";
 
 describe("describePointGraph", () => {
     const baseState: PointGraphState = {
@@ -22,14 +23,14 @@ describe("describePointGraph", () => {
 
     it(`returns "No interactive elements" for a graph with no points`, () => {
         const state: PointGraphState = {...baseState, coords: []};
-        expect(describePointGraph(state, mockStrings)).toBe(
+        expect(describePointGraph(state, mockPerseusI18nContext)).toBe(
             "No interactive elements",
         );
     });
 
     it("describes one point", () => {
         const state: PointGraphState = {...baseState, coords: [[3, 5]]};
-        expect(describePointGraph(state, mockStrings)).toBe(
+        expect(describePointGraph(state, mockPerseusI18nContext)).toBe(
             "Interactive elements: Point at 3 comma 5",
         );
     });
@@ -42,7 +43,7 @@ describe("describePointGraph", () => {
                 [2, 4],
             ],
         };
-        expect(describePointGraph(state, mockStrings)).toBe(
+        expect(describePointGraph(state, mockPerseusI18nContext)).toBe(
             "Interactive elements: Point at 3 comma 5, Point at 2 comma 4",
         );
     });
@@ -52,7 +53,7 @@ describe("describePointGraph", () => {
             ...baseState,
             coords: [[-1.1234, 3.5678]],
         };
-        expect(describePointGraph(state, mockStrings)).toBe(
+        expect(describePointGraph(state, mockPerseusI18nContext)).toBe(
             "Interactive elements: Point at -1.123 comma 3.568",
         );
     });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
@@ -1,15 +1,18 @@
 import * as React from "react";
 
+import {usePerseusI18n} from "../../../components/i18n-context";
 import {actions} from "../reducer/interactive-graph-action";
 import useGraphConfig from "../reducer/use-graph-config";
 
 import {MovablePoint} from "./components/movable-point";
+import {srFormatNumber} from "./screenreader-text";
 import {
     useTransformDimensionsToPixels,
     useTransformVectorsToPixels,
     pixelsToVectors,
 } from "./use-transform";
 
+import type {PerseusStrings} from "../../../strings";
 import type {
     PointGraphState,
     MafsGraphProps,
@@ -23,7 +26,7 @@ export function renderPointGraph(
 ): InteractiveGraphElementSuite {
     return {
         graph: <PointGraph graphState={state} dispatch={dispatch} />,
-        screenreaderDescription: null,
+        screenreaderDescription: <PointGraphDescription state={state} />,
     };
 }
 
@@ -126,4 +129,30 @@ function UnlimitedPointGraph(props: PointGraphProps) {
             ))}
         </>
     );
+}
+
+function PointGraphDescription({state}: {state: PointGraphState}) {
+    const {strings} = usePerseusI18n();
+    return describePointGraph(state, strings);
+}
+
+// Exported for testing
+export function describePointGraph(
+    state: PointGraphState,
+    strings: PerseusStrings,
+): string {
+    if (state.coords.length === 0) {
+        return strings.srNoInteractiveElements;
+    }
+
+    const pointDescriptions = state.coords.map(([x, y]) =>
+        strings.srPointAtCoordinates({
+            x: srFormatNumber(x),
+            y: srFormatNumber(y),
+        }),
+    );
+
+    return strings.srInteractiveElements({
+        elements: pointDescriptions.join(", "),
+    });
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
@@ -131,7 +131,6 @@ function UnlimitedPointGraph(props: PointGraphProps) {
     );
 }
 
-
 function PointGraphDescription({state}: {state: PointGraphState}) {
     // PointGraphDescription needs to `usePerseusI18n`, so it has to be a
     // component rather than a function that simply returns a string.

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
@@ -132,23 +132,25 @@ function UnlimitedPointGraph(props: PointGraphProps) {
 }
 
 function PointGraphDescription({state}: {state: PointGraphState}) {
-    const {strings} = usePerseusI18n();
-    return describePointGraph(state, strings);
+    const i18n = usePerseusI18n();
+    return describePointGraph(state, i18n);
 }
 
 // Exported for testing
 export function describePointGraph(
     state: PointGraphState,
-    strings: PerseusStrings,
+    i18n: {strings: PerseusStrings, locale: string},
 ): string {
+    const {strings, locale} = i18n;
+
     if (state.coords.length === 0) {
         return strings.srNoInteractiveElements;
     }
 
     const pointDescriptions = state.coords.map(([x, y]) =>
         strings.srPointAtCoordinates({
-            x: srFormatNumber(x),
-            y: srFormatNumber(y),
+            x: srFormatNumber(x, locale),
+            y: srFormatNumber(y, locale),
         }),
     );
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
@@ -26,7 +26,7 @@ export function renderPointGraph(
 ): InteractiveGraphElementSuite {
     return {
         graph: <PointGraph graphState={state} dispatch={dispatch} />,
-        screenreaderDescription: <PointGraphDescription state={state} />,
+        interactiveElementsDescription: <PointGraphDescription state={state} />,
     };
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
@@ -131,7 +131,10 @@ function UnlimitedPointGraph(props: PointGraphProps) {
     );
 }
 
+
 function PointGraphDescription({state}: {state: PointGraphState}) {
+    // PointGraphDescription needs to `usePerseusI18n`, so it has to be a
+    // component rather than a function that simply returns a string.
     const i18n = usePerseusI18n();
     return describePointGraph(state, i18n);
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
@@ -139,7 +139,7 @@ function PointGraphDescription({state}: {state: PointGraphState}) {
 // Exported for testing
 export function describePointGraph(
     state: PointGraphState,
-    i18n: {strings: PerseusStrings, locale: string},
+    i18n: {strings: PerseusStrings; locale: string},
 ): string {
     const {strings, locale} = i18n;
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -26,7 +26,7 @@ export function renderPolygonGraph(
 ): InteractiveGraphElementSuite {
     return {
         graph: <PolygonGraph graphState={state} dispatch={dispatch} />,
-        screenreaderDescription: null,
+        interactiveElementsDescription: null,
     };
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
@@ -19,7 +19,7 @@ export function renderQuadraticGraph(
 ): InteractiveGraphElementSuite {
     return {
         graph: <QuadraticGraph graphState={state} dispatch={dispatch} />,
-        screenreaderDescription: null,
+        interactiveElementsDescription: null,
     };
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/ray.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/ray.tsx
@@ -18,7 +18,7 @@ export function renderRayGraph(
 ): InteractiveGraphElementSuite {
     return {
         graph: <RayGraph graphState={state} dispatch={dispatch} />,
-        screenreaderDescription: null,
+        interactiveElementsDescription: null,
     };
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.test.ts
@@ -1,12 +1,16 @@
 import {srFormatNumber} from "./screenreader-text";
 
 describe("srFormatNumber", () => {
-    it("trivially converts most integers to strings", () => {
+    it("trivially converts small integers to strings", () => {
         expect(srFormatNumber(3, "en")).toBe("3");
     });
 
     it("does not use thousands separators", () => {
         expect(srFormatNumber(1234567, "en")).toBe("1234567");
+    });
+
+    it("does not use scientific notation", () => {
+        expect(srFormatNumber(1e27, "en")).toBe("1000000000000000000000000000");
     });
 
     it("displays at most 3 decimal places", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.test.ts
@@ -1,0 +1,23 @@
+import {srFormatNumber} from "./screenreader-text";
+
+describe("srFormatNumber", () => {
+    it("trivially converts most integers to strings", () => {
+        expect(srFormatNumber(3)).toBe("3");
+    });
+
+    it("does not use thousands separators", () => {
+        expect(srFormatNumber(1234567)).toBe("1234567");
+    });
+
+    it("displays at most 3 decimal places", () => {
+        expect(srFormatNumber(0.123456)).toBe("0.123");
+    });
+
+    it("rounds to 3 decimal places", () => {
+        expect(srFormatNumber(1.2345)).toBe("1.235");
+    });
+
+    it("never displays a negative sign on zero", () => {
+        expect(srFormatNumber(-0)).toBe("0");
+    });
+});

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.test.ts
@@ -2,22 +2,26 @@ import {srFormatNumber} from "./screenreader-text";
 
 describe("srFormatNumber", () => {
     it("trivially converts most integers to strings", () => {
-        expect(srFormatNumber(3)).toBe("3");
+        expect(srFormatNumber(3, "en")).toBe("3");
     });
 
     it("does not use thousands separators", () => {
-        expect(srFormatNumber(1234567)).toBe("1234567");
+        expect(srFormatNumber(1234567, "en")).toBe("1234567");
     });
 
     it("displays at most 3 decimal places", () => {
-        expect(srFormatNumber(0.123456)).toBe("0.123");
+        expect(srFormatNumber(0.123456, "en")).toBe("0.123");
     });
 
     it("rounds to 3 decimal places", () => {
-        expect(srFormatNumber(1.2345)).toBe("1.235");
+        expect(srFormatNumber(1.2345, "en")).toBe("1.235");
     });
 
     it("never displays a negative sign on zero", () => {
-        expect(srFormatNumber(-0)).toBe("0");
+        expect(srFormatNumber(-0, "en")).toBe("0");
+    });
+
+    it("uses a locale-appropriate decimal separator", () => {
+        expect(srFormatNumber(1.5, "de")).toBe("1,5");
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.ts
@@ -3,5 +3,5 @@ export function srFormatNumber(a: number, locale: string): string {
     return (0 + a).toLocaleString(locale, {
         maximumFractionDigits: 3,
         useGrouping: false, // no thousands separators
-    })
+    });
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.ts
@@ -1,0 +1,12 @@
+const numberFormat = new Intl.NumberFormat(
+    undefined, // use default locale
+    {
+        maximumFractionDigits: 3,
+        useGrouping: false, // no thousands separators
+    },
+);
+
+export function srFormatNumber(a: number): string {
+    // adding zero here converts negative zero to positive zero.
+    return numberFormat.format(0 + a);
+}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.ts
@@ -1,12 +1,7 @@
-const numberFormat = new Intl.NumberFormat(
-    undefined, // use default locale
-    {
+export function srFormatNumber(a: number, locale: string): string {
+    // adding zero here converts negative zero to positive zero.
+    return (0 + a).toLocaleString(locale, {
         maximumFractionDigits: 3,
         useGrouping: false, // no thousands separators
-    },
-);
-
-export function srFormatNumber(a: number): string {
-    // adding zero here converts negative zero to positive zero.
-    return numberFormat.format(0 + a);
+    })
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
@@ -18,7 +18,7 @@ export function renderSegmentGraph(
 ): InteractiveGraphElementSuite {
     return {
         graph: <SegmentGraph graphState={state} dispatch={dispatch} />,
-        screenreaderDescription: null,
+        interactiveElementsDescription: null,
     };
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
@@ -21,7 +21,7 @@ export function renderSinusoidGraph(
 ): InteractiveGraphElementSuite {
     return {
         graph: <SinusoidGraph graphState={state} dispatch={dispatch} />,
-        screenreaderDescription: null,
+        interactiveElementsDescription: null,
     };
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -159,6 +159,35 @@ describe("MafsGraph", () => {
         ).toBeInTheDocument();
     });
 
+    it("renders a screenreader description summarizing the interactive elements on the graph", () => {
+        const state: InteractiveGraphState = {
+            type: "point",
+            hasBeenInteractedWith: true,
+            focusedPointIndex: null,
+            showRemovePointButton: false,
+            interactionMode: "keyboard",
+            showKeyboardInteractionInvitation: false,
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            snapStep: [0.5, 0.5],
+            coords: [[-7, 0.5]],
+        };
+
+        render(
+            <MafsGraph
+                {...getBaseMafsGraphProps()}
+                state={state}
+                dispatch={() => {}}
+            />,
+        );
+
+        expect(
+            screen.getByText("Interactive elements: Point at -7 comma 0.5"),
+        ).toBeInTheDocument();
+    });
+
     /**
      * regression LEMS-1885
      * Important parts of this test:

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -169,7 +169,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                         handleKeyboardEvent(event, state, dispatch);
                     }}
                     aria-label={fullGraphAriaLabel}
-                    aria-describedby={describedBy(
+                    aria-describedby={describedByIds(
                         fullGraphAriaDescription && descriptionId,
                         // FIXME: awkward naming
                         screenreaderDescription &&
@@ -647,7 +647,9 @@ const renderGraphElements = (props: {
     }
 };
 
-function describedBy(
+// Returns a space-separated string like "foo bar" given several optional
+// string IDs. If all args are falsy, returns undefined.
+function describedByIds(
     ...args: Array<string | false | 0 | null | undefined>
 ): string | undefined {
     return args.filter(Boolean).join(" ") || undefined;

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -93,6 +93,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
 
     const uniqueId = React.useId();
     const descriptionId = `interactive-graph-description-${uniqueId}`;
+    const interactiveElementsDescriptionId = `interactive-graph-interactive-elements-description-${uniqueId}`;
     const graphRef = React.useRef<HTMLElement>(null);
     const {analytics} = useDependencies();
 
@@ -129,7 +130,10 @@ export const MafsGraph = (props: MafsGraphProps) => {
         });
     });
 
-    const {graph} = renderGraphElements({state, dispatch});
+    const {graph, screenreaderDescription} = renderGraphElements({
+        state,
+        dispatch,
+    });
 
     return (
         <GraphConfigContext.Provider
@@ -165,9 +169,12 @@ export const MafsGraph = (props: MafsGraphProps) => {
                         handleKeyboardEvent(event, state, dispatch);
                     }}
                     aria-label={fullGraphAriaLabel}
-                    aria-describedby={
-                        fullGraphAriaDescription ? descriptionId : undefined
-                    }
+                    aria-describedby={describedBy(
+                        fullGraphAriaDescription && descriptionId,
+                        // FIXME: awkward naming
+                        screenreaderDescription &&
+                            interactiveElementsDescriptionId,
+                    )}
                     ref={graphRef}
                     tabIndex={0}
                     onFocus={(event) => {
@@ -181,13 +188,18 @@ export const MafsGraph = (props: MafsGraphProps) => {
                         <View
                             id={descriptionId}
                             tabIndex={-1}
-                            style={{
-                                width: 0,
-                                height: 0,
-                                overflow: "hidden",
-                            }}
+                            className="mafs-sr-only"
                         >
                             {fullGraphAriaDescription}
+                        </View>
+                    )}
+                    {screenreaderDescription && (
+                        <View
+                            id={interactiveElementsDescriptionId}
+                            tabIndex={-1}
+                            className="mafs-sr-only"
+                        >
+                            {screenreaderDescription}
                         </View>
                     )}
                     <LegacyGrid
@@ -634,3 +646,9 @@ const renderGraphElements = (props: {
             throw new UnreachableCaseError(type);
     }
 };
+
+function describedBy(
+    ...args: Array<string | false | 0 | null | undefined>
+): string | undefined {
+    return args.filter(Boolean).join(" ") || undefined;
+}

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -130,7 +130,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
         });
     });
 
-    const {graph, screenreaderDescription} = renderGraphElements({
+    const {graph, interactiveElementsDescription} = renderGraphElements({
         state,
         dispatch,
     });
@@ -171,8 +171,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                     aria-label={fullGraphAriaLabel}
                     aria-describedby={describedByIds(
                         fullGraphAriaDescription && descriptionId,
-                        // FIXME: awkward naming
-                        screenreaderDescription &&
+                        interactiveElementsDescription &&
                             interactiveElementsDescriptionId,
                     )}
                     ref={graphRef}
@@ -193,13 +192,13 @@ export const MafsGraph = (props: MafsGraphProps) => {
                             {fullGraphAriaDescription}
                         </View>
                     )}
-                    {screenreaderDescription && (
+                    {interactiveElementsDescription && (
                         <View
                             id={interactiveElementsDescriptionId}
                             tabIndex={-1}
                             className="mafs-sr-only"
                         >
-                            {screenreaderDescription}
+                            {interactiveElementsDescription}
                         </View>
                     )}
                     <LegacyGrid
@@ -641,7 +640,7 @@ const renderGraphElements = (props: {
         case "sinusoid":
             return renderSinusoidGraph(state, dispatch);
         case "none":
-            return {graph: null, screenreaderDescription: null};
+            return {graph: null, interactiveElementsDescription: null};
         default:
             throw new UnreachableCaseError(type);
     }

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -235,3 +235,9 @@
     stroke: black;
     stroke-width: 1px;
 }
+
+.mafs-sr-only {
+    height: 0;
+    width: 0;
+    overflow: hidden;
+}

--- a/packages/perseus/src/widgets/interactive-graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/types.ts
@@ -21,7 +21,7 @@ export type MafsGraphProps<T extends InteractiveGraphState> = {
 // end up in different sections of the DOM.
 export type InteractiveGraphElementSuite = {
     graph: ReactNode;
-    screenreaderDescription: ReactNode;
+    interactiveElementsDescription: ReactNode;
     // TODO(benchristel): add actionBar controls here
 };
 


### PR DESCRIPTION
## Summary:
When a user focuses a whole interactive graph, they should be able to
hear a description of all the interactive elements. This PR implements
this feature for point graphs.

Issue: https://khanacademy.atlassian.net/browse/LEMS-1725

Test plan:

- Use VoiceOver
- `yarn dev`
- `open http://localhost:5173`
- Tab to the point graph. You should hear a description including the
  coordinates of the interactive point.