### PR TITLE
Attempt bug fix for LabelImageEditor

### DIFF
--- a/.changeset/light-shirts-warn.md
+++ b/.changeset/light-shirts-warn.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Bug fix for LabelImageEditor URL race condition

--- a/packages/perseus-editor/src/widgets/label-image-editor.tsx
+++ b/packages/perseus-editor/src/widgets/label-image-editor.tsx
@@ -140,6 +140,14 @@ class LabelImageEditor extends React.Component<Props> {
     }
 
     handleImageChange: (url: string) => void = (url: string) => {
+        this.props.onChange({
+            imageUrl: url,
+            // Initially reset image size when URL is changed so it can be later
+            // measured.
+            imageWidth: 0,
+            imageHeight: 0,
+        });
+
         if (url) {
             Util.getImageSize(url, (width, height) => {
                 this.props.onChange({

--- a/packages/perseus-editor/src/widgets/label-image-editor.tsx
+++ b/packages/perseus-editor/src/widgets/label-image-editor.tsx
@@ -140,17 +140,10 @@ class LabelImageEditor extends React.Component<Props> {
     }
 
     handleImageChange: (url: string) => void = (url: string) => {
-        this.props.onChange({
-            imageUrl: url,
-            // Initially reset image size when URL is changed so it can be later
-            // measured.
-            imageWidth: 0,
-            imageHeight: 0,
-        });
-
         if (url) {
             Util.getImageSize(url, (width, height) => {
                 this.props.onChange({
+                    imageUrl: url,
                     imageWidth: width,
                     imageHeight: height,
                 });

--- a/packages/perseus-editor/src/widgets/label-image-editor.tsx
+++ b/packages/perseus-editor/src/widgets/label-image-editor.tsx
@@ -151,6 +151,13 @@ class LabelImageEditor extends React.Component<Props> {
         if (url) {
             Util.getImageSize(url, (width, height) => {
                 this.props.onChange({
+                    /**
+                     * Sending `imageUrl` up again
+                     * (even though we did so at the beginning of handleImageChange)
+                     * because we ran into a race condition (LEMS-2583) where
+                     * `imageUrl` was getting set to an empty string if measuring
+                     * happened too fast.
+                     */
                     imageUrl: url,
                     imageWidth: width,
                     imageHeight: height,


### PR DESCRIPTION
## Summary:
There's a race condition in the editing experience. I actually think the root of the issue has to do with code outside of Perseus, but CP is currently rewriting the editor so I'm just trying to patch for now and hope the real issue is resolved in the future.

Details are written out in the ticket, but the tl;dr is that there's some kind of race condition when changing the image and getting the image size. The outcome of the race condition was that `imageUrl` would become `""` when immediately calling `onChange` with an updated measurement. So to be doubly sure, I'm sending `imageUrl` with the measurements now.

**Risk:** I think there's a risk for a different type of race condition:
1. User changes URL
2. We start to measure the image size (async since we have to load the image)
3. User changes the URL again
4. We finish measuring the image size and bubble up the original `imageUrl` overwriting the new URL

I think this is less likely than the current race condition, but I thought I'd write it out in case there's a problem in the future.

Issue: [LEMS-2583](https://khanacademy.atlassian.net/browse/LEMS-2583)

## Test plan:
Since it's a race condition, this one was really hard to repro outside of Webapp. [Here are the instructions to repro](https://khanacademy.atlassian.net/browse/LEMS-2583?focusedCommentId=342225) in Webapp and ideally once this ships we won't be able to repro anymore.

[LEMS-2583]: https://khanacademy.atlassian.net/browse/LEMS-2583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ