### PR TITLE
Remove unnecessary MathJax 2 logic from Perseus.Init

### DIFF
--- a/.changeset/witty-hounds-melt.md
+++ b/.changeset/witty-hounds-melt.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Removal of unused MathJax2 initialization

--- a/packages/perseus/src/__tests__/init.test.ts
+++ b/packages/perseus/src/__tests__/init.test.ts
@@ -3,7 +3,7 @@ import {getWidget} from "../widgets";
 
 describe("init", () => {
     it("should correctly replace the transformer widget", async () => {
-        await init({skipMathJax: true});
+        await init();
 
         expect(getWidget("transformer")).not.toBeNull();
     });

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -159,7 +159,6 @@ export {default as WIDGET_PROP_DENYLIST} from "./mixins/widget-prop-denylist";
 /**
  * Types
  */
-export type {PerseusOptions} from "./init";
 export type {ILogger, LogErrorOptions} from "./logging/log";
 export type {ServerItemRenderer as ServerItemRendererComponent} from "./server-item-renderer";
 export type {

--- a/packages/perseus/src/init.ts
+++ b/packages/perseus/src/init.ts
@@ -2,57 +2,19 @@ import basicWidgets from "./basic-widgets";
 import extraWidgets from "./extra-widgets";
 import * as Widgets from "./widgets";
 
-declare const MathJax: any;
-
-export type PerseusOptions = {
-    // TODO(LEMS-1608): remove skipMathJax once we have completely removed the
-    // legacy MathJax 2 renderer from webapp.
-    skipMathJax: boolean;
-};
-
 /**
  * This should be called by all clients, specifying whether extra widgets are
  * needed via `loadExtraWidgets`. It is idempotent, so it's not a problem to
  * call it multiple times.
- *
- * skipMathJax:
- *   If false/undefined, MathJax will be configured, and the
- *   promise will wait for MathJax to load (if it hasn't already).
  */
-const init = function (options: PerseusOptions): Promise<undefined> {
+const init = function (): Promise<undefined> {
     Widgets.registerWidgets(basicWidgets);
     Widgets.registerWidgets(extraWidgets);
 
     Widgets.replaceDeprecatedWidgets();
 
-    // Pass skipMathJax: true if MathJax is already loaded and configured.
-    const skipMathJax = options.skipMathJax;
-
-    if (skipMathJax) {
-        // @ts-expect-error - TS2322 - Type 'Promise<void>' is not assignable to type 'Promise<undefined>'.
-        return Promise.resolve();
-    }
-
-    return new Promise(
-        (
-            resolve: (result: Promise<never>) => void,
-            reject: (error?: any) => void,
-        ) => {
-            MathJax.Hub.Config({
-                messageStyle: "none",
-                skipStartupTypeset: "none",
-                "HTML-CSS": {
-                    availableFonts: ["TeX"],
-                    imageFont: null,
-                    scale: 100,
-                    showMathMenu: false,
-                },
-            });
-
-            MathJax.Hub.Configured();
-            MathJax.Hub.Queue(resolve);
-        },
-    );
+    // @ts-expect-error - TS2322 - Type 'Promise<void>' is not assignable to type 'Promise<undefined>'.
+    return Promise.resolve();
 };
 
 export default init;

--- a/packages/perseus/src/init.ts
+++ b/packages/perseus/src/init.ts
@@ -7,14 +7,11 @@ import * as Widgets from "./widgets";
  * needed via `loadExtraWidgets`. It is idempotent, so it's not a problem to
  * call it multiple times.
  */
-const init = function (): Promise<undefined> {
+const init = function () {
     Widgets.registerWidgets(basicWidgets);
     Widgets.registerWidgets(extraWidgets);
 
     Widgets.replaceDeprecatedWidgets();
-
-    // @ts-expect-error - TS2322 - Type 'Promise<void>' is not assignable to type 'Promise<undefined>'.
-    return Promise.resolve();
 };
 
 export default init;

--- a/packages/perseus/src/widgets/explanation/explanation.cypress.ts
+++ b/packages/perseus/src/widgets/explanation/explanation.cypress.ts
@@ -16,7 +16,7 @@ describe("Explanation Widget", () => {
 
     beforeEach(() => {
         Dependencies.setDependencies(cypressTestDependencies);
-        Perseus.init({skipMathJax: true});
+        Perseus.init();
     });
 
     it("prevents interacting with actionable items within content when COLLAPSED (initial state)", () => {

--- a/packages/perseus/src/widgets/grapher/grapher.cypress.ts
+++ b/packages/perseus/src/widgets/grapher/grapher.cypress.ts
@@ -25,7 +25,7 @@ const LINES = "[data-interactive-kind-for-testing=movable-line] > svg > path";
 
 describe("Grapher widget", () => {
     beforeEach(() => {
-        Perseus.init({skipMathJax: true});
+        Perseus.init();
         Perseus.Dependencies.setDependencies(cypressTestDependencies);
     });
 


### PR DESCRIPTION
## Summary:
While investigating a regression on Webapp related to our Deprecated Stand-in Widget, we discovered we were initializing MathJax unnecessarily! This initialization is specifically for MathJax2 so it is safe to remove entirely. 

Issue: LEMS-2588

## Test plan:
- Manual testing 
- Knowledge that this code has not been running for 2 months, and we've had zero issues with our MathJax rendering
- Knowledge that this is unused due to being MathJax2 