### PR TITLE
Use 'satisfies' instead of 'as' for WidgetExports<T> objects

### DIFF
--- a/.changeset/curly-wombats-lay.md
+++ b/.changeset/curly-wombats-lay.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Type widget exports using 'satisfies' keyword instead of 'as'

--- a/packages/perseus/src/__tests__/mock-asset-loading-widget.tsx
+++ b/packages/perseus/src/__tests__/mock-asset-loading-widget.tsx
@@ -49,4 +49,4 @@ export default {
     name: "mocked-asset-widget",
     displayName: "Mocked Asset Widget",
     widget: MockAssetLoadingWidget,
-} as WidgetExports<typeof MockAssetLoadingWidget>;
+} satisfies WidgetExports<typeof MockAssetLoadingWidget>;

--- a/packages/perseus/src/widgets/categorizer/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.tsx
@@ -320,4 +320,4 @@ export default {
     },
     isLintable: true,
     validator: categorizerValidator,
-} as WidgetExports<typeof Categorizer>;
+} satisfies WidgetExports<typeof Categorizer>;

--- a/packages/perseus/src/widgets/cs-program/cs-program.tsx
+++ b/packages/perseus/src/widgets/cs-program/cs-program.tsx
@@ -200,4 +200,4 @@ export default {
     widget: CSProgram,
     hidden: true,
     validator: csProgramValidator,
-} as WidgetExports<typeof CSProgram>;
+} satisfies WidgetExports<typeof CSProgram>;

--- a/packages/perseus/src/widgets/definition/definition.tsx
+++ b/packages/perseus/src/widgets/definition/definition.tsx
@@ -106,4 +106,4 @@ export default {
     transform: (x: any) => x,
     // TODO: things that aren't interactive shouldn't need validators
     validator: () => noopValidator(),
-} as WidgetExports<typeof Definition>;
+} satisfies WidgetExports<typeof Definition>;

--- a/packages/perseus/src/widgets/deprecated-standin/deprecated-standin.tsx
+++ b/packages/perseus/src/widgets/deprecated-standin/deprecated-standin.tsx
@@ -43,4 +43,4 @@ export default {
     hidden: true,
     // TODO: things that aren't interactive shouldn't need validators
     validator: () => noopValidator(1),
-} as WidgetExports<typeof DeprecatedStandin>;
+} satisfies WidgetExports<typeof DeprecatedStandin>;

--- a/packages/perseus/src/widgets/dropdown/dropdown.tsx
+++ b/packages/perseus/src/widgets/dropdown/dropdown.tsx
@@ -119,4 +119,4 @@ export default {
     widget: Dropdown,
     transform: optionsTransform,
     validator: dropdownValidator,
-} as WidgetExports<typeof Dropdown>;
+} satisfies WidgetExports<typeof Dropdown>;

--- a/packages/perseus/src/widgets/explanation/explanation.test.ts
+++ b/packages/perseus/src/widgets/explanation/explanation.test.ts
@@ -267,10 +267,7 @@ describe("Explanation", function () {
 
     describe("validator", () => {
         it("should always return 0 points", async () => {
-            const result = ExplanationWidgetExports?.validator?.(
-                null as any,
-                null as any,
-            );
+            const result = ExplanationWidgetExports?.validator?.();
 
             expect(result).toHaveBeenAnsweredCorrectly({
                 shouldHavePoints: false,

--- a/packages/perseus/src/widgets/explanation/explanation.tsx
+++ b/packages/perseus/src/widgets/explanation/explanation.tsx
@@ -226,4 +226,4 @@ export default {
     isLintable: true,
     // TODO: things that aren't interactive shouldn't need validators
     validator: () => noopValidator(),
-} as WidgetExports<typeof Explanation>;
+} satisfies WidgetExports<typeof Explanation>;

--- a/packages/perseus/src/widgets/expression/expression.tsx
+++ b/packages/perseus/src/widgets/expression/expression.tsx
@@ -558,4 +558,4 @@ export default {
         }
         return correctAnswers[0].value;
     },
-} as WidgetExports<typeof ExpressionWithDependencies>;
+} satisfies WidgetExports<typeof ExpressionWithDependencies>;

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
@@ -258,7 +258,7 @@ export default {
     hidden: false,
     tracking: "all",
     isLintable: true,
-} as WidgetExports<typeof GradedGroupSet>;
+} satisfies WidgetExports<typeof GradedGroupSet>;
 
 const styles = StyleSheet.create({
     top: {

--- a/packages/perseus/src/widgets/graded-group/graded-group.tsx
+++ b/packages/perseus/src/widgets/graded-group/graded-group.tsx
@@ -474,4 +474,4 @@ export default {
     hidden: false,
     tracking: "all",
     isLintable: true,
-} as WidgetExports<typeof GradedGroup>;
+} satisfies WidgetExports<typeof GradedGroup>;

--- a/packages/perseus/src/widgets/grapher/grapher.tsx
+++ b/packages/perseus/src/widgets/grapher/grapher.tsx
@@ -647,4 +647,4 @@ export default {
     transform: propTransform,
     staticTransform: staticTransform,
     validator: grapherValidator,
-} as WidgetExports<typeof Grapher>;
+} satisfies WidgetExports<typeof Grapher>;

--- a/packages/perseus/src/widgets/group/group.tsx
+++ b/packages/perseus/src/widgets/group/group.tsx
@@ -196,4 +196,4 @@ export default {
     traverseChildWidgets: traverseChildWidgets,
     hidden: true,
     isLintable: true,
-} as WidgetExports<typeof Group>;
+} satisfies WidgetExports<typeof Group>;

--- a/packages/perseus/src/widgets/iframe/iframe.tsx
+++ b/packages/perseus/src/widgets/iframe/iframe.tsx
@@ -167,4 +167,4 @@ export default {
     // Let's not expose it to all content creators yet
     hidden: true,
     validator: iframeValidator,
-} as WidgetExports<typeof Iframe>;
+} satisfies WidgetExports<typeof Iframe>;

--- a/packages/perseus/src/widgets/image/image.tsx
+++ b/packages/perseus/src/widgets/image/image.tsx
@@ -21,7 +21,7 @@ const defaultBackgroundImage = {
     height: 0,
 } as const;
 
-const editorAlignments = ["block", "full-width"];
+const editorAlignments = ["block", "full-width"] as const;
 
 const DEFAULT_ALIGNMENT = "block";
 
@@ -259,4 +259,4 @@ export default {
     isLintable: true,
     // TODO: things that aren't interactive shouldn't need validators
     validator: () => noopValidator(),
-} as WidgetExports<typeof ImageWidget>;
+} satisfies WidgetExports<typeof ImageWidget>;

--- a/packages/perseus/src/widgets/input-number/input-number.test.ts
+++ b/packages/perseus/src/widgets/input-number/input-number.test.ts
@@ -237,7 +237,7 @@ describe("input-number", function () {
         if (!transform) {
             throw new Error("transform not defined");
         }
-        const widgetProps = transform(editorProps, mockStrings);
+        const widgetProps = transform(editorProps);
         expect(_.has(widgetProps, "value")).toBe(false);
     });
 });

--- a/packages/perseus/src/widgets/input-number/input-number.tsx
+++ b/packages/perseus/src/widgets/input-number/input-number.tsx
@@ -284,4 +284,4 @@ export default {
         }
         return answerString;
     },
-} as WidgetExports<typeof InputNumber>;
+} satisfies WidgetExports<typeof InputNumber>;

--- a/packages/perseus/src/widgets/interaction/interaction.tsx
+++ b/packages/perseus/src/widgets/interaction/interaction.tsx
@@ -808,4 +808,4 @@ export default {
     hidden: true,
     // TODO: things that aren't interactive shouldn't need validators
     validator: () => noopValidator(),
-} as WidgetExports<typeof Interaction>;
+} satisfies WidgetExports<typeof Interaction>;

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -2390,4 +2390,4 @@ export default {
     widget: InteractiveGraph,
     staticTransform: staticTransform,
     validator: interactiveGraphValidator,
-} as WidgetExports<typeof InteractiveGraph>;
+} satisfies WidgetExports<typeof InteractiveGraph>;

--- a/packages/perseus/src/widgets/label-image/label-image.tsx
+++ b/packages/perseus/src/widgets/label-image/label-image.tsx
@@ -738,4 +738,4 @@ export default {
     accessible: true,
     isLintable: true,
     validator: labelImageValidator,
-} as WidgetExports<typeof LabelImageWithDependencies>;
+} satisfies WidgetExports<typeof LabelImageWithDependencies>;

--- a/packages/perseus/src/widgets/matcher/matcher.tsx
+++ b/packages/perseus/src/widgets/matcher/matcher.tsx
@@ -283,4 +283,4 @@ export default {
     widget: Matcher,
     isLintable: true,
     validator: matcherValidator,
-} as WidgetExports<typeof Matcher>;
+} satisfies WidgetExports<typeof Matcher>;

--- a/packages/perseus/src/widgets/matrix/matrix.tsx
+++ b/packages/perseus/src/widgets/matrix/matrix.tsx
@@ -564,4 +564,4 @@ export default {
     staticTransform: staticTransform,
     isLintable: true,
     validator: matrixValidator,
-} as WidgetExports<typeof Matrix>;
+} satisfies WidgetExports<typeof Matrix>;

--- a/packages/perseus/src/widgets/measurer/measurer.tsx
+++ b/packages/perseus/src/widgets/measurer/measurer.tsx
@@ -201,4 +201,4 @@ export default {
     propUpgrades: propUpgrades,
     // TODO: things that aren't interactive shouldn't need validators
     validator: () => noopValidator(1),
-} as WidgetExports<typeof Measurer>;
+} satisfies WidgetExports<typeof Measurer>;

--- a/packages/perseus/src/widgets/molecule/molecule.tsx
+++ b/packages/perseus/src/widgets/molecule/molecule.tsx
@@ -161,4 +161,4 @@ export default {
     hidden: true,
     widget: MoleculeWidget,
     validator: () => noopValidator(),
-} as WidgetExports<typeof MoleculeWidget>;
+} satisfies WidgetExports<typeof MoleculeWidget>;

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -800,4 +800,4 @@ export default {
     transform: numberLineTransform,
     staticTransform: staticTransform,
     validator: numberLineValidator,
-} as WidgetExports<typeof NumberLine>;
+} satisfies WidgetExports<typeof NumberLine>;

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
@@ -93,9 +93,6 @@ describe("static function getOneCorrectAnswerFromRubric", () => {
         const singleAnswer =
             NumericInputWidgetExport.getOneCorrectAnswerFromRubric?.({
                 answers,
-                labelText: "",
-                size: "medium",
-                static: false,
                 coefficient: false,
             });
         expect(singleAnswer).toBe("12.2");
@@ -109,9 +106,6 @@ describe("static function getOneCorrectAnswerFromRubric", () => {
         const singleAnswer =
             NumericInputWidgetExport.getOneCorrectAnswerFromRubric?.({
                 answers,
-                labelText: "",
-                size: "medium",
-                static: false,
                 coefficient: false,
             });
         expect(singleAnswer).toBe("1252");
@@ -122,9 +116,6 @@ describe("static function getOneCorrectAnswerFromRubric", () => {
         const singleAnswer =
             NumericInputWidgetExport.getOneCorrectAnswerFromRubric?.({
                 answers,
-                labelText: "",
-                size: "medium",
-                static: false,
                 coefficient: false,
             });
         expect(singleAnswer).toBeUndefined();

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
@@ -379,4 +379,4 @@ export default {
         }
         return answerStrings[0];
     },
-} as WidgetExports<typeof NumericInput>;
+} satisfies WidgetExports<typeof NumericInput>;

--- a/packages/perseus/src/widgets/orderer/orderer.tsx
+++ b/packages/perseus/src/widgets/orderer/orderer.tsx
@@ -791,4 +791,4 @@ export default {
     widget: Orderer,
     isLintable: true,
     validator: ordererValidator,
-} as WidgetExports<typeof Orderer>;
+} satisfies WidgetExports<typeof Orderer>;

--- a/packages/perseus/src/widgets/passage-ref-target/passage-ref-target.tsx
+++ b/packages/perseus/src/widgets/passage-ref-target/passage-ref-target.tsx
@@ -71,4 +71,4 @@ export default {
     isLintable: true,
     // TODO: things that aren't interactive shouldn't need validators
     validator: () => noopValidator(),
-} as WidgetExports<typeof PassageRefTarget>;
+} satisfies WidgetExports<typeof PassageRefTarget>;

--- a/packages/perseus/src/widgets/passage-ref/passage-ref.tsx
+++ b/packages/perseus/src/widgets/passage-ref/passage-ref.tsx
@@ -179,4 +179,4 @@ export default {
     version: {major: 0, minor: 1},
     // TODO: things that aren't interactive shouldn't need validators
     validator: () => noopValidator(),
-} as WidgetExports<typeof PassageRef>;
+} satisfies WidgetExports<typeof PassageRef>;

--- a/packages/perseus/src/widgets/passage/passage.tsx
+++ b/packages/perseus/src/widgets/passage/passage.tsx
@@ -559,4 +559,4 @@ export default {
     },
     isLintable: true,
     validator: () => noopValidator(),
-} as WidgetExports<typeof Passage>;
+} satisfies WidgetExports<typeof Passage>;

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
@@ -255,4 +255,4 @@ export default {
     displayName: "PhET Simulation",
     widget: PhetSimulation,
     isLintable: true,
-} as WidgetExports<typeof PhetSimulation>;
+} satisfies WidgetExports<typeof PhetSimulation>;

--- a/packages/perseus/src/widgets/plotter/plotter.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.tsx
@@ -1174,4 +1174,4 @@ export default {
     widget: Plotter,
     staticTransform: staticTransform,
     validator: plotterValidator,
-} as WidgetExports<typeof Plotter>;
+} satisfies WidgetExports<typeof Plotter>;

--- a/packages/perseus/src/widgets/python-program/python-program.tsx
+++ b/packages/perseus/src/widgets/python-program/python-program.tsx
@@ -83,4 +83,4 @@ export default {
     name: "python-program",
     displayName: "Python Program",
     widget: PythonProgram,
-} as WidgetExports<typeof PythonProgram>;
+} satisfies WidgetExports<typeof PythonProgram>;

--- a/packages/perseus/src/widgets/radio/radio.ts
+++ b/packages/perseus/src/widgets/radio/radio.ts
@@ -157,4 +157,4 @@ export default {
     propUpgrades: propUpgrades,
     isLintable: true,
     validator: radioValidator,
-} as WidgetExports<typeof Radio>;
+} satisfies WidgetExports<typeof Radio>;

--- a/packages/perseus/src/widgets/sorter/sorter.tsx
+++ b/packages/perseus/src/widgets/sorter/sorter.tsx
@@ -128,4 +128,4 @@ export default {
     widget: Sorter,
     isLintable: true,
     validator: sorterValidator,
-} as WidgetExports<typeof Sorter>;
+} satisfies WidgetExports<typeof Sorter>;

--- a/packages/perseus/src/widgets/table/table.tsx
+++ b/packages/perseus/src/widgets/table/table.tsx
@@ -325,4 +325,4 @@ export default {
     hidden: true,
     isLintable: true,
     validator: tableValidator,
-} as WidgetExports<typeof Table>;
+} satisfies WidgetExports<typeof Table>;

--- a/packages/perseus/src/widgets/video/video.tsx
+++ b/packages/perseus/src/widgets/video/video.tsx
@@ -118,4 +118,4 @@ export default {
     widget: Video,
     // TODO: things that aren't interactive shouldn't need validators
     validator: () => noopValidator(),
-} as WidgetExports<typeof Video>;
+} satisfies WidgetExports<typeof Video>;


### PR DESCRIPTION
## Summary:

While working on some docs for Perseus, I noticed that we're still using `as` for our `WidgetExports` objects. `as` isn't great as we lost type safety when we use it. Instead, I've migrated them all to use `satisfies` which tells TypeScript that we think the object conforms to the type but that it should make sure. 

In doing this, I found a few places where our code/types were wrong and fixed them.

Issue: "none"

## Test plan: