### PR TITLE
More architecture documentation

### DIFF
--- a/.changeset/healthy-years-dream.md
+++ b/.changeset/healthy-years-dream.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Introduce a PerseusArticle type

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,8 +36,8 @@ with a short description and the main Perseus data type it accepts.
 </thead>
 <tbody>
     <tr>
-        <td>`ServerItemRenderer`</td>
-        <td>`PerseusItem`</td>
+        <td><code>ServerItemRenderer</code></td>
+        <td><code>PerseusItem</code></td>
         <td>
             The main exercise renderer. This component is a convenience wrapper
             around the `Renderer`. It adds some management of displaying hints
@@ -45,8 +45,8 @@ with a short description and the main Perseus data type it accepts.
         </td>
     </tr>
     <tr>
-        <td>`ArticleRenderer`</td>
-        <td>`PerseusRenderer` or `PerseusRenderer[]`</td>
+        <td><code>ArticleRenderer</code></td>
+        <td><code>PerseusRenderer</code> or <code>PerseusRenderer[]</code></td>
         <td>
             A renderer for long-form, read-only content. This renderer is very
             similar to the `ServerItemRenderer` but cannot score any input
@@ -56,8 +56,8 @@ with a short description and the main Perseus data type it accepts.
         </td>
     </tr>
     <tr>
-        <td>`MultiItemRenderer`</td>
-        <td> `{ _multi: any }`</td>
+        <td><code>MultiItemRenderer</code></td>
+        <td> <code>{ _multi: any }</code></td>
         <td>
             The `MultiItemRenderer` is a more advanced renderer. It accepts an
             object representing a tree of `PerseusRenderer` objects. A `Shape`
@@ -67,8 +67,8 @@ with a short description and the main Perseus data type it accepts.
         </td>
     </tr>
     <tr>
-        <td>`Renderer`</td>
-        <td>`PerseusRenderer`</td>
+        <td><code>Renderer</code></td>
+        <td><code>PerseusRenderer</code></td>
         <td>
             This is the core renderer. It manages all aspects of rendering
             widgets and math content (TeX). It also contains all the knowledge
@@ -85,8 +85,9 @@ with a short description and the main Perseus data type it accepts.
 
 TBD
 
-Render <EditorPage />
-editorPage.serialize() -> PerseusItem
+1. Render <EditorPage />
+2. `onChange` callbacks as data is edited
+3. `editorPageRef.current.serialize()` -> `PerseusItem`
 
 ## Rendering
 
@@ -97,37 +98,112 @@ accept only well-formed Javascript objects.
 
 **_Rough Notes_**
 
-DB
+```
+-> DB
     -> PerseusItem
         -> <ServerItemRenderer item={item}
             -> <Renderer content={item.question.content}
                          widgets={item.question.widgets} />
+```
 
 For each widget in `.widgets` the `Renderer`:
 1. Runs each widget's options through any upgrade transforms (see
     `Widgets.upgradeWidgetInfoToLatestVersion()` and
-    `WidgetExports.propUpgrades`)
-1. Prepares upgraded props for rendering by applying the widget's
+    `WidgetExports.propUpgrades`). See [Prop Upgrades](#Prop_Upgrades) for more info
+1. Prepares upgraded opions for rendering by applying the widget's
     `transform()` or `staticTransform()` (if rendering with
-    `static: true`).
+    `static: true`). These functions map the widget options to the widget's
+    render Props.
+1. Prepares a full set of widget options by adding common props to the render
+   props (see `WidgetProps<T>` and the `Renderer`'s
+   [`getWidgetProps`](https://github.com/Khan/perseus/blob/c6ee2662a18e6703c3a7816d5fb89a70e0f9f50b/packages/perseus/src/renderer.tsx#L570)
+   function.
 1. Renders each widget found in `.content` passing the render props
     from the previous step to each widget's React component
 
-
 # Typescript Types and Conventions
+
+## `PerseusItem`
+
+The `PerseusItem` is the top level structure that the `ServerItemRenderer`
+accepts. You can think of the `PerseusItem` type as the "data schema" for
+Perseus exercise questions.
+
+## `PerseusArticle`
+
+A `PerseusArticle` is just a series of `PerseusRenderer` objects. It can be a
+single object, but most often it is an array of them. These are never scored.
+
+## `PerseusRenderer`
+
+The `PerseusRenderer` type is the core structure used by Perseus. It is
+rendered by the `Renderer` component and is used throught Perseus to render
+content (even within widgets).
 
 ## `WidgetExports<T>`
 
-Defines a widget. Includes the React component that implements the widget and
-any required data transforms and metadata.
+The `WidgetExports<T>` type defines a widget. This structure defines which
+React component implements the widget as well as any required data transforms
+and metadata. You can look up these exports by using the
+`getWidgetExport(widgetType)` function from `widgets.ts`.
 
+## `WidgetOptions<T>`
+
+All widget options are contained within common "header" object that is
+represented by `WidgetOptions<T>`. The `T` generic type in this case is the
+widget type name (ie. `dropdown`, `interactive-graph`, etc.).
+
+This type contains a `options` key which then contains the options specific to
+the widget.
+
+## Widget Options
+
+Each widget defines its set of options through an options type (always defined
+in `perseus-types.ts`.
+
+These can be thought of as the "schema" for the widget.
 
 ## React Types
 
-### `ExternalProps`
+Each widget is implemented as a React component. As is common with React, the
+component receives data via render props.
+
+The code strives to use the following conventions to shape the various concepts
+of props.
+
+### `WidgetProps<T>`
+
+All widgets receive a common set of props from the parent `Renderer` component
+(see
+[`getWidgetProps`](https://github.com/Khan/perseus/blob/c6ee2662a18e6703c3a7816d5fb89a70e0f9f50b/packages/perseus/src/renderer.tsx#L570)).
+This set of props is defined by the `WidgetProps<T>` type (`T` being the
+specific render props the widget uses).
 
 ### `RenderProps`
 
+The `RenderProps` type defines the props that are returned by the widget's
+`transform` and `staticTransform` functions. If these fucntions are not defined
+on the widget's `WidgetExport<T>` object, then `RenderProps` is synonymous with
+the widgets options type (ie. the type `T` wrapped in `WidgetOptions<T>` from
+`perseus-types.ts`).
+
+### `ExternalProps`
+
+In a few rare cases, this type is defined as the sum of RenderProps wrapped in
+`WidgetOptions`.
+
+### `Rubric`
+
+This type defines the data that the scoring function needs in order to score
+the learner's guess (aka user input).
+
+### `Props`
+
+Finally, `Props` form the entire set of props that widget's component supports.
+Typically it is defined as `type Props = WidgetProps<RenderProps, Rubric>`. In
+cases where there are `RenderProps` that are optional that are provided via
+`DefaultProps`, this `Props` type "redefines" these props as `myProp:
+NonNullable<ExternalProps["myProps"]>;`.
 
 # Scoring
 

--- a/packages/perseus/src/article-renderer.tsx
+++ b/packages/perseus/src/article-renderer.tsx
@@ -14,14 +14,14 @@ import {ClassNames as ApiClassNames, ApiOptions} from "./perseus-api";
 import Renderer from "./renderer";
 import Util from "./util";
 
-import type {PerseusRenderer} from "./perseus-types";
+import type {PerseusArticle, PerseusRenderer} from "./perseus-types";
 import type {PerseusDependenciesV2, SharedRendererProps} from "./types";
 import type {KeypadAPI} from "@khanacademy/math-input";
 import type {KeypadContextRendererInterface} from "@khanacademy/perseus-core";
 
 type Props = Partial<React.ContextType<typeof DependenciesContext>> &
     SharedRendererProps & {
-        json: PerseusRenderer | ReadonlyArray<PerseusRenderer>;
+        json: PerseusArticle;
         // Whether to use the new Bibliotron styles for articles
         /**
          * @deprecated Does nothing

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -208,6 +208,7 @@ export type {
     CollinearTuple,
     MathFormat,
     InputNumberWidget, // TODO(jeremy): remove?
+    PerseusArticle,
     // Widget configuration types
     PerseusImageBackground,
     PerseusInputNumberWidgetOptions,

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -100,6 +100,12 @@ export type PerseusItem = {
 };
 
 /**
+ * A "PerseusArticle" is an item that is meant to be rendered as an article.
+ * This item is never scored and is rendered by the `ArticleRenderer`.
+ */
+export type PerseusArticle = PerseusRenderer | ReadonlyArray<PerseusRenderer>;
+
+/**
  * A "MultiItem" is an advanced Perseus item. It is rendered by the
  * `MultiRenderer` and you can control the layout of individual parts of the
  * item.

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -375,9 +375,9 @@ class Renderer extends React.Component<Props, State> {
         // WidgetContainers don't update their widgets' props when
         // they are re-rendered, so even if they've been
         // re-rendered we need to call these methods on them.
-        _.each(this.widgetIds, (id) => {
+        this.widgetIds.forEach((id) => {
             const container = this._widgetContainers.get(makeContainerId(id));
-            container && container.replaceWidgetProps(this.getWidgetProps(id));
+            container?.replaceWidgetProps(this.getWidgetProps(id));
         });
 
         if (
@@ -567,15 +567,13 @@ class Renderer extends React.Component<Props, State> {
         return null;
     };
 
-    getWidgetProps: (id: string) => WidgetProps<any, PerseusWidgetOptions> = (
-        id,
-    ) => {
+    getWidgetProps(widgetId: string): WidgetProps<any, PerseusWidgetOptions> {
         const apiOptions = this.getApiOptions();
-        const widgetProps = this.state.widgetProps[id] || {};
+        const widgetProps = this.state.widgetProps[widgetId] || {};
 
         // The widget needs access to its "rubric" at all times when in review
         // mode (which is really just part of its widget info).
-        const widgetInfo = this.state.widgetInfo[id];
+        const widgetInfo = this.state.widgetInfo[widgetId];
         const reviewModeRubric =
             this.props.reviewMode && widgetInfo ? widgetInfo.options : null;
 
@@ -583,20 +581,20 @@ class Renderer extends React.Component<Props, State> {
             this._interactionTrackers = {};
         }
 
-        let interactionTracker = this._interactionTrackers[id];
+        let interactionTracker = this._interactionTrackers[widgetId];
         if (!interactionTracker) {
-            interactionTracker = this._interactionTrackers[id] =
+            interactionTracker = this._interactionTrackers[widgetId] =
                 new InteractionTracker(
                     apiOptions.trackInteraction,
                     widgetInfo && widgetInfo.type,
-                    id,
+                    widgetId,
                     Widgets.getTracking(widgetInfo && widgetInfo.type),
                 );
         }
 
         return {
             ...widgetProps,
-            widgetId: id,
+            widgetId: widgetId,
             alignment: widgetInfo && widgetInfo.alignment,
             static: widgetInfo?.static,
             problemNum: this.props.problemNum,
@@ -604,18 +602,18 @@ class Renderer extends React.Component<Props, State> {
             keypadElement: this.props.keypadElement,
             questionCompleted: this.props.questionCompleted,
             showSolutions: this.props.showSolutions,
-            onFocus: _.partial(this._onWidgetFocus, id),
-            onBlur: _.partial(this._onWidgetBlur, id),
+            onFocus: _.partial(this._onWidgetFocus, widgetId),
+            onBlur: _.partial(this._onWidgetBlur, widgetId),
             findWidgets: this.findWidgets,
             reviewModeRubric: reviewModeRubric,
             reviewMode: this.props.reviewMode,
             onChange: (newProps, cb, silent = false) => {
-                this._setWidgetProps(id, newProps, cb, silent);
+                this._setWidgetProps(widgetId, newProps, cb, silent);
             },
             trackInteraction: interactionTracker.track,
-            isLastUsedWidget: id === this.state.lastUsedWidgetId,
+            isLastUsedWidget: widgetId === this.state.lastUsedWidgetId,
         };
-    };
+    }
 
     /**
      * Serializes the questions state so it can be recovered.


### PR DESCRIPTION
## Summary:

This PR adds a bit more to the architecture documentation. I've tried to explain some of our type conventions for widgets and how `WidgetProps` is fulfilled for widgets.

While doing this documentation, I realized that we don't have any type that represents the concept of an Article. Although it's simply a `PerseusRenderer` or `ReadonlyArray<PerseusRenderer>` I thought it worthwhile to add. 

Issue: "none"

## Test plan: