### PR TITLE
Pursuant to ADR 773, add parsers for remaining widgets

### DIFF
--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/graded-group-set-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/graded-group-set-widget.ts
@@ -1,0 +1,13 @@
+import {array, constant, object} from "../general-purpose-parsers";
+
+import {parseGradedGroupWidgetOptions} from "./graded-group-widget";
+import {parseWidget} from "./widget";
+
+import type {GradedGroupSetWidget} from "../../../perseus-types";
+import type {Parser} from "../parser-types";
+
+export const parseGradedGroupSetWidget: Parser<GradedGroupSetWidget> =
+    parseWidget(
+        constant("graded-group-set"),
+        object({gradedGroups: array(parseGradedGroupWidgetOptions)}),
+    );

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/graded-group-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/graded-group-widget.ts
@@ -16,30 +16,32 @@ import {parseWidgetsMap} from "./widgets-map";
 import type {GradedGroupWidget} from "../../../perseus-types";
 import type {Parser} from "../parser-types";
 
+export const parseGradedGroupWidgetOptions = object({
+    title: string,
+    hasHint: optional(nullable(boolean)),
+    // This module has an import cycle with parsePerseusRenderer.
+    // The anonymous function below ensures that we don't try to access
+    // parsePerseusRenderer before it's defined.
+    hint: optional(
+        nullable((rawVal, ctx) => parsePerseusRenderer(rawVal, ctx)),
+    ),
+    content: string,
+    // This module has an import cycle with parseWidgetsMap.
+    // The anonymous function below ensures that we don't try to access
+    // parseWidgetsMap before it's defined.
+    widgets: (rawVal, ctx) => parseWidgetsMap(rawVal, ctx),
+    widgetEnabled: optional(nullable(boolean)),
+    immutableWidgets: optional(nullable(boolean)),
+    images: record(
+        string,
+        object({
+            width: number,
+            height: number,
+        }),
+    ),
+});
+
 export const parseGradedGroupWidget: Parser<GradedGroupWidget> = parseWidget(
     constant("graded-group"),
-    object({
-        title: string,
-        hasHint: optional(nullable(boolean)),
-        // This module has an import cycle with parsePerseusRenderer.
-        // The anonymous function below ensures that we don't try to access
-        // parsePerseusRenderer before it's defined.
-        hint: optional(
-            nullable((rawVal, ctx) => parsePerseusRenderer(rawVal, ctx)),
-        ),
-        content: string,
-        // This module has an import cycle with parseWidgetsMap.
-        // The anonymous function below ensures that we don't try to access
-        // parseWidgetsMap before it's defined.
-        widgets: (rawVal, ctx) => parseWidgetsMap(rawVal, ctx),
-        widgetEnabled: optional(nullable(boolean)),
-        immutableWidgets: optional(nullable(boolean)),
-        images: record(
-            string,
-            object({
-                width: number,
-                height: number,
-            }),
-        ),
-    }),
+    parseGradedGroupWidgetOptions,
 );

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/graded-group-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/graded-group-widget.ts
@@ -1,0 +1,45 @@
+import {
+    boolean,
+    constant,
+    nullable,
+    number,
+    object,
+    optional,
+    record,
+    string,
+} from "../general-purpose-parsers";
+
+import {parsePerseusRenderer} from "./perseus-renderer";
+import {parseWidget} from "./widget";
+import {parseWidgetsMap} from "./widgets-map";
+
+import type {GradedGroupWidget} from "../../../perseus-types";
+import type {Parser} from "../parser-types";
+
+export const parseGradedGroupWidget: Parser<GradedGroupWidget> = parseWidget(
+    constant("graded-group"),
+    object({
+        title: string,
+        hasHint: optional(nullable(boolean)),
+        // This module has an import cycle with parsePerseusRenderer.
+        // The anonymous function below ensures that we don't try to access
+        // parsePerseusRenderer before it's defined.
+        hint: optional(
+            nullable((rawVal, ctx) => parsePerseusRenderer(rawVal, ctx)),
+        ),
+        content: string,
+        // This module has an import cycle with parseWidgetsMap.
+        // The anonymous function below ensures that we don't try to access
+        // parseWidgetsMap before it's defined.
+        widgets: (rawVal, ctx) => parseWidgetsMap(rawVal, ctx),
+        widgetEnabled: optional(nullable(boolean)),
+        immutableWidgets: optional(nullable(boolean)),
+        images: record(
+            string,
+            object({
+                width: number,
+                height: number,
+            }),
+        ),
+    }),
+);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/grapher-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/grapher-widget.ts
@@ -1,0 +1,109 @@
+import {
+    array,
+    boolean,
+    constant,
+    enumeration,
+    nullable,
+    number,
+    object,
+    optional,
+    pair,
+    string,
+    union,
+} from "../general-purpose-parsers";
+
+import {parseWidget} from "./widget";
+
+import type {GrapherWidget} from "../../../perseus-types";
+import type {Parser} from "../parser-types";
+
+const pairOfNumbers = pair(number, number);
+
+const pairOfPoints = pair(pairOfNumbers, pairOfNumbers);
+
+export const parseGrapherWidget: Parser<GrapherWidget> = parseWidget(
+    constant("grapher"),
+    object({
+        availableTypes: array(
+            enumeration(
+                "absolute_value",
+                "exponential",
+                "linear",
+                "logarithm",
+                "quadratic",
+                "sinusoid",
+                "tangent",
+            ),
+        ),
+        correct: union(
+            object({
+                type: constant("absolute_value"),
+                coords: pairOfPoints,
+            }),
+        )
+            .or(
+                object({
+                    type: constant("exponential"),
+                    asymptote: pairOfPoints,
+                    coords: pairOfPoints,
+                }),
+            )
+            .or(
+                object({
+                    type: constant("linear"),
+                    coords: pairOfPoints,
+                }),
+            )
+            .or(
+                object({
+                    type: constant("logarithm"),
+                    asymptote: pairOfPoints,
+                    coords: pairOfPoints,
+                }),
+            )
+            .or(
+                object({
+                    type: constant("quadratic"),
+                    coords: pairOfPoints,
+                }),
+            )
+            .or(
+                object({
+                    type: constant("sinusoid"),
+                    coords: pairOfPoints,
+                }),
+            )
+            .or(
+                object({
+                    type: constant("tangent"),
+                    coords: pairOfPoints,
+                }),
+            ).parser,
+        graph: object({
+            backgroundImage: object({
+                bottom: optional(number),
+                height: optional(number),
+                left: optional(number),
+                scale: optional(number),
+                url: optional(nullable(string)),
+                width: optional(number),
+            }),
+            box: optional(pairOfNumbers),
+            editableSettings: optional(
+                array(enumeration("graph", "snap", "image", "measure")),
+            ),
+            gridStep: optional(pairOfNumbers),
+            labels: pair(string, string),
+            markings: enumeration("graph", "none", "grid"),
+            range: pair(pairOfNumbers, pairOfNumbers),
+            rulerLabel: constant(""),
+            rulerTicks: number,
+            showProtractor: optional(boolean),
+            showRuler: optional(boolean),
+            showTooltips: optional(boolean),
+            snapStep: optional(pairOfNumbers),
+            step: pairOfNumbers,
+            valid: optional(union(boolean).or(string).parser),
+        }),
+    }),
+);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/group-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/group-widget.ts
@@ -1,0 +1,12 @@
+import {constant} from "../general-purpose-parsers";
+
+import {parsePerseusRenderer} from "./perseus-renderer";
+import {parseWidget} from "./widget";
+
+export const parseGroupWidget = parseWidget(
+    constant("group"),
+    // This module has an import cycle with parsePerseusRenderer.
+    // The anonymous function below ensures that we don't try to access
+    // parsePerseusRenderer before it's defined.
+    (rawVal, ctx) => parsePerseusRenderer(rawVal, ctx),
+);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/group-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/group-widget.ts
@@ -3,7 +3,10 @@ import {constant} from "../general-purpose-parsers";
 import {parsePerseusRenderer} from "./perseus-renderer";
 import {parseWidget} from "./widget";
 
-export const parseGroupWidget = parseWidget(
+import type {GroupWidget} from "../../../perseus-types";
+import type {Parser} from "../parser-types";
+
+export const parseGroupWidget: Parser<GroupWidget> = parseWidget(
     constant("group"),
     // This module has an import cycle with parsePerseusRenderer.
     // The anonymous function below ensures that we don't try to access

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/iframe-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/iframe-widget.ts
@@ -1,0 +1,28 @@
+import {
+    array,
+    boolean,
+    constant,
+    number,
+    object,
+    optional,
+    string,
+    union,
+} from "../general-purpose-parsers";
+
+import {parseWidget} from "./widget";
+
+import type {IFrameWidget} from "../../../perseus-types";
+import type {Parser} from "../parser-types";
+
+export const parseIframeWidget: Parser<IFrameWidget> = parseWidget(
+    constant("iframe"),
+    object({
+        url: string,
+        settings: array(object({name: string, value: string})),
+        width: union(number).or(string).parser,
+        height: union(number).or(string).parser,
+        allowFullScreen: boolean,
+        allowTopNavigation: optional(boolean),
+        static: boolean,
+    }),
+);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/image-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/image-widget.ts
@@ -1,0 +1,40 @@
+import {
+    array,
+    boolean,
+    constant,
+    number,
+    object,
+    optional,
+    pair,
+    string,
+} from "../general-purpose-parsers";
+
+import {parsePerseusImageBackground} from "./perseus-image-background";
+import {parseWidget} from "./widget";
+
+import type {ImageWidget} from "../../../perseus-types";
+import type {Parser} from "../parser-types";
+
+const pairOfNumbers = pair(number, number);
+
+export const parseImageWidget: Parser<ImageWidget> = parseWidget(
+    constant("image"),
+    object({
+        title: optional(string),
+        caption: optional(string),
+        alt: optional(string),
+        backgroundImage: parsePerseusImageBackground,
+        static: optional(boolean),
+        labels: optional(
+            array(
+                object({
+                    content: string,
+                    alignment: string,
+                    coordinates: array(number),
+                }),
+            ),
+        ),
+        range: optional(pair(pairOfNumbers, pairOfNumbers)),
+        box: optional(pairOfNumbers),
+    }),
+);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/input-number-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/input-number-widget.ts
@@ -1,0 +1,40 @@
+import {
+    boolean,
+    constant,
+    enumeration,
+    number,
+    object,
+    optional,
+    string,
+    union,
+} from "../general-purpose-parsers";
+
+import {parseWidget} from "./widget";
+
+import type {InputNumberWidget} from "../../../perseus-types";
+import type {Parser} from "../parser-types";
+
+export const parseInputNumberWidget: Parser<InputNumberWidget> = parseWidget(
+    constant("input-number"),
+    object({
+        answerType: optional(
+            enumeration(
+                "number",
+                "decimal",
+                "integer",
+                "rational",
+                "improper",
+                "mixed",
+                "percent",
+                "pi",
+            ),
+        ),
+        inexact: optional(boolean),
+        maxError: optional(union(number).or(string).parser),
+        rightAlign: optional(boolean),
+        simplify: enumeration("required", "optional", "enforced"),
+        size: enumeration("normal", "small"),
+        value: union(number).or(string).parser,
+        customKeypad: optional(boolean),
+    }),
+);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/interaction-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/interaction-widget.ts
@@ -1,0 +1,176 @@
+import {
+    array,
+    boolean,
+    constant,
+    enumeration,
+    number,
+    object,
+    optional, pair,
+    string,
+    union,
+} from "../general-purpose-parsers";
+
+import {parseWidget} from "./widget";
+
+import type {
+    InteractionWidget, PerseusInteractionElement
+} from "../../../perseus-types";
+import type {Parser} from "../parser-types";
+import {parsePerseusImageBackground} from "./perseus-image-background";
+
+const pairOfNumbers = pair(number, number);
+
+type FunctionElement = Extract<PerseusInteractionElement, {type: "function"}>;
+const parseFunctionElement: Parser<FunctionElement> = object({
+    type: constant("function"),
+    key: string,
+    options: object({
+        value: string,
+        funcName: string,
+        rangeMin: string,
+        rangeMax: string,
+        color: string,
+        strokeDasharray: string,
+        strokeWidth: number,
+    }),
+});
+
+type LabelElement = Extract<PerseusInteractionElement, {type: "label"}>;
+const parseLabelElement: Parser<LabelElement> = object({
+    type: constant("label"),
+    key: string,
+    options: object({
+        label: string,
+        color: string,
+        coordX: string,
+        coordY: string,
+    })
+})
+
+type LineElement = Extract<PerseusInteractionElement, {type: "line"}>;
+const parseLineElement: Parser<LineElement> = object({
+    type: constant("line"),
+    key: string,
+    options: object({
+        color: string,
+        startX: string,
+        startY: string,
+        endX: string,
+        endY: string,
+        strokeDasharray: string,
+        strokeWidth: number,
+        arrows: string,
+    }),
+})
+
+type MovableLineElement = Extract<PerseusInteractionElement, {type: "movable-line"}>;
+const parseMovableLineElement: Parser<MovableLineElement> = object({
+    type: constant("movable-line"),
+    key: string,
+    options: object({
+        startX: string,
+        startY: string,
+        startSubscript: number,
+        endX: string,
+        endY: string,
+        endSubscript: number,
+        constraint: string,
+        snap: number,
+        constraintFn: string,
+        constraintXMin: string,
+        constraintXMax: string,
+        constraintYMin: string,
+        constraintYMax: string,
+    }),
+})
+
+type MovablePointElement = Extract<PerseusInteractionElement, {type: "movable-point"}>;
+const parseMovablePointElement: Parser<MovablePointElement> = object({
+    type: constant("movable-point"),
+    key: string,
+    options: object({
+        startX: string,
+        startY: string,
+        varSubscript: number,
+        constraint: string,
+        snap: number,
+        constraintFn: string,
+        constraintXMin: string,
+        constraintXMax: string,
+        constraintYMin: string,
+        constraintYMax: string,
+    })
+})
+
+type ParametricElement = Extract<PerseusInteractionElement, {type: "parametric"}>;
+const parseParametricElement: Parser<ParametricElement> = object({
+    type: constant("parametric"),
+    key: string,
+    options: object({
+        x: string,
+        y: string,
+        rangeMin: string,
+        rangeMax: string,
+        color: string,
+        strokeDasharray: string,
+        strokeWidth: number,
+    })
+})
+
+type PointElement = Extract<PerseusInteractionElement, {type: "point"}>;
+const parsePointElement: Parser<PointElement> = object({
+    type: constant("point"),
+    key: string,
+    options: object({
+        color: string,
+        coordX: string,
+        coordY: string,
+    }),
+})
+
+type RectangleElement = Extract<PerseusInteractionElement, {type: "rectangle"}>;
+const parseRectangleElement: Parser<RectangleElement> = object({
+    type: constant("rectangle"),
+    key: string,
+    options: object({
+        color: string,
+        coordX: string,
+        coordY: string,
+        width: string,
+        height: string,
+    }),
+})
+
+export const parseInteractionWidget: Parser<InteractionWidget> = parseWidget(
+    constant("interaction"),
+    object({
+        static: boolean,
+        graph: object({
+            editableSettings: optional(array(enumeration("canvas", "graph"))),
+            box: pairOfNumbers,
+            labels: array(string),
+            range: pair(pairOfNumbers, pairOfNumbers),
+            gridStep: pairOfNumbers,
+            markings: enumeration("graph", "grid", "none"),
+            snapStep: optional(pairOfNumbers),
+            valid: optional(union(boolean).or(string).parser),
+            backgroundImage: optional(parsePerseusImageBackground),
+            showProtractor: optional(boolean),
+            showRuler: optional(boolean),
+            rulerLabel: optional(string),
+            rulerTicks: optional(number),
+            tickStep: pairOfNumbers,
+        }),
+        elements: array(
+            union(parseFunctionElement)
+                .or(parseLabelElement)
+                .or(parseLineElement)
+                .or(parseMovableLineElement)
+                .or(parseMovablePointElement)
+                .or(parseParametricElement)
+                .or(parsePointElement)
+                .or(parseRectangleElement)
+                .parser
+        )
+    }),
+);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/interaction-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/interaction-widget.ts
@@ -5,18 +5,20 @@ import {
     enumeration,
     number,
     object,
-    optional, pair,
+    optional,
+    pair,
     string,
     union,
 } from "../general-purpose-parsers";
 
+import {parsePerseusImageBackground} from "./perseus-image-background";
 import {parseWidget} from "./widget";
 
 import type {
-    InteractionWidget, PerseusInteractionElement
+    InteractionWidget,
+    PerseusInteractionElement,
 } from "../../../perseus-types";
 import type {Parser} from "../parser-types";
-import {parsePerseusImageBackground} from "./perseus-image-background";
 
 const pairOfNumbers = pair(number, number);
 
@@ -44,8 +46,8 @@ const parseLabelElement: Parser<LabelElement> = object({
         color: string,
         coordX: string,
         coordY: string,
-    })
-})
+    }),
+});
 
 type LineElement = Extract<PerseusInteractionElement, {type: "line"}>;
 const parseLineElement: Parser<LineElement> = object({
@@ -61,9 +63,12 @@ const parseLineElement: Parser<LineElement> = object({
         strokeWidth: number,
         arrows: string,
     }),
-})
+});
 
-type MovableLineElement = Extract<PerseusInteractionElement, {type: "movable-line"}>;
+type MovableLineElement = Extract<
+    PerseusInteractionElement,
+    {type: "movable-line"}
+>;
 const parseMovableLineElement: Parser<MovableLineElement> = object({
     type: constant("movable-line"),
     key: string,
@@ -82,9 +87,12 @@ const parseMovableLineElement: Parser<MovableLineElement> = object({
         constraintYMin: string,
         constraintYMax: string,
     }),
-})
+});
 
-type MovablePointElement = Extract<PerseusInteractionElement, {type: "movable-point"}>;
+type MovablePointElement = Extract<
+    PerseusInteractionElement,
+    {type: "movable-point"}
+>;
 const parseMovablePointElement: Parser<MovablePointElement> = object({
     type: constant("movable-point"),
     key: string,
@@ -99,10 +107,13 @@ const parseMovablePointElement: Parser<MovablePointElement> = object({
         constraintXMax: string,
         constraintYMin: string,
         constraintYMax: string,
-    })
-})
+    }),
+});
 
-type ParametricElement = Extract<PerseusInteractionElement, {type: "parametric"}>;
+type ParametricElement = Extract<
+    PerseusInteractionElement,
+    {type: "parametric"}
+>;
 const parseParametricElement: Parser<ParametricElement> = object({
     type: constant("parametric"),
     key: string,
@@ -114,8 +125,8 @@ const parseParametricElement: Parser<ParametricElement> = object({
         color: string,
         strokeDasharray: string,
         strokeWidth: number,
-    })
-})
+    }),
+});
 
 type PointElement = Extract<PerseusInteractionElement, {type: "point"}>;
 const parsePointElement: Parser<PointElement> = object({
@@ -126,7 +137,7 @@ const parsePointElement: Parser<PointElement> = object({
         coordX: string,
         coordY: string,
     }),
-})
+});
 
 type RectangleElement = Extract<PerseusInteractionElement, {type: "rectangle"}>;
 const parseRectangleElement: Parser<RectangleElement> = object({
@@ -139,7 +150,7 @@ const parseRectangleElement: Parser<RectangleElement> = object({
         width: string,
         height: string,
     }),
-})
+});
 
 export const parseInteractionWidget: Parser<InteractionWidget> = parseWidget(
     constant("interaction"),
@@ -169,8 +180,7 @@ export const parseInteractionWidget: Parser<InteractionWidget> = parseWidget(
                 .or(parseMovablePointElement)
                 .or(parseParametricElement)
                 .or(parsePointElement)
-                .or(parseRectangleElement)
-                .parser
-        )
+                .or(parseRectangleElement).parser,
+        ),
     }),
 );

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/label-image-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/label-image-widget.ts
@@ -1,0 +1,35 @@
+import {
+    array,
+    boolean,
+    constant,
+    number,
+    object,
+    string,
+} from "../general-purpose-parsers";
+
+import {parseWidget} from "./widget";
+
+import type {LabelImageWidget} from "../../../perseus-types";
+import type {Parser} from "../parser-types";
+
+export const parseLabelImageWidget: Parser<LabelImageWidget> = parseWidget(
+    constant("label-image"),
+    object({
+        choices: array(string),
+        imageUrl: string,
+        imageAlt: string,
+        imageHeight: number,
+        imageWidth: number,
+        markers: array(
+            object({
+                answers: array(string),
+                label: string,
+                x: number,
+                y: number,
+            }),
+        ),
+        hideChoicesFromInstructions: boolean,
+        multipleAnswers: boolean,
+        static: boolean,
+    }),
+);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/matcher-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/matcher-widget.ts
@@ -1,0 +1,23 @@
+import {
+    array,
+    boolean,
+    constant,
+    object,
+    string,
+} from "../general-purpose-parsers";
+
+import {parseWidget} from "./widget";
+
+import type {MatcherWidget} from "../../../perseus-types";
+import type {Parser} from "../parser-types";
+
+export const parseMatcherWidget: Parser<MatcherWidget> = parseWidget(
+    constant("matcher"),
+    object({
+        labels: array(string),
+        left: array(string),
+        right: array(string),
+        orderMatters: boolean,
+        padding: boolean,
+    }),
+);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/matrix-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/matrix-widget.ts
@@ -1,0 +1,25 @@
+import {
+    array,
+    boolean,
+    constant,
+    number,
+    object,
+    string,
+} from "../general-purpose-parsers";
+
+import {parseWidget} from "./widget";
+
+import type {MatrixWidget} from "../../../perseus-types";
+import type {Parser} from "../parser-types";
+
+export const parseMatrixWidget: Parser<MatrixWidget> = parseWidget(
+    constant("matrix"),
+    object({
+        prefix: string,
+        suffix: string,
+        answers: array(array(number)),
+        cursorPosition: array(number),
+        matrixBoardSize: array(number),
+        static: boolean,
+    }),
+);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/measurer-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/measurer-widget.ts
@@ -1,0 +1,29 @@
+import {
+    boolean,
+    constant,
+    number,
+    object,
+    pair,
+    string,
+} from "../general-purpose-parsers";
+
+import {parsePerseusImageBackground} from "./perseus-image-background";
+import {parseWidget} from "./widget";
+
+import type {MeasurerWidget} from "../../../perseus-types";
+import type {Parser} from "../parser-types";
+
+export const parseMeasurerWidget: Parser<MeasurerWidget> = parseWidget(
+    constant("measurer"),
+    object({
+        image: parsePerseusImageBackground,
+        showProtractor: boolean,
+        showRuler: boolean,
+        rulerLabel: string,
+        rulerTicks: number,
+        rulerPixels: number,
+        rulerLength: number,
+        box: pair(number, number),
+        static: boolean,
+    }),
+);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/molecule-renderer-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/molecule-renderer-widget.ts
@@ -1,0 +1,22 @@
+import {
+    constant,
+    object,
+    string,
+    number,
+    optional,
+} from "../general-purpose-parsers";
+
+import {parseWidget} from "./widget";
+
+import type {MoleculeRendererWidget} from "../../../perseus-types";
+import type {Parser} from "../parser-types";
+
+export const parseMoleculeRendererWidget: Parser<MoleculeRendererWidget> =
+    parseWidget(
+        constant("molecule-renderer"),
+        object({
+            widgetId: string,
+            rotationAngle: optional(number),
+            smiles: optional(string),
+        }),
+    );

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/number-line-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/number-line-widget.ts
@@ -1,0 +1,35 @@
+import {
+    constant,
+    object,
+    array,
+    number,
+    string,
+    boolean,
+    optional,
+    nullable,
+} from "../general-purpose-parsers";
+
+import {parseWidget} from "./widget";
+
+import type {NumberLineWidget} from "../../../perseus-types";
+import type {Parser} from "../parser-types";
+
+export const parseNumberLineWidget: Parser<NumberLineWidget> = parseWidget(
+    constant("number-line"),
+    object({
+        range: array(number),
+        labelRange: array(nullable(number)),
+        labelStyle: string,
+        labelTicks: boolean,
+        isTickCtrl: optional(nullable(boolean)),
+        divisionRange: array(number),
+        numDivisions: optional(nullable(number)),
+        snapDivisions: number,
+        tickStep: optional(nullable(number)),
+        correctRel: optional(nullable(string)),
+        correctX: number,
+        initialX: optional(nullable(number)),
+        showTooltip: optional(boolean),
+        static: boolean,
+    }),
+);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/numeric-input-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/numeric-input-widget.ts
@@ -1,0 +1,65 @@
+import {
+    constant,
+    object,
+    array,
+    string,
+    number,
+    optional,
+    enumeration,
+    boolean,
+    nullable,
+} from "../general-purpose-parsers";
+
+import {parseWidget} from "./widget";
+
+import type {NumericInputWidget} from "../../../perseus-types";
+import type {Parser} from "../parser-types";
+
+const parseMathFormat = enumeration(
+    "integer",
+    "mixed",
+    "improper",
+    "proper",
+    "decimal",
+    "percent",
+    "pi",
+);
+
+export const parseNumericInputWidget: Parser<NumericInputWidget> = parseWidget(
+    constant("numeric-input"),
+    object({
+        answers: array(
+            object({
+                message: string,
+                value: number,
+                status: string,
+                answerForms: optional(array(parseMathFormat)),
+                strict: boolean,
+                maxError: optional(nullable(number)),
+                simplify: optional(nullable(string)),
+            }),
+        ),
+        labelText: string,
+        size: string,
+        coefficient: boolean,
+        rightAlign: optional(boolean),
+        static: boolean,
+        answerForms: optional(
+            array(
+                object({
+                    name: parseMathFormat,
+                    simplify: optional(
+                        nullable(
+                            enumeration(
+                                "required",
+                                "correct",
+                                "enforced",
+                                "optional",
+                            ),
+                        ),
+                    ),
+                }),
+            ),
+        ),
+    }),
+);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/orderer-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/orderer-widget.ts
@@ -1,0 +1,25 @@
+import {array, constant, object, string} from "../general-purpose-parsers";
+
+import {parsePerseusRenderer} from "./perseus-renderer";
+import {parseWidget} from "./widget";
+
+import type {OrdererWidget} from "../../../perseus-types";
+import type {Parser} from "../parser-types";
+
+// There is an import cycle between orderer-widget.ts and perseus-renderer.ts.
+// This wrapper ensures that we don't refer to parsePerseusRenderer before
+// it's defined.
+function parseRenderer(rawValue, ctx) {
+    return parsePerseusRenderer(rawValue, ctx);
+}
+
+export const parseOrdererWidget: Parser<OrdererWidget> = parseWidget(
+    constant("orderer"),
+    object({
+        options: array(parseRenderer),
+        correctOptions: array(parseRenderer),
+        otherOptions: array(parseRenderer),
+        height: string,
+        layout: string,
+    }),
+);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/passage-ref-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/passage-ref-widget.ts
@@ -1,0 +1,15 @@
+import {constant, object, string, number} from "../general-purpose-parsers";
+
+import {parseWidget} from "./widget";
+
+import type {PassageRefWidget} from "../../../perseus-types";
+import type {Parser} from "../parser-types";
+
+export const parsePassageRefWidget: Parser<PassageRefWidget> = parseWidget(
+    constant("passage-ref"),
+    object({
+        passageNumber: number,
+        referenceNumber: number,
+        summaryText: string,
+    }),
+);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/passage-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/passage-widget.ts
@@ -1,0 +1,17 @@
+import {constant, object, string, boolean} from "../general-purpose-parsers";
+
+import {parseWidget} from "./widget";
+
+import type {PassageWidget} from "../../../perseus-types";
+import type {Parser} from "../parser-types";
+
+export const parsePassageWidget: Parser<PassageWidget> = parseWidget(
+    constant("passage"),
+    object({
+        footnotes: string,
+        passageText: string,
+        passageTitle: string,
+        showLineNumbers: boolean,
+        static: boolean,
+    }),
+);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/perseus-renderer.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/perseus-renderer.ts
@@ -14,7 +14,11 @@ import type {Parser} from "../parser-types";
 
 export const parsePerseusRenderer: Parser<PerseusRenderer> = object({
     content: string,
-    widgets: parseWidgetsMap,
+    // This module has an import cycle with parseWidgetsMap, because the
+    // `group` widget can contain another renderer.
+    // The anonymous function below ensures that we don't try to access
+    // parseWidgetsMap before it's defined.
+    widgets: (rawVal, ctx) => parseWidgetsMap(rawVal, ctx),
     metadata: optional(array(string)),
     images: record(
         string,

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/phet-simulation-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/phet-simulation-widget.ts
@@ -1,0 +1,15 @@
+import {constant, object, string} from "../general-purpose-parsers";
+
+import {parseWidget} from "./widget";
+
+import type {PhetSimulationWidget} from "../../../perseus-types";
+import type {Parser} from "../parser-types";
+
+export const parsePhetSimulationWidget: Parser<PhetSimulationWidget> =
+    parseWidget(
+        constant("phet-simulation"),
+        object({
+            url: string,
+            description: string,
+        }),
+    );

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/plotter-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/plotter-widget.ts
@@ -1,0 +1,35 @@
+import {plotterPlotTypes} from "../../../perseus-types";
+import {
+    constant,
+    object,
+    string,
+    array,
+    number,
+    optional,
+    nullable,
+    enumeration,
+} from "../general-purpose-parsers";
+
+import {parseWidget} from "./widget";
+
+import type {PlotterWidget} from "../../../perseus-types";
+import type {Parser} from "../parser-types";
+
+export const parsePlotterWidget: Parser<PlotterWidget> = parseWidget(
+    constant("plotter"),
+    object({
+        labels: array(string),
+        categories: array(string),
+        type: enumeration(...plotterPlotTypes),
+        maxY: number,
+        scaleY: number,
+        labelInterval: optional(nullable(number)),
+        snapsPerLine: number,
+        starting: array(number),
+        correct: array(number),
+        picUrl: optional(nullable(string)),
+        picSize: optional(nullable(number)),
+        picBoxHeight: optional(nullable(number)),
+        plotDimensions: array(number),
+    }),
+);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/python-program-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/python-program-widget.ts
@@ -1,0 +1,15 @@
+import {constant, object, string, number} from "../general-purpose-parsers";
+
+import {parseWidget} from "./widget";
+
+import type {PythonProgramWidget} from "../../../perseus-types";
+import type {Parser} from "../parser-types";
+
+export const parsePythonProgramWidget: Parser<PythonProgramWidget> =
+    parseWidget(
+        constant("python-program"),
+        object({
+            programID: string,
+            height: number,
+        }),
+    );

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/radio-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/radio-widget.ts
@@ -1,0 +1,48 @@
+import {
+    any,
+    array,
+    boolean,
+    constant,
+    object,
+    optional,
+    string,
+} from "../general-purpose-parsers";
+
+import {parseWidget} from "./widget";
+import {parseWidgetsMap} from "./widgets-map";
+
+import type {RadioWidget} from "../../../perseus-types";
+import type {Parser} from "../parser-types";
+
+export const parseRadioWidget: Parser<RadioWidget> = parseWidget(
+    constant("radio"),
+    object({
+        choices: array(
+            object({
+                content: string,
+                clue: optional(string),
+                correct: optional(boolean),
+                isNoneOfTheAbove: optional(boolean),
+                // deprecated
+                // There is an import cycle between radio-widget.ts and
+                // widgets-map.ts. The anonymous function below ensures that we
+                // don't refer to parseWidgetsMap before it's defined.
+                widgets: optional((rawVal, ctx) =>
+                    parseWidgetsMap(rawVal, ctx),
+                ),
+            }),
+        ),
+        hasNoneOfTheAbove: optional(boolean),
+        countChoices: optional(boolean),
+        randomize: optional(boolean),
+        multipleSelect: optional(boolean),
+        deselectEnabled: optional(boolean),
+        // deprecated
+        onePerLine: optional(boolean),
+        // deprecated
+        displayCount: optional(any),
+        // v0 props
+        // `noneOfTheAbove` is still in use (but only set to `false`).
+        noneOfTheAbove: constant(false),
+    }),
+);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/sorter-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/sorter-widget.ts
@@ -1,0 +1,16 @@
+import {array, boolean, constant, enumeration, object, string} from "../general-purpose-parsers";
+
+import {parseWidget} from "./widget";
+
+import type {SorterWidget} from "../../../perseus-types";
+import type {Parser} from "../parser-types";
+
+export const parseSorterWidget: Parser<SorterWidget> =
+    parseWidget(
+        constant("sorter"),
+        object({
+            correct: array(string),
+            padding: boolean,
+            layout: enumeration("horizontal", "vertical"),
+        }),
+    );

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/sorter-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/sorter-widget.ts
@@ -1,16 +1,22 @@
-import {array, boolean, constant, enumeration, object, string} from "../general-purpose-parsers";
+import {
+    array,
+    boolean,
+    constant,
+    enumeration,
+    object,
+    string,
+} from "../general-purpose-parsers";
 
 import {parseWidget} from "./widget";
 
 import type {SorterWidget} from "../../../perseus-types";
 import type {Parser} from "../parser-types";
 
-export const parseSorterWidget: Parser<SorterWidget> =
-    parseWidget(
-        constant("sorter"),
-        object({
-            correct: array(string),
-            padding: boolean,
-            layout: enumeration("horizontal", "vertical"),
-        }),
-    );
+export const parseSorterWidget: Parser<SorterWidget> = parseWidget(
+    constant("sorter"),
+    object({
+        correct: array(string),
+        padding: boolean,
+        layout: enumeration("horizontal", "vertical"),
+    }),
+);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/table-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/table-widget.ts
@@ -1,17 +1,22 @@
-import {array, number, constant, object, string} from "../general-purpose-parsers";
+import {
+    array,
+    number,
+    constant,
+    object,
+    string,
+} from "../general-purpose-parsers";
 
 import {parseWidget} from "./widget";
 
 import type {TableWidget} from "../../../perseus-types";
 import type {Parser} from "../parser-types";
 
-export const parseTableWidget: Parser<TableWidget> =
-    parseWidget(
-        constant("table"),
-        object({
-            headers: array(string),
-            rows: number,
-            columns: number,
-            answers: array(array(string)),
-        }),
-    );
+export const parseTableWidget: Parser<TableWidget> = parseWidget(
+    constant("table"),
+    object({
+        headers: array(string),
+        rows: number,
+        columns: number,
+        answers: array(array(string)),
+    }),
+);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/table-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/table-widget.ts
@@ -1,0 +1,17 @@
+import {array, number, constant, object, string} from "../general-purpose-parsers";
+
+import {parseWidget} from "./widget";
+
+import type {TableWidget} from "../../../perseus-types";
+import type {Parser} from "../parser-types";
+
+export const parseTableWidget: Parser<TableWidget> =
+    parseWidget(
+        constant("table"),
+        object({
+            headers: array(string),
+            rows: number,
+            columns: number,
+            answers: array(array(string)),
+        }),
+    );

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/video-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/video-widget.ts
@@ -1,0 +1,20 @@
+import {
+    constant,
+    object,
+    string,
+    boolean,
+    optional,
+} from "../general-purpose-parsers";
+
+import {parseWidget} from "./widget";
+
+import type {VideoWidget} from "../../../perseus-types";
+import type {Parser} from "../parser-types";
+
+export const parseVideoWidget: Parser<VideoWidget> = parseWidget(
+    constant("video"),
+    object({
+        location: string,
+        static: optional(boolean),
+    }),
+);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -311,9 +311,25 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
+    it("accepts an input-number widget", () => {
+        const widgetsMap: unknown = {
+            "input-number 1": {
+                type: "input-number",
+                version: {major: 0, minor: 0},
+                options: {
+                    simplify: "required",
+                    size: "normal",
+                    value: "",
+                },
+            },
+        };
+
+        const result = parseWidgetsMap(widgetsMap, ctx());
+
+        expect(result).toEqual(success(widgetsMap));
+    });
+
     // TODO:
-    //  image: ImageWidget;
-    //  input-number: InputNumberWidget;
     //  interaction: InteractionWidget;
     //  interactive-graph: InteractiveGraphWidget;
     //  label-image: LabelImageWidget;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -251,8 +251,30 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
+    it("accepts a graded-group-set widget", () => {
+        const widgetsMap: unknown = {
+            "graded-group-set 1": {
+                type: "graded-group-set",
+                version: {major: 0, minor: 0},
+                options: {
+                    gradedGroups: [
+                        {
+                            title: "",
+                            content: "",
+                            widgets: {},
+                            images: {},
+                        },
+                    ],
+                },
+            },
+        };
+
+        const result = parseWidgetsMap(widgetsMap, ctx());
+
+        expect(result).toEqual(success(widgetsMap));
+    });
+
     // TODO:
-    //  graded-group-set: GradedGroupSetWidget;
     //  iframe: IFrameWidget;
     //  image: ImageWidget;
     //  input-number: InputNumberWidget;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -561,8 +561,24 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
+    it("accepts a phet-simulation widget", () => {
+        const widgetsMap: unknown = {
+            "phet-simulation 1": {
+                type: "phet-simulation",
+                version: {major: 0, minor: 0},
+                options: {
+                    url: "",
+                    description: "",
+                },
+            },
+        };
+
+        const result = parse(widgetsMap, parseWidgetsMap);
+
+        expect(result).toEqual(success(widgetsMap));
+    });
+
     // TODO:
-    //  phet-simulation: PhetSimulationWidget;
     //  plotter: PlotterWidget;
     //  python-program: PythonProgramWidget;
     //  radio: RadioWidget;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -420,8 +420,31 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
+    it("accepts a measurer widget", () => {
+        const widgetsMap: unknown = {
+            "measurer 1": {
+                type: "measurer",
+                version: {major: 0, minor: 0},
+                options: {
+                    image: {},
+                    showProtractor: false,
+                    showRuler: false,
+                    rulerLabel: "",
+                    rulerTicks: 1,
+                    rulerPixels: 1,
+                    rulerLength: 1,
+                    box: [1, 1],
+                    static: false,
+                },
+            },
+        };
+
+        const result = parse(widgetsMap, parseWidgetsMap);
+
+        expect(result).toEqual(success(widgetsMap));
+    });
+
     // TODO:
-    //  measurer: MeasurerWidget;
     //  molecule-renderer: MoleculeRendererWidget;
     //  number-line: NumberLineWidget;
     //  numeric-input: NumericInputWidget;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -295,6 +295,22 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
+    it("accepts an image widget", () => {
+        const widgetsMap: unknown = {
+            "image 1": {
+                type: "image",
+                version: {major: 0, minor: 0},
+                options: {
+                    backgroundImage: {},
+                },
+            },
+        };
+
+        const result = parseWidgetsMap(widgetsMap, ctx());
+
+        expect(result).toEqual(success(widgetsMap));
+    });
+
     // TODO:
     //  image: ImageWidget;
     //  input-number: InputNumberWidget;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -619,8 +619,24 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
+    it("accepts a radio widget", () => {
+        const widgetsMap: unknown = {
+            "radio 1": {
+                type: "radio",
+                version: {major: 0, minor: 0},
+                options: {
+                    choices: [],
+                    noneOfTheAbove: false,
+                },
+            },
+        };
+
+        const result = parse(widgetsMap, parseWidgetsMap);
+
+        expect(result).toEqual(success(widgetsMap));
+    });
+
     // TODO:
-    //  radio: RadioWidget;
     //  sorter: SorterWidget;
     //  table: TableWidget;
     //  video: VideoWidget;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -483,8 +483,27 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
+    it("accepts a numeric-input widget", () => {
+        const widgetsMap: unknown = {
+            "numeric-input 1": {
+                type: "numeric-input",
+                version: {major: 0, minor: 0},
+                options: {
+                    answers: [],
+                    labelText: "",
+                    size: "",
+                    coefficient: false,
+                    static: false,
+                },
+            },
+        };
+
+        const result = parse(widgetsMap, parseWidgetsMap);
+
+        expect(result).toEqual(success(widgetsMap));
+    });
+
     // TODO:
-    //  numeric-input: NumericInputWidget;
     //  orderer: OrdererWidget;
     //  passage: PassageWidget;
     //  passage-ref: PassageRefWidget;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -503,8 +503,27 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
+    it("accepts an orderer widget", () => {
+        const widgetsMap: unknown = {
+            "orderer 1": {
+                type: "orderer",
+                version: {major: 0, minor: 0},
+                options: {
+                    options: [],
+                    correctOptions: [],
+                    otherOptions: [],
+                    height: "",
+                    layout: "",
+                },
+            },
+        };
+
+        const result = parse(widgetsMap, parseWidgetsMap);
+
+        expect(result).toEqual(success(widgetsMap));
+    });
+
     // TODO:
-    //  orderer: OrdererWidget;
     //  passage: PassageWidget;
     //  passage-ref: PassageRefWidget;
     //  passage-ref-target: PassageRefWidget;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -673,8 +673,21 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
-    // TODO:
-    //  video: VideoWidget;
+    it("accepts a video widget", () => {
+        const widgetsMap: unknown = {
+            "video 1": {
+                type: "video",
+                version: {major: 0, minor: 0},
+                options: {
+                    location: "",
+                },
+            },
+        };
+
+        const result = parse(widgetsMap, parseWidgetsMap);
+
+        expect(result).toEqual(success(widgetsMap));
+    });
 
     it("rejects an unknown widget type", () => {
         const widgetsMap: unknown = {

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -232,8 +232,26 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
+    it("accepts a graded-group widget", () => {
+        const widgetsMap: unknown = {
+            "graded-group 1": {
+                type: "graded-group",
+                version: {major: 0, minor: 0},
+                options: {
+                    title: "",
+                    content: "",
+                    widgets: {},
+                    images: {},
+                },
+            },
+        };
+
+        const result = parseWidgetsMap(widgetsMap, ctx());
+
+        expect(result).toEqual(success(widgetsMap));
+    });
+
     // TODO:
-    //  graded-group: GradedGroupWidget;
     //  graded-group-set: GradedGroupSetWidget;
     //  iframe: IFrameWidget;
     //  image: ImageWidget;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -213,9 +213,26 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
+    it("accepts a group widget", () => {
+        const widgetsMap: unknown = {
+            "group 1": {
+                type: "group",
+                version: {major: 0, minor: 0},
+                options: {
+                    content: "",
+                    widgets: {},
+                    metadata: [],
+                    images: {},
+                },
+            },
+        };
+
+        const result = parseWidgetsMap(widgetsMap, ctx());
+
+        expect(result).toEqual(success(widgetsMap));
+    });
+
     // TODO:
-    //  grapher: GrapherWidget;
-    //  group: GroupWidget;
     //  graded-group: GradedGroupWidget;
     //  graded-group-set: GradedGroupSetWidget;
     //  iframe: IFrameWidget;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -274,8 +274,28 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
+    it("accepts an iframe widget", () => {
+        const widgetsMap: unknown = {
+            "iframe 1": {
+                type: "iframe",
+                version: {major: 0, minor: 0},
+                options: {
+                    url: "",
+                    settings: [],
+                    width: 1,
+                    height: 1,
+                    allowFullScreen: false,
+                    static: false,
+                },
+            },
+        };
+
+        const result = parseWidgetsMap(widgetsMap, ctx());
+
+        expect(result).toEqual(success(widgetsMap));
+    });
+
     // TODO:
-    //  iframe: IFrameWidget;
     //  image: ImageWidget;
     //  input-number: InputNumberWidget;
     //  interaction: InteractionWidget;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -602,8 +602,24 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
+    it("accepts a python-program widget", () => {
+        const widgetsMap: unknown = {
+            "python-program 1": {
+                type: "python-program",
+                version: {major: 0, minor: 0},
+                options: {
+                    programID: "",
+                    height: 0,
+                },
+            },
+        };
+
+        const result = parse(widgetsMap, parseWidgetsMap);
+
+        expect(result).toEqual(success(widgetsMap));
+    });
+
     // TODO:
-    //  python-program: PythonProgramWidget;
     //  radio: RadioWidget;
     //  sorter: SorterWidget;
     //  table: TableWidget;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -1,3 +1,4 @@
+import {array, boolean, string} from "../general-purpose-parsers";
 import {
     anyFailure,
     ctx,
@@ -381,8 +382,27 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
+    it("accepts a matcher widget", () => {
+        const widgetsMap: unknown = {
+            "matcher 1": {
+                type: "matcher",
+                version: {major: 0, minor: 0},
+                options: {
+                    labels: [],
+                    left: [],
+                    right: [],
+                    orderMatters: false,
+                    padding: false,
+                },
+            },
+        };
+
+        const result = parseWidgetsMap(widgetsMap, ctx());
+
+        expect(result).toEqual(success(widgetsMap));
+    });
+
     // TODO:
-    //  matcher: MatcherWidget;
     //  matrix: MatrixWidget;
     //  measurer: MeasurerWidget;
     //  molecule-renderer: MoleculeRendererWidget;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -402,8 +402,28 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
+    it("accepts a matrix widget", () => {
+        const widgetsMap: unknown = {
+            "matrix 1": {
+                type: "matrix",
+                version: {major: 0, minor: 0},
+                options: {
+                    prefix: "",
+                    suffix: "",
+                    answers: [],
+                    cursorPosition: [],
+                    matrixBoardSize: [],
+                    static: false,
+                },
+            },
+        };
+
+        const result = parseWidgetsMap(widgetsMap, ctx());
+
+        expect(result).toEqual(success(widgetsMap));
+    });
+
     // TODO:
-    //  matrix: MatrixWidget;
     //  measurer: MeasurerWidget;
     //  molecule-renderer: MoleculeRendererWidget;
     //  number-line: NumberLineWidget;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -578,8 +578,31 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
+    it("accepts a plotter widget", () => {
+        const widgetsMap: unknown = {
+            "plotter 1": {
+                type: "plotter",
+                version: {major: 0, minor: 0},
+                options: {
+                    labels: [],
+                    categories: [],
+                    type: "bar",
+                    maxY: 0,
+                    scaleY: 0,
+                    snapsPerLine: 0,
+                    starting: [],
+                    correct: [],
+                    plotDimensions: [],
+                },
+            },
+        };
+
+        const result = parse(widgetsMap, parseWidgetsMap);
+
+        expect(result).toEqual(success(widgetsMap));
+    });
+
     // TODO:
-    //  plotter: PlotterWidget;
     //  python-program: PythonProgramWidget;
     //  radio: RadioWidget;
     //  sorter: SorterWidget;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -562,7 +562,6 @@ describe("parseWidgetsMap", () => {
     });
 
     // TODO:
-    //  passage-ref-target: PassageRefWidget;
     //  phet-simulation: PhetSimulationWidget;
     //  plotter: PlotterWidget;
     //  python-program: PythonProgramWidget;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -178,6 +178,41 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
+    it("accepts a grapher widget", () => {
+        const widgetsMap: unknown = {
+            "grapher 1": {
+                type: "grapher",
+                version: {major: 0, minor: 0},
+                options: {
+                    availableTypes: ["absolute_value"],
+                    correct: {
+                        type: "absolute_value",
+                        coords: [
+                            [0, 1],
+                            [2, 3],
+                        ],
+                    },
+                    graph: {
+                        backgroundImage: {},
+                        labels: ["x", "y"],
+                        markings: "graph",
+                        range: [
+                            [-10, 10],
+                            [-10, 10],
+                        ],
+                        rulerLabel: "",
+                        rulerTicks: 5,
+                        step: [1, 1],
+                    },
+                },
+            },
+        };
+
+        const result = parseWidgetsMap(widgetsMap, ctx());
+
+        expect(result).toEqual(success(widgetsMap));
+    });
+
     // TODO:
     //  grapher: GrapherWidget;
     //  group: GroupWidget;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -338,7 +338,10 @@ describe("parseWidgetsMap", () => {
                     static: false,
                     graph: {
                         box: [1, 1],
-                        range: [[-10, 10], [-10, 10]],
+                        range: [
+                            [-10, 10],
+                            [-10, 10],
+                        ],
                         gridStep: [1, 1],
                         markings: "graph",
                         tickStep: [1, 1],
@@ -354,9 +357,31 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
+    it("accepts a label-image widget", () => {
+        const widgetsMap: unknown = {
+            "label-image 1": {
+                type: "label-image",
+                version: {major: 0, minor: 0},
+                options: {
+                    choices: [],
+                    imageUrl: "",
+                    imageAlt: "",
+                    imageHeight: 0,
+                    imageWidth: 0,
+                    markers: [],
+                    hideChoicesFromInstructions: false,
+                    multipleAnswers: false,
+                    static: false,
+                },
+            },
+        };
+
+        const result = parseWidgetsMap(widgetsMap, ctx());
+
+        expect(result).toEqual(success(widgetsMap));
+    });
+
     // TODO:
-    //  interactive-graph: InteractiveGraphWidget;
-    //  label-image: LabelImageWidget;
     //  matcher: MatcherWidget;
     //  matrix: MatrixWidget;
     //  measurer: MeasurerWidget;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -460,8 +460,30 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
+    it("accepts a number-line widget", () => {
+        const widgetsMap: unknown = {
+            "number-line 1": {
+                type: "number-line",
+                version: {major: 0, minor: 0},
+                options: {
+                    range: [],
+                    labelRange: [],
+                    labelStyle: "",
+                    labelTicks: false,
+                    divisionRange: [],
+                    snapDivisions: 1,
+                    correctX: 1,
+                    static: false,
+                },
+            },
+        };
+
+        const result = parse(widgetsMap, parseWidgetsMap);
+
+        expect(result).toEqual(success(widgetsMap));
+    });
+
     // TODO:
-    //  number-line: NumberLineWidget;
     //  numeric-input: NumericInputWidget;
     //  orderer: OrdererWidget;
     //  passage: PassageWidget;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -444,8 +444,23 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
+    it("accepts a molecule-renderer widget", () => {
+        const widgetsMap: unknown = {
+            "molecule-renderer 1": {
+                type: "molecule-renderer",
+                version: {major: 0, minor: 0},
+                options: {
+                    widgetId: "",
+                },
+            },
+        };
+
+        const result = parse(widgetsMap, parseWidgetsMap);
+
+        expect(result).toEqual(success(widgetsMap));
+    });
+
     // TODO:
-    //  molecule-renderer: MoleculeRendererWidget;
     //  number-line: NumberLineWidget;
     //  numeric-input: NumericInputWidget;
     //  orderer: OrdererWidget;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -1,27 +1,24 @@
 import {registerWidget} from "../../../widgets";
-import {
-    anyFailure,
-    ctx,
-    parseFailureWith,
-} from "../general-purpose-parsers/test-helpers";
-import {success} from "../result";
+import {anyFailure} from "../general-purpose-parsers/test-helpers";
+import {parse} from "../parse";
+import {failure, success} from "../result";
 
 import {parseWidgetsMap} from "./widgets-map";
 
 describe("parseWidgetsMap", () => {
     it("rejects null", () => {
-        const result = parseWidgetsMap(null, ctx());
+        const result = parse(null, parseWidgetsMap);
         expect(result).toEqual(anyFailure);
     });
 
     it("rejects an array", () => {
-        const result = parseWidgetsMap([], ctx());
+        const result = parse([], parseWidgetsMap);
         expect(result).toEqual(anyFailure);
     });
 
     it("accepts an empty object (no widgets)", () => {
         const widgetsMap: unknown = {};
-        const result = parseWidgetsMap(widgetsMap, ctx());
+        const result = parse(widgetsMap, parseWidgetsMap);
         expect(result).toEqual(success({}));
     });
 
@@ -30,7 +27,7 @@ describe("parseWidgetsMap", () => {
             asdf: "foobar",
         };
 
-        const result = parseWidgetsMap(widgetsMap, ctx());
+        const result = parse(widgetsMap, parseWidgetsMap);
 
         expect(result).toEqual(anyFailure);
     });
@@ -50,7 +47,7 @@ describe("parseWidgetsMap", () => {
             },
         };
 
-        const result = parseWidgetsMap(widgetsMap, ctx());
+        const result = parse(widgetsMap, parseWidgetsMap);
 
         expect(result).toEqual(success(widgetsMap));
     });
@@ -72,7 +69,7 @@ describe("parseWidgetsMap", () => {
             },
         };
 
-        const result = parseWidgetsMap(widgetsMap, ctx());
+        const result = parse(widgetsMap, parseWidgetsMap);
 
         expect(result).toEqual(success(widgetsMap));
     });
@@ -90,7 +87,7 @@ describe("parseWidgetsMap", () => {
             },
         };
 
-        const result = parseWidgetsMap(widgetsMap, ctx());
+        const result = parse(widgetsMap, parseWidgetsMap);
 
         expect(result).toEqual(success(widgetsMap));
     });
@@ -108,7 +105,7 @@ describe("parseWidgetsMap", () => {
             },
         };
 
-        const result = parseWidgetsMap(widgetsMap, ctx());
+        const result = parse(widgetsMap, parseWidgetsMap);
 
         expect(result).toEqual(success(widgetsMap));
     });
@@ -128,7 +125,7 @@ describe("parseWidgetsMap", () => {
             },
         };
 
-        const result = parseWidgetsMap(widgetsMap, ctx());
+        const result = parse(widgetsMap, parseWidgetsMap);
 
         expect(result).toEqual(success(widgetsMap));
     });
@@ -147,7 +144,7 @@ describe("parseWidgetsMap", () => {
             },
         };
 
-        const result = parseWidgetsMap(widgetsMap, ctx());
+        const result = parse(widgetsMap, parseWidgetsMap);
 
         expect(result).toEqual(success(widgetsMap));
     });
@@ -174,7 +171,7 @@ describe("parseWidgetsMap", () => {
             },
         };
 
-        const result = parseWidgetsMap(widgetsMap, ctx());
+        const result = parse(widgetsMap, parseWidgetsMap);
 
         expect(result).toEqual(success(widgetsMap));
     });
@@ -209,7 +206,7 @@ describe("parseWidgetsMap", () => {
             },
         };
 
-        const result = parseWidgetsMap(widgetsMap, ctx());
+        const result = parse(widgetsMap, parseWidgetsMap);
 
         expect(result).toEqual(success(widgetsMap));
     });
@@ -228,7 +225,7 @@ describe("parseWidgetsMap", () => {
             },
         };
 
-        const result = parseWidgetsMap(widgetsMap, ctx());
+        const result = parse(widgetsMap, parseWidgetsMap);
 
         expect(result).toEqual(success(widgetsMap));
     });
@@ -247,7 +244,7 @@ describe("parseWidgetsMap", () => {
             },
         };
 
-        const result = parseWidgetsMap(widgetsMap, ctx());
+        const result = parse(widgetsMap, parseWidgetsMap);
 
         expect(result).toEqual(success(widgetsMap));
     });
@@ -270,7 +267,7 @@ describe("parseWidgetsMap", () => {
             },
         };
 
-        const result = parseWidgetsMap(widgetsMap, ctx());
+        const result = parse(widgetsMap, parseWidgetsMap);
 
         expect(result).toEqual(success(widgetsMap));
     });
@@ -291,7 +288,7 @@ describe("parseWidgetsMap", () => {
             },
         };
 
-        const result = parseWidgetsMap(widgetsMap, ctx());
+        const result = parse(widgetsMap, parseWidgetsMap);
 
         expect(result).toEqual(success(widgetsMap));
     });
@@ -307,7 +304,7 @@ describe("parseWidgetsMap", () => {
             },
         };
 
-        const result = parseWidgetsMap(widgetsMap, ctx());
+        const result = parse(widgetsMap, parseWidgetsMap);
 
         expect(result).toEqual(success(widgetsMap));
     });
@@ -325,7 +322,7 @@ describe("parseWidgetsMap", () => {
             },
         };
 
-        const result = parseWidgetsMap(widgetsMap, ctx());
+        const result = parse(widgetsMap, parseWidgetsMap);
 
         expect(result).toEqual(success(widgetsMap));
     });
@@ -353,7 +350,7 @@ describe("parseWidgetsMap", () => {
             },
         };
 
-        const result = parseWidgetsMap(widgetsMap, ctx());
+        const result = parse(widgetsMap, parseWidgetsMap);
 
         expect(result).toEqual(success(widgetsMap));
     });
@@ -377,7 +374,7 @@ describe("parseWidgetsMap", () => {
             },
         };
 
-        const result = parseWidgetsMap(widgetsMap, ctx());
+        const result = parse(widgetsMap, parseWidgetsMap);
 
         expect(result).toEqual(success(widgetsMap));
     });
@@ -397,7 +394,7 @@ describe("parseWidgetsMap", () => {
             },
         };
 
-        const result = parseWidgetsMap(widgetsMap, ctx());
+        const result = parse(widgetsMap, parseWidgetsMap);
 
         expect(result).toEqual(success(widgetsMap));
     });
@@ -418,7 +415,7 @@ describe("parseWidgetsMap", () => {
             },
         };
 
-        const result = parseWidgetsMap(widgetsMap, ctx());
+        const result = parse(widgetsMap, parseWidgetsMap);
 
         expect(result).toEqual(success(widgetsMap));
     });
@@ -445,13 +442,12 @@ describe("parseWidgetsMap", () => {
             "transmogrifier 1": {type: "transmogrifier"},
         };
 
-        const result = parseWidgetsMap(widgetsMap, ctx());
+        const result = parse(widgetsMap, parseWidgetsMap);
 
         expect(result).toEqual(
-            parseFailureWith({
-                expected: ["a valid widget type"],
-                badValue: "transmogrifier",
-            }),
+            failure(
+                `At (root)["transmogrifier 1"] -- expected a valid widget type, but got "transmogrifier"`,
+            ),
         );
     });
 
@@ -469,7 +465,7 @@ describe("parseWidgetsMap", () => {
             },
         };
 
-        const result = parseWidgetsMap(widgetsMap, ctx());
+        const result = parse(widgetsMap, parseWidgetsMap);
 
         expect(result).toEqual(success(widgetsMap));
     });
@@ -479,7 +475,7 @@ describe("parseWidgetsMap", () => {
             categorizer: {type: "categorizer"},
         };
 
-        const result = parseWidgetsMap(widgetsMap, ctx());
+        const result = parse(widgetsMap, parseWidgetsMap);
 
         expect(result).toEqual(anyFailure);
     });

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -636,8 +636,25 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
+    it("accepts a sorter widget", () => {
+        const widgetsMap: unknown = {
+            "sorter 1": {
+                type: "sorter",
+                version: {major: 0, minor: 0},
+                options: {
+                    correct: [],
+                    padding: false,
+                    layout: "horizontal",
+                },
+            },
+        };
+
+        const result = parse(widgetsMap, parseWidgetsMap);
+
+        expect(result).toEqual(success(widgetsMap));
+    });
+
     // TODO:
-    //  sorter: SorterWidget;
     //  table: TableWidget;
     //  video: VideoWidget;
 

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -654,8 +654,26 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
+    it("accepts a table widget", () => {
+        const widgetsMap: unknown = {
+            "table 1": {
+                type: "table",
+                version: {major: 0, minor: 0},
+                options: {
+                    headers: [],
+                    rows: 0,
+                    columns: 0,
+                    answers: [],
+                },
+            },
+        };
+
+        const result = parse(widgetsMap, parseWidgetsMap);
+
+        expect(result).toEqual(success(widgetsMap));
+    });
+
     // TODO:
-    //  table: TableWidget;
     //  video: VideoWidget;
 
     it("rejects an unknown widget type", () => {

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -523,8 +523,27 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
+    it("accepts a passage widget", () => {
+        const widgetsMap: unknown = {
+            "passage 1": {
+                type: "passage",
+                version: {major: 0, minor: 0},
+                options: {
+                    footnotes: "",
+                    passageText: "",
+                    passageTitle: "",
+                    showLineNumbers: false,
+                    static: false,
+                },
+            },
+        };
+
+        const result = parse(widgetsMap, parseWidgetsMap);
+
+        expect(result).toEqual(success(widgetsMap));
+    });
+
     // TODO:
-    //  passage: PassageWidget;
     //  passage-ref: PassageRefWidget;
     //  passage-ref-target: PassageRefWidget;
     //  phet-simulation: PhetSimulationWidget;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -1,4 +1,4 @@
-import {array, boolean, string} from "../general-purpose-parsers";
+import {registerWidget} from "../../../widgets";
 import {
     anyFailure,
     ctx,
@@ -433,6 +433,25 @@ describe("parseWidgetsMap", () => {
                 badValue: "transmogrifier",
             }),
         );
+    });
+
+    it("accepts a dynamically-registered widget type without checking its options", () => {
+        registerWidget("fake-widget-for-widgets-map-parser-test", {
+            name: "fake-widget-for-widgets-map-parser-test",
+            displayName: "",
+            widget: () => null,
+        });
+
+        const widgetsMap: unknown = {
+            "fake-widget-for-widgets-map-parser-test 1": {
+                type: "fake-widget-for-widgets-map-parser-test",
+                options: {foo: "whatever"},
+            },
+        };
+
+        const result = parseWidgetsMap(widgetsMap, ctx());
+
+        expect(result).toEqual(success(widgetsMap));
     });
 
     it("rejects a key with no ID", () => {

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -329,8 +329,32 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
+    it("accepts an interaction widget", () => {
+        const widgetsMap: unknown = {
+            "interaction 1": {
+                type: "interaction",
+                version: {major: 0, minor: 0},
+                options: {
+                    static: false,
+                    graph: {
+                        box: [1, 1],
+                        range: [[-10, 10], [-10, 10]],
+                        gridStep: [1, 1],
+                        markings: "graph",
+                        tickStep: [1, 1],
+                        labels: [],
+                    },
+                    elements: [],
+                },
+            },
+        };
+
+        const result = parseWidgetsMap(widgetsMap, ctx());
+
+        expect(result).toEqual(success(widgetsMap));
+    });
+
     // TODO:
-    //  interaction: InteractionWidget;
     //  interactive-graph: InteractiveGraphWidget;
     //  label-image: LabelImageWidget;
     //  matcher: MatcherWidget;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -543,8 +543,25 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
+    it("accepts a passage-ref widget", () => {
+        const widgetsMap: unknown = {
+            "passage-ref 1": {
+                type: "passage-ref",
+                version: {major: 0, minor: 0},
+                options: {
+                    passageNumber: 0,
+                    referenceNumber: 0,
+                    summaryText: "",
+                },
+            },
+        };
+
+        const result = parse(widgetsMap, parseWidgetsMap);
+
+        expect(result).toEqual(success(widgetsMap));
+    });
+
     // TODO:
-    //  passage-ref: PassageRefWidget;
     //  passage-ref-target: PassageRefWidget;
     //  phet-simulation: PhetSimulationWidget;
     //  plotter: PlotterWidget;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -17,6 +17,7 @@ import {parseInputNumberWidget} from "./input-number-widget";
 import {parseInteractionWidget} from "./interaction-widget";
 import {parseInteractiveGraphWidget} from "./interactive-graph-widget";
 import {parseLabelImageWidget} from "./label-image-widget";
+import {parseMatcherWidget} from "./matcher-widget";
 
 import type {PerseusWidgetsMap} from "../../../perseus-types";
 import type {ParseContext, Parser, ParseResult} from "../parser-types";
@@ -110,8 +111,7 @@ const parseWidgetsMapEntry: (
         case "label-image":
             return parseAndAssign(`label-image ${id}`, parseLabelImageWidget);
         case "matcher":
-            // TODO(LEMS-2585): implement a real parser for this widget
-            return parseAndAssign(`matcher ${id}`, any);
+            return parseAndAssign(`matcher ${id}`, parseMatcherWidget);
         case "matrix":
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`matrix ${id}`, any);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -35,6 +35,7 @@ import {parseRadioWidget} from "./radio-widget";
 import type {PerseusWidgetsMap} from "../../../perseus-types";
 import type {ParseContext, Parser, ParseResult} from "../parser-types";
 import {parseSorterWidget} from "./sorter-widget";
+import {parseTableWidget} from "./table-widget";
 
 export const parseWidgetsMap: Parser<PerseusWidgetsMap> = (rawValue, ctx) => {
     if (!isObject(rawValue)) {
@@ -170,8 +171,7 @@ const parseWidgetsMapEntry: (
         case "sorter":
             return parseAndAssign(`sorter ${id}`, parseSorterWidget);
         case "table":
-            // TODO(LEMS-2585): implement a real parser for this widget
-            return parseAndAssign(`table ${id}`, any);
+            return parseAndAssign(`table ${id}`, parseTableWidget);
         case "video":
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`video ${id}`, any);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -7,6 +7,7 @@ import {parseDefinitionWidget} from "./definition-widget";
 import {parseDropdownWidget} from "./dropdown-widget";
 import {parseExplanationWidget} from "./explanation-widget";
 import {parseExpressionWidget} from "./expression-widget";
+import {parseGradedGroupWidget} from "./graded-group-widget";
 import {parseGrapherWidget} from "./grapher-widget";
 import {parseGroupWidget} from "./group-widget";
 import {parseInteractiveGraphWidget} from "./interactive-graph-widget";
@@ -81,8 +82,7 @@ const parseWidgetsMapEntry: (
         case "group":
             return parseAndAssign(`group ${id}`, parseGroupWidget);
         case "graded-group":
-            // TODO(LEMS-2585): implement a real parser for this widget
-            return parseAndAssign(`graded-group ${id}`, any);
+            return parseAndAssign(`graded-group ${id}`, parseGradedGroupWidget);
         case "graded-group-set":
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`graded-group-set ${id}`, any);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -19,6 +19,7 @@ import {parseInteractionWidget} from "./interaction-widget";
 import {parseInteractiveGraphWidget} from "./interactive-graph-widget";
 import {parseLabelImageWidget} from "./label-image-widget";
 import {parseMatcherWidget} from "./matcher-widget";
+import {parseMatrixWidget} from "./matrix-widget";
 
 import type {PerseusWidgetsMap} from "../../../perseus-types";
 import type {ParseContext, Parser, ParseResult} from "../parser-types";
@@ -114,8 +115,7 @@ const parseWidgetsMapEntry: (
         case "matcher":
             return parseAndAssign(`matcher ${id}`, parseMatcherWidget);
         case "matrix":
-            // TODO(LEMS-2585): implement a real parser for this widget
-            return parseAndAssign(`matrix ${id}`, any);
+            return parseAndAssign(`matrix ${id}`, parseMatrixWidget);
         case "measurer":
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`measurer ${id}`, any);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -7,6 +7,7 @@ import {parseDefinitionWidget} from "./definition-widget";
 import {parseDropdownWidget} from "./dropdown-widget";
 import {parseExplanationWidget} from "./explanation-widget";
 import {parseExpressionWidget} from "./expression-widget";
+import {parseGradedGroupSetWidget} from "./graded-group-set-widget";
 import {parseGradedGroupWidget} from "./graded-group-widget";
 import {parseGrapherWidget} from "./grapher-widget";
 import {parseGroupWidget} from "./group-widget";
@@ -84,8 +85,10 @@ const parseWidgetsMapEntry: (
         case "graded-group":
             return parseAndAssign(`graded-group ${id}`, parseGradedGroupWidget);
         case "graded-group-set":
-            // TODO(LEMS-2585): implement a real parser for this widget
-            return parseAndAssign(`graded-group-set ${id}`, any);
+            return parseAndAssign(
+                `graded-group-set ${id}`,
+                parseGradedGroupSetWidget,
+            );
         case "iframe":
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`iframe ${id}`, any);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -31,11 +31,12 @@ import {parsePhetSimulationWidget} from "./phet-simulation-widget";
 import {parsePlotterWidget} from "./plotter-widget";
 import {parsePythonProgramWidget} from "./python-program-widget";
 import {parseRadioWidget} from "./radio-widget";
+import {parseSorterWidget} from "./sorter-widget";
+import {parseTableWidget} from "./table-widget";
+import {parseVideoWidget} from "./video-widget";
 
 import type {PerseusWidgetsMap} from "../../../perseus-types";
 import type {ParseContext, Parser, ParseResult} from "../parser-types";
-import {parseSorterWidget} from "./sorter-widget";
-import {parseTableWidget} from "./table-widget";
 
 export const parseWidgetsMap: Parser<PerseusWidgetsMap> = (rawValue, ctx) => {
     if (!isObject(rawValue)) {

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -24,6 +24,7 @@ import {parseMeasurerWidget} from "./measurer-widget";
 import {parseMoleculeRendererWidget} from "./molecule-renderer-widget";
 import {parseNumberLineWidget} from "./number-line-widget";
 import {parseNumericInputWidget} from "./numeric-input-widget";
+import {parseOrdererWidget} from "./orderer-widget";
 
 import type {PerseusWidgetsMap} from "../../../perseus-types";
 import type {ParseContext, Parser, ParseResult} from "../parser-types";
@@ -135,8 +136,7 @@ const parseWidgetsMapEntry: (
                 parseNumericInputWidget,
             );
         case "orderer":
-            // TODO(LEMS-2585): implement a real parser for this widget
-            return parseAndAssign(`orderer ${id}`, any);
+            return parseAndAssign(`orderer ${id}`, parseOrdererWidget);
         case "passage":
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`passage ${id}`, any);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -28,6 +28,7 @@ import {parseOrdererWidget} from "./orderer-widget";
 import {parsePassageRefWidget} from "./passage-ref-widget";
 import {parsePassageWidget} from "./passage-widget";
 import {parsePhetSimulationWidget} from "./phet-simulation-widget";
+import {parsePlotterWidget} from "./plotter-widget";
 
 import type {PerseusWidgetsMap} from "../../../perseus-types";
 import type {ParseContext, Parser, ParseResult} from "../parser-types";
@@ -155,8 +156,7 @@ const parseWidgetsMapEntry: (
                 parsePhetSimulationWidget,
             );
         case "plotter":
-            // TODO(LEMS-2585): implement a real parser for this widget
-            return parseAndAssign(`plotter ${id}`, any);
+            return parseAndAssign(`plotter ${id}`, parsePlotterWidget);
         case "python-program":
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`python-program ${id}`, any);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -25,6 +25,7 @@ import {parseMoleculeRendererWidget} from "./molecule-renderer-widget";
 import {parseNumberLineWidget} from "./number-line-widget";
 import {parseNumericInputWidget} from "./numeric-input-widget";
 import {parseOrdererWidget} from "./orderer-widget";
+import {parsePassageRefWidget} from "./passage-ref-widget";
 import {parsePassageWidget} from "./passage-widget";
 
 import type {PerseusWidgetsMap} from "../../../perseus-types";
@@ -141,8 +142,7 @@ const parseWidgetsMapEntry: (
         case "passage":
             return parseAndAssign(`passage ${id}`, parsePassageWidget);
         case "passage-ref":
-            // TODO(LEMS-2585): implement a real parser for this widget
-            return parseAndAssign(`passage-ref ${id}`, any);
+            return parseAndAssign(`passage-ref ${id}`, parsePassageRefWidget);
         case "passage-ref-target":
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`passage-ref-target ${id}`, any);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -1,3 +1,4 @@
+import {getWidget} from "../../../widgets";
 import {any, pair, isObject, string} from "../general-purpose-parsers";
 import {isFailure} from "../result";
 
@@ -161,10 +162,11 @@ const parseWidgetsMapEntry: (
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`video ${id}`, any);
 
-        // TODO(LEMS-2585): add cases for deprecated-standin and the
-        // widgets that it replaces
-
         default:
+            if (getWidget(type)) {
+                // @ts-expect-error - 'type' is not a valid widget type
+                return parseAndAssign(`${type} ${id}`, any);
+            }
             return ctx.failure("a valid widget type", type);
     }
 };

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -12,11 +12,12 @@ import {parseGradedGroupWidget} from "./graded-group-widget";
 import {parseGrapherWidget} from "./grapher-widget";
 import {parseGroupWidget} from "./group-widget";
 import {parseIframeWidget} from "./iframe-widget";
+import {parseImageWidget} from "./image-widget";
+import {parseInputNumberWidget} from "./input-number-widget";
 import {parseInteractiveGraphWidget} from "./interactive-graph-widget";
 
 import type {PerseusWidgetsMap} from "../../../perseus-types";
 import type {ParseContext, Parser, ParseResult} from "../parser-types";
-import {parseImageWidget} from "./image-widget";
 
 export const parseWidgetsMap: Parser<PerseusWidgetsMap> = (rawValue, ctx) => {
     if (!isObject(rawValue)) {
@@ -96,8 +97,7 @@ const parseWidgetsMapEntry: (
         case "image":
             return parseAndAssign(`image ${id}`, parseImageWidget);
         case "input-number":
-            // TODO(LEMS-2585): implement a real parser for this widget
-            return parseAndAssign(`input-number ${id}`, any);
+            return parseAndAssign(`input-number ${id}`, parseInputNumberWidget);
         case "interaction":
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`interaction ${id}`, any);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -11,6 +11,7 @@ import {parseGradedGroupSetWidget} from "./graded-group-set-widget";
 import {parseGradedGroupWidget} from "./graded-group-widget";
 import {parseGrapherWidget} from "./grapher-widget";
 import {parseGroupWidget} from "./group-widget";
+import {parseIframeWidget} from "./iframe-widget";
 import {parseInteractiveGraphWidget} from "./interactive-graph-widget";
 
 import type {PerseusWidgetsMap} from "../../../perseus-types";
@@ -90,8 +91,7 @@ const parseWidgetsMapEntry: (
                 parseGradedGroupSetWidget,
             );
         case "iframe":
-            // TODO(LEMS-2585): implement a real parser for this widget
-            return parseAndAssign(`iframe ${id}`, any);
+            return parseAndAssign(`iframe ${id}`, parseIframeWidget);
         case "image":
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`image ${id}`, any);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -16,6 +16,7 @@ import {parseInteractiveGraphWidget} from "./interactive-graph-widget";
 
 import type {PerseusWidgetsMap} from "../../../perseus-types";
 import type {ParseContext, Parser, ParseResult} from "../parser-types";
+import {parseImageWidget} from "./image-widget";
 
 export const parseWidgetsMap: Parser<PerseusWidgetsMap> = (rawValue, ctx) => {
     if (!isObject(rawValue)) {
@@ -93,8 +94,7 @@ const parseWidgetsMapEntry: (
         case "iframe":
             return parseAndAssign(`iframe ${id}`, parseIframeWidget);
         case "image":
-            // TODO(LEMS-2585): implement a real parser for this widget
-            return parseAndAssign(`image ${id}`, any);
+            return parseAndAssign(`image ${id}`, parseImageWidget);
         case "input-number":
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`input-number ${id}`, any);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -14,11 +14,12 @@ import {parseGroupWidget} from "./group-widget";
 import {parseIframeWidget} from "./iframe-widget";
 import {parseImageWidget} from "./image-widget";
 import {parseInputNumberWidget} from "./input-number-widget";
+import {parseInteractionWidget} from "./interaction-widget";
 import {parseInteractiveGraphWidget} from "./interactive-graph-widget";
+import {parseLabelImageWidget} from "./label-image-widget";
 
 import type {PerseusWidgetsMap} from "../../../perseus-types";
 import type {ParseContext, Parser, ParseResult} from "../parser-types";
-import {parseInteractionWidget} from "./interaction-widget";
 
 export const parseWidgetsMap: Parser<PerseusWidgetsMap> = (rawValue, ctx) => {
     if (!isObject(rawValue)) {
@@ -107,8 +108,7 @@ const parseWidgetsMapEntry: (
                 parseInteractiveGraphWidget,
             );
         case "label-image":
-            // TODO(LEMS-2585): implement a real parser for this widget
-            return parseAndAssign(`label-image ${id}`, any);
+            return parseAndAssign(`label-image ${id}`, parseLabelImageWidget);
         case "matcher":
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`matcher ${id}`, any);
@@ -161,11 +161,8 @@ const parseWidgetsMapEntry: (
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`video ${id}`, any);
 
-
-            // TODO(LEMS-2585): add cases for deprecated-standin and the
-            // widgets that it replaces
-
-
+        // TODO(LEMS-2585): add cases for deprecated-standin and the
+        // widgets that it replaces
 
         default:
             return ctx.failure("a valid widget type", type);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -18,6 +18,7 @@ import {parseInteractiveGraphWidget} from "./interactive-graph-widget";
 
 import type {PerseusWidgetsMap} from "../../../perseus-types";
 import type {ParseContext, Parser, ParseResult} from "../parser-types";
+import {parseInteractionWidget} from "./interaction-widget";
 
 export const parseWidgetsMap: Parser<PerseusWidgetsMap> = (rawValue, ctx) => {
     if (!isObject(rawValue)) {
@@ -99,8 +100,7 @@ const parseWidgetsMapEntry: (
         case "input-number":
             return parseAndAssign(`input-number ${id}`, parseInputNumberWidget);
         case "interaction":
-            // TODO(LEMS-2585): implement a real parser for this widget
-            return parseAndAssign(`interaction ${id}`, any);
+            return parseAndAssign(`interaction ${id}`, parseInteractionWidget);
         case "interactive-graph":
             return parseAndAssign(
                 `interactive-graph ${id}`,
@@ -160,6 +160,13 @@ const parseWidgetsMapEntry: (
         case "video":
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`video ${id}`, any);
+
+
+            // TODO(LEMS-2585): add cases for deprecated-standin and the
+            // widgets that it replaces
+
+
+
         default:
             return ctx.failure("a valid widget type", type);
     }

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -25,6 +25,7 @@ import {parseMoleculeRendererWidget} from "./molecule-renderer-widget";
 import {parseNumberLineWidget} from "./number-line-widget";
 import {parseNumericInputWidget} from "./numeric-input-widget";
 import {parseOrdererWidget} from "./orderer-widget";
+import {parsePassageWidget} from "./passage-widget";
 
 import type {PerseusWidgetsMap} from "../../../perseus-types";
 import type {ParseContext, Parser, ParseResult} from "../parser-types";
@@ -138,8 +139,7 @@ const parseWidgetsMapEntry: (
         case "orderer":
             return parseAndAssign(`orderer ${id}`, parseOrdererWidget);
         case "passage":
-            // TODO(LEMS-2585): implement a real parser for this widget
-            return parseAndAssign(`passage ${id}`, any);
+            return parseAndAssign(`passage ${id}`, parsePassageWidget);
         case "passage-ref":
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`passage-ref ${id}`, any);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -30,6 +30,7 @@ import {parsePassageWidget} from "./passage-widget";
 import {parsePhetSimulationWidget} from "./phet-simulation-widget";
 import {parsePlotterWidget} from "./plotter-widget";
 import {parsePythonProgramWidget} from "./python-program-widget";
+import {parseRadioWidget} from "./radio-widget";
 
 import type {PerseusWidgetsMap} from "../../../perseus-types";
 import type {ParseContext, Parser, ParseResult} from "../parser-types";
@@ -164,8 +165,7 @@ const parseWidgetsMapEntry: (
                 parsePythonProgramWidget,
             );
         case "radio":
-            // TODO(LEMS-2585): implement a real parser for this widget
-            return parseAndAssign(`radio ${id}`, any);
+            return parseAndAssign(`radio ${id}`, parseRadioWidget);
         case "sorter":
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`sorter ${id}`, any);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -8,6 +8,7 @@ import {parseDropdownWidget} from "./dropdown-widget";
 import {parseExplanationWidget} from "./explanation-widget";
 import {parseExpressionWidget} from "./expression-widget";
 import {parseGrapherWidget} from "./grapher-widget";
+import {parseGroupWidget} from "./group-widget";
 import {parseInteractiveGraphWidget} from "./interactive-graph-widget";
 
 import type {PerseusWidgetsMap} from "../../../perseus-types";
@@ -78,8 +79,7 @@ const parseWidgetsMapEntry: (
         case "grapher":
             return parseAndAssign(`grapher ${id}`, parseGrapherWidget);
         case "group":
-            // TODO(LEMS-2585): implement a real parser for this widget
-            return parseAndAssign(`group ${id}`, any);
+            return parseAndAssign(`group ${id}`, parseGroupWidget);
         case "graded-group":
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`graded-group ${id}`, any);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -7,6 +7,7 @@ import {parseDefinitionWidget} from "./definition-widget";
 import {parseDropdownWidget} from "./dropdown-widget";
 import {parseExplanationWidget} from "./explanation-widget";
 import {parseExpressionWidget} from "./expression-widget";
+import {parseGrapherWidget} from "./grapher-widget";
 import {parseInteractiveGraphWidget} from "./interactive-graph-widget";
 
 import type {PerseusWidgetsMap} from "../../../perseus-types";
@@ -75,8 +76,7 @@ const parseWidgetsMapEntry: (
         case "expression":
             return parseAndAssign(`expression ${id}`, parseExpressionWidget);
         case "grapher":
-            // TODO(LEMS-2585): implement a real parser for this widget
-            return parseAndAssign(`grapher ${id}`, any);
+            return parseAndAssign(`grapher ${id}`, parseGrapherWidget);
         case "group":
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`group ${id}`, any);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -22,6 +22,7 @@ import {parseMatcherWidget} from "./matcher-widget";
 import {parseMatrixWidget} from "./matrix-widget";
 import {parseMeasurerWidget} from "./measurer-widget";
 import {parseMoleculeRendererWidget} from "./molecule-renderer-widget";
+import {parseNumberLineWidget} from "./number-line-widget";
 
 import type {PerseusWidgetsMap} from "../../../perseus-types";
 import type {ParseContext, Parser, ParseResult} from "../parser-types";
@@ -126,8 +127,7 @@ const parseWidgetsMapEntry: (
                 parseMoleculeRendererWidget,
             );
         case "number-line":
-            // TODO(LEMS-2585): implement a real parser for this widget
-            return parseAndAssign(`number-line ${id}`, any);
+            return parseAndAssign(`number-line ${id}`, parseNumberLineWidget);
         case "numeric-input":
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`numeric-input ${id}`, any);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -29,6 +29,7 @@ import {parsePassageRefWidget} from "./passage-ref-widget";
 import {parsePassageWidget} from "./passage-widget";
 import {parsePhetSimulationWidget} from "./phet-simulation-widget";
 import {parsePlotterWidget} from "./plotter-widget";
+import {parsePythonProgramWidget} from "./python-program-widget";
 
 import type {PerseusWidgetsMap} from "../../../perseus-types";
 import type {ParseContext, Parser, ParseResult} from "../parser-types";
@@ -158,8 +159,10 @@ const parseWidgetsMapEntry: (
         case "plotter":
             return parseAndAssign(`plotter ${id}`, parsePlotterWidget);
         case "python-program":
-            // TODO(LEMS-2585): implement a real parser for this widget
-            return parseAndAssign(`python-program ${id}`, any);
+            return parseAndAssign(
+                `python-program ${id}`,
+                parsePythonProgramWidget,
+            );
         case "radio":
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`radio ${id}`, any);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -21,6 +21,7 @@ import {parseLabelImageWidget} from "./label-image-widget";
 import {parseMatcherWidget} from "./matcher-widget";
 import {parseMatrixWidget} from "./matrix-widget";
 import {parseMeasurerWidget} from "./measurer-widget";
+import {parseMoleculeRendererWidget} from "./molecule-renderer-widget";
 
 import type {PerseusWidgetsMap} from "../../../perseus-types";
 import type {ParseContext, Parser, ParseResult} from "../parser-types";
@@ -120,8 +121,10 @@ const parseWidgetsMapEntry: (
         case "measurer":
             return parseAndAssign(`measurer ${id}`, parseMeasurerWidget);
         case "molecule-renderer":
-            // TODO(LEMS-2585): implement a real parser for this widget
-            return parseAndAssign(`molecule-renderer ${id}`, any);
+            return parseAndAssign(
+                `molecule-renderer ${id}`,
+                parseMoleculeRendererWidget,
+            );
         case "number-line":
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`number-line ${id}`, any);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -23,6 +23,7 @@ import {parseMatrixWidget} from "./matrix-widget";
 import {parseMeasurerWidget} from "./measurer-widget";
 import {parseMoleculeRendererWidget} from "./molecule-renderer-widget";
 import {parseNumberLineWidget} from "./number-line-widget";
+import {parseNumericInputWidget} from "./numeric-input-widget";
 
 import type {PerseusWidgetsMap} from "../../../perseus-types";
 import type {ParseContext, Parser, ParseResult} from "../parser-types";
@@ -129,8 +130,10 @@ const parseWidgetsMapEntry: (
         case "number-line":
             return parseAndAssign(`number-line ${id}`, parseNumberLineWidget);
         case "numeric-input":
-            // TODO(LEMS-2585): implement a real parser for this widget
-            return parseAndAssign(`numeric-input ${id}`, any);
+            return parseAndAssign(
+                `numeric-input ${id}`,
+                parseNumericInputWidget,
+            );
         case "orderer":
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`orderer ${id}`, any);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -173,8 +173,7 @@ const parseWidgetsMapEntry: (
         case "table":
             return parseAndAssign(`table ${id}`, parseTableWidget);
         case "video":
-            // TODO(LEMS-2585): implement a real parser for this widget
-            return parseAndAssign(`video ${id}`, any);
+            return parseAndAssign(`video ${id}`, parseVideoWidget);
 
         default:
             if (getWidget(type)) {

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -27,6 +27,7 @@ import {parseNumericInputWidget} from "./numeric-input-widget";
 import {parseOrdererWidget} from "./orderer-widget";
 import {parsePassageRefWidget} from "./passage-ref-widget";
 import {parsePassageWidget} from "./passage-widget";
+import {parsePhetSimulationWidget} from "./phet-simulation-widget";
 
 import type {PerseusWidgetsMap} from "../../../perseus-types";
 import type {ParseContext, Parser, ParseResult} from "../parser-types";
@@ -149,8 +150,10 @@ const parseWidgetsMapEntry: (
             // https://www.khanacademy.org/devadmin/content/search?query=widget:passage-ref-target
             return parseAndAssign(`passage-ref-target ${id}`, any);
         case "phet-simulation":
-            // TODO(LEMS-2585): implement a real parser for this widget
-            return parseAndAssign(`phet-simulation ${id}`, any);
+            return parseAndAssign(
+                `phet-simulation ${id}`,
+                parsePhetSimulationWidget,
+            );
         case "plotter":
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`plotter ${id}`, any);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -144,7 +144,9 @@ const parseWidgetsMapEntry: (
         case "passage-ref":
             return parseAndAssign(`passage-ref ${id}`, parsePassageRefWidget);
         case "passage-ref-target":
-            // TODO(LEMS-2585): implement a real parser for this widget
+            // NOTE(benchristel): as of 2024-11-12, passage-ref-target is only
+            // used in test content. See:
+            // https://www.khanacademy.org/devadmin/content/search?query=widget:passage-ref-target
             return parseAndAssign(`passage-ref-target ${id}`, any);
         case "phet-simulation":
             // TODO(LEMS-2585): implement a real parser for this widget

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -34,6 +34,7 @@ import {parseRadioWidget} from "./radio-widget";
 
 import type {PerseusWidgetsMap} from "../../../perseus-types";
 import type {ParseContext, Parser, ParseResult} from "../parser-types";
+import {parseSorterWidget} from "./sorter-widget";
 
 export const parseWidgetsMap: Parser<PerseusWidgetsMap> = (rawValue, ctx) => {
     if (!isObject(rawValue)) {
@@ -167,8 +168,7 @@ const parseWidgetsMapEntry: (
         case "radio":
             return parseAndAssign(`radio ${id}`, parseRadioWidget);
         case "sorter":
-            // TODO(LEMS-2585): implement a real parser for this widget
-            return parseAndAssign(`sorter ${id}`, any);
+            return parseAndAssign(`sorter ${id}`, parseSorterWidget);
         case "table":
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`table ${id}`, any);

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -20,6 +20,7 @@ import {parseInteractiveGraphWidget} from "./interactive-graph-widget";
 import {parseLabelImageWidget} from "./label-image-widget";
 import {parseMatcherWidget} from "./matcher-widget";
 import {parseMatrixWidget} from "./matrix-widget";
+import {parseMeasurerWidget} from "./measurer-widget";
 
 import type {PerseusWidgetsMap} from "../../../perseus-types";
 import type {ParseContext, Parser, ParseResult} from "../parser-types";
@@ -117,8 +118,7 @@ const parseWidgetsMapEntry: (
         case "matrix":
             return parseAndAssign(`matrix ${id}`, parseMatrixWidget);
         case "measurer":
-            // TODO(LEMS-2585): implement a real parser for this widget
-            return parseAndAssign(`measurer ${id}`, any);
+            return parseAndAssign(`measurer ${id}`, parseMeasurerWidget);
         case "molecule-renderer":
             // TODO(LEMS-2585): implement a real parser for this widget
             return parseAndAssign(`molecule-renderer ${id}`, any);


### PR DESCRIPTION
[A previous PR][1] added infrastructure for parsing PerseusItems
from untrusted JSON, but did not include parsers for all widget types.
This PR adds parsers for the rest of the widgets.

See [ADR 773][2] for context.

[1]: https://github.com/Khan/perseus/pull/1785
[2]: https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/3318349891/ADR+773+Validate+widget+data+on+input+in+Perseus

Issue: https://khanacademy.atlassian.net/browse/LEMS-2585

Test plan:

`yarn test`

Note: the parsing code is not hooked up to anything in production yet, so this
change should have no possible user-facing impact.

## Summary:
Fix lint
Add parser for video widgets
Add parser for table widgets
Add parser for sorter widgets
Add parser for radio widgets
Add parser for python-program widgets
Add parser for plotter widgets
Add parser for PHET widgets
Note that we won't parse passage-ref-target
Add parser for passage-ref widgets
Add parser for passage widgets
Add a parser for orderer widgets
Add numeric-input widget parser
Add number-line widget parser
Add molecule-renderer widget parser
Add parser for measurer widget
Add parser for matrix widget
Parse dynamically-rendered widgets
Add parser for matcher widget
Add parser for label-image widget
Add parser for interaction widget
Add input-number widget parser
Add parser for image widget
Add iframe widget parser
Add parser for graded-group-set widget
Extract parseGradedGroupWidgetOptions
Add parser for graded-group widget
Type group widget parser
Add parser for group widget
Add parser for grapher widget

Issue: XXX-XXXX

## Test plan: