### PR TITLE
[Locked Labels] Make `{$}` show up as regular symbols inside TeX

### DIFF
--- a/.changeset/small-pots-kick.md
+++ b/.changeset/small-pots-kick.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+[Locked Labels] Allow the usage of `{$}` to denote actual dollar signs within locked label TeX

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
@@ -1239,9 +1239,9 @@ describe("locked layer", () => {
         expect(labels).toHaveLength(3);
 
         // content
-        expect(labels[0]).toHaveTextContent("small \\frac{1}{2}");
-        expect(labels[1]).toHaveTextContent("medium E_0 = mc^2");
-        expect(labels[2]).toHaveTextContent("large \\sqrt{2a}");
+        expect(labels[0]).toHaveTextContent("\\text{small }\\frac{1}{2}");
+        expect(labels[1]).toHaveTextContent("\\text{medium }E_0 = mc^2");
+        expect(labels[2]).toHaveTextContent("\\text{large }\\sqrt{2a}");
 
         // styles
         expect(labels[0]).toHaveStyle({

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -829,15 +829,15 @@ export const segmentWithLockedFunction = (
 
 export const segmentWithLockedLabels: PerseusRenderer =
     interactiveGraphQuestionBuilder()
-        .addLockedLabel("small \\frac{1}{2}", [-6, 2], {
+        .addLockedLabel("small $\\frac{1}{2}$", [-6, 2], {
             color: "pink",
             size: "small",
         })
-        .addLockedLabel("medium E_0 = mc^2", [1, 2], {
+        .addLockedLabel("medium $E_0 = mc^2$", [1, 2], {
             color: "blue",
             size: "medium",
         })
-        .addLockedLabel("large \\sqrt{2a}", [-3, -2], {
+        .addLockedLabel("large $\\sqrt{2a}$", [-3, -2], {
             color: "green",
             size: "large",
         })

--- a/packages/perseus/src/widgets/interactive-graphs/utils.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/utils.test.ts
@@ -71,7 +71,10 @@ describe("replaceOutsideTeX", () => {
         const mathString = "x^2";
         const convertedString = replaceOutsideTeX(mathString);
 
-        expect(convertedString).toEqual("\\text{x^2}");
+        // For some reason, the parser starts a new text block once it hits
+        // the '^' character. The result is still the same though.
+        // This is functionally equal to "\\text{x^2}"
+        expect(convertedString).toEqual("\\text{x}\\text{^2}");
     });
 
     test("$s surrounding string", () => {
@@ -118,5 +121,24 @@ describe("replaceOutsideTeX", () => {
         expect(convertedString).toEqual(
             "\\text{Square }A\\text{ is }B\\text{ also}",
         );
+    });
+
+    test("with a real $ inside a regular string", () => {
+        const string = "This sandwich is \\$12";
+        const convertedString = replaceOutsideTeX(string);
+
+        // For some reason, the parser starts a new text block once it hits
+        // the '$' character. The result is still the same though.
+        // This is functionally equal to "\\text{This sandwich is $12}"
+        expect(convertedString).toEqual(
+            "\\text{This sandwich is }\\text{$}\\text{12}",
+        );
+    });
+
+    test("with a real $ inside a TeX string", () => {
+        const mathString = "This sandwich is ${$}12$";
+        const convertedString = replaceOutsideTeX(mathString);
+
+        expect(convertedString).toEqual("\\text{This sandwich is }{$}12");
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/utils.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/utils.test.ts
@@ -71,10 +71,7 @@ describe("replaceOutsideTeX", () => {
         const mathString = "x^2";
         const convertedString = replaceOutsideTeX(mathString);
 
-        // For some reason, the parser starts a new text block once it hits
-        // the '^' character. The result is still the same though.
-        // This is functionally equal to "\\text{x^2}"
-        expect(convertedString).toEqual("\\text{x}\\text{^2}");
+        expect(convertedString).toEqual("\\text{x^2}");
     });
 
     test("$s surrounding string", () => {
@@ -127,12 +124,7 @@ describe("replaceOutsideTeX", () => {
         const string = "This sandwich is \\$12";
         const convertedString = replaceOutsideTeX(string);
 
-        // For some reason, the parser starts a new text block once it hits
-        // the '$' character. The result is still the same though.
-        // This is functionally equal to "\\text{This sandwich is $12}"
-        expect(convertedString).toEqual(
-            "\\text{This sandwich is }\\text{$}\\text{12}",
-        );
+        expect(convertedString).toEqual("\\text{This sandwich is \\$12}");
     });
 
     test("with a real $ inside a TeX string", () => {
@@ -140,5 +132,19 @@ describe("replaceOutsideTeX", () => {
         const convertedString = replaceOutsideTeX(mathString);
 
         expect(convertedString).toEqual("\\text{This sandwich is }{$}12");
+    });
+
+    test("escapes curly braces", () => {
+        const mathString = "Hello}{";
+        const convertedString = replaceOutsideTeX(mathString);
+
+        expect(convertedString).toEqual("\\text{Hello\\}\\{}");
+    });
+
+    test("escapes backslashes", () => {
+        const mathString = "\\";
+        const convertedString = replaceOutsideTeX(mathString);
+
+        expect(convertedString).toEqual("\\text{\\\\}");
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/utils.ts
@@ -79,26 +79,61 @@ export function isUnlimitedGraphState(
  * and the text outside of the $ blocks will be non-TeX text.
  */
 export function replaceOutsideTeX(mathString: string) {
-    let result = "";
-
     // All the information we need is in the first section,
     // whether it's typed as "blockmath" or "paragraph"
     const firstSection = SimpleMarkdown.parse(mathString)[0];
 
     // If it's blockMath, the outer level has the full math content.
     if (firstSection.type === "blockMath") {
-        result += firstSection.content;
+        return firstSection.content;
     }
 
     // If it's a paragraph, we need to iterate through the sections
     // to look for individual math blocks.
-    if (firstSection.type === "paragraph") {
-        for (const piece of firstSection.content) {
-            piece.type === "math"
-                ? (result += piece.content)
-                : (result += `\\text{${piece.content}}`);
-        }
+    const condensedNodes = condenseTextNodes(firstSection.content);
+    let result = "";
+
+    for (const piece of condensedNodes) {
+        piece.type === "math"
+            ? (result += piece.content)
+            : (result += `\\text{${escapeSpecialChars(piece.content)}}`);
     }
 
     return result;
+}
+
+type ParsedNode = {
+    type: "math" | "text";
+    content: string;
+};
+
+// Helper function for replaceOutsideTeX()
+// Condense adjacent text nodes into a single text node
+function condenseTextNodes(nodes: Array<ParsedNode>): Array<ParsedNode> {
+    const result: ParsedNode[] = [];
+
+    let currentText = "";
+    for (const node of nodes) {
+        if (node.type === "math") {
+            if (currentText) {
+                result.push({type: "text", content: currentText});
+                currentText = "";
+            }
+            result.push(node);
+        } else {
+            currentText += node.content;
+        }
+    }
+
+    if (currentText) {
+        result.push({type: "text", content: currentText});
+    }
+
+    return result;
+}
+
+// Helper function for replaceOutsideTeX()
+function escapeSpecialChars(str) {
+    // Escape $, \, {, and } characters
+    return str.replace(/([$\\{}])/g, "\\$1");
 }


### PR DESCRIPTION
## Summary:
With the current implementation, all `$` symbols are removed when
they are used to denote TeX inside `$...$` blocks. There is no way
to denote something like `$50` within TeX with this crude implementation.

To remedy this, I'm using the simple markdown parser to correctly
and more sophisticatedly determine which blocks are math.

- `{$}` and `\$` both show up as a regular dollar sign in the labels

Issue: https://khanacademy.atlassian.net/browse/LEMS-2591

## Test plan:
`yarn jest packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx`

Storybook
- Go to http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--mafs-with-locked-figure-labels-all-flags
- Use `{$}` within the locked label and locked figure labels,
  with a combination of TeX and non-TeX

<img width="858" alt="Screenshot 2024-11-12 at 4 59 39 PM" src="https://github.com/user-attachments/assets/b6f396e9-d277-4ddb-8e65-d31b9a495b40">