### PR TITLE
Table: Extract validation out of scoring

### DIFF
--- a/.changeset/curvy-glasses-poke.md
+++ b/.changeset/curvy-glasses-poke.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Introduce validation function for `table` widget - useful for checking if the learner has filled in the table sufficiently to score it (fully client-side)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,7 +110,7 @@ For each widget in `.widgets` the `Renderer`:
 1. Runs each widget's options through any upgrade transforms (see
     `Widgets.upgradeWidgetInfoToLatestVersion()` and
     `WidgetExports.propUpgrades`). See [Prop Upgrades](#Prop_Upgrades) for more info
-1. Prepares upgraded opions for rendering by applying the widget's
+1. Prepares upgraded options for rendering by applying the widget's
     `transform()` or `staticTransform()` (if rendering with
     `static: true`). These functions map the widget options to the widget's
     render Props.

--- a/packages/perseus/src/util/answer-types.ts
+++ b/packages/perseus/src/util/answer-types.ts
@@ -26,7 +26,7 @@ export type Score = {
     ungraded?: boolean;
 };
 
-/*
+/**
  * Answer types
  *
  * Utility for creating answerable questions displayed in exercises
@@ -69,7 +69,6 @@ export type Score = {
  * TODO(alpert): Think of a less-absurd name for createValidatorFunctional.
  *
  */
-
 const KhanAnswerTypes = {
     /*
      * predicate answer type

--- a/packages/perseus/src/util/answer-types.ts
+++ b/packages/perseus/src/util/answer-types.ts
@@ -11,7 +11,7 @@ import type {PerseusStrings} from "../strings";
 const MAXERROR_EPSILON = Math.pow(2, -42);
 
 type Guess = any;
-type Predicate = any;
+type Predicate = (guess: number, maxError: number) => boolean;
 
 // TOOD(kevinb): Figure out how this relates to KEScore in
 // perseus-all-package/types.js and see if there's a way to
@@ -624,11 +624,11 @@ const KhanAnswerTypes = {
         convertToPredicate: function (
             correctAnswer: string,
             options: any,
-        ): Predicate {
+        ): [predicate: Predicate, options: any] {
             const correctFloat = parseFloat(correctAnswer);
 
             return [
-                function (guess: Predicate, maxError: Predicate) {
+                function (guess, maxError) {
                     return Math.abs(guess - correctFloat) < maxError;
                 },
                 $.extend({}, options, {type: "predicate"}),
@@ -640,7 +640,6 @@ const KhanAnswerTypes = {
             strings: PerseusStrings,
         ): (arg1: Guess) => Score {
             return KhanAnswerTypes.predicate.createValidatorFunctional(
-                // @ts-expect-error - TS2556 - A spread argument must either have a tuple type or be passed to a rest parameter.
                 ...KhanAnswerTypes.number.convertToPredicate(
                     correctAnswer,
                     options,

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -180,7 +180,14 @@ export type PerseusSorterUserInput = {
     changed: boolean;
 };
 
-export type PerseusTableRubric = PerseusTableWidgetOptions;
+export type PerseusTableRubric = {
+    // The number of rows to display
+    rows: number;
+    // The number of columns to display
+    columns: number;
+    // Translatable Text; A 2-dimensional array of text to populate the table with
+    answers: ReadonlyArray<ReadonlyArray<string>>;
+};
 
 export type PerseusTableUserInput = ReadonlyArray<ReadonlyArray<string>>;
 

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -13,7 +13,6 @@ import type {
     PerseusOrdererWidgetOptions,
     PerseusPlotterWidgetOptions,
     PerseusRadioChoice,
-    PerseusTableWidgetOptions,
     PerseusGraphCorrectType,
 } from "./perseus-types";
 import type {InteractiveMarkerType} from "./widgets/label-image/types";

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -180,10 +180,6 @@ export type PerseusSorterUserInput = {
 };
 
 export type PerseusTableRubric = {
-    // The number of rows to display
-    rows: number;
-    // The number of columns to display
-    columns: number;
     // Translatable Text; A 2-dimensional array of text to populate the table with
     answers: ReadonlyArray<ReadonlyArray<string>>;
 };

--- a/packages/perseus/src/widgets/table/score-table.test.ts
+++ b/packages/perseus/src/widgets/table/score-table.test.ts
@@ -16,8 +16,6 @@ describe("scoreTable", () => {
         ];
 
         const rubric: PerseusTableRubric = {
-            rows: 2,
-            columns: 2,
             answers: [
                 ["1", "2"],
                 ["3", "4"],
@@ -40,8 +38,6 @@ describe("scoreTable", () => {
         ];
 
         const rubric: PerseusTableRubric = {
-            rows: 2,
-            columns: 2,
             answers: [
                 ["1", "2"],
                 ["3", "4"],
@@ -63,8 +59,6 @@ describe("scoreTable", () => {
         ];
 
         const rubric: PerseusTableRubric = {
-            rows: 2,
-            columns: 2,
             answers: [
                 ["1", "2"],
                 ["3", "4"],
@@ -86,8 +80,6 @@ describe("scoreTable", () => {
         ];
 
         const rubric: PerseusTableRubric = {
-            rows: 2,
-            columns: 2,
             answers: [
                 ["1", "2"],
                 ["3", "4"],
@@ -109,8 +101,6 @@ describe("scoreTable", () => {
         ];
 
         const rubric: PerseusTableRubric = {
-            rows: 2,
-            columns: 2,
             answers: [
                 ["1", "2"],
                 ["3", "4"],

--- a/packages/perseus/src/widgets/table/score-table.test.ts
+++ b/packages/perseus/src/widgets/table/score-table.test.ts
@@ -16,7 +16,6 @@ describe("scoreTable", () => {
         ];
 
         const rubric: PerseusTableRubric = {
-            headers: ["Col 1", "Col 2"],
             rows: 2,
             columns: 2,
             answers: [
@@ -41,7 +40,6 @@ describe("scoreTable", () => {
         ];
 
         const rubric: PerseusTableRubric = {
-            headers: ["Col 1", "Col 2"],
             rows: 2,
             columns: 2,
             answers: [
@@ -65,7 +63,6 @@ describe("scoreTable", () => {
         ];
 
         const rubric: PerseusTableRubric = {
-            headers: ["Col 1", "Col 2"],
             rows: 2,
             columns: 2,
             answers: [
@@ -89,7 +86,6 @@ describe("scoreTable", () => {
         ];
 
         const rubric: PerseusTableRubric = {
-            headers: ["Col 1", "Col 2"],
             rows: 2,
             columns: 2,
             answers: [
@@ -113,7 +109,6 @@ describe("scoreTable", () => {
         ];
 
         const rubric: PerseusTableRubric = {
-            headers: ["Col 1", "Col 2"],
             rows: 2,
             columns: 2,
             answers: [

--- a/packages/perseus/src/widgets/table/score-table.ts
+++ b/packages/perseus/src/widgets/table/score-table.ts
@@ -13,16 +13,16 @@ import type {
 } from "../../validation.types";
 
 function scoreTable(
-    state: PerseusTableUserInput,
+    userInput: PerseusTableUserInput,
     rubric: PerseusTableRubric,
     strings: PerseusStrings,
 ): PerseusScore {
-    const validationResult = validateTable(state);
+    const validationResult = validateTable(userInput);
     if (validationResult.type === "invalid") {
         return validationResult;
     }
 
-    const supplied = filterNonEmpty(state);
+    const supplied = filterNonEmpty(userInput);
     const solution = filterNonEmpty(rubric.answers);
     if (supplied.length !== solution.length) {
         return {

--- a/packages/perseus/src/widgets/table/score-table.ts
+++ b/packages/perseus/src/widgets/table/score-table.ts
@@ -3,7 +3,7 @@ import _ from "underscore";
 import KhanAnswerTypes from "../../util/answer-types";
 
 import {filterNonEmpty} from "./utils";
-import {validateTable} from "./validate-table";
+import validateTable from "./validate-table";
 
 import type {PerseusStrings} from "../../strings";
 import type {PerseusScore} from "../../types";

--- a/packages/perseus/src/widgets/table/score-table.ts
+++ b/packages/perseus/src/widgets/table/score-table.ts
@@ -34,7 +34,7 @@ function scoreTable(
     }
 
     const createValidator = KhanAnswerTypes.number.createValidatorFunctional;
-    let message = null;
+    let message: string | null = null;
     const allCorrect = solution.every(function (rowSolution) {
         for (let i = 0; i < supplied.length; i++) {
             const rowSupplied = supplied[i];
@@ -49,7 +49,6 @@ function scoreTable(
                 );
                 const result = validator(cellSupplied);
                 if (result.message) {
-                    // @ts-expect-error - TS2322 - Type 'string' is not assignable to type 'null'.
                     message = result.message;
                 }
                 return result.correct;
@@ -65,7 +64,7 @@ function scoreTable(
         type: "points",
         earned: allCorrect ? 1 : 0,
         total: 1,
-        message: message,
+        message,
     };
 }
 

--- a/packages/perseus/src/widgets/table/score-table.ts
+++ b/packages/perseus/src/widgets/table/score-table.ts
@@ -18,7 +18,7 @@ function scoreTable(
     strings: PerseusStrings,
 ): PerseusScore {
     const validationResult = validateTable(userInput);
-    if (validationResult.type === "invalid") {
+    if (validationResult != null) {
         return validationResult;
     }
 

--- a/packages/perseus/src/widgets/table/utils.ts
+++ b/packages/perseus/src/widgets/table/utils.ts
@@ -1,0 +1,14 @@
+import type {PerseusTableUserInput} from "../../validation.types";
+
+/**
+ * Filters the given table (modelled as a 2D array) to remove any rows that are
+ * completely empty.
+ *
+ * @returns A new table with only non-empty rows.
+ */
+export const filterNonEmpty = function (table: PerseusTableUserInput) {
+    return table.filter(function (row) {
+        // Return only rows that are non-empty.
+        return row.some((cell) => cell);
+    });
+};

--- a/packages/perseus/src/widgets/table/utils.ts
+++ b/packages/perseus/src/widgets/table/utils.ts
@@ -1,12 +1,12 @@
-import type {PerseusTableUserInput} from "../../validation.types";
-
 /**
  * Filters the given table (modelled as a 2D array) to remove any rows that are
  * completely empty.
  *
  * @returns A new table with only non-empty rows.
  */
-export const filterNonEmpty = function (table: PerseusTableUserInput) {
+export const filterNonEmpty = function (
+    table: ReadonlyArray<ReadonlyArray<string>>,
+) {
     return table.filter(function (row) {
         // Return only rows that are non-empty.
         return row.some((cell) => cell);

--- a/packages/perseus/src/widgets/table/validate-table.test.ts
+++ b/packages/perseus/src/widgets/table/validate-table.test.ts
@@ -1,4 +1,4 @@
-import {validateTable} from "./validate-table";
+import validateTable from "./validate-table";
 
 import type {PerseusTableUserInput} from "../../validation.types";
 

--- a/packages/perseus/src/widgets/table/validate-table.test.ts
+++ b/packages/perseus/src/widgets/table/validate-table.test.ts
@@ -1,0 +1,33 @@
+import {validateTable} from "./validate-table";
+
+import type {PerseusTableUserInput} from "../../validation.types";
+
+describe("tableValidator", () => {
+    it("is invalid if there is an empty cell", () => {
+        // Arrange
+        const userInput: PerseusTableUserInput = [
+            ["1", ""],
+            ["3", "4"],
+        ];
+
+        // Act
+        const result = validateTable(userInput);
+
+        // Assert
+        expect(result).toHaveInvalidInput();
+    });
+
+    it("is valid, not not correct, if all cells are provided", () => {
+        // Arrange
+        const userInput: PerseusTableUserInput = [
+            ["1", "2"],
+            ["3", "4"],
+        ];
+
+        // Act
+        const result = validateTable(userInput);
+
+        // Assert
+        expect(result).toHaveBeenAnsweredCorrectly({shouldHavePoints: false});
+    });
+});

--- a/packages/perseus/src/widgets/table/validate-table.test.ts
+++ b/packages/perseus/src/widgets/table/validate-table.test.ts
@@ -17,7 +17,7 @@ describe("tableValidator", () => {
         expect(result).toHaveInvalidInput();
     });
 
-    it("is valid, not not correct, if all cells are provided", () => {
+    it("is valid, not correct, if all cells are provided", () => {
         // Arrange
         const userInput: PerseusTableUserInput = [
             ["1", "2"],

--- a/packages/perseus/src/widgets/table/validate-table.test.ts
+++ b/packages/perseus/src/widgets/table/validate-table.test.ts
@@ -17,7 +17,7 @@ describe("tableValidator", () => {
         expect(result).toHaveInvalidInput();
     });
 
-    it("is valid, not correct, if all cells are provided", () => {
+    it("is null if all cells are provided", () => {
         // Arrange
         const userInput: PerseusTableUserInput = [
             ["1", "2"],
@@ -28,6 +28,6 @@ describe("tableValidator", () => {
         const result = validateTable(userInput);
 
         // Assert
-        expect(result).toHaveBeenAnsweredCorrectly({shouldHavePoints: false});
+        expect(result).toBeNull();
     });
 });

--- a/packages/perseus/src/widgets/table/validate-table.ts
+++ b/packages/perseus/src/widgets/table/validate-table.ts
@@ -3,8 +3,8 @@ import {filterNonEmpty} from "./utils";
 import type {PerseusScore} from "../../types";
 import type {PerseusTableUserInput} from "../../validation.types";
 
-export function validateTable(state: PerseusTableUserInput): PerseusScore {
-    const supplied = filterNonEmpty(state);
+export function validateTable(userInput: PerseusTableUserInput): PerseusScore {
+    const supplied = filterNonEmpty(userInput);
 
     const hasEmptyCell = supplied.some(function (row) {
         return row.some(function (cell) {

--- a/packages/perseus/src/widgets/table/validate-table.ts
+++ b/packages/perseus/src/widgets/table/validate-table.ts
@@ -1,0 +1,24 @@
+import {filterNonEmpty} from "./utils";
+
+import type {PerseusScore} from "../../types";
+import type {PerseusTableUserInput} from "../../validation.types";
+
+export function validateTable(state: PerseusTableUserInput): PerseusScore {
+    const supplied = filterNonEmpty(state);
+
+    const hasEmptyCell = supplied.some(function (row) {
+        return row.some(function (cell) {
+            return cell === "";
+        });
+    });
+
+    if (hasEmptyCell || !supplied.length) {
+        return {
+            type: "invalid",
+            message: null,
+        };
+    }
+
+    // No points earned, but at least we're not invalid
+    return {type: "points", earned: 0, total: 0};
+}

--- a/packages/perseus/src/widgets/table/validate-table.ts
+++ b/packages/perseus/src/widgets/table/validate-table.ts
@@ -3,7 +3,9 @@ import {filterNonEmpty} from "./utils";
 import type {PerseusScore} from "../../types";
 import type {PerseusTableUserInput} from "../../validation.types";
 
-function validateTable(userInput: PerseusTableUserInput): PerseusScore {
+function validateTable(
+    userInput: PerseusTableUserInput,
+): Extract<PerseusScore, {type: "invalid"}> | null {
     const supplied = filterNonEmpty(userInput);
 
     const hasEmptyCell = supplied.some(function (row) {
@@ -19,8 +21,7 @@ function validateTable(userInput: PerseusTableUserInput): PerseusScore {
         };
     }
 
-    // No points earned, but at least we're not invalid
-    return {type: "points", earned: 0, total: 0};
+    return null;
 }
 
 export default validateTable;

--- a/packages/perseus/src/widgets/table/validate-table.ts
+++ b/packages/perseus/src/widgets/table/validate-table.ts
@@ -3,7 +3,7 @@ import {filterNonEmpty} from "./utils";
 import type {PerseusScore} from "../../types";
 import type {PerseusTableUserInput} from "../../validation.types";
 
-export function validateTable(userInput: PerseusTableUserInput): PerseusScore {
+function validateTable(userInput: PerseusTableUserInput): PerseusScore {
     const supplied = filterNonEmpty(userInput);
 
     const hasEmptyCell = supplied.some(function (row) {
@@ -22,3 +22,5 @@ export function validateTable(userInput: PerseusTableUserInput): PerseusScore {
     // No points earned, but at least we're not invalid
     return {type: "points", earned: 0, total: 0};
 }
+
+export default validateTable;


### PR DESCRIPTION
## Summary:

This PR is a test run for extracting validation logic from scoring (using `table` as the test subject). I've used a pattern where the validator still returns a `PerseusScore`. This means that we can call the validator as the first step in scoring and return the score if it's `invalid`.  

Issue: LEMS-2606

## Test plan:

All tests should still pass.