### PR TITLE
Add TUT team as owner of widget-ai-utils/ code

### DIFF
--- a/.github/REVIEWERS
+++ b/.github/REVIEWERS
@@ -50,3 +50,6 @@ Regex Examples:
 [ON PULL REQUEST] (DO NOT DELETE THIS LINE)
 
 **/*    @Khan/perseus!
+
+# AI Utils are owned by Tutor Platform
+widget-ai-utils/* @Khan/tut


### PR DESCRIPTION
## Summary:

This PR adds [`TUT`](https://github.com/orgs/Khan/teams/tut) as a reviewer to any pull requests for `widget-ai-utils/*` code.

Issue: "none"

## Test plan:

Open a PR with changes in `widget-ai-utils/` and notice that `TUT` is tagged by Gerald