### PR TITLE
[Locked Figure Labels] Fix bug that's causing the editor to crash when the label input is empty (and on load)

### DIFF
--- a/.changeset/dry-moles-notice.md
+++ b/.changeset/dry-moles-notice.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Locked Figure Labels] Fix bug that's causing the editor to crash when the label input is empty (and on load)

--- a/packages/perseus/src/widgets/interactive-graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/utils.ts
@@ -109,8 +109,12 @@ type ParsedNode = {
 
 // Helper function for replaceOutsideTeX()
 // Condense adjacent text nodes into a single text node
-function condenseTextNodes(nodes: Array<ParsedNode>): Array<ParsedNode> {
+function condenseTextNodes(nodes: ParsedNode[] | undefined): Array<ParsedNode> {
     const result: ParsedNode[] = [];
+
+    if (!nodes) {
+        return result;
+    }
 
     let currentText = "";
     for (const node of nodes) {


### PR DESCRIPTION
## Summary:
I need to add a null check after my $ TeX updates in https://github.com/Khan/perseus/pull/1847.

This is actually already added in a larger PR, but this fix needs to get out ASAP.

Issue: none

## Test plan:
- Go to http://localhost:6006/iframe.html?id=perseuseditor-widgets-interactive-graph--mafs-with-locked-figure-labels-all-flags&viewMode=story
- Backspace in the locked point visible label input field
- Confirm that there is no crash