### PR TITLE
Categorizer: Extract validation out of scoring

### DIFF
--- a/.changeset/green-ghosts-burn.md
+++ b/.changeset/green-ghosts-burn.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Split out validation function for the `categorizer` widget. This can be used to check if the user selected an answer for every row, confirming the question is ready to be scored.

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -20,16 +20,14 @@ import type {Relationship} from "./widgets/number-line/number-line";
 
 export type UserInputStatus = "correct" | "incorrect" | "incomplete";
 
-export type PerseusCategorizerRubric = {
+export type PerseusCategorizerScoringData = {
     // The correct answers where index relates to the items and value relates
     // to the category.  e.g. [0, 1, 0, 1, 2]
     values: ReadonlyArray<number>;
-    // Translatable text; a list of items to categorize. e.g. ["banana", "yellow", "apple", "purple", "shirt"]
-    items: ReadonlyArray<string>;
-};
+} & PerseusCategorizerValidationData;
 
 export type PerseusCategorizerUserInput = {
-    values: PerseusCategorizerRubric["values"];
+    values: PerseusCategorizerScoringData["values"];
 };
 
 export type PerseusCategorizerValidationData = {
@@ -195,7 +193,7 @@ export type PerseusTableRubric = {
 export type PerseusTableUserInput = ReadonlyArray<ReadonlyArray<string>>;
 
 export type Rubric =
-    | PerseusCategorizerRubric
+    | PerseusCategorizerScoringData
     | PerseusCSProgramRubric
     | PerseusDropdownRubric
     | PerseusExpressionRubric

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -24,6 +24,8 @@ export type PerseusCategorizerRubric = {
     // The correct answers where index relates to the items and value relates
     // to the category.  e.g. [0, 1, 0, 1, 2]
     values: ReadonlyArray<number>;
+    // Translatable text; a list of items to categorize. e.g. ["banana", "yellow", "apple", "purple", "shirt"]
+    items: ReadonlyArray<string>;
 };
 
 export type PerseusCategorizerUserInput = {

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -31,6 +31,12 @@ export type PerseusCategorizerRubric = {
 export type PerseusCategorizerUserInput = {
     values: PerseusCategorizerRubric["values"];
 };
+
+export type PerseusCategorizerValidationData = {
+    // Translatable text; a list of items to categorize. e.g. ["banana", "yellow", "apple", "purple", "shirt"]
+    items: ReadonlyArray<string>;
+};
+
 // TODO(LEMS-2440): Can possibly be removed during 2440?
 // This is not used for grading at all. The only place it is used is to define
 // Props type in cs-program.tsx, but RenderProps already contains WidgetOptions

--- a/packages/perseus/src/widgets/categorizer/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.tsx
@@ -21,12 +21,12 @@ import scoreCategorizer from "./score-categorizer";
 import type {PerseusCategorizerWidgetOptions} from "../../perseus-types";
 import type {Widget, WidgetExports, WidgetProps} from "../../types";
 import type {
-    PerseusCategorizerRubric,
+    PerseusCategorizerScoringData,
     PerseusCategorizerUserInput,
 } from "../../validation.types";
 import type {CategorizerPromptJSON} from "../../widget-ai-utils/categorizer/prompt-utils";
 
-type Props = WidgetProps<RenderProps, PerseusCategorizerRubric> & {
+type Props = WidgetProps<RenderProps, PerseusCategorizerScoringData> & {
     values: ReadonlyArray<string>;
 };
 

--- a/packages/perseus/src/widgets/categorizer/score-categorizer.test.ts
+++ b/packages/perseus/src/widgets/categorizer/score-categorizer.test.ts
@@ -8,6 +8,7 @@ describe("scoreCategorizer", () => {
     it("gives points when the answer is correct", () => {
         const rubric: PerseusCategorizerRubric = {
             values: [1, 3],
+            items: ["apples", "oranges"],
         };
 
         const userInput = {
@@ -21,6 +22,7 @@ describe("scoreCategorizer", () => {
     it("does not give points when incorrectly answered", () => {
         const rubric: PerseusCategorizerRubric = {
             values: [1, 3],
+            items: ["apples", "oranges"],
         };
 
         const userInput = {

--- a/packages/perseus/src/widgets/categorizer/score-categorizer.test.ts
+++ b/packages/perseus/src/widgets/categorizer/score-categorizer.test.ts
@@ -30,19 +30,4 @@ describe("scoreCategorizer", () => {
 
         expect(score).toHaveBeenAnsweredIncorrectly();
     });
-
-    it("tells the learner its not complete if not selected", () => {
-        const rubric: PerseusCategorizerRubric = {
-            values: [1, 3],
-        };
-
-        const userInput = {
-            values: [2],
-        } as const;
-        const score = scoreCategorizer(userInput, rubric, mockStrings);
-
-        expect(score).toHaveInvalidInput(
-            "Make sure you select something for every row.",
-        );
-    });
 });

--- a/packages/perseus/src/widgets/categorizer/score-categorizer.test.ts
+++ b/packages/perseus/src/widgets/categorizer/score-categorizer.test.ts
@@ -2,11 +2,11 @@ import {mockStrings} from "../../strings";
 
 import scoreCategorizer from "./score-categorizer";
 
-import type {PerseusCategorizerRubric} from "../../validation.types";
+import type {PerseusCategorizerScoringData} from "../../validation.types";
 
 describe("scoreCategorizer", () => {
     it("gives points when the answer is correct", () => {
-        const rubric: PerseusCategorizerRubric = {
+        const scoringData: PerseusCategorizerScoringData = {
             values: [1, 3],
             items: ["apples", "oranges"],
         };
@@ -14,13 +14,13 @@ describe("scoreCategorizer", () => {
         const userInput = {
             values: [1, 3],
         } as const;
-        const score = scoreCategorizer(userInput, rubric, mockStrings);
+        const score = scoreCategorizer(userInput, scoringData, mockStrings);
 
         expect(score).toHaveBeenAnsweredCorrectly();
     });
 
     it("does not give points when incorrectly answered", () => {
-        const rubric: PerseusCategorizerRubric = {
+        const scoringData: PerseusCategorizerScoringData = {
             values: [1, 3],
             items: ["apples", "oranges"],
         };
@@ -28,7 +28,7 @@ describe("scoreCategorizer", () => {
         const userInput = {
             values: [2, 3],
         } as const;
-        const score = scoreCategorizer(userInput, rubric, mockStrings);
+        const score = scoreCategorizer(userInput, scoringData, mockStrings);
 
         expect(score).toHaveBeenAnsweredIncorrectly();
     });

--- a/packages/perseus/src/widgets/categorizer/score-categorizer.ts
+++ b/packages/perseus/src/widgets/categorizer/score-categorizer.ts
@@ -1,3 +1,5 @@
+import validateCategorizer from "./validate-categorizer";
+
 import type {PerseusStrings} from "../../strings";
 import type {PerseusScore} from "../../types";
 import type {
@@ -10,22 +12,17 @@ function scoreCategorizer(
     rubric: PerseusCategorizerRubric,
     strings: PerseusStrings,
 ): PerseusScore {
-    let completed = true;
+    const validationResult = validateCategorizer(userInput, rubric, strings);
+    if (validationResult) {
+        return validationResult;
+    }
+
     let allCorrect = true;
     rubric.values.forEach((value, i) => {
-        if (userInput.values[i] == null) {
-            completed = false;
-        }
         if (userInput.values[i] !== value) {
             allCorrect = false;
         }
     });
-    if (!completed) {
-        return {
-            type: "invalid",
-            message: strings.invalidSelection,
-        };
-    }
     return {
         type: "points",
         earned: allCorrect ? 1 : 0,

--- a/packages/perseus/src/widgets/categorizer/score-categorizer.ts
+++ b/packages/perseus/src/widgets/categorizer/score-categorizer.ts
@@ -12,9 +12,9 @@ function scoreCategorizer(
     rubric: PerseusCategorizerRubric,
     strings: PerseusStrings,
 ): PerseusScore {
-    const validationResult = validateCategorizer(userInput, rubric, strings);
-    if (validationResult) {
-        return validationResult;
+    const validationError = validateCategorizer(userInput, rubric, strings);
+    if (validationError) {
+        return validationError;
     }
 
     let allCorrect = true;

--- a/packages/perseus/src/widgets/categorizer/score-categorizer.ts
+++ b/packages/perseus/src/widgets/categorizer/score-categorizer.ts
@@ -3,22 +3,26 @@ import validateCategorizer from "./validate-categorizer";
 import type {PerseusStrings} from "../../strings";
 import type {PerseusScore} from "../../types";
 import type {
-    PerseusCategorizerRubric,
+    PerseusCategorizerScoringData,
     PerseusCategorizerUserInput,
 } from "../../validation.types";
 
 function scoreCategorizer(
     userInput: PerseusCategorizerUserInput,
-    rubric: PerseusCategorizerRubric,
+    scoringData: PerseusCategorizerScoringData,
     strings: PerseusStrings,
 ): PerseusScore {
-    const validationError = validateCategorizer(userInput, rubric, strings);
+    const validationError = validateCategorizer(
+        userInput,
+        scoringData,
+        strings,
+    );
     if (validationError) {
         return validationError;
     }
 
     let allCorrect = true;
-    rubric.values.forEach((value, i) => {
+    scoringData.values.forEach((value, i) => {
         if (userInput.values[i] !== value) {
             allCorrect = false;
         }

--- a/packages/perseus/src/widgets/categorizer/validate-categorizer.test.ts
+++ b/packages/perseus/src/widgets/categorizer/validate-categorizer.test.ts
@@ -8,6 +8,7 @@ describe("validateCategorizer", () => {
     it("tells the learner its not complete if not selected", () => {
         const rubric: PerseusCategorizerRubric = {
             values: [1, 3],
+            items: ["apples", "oranges"],
         };
 
         const userInput = {

--- a/packages/perseus/src/widgets/categorizer/validate-categorizer.test.ts
+++ b/packages/perseus/src/widgets/categorizer/validate-categorizer.test.ts
@@ -20,4 +20,18 @@ describe("validateCategorizer", () => {
             "Make sure you select something for every row.",
         );
     });
+
+    it("returns null if the userInput is valid", () => {
+        const rubric: PerseusCategorizerRubric = {
+            values: [1, 3],
+            items: ["apples", "oranges"],
+        };
+
+        const userInput = {
+            values: [2, 4],
+        } as const;
+        const score = validateCategorizer(userInput, rubric, mockStrings);
+
+        expect(score).toBeNull();
+    });
 });

--- a/packages/perseus/src/widgets/categorizer/validate-categorizer.test.ts
+++ b/packages/perseus/src/widgets/categorizer/validate-categorizer.test.ts
@@ -1,0 +1,22 @@
+import {mockStrings} from "../../strings";
+
+import validateCategorizer from "./validate-categorizer";
+
+import type {PerseusCategorizerRubric} from "../../validation.types";
+
+describe("validateCategorizer", () => {
+    it("tells the learner its not complete if not selected", () => {
+        const rubric: PerseusCategorizerRubric = {
+            values: [1, 3],
+        };
+
+        const userInput = {
+            values: [2],
+        } as const;
+        const score = validateCategorizer(userInput, rubric, mockStrings);
+
+        expect(score).toHaveInvalidInput(
+            "Make sure you select something for every row.",
+        );
+    });
+});

--- a/packages/perseus/src/widgets/categorizer/validate-categorizer.test.ts
+++ b/packages/perseus/src/widgets/categorizer/validate-categorizer.test.ts
@@ -2,19 +2,22 @@ import {mockStrings} from "../../strings";
 
 import validateCategorizer from "./validate-categorizer";
 
-import type {PerseusCategorizerRubric} from "../../validation.types";
+import type {PerseusCategorizerValidationData} from "../../validation.types";
 
 describe("validateCategorizer", () => {
     it("tells the learner its not complete if not selected", () => {
-        const rubric: PerseusCategorizerRubric = {
-            values: [1, 3],
+        const validationData: PerseusCategorizerValidationData = {
             items: ["apples", "oranges"],
         };
 
         const userInput = {
             values: [2],
         } as const;
-        const score = validateCategorizer(userInput, rubric, mockStrings);
+        const score = validateCategorizer(
+            userInput,
+            validationData,
+            mockStrings,
+        );
 
         expect(score).toHaveInvalidInput(
             "Make sure you select something for every row.",
@@ -22,15 +25,18 @@ describe("validateCategorizer", () => {
     });
 
     it("returns null if the userInput is valid", () => {
-        const rubric: PerseusCategorizerRubric = {
-            values: [1, 3],
+        const validationData: PerseusCategorizerValidationData = {
             items: ["apples", "oranges"],
         };
 
         const userInput = {
             values: [2, 4],
         } as const;
-        const score = validateCategorizer(userInput, rubric, mockStrings);
+        const score = validateCategorizer(
+            userInput,
+            validationData,
+            mockStrings,
+        );
 
         expect(score).toBeNull();
     });

--- a/packages/perseus/src/widgets/categorizer/validate-categorizer.ts
+++ b/packages/perseus/src/widgets/categorizer/validate-categorizer.ts
@@ -11,7 +11,7 @@ function validateCategorizer(
     strings: PerseusStrings,
 ): Extract<PerseusScore, {type: "invalid"}> | null {
     let completed = true;
-    rubric.values.forEach((_, i) => {
+    rubric.items.forEach((_, i) => {
         if (userInput.values[i] == null) {
             completed = false;
         }

--- a/packages/perseus/src/widgets/categorizer/validate-categorizer.ts
+++ b/packages/perseus/src/widgets/categorizer/validate-categorizer.ts
@@ -1,0 +1,28 @@
+import type {PerseusStrings} from "../../strings";
+import type {PerseusScore} from "../../types";
+import type {
+    PerseusCategorizerRubric,
+    PerseusCategorizerUserInput,
+} from "../../validation.types";
+
+function validateCategorizer(
+    userInput: PerseusCategorizerUserInput,
+    rubric: PerseusCategorizerRubric,
+    strings: PerseusStrings,
+): Extract<PerseusScore, {type: "invalid"}> | null {
+    let completed = true;
+    rubric.values.forEach((_, i) => {
+        if (userInput.values[i] == null) {
+            completed = false;
+        }
+    });
+    if (!completed) {
+        return {
+            type: "invalid",
+            message: strings.invalidSelection,
+        };
+    }
+    return null;
+}
+
+export default validateCategorizer;

--- a/packages/perseus/src/widgets/categorizer/validate-categorizer.ts
+++ b/packages/perseus/src/widgets/categorizer/validate-categorizer.ts
@@ -1,16 +1,18 @@
 import type {PerseusStrings} from "../../strings";
 import type {PerseusScore} from "../../types";
 import type {
-    PerseusCategorizerRubric,
     PerseusCategorizerUserInput,
+    PerseusCategorizerValidationData,
 } from "../../validation.types";
 
 function validateCategorizer(
     userInput: PerseusCategorizerUserInput,
-    rubric: PerseusCategorizerRubric,
+    validationData: PerseusCategorizerValidationData,
     strings: PerseusStrings,
 ): Extract<PerseusScore, {type: "invalid"}> | null {
-    const incomplete = rubric.items.some((_, i) => userInput.values[i] == null);
+    const incomplete = validationData.items.some(
+        (_, i) => userInput.values[i] == null,
+    );
 
     if (incomplete) {
         return {

--- a/packages/perseus/src/widgets/categorizer/validate-categorizer.ts
+++ b/packages/perseus/src/widgets/categorizer/validate-categorizer.ts
@@ -10,13 +10,9 @@ function validateCategorizer(
     rubric: PerseusCategorizerRubric,
     strings: PerseusStrings,
 ): Extract<PerseusScore, {type: "invalid"}> | null {
-    let completed = true;
-    rubric.items.forEach((_, i) => {
-        if (userInput.values[i] == null) {
-            completed = false;
-        }
-    });
-    if (!completed) {
+    const incomplete = rubric.items.some((_, i) => userInput.values[i] == null);
+
+    if (incomplete) {
         return {
             type: "invalid",
             message: strings.invalidSelection,

--- a/packages/perseus/src/widgets/categorizer/validate-categorizer.ts
+++ b/packages/perseus/src/widgets/categorizer/validate-categorizer.ts
@@ -5,6 +5,14 @@ import type {
     PerseusCategorizerValidationData,
 } from "../../validation.types";
 
+/**
+ * Checks userInput from the categorizer widget to see if the user has selected
+ * a category for each item.
+ * @param userInput - The user's input corresponding to an array of indices that
+ * represent the selected category for each row/item.
+ * @param validationData - An array of strings corresponding to each row/item
+ * @param strings - Used to provide a validation message
+ */
 function validateCategorizer(
     userInput: PerseusCategorizerUserInput,
     validationData: PerseusCategorizerValidationData,


### PR DESCRIPTION
## Summary:
In order to complete scoring server-side, we need to separate out the validation logic from the scoring logic. This work separates those two functions and updates associated tests.

Issue: LEMS-2596

## Test plan:
- Confirm all checks pass
- Confirm the widget still behaves as it should.