### PR TITLE
ADR 773: Add exhaustive test tool for PerseusItem parser

### DIFF
--- a/.changeset/green-suns-battle.md
+++ b/.changeset/green-suns-battle.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Add script for exhaustive testing of PerseusItem parser

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "@types/classnames": "^2.3.1",
         "@types/jest": "29",
         "@types/jquery": "^3.5.16",
-        "@types/node": "^18.14.1",
+        "@types/node": "^20.11.1",
         "@types/react": "~18.2.64",
         "@types/react-dom": "~18.2.19",
         "@types/underscore": "^1.11.4",

--- a/packages/perseus/src/util/parse-perseus-json/exhaustive-test-tool/index.ts
+++ b/packages/perseus/src/util/parse-perseus-json/exhaustive-test-tool/index.ts
@@ -30,6 +30,7 @@ async function main() {
     // `node` and the path to this script, so we can get rid of them.
     const realArgs = process.argv.slice(2);
     const {inputDir} = parseCommandLineArguments(realArgs);
+    // eslint-disable-next-line no-console
     console.log("testing files in " + inputDir);
 
     let numFiles = 0;
@@ -38,6 +39,7 @@ async function main() {
         numFiles++;
     }
 
+    // eslint-disable-next-line no-console
     console.log("tested " + numFiles + " files");
 }
 
@@ -54,6 +56,7 @@ async function testFile(path: string) {
     try {
         assessmentItems = JSON.parse(json);
     } catch {
+        // eslint-disable-next-line no-console
         console.warn("Failed to parse JSON file: " + path);
         return;
     }
@@ -82,9 +85,9 @@ async function testFile(path: string) {
 
 function getAssessmentItemData(raw: unknown): unknown {
     if (raw && typeof raw === "object" && "item_data" in raw) {
-        return raw.item_data
+        return raw.item_data;
     } else {
-        return raw
+        return raw;
     }
 }
 

--- a/packages/perseus/src/util/parse-perseus-json/exhaustive-test-tool/index.ts
+++ b/packages/perseus/src/util/parse-perseus-json/exhaustive-test-tool/index.ts
@@ -1,0 +1,123 @@
+#!/usr/bin/env -S node -r @swc-node/register
+
+// This is a NodeJS script that tests the Perseus JSON parsing code against a
+// content data dump.
+//
+// USAGE:
+// First, download the content data dump:
+//
+//     mkdir ~/Desktop/content
+//     gsutil -m cp -r gs://content-property.khanacademy.org/{Article,Exercise}.{Translated,}PerseusContent ~/Desktop/content
+//
+// Then, run the test tool over the content like so:
+//
+//     find ~/Desktop/content/*/* -type d | xargs -n1 packages/perseus/src/util/parse-perseus-json/exhaustive-test-tool/index.ts
+
+import {formatPath} from "../object-path";
+import {Mismatch} from "../parser-types";
+import {createHash} from "crypto";
+import * as fs from "fs/promises"
+import {Dirent} from "fs";
+import {join} from "path";
+import {parsePerseusItem} from "../perseus-parsers/perseus-item";
+import {isSuccess} from "../result";
+import {ErrorTrackingParseContext} from "../error-tracking-parse-context";
+
+let numFiles = 0;
+async function main() {
+    // process.argv.slice(2) is a common NodeJS idiom. The first two args are
+    // `node` and the path to this script, so we can get rid of them.
+    const realArgs = process.argv.slice(2)
+    const {inputDir} = parseCommandLineArguments(realArgs);
+    console.log("testing files in " + inputDir)
+
+    for await (const dirent of listFilesRecursively(inputDir)) {
+        await testFile(getPathOfDirent(dirent))
+        numFiles++
+    }
+
+    console.log("tested " + numFiles + " files")
+}
+
+function parseCommandLineArguments(args: string[]) {
+    return {inputDir: args[0]}
+}
+
+async function testFile(path: string) {
+    if (!path.endsWith(".json")) {
+        return;
+    }
+    const json = await fs.readFile(path, "utf-8")
+    let assessmentItems = null
+    try {
+        assessmentItems = JSON.parse(json)
+    } catch {
+        console.warn("Failed to parse JSON file: " + path)
+        return;
+    }
+    if (!Array.isArray(assessmentItems)) {
+        return
+    }
+
+    for (const rawItem of assessmentItems.map(i => "item_data" in i ? i.item_data : i)) {
+        for (const mismatch of getMismatches(rawItem)) {
+            const desc = describeMismatch(mismatch)
+            const hash = sha256(desc)
+            await fs.mkdir("/tmp/test-results/" + hash, {recursive: true})
+            await fs.writeFile(`/tmp/test-results/${hash}/mismatch.txt`, desc, "utf-8")
+            await fs.writeFile(`/tmp/test-results/${hash}/item.json`, String(JSON.stringify(rawItem)), "utf-8")
+        }
+    }
+}
+
+function getMismatches(rawItem: unknown): Mismatch[] {
+    const result = parsePerseusItem(rawItem, new ErrorTrackingParseContext([]))
+    if (isSuccess(result)) {
+        return []
+    }
+    return result.detail
+}
+
+function describeMismatch(mismatch: Mismatch): string {
+    const path = formatPath(mismatch.path)
+        // Replace numbered widget IDs with generic ones, e.g.
+        // ["interactive-graph 1"] -> ["interactive-graph N"]
+        .replace(/\["([^"\d]+)\d+"]/g, `["$1N"]`)
+        // Replace array indices with generic ones, e.g.
+        // [5] -> [N]
+        .replace(/\[(\d+)]/g, "[N]")
+    return `${path} -- expected ${mismatch.expected.join(", ")}; got ${typeName(mismatch.badValue)}\n`
+}
+
+function typeName(value: unknown): string {
+    if (value === null) {
+        return "null"
+    }
+    if (value === undefined) {
+        return "undefined"
+    }
+    if (Array.isArray(value)) {
+        return "array"
+    }
+    return typeof value
+}
+
+async function* listFilesRecursively(dir: string) {
+    for await (const entry of await fs.opendir(dir, {recursive: true})) {
+        if (entry.isFile()) {
+            yield entry;
+        }
+    }
+}
+
+function getPathOfDirent(dirent: Dirent): string {
+    // We read from both `parentPath` (introduced in Node 20.12) and `path`
+    // (deprecated in Node 20.12) to support as many Node versions as possible.
+    return join(dirent.parentPath || dirent.path, dirent.name)
+}
+
+function sha256(s: string): string {
+    return createHash("sha256").update(s, "utf-8").digest().toString("hex")
+}
+
+main()

--- a/yarn.lock
+++ b/yarn.lock
@@ -4612,10 +4612,12 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^18.14.1":
-  version "18.15.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.7.tgz#33514fca9bdf136f77027358850c0fb9cd93c669"
-  integrity sha512-LFmUbFunqmBn26wJZgZPYZPrDR1RwGOu2v79Mgcka1ndO6V0/cwjivPTc4yoK6n9kmw4/ls1r8cLrvh2iMibFA==
+"@types/node@^20.11.1":
+  version "20.17.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.17.6.tgz#6e4073230c180d3579e8c60141f99efdf5df0081"
+  integrity sha512-VEI7OdvK2wP7XHnsuXbAJnEpEkF6NjSN45QJlL4VGqZSXsnicpesdTWsg9RISeSdYd3yeRj/y3k5KGjUXYnFwQ==
+  dependencies:
+    undici-types "~6.19.2"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.3"
@@ -15168,7 +15170,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -15185,15 +15187,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -15279,7 +15272,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15292,13 +15285,6 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -15988,6 +15974,11 @@ undici-types@~5.26.4:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
+undici-types@~6.19.2:
+  version "6.19.8"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
+  integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
+
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz#301acdc525631670d39f6146e0e77ff6bbdebddc"
@@ -16528,7 +16519,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -16541,15 +16532,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Before we deploy the parsing code described in [ADR 773][1] to production, we
want to make sure it can handle all our production data.

[1]: https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/3318349891/ADR+773+Validate+widget+data+on+input+in+Perseus

This PR adds a tool that will run an exhaustive set of tests, checking the
parser code against every single content item. It tries to summarize the parse
errors intelligently, uniquing them by object path. The output of this tool can
be used to create a suite of regression tests for the parser, which will ensure
it can handle old data formats in perpetuity.

Issue: LEMS-2581

## Test plan:

Run the test tool as described in the comment in
`exhaustive-test-tool/index.ts`. (Note: this will take approximately 4 hours to
run, plus a couple hours to download the data).

You should get 188 errors as measured by `ls /tmp/test-results | wc -l`