### PR TITLE
Noticed a regression for Input Number while testing on webapp. Testing this logic fix

### DIFF
--- a/.changeset/many-boxes-wave.md
+++ b/.changeset/many-boxes-wave.md
@@ -1,5 +1,0 @@
----
-"@khanacademy/perseus-editor": minor
----
-
-Addition of a new alert for the content editors when Input numbers are converted to Numeric Inputs

--- a/.changeset/moody-dingos-relate.md
+++ b/.changeset/moody-dingos-relate.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Fixing a regression and a bug in the Input Conversion Logic

--- a/.changeset/quick-mangos-end.md
+++ b/.changeset/quick-mangos-end.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Fixing a regression in the Input Conversion Logic

--- a/packages/perseus-editor/src/article-editor.tsx
+++ b/packages/perseus-editor/src/article-editor.tsx
@@ -74,9 +74,7 @@ export default class ArticleEditor extends React.Component<Props, State> {
         // Check if the json needs to be converted
         const conversionWarningRequired =
             props.json instanceof Array
-                ? props.json
-                      .map(conversionRequired)
-                      .reduce((p, v) => p && v, false)
+                ? props.json.some(conversionRequired)
                 : conversionRequired(props.json);
 
         let json = props.json;

--- a/packages/perseus-editor/src/util/deprecated-widgets/input-number.ts
+++ b/packages/perseus-editor/src/util/deprecated-widgets/input-number.ts
@@ -52,8 +52,11 @@ export const convertInputNumberWidgetOptions = (
         }
         // Check if the widget is an input-number
         if (widgets[key].type === "input-number") {
+            // If the answerType is not number or percent, we need to provide
+            // the answer form for the numeric-input widget
             const provideAnswerForm =
-                widgets[key].options.answerType !== "number";
+                widgets[key].options.answerType !== "number" &&
+                widgets[key].options.answerType !== "percent";
             // We need to determine the mathFormat for the numeric-input widget
             const mathFormat =
                 widgets[key].options.answerType === "rational"

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -1074,7 +1074,6 @@ export type MathFormat =
     | "improper"
     | "proper"
     | "decimal"
-    | "percent"
     | "pi";
 
 export type PerseusNumericInputAnswerForm = {

--- a/packages/perseus/src/perseus-types.ts
+++ b/packages/perseus/src/perseus-types.ts
@@ -1074,6 +1074,7 @@ export type MathFormat =
     | "improper"
     | "proper"
     | "decimal"
+    | "percent"
     | "pi";
 
 export type PerseusNumericInputAnswerForm = {

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
@@ -349,7 +349,11 @@ const propUpgrades = {
         // input-number to numeric-input. In this case, we need to upgrade
         // the widget options accordingly.
         if (initialProps.value) {
-            const provideAnswerForm = initialProps.answerType !== "number";
+            // If the answerType is not number or percent, we need to provide
+            // the answer form for the numeric-input widget
+            const provideAnswerForm =
+                initialProps.answerType !== "number" &&
+                initialProps.answerType !== "percent";
 
             // We need to determine the mathFormat for the numeric-input widget
             const mathFormat =


### PR DESCRIPTION
## Summary:
Discovered a regression after addressing some PR feedback for the InputNumber Conversion project. This small change ensures that we're getting the proper result for `conversionWarningRequired` in the Article Renderer. 

## Screenshot:
![Screenshot 2024-11-14 at 5 26 03 PM](https://github.com/user-attachments/assets/31dd13c8-11be-4cd4-b7dc-5c6fe587e3b8)

Issue: None

## Test plan:
- Manual Testing 
- Snapshot testing in Webapp