### PR TITLE
[SR] Represent point order in interactive elements' aria labels

### DIFF
--- a/.changeset/strong-numbers-enjoy.md
+++ b/.changeset/strong-numbers-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[SR] Represent point order in interactive elements' aria labels

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -133,7 +133,15 @@ export type PerseusStrings = {
     addPoint: string;
     removePoint: string;
     graphKeyboardPrompt: string;
-    srPointAtCoordinates: ({x, y}: {x: string; y: string}) => string;
+    srPointAtCoordinates: ({
+        num,
+        x,
+        y,
+    }: {
+        num: number;
+        x: string;
+        y: string;
+    }) => string;
     srInteractiveElements: ({elements}: {elements: string}) => string;
     srNoInteractiveElements: string;
 };
@@ -313,7 +321,7 @@ export const strings: {
     graphKeyboardPrompt: "Press Shift + Enter to interact with the graph",
     srPointAtCoordinates: {
         context: "Screenreader-accessible description of a point on a graph",
-        message: "Point at %(x)s comma %(y)s",
+        message: "Point %(num) at %(x)s comma %(y)s",
     },
     srInteractiveElements: "Interactive elements: %(elements)s",
     srNoInteractiveElements: "No interactive elements",
@@ -476,7 +484,7 @@ export const mockStrings: PerseusStrings = {
     addPoint: "Add Point",
     removePoint: "Remove Point",
     graphKeyboardPrompt: "Press Shift + Enter to interact with the graph",
-    srPointAtCoordinates: ({x, y}) => `Point at ${x} comma ${y}`,
+    srPointAtCoordinates: ({num, x, y}) => `Point ${num} at ${x} comma ${y}`,
     srInteractiveElements: ({elements}) => `Interactive elements: ${elements}`,
     srNoInteractiveElements: "No interactive elements",
 };

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/angle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/angle.tsx
@@ -103,6 +103,7 @@ function AngleGraph(props: AngleGraphProps) {
             {/* vertex */}
             <MovablePoint
                 point={coords[1]}
+                currentPointOrder={1}
                 constrain={(p) => p}
                 onMove={(destination: vec.Vector2) =>
                     dispatch(actions.angle.movePoint(1, destination))
@@ -111,6 +112,7 @@ function AngleGraph(props: AngleGraphProps) {
             {/* side 1 */}
             <MovablePoint
                 point={coords[0]}
+                currentPointOrder={2}
                 constrain={getAngleSideConstraint(
                     coords[0],
                     coords[1],
@@ -123,6 +125,7 @@ function AngleGraph(props: AngleGraphProps) {
             {/* side 2 */}
             <MovablePoint
                 point={coords[2]}
+                currentPointOrder={3}
                 constrain={getAngleSideConstraint(
                     coords[2],
                     coords[1],

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -46,6 +46,7 @@ function CircleGraph(props: CircleGraphProps) {
             />
             <MovablePoint
                 point={radiusPoint}
+                currentPointOrder={1}
                 cursor="ew-resize"
                 onMove={(newRadiusPoint) => {
                     dispatch(actions.circle.moveRadiusPoint(newRadiusPoint));

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/__snapshots__/movable-line.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/__snapshots__/movable-line.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Rendering Does NOT render extensions of line when option is disabled 1`
       width="200"
     >
       <g
-        aria-label="Point at -1 comma -1"
+        aria-label="Point 1 at -1 comma -1"
         aria-live="assertive"
         class="movable-point__focusable-handle"
         data-testid="movable-point__focusable-handle"
@@ -60,7 +60,7 @@ exports[`Rendering Does NOT render extensions of line when option is disabled 1`
         />
       </g>
       <g
-        aria-label="Point at 1 comma 1"
+        aria-label="Point 2 at 1 comma 1"
         aria-live="assertive"
         class="movable-point__focusable-handle"
         data-testid="movable-point__focusable-handle"
@@ -155,7 +155,7 @@ exports[`Rendering Does NOT render extensions of line when option is not provide
       width="200"
     >
       <g
-        aria-label="Point at -1 comma -1"
+        aria-label="Point 1 at -1 comma -1"
         aria-live="assertive"
         class="movable-point__focusable-handle"
         data-testid="movable-point__focusable-handle"
@@ -200,7 +200,7 @@ exports[`Rendering Does NOT render extensions of line when option is not provide
         />
       </g>
       <g
-        aria-label="Point at 1 comma 1"
+        aria-label="Point 2 at 1 comma 1"
         aria-live="assertive"
         class="movable-point__focusable-handle"
         data-testid="movable-point__focusable-handle"
@@ -295,7 +295,7 @@ exports[`Rendering Does render extensions of line when option is enabled 1`] = `
       width="200"
     >
       <g
-        aria-label="Point at -1 comma -1"
+        aria-label="Point 1 at -1 comma -1"
         aria-live="assertive"
         class="movable-point__focusable-handle"
         data-testid="movable-point__focusable-handle"
@@ -394,7 +394,7 @@ exports[`Rendering Does render extensions of line when option is enabled 1`] = `
         </g>
       </g>
       <g
-        aria-label="Point at 1 comma 1"
+        aria-label="Point 2 at 1 comma 1"
         aria-live="assertive"
         class="movable-point__focusable-handle"
         data-testid="movable-point__focusable-handle"

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -50,12 +50,14 @@ export const MovableLine = (props: Props) => {
     const {visiblePoint: visiblePoint1, focusableHandle: focusableHandle1} =
         useControlPoint({
             point: start,
+            currentPointOrder: 1,
             color,
             onMove: (p) => onMovePoint(0, p),
         });
     const {visiblePoint: visiblePoint2, focusableHandle: focusableHandle2} =
         useControlPoint({
             point: end,
+            currentPointOrder: 2,
             color,
             onMove: (p) => onMovePoint(1, p),
         });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.test.tsx
@@ -80,7 +80,12 @@ describe("MovablePoint", () => {
             useGraphConfigMock.mockReturnValue(graphConfigContextWithTooltips);
             render(
                 <Mafs width={200} height={200}>
-                    <MovablePoint point={[0, 0]} onMove={() => {}} />,
+                    <MovablePoint
+                        point={[0, 0]}
+                        currentPointOrder={1}
+                        onMove={() => {}}
+                    />
+                    ,
                 </Mafs>,
             );
             expect(Tooltip).toHaveBeenCalled();
@@ -90,7 +95,12 @@ describe("MovablePoint", () => {
             useGraphConfigMock.mockReturnValue(baseGraphConfigContext);
             render(
                 <Mafs width={200} height={200}>
-                    <MovablePoint point={[0, 0]} onMove={() => {}} />,
+                    <MovablePoint
+                        point={[0, 0]}
+                        currentPointOrder={1}
+                        onMove={() => {}}
+                    />
+                    ,
                 </Mafs>,
             );
             expect(Tooltip).not.toHaveBeenCalled();
@@ -100,7 +110,12 @@ describe("MovablePoint", () => {
             useGraphConfigMock.mockReturnValue(graphConfigContextWithTooltips);
             render(
                 <Mafs width={200} height={200}>
-                    <MovablePoint point={[0, 0]} onMove={() => {}} />,
+                    <MovablePoint
+                        point={[0, 0]}
+                        currentPointOrder={1}
+                        onMove={() => {}}
+                    />
+                    ,
                 </Mafs>,
             );
             // @ts-expect-error // TS2339: Property mock does not exist on type typeof Tooltip
@@ -115,6 +130,7 @@ describe("MovablePoint", () => {
                 <Mafs width={200} height={200}>
                     <MovablePoint
                         point={[0, 0]}
+                        currentPointOrder={1}
                         color="#9059ff"
                         onMove={() => {}}
                     />
@@ -133,6 +149,7 @@ describe("MovablePoint", () => {
                 <Mafs width={200} height={200}>
                     <MovablePoint
                         point={[0, 0]}
+                        currentPointOrder={1}
                         color="#f00"
                         onMove={() => {}}
                     />
@@ -152,7 +169,12 @@ describe("MovablePoint", () => {
             useDraggableMock.mockReturnValue({dragging: true});
             const {container} = render(
                 <Mafs width={200} height={200}>
-                    <MovablePoint point={[0, 0]} onMove={() => {}} />,
+                    <MovablePoint
+                        point={[0, 0]}
+                        currentPointOrder={1}
+                        onMove={() => {}}
+                    />
+                    ,
                 </Mafs>,
             );
 
@@ -165,7 +187,12 @@ describe("MovablePoint", () => {
             useGraphConfigMock.mockReturnValue(baseGraphConfigContext);
             const {container} = render(
                 <Mafs width={200} height={200}>
-                    <MovablePoint point={[0, 0]} onMove={() => {}} />,
+                    <MovablePoint
+                        point={[0, 0]}
+                        currentPointOrder={1}
+                        onMove={() => {}}
+                    />
+                    ,
                 </Mafs>,
             );
 
@@ -181,7 +208,12 @@ describe("MovablePoint", () => {
             useDraggableMock.mockReturnValue({dragging: true});
             const {container} = render(
                 <Mafs width={200} height={200}>
-                    <MovablePoint point={[0, 0]} onMove={() => {}} />,
+                    <MovablePoint
+                        point={[0, 0]}
+                        currentPointOrder={1}
+                        onMove={() => {}}
+                    />
+                    ,
                 </Mafs>,
             );
 
@@ -195,7 +227,12 @@ describe("MovablePoint", () => {
         const focusSpy = jest.fn();
         render(
             <Mafs width={200} height={200}>
-                <MovablePoint point={[0, 0]} onFocus={focusSpy} />,
+                <MovablePoint
+                    point={[0, 0]}
+                    currentPointOrder={1}
+                    onFocus={focusSpy}
+                />
+                ,
             </Mafs>,
         );
 
@@ -211,7 +248,12 @@ describe("MovablePoint", () => {
         const blurSpy = jest.fn();
         render(
             <Mafs width={200} height={200}>
-                <MovablePoint point={[0, 0]} onBlur={blurSpy} />,
+                <MovablePoint
+                    point={[0, 0]}
+                    currentPointOrder={1}
+                    onBlur={blurSpy}
+                />
+                ,
             </Mafs>,
         );
 
@@ -228,7 +270,12 @@ describe("MovablePoint", () => {
         const focusSpy = jest.fn();
         render(
             <Mafs width={200} height={200}>
-                <MovablePoint point={[0, 0]} onFocus={focusSpy} />,
+                <MovablePoint
+                    point={[0, 0]}
+                    currentPointOrder={1}
+                    onFocus={focusSpy}
+                />
+                ,
             </Mafs>,
         );
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
@@ -8,6 +8,11 @@ import type {vec} from "mafs";
 
 type Props = {
     point: vec.Vector2;
+    /**
+     * Represents where this point stands in the overall point order.
+     * This is used to provide screen readers with context about the point.
+     */
+    currentPointOrder: number;
     onMove?: (newPoint: vec.Vector2) => unknown;
     onClick?: () => unknown;
     color?: string;

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -17,6 +17,11 @@ type Params = {
     point: vec.Vector2;
     color?: string | undefined;
     cursor?: CSSCursor | undefined;
+    /**
+     * Represents where this point stands in the overall point order.
+     * This is used to provide screen readers with context about the point.
+     */
+    currentPointOrder: number;
     constrain?: KeyboardMovementConstraint;
     onMove?: ((newPoint: vec.Vector2) => unknown) | undefined;
     onClick?: (() => unknown) | undefined;
@@ -37,6 +42,7 @@ export function useControlPoint(params: Params): Return {
     const {snapStep, disableKeyboardInteraction} = useGraphConfig();
     const {
         point,
+        currentPointOrder,
         color,
         cursor,
         constrain = (p) => snap(snapStep, p),
@@ -78,6 +84,7 @@ export function useControlPoint(params: Params): Return {
             ref={focusableHandleRef}
             role="button"
             aria-label={strings.srPointAtCoordinates({
+                num: currentPointOrder,
                 x: srFormatNumber(point[X], locale),
                 y: srFormatNumber(point[Y], locale),
             })}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.test.ts
@@ -30,7 +30,7 @@ describe("describePointGraph", () => {
     it("describes one point", () => {
         const state: PointGraphState = {...baseState, coords: [[3, 5]]};
         expect(describePointGraph(state, mockPerseusI18nContext)).toBe(
-            "Interactive elements: Point at 3 comma 5",
+            "Interactive elements: Point 1 at 3 comma 5",
         );
     });
 
@@ -43,7 +43,7 @@ describe("describePointGraph", () => {
             ],
         };
         expect(describePointGraph(state, mockPerseusI18nContext)).toBe(
-            "Interactive elements: Point at 3 comma 5, Point at 2 comma 4",
+            "Interactive elements: Point 1 at 3 comma 5, Point 2 at 2 comma 4",
         );
     });
 
@@ -53,7 +53,7 @@ describe("describePointGraph", () => {
             coords: [[-1.1234, 3.5678]],
         };
         expect(describePointGraph(state, mockPerseusI18nContext)).toBe(
-            "Interactive elements: Point at -1.123 comma 3.568",
+            "Interactive elements: Point 1 at -1.123 comma 3.568",
         );
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
@@ -50,6 +50,7 @@ function LimitedPointGraph(props: PointGraphProps) {
                 <MovablePoint
                     key={i}
                     point={point}
+                    currentPointOrder={i + 1}
                     onMove={(destination) =>
                         dispatch(actions.pointGraph.movePoint(i, destination))
                     }
@@ -113,6 +114,7 @@ function UnlimitedPointGraph(props: PointGraphProps) {
                 <MovablePoint
                     key={i}
                     point={point}
+                    currentPointOrder={i + 1}
                     onMove={(destination) =>
                         dispatch(actions.pointGraph.movePoint(i, destination))
                     }
@@ -149,8 +151,9 @@ export function describePointGraph(
         return strings.srNoInteractiveElements;
     }
 
-    const pointDescriptions = state.coords.map(([x, y]) =>
+    const pointDescriptions = state.coords.map(([x, y], index) =>
         strings.srPointAtCoordinates({
+            num: index + 1,
             x: srFormatNumber(x, locale),
             y: srFormatNumber(y, locale),
         }),

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -153,6 +153,7 @@ const LimitedPolygonGraph = (props: Props) => {
                     key={"point-" + i}
                     constrain={constrain}
                     point={point}
+                    currentPointOrder={i + 1}
                     onMove={(destination: vec.Vector2) => {
                         const now = Date.now();
                         const targetFPS = 40;
@@ -345,6 +346,7 @@ const UnlimitedPolygonGraph = (props: Props) => {
                 <MovablePoint
                     key={i}
                     point={point}
+                    currentPointOrder={i + 1}
                     onMove={(destination) =>
                         dispatch(actions.pointGraph.movePoint(i, destination))
                     }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
@@ -54,6 +54,7 @@ function QuadraticGraph(props: QuadraticGraphProps) {
                 <MovablePoint
                     key={"point-" + i}
                     point={coord}
+                    currentPointOrder={i + 1}
                     onMove={(destination) =>
                         dispatch(actions.quadratic.movePoint(i, destination))
                     }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
@@ -69,6 +69,7 @@ function SinusoidGraph(props: SinusoidGraphProps) {
                 <MovablePoint
                     key={"point-" + i}
                     point={coord}
+                    currentPointOrder={i + 1}
                     onMove={(destination) =>
                         dispatch(actions.sinusoid.movePoint(i, destination))
                     }

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -16,6 +16,10 @@ import type {InteractiveGraphState} from "./types";
 import type {GraphRange} from "../../perseus-types";
 import type {UserEvent} from "@testing-library/user-event";
 
+function expectLabelInDoc(label: string) {
+    expect(screen.getByLabelText(label)).toBeInTheDocument();
+}
+
 function getBaseMafsGraphProps(): MafsGraphProps {
     return {
         box: [400, 400],
@@ -128,7 +132,7 @@ describe("MafsGraph", () => {
         expect(line.getAttribute("y2")).toBe(-expectedY2 + "");
     });
 
-    it("renders ARIA labels for each point", () => {
+    it("renders ARIA labels for each point (segment)", () => {
         const state: InteractiveGraphState = {
             type: "segment",
             hasBeenInteractedWith: true,
@@ -153,10 +157,312 @@ describe("MafsGraph", () => {
             />,
         );
 
-        expect(screen.getByLabelText("Point at 0 comma 0")).toBeInTheDocument();
-        expect(
-            screen.getByLabelText("Point at -7 comma 0.5"),
-        ).toBeInTheDocument();
+        expectLabelInDoc("Point 1 at 0 comma 0");
+        expectLabelInDoc("Point 2 at -7 comma 0.5");
+    });
+
+    it("renders ARIA labels for each point (multiple segments)", () => {
+        const state: InteractiveGraphState = {
+            type: "segment",
+            hasBeenInteractedWith: true,
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            snapStep: [0.5, 0.5],
+            coords: [
+                [
+                    [0, 0],
+                    [-7, 0.5],
+                ],
+                [
+                    [1, 1],
+                    [7, 0.5],
+                ],
+            ],
+        };
+
+        render(
+            <MafsGraph
+                {...getBaseMafsGraphProps()}
+                state={state}
+                dispatch={() => {}}
+            />,
+        );
+
+        expectLabelInDoc("Point 1 at 0 comma 0");
+        expectLabelInDoc("Point 2 at -7 comma 0.5");
+        expectLabelInDoc("Point 1 at 1 comma 1");
+        expectLabelInDoc("Point 2 at 7 comma 0.5");
+    });
+
+    it("renders ARIA labels for each point (linear)", () => {
+        const state: InteractiveGraphState = {
+            type: "linear",
+            hasBeenInteractedWith: true,
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            snapStep: [0.5, 0.5],
+            coords: [
+                [0, 0],
+                [-7, 0.5],
+            ],
+        };
+
+        render(
+            <MafsGraph
+                {...getBaseMafsGraphProps()}
+                state={state}
+                dispatch={() => {}}
+            />,
+        );
+
+        expectLabelInDoc("Point 1 at 0 comma 0");
+        expectLabelInDoc("Point 2 at -7 comma 0.5");
+    });
+
+    it("renders ARIA labels for each point (linear system)", () => {
+        const state: InteractiveGraphState = {
+            type: "linear-system",
+            hasBeenInteractedWith: true,
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            snapStep: [0.5, 0.5],
+            coords: [
+                [
+                    [0, 0],
+                    [-7, 0.5],
+                ],
+                [
+                    [1, 1],
+                    [7, 0.5],
+                ],
+            ],
+        };
+
+        render(
+            <MafsGraph
+                {...getBaseMafsGraphProps()}
+                state={state}
+                dispatch={() => {}}
+            />,
+        );
+
+        expectLabelInDoc("Point 1 at 0 comma 0");
+        expectLabelInDoc("Point 2 at -7 comma 0.5");
+        expectLabelInDoc("Point 1 at 1 comma 1");
+        expectLabelInDoc("Point 2 at 7 comma 0.5");
+    });
+
+    it("renders ARIA labels for each point (ray)", () => {
+        const state: InteractiveGraphState = {
+            type: "ray",
+            hasBeenInteractedWith: true,
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            snapStep: [0.5, 0.5],
+            coords: [
+                [0, 0],
+                [-7, 0.5],
+            ],
+        };
+
+        render(
+            <MafsGraph
+                {...getBaseMafsGraphProps()}
+                state={state}
+                dispatch={() => {}}
+            />,
+        );
+
+        expectLabelInDoc("Point 1 at 0 comma 0");
+        expectLabelInDoc("Point 2 at -7 comma 0.5");
+    });
+
+    it("renders ARIA labels for each point (circle)", () => {
+        const state: InteractiveGraphState = {
+            type: "circle",
+            hasBeenInteractedWith: true,
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            snapStep: [0.5, 0.5],
+            center: [0, 0],
+            radiusPoint: [2, 0],
+        };
+
+        render(
+            <MafsGraph
+                {...getBaseMafsGraphProps()}
+                state={state}
+                dispatch={() => {}}
+            />,
+        );
+
+        // Radius point is the only point in a circle graph
+        expectLabelInDoc("Point 1 at 2 comma 0");
+    });
+
+    it("renders ARIA labels for each point (quadratic)", () => {
+        const state: InteractiveGraphState = {
+            type: "quadratic",
+            hasBeenInteractedWith: true,
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            snapStep: [0.5, 0.5],
+            coords: [
+                [-1, 1],
+                [0, 0],
+                [1, 1],
+            ],
+        };
+
+        render(
+            <MafsGraph
+                {...getBaseMafsGraphProps()}
+                state={state}
+                dispatch={() => {}}
+            />,
+        );
+
+        expectLabelInDoc("Point 1 at -1 comma 1");
+        expectLabelInDoc("Point 2 at 0 comma 0");
+        expectLabelInDoc("Point 3 at 1 comma 1");
+    });
+
+    it("renders ARIA labels for each point (sinusoid)", () => {
+        const state: InteractiveGraphState = {
+            type: "sinusoid",
+            hasBeenInteractedWith: true,
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            snapStep: [0.5, 0.5],
+            coords: [
+                [-1, 1],
+                [0, 0],
+            ],
+        };
+
+        render(
+            <MafsGraph
+                {...getBaseMafsGraphProps()}
+                state={state}
+                dispatch={() => {}}
+            />,
+        );
+
+        expectLabelInDoc("Point 1 at -1 comma 1");
+        expectLabelInDoc("Point 2 at 0 comma 0");
+    });
+
+    it("renders ARIA labels for each point (point)", () => {
+        const state: InteractiveGraphState = {
+            type: "point",
+            hasBeenInteractedWith: true,
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            snapStep: [0.5, 0.5],
+            focusedPointIndex: null,
+            showRemovePointButton: false,
+            interactionMode: "mouse",
+            showKeyboardInteractionInvitation: false,
+            // 2 points
+            coords: [
+                [-1, 1],
+                [0, 0],
+            ],
+        };
+
+        render(
+            <MafsGraph
+                {...getBaseMafsGraphProps()}
+                state={state}
+                dispatch={() => {}}
+            />,
+        );
+
+        expectLabelInDoc("Point 1 at -1 comma 1");
+        expectLabelInDoc("Point 2 at 0 comma 0");
+    });
+
+    it("renders ARIA labels for each point (polygon)", () => {
+        const state: InteractiveGraphState = {
+            type: "polygon",
+            hasBeenInteractedWith: true,
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            snapStep: [0.5, 0.5],
+            showAngles: false,
+            showSides: false,
+            snapTo: "grid",
+            focusedPointIndex: null,
+            showRemovePointButton: false,
+            interactionMode: "mouse",
+            showKeyboardInteractionInvitation: false,
+            coords: [
+                [-1, 1],
+                [0, 0],
+                [1, 1],
+            ],
+        };
+
+        render(
+            <MafsGraph
+                {...getBaseMafsGraphProps()}
+                state={state}
+                dispatch={() => {}}
+            />,
+        );
+
+        expectLabelInDoc("Point 1 at -1 comma 1");
+        expectLabelInDoc("Point 2 at 0 comma 0");
+        expectLabelInDoc("Point 3 at 1 comma 1");
+    });
+
+    it("renders ARIA labels for each point (angle)", () => {
+        const state: InteractiveGraphState = {
+            type: "angle",
+            hasBeenInteractedWith: true,
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            snapStep: [0.5, 0.5],
+            coords: [
+                [-1, 1],
+                [0, 0],
+                [1, 1],
+            ],
+        };
+
+        render(
+            <MafsGraph
+                {...getBaseMafsGraphProps()}
+                state={state}
+                dispatch={() => {}}
+            />,
+        );
+
+        // The middle coords are actually the first point because we want
+        // the vertex to show up first in the point tab order.
+        expectLabelInDoc("Point 1 at 0 comma 0");
+        expectLabelInDoc("Point 2 at -1 comma 1");
+        expectLabelInDoc("Point 3 at 1 comma 1");
     });
 
     it("renders a screenreader description summarizing the interactive elements on the graph", () => {
@@ -184,7 +490,7 @@ describe("MafsGraph", () => {
         );
 
         expect(
-            screen.getByText("Interactive elements: Point at -7 comma 0.5"),
+            screen.getByText("Interactive elements: Point 1 at -7 comma 0.5"),
         ).toBeInTheDocument();
     });
 


### PR DESCRIPTION
## Summary:
- Include the current point order in the points' aria labels

According to Caitlyn’s SRUX doc, each element on the interactive graph should be labeled in the following format:

```
Element Type, Order, Math Details, Visual Details, Instructions.
```

For example:

```
Point 1 at ( 1, 2 ). Angle approximately equal to 187°. Use the Arrow keys to move the element within the graph. Use the Delete key to remove the element from the graph.
```

Issue: https://khanacademy.atlassian.net/browse/LEMS-2620

## Test plan:
todo