### PR TITLE
Orderer: Extract validation out of scoring

### DIFF
--- a/.changeset/sharp-radios-burn.md
+++ b/.changeset/sharp-radios-burn.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Split out validation function for the `orderer` widget. This can be used to check if the user has ordered at least one option, confirming the question is ready to be scored.

--- a/packages/perseus/src/widgets/orderer/score-orderer.test.ts
+++ b/packages/perseus/src/widgets/orderer/score-orderer.test.ts
@@ -6,7 +6,7 @@ import type {
     PerseusOrdererUserInput,
 } from "../../validation.types";
 
-describe("ordererValiator", () => {
+describe("scoreOrderer", () => {
     it("is correct when the userInput is in the same order and is the same length as the rubric's correctOption content items", () => {
         // Arrange
         const rubric: PerseusOrdererRubric =
@@ -55,21 +55,5 @@ describe("ordererValiator", () => {
 
         // assert
         expect(result).toHaveBeenAnsweredIncorrectly();
-    });
-
-    it("is invalid when the when the user has not started ordering the options and current is empty", () => {
-        // Arrange
-        const rubric: PerseusOrdererRubric =
-            question1.widgets["orderer 1"].options;
-
-        const userInput: PerseusOrdererUserInput = {
-            current: [],
-        };
-
-        // Act
-        const result = scoreOrderer(userInput, rubric);
-
-        // assert
-        expect(result).toHaveInvalidInput();
     });
 });

--- a/packages/perseus/src/widgets/orderer/score-orderer.test.ts
+++ b/packages/perseus/src/widgets/orderer/score-orderer.test.ts
@@ -56,4 +56,20 @@ describe("scoreOrderer", () => {
         // assert
         expect(result).toHaveBeenAnsweredIncorrectly();
     });
+
+    it("is invalid when the when the user has not started ordering the options and current is empty", () => {
+        // Arrange
+        const rubric: PerseusOrdererRubric =
+            question1.widgets["orderer 1"].options;
+
+        const userInput: PerseusOrdererUserInput = {
+            current: [],
+        };
+
+        // Act
+        const result = scoreOrderer(userInput, rubric);
+
+        // assert
+        expect(result).toHaveInvalidInput();
+    });
 });

--- a/packages/perseus/src/widgets/orderer/score-orderer.test.ts
+++ b/packages/perseus/src/widgets/orderer/score-orderer.test.ts
@@ -1,5 +1,6 @@
 import {question1} from "./orderer.testdata";
 import {scoreOrderer} from "./score-orderer";
+import * as OrdererValidator from "./validate-orderer";
 
 import type {
     PerseusOrdererRubric,
@@ -21,7 +22,7 @@ describe("scoreOrderer", () => {
         // Act
         const result = scoreOrderer(userInput, rubric);
 
-        // assert
+        // Assert
         expect(result).toHaveBeenAnsweredCorrectly();
     });
 
@@ -37,7 +38,7 @@ describe("scoreOrderer", () => {
         // Act
         const result = scoreOrderer(userInput, rubric);
 
-        // assert
+        // Assert
         expect(result).toHaveBeenAnsweredIncorrectly();
     });
 
@@ -53,12 +54,41 @@ describe("scoreOrderer", () => {
         // Act
         const result = scoreOrderer(userInput, rubric);
 
-        // assert
+        // Assert
         expect(result).toHaveBeenAnsweredIncorrectly();
     });
 
-    it("is invalid when the when the user has not started ordering the options and current is empty", () => {
+    it("should be correctly answerable if validation passes", () => {
         // Arrange
+        const mockValidator = jest
+            .spyOn(OrdererValidator, "default")
+            .mockReturnValue(null);
+
+        const rubric: PerseusOrdererRubric =
+            question1.widgets["orderer 1"].options;
+
+        const userInput: PerseusOrdererUserInput = {
+            current: question1.widgets["orderer 1"].options.correctOptions.map(
+                (option) => option.content,
+            ),
+        };
+        // Act
+        const result = scoreOrderer(userInput, rubric);
+
+        // Assert
+        expect(mockValidator).toHaveBeenCalledWith(userInput);
+        expect(result).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("should return an invalid response if validation fails", () => {
+        // Arrange
+        const mockValidator = jest
+            .spyOn(OrdererValidator, "default")
+            .mockReturnValue({
+                type: "invalid",
+                message: null,
+            });
+
         const rubric: PerseusOrdererRubric =
             question1.widgets["orderer 1"].options;
 
@@ -69,7 +99,8 @@ describe("scoreOrderer", () => {
         // Act
         const result = scoreOrderer(userInput, rubric);
 
-        // assert
+        // Assert
+        expect(mockValidator).toHaveBeenCalledWith(userInput);
         expect(result).toHaveInvalidInput();
     });
 });

--- a/packages/perseus/src/widgets/orderer/score-orderer.ts
+++ b/packages/perseus/src/widgets/orderer/score-orderer.ts
@@ -19,7 +19,7 @@ export function scoreOrderer(
 
     const correct = _.isEqual(
         userInput.current,
-        _.pluck(rubric.correctOptions, "content"),
+        rubric.correctOptions.map((option) => option.content),
     );
 
     return {

--- a/packages/perseus/src/widgets/orderer/score-orderer.ts
+++ b/packages/perseus/src/widgets/orderer/score-orderer.ts
@@ -1,5 +1,7 @@
 import _ from "underscore";
 
+import {validateOrderer} from "./validate-orderer";
+
 import type {PerseusScore} from "../../types";
 import type {
     PerseusOrdererRubric,
@@ -10,11 +12,9 @@ export function scoreOrderer(
     userInput: PerseusOrdererUserInput,
     rubric: PerseusOrdererRubric,
 ): PerseusScore {
-    if (userInput.current.length === 0) {
-        return {
-            type: "invalid",
-            message: null,
-        };
+    const validateError = validateOrderer(userInput);
+    if (validateError) {
+        return validateError;
     }
 
     const correct = _.isEqual(

--- a/packages/perseus/src/widgets/orderer/score-orderer.ts
+++ b/packages/perseus/src/widgets/orderer/score-orderer.ts
@@ -1,6 +1,6 @@
 import _ from "underscore";
 
-import {validateOrderer} from "./validate-orderer";
+import validateOrderer from "./validate-orderer";
 
 import type {PerseusScore} from "../../types";
 import type {

--- a/packages/perseus/src/widgets/orderer/validate-orderer.test.ts
+++ b/packages/perseus/src/widgets/orderer/validate-orderer.test.ts
@@ -1,0 +1,31 @@
+import {validateOrderer} from "./validate-orderer";
+
+import type {PerseusOrdererUserInput} from "../../validation.types";
+
+describe("validateOrderer", () => {
+    it("is invalid when the user has not started ordering the options and current is empty", () => {
+        // Arrange
+        const userInput: PerseusOrdererUserInput = {
+            current: [],
+        };
+
+        // Act
+        const result = validateOrderer(userInput);
+
+        // Assert
+        expect(result).toHaveInvalidInput();
+    });
+
+    it("is null when the user has started ordering the options and current has at least one option", () => {
+        // Arrange
+        const userInput: PerseusOrdererUserInput = {
+            current: ["$10.9$"],
+        };
+
+        // Act
+        const result = validateOrderer(userInput);
+
+        // Assert
+        expect(result).toBeNull();
+    });
+});

--- a/packages/perseus/src/widgets/orderer/validate-orderer.test.ts
+++ b/packages/perseus/src/widgets/orderer/validate-orderer.test.ts
@@ -1,4 +1,4 @@
-import {validateOrderer} from "./validate-orderer";
+import validateOrderer from "./validate-orderer";
 
 import type {PerseusOrdererUserInput} from "../../validation.types";
 

--- a/packages/perseus/src/widgets/orderer/validate-orderer.ts
+++ b/packages/perseus/src/widgets/orderer/validate-orderer.ts
@@ -1,0 +1,15 @@
+import type {PerseusScore} from "../../types";
+import type {PerseusOrdererUserInput} from "../../validation.types";
+
+export function validateOrderer(
+    userInput: PerseusOrdererUserInput,
+): Extract<PerseusScore, {type: "invalid"}> | null {
+    if (userInput.current.length === 0) {
+        return {
+            type: "invalid",
+            message: null,
+        };
+    }
+
+    return null;
+}

--- a/packages/perseus/src/widgets/orderer/validate-orderer.ts
+++ b/packages/perseus/src/widgets/orderer/validate-orderer.ts
@@ -1,6 +1,12 @@
 import type {PerseusScore} from "../../types";
 import type {PerseusOrdererUserInput} from "../../validation.types";
 
+/**
+ * Checks user inputfrom the orderer widget to see if the user has started
+ * ordering the options, making the widget scorable.
+ * @param userInput
+ * @see `scoreOrderer` for more details.
+ */
 function validateOrderer(
     userInput: PerseusOrdererUserInput,
 ): Extract<PerseusScore, {type: "invalid"}> | null {

--- a/packages/perseus/src/widgets/orderer/validate-orderer.ts
+++ b/packages/perseus/src/widgets/orderer/validate-orderer.ts
@@ -1,7 +1,7 @@
 import type {PerseusScore} from "../../types";
 import type {PerseusOrdererUserInput} from "../../validation.types";
 
-export function validateOrderer(
+function validateOrderer(
     userInput: PerseusOrdererUserInput,
 ): Extract<PerseusScore, {type: "invalid"}> | null {
     if (userInput.current.length === 0) {
@@ -13,3 +13,5 @@ export function validateOrderer(
 
     return null;
 }
+
+export default validateOrderer;

--- a/packages/perseus/src/widgets/orderer/validate-orderer.ts
+++ b/packages/perseus/src/widgets/orderer/validate-orderer.ts
@@ -2,7 +2,7 @@ import type {PerseusScore} from "../../types";
 import type {PerseusOrdererUserInput} from "../../validation.types";
 
 /**
- * Checks user inputfrom the orderer widget to see if the user has started
+ * Checks user input from the orderer widget to see if the user has started
  * ordering the options, making the widget scorable.
  * @param userInput
  * @see `scoreOrderer` for more details.


### PR DESCRIPTION
## Summary:
To complete server-side scoring, we are separating out validation logic from scoring logic. This separates that logic and updates associated tests.

Issue: LEMS-2603

## Test plan:
- Confirm all checks pass
- Confirm widget still works as expected