### PR TITLE
ADR 773: Look for the shortest assessment item to repro each parse error

### DIFF
--- a/.changeset/late-sheep-rush.md
+++ b/.changeset/late-sheep-rush.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: make the exhaustive test tool for PerseusItem parsing find the shortest input file that repros each failure

--- a/packages/perseus/src/util/parse-perseus-json/exhaustive-test-tool/index.ts
+++ b/packages/perseus/src/util/parse-perseus-json/exhaustive-test-tool/index.ts
@@ -131,7 +131,7 @@ function typeName(value: unknown): string {
 async function writeFileIfShorterThanExisting(
     path: string,
     content: string,
-    encoding: BufferEncoding,
+    encoding: "utf-8", // TODO(benchristel): add more encodings if needed
 ) {
     const size = await fs
         .stat(path)

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/perseus-item.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/perseus-item.ts
@@ -3,14 +3,11 @@ import {
     any,
     array,
     boolean,
-    constant,
     enumeration,
     number,
     object,
     record,
-    union,
 } from "../general-purpose-parsers";
-import {composeParsers} from "../general-purpose-parsers/compose-parsers";
 
 import {parseHint} from "./hint";
 import {parsePerseusRenderer} from "./perseus-renderer";
@@ -21,13 +18,7 @@ import type {Parser} from "../parser-types";
 export const parsePerseusItem: Parser<PerseusItem> = object({
     question: parsePerseusRenderer,
     hints: array(parseHint),
-    answerArea: record(
-        enumeration(...ItemExtras),
-        composeParsers(
-            union(boolean).or(constant("multiple")).parser,
-            (val, ctx) => ctx.success(Boolean(val)),
-        ),
-    ),
+    answerArea: record(enumeration(...ItemExtras), boolean),
     itemDataVersion: object({
         major: number,
         minor: number,

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/perseus-item.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/perseus-item.ts
@@ -3,11 +3,14 @@ import {
     any,
     array,
     boolean,
+    constant,
     enumeration,
     number,
     object,
     record,
+    union,
 } from "../general-purpose-parsers";
+import {composeParsers} from "../general-purpose-parsers/compose-parsers";
 
 import {parseHint} from "./hint";
 import {parsePerseusRenderer} from "./perseus-renderer";
@@ -18,7 +21,13 @@ import type {Parser} from "../parser-types";
 export const parsePerseusItem: Parser<PerseusItem> = object({
     question: parsePerseusRenderer,
     hints: array(parseHint),
-    answerArea: record(enumeration(...ItemExtras), boolean),
+    answerArea: record(
+        enumeration(...ItemExtras),
+        composeParsers(
+            union(boolean).or(constant("multiple")).parser,
+            (val, ctx) => ctx.success(Boolean(val)),
+        ),
+    ),
     itemDataVersion: object({
         major: number,
         minor: number,


### PR DESCRIPTION
The exhaustive test tool for PerseusItem parsing outputs the `assessmentItem`s
that can't be parsed. The plan is to generate regression tests from these
assessment items.

Previously, the tool would output an arbitrary `assessmentItem` for each
failure.  This PR makes it keep the *shortest* `assessmentItem` instead. That
way, our regression test data won't be over-complicated.

Issue: none

## Test plan:

Run the exhaustive test tool on a subset of data.