### PR TITLE
[Locked Labels] Count lone unescaped $ as regular dollar signs

### DIFF
--- a/.changeset/small-owls-relate.md
+++ b/.changeset/small-owls-relate.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+[Locked Labels] Count lone unescaped \$ as regular dollar signs in TeX

--- a/packages/perseus/src/widgets/interactive-graphs/utils.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/utils.test.ts
@@ -147,4 +147,19 @@ describe("replaceOutsideTeX", () => {
 
         expect(convertedString).toEqual("\\text{\\\\}");
     });
+
+    test.each`
+        input     | expectedOutput
+        ${"$"}    | ${"\\text{\\$}"}
+        ${"$$"}   | ${""}
+        ${"\\$"}  | ${"\\text{\\$}"}
+        ${"$1$"}  | ${"1"}
+        ${"$1"}   | ${"\\text{\\$1}"}
+        ${"1$"}   | ${"\\text{1\\$}"}
+        ${"$$1$"} | ${"\\text{1\\$}"}
+        ${"$1$$"} | ${"1\\text{\\$}"}
+    `("counts lone unescaped $ as TeX", ({input, expectedOutput}) => {
+        const convertedString = replaceOutsideTeX(input);
+        expect(convertedString).toEqual(expectedOutput);
+    });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/utils.ts
@@ -103,7 +103,7 @@ export function replaceOutsideTeX(mathString: string) {
 }
 
 type ParsedNode = {
-    type: "math" | "text";
+    type: "math" | "text" | "unescapedDollar";
     content: string;
 };
 
@@ -118,14 +118,23 @@ function condenseTextNodes(nodes: ParsedNode[] | undefined): Array<ParsedNode> {
 
     let currentText = "";
     for (const node of nodes) {
-        if (node.type === "math") {
-            if (currentText) {
-                result.push({type: "text", content: currentText});
-                currentText = "";
-            }
-            result.push(node);
-        } else {
-            currentText += node.content;
+        switch (node.type) {
+            case "math":
+                if (currentText) {
+                    result.push({type: "text", content: currentText});
+                    currentText = "";
+                }
+                result.push(node);
+                break;
+            case "unescapedDollar":
+                // If the unescaped dollar had a closing pair to define
+                // math, it would have been caught by the "math" case above.
+                // Since this unescaped dollar is caught here, we can
+                // assume it is alone and used as as a literal dollar sign.
+                currentText += "$";
+                break;
+            default:
+                currentText += node.content;
         }
     }
 


### PR DESCRIPTION
## Summary:
Right now, if you type "$1" into the locked label input, it
shows up as "undefined1" in the graph TeX.

- Update the parsed content to count a lone unescaped $
  as a regular $.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2591

## Test plan:
`yarn jest packages/perseus/src/widgets/interactive-graphs/utils.test.ts`

Storybook
- Go to http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--interactive-graph-with-aria-label
- Create a new locked figure
- Add a label "$1" and confirm it shows up as "$1" in the preview
- Play around with different escaped and unescaped dollar signs
  and confirm they work as expected