### PR TITLE
Sorter: Extract validation out of scoring

### DIFF
--- a/.changeset/sweet-trainers-drop.md
+++ b/.changeset/sweet-trainers-drop.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Split out validation function for the `sorter` widget. This can be used to check if the user has made any changes to the sorting order, confirming whether or not the question can be scored.

--- a/packages/perseus/src/widgets/sorter/score-sorter.test.ts
+++ b/packages/perseus/src/widgets/sorter/score-sorter.test.ts
@@ -29,16 +29,4 @@ describe("scoreSorter", () => {
         const result = scoreSorter(userInput, rubric);
         expect(result).toHaveBeenAnsweredIncorrectly();
     });
-
-    it("is invalid when the user has not made any changes", () => {
-        const userInput: PerseusSorterUserInput = {
-            options: ["$15$ grams", "$55$ grams", "$0.005$ kilograms"],
-            changed: false,
-        };
-        const rubric: PerseusSorterRubric = {
-            correct: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],
-        };
-        const result = scoreSorter(userInput, rubric);
-        expect(result).toHaveInvalidInput();
-    });
 });

--- a/packages/perseus/src/widgets/sorter/score-sorter.test.ts
+++ b/packages/perseus/src/widgets/sorter/score-sorter.test.ts
@@ -8,6 +8,7 @@ import type {
 
 describe("scoreSorter", () => {
     it("is correct when the user input values are in the order defined in the rubric", () => {
+        // Arrange
         const userInput: PerseusSorterUserInput = {
             options: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],
             changed: true,
@@ -15,11 +16,16 @@ describe("scoreSorter", () => {
         const rubric: PerseusSorterRubric = {
             correct: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],
         };
+
+        // Act
         const result = scoreSorter(userInput, rubric);
+
+        // Assert
         expect(result).toHaveBeenAnsweredCorrectly();
     });
 
     it("is incorrect when the user input values are not in the order defined in the rubric", () => {
+        // Arrange
         const userInput: PerseusSorterUserInput = {
             options: ["$15$ grams", "$55$ grams", "$0.005$ kilograms"],
             changed: true,
@@ -27,7 +33,11 @@ describe("scoreSorter", () => {
         const rubric: PerseusSorterRubric = {
             correct: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],
         };
+
+        // Act
         const result = scoreSorter(userInput, rubric);
+
+        // Assert
         expect(result).toHaveBeenAnsweredIncorrectly();
     });
 
@@ -46,6 +56,7 @@ describe("scoreSorter", () => {
             correct: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],
         };
 
+        // Act
         const result = scoreSorter(userInput, rubric);
 
         // Assert

--- a/packages/perseus/src/widgets/sorter/score-sorter.test.ts
+++ b/packages/perseus/src/widgets/sorter/score-sorter.test.ts
@@ -1,4 +1,5 @@
 import scoreSorter from "./score-sorter";
+import * as SorterValidator from "./validate-sorter";
 
 import type {
     PerseusSorterRubric,
@@ -28,5 +29,50 @@ describe("scoreSorter", () => {
         };
         const result = scoreSorter(userInput, rubric);
         expect(result).toHaveBeenAnsweredIncorrectly();
+    });
+
+    it("should score if validator passes", () => {
+        // Arrange
+        // Mock validator saying "all good"
+        const mockValidate = jest
+            .spyOn(SorterValidator, "default")
+            .mockReturnValue(null);
+
+        const userInput: PerseusSorterUserInput = {
+            options: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],
+            changed: true,
+        };
+        const rubric: PerseusSorterRubric = {
+            correct: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],
+        };
+
+        // Act
+        const score = scoreSorter(userInput, rubric);
+
+        // Assert
+        expect(mockValidate).toHaveBeenCalled();
+        expect(score).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("should abort if validator returns invalid", () => {
+        // Arrange
+        // Mock validator saying input is invalid
+        const mockValidate = jest
+            .spyOn(SorterValidator, "default")
+            .mockReturnValue({type: "invalid", message: null});
+
+        const userInput: PerseusSorterUserInput = {
+            options: ["$15$ grams", "$55$ grams", "$0.005$ kilograms"],
+            changed: true,
+        };
+        const rubric: PerseusSorterRubric = {
+            correct: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],
+        };
+
+        const score = scoreSorter(userInput, rubric);
+
+        // Assert
+        expect(mockValidate).toHaveBeenCalled();
+        expect(score).toHaveInvalidInput();
     });
 });

--- a/packages/perseus/src/widgets/sorter/score-sorter.test.ts
+++ b/packages/perseus/src/widgets/sorter/score-sorter.test.ts
@@ -46,11 +46,11 @@ describe("scoreSorter", () => {
             correct: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],
         };
 
-        const score = scoreSorter(userInput, rubric);
+        const result = scoreSorter(userInput, rubric);
 
         // Assert
         expect(mockValidate).toHaveBeenCalledWith(userInput);
-        expect(score).toHaveInvalidInput();
+        expect(result).toHaveInvalidInput();
     });
 
     it("should score if validator passes", () => {
@@ -69,10 +69,10 @@ describe("scoreSorter", () => {
         };
 
         // Act
-        const score = scoreSorter(userInput, rubric);
+        const result = scoreSorter(userInput, rubric);
 
         // Assert
         expect(mockValidate).toHaveBeenCalledWith(userInput);
-        expect(score).toHaveBeenAnsweredCorrectly();
+        expect(result).toHaveBeenAnsweredCorrectly();
     });
 });

--- a/packages/perseus/src/widgets/sorter/score-sorter.test.ts
+++ b/packages/perseus/src/widgets/sorter/score-sorter.test.ts
@@ -40,7 +40,7 @@ describe("scoreSorter", () => {
 
         const userInput: PerseusSorterUserInput = {
             options: ["$15$ grams", "$55$ grams", "$0.005$ kilograms"],
-            changed: true,
+            changed: false,
         };
         const rubric: PerseusSorterRubric = {
             correct: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],

--- a/packages/perseus/src/widgets/sorter/score-sorter.test.ts
+++ b/packages/perseus/src/widgets/sorter/score-sorter.test.ts
@@ -50,7 +50,7 @@ describe("scoreSorter", () => {
         const score = scoreSorter(userInput, rubric);
 
         // Assert
-        expect(mockValidate).toHaveBeenCalled();
+        expect(mockValidate).toHaveBeenCalledWith(userInput);
         expect(score).toHaveBeenAnsweredCorrectly();
     });
 
@@ -72,7 +72,7 @@ describe("scoreSorter", () => {
         const score = scoreSorter(userInput, rubric);
 
         // Assert
-        expect(mockValidate).toHaveBeenCalled();
+        expect(mockValidate).toHaveBeenCalledWith(userInput);
         expect(score).toHaveInvalidInput();
     });
 });

--- a/packages/perseus/src/widgets/sorter/score-sorter.test.ts
+++ b/packages/perseus/src/widgets/sorter/score-sorter.test.ts
@@ -31,6 +31,28 @@ describe("scoreSorter", () => {
         expect(result).toHaveBeenAnsweredIncorrectly();
     });
 
+    it("should abort if validator returns invalid", () => {
+        // Arrange
+        // Mock validator saying input is invalid
+        const mockValidate = jest
+            .spyOn(SorterValidator, "default")
+            .mockReturnValue({type: "invalid", message: null});
+
+        const userInput: PerseusSorterUserInput = {
+            options: ["$15$ grams", "$55$ grams", "$0.005$ kilograms"],
+            changed: true,
+        };
+        const rubric: PerseusSorterRubric = {
+            correct: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],
+        };
+
+        const score = scoreSorter(userInput, rubric);
+
+        // Assert
+        expect(mockValidate).toHaveBeenCalledWith(userInput);
+        expect(score).toHaveInvalidInput();
+    });
+
     it("should score if validator passes", () => {
         // Arrange
         // Mock validator saying "all good"
@@ -52,27 +74,5 @@ describe("scoreSorter", () => {
         // Assert
         expect(mockValidate).toHaveBeenCalledWith(userInput);
         expect(score).toHaveBeenAnsweredCorrectly();
-    });
-
-    it("should abort if validator returns invalid", () => {
-        // Arrange
-        // Mock validator saying input is invalid
-        const mockValidate = jest
-            .spyOn(SorterValidator, "default")
-            .mockReturnValue({type: "invalid", message: null});
-
-        const userInput: PerseusSorterUserInput = {
-            options: ["$15$ grams", "$55$ grams", "$0.005$ kilograms"],
-            changed: true,
-        };
-        const rubric: PerseusSorterRubric = {
-            correct: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],
-        };
-
-        const score = scoreSorter(userInput, rubric);
-
-        // Assert
-        expect(mockValidate).toHaveBeenCalledWith(userInput);
-        expect(score).toHaveInvalidInput();
     });
 });

--- a/packages/perseus/src/widgets/sorter/score-sorter.ts
+++ b/packages/perseus/src/widgets/sorter/score-sorter.ts
@@ -1,5 +1,7 @@
 import Util from "../../util";
 
+import validateSorter from "./validate-sorter";
+
 import type {PerseusScore} from "../../types";
 import type {
     PerseusSorterRubric,
@@ -10,17 +12,9 @@ function scoreSorter(
     userInput: PerseusSorterUserInput,
     rubric: PerseusSorterRubric,
 ): PerseusScore {
-    // If the sorter widget hasn't been changed yet, we treat it as "empty" which
-    // prevents the "Check" button from becoming active. We want the user
-    // to make a change before trying to move forward. This makes an
-    // assumption that the initial order isn't the correct order! However,
-    // this should be rare if it happens, and interacting with the list
-    // will enable the button, so they won't be locked out of progressing.
-    if (!userInput.changed) {
-        return {
-            type: "invalid",
-            message: null,
-        };
+    const validationError = validateSorter(userInput, rubric);
+    if (validationError) {
+        return validationError;
     }
 
     const correct = Util.deepEq(userInput.options, rubric.correct);

--- a/packages/perseus/src/widgets/sorter/score-sorter.ts
+++ b/packages/perseus/src/widgets/sorter/score-sorter.ts
@@ -12,7 +12,7 @@ function scoreSorter(
     userInput: PerseusSorterUserInput,
     rubric: PerseusSorterRubric,
 ): PerseusScore {
-    const validationError = validateSorter(userInput, rubric);
+    const validationError = validateSorter(userInput);
     if (validationError) {
         return validationError;
     }

--- a/packages/perseus/src/widgets/sorter/validate-sorter.test.ts
+++ b/packages/perseus/src/widgets/sorter/validate-sorter.test.ts
@@ -1,0 +1,32 @@
+import validateSorter from "./validate-sorter";
+
+import type {
+    PerseusSorterRubric,
+    PerseusSorterUserInput,
+} from "../../validation.types";
+
+describe("validateSorter", () => {
+    it("is invalid when the user has not made any changes", () => {
+        const userInput: PerseusSorterUserInput = {
+            options: ["$15$ grams", "$55$ grams", "$0.005$ kilograms"],
+            changed: false,
+        };
+        const rubric: PerseusSorterRubric = {
+            correct: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],
+        };
+        const result = validateSorter(userInput, rubric);
+        expect(result).toHaveInvalidInput();
+    });
+
+    it("returns null when the user has made any changes", () => {
+        const userInput: PerseusSorterUserInput = {
+            options: ["$55$ grams", "$0.005$ kilograms", "$15$ grams"],
+            changed: true,
+        };
+        const rubric: PerseusSorterRubric = {
+            correct: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],
+        };
+        const result = validateSorter(userInput, rubric);
+        expect(result).toBeNull();
+    });
+});

--- a/packages/perseus/src/widgets/sorter/validate-sorter.test.ts
+++ b/packages/perseus/src/widgets/sorter/validate-sorter.test.ts
@@ -4,22 +4,30 @@ import type {PerseusSorterUserInput} from "../../validation.types";
 
 describe("validateSorter", () => {
     it("is invalid when the user has not made any changes", () => {
+        // Arrange
         const userInput: PerseusSorterUserInput = {
             options: ["$15$ grams", "$55$ grams", "$0.005$ kilograms"],
             changed: false,
         };
 
+        // Act
         const result = validateSorter(userInput);
+
+        // Assert
         expect(result).toHaveInvalidInput();
     });
 
     it("returns null when the user has made any changes", () => {
+        // Arrange
         const userInput: PerseusSorterUserInput = {
             options: ["$55$ grams", "$0.005$ kilograms", "$15$ grams"],
             changed: true,
         };
 
+        // Act
         const result = validateSorter(userInput);
+
+        // Assert
         expect(result).toBeNull();
     });
 });

--- a/packages/perseus/src/widgets/sorter/validate-sorter.test.ts
+++ b/packages/perseus/src/widgets/sorter/validate-sorter.test.ts
@@ -1,9 +1,6 @@
 import validateSorter from "./validate-sorter";
 
-import type {
-    PerseusSorterRubric,
-    PerseusSorterUserInput,
-} from "../../validation.types";
+import type {PerseusSorterUserInput} from "../../validation.types";
 
 describe("validateSorter", () => {
     it("is invalid when the user has not made any changes", () => {
@@ -11,10 +8,8 @@ describe("validateSorter", () => {
             options: ["$15$ grams", "$55$ grams", "$0.005$ kilograms"],
             changed: false,
         };
-        const rubric: PerseusSorterRubric = {
-            correct: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],
-        };
-        const result = validateSorter(userInput, rubric);
+
+        const result = validateSorter(userInput);
         expect(result).toHaveInvalidInput();
     });
 
@@ -23,10 +18,8 @@ describe("validateSorter", () => {
             options: ["$55$ grams", "$0.005$ kilograms", "$15$ grams"],
             changed: true,
         };
-        const rubric: PerseusSorterRubric = {
-            correct: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],
-        };
-        const result = validateSorter(userInput, rubric);
+
+        const result = validateSorter(userInput);
         expect(result).toBeNull();
     });
 });

--- a/packages/perseus/src/widgets/sorter/validate-sorter.ts
+++ b/packages/perseus/src/widgets/sorter/validate-sorter.ts
@@ -1,0 +1,26 @@
+import type {PerseusScore} from "../../types";
+import type {
+    PerseusSorterRubric,
+    PerseusSorterUserInput,
+} from "../../validation.types";
+
+function validateSorter(
+    userInput: PerseusSorterUserInput,
+    rubric: PerseusSorterRubric,
+): Extract<PerseusScore, {type: "invalid"}> | null {
+    // If the sorter widget hasn't been changed yet, we treat it as "empty" which
+    // prevents the "Check" button from becoming active. We want the user
+    // to make a change before trying to move forward. This makes an
+    // assumption that the initial order isn't the correct order! However,
+    // this should be rare if it happens, and interacting with the list
+    // will enable the button, so they won't be locked out of progressing.
+    if (!userInput.changed) {
+        return {
+            type: "invalid",
+            message: null,
+        };
+    }
+    return null;
+}
+
+export default validateSorter;

--- a/packages/perseus/src/widgets/sorter/validate-sorter.ts
+++ b/packages/perseus/src/widgets/sorter/validate-sorter.ts
@@ -1,6 +1,13 @@
 import type {PerseusScore} from "../../types";
 import type {PerseusSorterUserInput} from "../../validation.types";
 
+/**
+ * Checks user input for the sorter widget to ensure that the user has made
+ * changes before attempting to score the widget.
+ * @param userInput
+ * @see 'scoreSorter' in 'packages/perseus/src/widgets/sorter/score-sorter.ts'
+ * for more details on how the sorter widget is scored.
+ */
 function validateSorter(
     userInput: PerseusSorterUserInput,
 ): Extract<PerseusScore, {type: "invalid"}> | null {

--- a/packages/perseus/src/widgets/sorter/validate-sorter.ts
+++ b/packages/perseus/src/widgets/sorter/validate-sorter.ts
@@ -1,12 +1,8 @@
 import type {PerseusScore} from "../../types";
-import type {
-    PerseusSorterRubric,
-    PerseusSorterUserInput,
-} from "../../validation.types";
+import type {PerseusSorterUserInput} from "../../validation.types";
 
 function validateSorter(
     userInput: PerseusSorterUserInput,
-    rubric: PerseusSorterRubric,
 ): Extract<PerseusScore, {type: "invalid"}> | null {
     // If the sorter widget hasn't been changed yet, we treat it as "empty" which
     // prevents the "Check" button from becoming active. We want the user


### PR DESCRIPTION
## Summary:
To complete server-side scoring, we are separating out validation logic from scoring logic. This separates that logic for the sorter widget and updates associated tests.

Issue: LEMS-2605

## Test plan:
- Confirm all checks pass
- Confirm widget still works as expected via Storybook