### PR TITLE
Expression: Extract validation from scorer

### DIFF
--- a/.changeset/warm-llamas-tease.md
+++ b/.changeset/warm-llamas-tease.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Add expression validator function

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -55,6 +55,8 @@ export type PerseusExpressionRubric = {
 
 export type PerseusExpressionUserInput = string;
 
+export type ExpressionValidationData = Empty;
+
 export type PerseusGroupRubric = PerseusGroupWidgetOptions;
 
 export type PerseusGradedGroupRubric = PerseusGradedGroupWidgetOptions;

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -1,3 +1,32 @@
+/**
+ * This file contains types used for validation and scoring. The types abide by
+ * a naming convention so that they're easy to follow and that we remain
+ * consistent across all of the widgets.
+ *
+ * These types are:
+ *
+ * `Perseus<Widget>UserInput`: the data returned by the widget that the user
+ * entered. This is referred to as the 'guess' in some older parts of Perseus.
+ *
+ * `Perseus<Widget>ValidationData`: the data needed to do validation of the
+ * user input. Validation is the checks we can do both on the client-side,
+ * before submitting user input for scoring, and on the server-side when we
+ * score it. As such, it cannot contain any of the sensitive scoring data
+ * that would reveal the answer.
+ *
+ * `Perseus<Widget>ScoringData` (nee `Perseus<Widget>Rubric`): the data needed
+ * to score the user input. By convention, this type is defined as the set of
+ * sensitive answer data and then intersected with
+ * `Perseus<Widget>ValidationData`.
+ *
+ * For example:
+ * ```
+ * type Perseus<Widget>ScoringData = {
+ *     correct: string;
+ * } & Perseus<Widget>ValidationData;
+ * ```
+ */
+
 import type {
     GrapherAnswerTypes,
     PerseusDropdownChoice,
@@ -51,11 +80,9 @@ export type PerseusDropdownUserInput = {
 export type PerseusExpressionRubric = {
     answerForms: ReadonlyArray<PerseusExpressionAnswerForm>;
     functions: ReadonlyArray<string>;
-} & PerseusExpressionValidationData;
+};
 
 export type PerseusExpressionUserInput = string;
-
-export type PerseusExpressionValidationData = Empty;
 
 export type PerseusGroupRubric = PerseusGroupWidgetOptions;
 

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -48,14 +48,14 @@ export type PerseusDropdownUserInput = {
     value: number;
 };
 
-export type PerseusExpressionRubric = {
+export type PerseusExpressionScoringData = {
     answerForms: ReadonlyArray<PerseusExpressionAnswerForm>;
     functions: ReadonlyArray<string>;
-};
+} & PerseusExpressionValidationData;
 
 export type PerseusExpressionUserInput = string;
 
-export type ExpressionValidationData = Empty;
+export type PerseusExpressionValidationData = Empty;
 
 export type PerseusGroupRubric = PerseusGroupWidgetOptions;
 

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -48,7 +48,7 @@ export type PerseusDropdownUserInput = {
     value: number;
 };
 
-export type PerseusExpressionScoringData = {
+export type PerseusExpressionRubric = {
     answerForms: ReadonlyArray<PerseusExpressionAnswerForm>;
     functions: ReadonlyArray<string>;
 } & PerseusExpressionValidationData;

--- a/packages/perseus/src/widgets/expression/expression.tsx
+++ b/packages/perseus/src/widgets/expression/expression.tsx
@@ -25,7 +25,7 @@ import type {DependenciesContext} from "../../dependencies";
 import type {PerseusExpressionWidgetOptions} from "../../perseus-types";
 import type {FocusPath, Widget, WidgetExports, WidgetProps} from "../../types";
 import type {
-    PerseusExpressionScoringData,
+    PerseusExpressionRubric,
     PerseusExpressionUserInput,
 } from "../../validation.types";
 import type {ExpressionPromptJSON} from "../../widget-ai-utils/expression/expression-ai-utils";
@@ -69,7 +69,7 @@ type RenderProps = {
     keypadConfiguration: ReturnType<typeof keypadConfigurationForProps>;
 };
 
-type ExternalProps = WidgetProps<RenderProps, PerseusExpressionScoringData>;
+type ExternalProps = WidgetProps<RenderProps, PerseusExpressionRubric>;
 
 export type Props = ExternalProps &
     Partial<React.ContextType<typeof DependenciesContext>> & {
@@ -554,7 +554,7 @@ export default {
     scorer: scoreExpression,
 
     getOneCorrectAnswerFromRubric(
-        rubric: PerseusExpressionScoringData,
+        rubric: PerseusExpressionRubric,
     ): string | null | undefined {
         const correctAnswers = (rubric.answerForms || []).filter(
             (answerForm) => answerForm.considered === "correct",

--- a/packages/perseus/src/widgets/expression/expression.tsx
+++ b/packages/perseus/src/widgets/expression/expression.tsx
@@ -25,7 +25,7 @@ import type {DependenciesContext} from "../../dependencies";
 import type {PerseusExpressionWidgetOptions} from "../../perseus-types";
 import type {FocusPath, Widget, WidgetExports, WidgetProps} from "../../types";
 import type {
-    PerseusExpressionRubric,
+    PerseusExpressionScoringData,
     PerseusExpressionUserInput,
 } from "../../validation.types";
 import type {ExpressionPromptJSON} from "../../widget-ai-utils/expression/expression-ai-utils";
@@ -69,7 +69,7 @@ type RenderProps = {
     keypadConfiguration: ReturnType<typeof keypadConfigurationForProps>;
 };
 
-type ExternalProps = WidgetProps<RenderProps, PerseusExpressionRubric>;
+type ExternalProps = WidgetProps<RenderProps, PerseusExpressionScoringData>;
 
 export type Props = ExternalProps &
     Partial<React.ContextType<typeof DependenciesContext>> & {
@@ -554,7 +554,7 @@ export default {
     scorer: scoreExpression,
 
     getOneCorrectAnswerFromRubric(
-        rubric: PerseusExpressionRubric,
+        rubric: PerseusExpressionScoringData,
     ): string | null | undefined {
         const correctAnswers = (rubric.answerForms || []).filter(
             (answerForm) => answerForm.considered === "correct",

--- a/packages/perseus/src/widgets/expression/score-expression.test.ts
+++ b/packages/perseus/src/widgets/expression/score-expression.test.ts
@@ -4,7 +4,7 @@ import {expressionItem3Options} from "./expression.testdata";
 import scoreExpression from "./score-expression";
 import * as ExpressionValidator from "./validate-expression";
 
-import type {PerseusExpressionScoringData} from "../../validation.types";
+import type {PerseusExpressionRubric} from "../../validation.types";
 
 describe("scoreExpression", () => {
     it("should be correctly answerable if validation passes", function () {
@@ -12,8 +12,7 @@ describe("scoreExpression", () => {
         const mockValidator = jest
             .spyOn(ExpressionValidator, "default")
             .mockReturnValue(null);
-        const scoringData: PerseusExpressionScoringData =
-            expressionItem3Options;
+        const scoringData: PerseusExpressionRubric = expressionItem3Options;
 
         // Act
         const score = scoreExpression("z+1", scoringData, mockStrings, "en");
@@ -33,8 +32,7 @@ describe("scoreExpression", () => {
         const mockValidator = jest
             .spyOn(ExpressionValidator, "default")
             .mockReturnValue({type: "invalid", message: null});
-        const scoringData: PerseusExpressionScoringData =
-            expressionItem3Options;
+        const scoringData: PerseusExpressionRubric = expressionItem3Options;
 
         // Act
         const score = scoreExpression("z+1", scoringData, mockStrings, "en");

--- a/packages/perseus/src/widgets/expression/score-expression.test.ts
+++ b/packages/perseus/src/widgets/expression/score-expression.test.ts
@@ -2,8 +2,53 @@ import {mockStrings} from "../../strings";
 
 import {expressionItem3Options} from "./expression.testdata";
 import scoreExpression from "./score-expression";
+import * as ExpressionValidator from "./validate-expression";
+
+import type {PerseusExpressionScoringData} from "../../validation.types";
 
 describe("scoreExpression", () => {
+    it("should be correctly answerable if validation passes", function () {
+        // Arrange
+        const mockValidator = jest
+            .spyOn(ExpressionValidator, "default")
+            .mockReturnValue(null);
+        const scoringData: PerseusExpressionScoringData =
+            expressionItem3Options;
+
+        // Act
+        const score = scoreExpression("z+1", scoringData, mockStrings, "en");
+
+        // Assert
+        expect(mockValidator).toHaveBeenCalledWith(
+            "z+1",
+            scoringData,
+            mockStrings,
+            "en",
+        );
+        expect(score).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("should return 'empty' result if validation fails", function () {
+        // Arrange
+        const mockValidator = jest
+            .spyOn(ExpressionValidator, "default")
+            .mockReturnValue({type: "invalid", message: null});
+        const scoringData: PerseusExpressionScoringData =
+            expressionItem3Options;
+
+        // Act
+        const score = scoreExpression("z+1", scoringData, mockStrings, "en");
+
+        // Assert
+        expect(mockValidator).toHaveBeenCalledWith(
+            "z+1",
+            scoringData,
+            mockStrings,
+            "en",
+        );
+        expect(score).toHaveInvalidInput();
+    });
+
     it("should handle defined ungraded answer case with no error callback", function () {
         const err = scoreExpression(
             "x+1",

--- a/packages/perseus/src/widgets/expression/score-expression.test.ts
+++ b/packages/perseus/src/widgets/expression/score-expression.test.ts
@@ -12,15 +12,15 @@ describe("scoreExpression", () => {
         const mockValidator = jest
             .spyOn(ExpressionValidator, "default")
             .mockReturnValue(null);
-        const scoringData: PerseusExpressionRubric = expressionItem3Options;
+        const rubric: PerseusExpressionRubric = expressionItem3Options;
 
         // Act
-        const score = scoreExpression("z+1", scoringData, mockStrings, "en");
+        const score = scoreExpression("z+1", rubric, mockStrings, "en");
 
         // Assert
         expect(mockValidator).toHaveBeenCalledWith(
             "z+1",
-            scoringData,
+            rubric,
             mockStrings,
             "en",
         );
@@ -32,15 +32,15 @@ describe("scoreExpression", () => {
         const mockValidator = jest
             .spyOn(ExpressionValidator, "default")
             .mockReturnValue({type: "invalid", message: null});
-        const scoringData: PerseusExpressionRubric = expressionItem3Options;
+        const rubric: PerseusExpressionRubric = expressionItem3Options;
 
         // Act
-        const score = scoreExpression("z+1", scoringData, mockStrings, "en");
+        const score = scoreExpression("z+1", rubric, mockStrings, "en");
 
         // Assert
         expect(mockValidator).toHaveBeenCalledWith(
             "z+1",
-            scoringData,
+            rubric,
             mockStrings,
             "en",
         );

--- a/packages/perseus/src/widgets/expression/score-expression.test.ts
+++ b/packages/perseus/src/widgets/expression/score-expression.test.ts
@@ -18,12 +18,7 @@ describe("scoreExpression", () => {
         const score = scoreExpression("z+1", rubric, mockStrings, "en");
 
         // Assert
-        expect(mockValidator).toHaveBeenCalledWith(
-            "z+1",
-            rubric,
-            mockStrings,
-            "en",
-        );
+        expect(mockValidator).toHaveBeenCalledWith("z+1");
         expect(score).toHaveBeenAnsweredCorrectly();
     });
 
@@ -38,12 +33,7 @@ describe("scoreExpression", () => {
         const score = scoreExpression("z+1", rubric, mockStrings, "en");
 
         // Assert
-        expect(mockValidator).toHaveBeenCalledWith(
-            "z+1",
-            rubric,
-            mockStrings,
-            "en",
-        );
+        expect(mockValidator).toHaveBeenCalledWith("z+1");
         expect(score).toHaveInvalidInput();
     });
 

--- a/packages/perseus/src/widgets/expression/score-expression.ts
+++ b/packages/perseus/src/widgets/expression/score-expression.ts
@@ -41,14 +41,9 @@ function scoreExpression(
     strings: PerseusStrings,
     locale: string,
 ): PerseusScore {
-    const validationResult = validateExpression(
-        userInput,
-        rubric,
-        strings,
-        locale,
-    );
-    if (validationResult) {
-        return validationResult;
+    const validationError = validateExpression(userInput);
+    if (validationError) {
+        return validationError;
     }
 
     const options = _.clone(rubric);

--- a/packages/perseus/src/widgets/expression/score-expression.ts
+++ b/packages/perseus/src/widgets/expression/score-expression.ts
@@ -13,7 +13,7 @@ import type {PerseusStrings} from "../../strings";
 import type {PerseusScore} from "../../types";
 import type {Score} from "../../util/answer-types";
 import type {
-    PerseusExpressionRubric,
+    PerseusExpressionScoringData,
     PerseusExpressionUserInput,
 } from "../../validation.types";
 
@@ -37,13 +37,13 @@ import type {
  */
 function scoreExpression(
     userInput: PerseusExpressionUserInput,
-    rubric: PerseusExpressionRubric,
+    scoringData: PerseusExpressionScoringData,
     strings: PerseusStrings,
     locale: string,
 ): PerseusScore {
     const validationResult = validateExpression(
         userInput,
-        rubric,
+        scoringData,
         strings,
         locale,
     );
@@ -51,7 +51,7 @@ function scoreExpression(
         return validationResult;
     }
 
-    const options = _.clone(rubric);
+    const options = _.clone(scoringData);
     _.extend(options, {
         decimal_separator: getDecimalSeparator(locale),
     });
@@ -61,7 +61,7 @@ function scoreExpression(
         // solution answer, not the student answer, and we don't want a
         // solution to work if the student is using a different language
         // (different from the content creation language, ie. English).
-        const expression = KAS.parse(answer.value, rubric);
+        const expression = KAS.parse(answer.value, scoringData);
         // An answer may not be parsed if the expression was defined
         // incorrectly. For example if the answer is using a symbol defined
         // in the function variables list for the expression.
@@ -70,7 +70,7 @@ function scoreExpression(
             Log.error(
                 "Unable to parse solution answer for expression",
                 Errors.InvalidInput,
-                {loggedMetadata: {rubric: JSON.stringify(rubric)}},
+                {loggedMetadata: {rubric: JSON.stringify(scoringData)}},
             );
             return null;
         }
@@ -100,7 +100,7 @@ function scoreExpression(
     let matchMessage: string | undefined;
     let allEmpty = true;
     let firstUngradedResult: Score | undefined;
-    for (const answerForm of rubric.answerForms || []) {
+    for (const answerForm of scoringData.answerForms || []) {
         const validator = createValidator(answerForm);
         if (!validator) {
             continue;

--- a/packages/perseus/src/widgets/expression/score-expression.ts
+++ b/packages/perseus/src/widgets/expression/score-expression.ts
@@ -13,7 +13,7 @@ import type {PerseusStrings} from "../../strings";
 import type {PerseusScore} from "../../types";
 import type {Score} from "../../util/answer-types";
 import type {
-    PerseusExpressionScoringData,
+    PerseusExpressionRubric,
     PerseusExpressionUserInput,
 } from "../../validation.types";
 
@@ -37,7 +37,7 @@ import type {
  */
 function scoreExpression(
     userInput: PerseusExpressionUserInput,
-    scoringData: PerseusExpressionScoringData,
+    scoringData: PerseusExpressionRubric,
     strings: PerseusStrings,
     locale: string,
 ): PerseusScore {

--- a/packages/perseus/src/widgets/expression/score-expression.ts
+++ b/packages/perseus/src/widgets/expression/score-expression.ts
@@ -37,13 +37,13 @@ import type {
  */
 function scoreExpression(
     userInput: PerseusExpressionUserInput,
-    scoringData: PerseusExpressionRubric,
+    rubric: PerseusExpressionRubric,
     strings: PerseusStrings,
     locale: string,
 ): PerseusScore {
     const validationResult = validateExpression(
         userInput,
-        scoringData,
+        rubric,
         strings,
         locale,
     );
@@ -51,7 +51,7 @@ function scoreExpression(
         return validationResult;
     }
 
-    const options = _.clone(scoringData);
+    const options = _.clone(rubric);
     _.extend(options, {
         decimal_separator: getDecimalSeparator(locale),
     });
@@ -61,7 +61,7 @@ function scoreExpression(
         // solution answer, not the student answer, and we don't want a
         // solution to work if the student is using a different language
         // (different from the content creation language, ie. English).
-        const expression = KAS.parse(answer.value, scoringData);
+        const expression = KAS.parse(answer.value, rubric);
         // An answer may not be parsed if the expression was defined
         // incorrectly. For example if the answer is using a symbol defined
         // in the function variables list for the expression.
@@ -70,7 +70,7 @@ function scoreExpression(
             Log.error(
                 "Unable to parse solution answer for expression",
                 Errors.InvalidInput,
-                {loggedMetadata: {rubric: JSON.stringify(scoringData)}},
+                {loggedMetadata: {rubric: JSON.stringify(rubric)}},
             );
             return null;
         }
@@ -100,7 +100,7 @@ function scoreExpression(
     let matchMessage: string | undefined;
     let allEmpty = true;
     let firstUngradedResult: Score | undefined;
-    for (const answerForm of scoringData.answerForms || []) {
+    for (const answerForm of rubric.answerForms || []) {
         const validator = createValidator(answerForm);
         if (!validator) {
             continue;

--- a/packages/perseus/src/widgets/expression/score-expression.ts
+++ b/packages/perseus/src/widgets/expression/score-expression.ts
@@ -6,6 +6,7 @@ import {Log} from "../../logging/log";
 import KhanAnswerTypes from "../../util/answer-types";
 
 import getDecimalSeparator from "./get-decimal-separator";
+import validateExpression from "./validate-expression";
 
 import type {PerseusExpressionAnswerForm} from "../../perseus-types";
 import type {PerseusStrings} from "../../strings";
@@ -40,6 +41,16 @@ function scoreExpression(
     strings: PerseusStrings,
     locale: string,
 ): PerseusScore {
+    const validationResult = validateExpression(
+        userInput,
+        rubric,
+        strings,
+        locale,
+    );
+    if (validationResult) {
+        return validationResult;
+    }
+
     const options = _.clone(rubric);
     _.extend(options, {
         decimal_separator: getDecimalSeparator(locale),

--- a/packages/perseus/src/widgets/expression/validate-expression.test.ts
+++ b/packages/perseus/src/widgets/expression/validate-expression.test.ts
@@ -1,15 +1,13 @@
-import {mockStrings} from "../../strings";
-
 import validateExpression from "./validate-expression";
 
 describe("expression validation", () => {
     it("should return invalid for empty user input", () => {
-        const result = validateExpression("", {}, mockStrings, "en");
+        const result = validateExpression("");
         expect(result).toHaveInvalidInput();
     });
 
     it("should return null for non-empty user input", () => {
-        const result = validateExpression("x+1", {}, mockStrings, "en");
+        const result = validateExpression("x+1");
         expect(result).toBeNull();
     });
 });

--- a/packages/perseus/src/widgets/expression/validate-expression.test.ts
+++ b/packages/perseus/src/widgets/expression/validate-expression.test.ts
@@ -1,0 +1,20 @@
+import {mockStrings} from "../../strings";
+
+import validateExpression from "./validate-expression";
+
+describe("expression validation", () => {
+    it("should always return null", () => {
+        const result = validateExpression("", {}, mockStrings, "en");
+        expect(result).toBeNull();
+    });
+
+    it("should return null for empty user input", () => {
+        const result = validateExpression("", {}, mockStrings, "en");
+        expect(result).toBeNull();
+    });
+
+    it("should return null for non-empty user input", () => {
+        const result = validateExpression("x+1", {}, mockStrings, "en");
+        expect(result).toBeNull();
+    });
+});

--- a/packages/perseus/src/widgets/expression/validate-expression.test.ts
+++ b/packages/perseus/src/widgets/expression/validate-expression.test.ts
@@ -3,14 +3,9 @@ import {mockStrings} from "../../strings";
 import validateExpression from "./validate-expression";
 
 describe("expression validation", () => {
-    it("should always return null", () => {
+    it("should return invalid for empty user input", () => {
         const result = validateExpression("", {}, mockStrings, "en");
-        expect(result).toBeNull();
-    });
-
-    it("should return null for empty user input", () => {
-        const result = validateExpression("", {}, mockStrings, "en");
-        expect(result).toBeNull();
+        expect(result).toHaveInvalidInput();
     });
 
     it("should return null for non-empty user input", () => {

--- a/packages/perseus/src/widgets/expression/validate-expression.ts
+++ b/packages/perseus/src/widgets/expression/validate-expression.ts
@@ -1,7 +1,7 @@
 import type {PerseusStrings} from "../../strings";
 import type {PerseusScore} from "../../types";
 import type {
-    ExpressionValidationData,
+    PerseusExpressionValidationData,
     PerseusExpressionUserInput,
 } from "../../validation.types";
 
@@ -14,7 +14,7 @@ import type {
  */
 function validateExpression(
     userInput: PerseusExpressionUserInput,
-    validationData: ExpressionValidationData,
+    validationData: PerseusExpressionValidationData,
     strings: PerseusStrings,
     locale: string,
 ): Extract<PerseusScore, {type: "invalid"}> | null {

--- a/packages/perseus/src/widgets/expression/validate-expression.ts
+++ b/packages/perseus/src/widgets/expression/validate-expression.ts
@@ -1,22 +1,16 @@
-import type {PerseusStrings} from "../../strings";
 import type {PerseusScore} from "../../types";
-import type {
-    PerseusExpressionValidationData,
-    PerseusExpressionUserInput,
-} from "../../validation.types";
+import type {PerseusExpressionUserInput} from "../../validation.types";
 
 /**
- * Checks user input from the expression widget to see if it is gradable. Most
- * of the expression widget's validation requires the Rubric because of its
- * use of KhanAnswerTypes as a core part of scoring.
+ * Checks user input from the expression widget to see if it is scorable.
+ *
+ * Note: Most of the expression widget's validation requires the Rubric because
+ * of its use of KhanAnswerTypes as a core part of scoring.
  *
  * @see `scoreExpression()` for more details.
  */
 function validateExpression(
     userInput: PerseusExpressionUserInput,
-    validationData: PerseusExpressionValidationData,
-    strings: PerseusStrings,
-    locale: string,
 ): Extract<PerseusScore, {type: "invalid"}> | null {
     if (userInput === "") {
         return {type: "invalid", message: null};

--- a/packages/perseus/src/widgets/expression/validate-expression.ts
+++ b/packages/perseus/src/widgets/expression/validate-expression.ts
@@ -1,0 +1,24 @@
+import type {PerseusStrings} from "../../strings";
+import type {PerseusScore} from "../../types";
+import type {
+    ExpressionValidationData,
+    PerseusExpressionUserInput,
+} from "../../validation.types";
+
+/**
+ * Checks user input from the expression widget to see if it is gradable. The
+ * expression widget cannot do any validation without the Rubric because of its
+ * use of KhanAnswerTypes as a core part of scoring.
+ *
+ * @see `scoreExpression()` for more details.
+ */
+function validateExpression(
+    userInput: PerseusExpressionUserInput,
+    validationData: ExpressionValidationData,
+    strings: PerseusStrings,
+    locale: string,
+): Extract<PerseusScore, {type: "invalid"}> | null {
+    return null;
+}
+
+export default validateExpression;

--- a/packages/perseus/src/widgets/expression/validate-expression.ts
+++ b/packages/perseus/src/widgets/expression/validate-expression.ts
@@ -6,8 +6,8 @@ import type {
 } from "../../validation.types";
 
 /**
- * Checks user input from the expression widget to see if it is gradable. The
- * expression widget cannot do any validation without the Rubric because of its
+ * Checks user input from the expression widget to see if it is gradable. Most
+ * of the expression widget's validation requires the Rubric because of its
  * use of KhanAnswerTypes as a core part of scoring.
  *
  * @see `scoreExpression()` for more details.
@@ -18,6 +18,10 @@ function validateExpression(
     strings: PerseusStrings,
     locale: string,
 ): Extract<PerseusScore, {type: "invalid"}> | null {
+    if (userInput === "") {
+        return {type: "invalid", message: null};
+    }
+
     return null;
 }
 


### PR DESCRIPTION
## Summary:

Arguably, this validator is quite useless in that it does nothing. However, I was thinking that we'd be better off if all of our widgets had a validator, even if it does nothing, rather than have some widgets have a validator and some not. In my mind, we're better off with the same convention everywhere.

This PR introduces the concept of "validation data" that we discussed earlier today (November 18). This represents _only_ the data needed by the validator. It intersects that type into the ScoringData type (nee Rubric) to ensure that the scoring function has all the data it needs to score (but also validate).

  * `PerseusExpressionRubric` - the data needed to score the `expression` user input (Note: this will be renamed to `PerseusExpressionScoringData` in the near future)
  * `PerseusExpressionValidationData` - the data needed to validate the `expression` user input
  * `ExpressionWidgetOptions` - the data needed to render the `expression` widget 

In the `expression` widget case, the validation data is empty, but in other widgets, the data in this type would also need to be in both the rubric and widget options (as the widget will call the validator on the client with only the widget options in hand and the scorer will call the validator on the server with only the rubric in hand). 


Issue: LEMS-2598

## Test plan:

`yarn test`
`yarn typecheck`