### PR TITLE
Add snapshot tests for parseAndTypecheckPerseusItem

### DIFF
--- a/.changeset/great-jobs-flash.md
+++ b/.changeset/great-jobs-flash.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: add snapshot tests for `parseAndTypecheckPerseusItem`.

--- a/packages/perseus/src/util/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-snapshot.test.ts.snap
+++ b/packages/perseus/src/util/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-snapshot.test.ts.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`parseAndTypecheckPerseusItem correctly parses data/radio-missing-noneOfTheAbove.json 1`] = `
+{
+  "answer": undefined,
+  "answerArea": {
+    "calculator": false,
+    "chi2Table": false,
+    "periodicTable": false,
+    "tTable": false,
+    "zTable": false,
+  },
+  "hints": [],
+  "itemDataVersion": {
+    "major": 0,
+    "minor": 1,
+  },
+  "question": {
+    "content": "$\\begin{align} 
+A &= \\{x: x \\text{ is a rectangle in the plane P} \\} \\\\\\\\
+B &= \\{x: x \\text{ is a square in the plane P} \\}
+\\end{align}$
+
+**Is $A \\subset B$ ?**
+
+[[☃ radio 1]]
+",
+    "images": {},
+    "metadata": undefined,
+    "widgets": {
+      "radio 1": {
+        "alignment": "default",
+        "graded": true,
+        "key": undefined,
+        "options": {
+          "choices": [
+            {
+              "clue": undefined,
+              "content": "Yes",
+              "correct": false,
+              "isNoneOfTheAbove": undefined,
+              "widgets": undefined,
+            },
+            {
+              "clue": undefined,
+              "content": "No",
+              "correct": true,
+              "isNoneOfTheAbove": undefined,
+              "widgets": undefined,
+            },
+          ],
+          "countChoices": false,
+          "deselectEnabled": false,
+          "displayCount": null,
+          "hasNoneOfTheAbove": false,
+          "multipleSelect": false,
+          "noneOfTheAbove": undefined,
+          "onePerLine": undefined,
+          "randomize": false,
+        },
+        "static": false,
+        "type": "radio",
+        "version": {
+          "major": 1,
+          "minor": 0,
+        },
+      },
+    },
+  },
+}
+`;

--- a/packages/perseus/src/util/parse-perseus-json/regression-tests/parse-perseus-json-snapshot.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/regression-tests/parse-perseus-json-snapshot.test.ts
@@ -1,0 +1,22 @@
+import * as fs from "fs";
+import {join} from "path";
+
+import {parseAndTypecheckPerseusItem} from "../index";
+import {assertSuccess} from "../result";
+
+const dataFiles = fs.readdirSync(join(__dirname, "data"));
+
+// If you change the parsers to migrate/convert data to a new format, you may
+// have to regenerate these snapshots. That's expected and okay!
+
+describe("parseAndTypecheckPerseusItem", () => {
+    it.each(dataFiles)("correctly parses data/%s", (filename) => {
+        const json = fs.readFileSync(
+            join(__dirname, "data", filename),
+            "utf-8",
+        );
+        const result = parseAndTypecheckPerseusItem(json);
+        assertSuccess(result);
+        expect(result.value).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
The other regression tests only assert that we can successfully parse each
assessmentItem in the regression dataset. However, a successful parse doesn't
necessarily mean we preserved all input data or migrated it correctly to the
latest format.

This PR adds snapshot tests to fix that gap in our coverage.

Issue: none

## Test plan:

`yarn test`