### PR TITLE
Fixing issue with Input Numbers that have a value of 0 

### DIFF
--- a/.changeset/violet-melons-sneeze.md
+++ b/.changeset/violet-melons-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Hypothesis

--- a/packages/perseus/src/__stories__/server-item-renderer.stories.tsx
+++ b/packages/perseus/src/__stories__/server-item-renderer.stories.tsx
@@ -5,6 +5,7 @@ import {ServerItemRendererWithDebugUI} from "../../../../testing/server-item-ren
 import {storybookDependenciesV2} from "../../../../testing/test-dependencies";
 import {
     itemWithInput,
+    itemWithInputNumber,
     itemWithLintingError,
     labelImageItem,
     itemWithImages,
@@ -25,6 +26,10 @@ export default {
 
 export const NumericInputItem = (args: StoryArgs): React.ReactElement => {
     return <ServerItemRendererWithDebugUI item={itemWithInput} />;
+};
+
+export const InputNumberItem = (args: StoryArgs): React.ReactElement => {
+    return <ServerItemRendererWithDebugUI item={itemWithInputNumber} />;
 };
 
 export const LabelImageItem = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus/src/__testdata__/server-item-renderer.testdata.ts
+++ b/packages/perseus/src/__testdata__/server-item-renderer.testdata.ts
@@ -60,7 +60,7 @@ export const itemWithInputNumber: PerseusItem = {
                 graded: true,
                 options: {
                     static: false,
-                    value: 1,
+                    value: 0,
                     simplify: "required",
                     maxError: 0.1,
                     inexact: false,

--- a/packages/perseus/src/__testdata__/server-item-renderer.testdata.ts
+++ b/packages/perseus/src/__testdata__/server-item-renderer.testdata.ts
@@ -7,6 +7,7 @@ import {
     type ExpressionWidget,
     type RadioWidget,
     type NumericInputWidget,
+    type InputNumberWidget,
 } from "../perseus-types";
 
 export const itemWithInput: PerseusItem = {
@@ -36,6 +37,37 @@ export const itemWithInput: PerseusItem = {
                     rightAlign: false,
                 },
             } as NumericInputWidget,
+        },
+    },
+    hints: [
+        {content: "Hint #1", images: {}, widgets: {}},
+        {content: "Hint #2", images: {}, widgets: {}},
+        {content: "Hint #3", images: {}, widgets: {}},
+    ],
+    answerArea: null,
+    itemDataVersion: {major: 0, minor: 0},
+    answer: null,
+};
+
+export const itemWithInputNumber: PerseusItem = {
+    question: {
+        content:
+            "Enter the number $$-42$$ in the box: [[\u2603 input-number 1]]",
+        images: {},
+        widgets: {
+            "input-number 1": {
+                type: "input-number",
+                graded: true,
+                options: {
+                    static: false,
+                    value: 1,
+                    simplify: "required",
+                    maxError: 0.1,
+                    inexact: false,
+                    answerType: "number",
+                    size: "small",
+                },
+            } as InputNumberWidget,
         },
     },
     hints: [

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
@@ -348,7 +348,7 @@ const propUpgrades = {
         // If the initialProps has a value, it means we're upgrading from
         // input-number to numeric-input. In this case, we need to upgrade
         // the widget options accordingly.
-        if (initialProps.value) {
+        if (initialProps.simplify) {
             // If the answerType is not number or percent, we need to provide
             // the answer form for the numeric-input widget
             const provideAnswerForm =
@@ -363,10 +363,11 @@ const propUpgrades = {
 
             // If adjusting this logic, also adjust the logic in the convertInputNumberWidgetOptions
             // function in input-number.ts in the Perseus Editor package's util folder
-            const answers: PerseusNumericInputWidgetOptions["answers"] = [
+            const answers = [
                 {
                     value: initialProps.value,
                     simplify: initialProps.simplify,
+                    answerForms: provideAnswerForm ? [mathFormat] : undefined,
                     strict: initialProps.inexact,
                     // We only want to set maxError if the inexact prop is true
                     maxError: initialProps.inexact ? initialProps.maxError : 0,
@@ -374,10 +375,6 @@ const propUpgrades = {
                     message: "",
                 },
             ];
-
-            if (provideAnswerForm) {
-                answers[0].answerForms = [mathFormat];
-            }
 
             return {
                 answers,

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
@@ -363,11 +363,10 @@ const propUpgrades = {
 
             // If adjusting this logic, also adjust the logic in the convertInputNumberWidgetOptions
             // function in input-number.ts in the Perseus Editor package's util folder
-            const answers = [
+            const answers: PerseusNumericInputWidgetOptions["answers"] = [
                 {
                     value: initialProps.value,
                     simplify: initialProps.simplify,
-                    answerForms: provideAnswerForm ? [mathFormat] : undefined,
                     strict: initialProps.inexact,
                     // We only want to set maxError if the inexact prop is true
                     maxError: initialProps.inexact ? initialProps.maxError : 0,
@@ -375,6 +374,10 @@ const propUpgrades = {
                     message: "",
                 },
             ];
+
+            if (provideAnswerForm) {
+                answers[0].answerForms = [mathFormat];
+            }
 
             return {
                 answers,

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
@@ -348,7 +348,7 @@ const propUpgrades = {
         // If the initialProps has simplify, it means we're upgrading from
         // input-number to numeric-input. In this case, we need to upgrade
         // the widget options accordingly.
-        if (initialProps.simplify) {
+        if (initialProps.simplify !== undefined) {
             // If the answerType is not number or percent, we need to provide
             // the answer form for the numeric-input widget
             const provideAnswerForm =

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
@@ -345,7 +345,7 @@ const propsTransform = function (
 const propUpgrades = {
     /* c8 ignore next */
     "1": (initialProps: any): PerseusNumericInputWidgetOptions => {
-        // If the initialProps has a value, it means we're upgrading from
+        // If the initialProps has simplify, it means we're upgrading from
         // input-number to numeric-input. In this case, we need to upgrade
         // the widget options accordingly.
         if (initialProps.simplify) {


### PR DESCRIPTION
## Summary:
This PR fixes an issue with the Input Number Conversion project that specifically pertains to widgets that have a value of 0, as it results in a falsy situation. As a result of this issue, exercises that contain the offending widget settings would fail to render. 

This PR updates the logic to a safer key, and ensures that it is not undefined. 

# Test:
- Manual testing both in Storybook and Webapp to confirm that failing cases now render properly. 