### PR TITLE
Turn on strictFunctionTypes in tsconfig and suppress errors

### DIFF
--- a/packages/kas/src/__tests__/units.test.ts
+++ b/packages/kas/src/__tests__/units.test.ts
@@ -77,6 +77,7 @@ expect.extend({
             return {pass: false, message: () => `could not parse ${x}`};
         }
 
+        // @ts-expect-error: Type 'Expression' is not assignable to type 'Expr'.
         const equal = KAS.compare(parsedX.unit, parsedY.unit).equal;
 
         return equal
@@ -167,6 +168,7 @@ describe("units", () => {
 
         expect(
             KAS.compare(
+                // @ts-expect-error: Type 'Expression' is not assignable to type 'Expr'.
                 new KAS.Mul(new KAS.Int(50), new KAS.Unit("m")),
                 new KAS.Int(50),
             ).equal,

--- a/packages/kas/src/nodes.ts
+++ b/packages/kas/src/nodes.ts
@@ -313,6 +313,7 @@ abstract class Expr {
 
     // return the child nodes of this node
     exprArgs(): Expr[] {
+        // @ts-expect-error: Type 'string | number | Expr | undefined' is not assignable to type 'string | Expr'.
         return this.args().filter(isExpr);
     }
 
@@ -817,6 +818,7 @@ export class Add extends Seq {
     reduce(options?: Options): Expr {
         return _.reduce(
             this.terms,
+            // @ts-expect-error: Type 'Expr' is not assignable to type 'Num'.
             (memo, term) => {
                 return memo.add(term, options);
             },
@@ -1300,6 +1302,7 @@ export class Mul extends Seq {
     reduce(options?: {preciseFloats: boolean}) {
         return _.reduce(
             this.terms,
+            // @ts-expect-error: Type 'Expr' is not assignable to type 'Num'.
             (memo, term) => {
                 return memo.mul(term, options);
             },
@@ -1557,12 +1560,15 @@ export class Mul extends Seq {
                 return pos(num) || neg(num);
             };
 
+            // @ts-expect-error: Type 'Expr' is not assignable to type 'Num'.
             const posNum = numbers.find(pos);
+            // @ts-expect-error: Type 'Expr' is not assignable to type 'Num'.
             const negNum = numbers.find(neg);
             if (
                 numbers.length > 1 &&
                 negNum &&
                 posNum &&
+                // @ts-expect-error: Type 'Expr' is not assignable to type 'Num'.
                 _.every(numbers, posOrNeg)
             ) {
                 var firstNeg = _.indexOf(expr.terms, negNum);

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -984,6 +984,7 @@ class MathInput extends React.Component<Props, State> {
                         }}
                         onTouchMove={this.handleTouchMove}
                         onTouchEnd={this.handleTouchEnd}
+                        // @ts-expect-error: Type '(e: React.MouseEvent<HTMLDivElement>) => void' is not assignable to type '(arg1: SyntheticEvent<HTMLDivElement, Event>) => void'.
                         onClick={(e: React.MouseEvent<HTMLDivElement>) => {
                             this.handleClick(e, keypadActive, setKeypadActive);
                         }}

--- a/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
+++ b/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
@@ -31,6 +31,7 @@ export function V2KeypadWithMathquill() {
                 mathFieldWrapperRef.current,
                 "en",
                 mockStrings,
+                // @ts-expect-error: Type 'EditableMathQuill' is not assignable to type 'MathFieldInterface'.
                 (baseConfig) => ({
                     ...baseConfig,
                     handlers: {

--- a/packages/perseus-editor/src/__stories__/editor.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/editor.stories.tsx
@@ -102,6 +102,7 @@ export const DemoInteractiveGraph = (): React.ReactElement => {
                             showWordCount={true}
                             warnNoPrompt={false}
                             warnNoWidgets={true}
+                            // @ts-expect-error: Type '(props: Partial<PerseusRenderer>) => void' is not assignable to type 'ChangeHandler'.
                             onChange={(props: Partial<PerseusRenderer>) => {
                                 action("onChange")(props);
                                 if (props.content) {

--- a/packages/perseus-editor/src/article-editor.tsx
+++ b/packages/perseus-editor/src/article-editor.tsx
@@ -242,6 +242,7 @@ export default class ArticleEditor extends React.Component<Props, State> {
                                     {...section}
                                     apiOptions={apiOptions}
                                     imageUploader={imageUploader}
+                                    // @ts-expect-error: Types of parameters 'p2' and 'arg1' are incompatible. Type 'undefined' is not assignable to type 'string'.
                                     onChange={_.partial(
                                         this._handleEditorChange,
                                         i,

--- a/packages/perseus-editor/src/components/__stories__/color-select.stories.tsx
+++ b/packages/perseus-editor/src/components/__stories__/color-select.stories.tsx
@@ -36,6 +36,7 @@ export const Controlled = {
         return (
             <ColorSelect
                 selectedValue={selectedValue}
+                // @ts-expect-error: Type 'string' is not assignable to type '"pink" | "blue" | "green" | "orange" | "purple" | "red" | "grayH"'.
                 onChange={handleColorChange}
             />
         );

--- a/packages/perseus-editor/src/components/graph-settings.tsx
+++ b/packages/perseus-editor/src/components/graph-settings.tsx
@@ -121,7 +121,10 @@ const GraphSettings = createReactClass({
         };
     },
 
-    change(...args) {
+    // TODO(benchristel): Refactor this component to be an ES6 class, so we can
+    // type change as ChangeFn.
+    change: (...args) => {
+        // @ts-expect-error: Argument of type 'any[]' is not assignable to parameter of type '[newPropsOrSinglePropName: string | { [key: string]: any; }, propValue?: any, callback?: (() => unknown) | undefined]'. Target requires 1 element(s) but source may have fewer.
         return Changeable.change.apply(this, args);
     },
 

--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -634,6 +634,7 @@ class Editor extends React.Component<Props, State> {
         return safeWidgetMapping;
     };
 
+    // @ts-expect-error: Types of parameter 'widgetType' and 'widgetType' are incompatible. Type 'string' is not assignable to type '"cs-program" | "iframe" | "table" | "video" | "image" | "deprecated-standin" | "categorizer" | "definition" | "dropdown" | "explanation" | "expression" | "graded-group" | "graded-group-set" | ... 20 more ... | "radio"'.
     _addWidgetToContent: (
         oldContent: string,
         cursorRange: ReadonlyArray<number>,

--- a/packages/perseus-editor/src/widgets/__stories__/expression-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/expression-editor.stories.tsx
@@ -59,6 +59,7 @@ class WithDebug extends React.Component<Empty, State> {
                 <div className={css(styles.editorWrapper)}>
                     <ExpressionEditor
                         {...this.state}
+                        // @ts-expect-error: Types of parameters 'props' and 'values' are incompatible. Type '{ [key: string]: any; }' is missing the following properties from type 'PerseusExpressionWidgetOptions': answerForms, buttonSets, functions, times
                         onChange={(props: PerseusExpressionWidgetOptions) => {
                             this.setState({
                                 ...props,

--- a/packages/perseus-editor/src/widgets/cs-program-editor.tsx
+++ b/packages/perseus-editor/src/widgets/cs-program-editor.tsx
@@ -18,6 +18,7 @@ import * as React from "react";
 import _ from "underscore";
 
 import BlurInput from "../components/blur-input";
+import {ChangeFn} from "@khanacademy/perseus/src/types";
 
 const {InfoTip} = components;
 
@@ -39,7 +40,7 @@ class PairEditor extends React.Component<any> {
         value: "",
     };
 
-    change = (...args) => {
+    change: ChangeFn = (...args) => {
         return Changeable.change.apply(this, args);
     };
 
@@ -84,7 +85,7 @@ class PairsEditor extends React.Component<any> {
         ).isRequired,
     };
 
-    change = (...args) => {
+    change: ChangeFn = (...args) => {
         return Changeable.change.apply(this, args);
     };
 

--- a/packages/perseus-editor/src/widgets/expression-editor.tsx
+++ b/packages/perseus-editor/src/widgets/expression-editor.tsx
@@ -26,6 +26,7 @@ import type {
     PerseusExpressionWidgetOptions,
     LegacyButtonSets,
 } from "@khanacademy/perseus";
+import {ChangeFn} from "@khanacademy/perseus/src/types";
 
 const {InfoTip} = components;
 
@@ -109,7 +110,7 @@ class ExpressionEditor extends React.Component<Props, State> {
         };
     }
 
-    change(...args) {
+    change: ChangeFn = (...args) => {
         return Changeable.change.apply(this, args);
     }
 
@@ -356,6 +357,7 @@ class ExpressionEditor extends React.Component<Props, State> {
                     buttonSets: this.props.buttonSets,
                     buttonsVisible: "focused",
                     value: ans.value,
+                    // @ts-expect-error: Type '(props: React.ComponentProps<typeof Expression>) => void' is not assignable to type 'ChangeHandler'. Types of parameters 'props' and 'arg1' are incompatible.
                     onChange: (
                         props: React.ComponentProps<typeof Expression>,
                     ) => this.changeExpressionWidget(key, props),
@@ -553,7 +555,7 @@ class AnswerOption extends React.Component<
 > {
     state = {deleteFocused: false};
 
-    change = (...args) => {
+    change: ChangeFn = (...args) => {
         return Changeable.change.apply(this, args);
     };
 

--- a/packages/perseus-editor/src/widgets/iframe-editor.tsx
+++ b/packages/perseus-editor/src/widgets/iframe-editor.tsx
@@ -6,6 +6,7 @@ import * as React from "react";
 import _ from "underscore";
 
 import BlurInput from "../components/blur-input";
+import {ChangeFn} from "@khanacademy/perseus/src/types";
 
 type PairEditorProps = any;
 
@@ -24,7 +25,7 @@ class PairEditor extends React.Component<PairEditorProps> {
         value: "",
     };
 
-    change = (...args) => {
+    change: ChangeFn = (...args) => {
         return Changeable.change.apply(this, args);
     };
 
@@ -70,7 +71,7 @@ class PairsEditor extends React.Component<PairsEditorProps> {
         ).isRequired,
     };
 
-    change = (...args) => {
+    change: ChangeFn = (...args) => {
         return Changeable.change.apply(this, args);
     };
 

--- a/packages/perseus-editor/src/widgets/image-editor.tsx
+++ b/packages/perseus-editor/src/widgets/image-editor.tsx
@@ -13,6 +13,7 @@ import BlurInput from "../components/blur-input";
 import Editor from "../editor";
 
 import type {APIOptions, Range, Size} from "@khanacademy/perseus";
+import {ChangeFn} from "@khanacademy/perseus/src/types";
 
 const {InfoTip, InlineIcon, RangeInput} = components;
 
@@ -159,7 +160,7 @@ class ImageEditor extends React.Component<Props> {
         );
     }
 
-    change(...args) {
+    change: ChangeFn = (...args) => {
         return Changeable.change.apply(this, args);
     }
 

--- a/packages/perseus-editor/src/widgets/interaction-editor/mathquill-input.tsx
+++ b/packages/perseus-editor/src/widgets/interaction-editor/mathquill-input.tsx
@@ -31,6 +31,7 @@ export default function MathquillInput(props: Props) {
                 mathFieldWrapperRef.current,
                 locale,
                 strings,
+                // @ts-expect-error: Types of parameters 'mathField' and 'mq' are incompatible. Type 'EditableMathQuill | BaseMathQuill' is not assignable to type 'MathFieldInterface'.
                 (baseConfig) => ({
                     ...baseConfig,
                     handlers: {

--- a/packages/perseus-editor/src/widgets/interaction-editor/movable-line-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interaction-editor/movable-line-editor.tsx
@@ -9,6 +9,7 @@ import _ from "underscore";
 
 import ConstraintEditor from "./constraint-editor";
 import MathquillInput from "./mathquill-input";
+import {ChangeFn} from "@khanacademy/perseus/src/types";
 
 const {NumberInput} = components;
 const {getDependencies} = Dependencies;
@@ -53,7 +54,7 @@ class MovableLineEditor extends React.Component<Props> {
         constraintYMax: "10",
     };
 
-    change = (...args) => {
+    change: ChangeFn = (...args) => {
         return Changeable.change.apply(this, args);
     };
 

--- a/packages/perseus-editor/src/widgets/interaction-editor/movable-point-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interaction-editor/movable-point-editor.tsx
@@ -9,6 +9,7 @@ import _ from "underscore";
 
 import ConstraintEditor from "./constraint-editor";
 import MathquillInput from "./mathquill-input";
+import {ChangeFn} from "@khanacademy/perseus/src/types";
 
 const {NumberInput} = components;
 const {getDependencies} = Dependencies;
@@ -46,7 +47,7 @@ class MovablePointEditor extends React.Component<Props> {
         constraintYMax: "10",
     };
 
-    change = (...args) => {
+    change: ChangeFn = (...args) => {
         return Changeable.change.apply(this, args);
     };
 

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-settings.tsx
@@ -20,6 +20,7 @@ import Heading from "../../../components/heading";
 import LabeledRow from "../locked-figures/labeled-row";
 
 import type {PerseusImageBackground} from "@khanacademy/perseus";
+import {ChangeFn} from "@khanacademy/perseus/src/types";
 
 const {ButtonGroup, InfoTip, RangeInput} = components;
 
@@ -175,7 +176,7 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
         this._isMounted = false;
     }
 
-    change = (...args) => {
+    change: ChangeFn = (...args) => {
         return Changeable.change.apply(this, args);
     };
 

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
@@ -358,6 +358,7 @@ class InteractiveGraphEditor extends React.Component<Props> {
                             this.props.graph?.type ??
                             InteractiveGraph.defaultProps.graph.type
                         }
+                        // @ts-expect-error: Type 'string' is not assignable to type '"none" | "circle" | "polygon" | "point" | "linear" | "angle" | "linear-system" | "quadratic" | "ray" | "segment" | "sinusoid"'.
                         onChange={(
                             type: Required<InteractiveGraphProps>["graph"]["type"],
                         ) => {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-ellipse-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-ellipse-settings.tsx
@@ -213,6 +213,7 @@ const LockedEllipseSettings = (props: Props) => {
                 {/* Color */}
                 <ColorSelect
                     selectedValue={color}
+                    // @ts-expect-error: Type 'string' is not assignable to type '"blue" | "green" | "orange" | "pink" | "purple" | "red" | "grayH"'.
                     onChange={handleColorChange}
                 />
                 <Strut size={spacing.medium_16} />
@@ -226,6 +227,7 @@ const LockedEllipseSettings = (props: Props) => {
                     <Strut size={spacing.xxSmall_6} />
                     <SingleSelect
                         selectedValue={fillStyle}
+                        // @ts-expect-error: Type 'string' is not assignable to type 'LockedFigureFillType'.
                         onChange={(value: LockedFigureFillType) =>
                             onChangeProps({fillStyle: value})
                         }
@@ -246,6 +248,7 @@ const LockedEllipseSettings = (props: Props) => {
             {/* Stroke style */}
             <LineStrokeSelect
                 selectedValue={strokeStyle}
+                // @ts-expect-error: Type 'string' is not assignable to type '"solid" | "dashed"'.
                 onChange={(value: "solid" | "dashed") =>
                     onChangeProps({strokeStyle: value})
                 }
@@ -280,6 +283,7 @@ const LockedEllipseSettings = (props: Props) => {
                         <LockedLabelSettings
                             {...label}
                             expanded={true}
+                            // @ts-expect-error: Type 'Partial<LockedFigure>' is not assignable to type 'LockedLabelType'.
                             onChangeProps={(newLabel: LockedLabelType) => {
                                 handleLabelChange(newLabel, labelIndex);
                             }}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figures-section.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figures-section.tsx
@@ -191,6 +191,7 @@ const LockedFiguresSection = (props: Props) => {
                         <LockedFigureSelect
                             showLabelsFlag={props.showLabelsFlag}
                             id={`${uniqueId}-select`}
+                            // @ts-expect-error: Type 'string' is not assignable to type '"function" | "label" | "ellipse" | "line" | "polygon" | "point" | "vector"'.
                             onChange={addLockedFigure}
                         />
                         <Strut size={spacing.small_12} />

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.tsx
@@ -210,6 +210,7 @@ const LockedFunctionSettings = (props: Props) => {
                 {/* Line color settings */}
                 <ColorSelect
                     selectedValue={lineColor}
+                    // @ts-expect-error: Type 'string' is not assignable to type '"blue" | "green" | "orange" | "pink" | "purple" | "red" | "grayH"'.
                     onChange={handleColorChange}
                 />
                 <Strut size={spacing.small_12} />
@@ -360,6 +361,7 @@ const LockedFunctionSettings = (props: Props) => {
                             key={labelIndex}
                             {...label}
                             expanded={true}
+                            // @ts-expect-error: Type 'Partial<LockedFigure>' is not assignable to type 'LockedLabelType'.
                             onChangeProps={(newLabel: LockedLabelType) => {
                                 handleLabelChange(newLabel, labelIndex);
                             }}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-label-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-label-settings.tsx
@@ -150,6 +150,7 @@ export default function LockedLabelSettings(props: Props) {
             <View style={styles.row}>
                 <ColorSelect
                     selectedValue={color}
+                    // @ts-expect-error: Type 'string' is not assignable to type '"blue" | "green" | "grayH" | "purple" | "pink" | "orange" | "red"'.
                     onChange={(newColor: LockedFigureColor) => {
                         onChangeProps({color: newColor});
                     }}
@@ -163,6 +164,7 @@ export default function LockedLabelSettings(props: Props) {
                     <Strut size={spacing.xSmall_8} />
                     <SingleSelect
                         selectedValue={size}
+                        // @ts-expect-error: Type 'string' is not assignable to type '"small" | "medium" | "large"'.
                         onChange={(newValue: "small" | "medium" | "large") =>
                             onChangeProps({
                                 size: newValue,

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-line-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-line-settings.tsx
@@ -223,6 +223,7 @@ const LockedLineSettings = (props: Props) => {
                 <Strut size={spacing.xxxSmall_4} />
                 <SingleSelect
                     selectedValue={kind}
+                    // @ts-expect-error: Type 'string' is not assignable to type '"line" | "ray" | "segment"'.
                     onChange={(value: "line" | "segment" | "ray") =>
                         onChangeProps({kind: value})
                     }
@@ -239,6 +240,7 @@ const LockedLineSettings = (props: Props) => {
                 {/* Line color settings */}
                 <ColorSelect
                     selectedValue={lineColor}
+                    // @ts-expect-error: Type 'string' is not assignable to type '"blue" | "green" | "orange" | "pink" | "purple" | "red" | "grayH"'.
                     onChange={handleColorChange}
                 />
                 <Strut size={spacing.small_12} />
@@ -246,6 +248,7 @@ const LockedLineSettings = (props: Props) => {
                 {/* Line style settings */}
                 <LineStrokeSelect
                     selectedValue={lineStyle}
+                    // @ts-expect-error:  Type 'string' is not assignable to type '"solid" | "dashed"'.
                     onChange={(value: "solid" | "dashed") =>
                         onChangeProps({lineStyle: value})
                     }
@@ -312,6 +315,7 @@ const LockedLineSettings = (props: Props) => {
                         <LockedLabelSettings
                             {...label}
                             expanded={true}
+                            // @ts-expect-error: Type 'Partial<LockedFigure>' is not assignable to type 'LockedLabelType'.
                             onChangeProps={(newLabel: LockedLabelType) => {
                                 handleLabelChange(newLabel, labelIndex);
                             }}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-point-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-point-settings.tsx
@@ -278,6 +278,7 @@ const LockedPointSettings = (props: Props) => {
                                 styles.lockedPointLabelContainer
                             }
                             expanded={true}
+                            // @ts-expect-error: Type 'Partial<LockedFigure>' is not assignable to type 'LockedLabelType'.
                             onChangeProps={(newLabel: LockedLabelType) => {
                                 handleLabelChange(newLabel, labelIndex);
                             }}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.tsx
@@ -194,6 +194,7 @@ const LockedPolygonSettings = (props: Props) => {
                 {/* Color */}
                 <ColorSelect
                     selectedValue={color}
+                    // @ts-expect-error: Type 'string' is not assignable to type '"blue" | "green" | "orange" | "pink" | "purple" | "red" | "grayH"'.
                     onChange={handleColorChange}
                 />
                 <Strut size={spacing.medium_16} />
@@ -207,6 +208,7 @@ const LockedPolygonSettings = (props: Props) => {
                     <Strut size={spacing.xxSmall_6} />
                     <SingleSelect
                         selectedValue={fillStyle}
+                        // @ts-expect-error: Type 'string' is not assignable to type 'LockedFigureFillType'.
                         onChange={(value: LockedFigureFillType) =>
                             onChangeProps({fillStyle: value})
                         }
@@ -227,6 +229,7 @@ const LockedPolygonSettings = (props: Props) => {
             {/* Stroke style */}
             <LineStrokeSelect
                 selectedValue={strokeStyle}
+                // @ts-expect-error: Type 'string' is not assignable to type '"solid" | "dashed"'.
                 onChange={(value: "solid" | "dashed") =>
                     onChangeProps({strokeStyle: value})
                 }
@@ -371,6 +374,7 @@ const LockedPolygonSettings = (props: Props) => {
                         <LockedLabelSettings
                             {...label}
                             expanded={true}
+                            // @ts-expect-error: Type 'Partial<LockedFigure>' is not assignable to type 'LockedLabelType'.
                             onChangeProps={(newLabel: LockedLabelType) => {
                                 handleLabelChange(newLabel, labelIndex);
                             }}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-vector-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-vector-settings.tsx
@@ -164,6 +164,7 @@ const LockedVectorSettings = (props: Props) => {
                 {/* Line color settings */}
                 <ColorSelect
                     selectedValue={lineColor}
+                    // @ts-expect-error: Type 'string' is not assignable to type '"blue" | "green" | "orange" | "pink" | "purple" | "red" | "grayH"'.
                     onChange={handleColorChange}
                 />
             </View>
@@ -241,6 +242,7 @@ const LockedVectorSettings = (props: Props) => {
                         <LockedLabelSettings
                             {...label}
                             expanded={true}
+                            // @ts-expect-error: Type 'Partial<LockedFigure>' is not assignable to type 'LockedLabelType'
                             onChangeProps={(newLabel: LockedLabelType) => {
                                 handleLabelChange(newLabel, labelIndex);
                             }}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.test.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.test.ts
@@ -118,7 +118,7 @@ describe("generateLockedFigureAppearanceDescription", () => {
         expect(description).toBe(`. Appearance solid gray.`);
     });
 
-    test.each([["red"], ["blue"], ["green"], ["purple"], ["orange"]])(
+    test.each([["red"], ["blue"], ["green"], ["purple"], ["orange"]] as const)(
         `should return a string with a %s color and a solid stroke style`,
         (color: LockedFigureColor) => {
             const description =
@@ -132,7 +132,7 @@ describe("generateLockedFigureAppearanceDescription", () => {
     test.each([
         ["blue", "solid"],
         ["green", "dashed"],
-    ])(
+    ] as const)(
         `should return a string with color of %s and a stroke style of %s`,
         (color: LockedFigureColor, strokeStyle: LockedLineStyle) => {
             const description = generateLockedFigureAppearanceDescription(
@@ -159,7 +159,7 @@ describe("generateLockedFigureAppearanceDescription", () => {
     test.each([
         ["blue", "solid", "none"],
         ["red", "dashed", "none"],
-    ])(
+    ] as const)(
         `should return a string with a %s color, %s stroke and no fill`,
         (
             color: LockedFigureColor,
@@ -193,7 +193,7 @@ describe("generateLockedFigureAppearanceDescription", () => {
     test.each([
         ["pink", "solid", "white"],
         ["red", "dashed", "white"],
-    ])(
+    ] as const)(
         `should return a string with a %s color, %s stroke and a white fill`,
         (
             color: LockedFigureColor,
@@ -240,7 +240,7 @@ describe("generateLockedFigureAppearanceDescription", () => {
         ["red", "dashed", "solid"],
         ["green", "dashed", "translucent"],
         ["purple", "solid", "translucent"],
-    ])(
+    ] as const)(
         `should return a string with a %s color, %s stroke, and a %s fill`,
         (
             color: LockedFigureColor,

--- a/packages/perseus-editor/src/widgets/numeric-input-editor.tsx
+++ b/packages/perseus-editor/src/widgets/numeric-input-editor.tsx
@@ -15,6 +15,7 @@ import Editor from "../editor";
 import {iconGear} from "../styles/icon-paths";
 
 import type {APIOptionsWithDefaults} from "@khanacademy/perseus";
+import {ChangeFn} from "@khanacademy/perseus/src/types";
 
 const {
     ButtonGroup,
@@ -123,7 +124,7 @@ class NumericInputEditor extends React.Component<Props, State> {
         };
     }
 
-    change = (...args) => {
+    change: ChangeFn = (...args) => {
         return Changeable.change.apply(this, args);
     };
 

--- a/packages/perseus/src/__tests__/renderer.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.test.tsx
@@ -47,7 +47,9 @@ jest.mock("../translation-linter", () => {
 
 describe("renderer", () => {
     beforeAll(() => {
+        // @ts-expect-error: InputNumberExport is not assignable to type WidgetExports
         registerWidget("numeric-input", InputNumberExport);
+        // @ts-expect-error: RadioWidgetExport is not assignable to type WidgetExports
         registerWidget("radio", RadioWidgetExport);
     });
 

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -68,7 +68,9 @@ const renderQuestion = (
 
 describe("server item renderer", () => {
     beforeAll(() => {
+        // @ts-expect-error: NumericInputExport is not assignable to type WidgetExports
         registerWidget("numeric-input", NumericInputExport);
+        // @ts-expect-error: RadioWidgetExport is not assignable to type WidgetExports
         registerWidget("radio", RadioWidgetExport);
     });
 

--- a/packages/perseus/src/components/__stories__/multi-button-group.stories.tsx
+++ b/packages/perseus/src/components/__stories__/multi-button-group.stories.tsx
@@ -12,6 +12,7 @@ const meta: Meta = {
         allowEmpty: true,
         buttons: [],
     },
+    // @ts-expect-error: Type 'Args' is missing the following properties from type 'Pick<Props, "onChange" | "buttons">': onChange, buttons
     render: function WithState(props: PropsFor<typeof MultiButtonGroup>) {
         const [values, updateValues] = React.useState(props.values);
         return (

--- a/packages/perseus/src/components/image-loader.tsx
+++ b/packages/perseus/src/components/image-loader.tsx
@@ -90,6 +90,7 @@ class ImageLoader extends React.Component<Props, State> {
 
         this.img = new Image();
         this.img.onload = this.handleLoad;
+        // @ts-expect-error: Type 'string | Event' is not assignable to type 'Event'.
         this.img.onerror = this.handleError;
         this.img.src = this.props.src;
     };

--- a/packages/perseus/src/components/math-input.tsx
+++ b/packages/perseus/src/components/math-input.tsx
@@ -173,6 +173,7 @@ class InnerMathInput extends React.Component<InnerProps, State> {
                 this.__mathFieldWrapperRef,
                 locale,
                 this.props.mathInputStrings,
+                // @ts-expect-error: Type 'EditableMathQuill' is not assignable to type 'MathFieldInterface'.
                 (baseConfig) => ({
                     ...baseConfig,
                     handlers: {

--- a/packages/perseus/src/components/svg-image.tsx
+++ b/packages/perseus/src/components/svg-image.tsx
@@ -413,7 +413,7 @@ class SvgImage extends React.Component<Props, State> {
     onDataLoaded: (
         data: {
             labels: ReadonlyArray<any>;
-            range: ReadonlyArray<any>;
+            range: [Coord, Coord];
         },
         localized: boolean,
     ) => void = (

--- a/packages/perseus/src/interaction-tracker.ts
+++ b/packages/perseus/src/interaction-tracker.ts
@@ -34,6 +34,7 @@ class InteractionTracker<T> {
             this.widgetType = widgetType;
             this.widgetID = widgetID;
             this.setting = setting;
+            // @ts-expect-error: Type 'T | undefined' is not assignable to type 'T'.
             this.track = this._track;
         }
     }

--- a/packages/perseus/src/interactive2/movable-line-options.ts
+++ b/packages/perseus/src/interactive2/movable-line-options.ts
@@ -255,6 +255,7 @@ const constraints = {
             // bound the delta by the calculated bounds
             const boundedDelta = _.reduce(
                 deltaBounds,
+                // @ts-expect-error: Type 'number[]' is not assignable to type 'Coord'.
                 function (delta, bound) {
                     const lower = bound[0];
                     const upper = bound[1];

--- a/packages/perseus/src/interactive2/movable-point-options.ts
+++ b/packages/perseus/src/interactive2/movable-point-options.ts
@@ -127,6 +127,7 @@ const constraints = {
     },
 
     snap: function (snap?: number | null): Constraint {
+        // @ts-expect-error: Type 'boolean | Coord' is not assignable to type 'Coord'.
         return function (coord: Coord) {
             if (snap === null) {
                 // TODO(benchristel), NOTE(kevinb): this should probably return
@@ -155,6 +156,7 @@ const constraints = {
             }
         })();
 
+        // @ts-expect-error: Type 'boolean | Coord' is not assignable to type 'Coord'.
         return function (
             coord: Coord,
             prev: Coord,

--- a/packages/perseus/src/interactive2/movable-polygon-options.ts
+++ b/packages/perseus/src/interactive2/movable-polygon-options.ts
@@ -337,6 +337,7 @@ const constraints = {
             // bound the delta by the calculated bounds
             const boundedDelta = _.reduce(
                 deltaBounds,
+                // @ts-expect-error - TS2345 - Type 'number[]' is not assignable to type 'Coord'.
                 function (delta, bound) {
                     const lower = bound[0];
                     const upper = bound[1];
@@ -353,7 +354,6 @@ const constraints = {
                 delta,
             );
 
-            // @ts-expect-error - TS2322 - Type 'number[]' is not assignable to type 'Coord'.
             return kvector.add(prevCoord, boundedDelta);
         };
     },

--- a/packages/perseus/src/util.ts
+++ b/packages/perseus/src/util.ts
@@ -66,6 +66,7 @@ const nestedMap = function <T, M>(
             return nestedMap(child, func);
         });
     }
+    // @ts-expect-error: T | ReadonlyArray<T> is not assignable to T
     return func.call(context, children);
 };
 

--- a/packages/perseus/src/widgets/__testutils__/renderQuestion.tsx
+++ b/packages/perseus/src/widgets/__testutils__/renderQuestion.tsx
@@ -81,7 +81,7 @@ export const renderQuestion = (
         }
     };
 
-    return {container, renderer, rerender: renderAgain, unmount};
+    return {container, renderer, rerender: renderAgain as any, unmount};
 };
 
 const Renderer = React.forwardRef<

--- a/packages/perseus/src/widgets/categorizer/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.tsx
@@ -325,5 +325,6 @@ export default {
         );
     },
     isLintable: true,
+    // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusCSProgramUserInput'.
     scorer: scoreCategorizer,
 } satisfies WidgetExports<typeof Categorizer>;

--- a/packages/perseus/src/widgets/cs-program/cs-program.tsx
+++ b/packages/perseus/src/widgets/cs-program/cs-program.tsx
@@ -205,5 +205,6 @@ export default {
     supportedAlignments: ["block", "full-width"],
     widget: CSProgram,
     hidden: true,
+    // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusCSProgramUserInput'.
     scorer: scoreCSProgram,
 } satisfies WidgetExports<typeof CSProgram>;

--- a/packages/perseus/src/widgets/dropdown/dropdown.tsx
+++ b/packages/perseus/src/widgets/dropdown/dropdown.tsx
@@ -124,5 +124,6 @@ export default {
     accessible: true,
     widget: Dropdown,
     transform: optionsTransform,
+    // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusDropdownUserInput'.
     scorer: scoreDropdown,
 } satisfies WidgetExports<typeof Dropdown>;

--- a/packages/perseus/src/widgets/expression/expression-mobile.test.tsx
+++ b/packages/perseus/src/widgets/expression/expression-mobile.test.tsx
@@ -81,6 +81,7 @@ function ConnectedRenderer({item = expressionItem2}) {
 
 describe("expression mobile", () => {
     beforeAll(() => {
+        // @ts-expect-error: ExpressionExport is not assignable to type WidgetExports
         registerWidget("expression", ExpressionExport);
     });
 

--- a/packages/perseus/src/widgets/expression/expression.tsx
+++ b/packages/perseus/src/widgets/expression/expression.tsx
@@ -250,12 +250,14 @@ export class Expression
         return true;
     };
 
+    // @ts-expect-error: Type 'FocusPath' is not assignable to type 'InputPath'.
     focusInputPath(inputPath: InputPath) {
         // eslint-disable-next-line react/no-string-refs
         // @ts-expect-error - TS2339 - Property 'focus' does not exist on type 'ReactInstance'.
         this.refs.input.focus();
     }
 
+    // @ts-expect-error: Type 'FocusPath' is not assignable to type 'InputPath'.
     blurInputPath(inputPath: InputPath) {
         // eslint-disable-next-line react/no-string-refs
         // @ts-expect-error - TS2339 - Property 'blur' does not exist on type 'ReactInstance'.
@@ -280,7 +282,7 @@ export class Expression
         return [[]];
     };
 
-    setInputValue(path: FocusPath, newValue: string, cb: () => void) {
+    setInputValue(path: FocusPath, newValue: string, cb?: () => void) {
         this.props.onChange(
             {
                 value: newValue,
@@ -551,8 +553,10 @@ export default {
 
     // For use by the editor
     isLintable: true,
+    // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusExpressionUserInput'.
     scorer: scoreExpression,
 
+    // @ts-expect-error: Type 'Rubric' is not assignable to type 'PerseusExpressionRubric'.
     getOneCorrectAnswerFromRubric(
         rubric: PerseusExpressionRubric,
     ): string | null | undefined {

--- a/packages/perseus/src/widgets/grapher/grapher.tsx
+++ b/packages/perseus/src/widgets/grapher/grapher.tsx
@@ -113,6 +113,7 @@ class FunctionGrapher extends React.Component<FunctionGrapherProps> {
     };
 
     change = (...args) => {
+        // @ts-expect-error: Argument of type 'any[]' is not assignable to parameter of type '[newPropsOrSinglePropName: string | { [key: string]: any; }, propValue?: any, callback?: (() => unknown) | undefined]'. Target requires 1 element(s) but source may have fewer.
         return Changeable.change.apply(this, args);
     };
 
@@ -652,5 +653,6 @@ export default {
     widget: Grapher,
     transform: propTransform,
     staticTransform: staticTransform,
+    // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusGrapherUserInput'.
     scorer: scoreGrapher,
 } satisfies WidgetExports<typeof Grapher>;

--- a/packages/perseus/src/widgets/group/group.tsx
+++ b/packages/perseus/src/widgets/group/group.tsx
@@ -90,7 +90,7 @@ class Group extends React.Component<Props> implements Widget {
     setInputValue: (
         arg1: FocusPath,
         arg2: string,
-        arg3: () => unknown,
+        arg3?: () => unknown,
     ) => void = (path, newValue, callback) => {
         return this.rendererRef?.setInputValue(path, newValue, callback);
     };

--- a/packages/perseus/src/widgets/iframe/iframe.tsx
+++ b/packages/perseus/src/widgets/iframe/iframe.tsx
@@ -172,5 +172,6 @@ export default {
     widget: Iframe,
     // Let's not expose it to all content creators yet
     hidden: true,
+    // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusIframeUserInput'.
     scorer: scoreIframe,
 } satisfies WidgetExports<typeof Iframe>;

--- a/packages/perseus/src/widgets/input-number/input-number.tsx
+++ b/packages/perseus/src/widgets/input-number/input-number.tsx
@@ -125,12 +125,14 @@ class InputNumber extends React.Component<Props> implements Widget {
         return true;
     };
 
+    // @ts-expect-error: Type 'FocusPath' is not assignable to type 'Path'.
     focusInputPath: (arg1: Path) => void = (inputPath) => {
         // eslint-disable-next-line react/no-string-refs
         // @ts-expect-error - TS2339 - Property 'focus' does not exist on type 'ReactInstance'.
         this.refs.input.focus();
     };
 
+    // @ts-expect-error: Type 'FocusPath' is not assignable to type 'Path'.
     blurInputPath: (arg1: Path) => void = (inputPath) => {
         // eslint-disable-next-line react/no-string-refs
         // @ts-expect-error - TS2339 - Property 'blur' does not exist on type 'ReactInstance'.
@@ -148,6 +150,7 @@ class InputNumber extends React.Component<Props> implements Widget {
         return [[]];
     };
 
+    // @ts-expect-error: Type 'FocusPath' is not assignable to type 'Path'.
     setInputValue: (arg1: Path, arg2: string, arg3: () => void) => void = (
         path,
         newValue,
@@ -278,6 +281,7 @@ export default {
     widget: InputNumber,
     transform: propTransform,
     isLintable: true,
+    // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusInputNumberUserInput'.
     scorer: scoreInputNumber,
 
     getOneCorrectAnswerFromRubric(rubric: any): string | null | undefined {

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -2396,5 +2396,6 @@ export default {
     displayName: "Interactive graph (Assessments only)",
     widget: InteractiveGraph,
     staticTransform: staticTransform,
+    // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusInteractiveGraphUserInput'.
     scorer: scoreInteractiveGraph,
 } satisfies WidgetExports<typeof InteractiveGraph>;

--- a/packages/perseus/src/widgets/label-image/label-image.tsx
+++ b/packages/perseus/src/widgets/label-image/label-image.tsx
@@ -743,5 +743,6 @@ export default {
     widget: LabelImageWithDependencies,
     accessible: true,
     isLintable: true,
+    // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusLabelImageUserInput'.
     scorer: scoreLabelImage,
 } satisfies WidgetExports<typeof LabelImageWithDependencies>;

--- a/packages/perseus/src/widgets/matcher/matcher.tsx
+++ b/packages/perseus/src/widgets/matcher/matcher.tsx
@@ -288,5 +288,6 @@ export default {
     displayName: "Matcher (two column)",
     widget: Matcher,
     isLintable: true,
+    // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusMatcherUserInput'.
     scorer: scoreMatcher,
 } satisfies WidgetExports<typeof Matcher>;

--- a/packages/perseus/src/widgets/matrix/matrix.tsx
+++ b/packages/perseus/src/widgets/matrix/matrix.tsx
@@ -569,5 +569,6 @@ export default {
     transform: propTransform,
     staticTransform: staticTransform,
     isLintable: true,
+    // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusMatrixUserInput'.
     scorer: scoreMatrix,
 } satisfies WidgetExports<typeof Matrix>;

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -805,5 +805,6 @@ export default {
     widget: NumberLine,
     transform: numberLineTransform,
     staticTransform: staticTransform,
+    // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusNumberLineUserInput'.
     scorer: scoreNumberLine,
 } satisfies WidgetExports<typeof NumberLine>;

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
@@ -402,8 +402,10 @@ export default {
     transform: propsTransform,
     propUpgrades: propUpgrades,
     isLintable: true,
+    // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusNumericInputUserInput'.
     scorer: scoreNumericInput,
 
+    // @ts-expect-error: Type 'Rubric' is not assignable to type 'PerseusNumericInputRubric'
     getOneCorrectAnswerFromRubric(
         rubric: PerseusNumericInputRubric,
     ): string | null | undefined {

--- a/packages/perseus/src/widgets/orderer/orderer.tsx
+++ b/packages/perseus/src/widgets/orderer/orderer.tsx
@@ -796,5 +796,6 @@ export default {
     hidden: true,
     widget: Orderer,
     isLintable: true,
+    // @ts-expect-error: Type UserInput is not assignable to type PerseusOrdererUserInput
     scorer: scoreOrderer,
 } satisfies WidgetExports<typeof Orderer>;

--- a/packages/perseus/src/widgets/passage/passage-markdown.tsx
+++ b/packages/perseus/src/widgets/passage/passage-markdown.tsx
@@ -462,6 +462,7 @@ const CIRCLE_LABEL_STYLE = {
     textAlign: "center",
 } as const;
 
+// @ts-expect-error: State is not assignable to ParseState
 const builtParser = SimpleMarkdown.parserFor(rules);
 const parse: (
     arg1: string,

--- a/packages/perseus/src/widgets/plotter/plotter.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.tsx
@@ -1179,5 +1179,6 @@ export default {
     hidden: true,
     widget: Plotter,
     staticTransform: staticTransform,
+    // @ts-expect-error: Type UserInput is not assignable to type PerseusPlotterUserInput
     scorer: scorePlotter,
 } satisfies WidgetExports<typeof Plotter>;

--- a/packages/perseus/src/widgets/radio/__stories__/radio.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__stories__/radio.stories.tsx
@@ -41,6 +41,7 @@ export default {
             },
         },
     },
+    // @ts-expect-error: Type 'Args' is not assignable to type 'StoryArgs'.
     render: (args: StoryArgs) => (
         <RendererWithDebugUI
             question={applyStoryArgs(args)}

--- a/packages/perseus/src/widgets/radio/radio.ts
+++ b/packages/perseus/src/widgets/radio/radio.ts
@@ -156,5 +156,6 @@ export default {
     version: {major: 1, minor: 0},
     propUpgrades: propUpgrades,
     isLintable: true,
+    // @ts-expect-error: Type UserInput is not assignable to type PerseusRadioUserInput
     scorer: scoreRadio,
 } satisfies WidgetExports<typeof Radio>;

--- a/packages/perseus/src/widgets/sorter/sorter.tsx
+++ b/packages/perseus/src/widgets/sorter/sorter.tsx
@@ -133,5 +133,6 @@ export default {
     displayName: "Sorter",
     widget: Sorter,
     isLintable: true,
+    // @ts-expect-error: Type UserInput is not assignable to type PerseusSorterUserInput
     scorer: scoreSorter,
 } satisfies WidgetExports<typeof Sorter>;

--- a/packages/perseus/src/widgets/table/score-table.ts
+++ b/packages/perseus/src/widgets/table/score-table.ts
@@ -9,7 +9,7 @@ import type {PerseusStrings} from "../../strings";
 import type {PerseusScore} from "../../types";
 import type {
     PerseusTableRubric,
-    PerseusTableUserInput,
+    PerseusTableUserInput, UserInput,
 } from "../../validation.types";
 
 function scoreTable(

--- a/packages/perseus/src/widgets/table/table.tsx
+++ b/packages/perseus/src/widgets/table/table.tsx
@@ -324,5 +324,6 @@ export default {
     transform: propTransform,
     hidden: true,
     isLintable: true,
+    // @ts-expect-error: Type UserInput is not assignable to type PerseusTableUserInput
     scorer: scoreTable,
 } satisfies WidgetExports<typeof Table>;

--- a/packages/simple-markdown/src/index.ts
+++ b/packages/simple-markdown/src/index.ts
@@ -2085,6 +2085,7 @@ var SimpleMarkdown: Exports = {
                 "defaultParse is deprecated, please use `defaultImplicitParse`",
             );
         }
+        // @ts-expect-error - Argument of type 'any[]' is not assignable to parameter of type '[node: ASTNode, state?: State | null | undefined]'. Target requires 1 element(s) but source may have fewer.
         return defaultImplicitParse.apply(null, args);
     },
     defaultOutput: function (...args) {
@@ -2093,6 +2094,7 @@ var SimpleMarkdown: Exports = {
                 "defaultOutput is deprecated, please use `defaultReactOutput`",
             );
         }
+        // @ts-expect-error - Argument of type 'any[]' is not assignable to parameter of type '[node: ASTNode, state?: State | null | undefined]'. Target requires 1 element(s) but source may have fewer.
         return defaultReactOutput.apply(null, args);
     },
 };

--- a/tsconfig-common.json
+++ b/tsconfig-common.json
@@ -17,7 +17,7 @@
         /* Type Checking */
         "strict": true,
         "strictNullChecks": true,
-        "strictFunctionTypes": false,
+        "strictFunctionTypes": true,
         "strictPropertyInitialization": true,
         "strictBindCallApply": true,
         "noImplicitAny": false,


### PR DESCRIPTION
I noticed that I wasn't getting type errors when I thought I should, and it
turned out to be because of this setting.

Issue: none

## Test plan:

`yarn tsc`