### PR TITLE
[Locked Labels + Aria] Create math only parser to help parse TeX how we want

### DIFF
--- a/.changeset/mighty-cobras-kick.md
+++ b/.changeset/mighty-cobras-kick.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Locked Labels + Aria] Create math only parser to help parse TeX how we want

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -105,6 +105,7 @@ export {
     containerSizeClass,
     getInteractiveBoxFromSizeClass,
 } from "./util/sizing-utils";
+export {mathOnlyParser} from "./widgets/interactive-graphs/utils";
 export {
     getAnswersFromWidgets,
     injectWidgets,

--- a/packages/perseus/src/widgets/interactive-graphs/utils.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/utils.test.ts
@@ -201,6 +201,31 @@ describe("mathOnlyParser", () => {
         ]);
     });
 
+    test("math text without math markers", () => {
+        const nodes = mathOnlyParser("yippee x^2");
+
+        expect(nodes).toEqual([{content: "yippee x^2", type: "text"}]);
+    });
+
+    test("lone unescaped dollar sign middle", () => {
+        const nodes = mathOnlyParser("yippee $x^2");
+
+        expect(nodes).toEqual([
+            {content: "yippee ", type: "text"},
+            {content: "$", type: "specialCharacter"},
+            {content: "x^2", type: "text"},
+        ]);
+    });
+
+    test("lone unescaped dollar sign end", () => {
+        const nodes = mathOnlyParser("yippee x^2$");
+
+        expect(nodes).toEqual([
+            {content: "yippee x^2", type: "text"},
+            {content: "$", type: "specialCharacter"},
+        ]);
+    });
+
     test("multiple math blocks", () => {
         const nodes = mathOnlyParser("$x^2$ and $y^2$");
 
@@ -208,6 +233,23 @@ describe("mathOnlyParser", () => {
             {content: "x^2", type: "math"},
             {content: " and ", type: "text"},
             {content: "y^2", type: "math"},
+        ]);
+    });
+
+    test("TeX syntax without dollars", () => {
+        const nodes = mathOnlyParser("\\frac{1}{2}");
+
+        // This looks odd, but this is expected based on our logic
+        // since this is within a text block, not a math block
+        expect(nodes).toEqual([
+            {content: "\\f", type: "specialCharacter"},
+            {content: "rac", type: "text"},
+            {content: "{", type: "specialCharacter"},
+            {content: "1", type: "text"},
+            {content: "}", type: "specialCharacter"},
+            {content: "{", type: "specialCharacter"},
+            {content: "2", type: "text"},
+            {content: "}", type: "specialCharacter"},
         ]);
     });
 


### PR DESCRIPTION
## Summary:
We want to be able to parse a string meant for TeX into its most basic
essential parts. To do this, we are creating a `mathOnlyParser()` parser.

Using the default `parse()` function from SimpleMarkdown breaks up
text into too many sections, and parsing from scratch can get very
complicated. The ideal way to do this is to use the existing `parserFor()`
function from SimpleMarkdown that lets us customize the parser.

This will be used in
- Generating the TeX for Locked Labels and Locked Figure labels so that
  it shows up correctly on the graph. Non-TeX should show up with regular
  text styling and allow spaces.
- Generating the aria label for locked figures with TeX labels. The speech
  rule engine will only be run on the math sections of the parsed output.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2548
(and also https://khanacademy.atlassian.net/browse/LEMS-2591)

## Test plan:
`yarn jest packages/perseus/src/widgets/interactive-graphs/utils.test.ts`