### PR TITLE
[SR] Add comment about creating translation tickets

### DIFF
--- a/.changeset/selfish-spies-film.md
+++ b/.changeset/selfish-spies-film.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[SR] Add comment about making translation tickets

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -323,12 +323,17 @@ export const strings: {
     graphKeyboardPrompt: "Press Shift + Enter to interact with the graph",
     closePolygon: "Close shape",
     openPolygon: "Re-open shape",
+    srInteractiveElements: "Interactive elements: %(elements)s",
+    srNoInteractiveElements: "No interactive elements",
+
+    // TODO(LEMS-2660): The following strings are ones that will need
+    // translation tickets after all interactive graph SR strings have
+    // been finalized. Remove this comment after the tickets have been
+    // created.
     srPointAtCoordinates: {
         context: "Screenreader-accessible description of a point on a graph",
         message: "Point %(num)s at %(x)s comma %(y)s",
     },
-    srInteractiveElements: "Interactive elements: %(elements)s",
-    srNoInteractiveElements: "No interactive elements",
 };
 
 /**


### PR DESCRIPTION
## Summary:
Add a comment to the `strings.ts` file so it's easy
to keep track of which strings will need to be
finalized before translation tickets are made.

We want to wait until all the interactive element
strings for interactive graph have been written
and confirmed before creating their respective
translation tickets.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2660

## Test plan:
N/A