### PR TITLE
Fix: Open unlimited polygon does not restrict crossing sides.

### DIFF
--- a/.changeset/chilled-pianos-cheat.md
+++ b/.changeset/chilled-pianos-cheat.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fixing intersecting polygon sides issues for unlimited sided polygon.

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -420,6 +420,10 @@ const renderPolygonGraphControls = (props: {
     const shouldShowRemoveButton =
         showRemovePointButton && focusedPointIndex !== null;
 
+    // We want to disable the closePolygon button when
+    // there are not enough coords to make a polygon
+    const disableCloseButton = coords.length < 3;
+
     // If polygon is closed, show open button.
     // If polygon is open, show close button.
     const polygonButton = closedPolygon ? (
@@ -441,12 +445,12 @@ const renderPolygonGraphControls = (props: {
             kind="secondary"
             // Conditional disable when there are less than 3 points in
             // the graph
-            disabled={coords.length < 3}
+            disabled={disableCloseButton}
             style={{
                 width: "100%",
                 marginLeft: "20px",
             }}
-            tabIndex={coords.length < 3 ? -1 : 0}
+            tabIndex={disableCloseButton ? -1 : 0}
             onClick={() => {
                 props.dispatch(actions.polygon.closePolygon());
             }}

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -94,6 +94,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
     const uniqueId = React.useId();
     const descriptionId = `interactive-graph-description-${uniqueId}`;
     const interactiveElementsDescriptionId = `interactive-graph-interactive-elements-description-${uniqueId}`;
+    const unlimitedGraphKeyboardPromptId = `unlimited-graph-keyboard-prompt-${uniqueId}`;
     const graphRef = React.useRef<HTMLElement>(null);
     const {analytics} = useDependencies();
 
@@ -173,6 +174,8 @@ export const MafsGraph = (props: MafsGraphProps) => {
                         fullGraphAriaDescription && descriptionId,
                         interactiveElementsDescription &&
                             interactiveElementsDescriptionId,
+                        isUnlimitedGraphState(state) &&
+                            "unlimited-graph-keyboard-prompt",
                     )}
                     ref={graphRef}
                     tabIndex={0}
@@ -301,6 +304,9 @@ export const MafsGraph = (props: MafsGraphProps) => {
                     {interactionPrompt && (
                         <View
                             style={{
+                                display: interactionPrompt
+                                    ? undefined
+                                    : "hidden",
                                 textAlign: "center",
                                 backgroundColor: "white",
                                 border: "1px solid #21242C52",
@@ -314,7 +320,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                                 transform: "translateY(-50%)",
                             }}
                         >
-                            <LabelMedium>
+                            <LabelMedium id={unlimitedGraphKeyboardPromptId}>
                                 {strings.graphKeyboardPrompt}
                             </LabelMedium>
                         </View>
@@ -440,7 +446,7 @@ const renderPolygonGraphControls = (props: {
                 width: "100%",
                 marginLeft: "20px",
             }}
-            tabIndex={0}
+            tabIndex={coords.length < 3 ? -1 : 0}
             onClick={() => {
                 props.dispatch(actions.polygon.closePolygon());
             }}

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -643,6 +643,29 @@ describe("movePoint on a polygon graph", () => {
         expect(updated.coords[0]).toEqual([0, 0]);
     });
 
+    it("does not reject intersecting sides if the polygon is unlimited and it's open", () => {
+        const state: InteractiveGraphState = {
+            ...basePolygonGraphState,
+            numSides: "unlimited",
+            closedPolygon: false,
+            snapTo: "grid",
+            coords: [
+                [0, 0],
+                [0, 2],
+                [2, 2],
+                [2, 0],
+            ],
+        };
+
+        const updated = interactiveGraphReducer(
+            state,
+            actions.polygon.movePoint(0, [1, 3]),
+        );
+
+        invariant(updated.type === "polygon");
+        expect(updated.coords[0]).toEqual([1, 3]);
+    });
+
     it("does not snap to grid when snapTo is angles using moveAll", () => {
         const state: InteractiveGraphState = {
             ...basePolygonGraphState,

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -483,8 +483,14 @@ function doMovePoint(
                 newValue: newValue,
             });
 
-            // Reject the move if it would cause the sides of the polygon to cross
-            if (polygonSidesIntersect(newCoords)) {
+            // Boolean value to tract whether we can't let the polygon sides interact.
+            // They can't interact if it's a limited polygon or
+            // an unlimited polygon that is closed.
+            const polygonSidesCantIntersect =
+                state.numSides !== "unlimited" || state.closedPolygon;
+
+            // Reject the move if it would cause the sides of the polygon to cross.
+            if (polygonSidesCantIntersect && polygonSidesIntersect(newCoords)) {
                 return state;
             }
 

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -483,7 +483,7 @@ function doMovePoint(
                 newValue: newValue,
             });
 
-            // Boolean value to tract whether we can let the polygon sides interact.
+            // Boolean value to track whether we can let the polygon sides interact.
             // They can interact if it's an unlimited polygon that is open.
             const polygonSidesCanIntersect =
                 state.numSides === "unlimited" && !state.closedPolygon;

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -483,14 +483,13 @@ function doMovePoint(
                 newValue: newValue,
             });
 
-            // Boolean value to tract whether we can't let the polygon sides interact.
-            // They can't interact if it's a limited polygon or
-            // an unlimited polygon that is closed.
-            const polygonSidesCantIntersect =
-                state.numSides !== "unlimited" || state.closedPolygon;
+            // Boolean value to tract whether we can let the polygon sides interact.
+            // They can interact if it's an unlimited polygon that is open.
+            const polygonSidesCanIntersect =
+                state.numSides === "unlimited" && !state.closedPolygon;
 
             // Reject the move if it would cause the sides of the polygon to cross.
-            if (polygonSidesCantIntersect && polygonSidesIntersect(newCoords)) {
+            if (!polygonSidesCanIntersect && polygonSidesIntersect(newCoords)) {
                 return state;
             }
 


### PR DESCRIPTION
## Summary:
For keyboard users if they're drawing a polygon and it places a point at 0,0. There are cases where it could cross the sides of the polygon they are actively creating and cause the polygon to break. Mouse uses can get around this a bit. But it's not idea. This fix checks whether the polygon type allows intersecting sides and disables the rejection logic.

This PR also includes improvements to:
- Screen readers announcing instructions to enable graph (was not reading out before).
- Disabled buttons are not tabbable now.

Issue: LEMS-2618

## Test plan:
Go to /?path=/story/perseus-widgets-interactive-graph--unlimited-polygon-with-mafs in Storybook.
Use your keyboard to add points.
Move a few points in a way that a new point would cause the sides to intersect.
Add a new point and make sure you can still move points on the polygon.