### PR TITLE
[Storybook] Disable snapshots globally + enable for select few stories

### DIFF
--- a/.changeset/lucky-clouds-hang.md
+++ b/.changeset/lucky-clouds-hang.md
@@ -1,4 +1,5 @@
 ---
+"@khanacademy/math-input": patch
 "@khanacademy/perseus": patch
 "@khanacademy/perseus-editor": patch
 ---

--- a/.changeset/pretty-pens-end.md
+++ b/.changeset/pretty-pens-end.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+[Storybook] Disable snapshots globally + enable for select few stories

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -59,6 +59,12 @@ const preview: Preview = {
                 value,
             })),
         },
+        // Disabling Chromatic snapshots across all stories, since we have
+        // a limited snapshot budget. Set this explicitly to false on
+        // stories that we want snapshots for in their respective files.
+        chromatic: {
+            disableSnapshot: true,
+        },
     },
 };
 

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -23,7 +23,14 @@ const preview: Preview = {
         (Story) => (
             <RenderStateRoot>
                 <DependenciesContext.Provider value={storybookDependenciesV2}>
-                    <Story />
+                    {/* Most of our components have an expectation to be
+                        rendered inside of a .framework-perseus container.
+                        We want to make sure we can include it here, since it
+                        can also affect the styling.
+                    */}
+                    <div className="framework-perseus">
+                        <Story />
+                    </div>
                 </DependenciesContext.Provider>
             </RenderStateRoot>
         ),

--- a/packages/math-input/src/full-keypad.stories.tsx
+++ b/packages/math-input/src/full-keypad.stories.tsx
@@ -5,20 +5,24 @@ import * as React from "react";
 import Keypad from "./components/keypad";
 
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
-import type {ComponentStory} from "@storybook/react";
+import type {ComponentStory, Meta} from "@storybook/react";
 
 const opsPage = "Operators Page";
 const numsPage = "Numbers Page";
 const geoPage = "Geometry Page";
 const fracPage = "Fractions Page";
 
-export default {
+const meta: Meta = {
     title: "math-input/Full Keypad",
     parameters: {
         backgrounds: {
             values: [{name: "light background", value: "white", default: true}],
         },
         viewport: {defaultViewport: "iphone6", viewports: INITIAL_VIEWPORTS},
+        chromatic: {
+            // Visual snapshot testing for all the variants of the keypad.
+            disableSnapshot: false,
+        },
     },
     component: Keypad,
     args: {
@@ -84,6 +88,7 @@ export default {
         },
     },
 };
+export default meta;
 
 const Template: ComponentStory<typeof Keypad> = (
     args: PropsFor<typeof Keypad>,

--- a/packages/perseus-editor/src/__stories__/interactive-graph-editor.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/interactive-graph-editor.stories.tsx
@@ -34,12 +34,22 @@ import type {
     PerseusAnswerArea,
     PerseusRenderer,
 } from "@khanacademy/perseus";
+import type {Meta} from "@storybook/react";
 
 registerAllWidgetsAndEditorsForTesting(); // SIDE_EFFECTY!!!! :cry:
 
-export default {
+const meta: Meta = {
     title: "PerseusEditor/Widgets/Interactive Graph",
+    parameters: {
+        chromatic: {
+            // Enable chromatic snapshots for all the different
+            // visual cases in these stories.
+            disableSnapshot: false,
+        },
+    },
 };
+
+export default meta;
 
 const onChangeAction = action("onChange");
 

--- a/packages/perseus/src/__stories__/article-renderer.stories.tsx
+++ b/packages/perseus/src/__stories__/article-renderer.stories.tsx
@@ -13,14 +13,23 @@ import {
 import ArticleRenderer from "../article-renderer";
 import TestKeypadContextWrapper from "../widgets/__shared__/test-keypad-context-wrapper";
 
-export default {
+import type {Meta} from "@storybook/react";
+
+const meta: Meta = {
     title: "Perseus/Renderers/Article Renderer",
     argTypes: {
         useNewStyles: {
             control: "boolean",
         },
     },
+    parameters: {
+        chromatic: {
+            // Visual snapshot testing for all the stories here.
+            disableSnapshot: false,
+        },
+    },
 };
+export default meta;
 
 export const ASingleSectionArticle = (args: {
     useNewStyles;

--- a/packages/perseus/src/__stories__/hints-renderer.stories.tsx
+++ b/packages/perseus/src/__stories__/hints-renderer.stories.tsx
@@ -116,6 +116,13 @@ export const WithAllInteractiveGraphs: Story = {
             },
         ],
     },
+    parameters: {
+        chromatic: {
+            // Visual snapshot testing for this story in particular since
+            // it contains all the different interactive graph types.
+            disableSnapshot: false,
+        },
+    },
 };
 
 export const WithSegmentInteractiveGraph: Story = {

--- a/packages/perseus/src/__stories__/server-item-renderer.stories.tsx
+++ b/packages/perseus/src/__stories__/server-item-renderer.stories.tsx
@@ -18,11 +18,16 @@ import type {StoryObj, Meta} from "@storybook/react";
 
 type StoryArgs = StoryObj<ServerItemRenderer>;
 
-type Story = Meta<ServerItemRenderer>;
-
-export default {
+const meta: Meta = {
     title: "Perseus/Renderers/Server Item Renderer",
-} as Story;
+    parameters: {
+        chromatic: {
+            // Visual snapshot testing for all the stories here.
+            disableSnapshot: false,
+        },
+    },
+};
+export default meta;
 
 export const NumericInputItem = (args: StoryArgs): React.ReactElement => {
     return <ServerItemRendererWithDebugUI item={itemWithInput} />;

--- a/packages/perseus/src/components/__stories__/button-group.stories.tsx
+++ b/packages/perseus/src/components/__stories__/button-group.stories.tsx
@@ -1,4 +1,4 @@
-import {View, type PropsFor} from "@khanacademy/wonder-blocks-core";
+import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import * as React from "react";
@@ -7,39 +7,54 @@ import ButtonGroup from "../button-group";
 
 import type {Meta, StoryObj} from "@storybook/react";
 
-const meta: Meta = {
+type StoryArgs = StoryObj<ButtonGroup>;
+
+type Story = Meta<ButtonGroup>;
+
+export default {
     title: "Perseus/Components/Button Group",
-    component: ButtonGroup,
-    render: function WithState(props: PropsFor<typeof ButtonGroup>) {
-        const [value, updateValue] = React.useState(props.value);
-        return <ButtonGroup {...props} value={value} onChange={updateValue} />;
-    },
+} as Story;
+
+const HarnassedButtonGroup = (
+    props: Pick<React.ComponentProps<typeof ButtonGroup>, "buttons">,
+) => {
+    const [value, updateValue] = React.useState(
+        null as string | null | undefined,
+    );
+
+    return (
+        <ButtonGroup
+            buttons={props.buttons}
+            value={value}
+            onChange={(newValue) => {
+                updateValue(newValue);
+            }}
+        />
+    );
 };
-export default meta;
 
-type Story = StoryObj<typeof ButtonGroup>;
-
-export const ButtonsWithNoTitles: Story = {
-    args: {
-        buttons: [
-            {value: "One", content: "Item #1"},
-            {value: "Two", content: "Item #2"},
-            {value: "Three", content: "Item #3"},
-        ],
-    },
+export const ButtonsWithNoTitles = (args: StoryArgs): React.ReactElement => {
+    return (
+        <HarnassedButtonGroup
+            buttons={[
+                {value: "One", content: "Item #1"},
+                {value: "Two", content: "Item #2"},
+                {value: "Three", content: "Item #3"},
+            ]}
+        />
+    );
 };
 
-/**
- * Hover over the buttons to see their titles.
- */
-export const ButtonsWithTitles: Story = {
-    args: {
-        buttons: [
-            {value: "One", content: "Item #1", title: "The first item"},
-            {value: "Two", content: "Item #2", title: "The second item"},
-            {value: "Three", content: "Item #3", title: "The third item"},
-        ],
-    },
+export const ButtonsWithTitles = (args: StoryArgs): React.ReactElement => {
+    return (
+        <HarnassedButtonGroup
+            buttons={[
+                {value: "One", content: "Item #1", title: "The first item"},
+                {value: "Two", content: "Item #2", title: "The second item"},
+                {value: "Three", content: "Item #3", title: "The third item"},
+            ]}
+        />
+    );
 };
 
 // Putting all of these variants together in one story so that we only need

--- a/packages/perseus/src/components/__stories__/button-group.stories.tsx
+++ b/packages/perseus/src/components/__stories__/button-group.stories.tsx
@@ -1,55 +1,82 @@
+import {View, type PropsFor} from "@khanacademy/wonder-blocks-core";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import * as React from "react";
 
 import ButtonGroup from "../button-group";
 
 import type {Meta, StoryObj} from "@storybook/react";
 
-type StoryArgs = StoryObj<ButtonGroup>;
-
-type Story = Meta<ButtonGroup>;
-
-export default {
+const meta: Meta = {
     title: "Perseus/Components/Button Group",
-} as Story;
+    component: ButtonGroup,
+    render: function WithState(props: PropsFor<typeof ButtonGroup>) {
+        const [value, updateValue] = React.useState(props.value);
+        return <ButtonGroup {...props} value={value} onChange={updateValue} />;
+    },
+};
+export default meta;
 
-const HarnassedButtonGroup = (
-    props: Pick<React.ComponentProps<typeof ButtonGroup>, "buttons">,
-) => {
-    const [value, updateValue] = React.useState(
-        null as string | null | undefined,
-    );
+type Story = StoryObj<typeof ButtonGroup>;
 
-    return (
-        <ButtonGroup
-            buttons={props.buttons}
-            value={value}
-            onChange={(newValue) => {
-                updateValue(newValue);
-            }}
-        />
-    );
+export const ButtonsWithNoTitles: Story = {
+    args: {
+        buttons: [
+            {value: "One", content: "Item #1"},
+            {value: "Two", content: "Item #2"},
+            {value: "Three", content: "Item #3"},
+        ],
+    },
 };
 
-export const ButtonsWithNoTitles = (args: StoryArgs): React.ReactElement => {
-    return (
-        <HarnassedButtonGroup
-            buttons={[
-                {value: "One", content: "Item #1"},
-                {value: "Two", content: "Item #2"},
-                {value: "Three", content: "Item #3"},
-            ]}
-        />
-    );
+/**
+ * Hover over the buttons to see their titles.
+ */
+export const ButtonsWithTitles: Story = {
+    args: {
+        buttons: [
+            {value: "One", content: "Item #1", title: "The first item"},
+            {value: "Two", content: "Item #2", title: "The second item"},
+            {value: "Three", content: "Item #3", title: "The third item"},
+        ],
+    },
 };
 
-export const ButtonsWithTitles = (args: StoryArgs): React.ReactElement => {
-    return (
-        <HarnassedButtonGroup
-            buttons={[
-                {value: "One", content: "Item #1", title: "The first item"},
-                {value: "Two", content: "Item #2", title: "The second item"},
-                {value: "Three", content: "Item #3", title: "The third item"},
-            ]}
-        />
-    );
+// Putting all of these variants together in one story so that we only need
+// one snapshot test to capture all of them.
+/**
+ * This story shows what the ButtonGroup looks like when
+ * 1. No buttons are selected
+ * 2. A button is selected
+ */
+export const VisualVariants: Story = {
+    render: () => (
+        <View>
+            <ButtonGroup
+                buttons={[
+                    {value: "One", content: "Item #1"},
+                    {value: "Two", content: "Item #2"},
+                    {value: "Three", content: "Item #3"},
+                ]}
+                value=""
+                onChange={() => {}}
+            />
+            <Strut size={spacing.medium_16} />
+            <ButtonGroup
+                buttons={[
+                    {value: "One", content: "Item #1"},
+                    {value: "Two", content: "Item #2"},
+                    {value: "Three", content: "Item #3"},
+                ]}
+                value="One"
+                onChange={() => {}}
+            />
+        </View>
+    ),
+    parameters: {
+        chromatic: {
+            // Enable visual testing on the visual variants of this component.
+            disableSnapshot: false,
+        },
+    },
 };

--- a/packages/perseus/src/components/__stories__/graph.stories.tsx
+++ b/packages/perseus/src/components/__stories__/graph.stories.tsx
@@ -12,6 +12,12 @@ const meta: Meta = {
     args: {
         box: [size, size],
     },
+    parameters: {
+        chromatic: {
+            // Enable visual snapshot testing for all the stories here.
+            disableSnapshot: false,
+        },
+    },
 };
 export default meta;
 

--- a/packages/perseus/src/components/__stories__/lint.stories.tsx
+++ b/packages/perseus/src/components/__stories__/lint.stories.tsx
@@ -41,6 +41,12 @@ const meta: Meta = {
             },
         },
     },
+    parameters: {
+        chromatic: {
+            // Enable visual snapshot testing for all the stories here.
+            disableSnapshot: false,
+        },
+    },
 };
 
 export default meta;

--- a/packages/perseus/src/components/__stories__/math-input.stories.tsx
+++ b/packages/perseus/src/components/__stories__/math-input.stories.tsx
@@ -46,6 +46,13 @@ export const DefaultWithAriaLabel: Story = {
 
 export const KeypadOpenByDefault: Story = {
     args: {buttonsVisible: "always"},
+    parameters: {
+        chromatic: {
+            // Enable visual snapshot for this story in paritcular since
+            // it contains all the visual elements for this widget.
+            disableSnapshot: false,
+        },
+    },
 };
 
 export const KeypadNeverVisible: Story = {

--- a/packages/perseus/src/components/__stories__/multi-button-group.stories.tsx
+++ b/packages/perseus/src/components/__stories__/multi-button-group.stories.tsx
@@ -1,18 +1,19 @@
+import {View, type PropsFor} from "@khanacademy/wonder-blocks-core";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import * as React from "react";
 
 import MultiButtonGroup from "../multi-button-group";
 
-import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 import type {Meta, StoryObj} from "@storybook/react";
 
 const meta: Meta = {
-    title: "Perseus/Components/Muli-Button Group",
+    title: "Perseus/Components/Multi-Button Group",
     component: MultiButtonGroup,
     args: {
         allowEmpty: true,
         buttons: [],
     },
-    // @ts-expect-error: Type 'Args' is missing the following properties from type 'Pick<Props, "onChange" | "buttons">': onChange, buttons
     render: function WithState(props: PropsFor<typeof MultiButtonGroup>) {
         const [values, updateValues] = React.useState(props.values);
         return (
@@ -48,5 +49,43 @@ export const ButtonsWithTitles: Story = {
             {value: "Two", content: "Item #2", title: "The second item"},
             {value: "Three", content: "Item #3", title: "The third item"},
         ],
+    },
+};
+// Putting all of these variants together in one story so that we only need
+// one snapshot test to capture all of them.
+/**
+ * This story shows what the ButtonGroup looks like when
+ * 1. No buttons are selected
+ * 2. Two buttons are selected
+ */
+export const VisualVariants: Story = {
+    render: () => (
+        <View>
+            <MultiButtonGroup
+                buttons={[
+                    {value: "One", content: "Item #1"},
+                    {value: "Two", content: "Item #2"},
+                    {value: "Three", content: "Item #3"},
+                ]}
+                values={[]}
+                onChange={() => {}}
+            />
+            <Strut size={spacing.medium_16} />
+            <MultiButtonGroup
+                buttons={[
+                    {value: "One", content: "Item #1"},
+                    {value: "Two", content: "Item #2"},
+                    {value: "Three", content: "Item #3"},
+                ]}
+                values={["One", "Three"]}
+                onChange={() => {}}
+            />
+        </View>
+    ),
+    parameters: {
+        chromatic: {
+            // Enable visual testing on the visual variants of this component.
+            disableSnapshot: false,
+        },
     },
 };

--- a/packages/perseus/src/components/__stories__/multi-button-group.stories.tsx
+++ b/packages/perseus/src/components/__stories__/multi-button-group.stories.tsx
@@ -1,19 +1,21 @@
-import {View, type PropsFor} from "@khanacademy/wonder-blocks-core";
+import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import * as React from "react";
 
 import MultiButtonGroup from "../multi-button-group";
 
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 import type {Meta, StoryObj} from "@storybook/react";
 
 const meta: Meta = {
-    title: "Perseus/Components/Multi-Button Group",
+    title: "Perseus/Components/Muli-Button Group",
     component: MultiButtonGroup,
     args: {
         allowEmpty: true,
         buttons: [],
     },
+    // @ts-expect-error: Type 'Args' is missing the following properties from type 'Pick<Props, "onChange" | "buttons">': onChange, buttons
     render: function WithState(props: PropsFor<typeof MultiButtonGroup>) {
         const [values, updateValues] = React.useState(props.values);
         return (
@@ -51,6 +53,7 @@ export const ButtonsWithTitles: Story = {
         ],
     },
 };
+
 // Putting all of these variants together in one story so that we only need
 // one snapshot test to capture all of them.
 /**

--- a/packages/perseus/src/components/__stories__/number-input.stories.tsx
+++ b/packages/perseus/src/components/__stories__/number-input.stories.tsx
@@ -1,3 +1,6 @@
+import {View} from "@khanacademy/wonder-blocks-core";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {action} from "@storybook/addon-actions";
 
 import NumberInput from "../number-input";
@@ -50,5 +53,41 @@ export const SizeNormal: Story = {
     args: {
         size: "normal",
         placeholder: "Sample placeholder",
+    },
+};
+
+// Putting all of these variants together in one story so that we only need
+// one snapshot test to capture all of them.
+/**
+ * This story shows all the visual variants of the NumberInput component
+ * in one place:
+ * 1. Empty input
+ * 2. Populated input
+ * 3. Input with placeholder
+ * 4. "mini" size
+ * 5. "small" size
+ * 6. "normal" size
+ */
+export const VisualVariants: Story = {
+    render: () => (
+        <View style={{width: 200}}>
+            <NumberInput />
+            <Strut size={spacing.small_12} />
+            <NumberInput value={1234567890} />
+            <Strut size={spacing.small_12} />
+            <NumberInput placeholder="Sample placeholder" />
+            <Strut size={spacing.small_12} />
+            <NumberInput size="mini" />
+            <Strut size={spacing.small_12} />
+            <NumberInput size="small" />
+            <Strut size={spacing.small_12} />
+            <NumberInput size="normal" />
+        </View>
+    ),
+    parameters: {
+        chromatic: {
+            // Enable visual testing on the visual variants of this component.
+            disableSnapshot: false,
+        },
     },
 };

--- a/packages/perseus/src/components/__stories__/sortable.stories.tsx
+++ b/packages/perseus/src/components/__stories__/sortable.stories.tsx
@@ -8,6 +8,12 @@ const meta: Meta = {
     args: {
         options: ["Option 1", "Option 2", "Option 3"],
     },
+    parameters: {
+        chromatic: {
+            // Enable visual testing on the visual variants of this component.
+            disableSnapshot: false,
+        },
+    },
 };
 export default meta;
 

--- a/packages/perseus/src/multi-items/__stories__/multi-renderer.stories.tsx
+++ b/packages/perseus/src/multi-items/__stories__/multi-renderer.stories.tsx
@@ -57,6 +57,13 @@ export const SingleItem = (args: StoryArgs): React.ReactElement => {
     );
 };
 
+SingleItem.parameters = {
+    chromatic: {
+        // Enable visual snapshot testing for this story.
+        disableSnapshot: false,
+    },
+};
+
 const styles = StyleSheet.create({
     section: {
         backgroundColor: "#F5F5F5",

--- a/packages/perseus/src/widgets/categorizer/categorizer.stories.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.stories.tsx
@@ -4,12 +4,19 @@ import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui
 
 import {question1} from "./categorizer.testdata";
 
-export default {
+import type {Meta} from "@storybook/react";
+
+const meta: Meta = {
     title: "Perseus/Widgets/Categorizer",
 };
+export default meta;
 
-type StoryArgs = Record<any, any>;
-
-export const Question1 = (args: StoryArgs): React.ReactElement => {
-    return <RendererWithDebugUI question={question1} />;
+export const Question1 = {
+    render: () => <RendererWithDebugUI question={question1} />,
+    parameters: {
+        chromatic: {
+            // Visual snapshot testing for this widget.
+            disableSnapshot: false,
+        },
+    },
 };

--- a/packages/perseus/src/widgets/cs-program/cs-program.stories.tsx
+++ b/packages/perseus/src/widgets/cs-program/cs-program.stories.tsx
@@ -4,12 +4,19 @@ import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui
 
 import {question1} from "./cs-program.testdata";
 
-export default {
+import type {Meta} from "@storybook/react";
+
+const meta: Meta = {
     title: "Perseus/Widgets/CS Program",
 };
+export default meta;
 
-type StoryArgs = Record<any, any>;
-
-export const Question1 = (args: StoryArgs): React.ReactElement => {
-    return <RendererWithDebugUI question={question1} />;
+export const Question1 = {
+    render: () => <RendererWithDebugUI question={question1} />,
+    parameters: {
+        chromatic: {
+            // Visual snapshot testing for this widget.
+            disableSnapshot: false,
+        },
+    },
 };

--- a/packages/perseus/src/widgets/deprecated-standin/__stories__/deprecated-standin.stories.tsx
+++ b/packages/perseus/src/widgets/deprecated-standin/__stories__/deprecated-standin.stories.tsx
@@ -2,9 +2,12 @@ import * as React from "react";
 
 import {RendererWithDebugUI} from "../../../../../../testing/renderer-with-debug-ui";
 
-export default {
+import type {Meta} from "@storybook/react";
+
+const meta: Meta = {
     title: "Perseus/Widgets/Deprecated Standin",
 };
+export default meta;
 
 const question1 = {
     content:
@@ -23,8 +26,12 @@ const question1 = {
     },
 } as const;
 
-type StoryArgs = Record<any, any>;
-
-export const Question1 = (args: StoryArgs): React.ReactElement => {
-    return <RendererWithDebugUI question={question1} />;
+export const Question1 = {
+    render: () => <RendererWithDebugUI question={question1} />,
+    parameters: {
+        chromatic: {
+            // Visual snapshot testing for this widget.
+            disableSnapshot: false,
+        },
+    },
 };

--- a/packages/perseus/src/widgets/dropdown/dropdown.stories.tsx
+++ b/packages/perseus/src/widgets/dropdown/dropdown.stories.tsx
@@ -4,12 +4,19 @@ import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui
 
 import {question1} from "./dropdown.testdata";
 
-export default {
+import type {Meta} from "@storybook/react";
+
+const meta: Meta = {
     title: "Perseus/Widgets/Dropdown",
 };
+export default meta;
 
-type StoryArgs = Record<any, any>;
-
-export const Question1 = (args: StoryArgs): React.ReactElement => {
-    return <RendererWithDebugUI question={question1} />;
+export const Question1 = {
+    render: () => <RendererWithDebugUI question={question1} />,
+    parameters: {
+        chromatic: {
+            // Visual snapshot testing for this widget.
+            disableSnapshot: false,
+        },
+    },
 };

--- a/packages/perseus/src/widgets/explanation/explanation.stories.tsx
+++ b/packages/perseus/src/widgets/explanation/explanation.stories.tsx
@@ -9,9 +9,19 @@ import {
     wideButton,
 } from "./explanation.testdata";
 
-export default {
+import type {Meta} from "@storybook/react";
+
+const meta: Meta = {
     title: "Perseus/Widgets/Explanation",
+    parameters: {
+        chromatic: {
+            // Visual snapshot testing for all the variants of this widget.
+            disableSnapshot: false,
+        },
+    },
 };
+
+export default meta;
 
 type StoryArgs = Record<any, any>;
 

--- a/packages/perseus/src/widgets/expression/expression.stories.tsx
+++ b/packages/perseus/src/widgets/expression/expression.stories.tsx
@@ -11,14 +11,22 @@ import {expressionItem2, expressionItem3} from "./expression.testdata";
 
 import type {PerseusItem} from "../../perseus-types";
 import type {Keys as Key} from "@khanacademy/math-input";
+import type {Meta} from "@storybook/react";
+
+const meta: Meta = {
+    title: "Perseus/Widgets/Expression",
+    argTypes: {customKeypad: {control: "boolean"}},
+    parameters: {
+        chromatic: {
+            // Visual snapshot testing for all the variants of this widget.
+            disableSnapshot: false,
+        },
+    },
+};
+export default meta;
 
 type StoryArgs = {
     customKeypad: boolean;
-};
-
-type Story = {
-    title: string;
-    argTypes: any;
 };
 
 type WrappedKeypadContextProps = {
@@ -123,8 +131,3 @@ export const ExpressionItem3 = (args: StoryArgs): React.ReactElement => {
         />
     );
 };
-
-export default {
-    title: "Perseus/Widgets/Expression",
-    argTypes: {customKeypad: {control: "boolean"}},
-} as Story;

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.stories.tsx
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.stories.tsx
@@ -4,29 +4,33 @@ import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui
 
 import {article1} from "./graded-group-set.testdata";
 
+import type {Meta} from "@storybook/react";
+
+const meta: Meta = {
+    title: "Perseus/Widgets/Graded Group Set",
+    args: {
+        isMobile: false,
+    },
+};
+export default meta;
+
 type StoryArgs = {
     isMobile: boolean;
 };
 
-type GradedGroupSetStory = {
-    title: string;
-    args: StoryArgs;
-};
-
-export const Article1 = (args: StoryArgs): React.ReactElement => {
-    return (
+export const Article1 = {
+    render: (args: StoryArgs) => (
         <RendererWithDebugUI
             apiOptions={{
                 isMobile: args.isMobile,
             }}
             question={article1}
         />
-    );
-};
-
-export default {
-    title: "Perseus/Widgets/Graded Group Set",
-    args: {
-        isMobile: false,
+    ),
+    parameters: {
+        chromatic: {
+            // Visual snapshot testing for this widget.
+            disableSnapshot: false,
+        },
     },
-} as GradedGroupSetStory;
+};

--- a/packages/perseus/src/widgets/graded-group/graded-group.stories.tsx
+++ b/packages/perseus/src/widgets/graded-group/graded-group.stories.tsx
@@ -4,29 +4,33 @@ import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui
 
 import {question1} from "./graded-group.testdata";
 
+import type {Meta} from "@storybook/react";
+
+const meta: Meta = {
+    title: "Perseus/Widgets/Graded Group",
+    args: {
+        isMobile: false,
+    },
+};
+export default meta;
+
 type StoryArgs = {
     isMobile: boolean;
 };
 
-type Story = {
-    title: string;
-    args: StoryArgs;
-};
-
-export const Question1 = (args: StoryArgs): React.ReactElement => {
-    return (
+export const Question1 = {
+    render: (args: StoryArgs) => (
         <RendererWithDebugUI
             question={question1}
             apiOptions={{
                 isMobile: args.isMobile,
             }}
         />
-    );
-};
-
-export default {
-    title: "Perseus/Widgets/Graded Group",
-    args: {
-        isMobile: false,
+    ),
+    parameters: {
+        chromatic: {
+            // Visual snapshot testing for this widget.
+            disableSnapshot: false,
+        },
     },
-} as Story;
+};

--- a/packages/perseus/src/widgets/grapher/grapher.stories.tsx
+++ b/packages/perseus/src/widgets/grapher/grapher.stories.tsx
@@ -12,9 +12,18 @@ import {
     sinusoidQuestion,
 } from "./grapher.testdata";
 
-export default {
+import type {Meta} from "@storybook/react";
+
+const meta: Meta = {
     title: "Perseus/Widgets/Grapher",
+    parameters: {
+        chromatic: {
+            // Visual snapshot testing for all the variants of this widget.
+            disableSnapshot: false,
+        },
+    },
 };
+export default meta;
 
 type StoryArgs = Record<any, any>;
 

--- a/packages/perseus/src/widgets/group/group.stories.tsx
+++ b/packages/perseus/src/widgets/group/group.stories.tsx
@@ -4,12 +4,19 @@ import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui
 
 import {question1} from "./group.testdata";
 
-export default {
+import type {Meta} from "@storybook/react";
+
+const meta: Meta = {
     title: "Perseus/Widgets/Group",
 };
+export default meta;
 
-type StoryArgs = Record<any, any>;
-
-export const Question1 = (args: StoryArgs): React.ReactElement => {
-    return <RendererWithDebugUI question={question1} />;
+export const Question1 = {
+    render: () => <RendererWithDebugUI question={question1} />,
+    parameters: {
+        chromatic: {
+            // Visual snapshot testing for this widget.
+            disableSnapshot: false,
+        },
+    },
 };

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-regression.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-regression.stories.tsx
@@ -6,12 +6,22 @@ import {mockStrings} from "../../strings";
 import {interactiveGraphQuestionBuilder} from "./interactive-graph-question-builder";
 
 import type {PerseusRenderer} from "../../perseus-types";
+import type {Meta} from "@storybook/react";
 
 type StoryArgs = Record<any, any>;
 
-export default {
+const meta: Meta = {
     title: "Perseus/Widgets/Interactive Graph Visual Regression Tests",
+    parameters: {
+        chromatic: {
+            // We want snapshots for these regression tests, so that
+            // visual differences can be caught if there are any
+            // unexpected changes.
+            disableSnapshot: false,
+        },
+    },
 };
+export default meta;
 
 export const MafsWithCustomAxisLabels = (
     args: StoryArgs,

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.stories.tsx
@@ -25,6 +25,7 @@ import {
     staticGraphQuestionWithAnotherWidget,
     segmentWithLockedLabels,
     unlimitedPolygonQuestion,
+    segmentWithLockedFigures,
 } from "./interactive-graph.testdata";
 
 import type {APIOptions} from "../../types";
@@ -51,6 +52,12 @@ const enableMafs: APIOptions = {
             "unlimited-polygon": true,
             angle: true,
             "interactive-graph-locked-features-labels": true,
+            "locked-point-labels": true,
+            "locked-line-labels": true,
+            "locked-vector-labels": true,
+            "locked-ellipse-labels": true,
+            "locked-polygon-labels": true,
+            "locked-function-labels": true,
         },
     },
 };
@@ -208,6 +215,21 @@ export const StaticGraphWithAnotherWidget = (
         question={staticGraphQuestionWithAnotherWidget()}
     />
 );
+
+export const AllLabeledLockedFigures = {
+    render: () => (
+        <RendererWithDebugUI
+            apiOptions={enableMafs}
+            question={segmentWithLockedFigures}
+        />
+    ),
+    parameters: {
+        chromatic: {
+            // Visual snapshot testing for all locked figures.
+            disableSnapshot: false,
+        },
+    },
+};
 
 // TODO(jeremy): As of Jan 2022 there are no peresus items in production that
 // use the "quadratic" graph type.

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.stories.tsx
@@ -28,10 +28,20 @@ import {
 } from "./interactive-graph.testdata";
 
 import type {APIOptions} from "../../types";
+import type {Meta} from "@storybook/react";
 
-export default {
+const meta: Meta = {
     title: "Perseus/Widgets/Interactive Graph",
+    parameters: {
+        chromatic: {
+            // Enable chromatic snapshots for all the different
+            // visual cases in these stories.
+            disableSnapshot: false,
+        },
+    },
 };
+
+export default meta;
 
 const enableMafs: APIOptions = {
     flags: {

--- a/packages/perseus/src/widgets/number-line/number-line.stories.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.stories.tsx
@@ -8,10 +8,18 @@ import TestKeypadContextWrapper from "../__shared__/test-keypad-context-wrapper"
 import {question1, question2} from "./number-line.testdata";
 
 import type {PerseusItem} from "../../perseus-types";
+import type {Meta} from "@storybook/react";
 
-export default {
+const meta: Meta = {
     title: "Perseus/Widgets/Number Line",
+    parameters: {
+        chromatic: {
+            // Visual snapshot testing for all the variants of this widget.
+            disableSnapshot: false,
+        },
+    },
 };
+export default meta;
 
 type StoryArgs = Record<any, any>;
 

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.stories.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.stories.tsx
@@ -6,6 +6,8 @@ import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui
 import {NumericInput} from "./numeric-input";
 import {question1} from "./numeric-input.testdata";
 
+import type {Meta} from "@storybook/react";
+
 type StoryArgs = {
     coefficient: boolean;
     currentValue: string;
@@ -36,7 +38,7 @@ function generateProps(overwrite) {
     return {...base, ...overwrite};
 }
 
-export default {
+const meta: Meta = {
     title: "Perseus/Widgets/NumericInput",
     args: {
         coefficient: false,
@@ -51,6 +53,7 @@ export default {
         },
     },
 };
+export default meta;
 
 export const Question1 = (): React.ReactElement => {
     return <RendererWithDebugUI question={question1} />;
@@ -62,38 +65,54 @@ export const Interactive = (args: StoryArgs): React.ReactElement => {
     return <NumericInput {...props} />;
 };
 
-export const Sizes = (args: StoryArgs): React.ReactElement => {
-    const smallProps = generateProps({...args, size: "small"});
-    const normalProps = generateProps({...args, size: "normal"});
+export const Sizes = {
+    render: function Render(args: StoryArgs) {
+        const smallProps = generateProps({...args, size: "small"});
+        const normalProps = generateProps({...args, size: "normal"});
 
-    return (
-        <div>
-            <label>
-                Small:
-                <NumericInput {...smallProps} />
-            </label>
-            <label>
-                Normal:
-                <NumericInput {...normalProps} />
-            </label>
-        </div>
-    );
+        return (
+            <div>
+                <label>
+                    Small:
+                    <NumericInput {...smallProps} />
+                </label>
+                <label>
+                    Normal:
+                    <NumericInput {...normalProps} />
+                </label>
+            </div>
+        );
+    },
+    parameters: {
+        chromatic: {
+            // Visual snapshot testing for the different sizes.
+            disableSnapshot: false,
+        },
+    },
 };
 
-export const TextAlignment = (args: StoryArgs): React.ReactElement => {
-    const leftProps = generateProps({...args, rightAlign: false});
-    const rightProps = generateProps({...args, rightAlign: true});
+export const TextAlignment = {
+    render: function Render(args: StoryArgs) {
+        const leftProps = generateProps({...args, rightAlign: false});
+        const rightProps = generateProps({...args, rightAlign: true});
 
-    return (
-        <div>
-            <label>
-                Left:
-                <NumericInput {...leftProps} />
-            </label>
-            <label>
-                Right:
-                <NumericInput {...rightProps} />
-            </label>
-        </div>
-    );
+        return (
+            <div>
+                <label>
+                    Left:
+                    <NumericInput {...leftProps} />
+                </label>
+                <label>
+                    Right:
+                    <NumericInput {...rightProps} />
+                </label>
+            </div>
+        );
+    },
+    parameters: {
+        chromatic: {
+            // Visual snapshot testing for the different alignments.
+            disableSnapshot: false,
+        },
+    },
 };

--- a/packages/perseus/src/widgets/radio/__stories__/radio.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__stories__/radio.stories.tsx
@@ -24,7 +24,7 @@ type StoryArgs = {
     "reviewMode" | "showSolutions"
 >;
 
-export default {
+const meta: Meta = {
     title: "Perseus/Widgets/Radio",
     args: {
         static: false,
@@ -41,8 +41,6 @@ export default {
             },
         },
     },
-    // TODO(LEMS-2656): remove TS suppression
-    // @ts-expect-error: Type 'Args' is not assignable to type 'StoryArgs'.
     render: (args: StoryArgs) => (
         <RendererWithDebugUI
             question={applyStoryArgs(args)}
@@ -51,7 +49,14 @@ export default {
             showSolutions={args.showSolutions}
         />
     ),
-} satisfies Meta;
+    parameters: {
+        chromatic: {
+            // Visual snapshot testing for all the variants of this widget.
+            disableSnapshot: false,
+        },
+    },
+};
+export default meta;
 
 const applyStoryArgs = (args: StoryArgs): PerseusRenderer => {
     const q = {

--- a/packages/perseus/src/widgets/radio/__stories__/radio.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__stories__/radio.stories.tsx
@@ -41,6 +41,8 @@ const meta: Meta = {
             },
         },
     },
+    // TODO(LEMS-2656): remove TS suppression
+    // @ts-expect-error: Type 'Args' is not assignable to type 'StoryArgs'.
     render: (args: StoryArgs) => (
         <RendererWithDebugUI
             question={applyStoryArgs(args)}


### PR DESCRIPTION
## Summary:
We want to disable snapshots globally, since most of our stories
don't need visual snapshot testing anyway, and we keep going over
our monthly chromatic snapshot limit.

Instead, we should deliberately set snapshots to true for stories we
want chromatic snapshots for.

- turn off chromatic snapshots globally
- turn on chromatic snapshots for interactive graph stories

Issue: https://khanacademy.atlassian.net/browse/LEMS-2579

Test plan:
Look at the Chromatic snapshots number on this PR below.

| Before | After |
| --- | --- |
| <img width="166" alt="Screenshot 2024-11-20 at 4 11 35 PM" src="https://github.com/user-attachments/assets/724557fc-5a7b-4d29-a8a0-499fcc224f9b"> | <img width="173" alt="Screenshot 2024-11-20 at 4 11 41 PM" src="https://github.com/user-attachments/assets/75ea8e65-057d-4623-ba59-d414740acd77"> |
