### PR TITLE
Migrate expression widget to latest version in PerseusItem parser

### DIFF
--- a/.changeset/yellow-ducks-march.md
+++ b/.changeset/yellow-ducks-march.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Migrate expression widget options to the latest version in parseAndTypecheckPerseusItem (not yet used in production).

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/expression-widget.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/expression-widget.test.ts
@@ -1,65 +1,76 @@
-import {parseExpressionWidget} from "./expression-widget";
 import {parse} from "../parse";
-import {success} from "../result";
+import {failure, success} from "../result";
+
+import {parseExpressionWidget} from "./expression-widget";
 
 describe("parseExpressionWidget", () => {
     it("migrates v0 options to v1", () => {
         const widget = {
-            "type": "expression",
-            "graded": true,
-            "options": {
-                "value": "the value",
-                "form": false,
-                "simplify": false,
-                "times": false,
-                "buttonsVisible": "never",
-                "buttonSets": [
-                    "basic"
-                ],
-                "functions": [
-                    "f",
-                    "g",
-                    "h"
-                ],
+            type: "expression",
+            graded: true,
+            options: {
+                value: "the value",
+                form: false,
+                simplify: false,
+                times: false,
+                buttonsVisible: "never",
+                buttonSets: ["basic"],
+                functions: ["f", "g", "h"],
             },
-            "version": {
-                "major": 0,
-                "minor": 1
-            }
-        }
+            version: {
+                major: 0,
+                minor: 1,
+            },
+        };
 
-        expect(parse(widget, parseExpressionWidget)).toEqual(success({
-            "type": "expression",
-            "graded": true,
-            static: undefined,
-            key: undefined,
-            "alignment": undefined,
-            "options": {
-                "times": false,
-                ariaLabel: undefined,
-                visibleLabel: undefined,
-                "buttonsVisible": "never",
-                "buttonSets": [
-                    "basic"
-                ],
-                "functions": [
-                    "f",
-                    "g",
-                    "h"
-                ],
-                "answerForms": [
-                    {
-                        considered: "correct",
-                        form: false,
-                        simplify: false,
-                        value: "the value",
-                    },
-                ],
+        expect(parse(widget, parseExpressionWidget)).toEqual(
+            success({
+                type: "expression",
+                graded: true,
+                static: undefined,
+                key: undefined,
+                alignment: undefined,
+                options: {
+                    times: false,
+                    ariaLabel: undefined,
+                    visibleLabel: undefined,
+                    buttonsVisible: "never",
+                    buttonSets: ["basic"],
+                    functions: ["f", "g", "h"],
+                    answerForms: [
+                        {
+                            considered: "correct",
+                            form: false,
+                            simplify: false,
+                            value: "the value",
+                        },
+                    ],
+                },
+                version: {
+                    major: 1,
+                    minor: 0,
+                },
+            }),
+        );
+    });
+
+    it("rejects a widget with unrecognized version", () => {
+        const widget = {
+            type: "expression",
+            version: {
+                major: -1,
+                minor: 0,
             },
-            "version": {
-                "major": 1,
-                "minor": 0
-            }
-        }))
-    })
-})
+            graded: true,
+            options: {},
+        };
+
+        expect(parse(widget, parseExpressionWidget)).toEqual(
+            failure(
+                expect.stringContaining(
+                    "At (root).version.major -- expected 0, but got -1",
+                ),
+            ),
+        );
+    });
+});

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/expression-widget.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/expression-widget.test.ts
@@ -1,0 +1,65 @@
+import {parseExpressionWidget} from "./expression-widget";
+import {parse} from "../parse";
+import {success} from "../result";
+
+describe("parseExpressionWidget", () => {
+    it("migrates v0 options to v1", () => {
+        const widget = {
+            "type": "expression",
+            "graded": true,
+            "options": {
+                "value": "the value",
+                "form": false,
+                "simplify": false,
+                "times": false,
+                "buttonsVisible": "never",
+                "buttonSets": [
+                    "basic"
+                ],
+                "functions": [
+                    "f",
+                    "g",
+                    "h"
+                ],
+            },
+            "version": {
+                "major": 0,
+                "minor": 1
+            }
+        }
+
+        expect(parse(widget, parseExpressionWidget)).toEqual(success({
+            "type": "expression",
+            "graded": true,
+            static: undefined,
+            key: undefined,
+            "alignment": undefined,
+            "options": {
+                "times": false,
+                ariaLabel: undefined,
+                visibleLabel: undefined,
+                "buttonsVisible": "never",
+                "buttonSets": [
+                    "basic"
+                ],
+                "functions": [
+                    "f",
+                    "g",
+                    "h"
+                ],
+                "answerForms": [
+                    {
+                        considered: "correct",
+                        form: false,
+                        simplify: false,
+                        value: "the value",
+                    },
+                ],
+            },
+            "version": {
+                "major": 1,
+                "minor": 0
+            }
+        }))
+    })
+})

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/expression-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/expression-widget.ts
@@ -36,6 +36,29 @@ const parseAnswerForm: Parser<PerseusExpressionAnswerForm> = object({
     ).parser,
 });
 
+const parseExpressionWidgetLatest: Parser<ExpressionWidget> = parseWidget(
+    constant("expression"),
+    object({
+        answerForms: array(parseAnswerForm),
+        functions: array(string),
+        times: boolean,
+        visibleLabel: optional(string),
+        ariaLabel: optional(string),
+        buttonSets: array(
+            enumeration(
+                "basic",
+                "basic+div",
+                "trig",
+                "prealgebra",
+                "logarithms",
+                "basic relations",
+                "advanced relations",
+            ),
+        ),
+        buttonsVisible: optional(enumeration("always", "never", "focused")),
+    }),
+);
+
 const parseExpressionWidgetV0 = parseWidgetWithVersion(
     optional(object({major: constant(0), minor: number})),
     constant("expression"),
@@ -59,31 +82,8 @@ const parseExpressionWidgetV0 = parseWidgetWithVersion(
             ),
         ),
         buttonsVisible: optional(enumeration("always", "never", "focused")),
-    })
+    }),
 );
-
-const parseExpressionWidgetLatest: Parser<ExpressionWidget> = parseWidget(
-    constant("expression"),
-    object({
-        answerForms: array(parseAnswerForm),
-        functions: array(string),
-        times: boolean,
-        visibleLabel: optional(string),
-        ariaLabel: optional(string),
-        buttonSets: array(
-            enumeration(
-                "basic",
-                "basic+div",
-                "trig",
-                "prealgebra",
-                "logarithms",
-                "basic relations",
-                "advanced relations",
-            ),
-        ),
-        buttonsVisible: optional(enumeration("always", "never", "focused")),
-    })
-)
 
 function migrateV0ToLatest(widget: ParsedValue<typeof parseExpressionWidgetV0>, ctx: ParseContext): ParseResult<ExpressionWidget> {
     const {options} = widget;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/expression-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/expression-widget.ts
@@ -11,13 +11,20 @@ import {
     union,
 } from "../general-purpose-parsers";
 
-import {parseWidget} from "./widget";
+import {parseWidgetWithVersion, parseWidget} from "./widget";
+
+import Expression from "../../../widgets/expression/expression"
 
 import type {
     ExpressionWidget,
     PerseusExpressionAnswerForm,
 } from "../../../perseus-types";
-import type {Parser} from "../parser-types";
+import type {
+    ParseContext,
+    ParsedValue,
+    Parser,
+    ParseResult
+} from "../parser-types";
 
 const parseAnswerForm: Parser<PerseusExpressionAnswerForm> = object({
     value: string,
@@ -29,7 +36,33 @@ const parseAnswerForm: Parser<PerseusExpressionAnswerForm> = object({
     ).parser,
 });
 
-export const parseExpressionWidget: Parser<ExpressionWidget> = parseWidget(
+const parseExpressionWidgetV0 = parseWidgetWithVersion(
+    optional(object({major: constant(0), minor: number})),
+    constant("expression"),
+    object({
+        functions: array(string),
+        times: boolean,
+        visibleLabel: optional(string),
+        ariaLabel: optional(string),
+        form: boolean,
+        simplify: boolean,
+        value: string,
+        buttonSets: array(
+            enumeration(
+                "basic",
+                "basic+div",
+                "trig",
+                "prealgebra",
+                "logarithms",
+                "basic relations",
+                "advanced relations",
+            ),
+        ),
+        buttonsVisible: optional(enumeration("always", "never", "focused")),
+    })
+);
+
+const parseExpressionWidgetLatest: Parser<ExpressionWidget> = parseWidget(
     constant("expression"),
     object({
         answerForms: array(parseAnswerForm),
@@ -49,5 +82,34 @@ export const parseExpressionWidget: Parser<ExpressionWidget> = parseWidget(
             ),
         ),
         buttonsVisible: optional(enumeration("always", "never", "focused")),
-    }),
-);
+    })
+)
+
+function migrateV0ToLatest(widget: ParsedValue<typeof parseExpressionWidgetV0>, ctx: ParseContext): ParseResult<ExpressionWidget> {
+    const {options} = widget;
+    return ctx.success({
+        ...widget,
+        version: Expression.version,
+        options: {
+            times: options.times,
+            buttonSets: options.buttonSets,
+            functions: options.functions,
+            buttonsVisible: options.buttonsVisible,
+            visibleLabel: options.visibleLabel,
+            ariaLabel: options.ariaLabel,
+
+            answerForms: [
+                {
+                    considered: "correct",
+                    form: options.form,
+                    simplify: options.simplify,
+                    value: options.value,
+                },
+            ],
+        },
+    })
+}
+
+export const parseExpressionWidget: Parser<ExpressionWidget> =
+    union(pipeParsers(parseExpressionWidgetV0).then(migrateV0ToLatest).parser)
+        .or(parseExpressionWidgetLatest).parser

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widget.ts
@@ -29,7 +29,11 @@ export function parseWidget<Type extends string, Options>(
     });
 }
 
-export function parseWidgetWithVersion<Version extends {major: number, minor: number} | undefined, Type extends string, Options>(
+export function parseWidgetWithVersion<
+    Version extends {major: number; minor: number} | undefined,
+    Type extends string,
+    Options,
+>(
     parseVersion: Parser<Version>,
     parseType: Parser<Type>,
     parseOptions: Parser<Options>,

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widget.ts
@@ -28,3 +28,19 @@ export function parseWidget<Type extends string, Options>(
         ),
     });
 }
+
+export function parseWidgetWithVersion<Version extends {major: number, minor: number} | undefined, Type extends string, Options>(
+    parseVersion: Parser<Version>,
+    parseType: Parser<Type>,
+    parseOptions: Parser<Options>,
+): Parser<WidgetOptions<Type, Options>> {
+    return object({
+        type: parseType,
+        static: optional(boolean),
+        graded: optional(boolean),
+        alignment: optional(string),
+        options: parseOptions,
+        key: optional(number),
+        version: parseVersion,
+    });
+}

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -134,7 +134,7 @@ describe("parseWidgetsMap", () => {
         const widgetsMap: unknown = {
             "expression 1": {
                 type: "expression",
-                version: {major: 0, minor: 0},
+                version: {major: 1, minor: 0},
                 options: {
                     answerForms: [],
                     buttonSets: [],


### PR DESCRIPTION
This demonstrates how we can upgrade/migrate widget options in the parsing
code, obviating the need for `propUpgrades`.

The fact that `version` is an object makes this really annoying because
TypeScript can't discriminate unions based on nested properties like
`version.major`. Given that constraint, I think the approach I came up with is
reasonable, but I'm certainly open to feedback on how to improve it.

Issue: LEMS-2582

## Test plan:

`yarn test`