### PR TITLE
[Chromatic] Disable snapshots globally, only keep regression stories

### DIFF
--- a/.changeset/wise-dragons-prove.md
+++ b/.changeset/wise-dragons-prove.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Chromatic] Disable snapshots globally, only keep regression stories

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -43,4 +43,3 @@ jobs:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
                   autoAcceptChanges: "main"
-                  onlyStoryFiles: "**/*regression.stories.tsx"

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -23,7 +23,14 @@ const preview: Preview = {
         (Story) => (
             <RenderStateRoot>
                 <DependenciesContext.Provider value={storybookDependenciesV2}>
-                    <Story />
+                    {/* Most of our components have an expectation to be
+                        rendered inside of a .framework-perseus container.
+                        We want to make sure we can include it here, since it
+                        can also affect the styling.
+                    */}
+                    <div className="framework-perseus">
+                        <Story />
+                    </div>
                 </DependenciesContext.Provider>
             </RenderStateRoot>
         ),
@@ -58,6 +65,12 @@ const preview: Preview = {
                 name,
                 value,
             })),
+        },
+        // Disabling Chromatic snapshots across all stories, since we have
+        // a limited snapshot budget. Set this explicitly to false on
+        // stories that we want snapshots for in their respective files.
+        chromatic: {
+            disableSnapshot: true,
         },
     },
 };

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-regression.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-regression.stories.tsx
@@ -6,12 +6,22 @@ import {mockStrings} from "../../strings";
 import {interactiveGraphQuestionBuilder} from "./interactive-graph-question-builder";
 
 import type {PerseusRenderer} from "../../perseus-types";
+import type {Meta} from "@storybook/react";
 
 type StoryArgs = Record<any, any>;
 
-export default {
+const meta: Meta = {
     title: "Perseus/Widgets/Interactive Graph Visual Regression Tests",
+    parameters: {
+        chromatic: {
+            // We want snapshots for these regression tests, so that
+            // visual differences can be caught if there are any
+            // unexpected changes.
+            disableSnapshot: false,
+        },
+    },
 };
+export default meta;
 
 export const MafsWithCustomAxisLabels = (
     args: StoryArgs,


### PR DESCRIPTION
## Summary:
Right now, Chromatic snapshots are only supposed to run on files
that end with `.regression.stories.tsx`, but they seem to be running
on other stories as well in the github checks.

Instead of using the .yml to specify this, I'm disabling chromatic
using the `disableSnapshot` chromatic parameter globally, and
manually enabling it in the one regression stories file we have.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2579

## Test plan:
Check the chromatic info in the github checks below.