### PR TITLE
Add tests for propUpgrades functions

### DIFF
--- a/.changeset/two-feet-care.md
+++ b/.changeset/two-feet-care.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Add tests for propUpgrades functions (and remove underscore usage)

--- a/packages/perseus/src/widgets/expression/expression.test.tsx
+++ b/packages/perseus/src/widgets/expression/expression.test.tsx
@@ -523,4 +523,33 @@ describe("Expression Widget", function () {
             ).toBeNull();
         });
     });
+
+    describe("propUpgrades", () => {
+        it("can upgrade from v0 to v1", () => {
+            const v0props = {
+                times: false,
+                buttonSets: ["basic"],
+                functions: [],
+                form: false,
+                simplify: false,
+                value: "42",
+            };
+
+            const result = ExpressionWidgetExport.propUpgrades["1"](v0props);
+
+            expect(result).toEqual({
+                times: false,
+                buttonSets: ["basic"],
+                functions: [],
+                answerForms: [
+                    {
+                        considered: "correct",
+                        form: false,
+                        simplify: false,
+                        value: "42",
+                    },
+                ],
+            });
+        });
+    });
 });

--- a/packages/perseus/src/widgets/expression/expression.test.tsx
+++ b/packages/perseus/src/widgets/expression/expression.test.tsx
@@ -552,7 +552,8 @@ describe("Expression Widget", function () {
                 ],
             };
 
-            const result = ExpressionWidgetExport.propUpgrades["1"](v0props);
+            const result: PerseusExpressionWidgetOptions =
+                ExpressionWidgetExport.propUpgrades["1"](v0props);
 
             expect(result).toEqual(expected);
         });

--- a/packages/perseus/src/widgets/expression/expression.test.tsx
+++ b/packages/perseus/src/widgets/expression/expression.test.tsx
@@ -17,7 +17,10 @@ import {
     expressionItemWithLabels,
 } from "./expression.testdata";
 
-import type {PerseusItem} from "../../perseus-types";
+import type {
+    PerseusExpressionWidgetOptions,
+    PerseusItem,
+} from "../../perseus-types";
 import type {UserEvent} from "@testing-library/user-event";
 
 const renderAndAnswer = async (
@@ -535,9 +538,7 @@ describe("Expression Widget", function () {
                 value: "42",
             };
 
-            const result = ExpressionWidgetExport.propUpgrades["1"](v0props);
-
-            expect(result).toEqual({
+            const expected: PerseusExpressionWidgetOptions = {
                 times: false,
                 buttonSets: ["basic"],
                 functions: [],
@@ -549,7 +550,11 @@ describe("Expression Widget", function () {
                         value: "42",
                     },
                 ],
-            });
+            };
+
+            const result = ExpressionWidgetExport.propUpgrades["1"](v0props);
+
+            expect(result).toEqual(expected);
         });
     });
 });

--- a/packages/perseus/src/widgets/measurer/measurer.test.tsx
+++ b/packages/perseus/src/widgets/measurer/measurer.test.tsx
@@ -1,5 +1,7 @@
 import MeasurerWidgetExport from "./measurer";
 
+import type {PerseusMeasurerWidgetOptions} from "../../perseus-types";
+
 describe("measurer", () => {
     describe("propUpgrades", () => {
         it("can upgrade from v0 to v1", () => {
@@ -17,9 +19,7 @@ describe("measurer", () => {
                 static: false,
             };
 
-            const result = MeasurerWidgetExport.propUpgrades["1"](v0props);
-
-            expect(result).toEqual({
+            const expected: PerseusMeasurerWidgetOptions = {
                 image: {
                     url: "url",
                     top: 42,
@@ -33,7 +33,11 @@ describe("measurer", () => {
                 rulerLength: 4,
                 box: [4, 4],
                 static: false,
-            });
+            };
+
+            const result = MeasurerWidgetExport.propUpgrades["1"](v0props);
+
+            expect(result).toEqual(expected);
         });
     });
 });

--- a/packages/perseus/src/widgets/measurer/measurer.test.tsx
+++ b/packages/perseus/src/widgets/measurer/measurer.test.tsx
@@ -1,0 +1,39 @@
+import MeasurerWidgetExport from "./measurer";
+
+describe("measurer", () => {
+    describe("propUpgrades", () => {
+        it("can upgrade from v0 to v1", () => {
+            const v0props = {
+                imageUrl: "url",
+                imageTop: 42,
+                imageLeft: 42,
+                showProtractor: false,
+                showRuler: false,
+                rulerLabel: "test",
+                rulerTicks: 4,
+                rulerPixels: 4,
+                rulerLength: 4,
+                box: [4, 4],
+                static: false,
+            };
+
+            const result = MeasurerWidgetExport.propUpgrades["1"](v0props);
+
+            expect(result).toEqual({
+                image: {
+                    url: "url",
+                    top: 42,
+                    left: 42,
+                },
+                showProtractor: false,
+                showRuler: false,
+                rulerLabel: "test",
+                rulerTicks: 4,
+                rulerPixels: 4,
+                rulerLength: 4,
+                box: [4, 4],
+                static: false,
+            });
+        });
+    });
+});

--- a/packages/perseus/src/widgets/measurer/measurer.test.tsx
+++ b/packages/perseus/src/widgets/measurer/measurer.test.tsx
@@ -35,7 +35,8 @@ describe("measurer", () => {
                 static: false,
             };
 
-            const result = MeasurerWidgetExport.propUpgrades["1"](v0props);
+            const result: PerseusMeasurerWidgetOptions =
+                MeasurerWidgetExport.propUpgrades["1"](v0props);
 
             expect(result).toEqual(expected);
         });

--- a/packages/perseus/src/widgets/measurer/measurer.tsx
+++ b/packages/perseus/src/widgets/measurer/measurer.tsx
@@ -183,18 +183,16 @@ class Measurer extends React.Component<Props> implements Widget {
 
 const propUpgrades = {
     "1": (v0props: any): any => {
-        const v1props = _(v0props)
-            .chain()
-            .omit("imageUrl", "imageTop", "imageLeft")
-            .extend({
-                image: {
-                    url: v0props.imageUrl,
-                    top: v0props.imageTop,
-                    left: v0props.imageLeft,
-                },
-            })
-            .value();
-        return v1props;
+        const {imageUrl, imageTop, imageLeft, ...rest} = v0props;
+
+        return {
+            ...rest,
+            image: {
+                url: imageUrl,
+                top: imageTop,
+                left: imageLeft,
+            },
+        };
     },
 } as const;
 

--- a/packages/perseus/src/widgets/measurer/measurer.tsx
+++ b/packages/perseus/src/widgets/measurer/measurer.tsx
@@ -182,7 +182,7 @@ class Measurer extends React.Component<Props> implements Widget {
 }
 
 const propUpgrades = {
-    "1": (v0props: any): any => {
+    "1": (v0props: any): PerseusMeasurerWidgetOptions => {
         const {imageUrl, imageTop, imageLeft, ...rest} = v0props;
 
         return {

--- a/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
@@ -18,7 +18,10 @@ import {
     shuffledNoneQuestion,
 } from "./radio.testdata";
 
-import type {PerseusRenderer} from "../../../perseus-types";
+import type {
+    PerseusRadioWidgetOptions,
+    PerseusRenderer,
+} from "../../../perseus-types";
 import type {APIOptions} from "../../../types";
 import type {PerseusRadioUserInput} from "../../../validation.types";
 import type {UserEvent} from "@testing-library/user-event";
@@ -992,12 +995,14 @@ describe("propsUpgrade", () => {
             choices: [{content: "Choice 1"}, {content: "Choice 2"}],
         };
 
-        const result = RadioWidgetExport.propUpgrades["1"](v0props);
-
-        expect(result).toEqual({
+        const expected: PerseusRadioWidgetOptions = {
             choices: [{content: "Choice 1"}, {content: "Choice 2"}],
             hasNoneOfTheAbove: false,
-        });
+        };
+
+        const result = RadioWidgetExport.propUpgrades["1"](v0props);
+
+        expect(result).toEqual(expected);
     });
 
     it("throws from noneOfTheAbove", () => {

--- a/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
@@ -1000,7 +1000,8 @@ describe("propsUpgrade", () => {
             hasNoneOfTheAbove: false,
         };
 
-        const result = RadioWidgetExport.propUpgrades["1"](v0props);
+        const result: PerseusRadioWidgetOptions =
+            RadioWidgetExport.propUpgrades["1"](v0props);
 
         expect(result).toEqual(expected);
     });

--- a/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
@@ -8,6 +8,7 @@ import * as Dependencies from "../../../dependencies";
 import {mockStrings} from "../../../strings";
 import {renderQuestion} from "../../__testutils__/renderQuestion";
 import PassageWidget from "../../passage";
+import RadioWidgetExport from "../radio";
 import scoreRadio from "../score-radio";
 
 import {
@@ -982,5 +983,31 @@ describe("scoring", () => {
         // Assert
         expect(score).toHaveBeenAnsweredIncorrectly();
         expect(renderer).toHaveBeenAnsweredIncorrectly();
+    });
+});
+
+describe("propsUpgrade", () => {
+    it("can upgrade from v0 to v1", () => {
+        const v0props = {
+            choices: [{content: "Choice 1"}, {content: "Choice 2"}],
+        };
+
+        const result = RadioWidgetExport.propUpgrades["1"](v0props);
+
+        expect(result).toEqual({
+            choices: [{content: "Choice 1"}, {content: "Choice 2"}],
+            hasNoneOfTheAbove: false,
+        });
+    });
+
+    it("throws from noneOfTheAbove", () => {
+        const v0props = {
+            choices: [{content: "Choice 1"}, {content: "Choice 2"}],
+            noneOfTheAbove: true,
+        };
+
+        expect(() => RadioWidgetExport.propUpgrades["1"](v0props)).toThrow(
+            "radio widget v0 no longer supports auto noneOfTheAbove",
+        );
     });
 });

--- a/packages/perseus/src/widgets/radio/radio.ts
+++ b/packages/perseus/src/widgets/radio/radio.ts
@@ -127,10 +127,12 @@ const transform = (
 
 const propUpgrades = {
     "1": (v0props: any): any => {
+        const {noneOfTheAbove, ...rest} = v0props;
+
         let choices;
         let hasNoneOfTheAbove;
 
-        if (!v0props.noneOfTheAbove) {
+        if (!noneOfTheAbove) {
             choices = v0props.choices;
             hasNoneOfTheAbove = false;
         } else {
@@ -139,10 +141,11 @@ const propUpgrades = {
             );
         }
 
-        return _.extend(_.omit(v0props, "noneOfTheAbove"), {
-            choices: choices,
-            hasNoneOfTheAbove: hasNoneOfTheAbove,
-        });
+        return {
+            ...rest,
+            choices,
+            hasNoneOfTheAbove,
+        };
     },
 } as const;
 

--- a/packages/perseus/src/widgets/radio/radio.ts
+++ b/packages/perseus/src/widgets/radio/radio.ts
@@ -126,7 +126,7 @@ const transform = (
 };
 
 const propUpgrades = {
-    "1": (v0props: any): any => {
+    "1": (v0props: any): PerseusRadioWidgetOptions => {
         const {noneOfTheAbove, ...rest} = v0props;
 
         if (noneOfTheAbove) {

--- a/packages/perseus/src/widgets/radio/radio.ts
+++ b/packages/perseus/src/widgets/radio/radio.ts
@@ -129,13 +129,7 @@ const propUpgrades = {
     "1": (v0props: any): any => {
         const {noneOfTheAbove, ...rest} = v0props;
 
-        let choices;
-        let hasNoneOfTheAbove;
-
-        if (!noneOfTheAbove) {
-            choices = v0props.choices;
-            hasNoneOfTheAbove = false;
-        } else {
+        if (noneOfTheAbove) {
             throw new Error(
                 "radio widget v0 no longer supports auto noneOfTheAbove",
             );
@@ -143,8 +137,7 @@ const propUpgrades = {
 
         return {
             ...rest,
-            choices,
-            hasNoneOfTheAbove,
+            hasNoneOfTheAbove: false,
         };
     },
 } as const;


### PR DESCRIPTION
## Summary:
Only 3 widgets seem to use the `propUpgrades` mechanism:
- Radio
- Expression
- Measurer

None of them seemed to have tests (at least not direct tests), so this adds them.

I also took out underscore after I wrote the tests.

## Test plan:
This is the test plan