### PR TITLE
Enable TurboSnap for Chromatic

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -44,3 +44,4 @@ jobs:
                   projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
                   autoAcceptChanges: "main"
                   onlyStoryFiles: "**/*regression.stories.tsx"
+                  onlyChanged: true # Enable TurboSnap!

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -44,4 +44,6 @@ jobs:
                   projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
                   autoAcceptChanges: "main"
                   onlyStoryFiles: "**/*regression.stories.tsx"
-                  onlyChanged: true # Enable TurboSnap!
+                  # NOTE: We cannot enable `onlyChanged` because it is
+                  # incompatible with `onlyStoryFiles` which we use above.
+                  # onlyChanged: true # Enable TurboSnap!


### PR DESCRIPTION
## Summary:

EDIT: We _cannot_ enable TurboSnap for Perseus because we already use [`onlyStoryFiles`](https://www.chromatic.com/docs/configure/#onlystoryfiles) (which restricts the set of stories to run, but is incompatible with the `onlyChanged` setting.

As a result of ☝️, this PR has been updated to document that `onlyStoryFiles` prevents use of `onlyChanged`.

~~This PR enables TurboSnap for the Perseus repo. TurboSnap is already enabled or the Perseus project on Chromatic.com, but we noticed it wasn't enabled for the Github Action that runs it.~~

Issue: "none"

## Test plan:

Watch the actions on this build. We might have to land this and monitor future builds to see it working as I'm not sure if there'll be a proper baseline for TurboSnap to work off of.