### PR TITLE
Inline version in expression widget parser

### DIFF
--- a/.changeset/seven-owls-explain.md
+++ b/.changeset/seven-owls-explain.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Inline widget version into Expression widget parser.

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/expression-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/expression-widget.ts
@@ -1,4 +1,3 @@
-import ExpressionWidgetModule from "../../../widgets/expression/expression";
 import {
     array,
     boolean,
@@ -93,7 +92,7 @@ function migrateV0ToV1(
     const {options} = widget;
     return ctx.success({
         ...widget,
-        version: ExpressionWidgetModule.version,
+        version: {major: 1, minor: 0},
         options: {
             times: options.times,
             buttonSets: options.buttonSets,


### PR DESCRIPTION
The Expression widget imports the KAS parser, which contains generated code
with some syntax that `@swc-node/register` (which we use to run TypeScript from
the command line) can't parse. The parse error was preventing the exhaustive
tests for the parsers (packages/perseus/src/util/parse-perseus-json/exhaustive-test-tool/index.ts)
from running.

Since we can't change the generated code, the solution is to avoid importing
the version number from the Expression widget, and hardcode it instead. I think
this is okay, because the migration function that used the version number is
called `migrateV0ToV1`, so we actually want to hardcode version 1 rather than
taking the current version from the widget.


Issue: none

## Test plan:

Run the exhaustive test tool according to the instructions in the file.