### PR TITLE
Update TypeScript to version 5.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
         "storybook": "^7.6.17",
         "style-loader": "^3.3.3",
         "tiny-invariant": "^1.3.1",
-        "typescript": "^5.4.2",
+        "typescript": "5.7.2",
         "typescript-coverage-report": "^0.7.0",
         "vite-plugin-istanbul": "^5.0.0",
         "vite-plugin-turbosnap": "^1.0.3",

--- a/tsconfig-common.json
+++ b/tsconfig-common.json
@@ -9,7 +9,7 @@
         // Required for dynamic imports even though we aren't using
         // tsc to output any modules.
         "module": "ESNext",
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "resolveJsonModule": true,
         /* Interop Constraints */
         "esModuleInterop": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -15940,10 +15940,10 @@ typescript-coverage-report@^0.7.0:
     semantic-ui-react "^0.88.2"
     type-coverage-core "^2.23.0"
 
-typescript@^5.4.2:
-  version "5.4.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.2.tgz#0ae9cebcfae970718474fe0da2c090cad6577372"
-  integrity sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==
+typescript@5.7.2:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
+  integrity sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==
 
 ua-parser-js@^0.7.30:
   version "0.7.31"


### PR DESCRIPTION
## Summary:
Wonder Blocks is updating Storybook to 8.x which requires using "moduleResolution": "bundler" in its tsconfig, see https://stackoverflow.com/questions/72193784/why-doesnt-the-exports-field-of-npm-work-in-typescript for details.  To fix this, I decided to update TypeScript in Wonder Blocks.  Instead of updating to the minimally required version I figured I may as well upgrade to the most recent version since I'm upgrading anyways.

Although we probably don't need to update TypeScript in all of our repos at the same time (unless we start using new syntax), we may as well.  That way, if a new Wonder Blocks package is published with new TS syntax it its types, Perseus will be ready.

In theory, this shouldn't change the output of any of the packages since we're using babel for compilation.

Issue: None

## Test plan:
- yarn typecheck