### PR TITLE
Allow WB/WS packages otherwise groups don't match anything

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
       allow:
           - dependency-name: "@khanacademy/eslint-config"
           - dependency-name: "@khanacademy/eslint-plugin"
+          - dependency-name: "@khanacademy/wonder-blocks-*"
+          - dependency-name: "@khanacademy/wonder-stuff-*"
       assignees:
           - "@Khan/perseus"
 


### PR DESCRIPTION
## Summary:

I set up Dependabot updates for WonderBlocks and WonderStuff packages last week and set them so they'd be updated in groups. However, I missed adding them to the `allow` list, which prevented any updates to them. This PR adds them to the `allow` list so that Dependabot actually works. 

Issue: "none"

## Test plan:

Land and watch tonights Dependabot run.