### PR TITLE
Fix reviewers for dependabot - 'assignees' is only for individuals

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,8 @@ updates:
           - dependency-name: "@khanacademy/eslint-plugin"
           - dependency-name: "@khanacademy/wonder-blocks-*"
           - dependency-name: "@khanacademy/wonder-stuff-*"
-      assignees:
-          - "@Khan/perseus"
+      reviewers:
+          - "Khan/perseus"
 
       # Grouped updates for Wonder Blocks and Wonder Stuff releases.
       # This helps us to stay in sync with the latest releases of these packages.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,7 @@ updates:
           - dependency-name: "@khanacademy/wonder-stuff-*"
       reviewers:
           - "Khan/perseus"
+          - "Khan/wonder-blocks"
 
       # Grouped updates for Wonder Blocks and Wonder Stuff releases.
       # This helps us to stay in sync with the latest releases of these packages.


### PR DESCRIPTION
## Summary:

*sigh* I can't read. 

`assignees` => https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#assignees

> Use assignees to specify individual assignees for all pull requests raised for a package manager.

`reviewers` ==> https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#reviewers

> Use reviewers to specify individual reviewers or teams of reviewers for all pull requests raised for a package manager. You must use the full team name, including the organization, as if you were @mentioning the team.

Issue: "none"

## Test plan: