### PR TITLE
Switch to standard ES exports for objective utils

### DIFF
--- a/.changeset/chilled-cameras-play.md
+++ b/.changeset/chilled-cameras-play.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Refactor internally used object mapping utilities to use ES6 exports

--- a/packages/perseus/src/interactive2/movable-line.ts
+++ b/packages/perseus/src/interactive2/movable-line.ts
@@ -8,7 +8,7 @@ import KhanColors from "../util/colors";
 
 import InteractiveUtil from "./interactive-util";
 import MovableLineOptions from "./movable-line-options";
-import objective_ from "./objective_";
+import {pluck} from "./objective_";
 import WrappedLine from "./wrapped-line";
 
 const assert = InteractiveUtil.assert;
@@ -83,7 +83,7 @@ _.extend(MovableLine.prototype, {
                 //    - are objects, not primitives (and need a deeper copy)
                 //    - they don't need getters created for them
                 // TODO(jack): Consider "default" once we es3ify perseus
-                objective_.pluck(MovableLineOptions, "standard"),
+                pluck(MovableLineOptions, "standard"),
             ),
             DEFAULT_PROPS,
         );

--- a/packages/perseus/src/interactive2/movable-point.tsx
+++ b/packages/perseus/src/interactive2/movable-point.tsx
@@ -63,7 +63,7 @@ import Tex from "../util/tex";
 
 import InteractiveUtil from "./interactive-util";
 import MovablePointOptions from "./movable-point-options";
-import objective_ from "./objective_";
+import {pluck} from "./objective_";
 import WrappedEllipse from "./wrapped-ellipse";
 
 import type {Movable} from "./movable";
@@ -170,7 +170,7 @@ export class MovablePoint {
                 //    - are objects, not primitives (and need a deeper copy)
                 //    - they don't need getters created for them
                 // TODO(jack): Consider "default" once we es3ify perseus
-                objective_.pluck(MovablePointOptions, "standard"),
+                pluck(MovablePointOptions, "standard"),
                 // We only update props here, because we want things on state to
                 // be persistent, and updated appropriately in modify()
             ),

--- a/packages/perseus/src/interactive2/movable-polygon.ts
+++ b/packages/perseus/src/interactive2/movable-polygon.ts
@@ -10,7 +10,7 @@ import GraphUtils from "../util/graph-utils";
 
 import InteractiveUtil from "./interactive-util";
 import MovablePolygonOptions from "./movable-polygon-options";
-import objective_ from "./objective_";
+import {pluck} from "./objective_";
 
 const assert = InteractiveUtil.assert;
 const normalizeOptions = InteractiveUtil.normalizeOptions;
@@ -91,7 +91,7 @@ _.extend(MovablePolygon.prototype, {
                 //    - are objects, not primitives (and need a deeper copy)
                 //    - they don't need getters created for them
                 // TODO(jack): Consider "default" once we es3ify perseus
-                objective_.pluck(MovablePolygonOptions, "standard"),
+                pluck(MovablePolygonOptions, "standard"),
 
                 // We only update props here, because we want things on state to
                 // be persistent, and updated appropriately in modify()

--- a/packages/perseus/src/interactive2/objective_.ts
+++ b/packages/perseus/src/interactive2/objective_.ts
@@ -52,22 +52,3 @@ export const mapObject = function <K extends string, V, U>(
     });
     return result;
 };
-
-/**
- * Maps an array to an object
- *
- * > mapObjectFromArray(['a', 'b'], function(elem) {
- *       return elem + elem;
- *   });
- * {a: 'aa', b: 'bb'}
- */
-export const mapObjectFromArray = function <K extends string, V>(
-    arr: ReadonlyArray<K>,
-    lambda: (arg1: K) => V,
-): Record<K, V> {
-    const result: Record<string, any> = {};
-    arr.forEach((elem) => {
-        result[elem] = lambda(elem);
-    });
-    return result;
-};

--- a/packages/perseus/src/interactive2/objective_.ts
+++ b/packages/perseus/src/interactive2/objective_.ts
@@ -25,7 +25,7 @@ import _ from "underscore";
  *     rotation: false
  * }
  */
-const pluck = function (table: any, subKey: string): any {
+export const pluck = function (table: any, subKey: string): any {
     return _.object(
         _.map(table, function (value, key) {
             return [key, value[subKey]];
@@ -41,7 +41,7 @@ const pluck = function (table: any, subKey: string): any {
  *   });
  * {a: 2, b: 3}
  */
-const mapObject = function <K extends string, V, U>(
+export const mapObject = function <K extends string, V, U>(
     obj: Record<K, V>,
     lambda: (arg1: V, arg2: K) => U,
 ): Record<K, U> {
@@ -61,7 +61,7 @@ const mapObject = function <K extends string, V, U>(
  *   });
  * {a: 'aa', b: 'bb'}
  */
-const mapObjectFromArray = function <K extends string, V>(
+export const mapObjectFromArray = function <K extends string, V>(
     arr: ReadonlyArray<K>,
     lambda: (arg1: K) => V,
 ): Record<K, V> {
@@ -70,10 +70,4 @@ const mapObjectFromArray = function <K extends string, V>(
         result[elem] = lambda(elem);
     });
     return result;
-};
-
-export default {
-    pluck: pluck,
-    mapObject: mapObject,
-    mapObjectFromArray: mapObjectFromArray,
 };

--- a/packages/perseus/src/renderer-util.ts
+++ b/packages/perseus/src/renderer-util.ts
@@ -1,4 +1,4 @@
-import Objective from "./interactive2/objective_";
+import {mapObject} from "./interactive2/objective_";
 import Util from "./util";
 import {getWidgetIdsFromContent} from "./widget-type-utils";
 import {getWidgetScorer, upgradeWidgetInfoToLatestVersion} from "./widgets";
@@ -7,8 +7,6 @@ import type {PerseusRenderer, PerseusWidgetsMap} from "./perseus-types";
 import type {PerseusStrings} from "./strings";
 import type {PerseusScore} from "./types";
 import type {UserInput, UserInputMap} from "./validation.types";
-
-const {mapObject} = Objective;
 
 export function getUpgradedWidgetOptions(
     oldWidgetOptions: PerseusWidgetsMap,

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -19,7 +19,7 @@ import {DefinitionProvider} from "./definition-context";
 import {getDependencies} from "./dependencies";
 import ErrorBoundary from "./error-boundary";
 import InteractionTracker from "./interaction-tracker";
-import Objective from "./interactive2/objective_";
+import {mapObject} from "./interactive2/objective_";
 import JiptParagraphs from "./jipt-paragraphs";
 import {Log} from "./logging/log";
 import {ClassNames as ApiClassNames, ApiOptions} from "./perseus-api";
@@ -64,8 +64,6 @@ import type {KeypadAPI} from "@khanacademy/math-input";
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
 
 import "./styles/perseus-renderer.less";
-
-const {mapObject} = Objective;
 
 const rContainsNonWhitespace = /\S/;
 const rImageURL = /(web\+graphie|https):\/\/[^\s]*/;

--- a/packages/perseus/src/traversal.ts
+++ b/packages/perseus/src/traversal.ts
@@ -15,8 +15,7 @@
 
 import _ from "underscore";
 
-// TODO(aria): Pull this out of interactive2 / replace with new _.mapObject
-import objective_ from "./interactive2/objective_";
+import {mapObject} from "./interactive2/objective_";
 import * as Widgets from "./widgets";
 
 const noop = function () {};
@@ -93,7 +92,7 @@ const traverseRenderer = function (
         }
     }
 
-    const newWidgets = objective_.mapObject(
+    const newWidgets = mapObject(
         rendererOptions.widgets || {},
         function (widgetInfo, widgetId) {
             // Widgets without info or a type are empty widgets, and


### PR DESCRIPTION
## Summary:

I was working in an area where these "objective_" utils were used and it got annoying that I couldn't jump to the functions. So this PR adjusts the file to use the more modern ES6 `export` syntax instead of exporting an object. 

Issue: "none"

## Test plan:

`yarn test`
`yarn typecheck`