### PR TITLE
Update yarn.lock after browserslist update broke it

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5166,14 +5166,9 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001332, caniuse-lite@^1.0.30001541, caniuse-lite@^1.0.30001587:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001332, caniuse-lite@^1.0.30001541, caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001669:
   version "1.0.30001685"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001685.tgz"
-  integrity sha512-e/kJN1EMyHQzgcMEEgoo+YTCO1NGCmIYHk5Qk8jT6AazWemS5QFKJ5ShCJlH3GZrNIdZofcNCEwZqbMjjKzmnA==
-
-caniuse-lite@^1.0.30001669:
-  version "1.0.30001685"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001685.tgz#2d10d36c540a9a5d47ad6ab9e1ed5f61fdeadd8c"
   integrity sha512-e/kJN1EMyHQzgcMEEgoo+YTCO1NGCmIYHk5Qk8jT6AazWemS5QFKJ5ShCJlH3GZrNIdZofcNCEwZqbMjjKzmnA==
 
 caseless@~0.12.0:


### PR DESCRIPTION
## Summary:

This morning I landed a farily benign [PR](https://github.com/Khan/perseus/pull/1939) that is [generated periodically](https://github.com/Khan/perseus/actions/workflows/maintenance.yml) to update our browserslist reference. After landing it, it appears that running `yarn install` introduces changes to the `yarn.lock` file. 

This PR was created by running `yarn install` locally on a clean repo and committing the changes `yarn` made. 

The reason is not clear yet, but this PR applies the changes that `yarn` wants so that `main` can be clean again. 

Issue: "none"

## Test plan:

`yarn install` 

Git repo is still clean