### PR TITLE
Reverses PR #1944 (last Version Packages PR)

### DIFF
--- a/.changeset/calm-chefs-boil.md
+++ b/.changeset/calm-chefs-boil.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+TypeScript fixes

--- a/.changeset/chilled-cameras-play.md
+++ b/.changeset/chilled-cameras-play.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Refactor internally used object mapping utilities to use ES6 exports

--- a/.changeset/early-phones-remain.md
+++ b/.changeset/early-phones-remain.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Type fixes

--- a/.changeset/hip-pandas-argue.md
+++ b/.changeset/hip-pandas-argue.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Ensure that zoomed-in images retain alt text

--- a/.changeset/large-melons-deny.md
+++ b/.changeset/large-melons-deny.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Ensure links opening to style guide (Google Docs) set `rel="noreferrer"`

--- a/.changeset/many-keys-smash.md
+++ b/.changeset/many-keys-smash.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Numeric Input] - Show format options as a list

--- a/.changeset/mean-fans-boil.md
+++ b/.changeset/mean-fans-boil.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Minor refactoring of ServerItemRenderer's componentDidUpdate to reduce duplication

--- a/.changeset/metal-readers-impress.md
+++ b/.changeset/metal-readers-impress.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Refactor scoring for `group` widget to follow the same pattern as all other widgets

--- a/.changeset/odd-moons-remember.md
+++ b/.changeset/odd-moons-remember.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Numeric Input] - Associate format options tooltip content with input field for assistive technologies

--- a/.changeset/shiny-sloths-obey.md
+++ b/.changeset/shiny-sloths-obey.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Add global styles to reflect prod styling

--- a/.changeset/smooth-taxis-mate.md
+++ b/.changeset/smooth-taxis-mate.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: convert backgroundImage dimensions to numbers during parsing.

--- a/.changeset/stupid-apricots-retire.md
+++ b/.changeset/stupid-apricots-retire.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Remove debugging call in GraphSettings component

--- a/.changeset/sweet-ligers-arrive.md
+++ b/.changeset/sweet-ligers-arrive.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Introduces a validation function for the number line widget (extracted from the scoring function).

--- a/.changeset/tall-pianos-tap.md
+++ b/.changeset/tall-pianos-tap.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Improve comments on some Perseus types

--- a/.changeset/tender-planets-greet.md
+++ b/.changeset/tender-planets-greet.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Changes the PerseusWidgetsMap to be extensible so that widgets can be registered outside of Perseus and still have full type safety.

--- a/.changeset/tiny-feet-give.md
+++ b/.changeset/tiny-feet-give.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: add and pass regression tests for PerseusItem parser's handling of legacy data

--- a/.changeset/two-turtles-return.md
+++ b/.changeset/two-turtles-return.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+[Numeric Input] - Update the UI to match Expression widget

--- a/packages/perseus-editor/CHANGELOG.md
+++ b/packages/perseus-editor/CHANGELOG.md
@@ -1,18 +1,5 @@
 # @khanacademy/perseus-editor
 
-## 15.1.2
-
-### Patch Changes
-
--   [#1938](https://github.com/Khan/perseus/pull/1938) [`5e8d8468b`](https://github.com/Khan/perseus/commit/5e8d8468bb307ab8168be8e15d30af2be61ffd4a) Thanks [@jeremywiebe](https://github.com/jeremywiebe)! - Type fixes
-
-*   [#1937](https://github.com/Khan/perseus/pull/1937) [`3cdabf1a3`](https://github.com/Khan/perseus/commit/3cdabf1a39b4ef3e1f6b8a76f53669f64818e407) Thanks [@jeremywiebe](https://github.com/jeremywiebe)! - Ensure links opening to style guide (Google Docs) set `rel="noreferrer"`
-
--   [#1946](https://github.com/Khan/perseus/pull/1946) [`f35512786`](https://github.com/Khan/perseus/commit/f35512786117e51515a50f3a769c45de9714dfc2) Thanks [@jeremywiebe](https://github.com/jeremywiebe)! - Remove debugging call in GraphSettings component
-
--   Updated dependencies [[`3cdabf1a3`](https://github.com/Khan/perseus/commit/3cdabf1a39b4ef3e1f6b8a76f53669f64818e407), [`e21a3a39b`](https://github.com/Khan/perseus/commit/e21a3a39b69baf12a06ad13900fd7696ee0f3c87), [`5e8d8468b`](https://github.com/Khan/perseus/commit/5e8d8468bb307ab8168be8e15d30af2be61ffd4a), [`1d2b4e7bf`](https://github.com/Khan/perseus/commit/1d2b4e7bf13ec299f92da43024889702230014fa), [`763a4ba38`](https://github.com/Khan/perseus/commit/763a4ba380ac95f38e24e966107054dcd2dddd4c), [`b8926e38a`](https://github.com/Khan/perseus/commit/b8926e38a8fbdab126bff491de5cef333c483c03), [`f35512786`](https://github.com/Khan/perseus/commit/f35512786117e51515a50f3a769c45de9714dfc2), [`ef819ea95`](https://github.com/Khan/perseus/commit/ef819ea959fbab0849724529538f9a9912173aa3), [`e69ca3146`](https://github.com/Khan/perseus/commit/e69ca3146a237652837c3a02279e36583293ebd1), [`be8c06c75`](https://github.com/Khan/perseus/commit/be8c06c755f2fe5726e03866d1a15541e4258ad4), [`051c50cf7`](https://github.com/Khan/perseus/commit/051c50cf720b4766e353f24d2d15230ede1d499d), [`129adebef`](https://github.com/Khan/perseus/commit/129adebefe25e25c1b2a9e37f707cd13c673b64f), [`d05272661`](https://github.com/Khan/perseus/commit/d052726618fb9ec5a6b9d800d1a89183803e1882), [`2d89ef87d`](https://github.com/Khan/perseus/commit/2d89ef87d572b5d70dc0906bec7bfc309c16d2ab), [`e3062b3c8`](https://github.com/Khan/perseus/commit/e3062b3c8d7a27956bc49e2364e20169cba59781)]:
-    -   @khanacademy/perseus@45.1.0
-
 ## 15.1.1
 
 ### Patch Changes

--- a/packages/perseus-editor/package.json
+++ b/packages/perseus-editor/package.json
@@ -3,7 +3,7 @@
     "description": "Perseus editors",
     "author": "Khan Academy",
     "license": "MIT",
-    "version": "15.1.2",
+    "version": "15.1.1",
     "publishConfig": {
         "access": "public"
     },
@@ -38,7 +38,7 @@
         "@khanacademy/keypad-context": "^1.0.4",
         "@khanacademy/kmath": "^0.1.16",
         "@khanacademy/math-input": "^21.1.6",
-        "@khanacademy/perseus": "^45.1.0",
+        "@khanacademy/perseus": "^45.0.0",
         "@khanacademy/perseus-core": "1.5.3",
         "@khanacademy/pure-markdown": "^0.3.13",
         "mafs": "^0.19.0"

--- a/packages/perseus/CHANGELOG.md
+++ b/packages/perseus/CHANGELOG.md
@@ -1,41 +1,5 @@
 # @khanacademy/perseus
 
-## 45.1.0
-
-### Minor Changes
-
--   [#1901](https://github.com/Khan/perseus/pull/1901) [`051c50cf7`](https://github.com/Khan/perseus/commit/051c50cf720b4766e353f24d2d15230ede1d499d) Thanks [@Myranae](https://github.com/Myranae)! - Introduces a validation function for the number line widget (extracted from the scoring function).
-
-*   [#1936](https://github.com/Khan/perseus/pull/1936) [`d05272661`](https://github.com/Khan/perseus/commit/d052726618fb9ec5a6b9d800d1a89183803e1882) Thanks [@jeremywiebe](https://github.com/jeremywiebe)! - Changes the PerseusWidgetsMap to be extensible so that widgets can be registered outside of Perseus and still have full type safety.
-
--   [#1832](https://github.com/Khan/perseus/pull/1832) [`e3062b3c8`](https://github.com/Khan/perseus/commit/e3062b3c8d7a27956bc49e2364e20169cba59781) Thanks [@mark-fitzgerald](https://github.com/mark-fitzgerald)! - [Numeric Input] - Update the UI to match Expression widget
-
-### Patch Changes
-
--   [#1937](https://github.com/Khan/perseus/pull/1937) [`3cdabf1a3`](https://github.com/Khan/perseus/commit/3cdabf1a39b4ef3e1f6b8a76f53669f64818e407) Thanks [@jeremywiebe](https://github.com/jeremywiebe)! - TypeScript fixes
-
-*   [#1948](https://github.com/Khan/perseus/pull/1948) [`e21a3a39b`](https://github.com/Khan/perseus/commit/e21a3a39b69baf12a06ad13900fd7696ee0f3c87) Thanks [@jeremywiebe](https://github.com/jeremywiebe)! - Refactor internally used object mapping utilities to use ES6 exports
-
--   [#1938](https://github.com/Khan/perseus/pull/1938) [`5e8d8468b`](https://github.com/Khan/perseus/commit/5e8d8468bb307ab8168be8e15d30af2be61ffd4a) Thanks [@jeremywiebe](https://github.com/jeremywiebe)! - Type fixes
-
-*   [#1942](https://github.com/Khan/perseus/pull/1942) [`1d2b4e7bf`](https://github.com/Khan/perseus/commit/1d2b4e7bf13ec299f92da43024889702230014fa) Thanks [@SonicScrewdriver](https://github.com/SonicScrewdriver)! - Ensure that zoomed-in images retain alt text
-
--   [#1861](https://github.com/Khan/perseus/pull/1861) [`763a4ba38`](https://github.com/Khan/perseus/commit/763a4ba380ac95f38e24e966107054dcd2dddd4c) Thanks [@mark-fitzgerald](https://github.com/mark-fitzgerald)! - [Numeric Input] - Show format options as a list
-
-*   [#1947](https://github.com/Khan/perseus/pull/1947) [`b8926e38a`](https://github.com/Khan/perseus/commit/b8926e38a8fbdab126bff491de5cef333c483c03) Thanks [@jeremywiebe](https://github.com/jeremywiebe)! - Minor refactoring of ServerItemRenderer's componentDidUpdate to reduce duplication
-
--   [#1946](https://github.com/Khan/perseus/pull/1946) [`f35512786`](https://github.com/Khan/perseus/commit/f35512786117e51515a50f3a769c45de9714dfc2) Thanks [@jeremywiebe](https://github.com/jeremywiebe)! - Refactor scoring for `group` widget to follow the same pattern as all other widgets
-
-*   [#1891](https://github.com/Khan/perseus/pull/1891) [`ef819ea95`](https://github.com/Khan/perseus/commit/ef819ea959fbab0849724529538f9a9912173aa3) Thanks [@mark-fitzgerald](https://github.com/mark-fitzgerald)! - [Numeric Input] - Associate format options tooltip content with input field for assistive technologies
-
--   [#1945](https://github.com/Khan/perseus/pull/1945) [`e69ca3146`](https://github.com/Khan/perseus/commit/e69ca3146a237652837c3a02279e36583293ebd1) Thanks [@nishasy](https://github.com/nishasy)! - Add global styles to reflect prod styling
-
-*   [#1923](https://github.com/Khan/perseus/pull/1923) [`be8c06c75`](https://github.com/Khan/perseus/commit/be8c06c755f2fe5726e03866d1a15541e4258ad4) Thanks [@benchristel](https://github.com/benchristel)! - Internal: convert backgroundImage dimensions to numbers during parsing.
-
--   [#1934](https://github.com/Khan/perseus/pull/1934) [`129adebef`](https://github.com/Khan/perseus/commit/129adebefe25e25c1b2a9e37f707cd13c673b64f) Thanks [@jeremywiebe](https://github.com/jeremywiebe)! - Improve comments on some Perseus types
-
-*   [#1924](https://github.com/Khan/perseus/pull/1924) [`2d89ef87d`](https://github.com/Khan/perseus/commit/2d89ef87d572b5d70dc0906bec7bfc309c16d2ab) Thanks [@benchristel](https://github.com/benchristel)! - Internal: add and pass regression tests for PerseusItem parser's handling of legacy data
-
 ## 45.0.0
 
 ### Major Changes

--- a/packages/perseus/package.json
+++ b/packages/perseus/package.json
@@ -3,7 +3,7 @@
     "description": "Core Perseus API (includes renderers and widgets)",
     "author": "Khan Academy",
     "license": "MIT",
-    "version": "45.1.0",
+    "version": "45.0.0",
     "publishConfig": {
         "access": "public"
     },


### PR DESCRIPTION
## Summary:

The last release failed because the `yarn.lock` file was changed when `yarn install` ran (See #1957). 

This PR reverses (`git revert 5963ea185`) the release commit so that we can get a new Version Packages PR and land it (and trigger a new release).

<img width="932" alt="image" src="https://github.com/user-attachments/assets/81227009-bb4f-4638-9b0b-258e97879c8b">


PR #1957 must be landed after this PR, but _before_ we do a release. 

Issue: "none"

## Test plan: