### PR TITLE
Fix Jest inline snapshots

### DIFF
--- a/config/test/test.config.js
+++ b/config/test/test.config.js
@@ -42,6 +42,9 @@ const pkgMap = fs
 /** @type {import('jest').Config} */
 module.exports = {
     rootDir: path.join(__dirname, "../../"),
+    // Jest does not support Prettier v3!
+    // See: https://jestjs.io/docs/configuration/#prettierpath-string
+    prettierPath: require.resolve("prettier-2"),
     transform: {
         "^.+\\.(j|t)sx?$": "<rootDir>/config/test/test.transform.js",
         // Compile .svg files using a custom transformer that returns the

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
         "less-loader": "^11.1.3",
         "nyc": "^15.1.0",
         "prettier": "^3",
+        "prettier-2": "npm:prettier@^2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-json-view": "^1.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11759,6 +11759,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+"prettier-2@npm:prettier@^2":
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+
 prettier-linter-helpers@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"


### PR DESCRIPTION
## Summary:

While writing some tests, I wanted to use inline snapshots, but Jest complained that inline snapshots aren't supported on Prettier v3 (which we use). 

The solution is to install Prettier v2 beside v3 and customize Jest to use v2. 

Support for Prettier v3 has already [landed](https://github.com/jestjs/jest/pull/14566) and will be in Jest 30 but the last I saw was an [issue comment](https://github.com/jestjs/jest/issues/14305#issuecomment-1784898007) from Oct 2023 and even then the author was unsure when it would be released. I'll just use the workaround for now.

Issue: "none"

## Test plan:

Find a test that uses `.toMatchInlineSnapshot()` and delete the snapshot string passed to the function.
Save the file
`yarn test`
Note that the snapshot string is back!


https://github.com/user-attachments/assets/c33d2ac3-adae-43e1-8414-092880536d1d

