### PR TITLE
[Numeric Input] - BUGFIX - Adjust color contrast for tooltip text

### DIFF
--- a/.changeset/poor-numbers-reflect.md
+++ b/.changeset/poor-numbers-reflect.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Numeric Input] - BUGFIX - Adjust color contrast of tooltip text

--- a/packages/perseus/src/styles/perseus-renderer.less
+++ b/packages/perseus/src/styles/perseus-renderer.less
@@ -544,7 +544,7 @@
 
 .perseus-formats-tooltip {
     background: #fff;
-    color: #777;
+    color: #717378;
     padding: 5px 10px;
     width: 240px;
 }

--- a/packages/perseus/src/styles/perseus-renderer.less
+++ b/packages/perseus/src/styles/perseus-renderer.less
@@ -544,7 +544,7 @@
 
 .perseus-formats-tooltip {
     background: #fff;
-    color: #717378;
+    color: @textSecondary;
     padding: 5px 10px;
     width: 240px;
 }

--- a/packages/perseus/src/styles/variables.less
+++ b/packages/perseus/src/styles/variables.less
@@ -21,6 +21,8 @@
 @gray25: #3b3e40;
 @gray17: #21242c;
 
+@textSecondary: #717378;
+
 // Media query breakpoints
 // --------------------------------------------------
 


### PR DESCRIPTION
## Summary:
The text in the numeric input tooltip was slightly out of spec for accessibility. This change ensures that the text has a minimum 4.5:1 contrast ratio.

## Test plan:
1. Launch Storybook
2. Navigate to Perseus Editor => Editor => [Demo](http://localhost:6006/?path=/story/perseuseditor-editorpage--demo)
3. Add a Numeric Input widget
4. Configure the widget to have any number of format options
5. Place focus in the input field in the preview for the widget
6. Check the color value in the browser inspector for the text in the tooltip (it should be greater than 4.5:1)

## Affected UI:
### Before
![Color Contrast - Before](https://github.com/user-attachments/assets/2079d040-f240-45d1-91b7-a57fb062df5d)

### After
![Color Contrast - After](https://github.com/user-attachments/assets/3d064dd2-061e-4d8e-957f-3d362be01d7f)
