### PR TITLE
Remove `guessAndScore`

### DIFF
--- a/.changeset/large-flies-divide.md
+++ b/.changeset/large-flies-divide.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": major
+---
+
+Remove `guessAndScore` from Renderer

--- a/config/test/custom-matchers.ts
+++ b/config/test/custom-matchers.ts
@@ -19,56 +19,17 @@ declare global {
     }
 }
 
-type PerseusRenderer = {
-    guessAndScore: () => [Array<any>, PerseusScore];
-};
-
-type Answerable = PerseusRenderer | PerseusScore;
-
-function isRenderer(obj: Answerable): obj is PerseusRenderer {
-    // @ts-expect-error - TS(2339) - TS is annoying
-    return obj?.guessAndScore !== undefined;
-}
-
-function check(answerable: Answerable) {
-    let widgetState: string = "";
-    let score: PerseusScore;
-
-    if (isRenderer(answerable)) {
-        const result = answerable.guessAndScore();
-        widgetState = JSON.stringify(result[0]);
-        score = result[1];
-    } else {
-        score = answerable;
-    }
-
-    return {widgetState, score};
-}
-
-function maybeAddState(message: string, widgetState: string): string {
-    if (!widgetState) {
-        return message;
-    }
-
-    return message + `; widget state: ${widgetState}`;
-}
-
 expect.extend({
     toHaveBeenAnsweredCorrectly(
-        answerable: Answerable,
+        score: PerseusScore,
         options: {
             shouldHavePoints: boolean;
         },
     ) {
         const shouldHavePoints = options?.shouldHavePoints ?? true;
-        const {widgetState, score} = check(answerable);
 
         if (score.type === "invalid") {
-            const errMessage = maybeAddState(
-                `Invalid answer: ${score.message || "(no message)"}`,
-                widgetState,
-            );
-
+            const errMessage = `Invalid answer: ${score.message || "(no message)"}`;
             return {
                 pass: false,
                 message: () => errMessage,
@@ -83,10 +44,7 @@ expect.extend({
         }
 
         if (score.earned !== score.total) {
-            const errMessage = maybeAddState(
-                "Problem was answered incorrectly",
-                widgetState,
-            );
+            const errMessage = "Problem was answered incorrectly";
 
             return {
                 pass: false,
@@ -95,20 +53,14 @@ expect.extend({
         }
 
         if (shouldHavePoints && score.total < 1) {
-            const errMessage = maybeAddState(
-                "Score did not have any points",
-                widgetState,
-            );
+            const errMessage = "Score did not have any points";
 
             return {
                 pass: false,
                 message: () => errMessage,
             };
         } else if (!shouldHavePoints && score.total > 0) {
-            const errMessage = maybeAddState(
-                "Score had points when it shouldn't have",
-                widgetState,
-            );
+            const errMessage = "Score had points when it shouldn't have";
 
             return {
                 pass: false,
@@ -119,14 +71,9 @@ expect.extend({
         return {pass: true, message: () => ""};
     },
 
-    toHaveInvalidInput(answerable: Answerable, message: string | null) {
-        const {widgetState, score} = check(answerable);
-
+    toHaveInvalidInput(score: PerseusScore, message: string | null) {
         if (score.type !== "invalid") {
-            const errMessage = maybeAddState(
-                `Answer state is not invalid. Score: ${JSON.stringify(score)}`,
-                widgetState,
-            );
+            const errMessage = `Answer state is not invalid. Score: ${JSON.stringify(score)}`;
 
             return {
                 pass: false,
@@ -135,12 +82,9 @@ expect.extend({
         }
 
         if (message && (!score.message || !score.message.includes(message))) {
-            const errMessage = maybeAddState(
-                `Message shown for invalid input did not include "${message}": ${
-                    score.message || "(no message)"
-                }. Score: ${JSON.stringify(score)}`,
-                widgetState,
-            );
+            const errMessage = `Message shown for invalid input did not include "${message}": ${
+                score.message || "(no message)"
+            }. Score: ${JSON.stringify(score)}`;
 
             return {
                 pass: false,
@@ -151,14 +95,9 @@ expect.extend({
         return {pass: true, message: () => ""};
     },
 
-    toHaveBeenAnsweredIncorrectly(answerable: Answerable) {
-        const {widgetState, score} = check(answerable);
-
+    toHaveBeenAnsweredIncorrectly(score: PerseusScore) {
         if (score.type === "invalid") {
-            const errMessage = maybeAddState(
-                `Invalid answer: ${score.message || "(no message)"}`,
-                widgetState,
-            );
+            const errMessage = `Invalid answer: ${score.message || "(no message)"}`;
 
             return {
                 pass: false,
@@ -179,10 +118,7 @@ expect.extend({
         if (score.earned !== 0) {
             return {
                 pass: false,
-                message: () =>
-                    `Problem was answered correctly. Widget state: ${JSON.stringify(
-                        widgetState,
-                    )}`,
+                message: () => `Problem was answered correctly.`,
             };
         }
 

--- a/packages/perseus/src/__tests__/renderer-api.test.tsx
+++ b/packages/perseus/src/__tests__/renderer-api.test.tsx
@@ -12,6 +12,7 @@ import {ClassNames} from "../perseus-api";
 import Renderer from "../renderer";
 import {mockStrings} from "../strings";
 import {registerAllWidgetsForTesting} from "../util/register-all-widgets-for-testing";
+import {scorePerseusItemTesting} from "../util/test-utils";
 import {renderQuestion} from "../widgets/__testutils__/renderQuestion";
 
 import imageItem from "./test-items/image-item";
@@ -46,8 +47,13 @@ describe("Perseus API", function () {
             // Act
             act(() => renderer.setInputValue(["input-number 1"], "5"));
 
+            const score = scorePerseusItemTesting(
+                inputNumber1Item.question,
+                renderer.getUserInputMap(),
+            );
+
             // Assert
-            expect(renderer).toHaveBeenAnsweredCorrectly();
+            expect(score).toHaveBeenAnsweredCorrectly();
         });
 
         it("should be able to produce a wrong value", function () {
@@ -57,8 +63,13 @@ describe("Perseus API", function () {
             // Act
             act(() => renderer.setInputValue(["input-number 1"], "3"));
 
+            const score = scorePerseusItemTesting(
+                inputNumber1Item.question,
+                renderer.getUserInputMap(),
+            );
+
             // Assert
-            expect(renderer).toHaveBeenAnsweredIncorrectly();
+            expect(score).toHaveBeenAnsweredIncorrectly();
         });
 
         it("should be able to produce an empty score", function () {
@@ -66,10 +77,22 @@ describe("Perseus API", function () {
             const {renderer} = renderQuestion(inputNumber1Item.question);
 
             act(() => renderer.setInputValue(["input-number 1"], "3"));
-            expect(renderer).toHaveBeenAnsweredIncorrectly();
+
+            let score = scorePerseusItemTesting(
+                inputNumber1Item.question,
+                renderer.getUserInputMap(),
+            );
+
+            expect(score).toHaveBeenAnsweredIncorrectly();
 
             act(() => renderer.setInputValue(["input-number 1"], ""));
-            expect(renderer).toHaveInvalidInput();
+
+            score = scorePerseusItemTesting(
+                inputNumber1Item.question,
+                renderer.getUserInputMap(),
+            );
+
+            expect(score).toHaveInvalidInput();
         });
 
         it("should be able to accept a callback", function (done) {

--- a/packages/perseus/src/components/__tests__/sorter.test.tsx
+++ b/packages/perseus/src/components/__tests__/sorter.test.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import {wait} from "../../../../../testing/wait";
 import * as Dependencies from "../../dependencies";
+import {scorePerseusItemTesting} from "../../util/test-utils";
 import {renderQuestion} from "../../widgets/__testutils__/renderQuestion";
 import {question1} from "../__testdata__/sorter.testdata";
 
@@ -82,8 +83,13 @@ describe("sorter widget", () => {
             act(() => sorter.moveOptionToIndex(option, 3));
         });
 
+        const score = scorePerseusItemTesting(
+            question1,
+            renderer.getUserInputMap(),
+        );
+
         // Assert
-        expect(renderer).toHaveBeenAnsweredCorrectly();
+        expect(score).toHaveBeenAnsweredCorrectly();
     });
     it("can be answered incorrectly", () => {
         // Arrange
@@ -101,7 +107,12 @@ describe("sorter widget", () => {
             },
         );
 
+        const score = scorePerseusItemTesting(
+            question1,
+            renderer.getUserInputMap(),
+        );
+
         // Assert
-        expect(renderer).toHaveBeenAnsweredIncorrectly();
+        expect(score).toHaveBeenAnsweredIncorrectly();
     });
 });

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -1742,16 +1742,6 @@ class Renderer
         return combinedScore;
     }
 
-    /**
-     * @deprecated use scorePerseusItem
-     */
-    guessAndScore: () => [UserInputArray, PerseusScore] = () => {
-        const totalGuess = this.getUserInput();
-        const totalScore = this.score();
-
-        return [totalGuess, totalScore];
-    };
-
     // TranslationLinter callback
     handletranslationLintErrors: (lintErrors: ReadonlyArray<string>) => void = (
         lintErrors: ReadonlyArray<string>,

--- a/packages/perseus/src/util/test-utils.ts
+++ b/packages/perseus/src/util/test-utils.ts
@@ -1,11 +1,17 @@
+import {scorePerseusItem} from "../renderer-util";
+import {mockStrings} from "../strings";
+
 import type {
     CategorizerWidget,
     ExpressionWidget,
     InteractiveGraphWidget,
     NumericInputWidget,
     PerseusItem,
+    PerseusRenderer,
     RadioWidget,
 } from "../perseus-types";
+import type {PerseusScore} from "../types";
+import type {UserInputMap} from "../validation.types";
 
 export const genericPerseusItemData: PerseusItem = {
     question: {
@@ -31,6 +37,16 @@ export const genericPerseusItemData: PerseusItem = {
     hints: [],
     answer: null,
 } as const;
+
+/**
+ * Thin wrapper around scorePerseusItem for internal testing
+ */
+export function scorePerseusItemTesting(
+    perseusRenderData: PerseusRenderer,
+    userInputMap: UserInputMap,
+): PerseusScore {
+    return scorePerseusItem(perseusRenderData, userInputMap, mockStrings, "en");
+}
 
 /**
  * Generate a Perseus item object for testing purposes.

--- a/packages/perseus/src/widgets/categorizer/categorizer.test.ts
+++ b/packages/perseus/src/widgets/categorizer/categorizer.test.ts
@@ -5,6 +5,7 @@ import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
 import {scorePerseusItem} from "../../renderer-util";
 import {mockStrings} from "../../strings";
+import {scorePerseusItemTesting} from "../../util/test-utils";
 import {renderQuestion} from "../__testutils__/renderQuestion";
 
 import {Categorizer} from "./categorizer";
@@ -123,8 +124,13 @@ describe("categorizer widget", () => {
             })[1],
         );
 
+        const score = scorePerseusItemTesting(
+            question1,
+            renderer.getUserInputMap(),
+        );
+
         // assert
-        expect(renderer).toHaveBeenAnsweredCorrectly();
+        expect(score).toHaveBeenAnsweredCorrectly();
     });
 
     it("can get user input from props", () => {

--- a/packages/perseus/src/widgets/definition/definition.test.ts
+++ b/packages/perseus/src/widgets/definition/definition.test.ts
@@ -3,6 +3,7 @@ import {userEvent as userEventLib} from "@testing-library/user-event";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
+import {scorePerseusItemTesting} from "../../util/test-utils";
 import {renderQuestion} from "../__testutils__/renderQuestion";
 
 import type {UserEvent} from "@testing-library/user-event";
@@ -123,11 +124,17 @@ describe("Definition widget", () => {
     });
 
     it("should not affect answerable", () => {
-        // Arrange / Act
+        // Arrange
         const {renderer} = renderQuestion(question);
 
+        // Act
+        const score = scorePerseusItemTesting(
+            question,
+            renderer.getUserInputMap(),
+        );
+
         // Assert
-        expect(renderer).toHaveBeenAnsweredCorrectly({
+        expect(score).toHaveBeenAnsweredCorrectly({
             shouldHavePoints: false,
         });
     });

--- a/packages/perseus/src/widgets/deprecated-standin/__tests__/deprecated-standin.test.ts
+++ b/packages/perseus/src/widgets/deprecated-standin/__tests__/deprecated-standin.test.ts
@@ -1,5 +1,6 @@
 import {testDependencies} from "../../../../../../testing/test-dependencies";
 import * as Dependencies from "../../../dependencies";
+import {scorePerseusItemTesting} from "../../../util/test-utils";
 import {renderQuestion} from "../../__testutils__/renderQuestion";
 
 const question = {
@@ -41,10 +42,16 @@ describe("Deprecated Standin widget", () => {
     });
 
     it("should be scorable and always give points", () => {
-        // Arrange / Act
+        // Arrange
         const {renderer} = renderQuestion(question);
 
+        // Act
+        const score = scorePerseusItemTesting(
+            question,
+            renderer.getUserInputMap(),
+        );
+
         // Assert
-        expect(renderer).toHaveBeenAnsweredCorrectly();
+        expect(score).toHaveBeenAnsweredCorrectly();
     });
 });

--- a/packages/perseus/src/widgets/dropdown/dropdown.test.ts
+++ b/packages/perseus/src/widgets/dropdown/dropdown.test.ts
@@ -3,6 +3,7 @@ import {userEvent as userEventLib} from "@testing-library/user-event";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
+import {scorePerseusItemTesting} from "../../util/test-utils";
 import {renderQuestion} from "../__testutils__/renderQuestion";
 
 import {question1} from "./dropdown.testdata";
@@ -62,10 +63,14 @@ describe("Dropdown widget", () => {
         const dropdown = screen.getByRole("combobox");
         await userEvent.click(dropdown);
         await userEvent.click(screen.getByText("less than or equal to"));
+        const score = scorePerseusItemTesting(
+            question1,
+            renderer.getUserInputMap(),
+        );
 
         // Assert
         expect(dropdown).toHaveTextContent("less than or equal to");
-        expect(renderer).toHaveBeenAnsweredCorrectly();
+        expect(score).toHaveBeenAnsweredCorrectly();
     });
 
     it("should be answerable incorrectly", async () => {
@@ -76,18 +81,28 @@ describe("Dropdown widget", () => {
         const dropdown = screen.getByRole("combobox");
         await userEvent.click(dropdown);
         await userEvent.click(screen.getByText("greater than or equal to"));
+        const score = scorePerseusItemTesting(
+            question1,
+            renderer.getUserInputMap(),
+        );
 
         // Assert
         expect(dropdown).toHaveTextContent("greater than or equal to");
-        expect(renderer).toHaveBeenAnsweredIncorrectly();
+        expect(score).toHaveBeenAnsweredIncorrectly();
     });
 
     it("should be invalid on first render", async () => {
-        // Arrange and Act
+        // Arrange
         const {renderer} = renderQuestion(question1);
 
+        // Act
+        const score = scorePerseusItemTesting(
+            question1,
+            renderer.getUserInputMap(),
+        );
+
         // Assert
-        expect(renderer).toHaveInvalidInput();
+        expect(score).toHaveInvalidInput();
     });
 
     it("should be return true when focus() called", async () => {

--- a/packages/perseus/src/widgets/expression/expression.test.tsx
+++ b/packages/perseus/src/widgets/expression/expression.test.tsx
@@ -9,6 +9,7 @@ import {
 import * as Dependencies from "../../dependencies";
 import {scorePerseusItem} from "../../renderer-util";
 import {mockStrings} from "../../strings";
+import {scorePerseusItemTesting} from "../../util/test-utils";
 import {renderQuestion} from "../__testutils__/renderQuestion";
 
 import ExpressionWidgetExport from "./expression";
@@ -50,7 +51,11 @@ const assertCorrect = async (
         input,
         true,
     );
-    expect(renderer).toHaveBeenAnsweredCorrectly();
+    const score = scorePerseusItemTesting(
+        itemData.question,
+        renderer.getUserInputMap(),
+    );
+    expect(score).toHaveBeenAnsweredCorrectly();
 };
 
 const assertIncorrect = async (
@@ -64,7 +69,11 @@ const assertIncorrect = async (
         input,
         false,
     );
-    expect(renderer).toHaveBeenAnsweredIncorrectly();
+    const score = scorePerseusItemTesting(
+        itemData.question,
+        renderer.getUserInputMap(),
+    );
+    expect(score).toHaveBeenAnsweredIncorrectly();
 };
 
 // TODO: actually Assert that message is being set on the score object.
@@ -80,7 +89,11 @@ const assertInvalid = async (
         await userEvent.type(screen.getByRole("textbox"), input);
     }
     act(() => jest.runOnlyPendingTimers());
-    expect(renderer).toHaveInvalidInput();
+    const score = scorePerseusItemTesting(
+        itemData.question,
+        renderer.getUserInputMap(),
+    );
+    expect(score).toHaveInvalidInput();
 };
 
 describe("Expression Widget", function () {

--- a/packages/perseus/src/widgets/graded-group/graded-group.test.ts
+++ b/packages/perseus/src/widgets/graded-group/graded-group.test.ts
@@ -14,9 +14,7 @@ import type {UserEvent} from "@testing-library/user-event";
 const checkAnswer = async (
     userEvent: ReturnType<(typeof userEventLib)["setup"]>,
 ) => {
-    // NOTE(jeremy): The graded-group widget does not participate in
-    // Renderer grading. So we can't call `renderer.score()` and see that
-    // the widget is answered correctly. The only route to check the answer
+    // NOTE(jeremy): The only route to check the answer
     // is to use the "Check" button that is embedded _inside_ the widget.
     await userEvent.click(screen.getByRole("button", {name: "Check"}));
 };

--- a/packages/perseus/src/widgets/grapher/grapher.cypress.ts
+++ b/packages/perseus/src/widgets/grapher/grapher.cypress.ts
@@ -1,6 +1,7 @@
 import renderQuestionWithCypress from "../../../../../testing/render-question-with-cypress";
 import {cypressTestDependencies} from "../../../../../testing/test-dependencies";
 import * as Perseus from "../../index";
+import {scorePerseusItemTesting} from "../../util/test-utils";
 
 import {
     absoluteValueQuestion,
@@ -55,8 +56,12 @@ describe("Grapher widget", () => {
 
             // Assert
             cy.then(() => {
-                const state = getRenderer().guessAndScore();
-                expect(state[1]).toStrictEqual({
+                const userInput = getRenderer().getUserInputMap();
+                const score = scorePerseusItemTesting(
+                    absoluteValueQuestion,
+                    userInput,
+                );
+                expect(score).toStrictEqual({
                     type: "points",
                     earned: 1,
                     total: 1,
@@ -90,8 +95,12 @@ describe("Grapher widget", () => {
 
             // Assert
             cy.then(() => {
-                const state = getRenderer().guessAndScore();
-                expect(state[1]).toStrictEqual({
+                const userInput = getRenderer().getUserInputMap();
+                const score = scorePerseusItemTesting(
+                    absoluteValueQuestion,
+                    userInput,
+                );
+                expect(score).toStrictEqual({
                     type: "points",
                     earned: 0,
                     total: 1,
@@ -132,8 +141,12 @@ describe("Grapher widget", () => {
 
             // Assert
             cy.then(() => {
-                const state = getRenderer().guessAndScore();
-                expect(state[1]).toStrictEqual({
+                const userInput = getRenderer().getUserInputMap();
+                const score = scorePerseusItemTesting(
+                    exponentialQuestion,
+                    userInput,
+                );
+                expect(score).toStrictEqual({
                     type: "points",
                     earned: 1,
                     total: 1,
@@ -170,8 +183,12 @@ describe("Grapher widget", () => {
 
             // Assert
             cy.then(() => {
-                const state = getRenderer().guessAndScore();
-                expect(state[1]).toStrictEqual({
+                const userInput = getRenderer().getUserInputMap();
+                const score = scorePerseusItemTesting(
+                    exponentialQuestion,
+                    userInput,
+                );
+                expect(score).toStrictEqual({
                     type: "points",
                     earned: 0,
                     total: 1,
@@ -205,8 +222,12 @@ describe("Grapher widget", () => {
 
             // Assert
             cy.then(() => {
-                const state = getRenderer().guessAndScore();
-                expect(state[1]).toStrictEqual({
+                const userInput = getRenderer().getUserInputMap();
+                const score = scorePerseusItemTesting(
+                    linearQuestion,
+                    userInput,
+                );
+                expect(score).toStrictEqual({
                     type: "points",
                     earned: 1,
                     total: 1,
@@ -238,8 +259,12 @@ describe("Grapher widget", () => {
 
             // Assert
             cy.then(() => {
-                const state = getRenderer().guessAndScore();
-                expect(state[1]).toStrictEqual({
+                const userInput = getRenderer().getUserInputMap();
+                const score = scorePerseusItemTesting(
+                    linearQuestion,
+                    userInput,
+                );
+                expect(score).toStrictEqual({
                     type: "points",
                     earned: 0,
                     total: 1,
@@ -290,8 +315,12 @@ describe("Grapher widget", () => {
 
             // Assert
             cy.then(() => {
-                const state = getRenderer().guessAndScore();
-                expect(state[1]).toStrictEqual({
+                const userInput = getRenderer().getUserInputMap();
+                const score = scorePerseusItemTesting(
+                    logarithmQuestion,
+                    userInput,
+                );
+                expect(score).toStrictEqual({
                     type: "points",
                     earned: 1,
                     total: 1,
@@ -340,8 +369,12 @@ describe("Grapher widget", () => {
 
             // Assert
             cy.then(() => {
-                const state = getRenderer().guessAndScore();
-                expect(state[1]).toStrictEqual({
+                const userInput = getRenderer().getUserInputMap();
+                const score = scorePerseusItemTesting(
+                    logarithmQuestion,
+                    userInput,
+                );
+                expect(score).toStrictEqual({
                     type: "points",
                     earned: 0,
                     total: 1,
@@ -377,8 +410,12 @@ describe("Grapher widget", () => {
 
             // Assert
             cy.then(() => {
-                const state = getRenderer().guessAndScore();
-                expect(state[1]).toStrictEqual({
+                const userInput = getRenderer().getUserInputMap();
+                const score = scorePerseusItemTesting(
+                    quadraticQuestion,
+                    userInput,
+                );
+                expect(score).toStrictEqual({
                     type: "points",
                     earned: 1,
                     total: 1,
@@ -412,8 +449,12 @@ describe("Grapher widget", () => {
 
             // Assert
             cy.then(() => {
-                const state = getRenderer().guessAndScore();
-                expect(state[1]).toStrictEqual({
+                const userInput = getRenderer().getUserInputMap();
+                const score = scorePerseusItemTesting(
+                    quadraticQuestion,
+                    userInput,
+                );
+                expect(score).toStrictEqual({
                     type: "points",
                     earned: 0,
                     total: 1,
@@ -448,8 +489,12 @@ describe("Grapher widget", () => {
 
             // Assert
             cy.then(() => {
-                const state = getRenderer().guessAndScore();
-                expect(state[1]).toStrictEqual({
+                const userInput = getRenderer().getUserInputMap();
+                const score = scorePerseusItemTesting(
+                    sinusoidQuestion,
+                    userInput,
+                );
+                expect(score).toStrictEqual({
                     type: "points",
                     earned: 1,
                     total: 1,
@@ -482,8 +527,12 @@ describe("Grapher widget", () => {
 
             // Assert
             cy.then(() => {
-                const state = getRenderer().guessAndScore();
-                expect(state[1]).toStrictEqual({
+                const userInput = getRenderer().getUserInputMap();
+                const score = scorePerseusItemTesting(
+                    sinusoidQuestion,
+                    userInput,
+                );
+                expect(score).toStrictEqual({
                     type: "points",
                     earned: 0,
                     total: 1,
@@ -524,8 +573,12 @@ describe("Grapher widget", () => {
 
             // Assert
             cy.then(() => {
-                const state = getRenderer().guessAndScore();
-                expect(state[1]).toStrictEqual({
+                const userInput = getRenderer().getUserInputMap();
+                const score = scorePerseusItemTesting(
+                    multipleAvailableTypesQuestion,
+                    userInput,
+                );
+                expect(score).toStrictEqual({
                     type: "points",
                     earned: 1,
                     total: 1,
@@ -564,8 +617,12 @@ describe("Grapher widget", () => {
 
             // Assert
             cy.then(() => {
-                const state = getRenderer().guessAndScore();
-                expect(state[1]).toStrictEqual({
+                const userInput = getRenderer().getUserInputMap();
+                const score = scorePerseusItemTesting(
+                    multipleAvailableTypesQuestion,
+                    userInput,
+                );
+                expect(score).toStrictEqual({
                     type: "points",
                     earned: 0,
                     total: 1,

--- a/packages/perseus/src/widgets/image/image.test.ts
+++ b/packages/perseus/src/widgets/image/image.test.ts
@@ -2,6 +2,7 @@ import {describe, beforeEach, it} from "@jest/globals";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
+import {scorePerseusItemTesting} from "../../util/test-utils";
 import {isAccessible} from "../../widgets";
 import {renderQuestion} from "../__testutils__/renderQuestion";
 
@@ -33,9 +34,13 @@ describe.each([true, false])("image widget - isMobile %b", (isMobile) => {
 
         // Act
         const {renderer} = renderQuestion(question, apiOptions);
+        const score = scorePerseusItemTesting(
+            question,
+            renderer.getUserInputMap(),
+        );
 
         // Assert
-        expect(renderer).toHaveBeenAnsweredIncorrectly();
+        expect(score).toHaveBeenAnsweredIncorrectly();
     });
 
     it("should be accessible if background has 'alt' prop", () => {

--- a/packages/perseus/src/widgets/input-number/input-number.test.ts
+++ b/packages/perseus/src/widgets/input-number/input-number.test.ts
@@ -9,6 +9,7 @@ import _ from "underscore";
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
 import {mockStrings} from "../../strings";
+import {scorePerseusItemTesting} from "../../util/test-utils";
 import {renderQuestion} from "../__testutils__/renderQuestion";
 
 import InputNumber from "./input-number";
@@ -50,9 +51,13 @@ describe("input-number", function () {
             const textbox = screen.getByRole("textbox");
             await userEvent.click(textbox);
             await userEvent.type(textbox, "1/2");
+            const score = scorePerseusItemTesting(
+                question,
+                renderer.getUserInputMap(),
+            );
 
             // Assert
-            expect(renderer).toHaveBeenAnsweredCorrectly();
+            expect(score).toHaveBeenAnsweredCorrectly();
         });
 
         it("should reject an incorrect answer", async () => {
@@ -63,9 +68,13 @@ describe("input-number", function () {
             const textbox = screen.getByRole("textbox");
             await userEvent.click(textbox);
             await userEvent.type(textbox, "0.7");
+            const score = scorePerseusItemTesting(
+                question,
+                renderer.getUserInputMap(),
+            );
 
             // Assert
-            expect(renderer).toHaveBeenAnsweredIncorrectly();
+            expect(score).toHaveBeenAnsweredIncorrectly();
         });
 
         it("should refuse to score an incoherent answer", async () => {
@@ -76,9 +85,13 @@ describe("input-number", function () {
             const textbox = screen.getByRole("textbox");
             await userEvent.click(textbox);
             await userEvent.type(textbox, "0..7");
+            const score = scorePerseusItemTesting(
+                question,
+                renderer.getUserInputMap(),
+            );
 
             // Assert
-            expect(renderer).toHaveInvalidInput();
+            expect(score).toHaveInvalidInput();
         });
     });
 
@@ -206,9 +219,13 @@ describe("input-number", function () {
             const textbox = screen.getByRole("textbox");
             await userEvent.click(textbox);
             await userEvent.type(textbox, correct);
+            const score = scorePerseusItemTesting(
+                question,
+                renderer.getUserInputMap(),
+            );
 
             // Assert
-            expect(renderer).toHaveBeenAnsweredCorrectly();
+            expect(score).toHaveBeenAnsweredCorrectly();
         });
 
         it("should reject an incorrect answer", async () => {
@@ -219,9 +236,13 @@ describe("input-number", function () {
             const textbox = screen.getByRole("textbox");
             await userEvent.click(textbox);
             await userEvent.type(textbox, incorrect);
+            const score = scorePerseusItemTesting(
+                question,
+                renderer.getUserInputMap(),
+            );
 
             // Assert
-            expect(renderer).toHaveBeenAnsweredIncorrectly();
+            expect(score).toHaveBeenAnsweredIncorrectly();
         });
     });
 

--- a/packages/perseus/src/widgets/interaction/interaction.test.ts
+++ b/packages/perseus/src/widgets/interaction/interaction.test.ts
@@ -1,6 +1,7 @@
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import {waitForInitialGraphieRender} from "../../../../../testing/wait";
 import * as Dependencies from "../../dependencies";
+import {scorePerseusItemTesting} from "../../util/test-utils";
 import {renderQuestion} from "../__testutils__/renderQuestion";
 
 import {question1} from "./interaction.testdata";
@@ -22,13 +23,19 @@ describe("interaction widget", () => {
     });
 
     it("should be unanswerable", async () => {
-        // Arrange/Act
+        // Arrange
         const {renderer} = renderQuestion(question1);
         await waitForInitialGraphieRender();
+
+        // Act
+        const score = scorePerseusItemTesting(
+            question1,
+            renderer.getUserInputMap(),
+        );
 
         // Assert
         // Note that this widget can never be answered correctly, no matter
         // what state its in.
-        expect(renderer).toHaveBeenAnsweredIncorrectly();
+        expect(score).toHaveBeenAnsweredIncorrectly();
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
@@ -13,6 +13,7 @@ import {getDefaultFigureForType} from "../../../../perseus-editor/src/widgets/in
 import * as Dependencies from "../../dependencies";
 import {ApiOptions} from "../../perseus-api";
 import {lockedFigureColors} from "../../perseus-types";
+import {scorePerseusItemTesting} from "../../util/test-utils";
 import {renderQuestion} from "../__testutils__/renderQuestion";
 import {sinusoidQuestion} from "../grapher/grapher.testdata";
 
@@ -107,9 +108,13 @@ describe("interactive-graph widget", function () {
                     ),
                 );
                 await waitForInitialGraphieRender();
+                const score = scorePerseusItemTesting(
+                    question,
+                    renderer.getUserInputMap(),
+                );
 
                 // Assert
-                expect(renderer).toHaveBeenAnsweredCorrectly();
+                expect(score).toHaveBeenAnsweredCorrectly();
             });
 
             it("Should render predictably", async () => {
@@ -140,9 +145,13 @@ describe("interactive-graph widget", function () {
 
                 // Act
                 await waitForInitialGraphieRender();
+                const score = scorePerseusItemTesting(
+                    question,
+                    renderer.getUserInputMap(),
+                );
 
                 // Assert
-                expect(renderer).toHaveInvalidInput();
+                expect(score).toHaveInvalidInput();
             });
 
             it("should reject an incorrect answer", async () => {
@@ -158,9 +167,13 @@ describe("interactive-graph widget", function () {
                     ),
                 );
                 await waitForInitialGraphieRender();
+                const score = scorePerseusItemTesting(
+                    question,
+                    renderer.getUserInputMap(),
+                );
 
                 // Assert
-                expect(renderer).toHaveBeenAnsweredIncorrectly();
+                expect(score).toHaveBeenAnsweredIncorrectly();
             });
         },
     );
@@ -180,8 +193,12 @@ describe("interactive-graph widget", function () {
                 .withNoInteractiveFigure()
                 .build();
             const {renderer} = renderQuestion(question, blankOptions);
+            const score = scorePerseusItemTesting(
+                question,
+                renderer.getUserInputMap(),
+            );
 
-            expect(renderer).toHaveBeenAnsweredCorrectly({
+            expect(score).toHaveBeenAnsweredCorrectly({
                 shouldHavePoints: false,
             });
         });
@@ -247,10 +264,13 @@ describe("a mafs graph", () => {
                 const {renderer} = renderQuestion(question, apiOptions);
 
                 // Act
-                // no action
+                const score = scorePerseusItemTesting(
+                    question,
+                    renderer.getUserInputMap(),
+                );
 
                 // Assert
-                expect(renderer).toHaveInvalidInput();
+                expect(score).toHaveInvalidInput();
             });
         },
     );
@@ -277,7 +297,11 @@ describe("a mafs graph", () => {
                 // Assert
                 await waitFor(
                     () => {
-                        expect(renderer).toHaveBeenAnsweredIncorrectly();
+                        const score = scorePerseusItemTesting(
+                            question,
+                            renderer.getUserInputMap(),
+                        );
+                        expect(score).toHaveBeenAnsweredIncorrectly();
                     },
                     {timeout: 5000},
                 );
@@ -297,7 +321,11 @@ describe("a mafs graph", () => {
                 // Assert
                 await waitFor(
                     () => {
-                        expect(renderer).toHaveBeenAnsweredCorrectly();
+                        const score = scorePerseusItemTesting(
+                            question,
+                            renderer.getUserInputMap(),
+                        );
+                        expect(score).toHaveBeenAnsweredCorrectly();
                     },
                     {timeout: 5000},
                 );
@@ -317,7 +345,11 @@ describe("a mafs graph", () => {
                 // Assert
                 await waitFor(
                     () => {
-                        expect(renderer).toHaveInvalidInput();
+                        const score = scorePerseusItemTesting(
+                            question,
+                            renderer.getUserInputMap(),
+                        );
+                        expect(score).toHaveInvalidInput();
                     },
                     {timeout: 5000},
                 );

--- a/packages/perseus/src/widgets/matcher/matcher.test.tsx
+++ b/packages/perseus/src/widgets/matcher/matcher.test.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import {wait} from "../../../../../testing/wait";
 import * as Dependencies from "../../dependencies";
+import {scorePerseusItemTesting} from "../../util/test-utils";
 import {renderQuestion} from "../__testutils__/renderQuestion";
 
 import {question1} from "./matcher.testdata";
@@ -119,9 +120,13 @@ describe("matcher widget", () => {
         ].forEach((option, index) => {
             act(() => matcher.moveRightOptionToIndex(option, 4));
         });
+        const score = scorePerseusItemTesting(
+            question1,
+            renderer.getUserInputMap(),
+        );
 
         // assert
-        expect(renderer).toHaveBeenAnsweredCorrectly();
+        expect(score).toHaveBeenAnsweredCorrectly();
     });
 
     it("can be answered incorrectly", async () => {
@@ -145,9 +150,13 @@ describe("matcher widget", () => {
         ].forEach((option, index) => {
             matcher.moveLeftOptionToIndex(option, 0);
         });
+        const score = scorePerseusItemTesting(
+            question1,
+            renderer.getUserInputMap(),
+        );
 
         // Assert
-        expect(renderer).toHaveBeenAnsweredIncorrectly();
+        expect(score).toHaveBeenAnsweredIncorrectly();
     });
 
     it("is scored incorrect if the math renderer hasn't loaded yet", () => {
@@ -165,8 +174,12 @@ describe("matcher widget", () => {
             isMobile: false,
         };
         const {renderer} = renderQuestion(question1, apiOptions);
+        const score = scorePerseusItemTesting(
+            question1,
+            renderer.getUserInputMap(),
+        );
 
         // Assert
-        expect(renderer).toHaveBeenAnsweredIncorrectly();
+        expect(score).toHaveBeenAnsweredIncorrectly();
     });
 });

--- a/packages/perseus/src/widgets/matrix/matrix.test.ts
+++ b/packages/perseus/src/widgets/matrix/matrix.test.ts
@@ -3,6 +3,7 @@ import {userEvent as userEventLib} from "@testing-library/user-event";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
+import {scorePerseusItemTesting} from "../../util/test-utils";
 import {renderQuestion} from "../__testutils__/renderQuestion";
 
 import {question1} from "./matrix.testdata";
@@ -61,9 +62,13 @@ describe("matrix widget", () => {
         for (let i = 0; i < textboxes.length; i++) {
             await userEvent.type(textboxes[i], correctAnswers[i].toString());
         }
+        const score = scorePerseusItemTesting(
+            question1,
+            renderer.getUserInputMap(),
+        );
 
         // assert
-        expect(renderer).toHaveBeenAnsweredCorrectly();
+        expect(score).toHaveBeenAnsweredCorrectly();
     });
 
     it("can be answered incorrectly", async () => {
@@ -78,8 +83,12 @@ describe("matrix widget", () => {
         for (let i = 0; i < textboxes.length; i++) {
             await userEvent.type(textboxes[i], "1");
         }
+        const score = scorePerseusItemTesting(
+            question1,
+            renderer.getUserInputMap(),
+        );
 
         // Assert
-        expect(renderer).toHaveBeenAnsweredIncorrectly();
+        expect(score).toHaveBeenAnsweredIncorrectly();
     });
 });

--- a/packages/perseus/src/widgets/number-line/number-line.test.ts
+++ b/packages/perseus/src/widgets/number-line/number-line.test.ts
@@ -2,6 +2,7 @@ import {act} from "@testing-library/react";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
+import {scorePerseusItemTesting} from "../../util/test-utils";
 import {renderQuestion} from "../__testutils__/renderQuestion";
 
 import {question1} from "./number-line.testdata";
@@ -192,9 +193,13 @@ describe("number-line widget", () => {
         // Act
         const [numberLine] = renderer.findWidgets("number-line 1");
         act(() => numberLine.movePosition(-2.5));
+        const score = scorePerseusItemTesting(
+            question1,
+            renderer.getUserInputMap(),
+        );
 
         // assert
-        expect(renderer).toHaveBeenAnsweredCorrectly();
+        expect(score).toHaveBeenAnsweredCorrectly();
     });
 
     it("can be answered incorrectly", () => {
@@ -207,8 +212,12 @@ describe("number-line widget", () => {
         // Act
         const [numberLine] = renderer.findWidgets("number-line 1");
         act(() => numberLine.movePosition(3.5));
+        const score = scorePerseusItemTesting(
+            question1,
+            renderer.getUserInputMap(),
+        );
 
         // Assert
-        expect(renderer).toHaveBeenAnsweredIncorrectly();
+        expect(score).toHaveBeenAnsweredIncorrectly();
     });
 });

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
@@ -3,6 +3,7 @@ import {userEvent as userEventLib} from "@testing-library/user-event";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
+import {scorePerseusItemTesting} from "../../util/test-utils";
 import {renderQuestion} from "../__testutils__/renderQuestion";
 
 import NumericInputWidgetExport, {unionAnswerForms} from "./numeric-input";
@@ -42,9 +43,13 @@ describe("numeric-input widget", () => {
             screen.getByRole("textbox", {hidden: true}),
             correct,
         );
+        const score = scorePerseusItemTesting(
+            question,
+            renderer.getUserInputMap(),
+        );
 
         // Assert
-        expect(renderer).toHaveBeenAnsweredCorrectly();
+        expect(score).toHaveBeenAnsweredCorrectly();
     });
 
     it("should reject an incorrect answer", async () => {
@@ -56,9 +61,13 @@ describe("numeric-input widget", () => {
             screen.getByRole("textbox", {hidden: true}),
             incorrect,
         );
+        const score = scorePerseusItemTesting(
+            question,
+            renderer.getUserInputMap(),
+        );
 
         // Assert
-        expect(renderer).toHaveBeenAnsweredIncorrectly();
+        expect(score).toHaveBeenAnsweredIncorrectly();
     });
 
     it("Should render predictably", async () => {
@@ -233,9 +242,13 @@ describe("Numeric input widget", () => {
 
         // Act
         await userEvent.type(screen.getByRole("textbox", {hidden: true}), "1");
+        const score = scorePerseusItemTesting(
+            multipleAnswers,
+            renderer.getUserInputMap(),
+        );
 
         // Assert
-        expect(renderer).toHaveBeenAnsweredCorrectly();
+        expect(score).toHaveBeenAnsweredCorrectly();
     });
 
     it("can handle multiple correct answers (Part two)", async () => {
@@ -244,9 +257,13 @@ describe("Numeric input widget", () => {
 
         // Act
         await userEvent.type(screen.getByRole("textbox", {hidden: true}), "2");
+        const score = scorePerseusItemTesting(
+            multipleAnswers,
+            renderer.getUserInputMap(),
+        );
 
         // Assert
-        expect(renderer).toHaveBeenAnsweredCorrectly();
+        expect(score).toHaveBeenAnsweredCorrectly();
     });
 
     it("can handle duplicated answers", async () => {
@@ -258,9 +275,13 @@ describe("Numeric input widget", () => {
             screen.getByRole("textbox", {hidden: true}),
             "2.4",
         );
+        const score = scorePerseusItemTesting(
+            duplicatedAnswers,
+            renderer.getUserInputMap(),
+        );
 
         // Assert
-        expect(renderer).toHaveBeenAnsweredCorrectly();
+        expect(score).toHaveBeenAnsweredCorrectly();
     });
 
     it("can handle coefficients", async () => {
@@ -272,9 +293,13 @@ describe("Numeric input widget", () => {
             screen.getByRole("textbox", {hidden: true}),
             "1.0",
         );
+        const score = scorePerseusItemTesting(
+            withCoefficient,
+            renderer.getUserInputMap(),
+        );
 
         // Assert
-        expect(renderer).toHaveBeenAnsweredCorrectly();
+        expect(score).toHaveBeenAnsweredCorrectly();
     });
 
     it("handles answers that are percentages", async () => {
@@ -286,9 +311,13 @@ describe("Numeric input widget", () => {
             screen.getByRole("textbox", {hidden: true}),
             "33%",
         );
+        const score = scorePerseusItemTesting(
+            percentageProblem,
+            renderer.getUserInputMap(),
+        );
 
         // Assert
-        expect(renderer).toHaveBeenAnsweredCorrectly();
+        expect(score).toHaveBeenAnsweredCorrectly();
     });
 
     it("handles answers that are decimals", async () => {
@@ -300,9 +329,13 @@ describe("Numeric input widget", () => {
             screen.getByRole("textbox", {hidden: true}),
             "12.2",
         );
+        const score = scorePerseusItemTesting(
+            multipleAnswersWithDecimals,
+            renderer.getUserInputMap(),
+        );
 
         // Assert
-        expect(renderer).toHaveBeenAnsweredCorrectly();
+        expect(score).toHaveBeenAnsweredCorrectly();
     });
 
     it("styles differently on mobile", () => {

--- a/packages/perseus/src/widgets/orderer/orderer.test.ts
+++ b/packages/perseus/src/widgets/orderer/orderer.test.ts
@@ -2,6 +2,7 @@ import {act} from "@testing-library/react";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
+import {scorePerseusItemTesting} from "../../util/test-utils";
 import {renderQuestion} from "../__testutils__/renderQuestion";
 
 import {question2} from "./orderer.testdata";
@@ -51,9 +52,13 @@ describe("orderer widget", () => {
 
         // Act
         act(() => orderer.setListValues(["1", "2", "3"]));
+        const score = scorePerseusItemTesting(
+            question2,
+            renderer.getUserInputMap(),
+        );
 
         // assert
-        expect(renderer).toHaveBeenAnsweredCorrectly();
+        expect(score).toHaveBeenAnsweredCorrectly();
     });
 
     it("can be answered incorrectly", () => {
@@ -66,9 +71,13 @@ describe("orderer widget", () => {
 
         // Act
         act(() => orderer.setListValues(["3", "2", "1"]));
+        const score = scorePerseusItemTesting(
+            question2,
+            renderer.getUserInputMap(),
+        );
 
         // assert
-        expect(renderer).toHaveBeenAnsweredIncorrectly();
+        expect(score).toHaveBeenAnsweredIncorrectly();
     });
 
     it("is invalid when no options are selected", () => {
@@ -81,8 +90,12 @@ describe("orderer widget", () => {
 
         // Act
         act(() => orderer.setListValues([]));
+        const score = scorePerseusItemTesting(
+            question2,
+            renderer.getUserInputMap(),
+        );
 
         // assert
-        expect(renderer).toHaveInvalidInput();
+        expect(score).toHaveInvalidInput();
     });
 });

--- a/packages/perseus/src/widgets/passage-ref/passage-ref.test.ts
+++ b/packages/perseus/src/widgets/passage-ref/passage-ref.test.ts
@@ -2,6 +2,7 @@ import {act, screen} from "@testing-library/react";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
+import {scorePerseusItemTesting} from "../../util/test-utils";
 import {renderQuestion} from "../__testutils__/renderQuestion";
 import PassageExport from "../passage";
 
@@ -160,8 +161,12 @@ describe("passage-ref widget", () => {
         // Act
         const {renderer} = renderQuestion(question1);
         act(() => jest.runOnlyPendingTimers());
+        const score = scorePerseusItemTesting(
+            question1,
+            renderer.getUserInputMap(),
+        );
 
         // Assert
-        expect(renderer).toHaveBeenAnsweredIncorrectly();
+        expect(score).toHaveBeenAnsweredIncorrectly();
     });
 });

--- a/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
@@ -6,6 +6,7 @@ import {clone} from "../../../../../../testing/object-utils";
 import {testDependencies} from "../../../../../../testing/test-dependencies";
 import * as Dependencies from "../../../dependencies";
 import {mockStrings} from "../../../strings";
+import {scorePerseusItemTesting} from "../../../util/test-utils";
 import {renderQuestion} from "../../__testutils__/renderQuestion";
 import PassageWidget from "../../passage";
 import RadioWidgetExport from "../radio";
@@ -99,9 +100,13 @@ describe("single-choice question", () => {
 
                 // Act
                 await selectOption(userEvent, correct);
+                const score = scorePerseusItemTesting(
+                    question,
+                    renderer.getUserInputMap(),
+                );
 
                 // Assert
-                expect(renderer).toHaveBeenAnsweredCorrectly();
+                expect(score).toHaveBeenAnsweredCorrectly();
             });
 
             it("should accept the right answer (touch)", async () => {
@@ -117,9 +122,13 @@ describe("single-choice question", () => {
                 // does not support touch events so we have to do this ourselves.
                 // eslint-disable-next-line testing-library/prefer-user-event
                 fireEvent.click(correctRadio);
+                const score = scorePerseusItemTesting(
+                    question,
+                    renderer.getUserInputMap(),
+                );
 
                 // Assert
-                expect(renderer).toHaveBeenAnsweredCorrectly();
+                expect(score).toHaveBeenAnsweredCorrectly();
             });
 
             it.each(incorrect)(
@@ -130,9 +139,13 @@ describe("single-choice question", () => {
 
                     // Act
                     await selectOption(userEvent, incorrect);
+                    const score = scorePerseusItemTesting(
+                        question,
+                        renderer.getUserInputMap(),
+                    );
 
                     // Assert
-                    expect(renderer).toHaveBeenAnsweredIncorrectly();
+                    expect(score).toHaveBeenAnsweredIncorrectly();
                 },
             );
 
@@ -281,12 +294,13 @@ describe("single-choice question", () => {
         // item in the original choices. But because of enforced ordering,
         // it is now at the top of the list (and thus our correct answer).
         await userEvent.click(screen.getAllByRole("radio")[0]);
+        const score = scorePerseusItemTesting(q, renderer.getUserInputMap());
 
         // Assert
         const items = screen.getAllByRole("listitem");
         expect(items[0]).toHaveTextContent(answers[1]);
         expect(items[1]).toHaveTextContent(answers[0]);
-        expect(renderer).toHaveBeenAnsweredCorrectly();
+        expect(score).toHaveBeenAnsweredCorrectly();
     });
 
     it("should not change ordering of non-common answers", async () => {
@@ -568,9 +582,13 @@ describe("single-choice question", () => {
 
         // Act
         const {renderer} = renderQuestion(question, apiOptions);
+        const score = scorePerseusItemTesting(
+            question,
+            renderer.getUserInputMap(),
+        );
 
         // Assert
-        expect(renderer).toHaveInvalidInput();
+        expect(score).toHaveInvalidInput();
     });
 
     it("Should render correct option select statuses (rationales) when review mode enabled", async () => {
@@ -649,9 +667,10 @@ describe("single-choice question", () => {
             name: "(Choice D) None of the above",
         });
         await userEvent.click(noneOption);
+        const score = scorePerseusItemTesting(q, renderer.getUserInputMap());
 
         // Assert
-        expect(renderer).toHaveBeenAnsweredCorrectly();
+        expect(score).toHaveBeenAnsweredCorrectly();
     });
 });
 
@@ -681,9 +700,13 @@ describe("multi-choice question", () => {
         for (const i of correct) {
             await userEvent.click(options[i]);
         }
+        const score = scorePerseusItemTesting(
+            question,
+            renderer.getUserInputMap(),
+        );
 
         // Assert
-        expect(renderer).toHaveBeenAnsweredCorrectly();
+        expect(score).toHaveBeenAnsweredCorrectly();
     });
 
     it("should select multiple options when clicked", async () => {
@@ -796,9 +819,13 @@ describe("multi-choice question", () => {
 
         // Act
         const {renderer} = renderQuestion(question, apiOptions);
+        const score = scorePerseusItemTesting(
+            question,
+            renderer.getUserInputMap(),
+        );
 
         // Assert
-        expect(renderer).toHaveInvalidInput();
+        expect(score).toHaveInvalidInput();
     });
 
     it("should be invalid when incorrect number of choices selected", async () => {
@@ -842,9 +869,13 @@ describe("multi-choice question", () => {
         await userEvent.click(option[0]); // correct
         await userEvent.click(option[1]); // correct
         await userEvent.click(option[2]); // incorrect
+        const score = scorePerseusItemTesting(
+            multipleCorrectChoicesQuestion,
+            renderer.getUserInputMap(),
+        );
 
         // Assert
-        expect(renderer).toHaveInvalidInput(
+        expect(score).toHaveInvalidInput(
             "Please choose the correct number of answers",
         );
     });
@@ -860,9 +891,13 @@ describe("multi-choice question", () => {
             for (let i = 0; i < choices.length; i++) {
                 await userEvent.click(option[i]);
             }
+            const score = scorePerseusItemTesting(
+                question,
+                renderer.getUserInputMap(),
+            );
 
             // Assert
-            expect(renderer).toHaveBeenAnsweredIncorrectly();
+            expect(score).toHaveBeenAnsweredIncorrectly();
         },
     );
 
@@ -877,9 +912,13 @@ describe("multi-choice question", () => {
             for (const i of choices) {
                 await userEvent.click(option[i]);
             }
+            const score = scorePerseusItemTesting(
+                question,
+                renderer.getUserInputMap(),
+            );
 
             // Assert
-            expect(renderer).toHaveInvalidInput();
+            expect(score).toHaveInvalidInput();
         },
     );
 });
@@ -912,11 +951,15 @@ describe("scoring", () => {
 
         const userInput = renderer.getUserInput()[0] as PerseusRadioUserInput;
         const rubric = shuffledQuestion.widgets["radio 1"].options;
-        const score = scoreRadio(userInput, rubric, mockStrings);
+        const widgetScore = scoreRadio(userInput, rubric, mockStrings);
+        const rendererScore = scorePerseusItemTesting(
+            shuffledQuestion,
+            renderer.getUserInputMap(),
+        );
 
         // Assert
-        expect(score).toHaveBeenAnsweredCorrectly();
-        expect(renderer).toHaveBeenAnsweredCorrectly();
+        expect(widgetScore).toHaveBeenAnsweredCorrectly();
+        expect(rendererScore).toHaveBeenAnsweredCorrectly();
     });
 
     /**
@@ -935,11 +978,15 @@ describe("scoring", () => {
 
         const userInput = renderer.getUserInput()[0] as PerseusRadioUserInput;
         const rubric = shuffledQuestion.widgets["radio 1"].options;
-        const score = scoreRadio(userInput, rubric, mockStrings);
+        const widgetScore = scoreRadio(userInput, rubric, mockStrings);
+        const rendererScore = scorePerseusItemTesting(
+            shuffledQuestion,
+            renderer.getUserInputMap(),
+        );
 
         // Assert
-        expect(score).toHaveBeenAnsweredIncorrectly();
-        expect(renderer).toHaveBeenAnsweredIncorrectly();
+        expect(widgetScore).toHaveBeenAnsweredIncorrectly();
+        expect(rendererScore).toHaveBeenAnsweredIncorrectly();
     });
 
     /**
@@ -958,11 +1005,15 @@ describe("scoring", () => {
 
         const userInput = renderer.getUserInput()[0] as PerseusRadioUserInput;
         const rubric = shuffledNoneQuestion.widgets["radio 1"].options;
-        const score = scoreRadio(userInput, rubric, mockStrings);
+        const widgetScore = scoreRadio(userInput, rubric, mockStrings);
+        const rendererScore = scorePerseusItemTesting(
+            shuffledNoneQuestion,
+            renderer.getUserInputMap(),
+        );
 
         // Assert
-        expect(score).toHaveBeenAnsweredCorrectly();
-        expect(renderer).toHaveBeenAnsweredCorrectly();
+        expect(widgetScore).toHaveBeenAnsweredCorrectly();
+        expect(rendererScore).toHaveBeenAnsweredCorrectly();
     });
 
     /**
@@ -981,11 +1032,15 @@ describe("scoring", () => {
 
         const userInput = renderer.getUserInput()[0] as PerseusRadioUserInput;
         const rubric = shuffledNoneQuestion.widgets["radio 1"].options;
-        const score = scoreRadio(userInput, rubric, mockStrings);
+        const widgetScore = scoreRadio(userInput, rubric, mockStrings);
+        const rendererScore = scorePerseusItemTesting(
+            shuffledQuestion,
+            renderer.getUserInputMap(),
+        );
 
         // Assert
-        expect(score).toHaveBeenAnsweredIncorrectly();
-        expect(renderer).toHaveBeenAnsweredIncorrectly();
+        expect(widgetScore).toHaveBeenAnsweredIncorrectly();
+        expect(rendererScore).toHaveBeenAnsweredIncorrectly();
     });
 });
 


### PR DESCRIPTION
## Summary:
Remove `guessAndScore` from Renderer. This hasn't been used in learner-facing logic for a little bit now. The bulk of this PR is updating internal usage - tools for testing exercise correctness were using this (specifically in Cypress and our custom matchers for Jest); so most of the work was porting tests to use `scorePerseusItem` instead.

## Test plan:
From a learner's perspective, this is dead code. So while this is a major API change, it's mostly removing dead code and updating tests. Tests should continue to run successfully.