### PR TITLE
[Locked Figure Labels] Update placeholder to include TeX $s

### DIFF
--- a/.changeset/chilly-pigs-clean.md
+++ b/.changeset/chilly-pigs-clean.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Locked Figure Labels] Update placeholder to include TeX \$s

--- a/.changeset/chilly-pigs-clean.md
+++ b/.changeset/chilly-pigs-clean.md
@@ -2,4 +2,4 @@
 "@khanacademy/perseus-editor": patch
 ---
 
-[Locked Figure Labels] Update placeholder to include TeX \$s
+[Locked Figure Labels] Update placeholder to include TeX \$s. Start new visible labels with text "label".

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-label-settings.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-label-settings.test.tsx
@@ -146,6 +146,7 @@ describe("Locked Label Settings", () => {
             render(
                 <LockedLabelSettings
                     {...defaultProps}
+                    text=""
                     onChangeProps={onChangeProps}
                 />,
                 {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-label-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-label-settings.tsx
@@ -125,7 +125,7 @@ export default function LockedLabelSettings(props: Props) {
                     <Strut size={spacing.xSmall_8} />
                     <TextField
                         value={text}
-                        placeholder="ex. x^2 or \frac{1}{2}"
+                        placeholder="ex. $x^2$ or $\frac{1}{2}$"
                         onChange={(newValue) =>
                             onChangeProps({
                                 text: newValue,

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.test.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.test.ts
@@ -106,7 +106,7 @@ describe("getDefaultFigureForType", () => {
         expect(figure).toEqual({
             type: "label",
             coord: [0, 0],
-            text: "",
+            text: "label",
             color: "grayH",
             size: "medium",
         });

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.ts
@@ -95,7 +95,7 @@ export function getDefaultFigureForType(type: LockedFigureType): LockedFigure {
             return {
                 type: "label",
                 coord: [0, 0],
-                text: "",
+                text: "label",
                 color: DEFAULT_COLOR,
                 size: "medium",
             };


### PR DESCRIPTION
## Summary:
Now that TeX needs $s around it to render as TeX,
update the placeholder in the interactive graph editor
label settings to reflect that.

While I'm here, I also updated the starting text on
the locked label settings to be "label" so that it's
easier to prevent empty labels. Charlie also expressed
that this makes it easier to tell the labels' tab orders.
The placeholder will still show up if the text is deleted.

Issue: none

## Test plan:
- http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--mafs-with-locked-figure-labels-all-flags
- Go to locked label's settings
- Clear the text field
- Confirm that the placeholder says "ex. $x^2$ or $\frac{1}{2}$"

| Before | After |
| --- | --- |
| ![Screenshot 2024-12-11 at 1 50 20 PM](https://github.com/user-attachments/assets/ffa1cbbc-77f9-4c5e-8507-e3369b92a109) | ![Screenshot 2024-12-11 at 1 50 24 PM](https://github.com/user-attachments/assets/703649b5-5a7d-4db3-b486-58821839e4c5) |
