### PR TITLE
remove combobox role from dropdown widget

### DIFF
--- a/packages/perseus/src/widgets/dropdown/dropdown.tsx
+++ b/packages/perseus/src/widgets/dropdown/dropdown.tsx
@@ -74,7 +74,7 @@ class Dropdown extends React.Component<Props> implements Widget {
                 key="placeholder"
                 value="0"
                 disabled
-                label={this.props.placeholder || " "}
+                label={this.props.placeholder}
             />,
             ...this.props.choices.map((choice, i) => (
                 <OptionItem
@@ -97,6 +97,11 @@ class Dropdown extends React.Component<Props> implements Widget {
                         onTouchStart={(e) => {
                             e.stopPropagation();
                         }}
+                        aria-label={
+                            this.props.ariaLabel ||
+                            this.props.visibleLabel ||
+                            this.context.strings.selectAnAnswer
+                        }
                     >
                         {this.props.visibleLabel && (
                             <LabelLarge
@@ -114,16 +119,6 @@ class Dropdown extends React.Component<Props> implements Widget {
                             }
                             selectedValue={String(this.props.selected)}
                             disabled={this.props.apiOptions.readOnly}
-                            aria-label={
-                                this.props.ariaLabel ||
-                                this.props.visibleLabel ||
-                                this.context.strings.selectAnAnswer
-                            }
-                            // This is currently necessary for SRs to read the labels properly.
-                            // However, WB is working on a change to add the "combobox" role to
-                            // all dropdowns.
-                            // See https://khanacademy.atlassian.net/browse/WB-1671
-                            role="combobox"
                         >
                             {children}
                         </SingleSelect>


### PR DESCRIPTION
## Summary:
This is causing tons of issues in Safari.

Issue: LIT-1490

## Test plan: