### PR TITLE
SSS: Introduce ValidationResult type so things are standardized

### DIFF
--- a/.changeset/nervous-zoos-lick.md
+++ b/.changeset/nervous-zoos-lick.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: introduce `ValidationResult` for use in validation functions

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -576,6 +576,8 @@ export type WidgetTransform = (
     problemNumber?: number,
 ) => any;
 
+export type ValidationResult = Extract<PerseusScore, {type: "invalid"}> | null;
+
 export type WidgetScorerFunction = (
     // The user data needed to score
     userInput: UserInput,

--- a/packages/perseus/src/widgets/categorizer/validate-categorizer.ts
+++ b/packages/perseus/src/widgets/categorizer/validate-categorizer.ts
@@ -1,5 +1,5 @@
 import type {PerseusStrings} from "../../strings";
-import type {PerseusScore} from "../../types";
+import type {ValidationResult} from "../../types";
 import type {
     PerseusCategorizerUserInput,
     PerseusCategorizerValidationData,
@@ -17,7 +17,7 @@ function validateCategorizer(
     userInput: PerseusCategorizerUserInput,
     validationData: PerseusCategorizerValidationData,
     strings: PerseusStrings,
-): Extract<PerseusScore, {type: "invalid"}> | null {
+): ValidationResult {
     const incomplete = validationData.items.some(
         (_, i) => userInput.values[i] == null,
     );

--- a/packages/perseus/src/widgets/dropdown/validate-dropdown.ts
+++ b/packages/perseus/src/widgets/dropdown/validate-dropdown.ts
@@ -1,4 +1,4 @@
-import type {PerseusScore} from "../../types";
+import type {ValidationResult} from "../../types";
 import type {PerseusDropdownUserInput} from "../../validation.types";
 
 /**
@@ -7,7 +7,7 @@ import type {PerseusDropdownUserInput} from "../../validation.types";
  */
 function validateDropdown(
     userInput: PerseusDropdownUserInput,
-): Extract<PerseusScore, {type: "invalid"}> | null {
+): ValidationResult {
     if (userInput.value === 0) {
         return {
             type: "invalid",

--- a/packages/perseus/src/widgets/expression/validate-expression.ts
+++ b/packages/perseus/src/widgets/expression/validate-expression.ts
@@ -1,4 +1,4 @@
-import type {PerseusScore} from "../../types";
+import type {ValidationResult} from "../../types";
 import type {PerseusExpressionUserInput} from "../../validation.types";
 
 /**
@@ -11,7 +11,7 @@ import type {PerseusExpressionUserInput} from "../../validation.types";
  */
 function validateExpression(
     userInput: PerseusExpressionUserInput,
-): Extract<PerseusScore, {type: "invalid"}> | null {
+): ValidationResult {
     if (userInput === "") {
         return {type: "invalid", message: null};
     }

--- a/packages/perseus/src/widgets/matrix/validate-matrix.ts
+++ b/packages/perseus/src/widgets/matrix/validate-matrix.ts
@@ -3,7 +3,7 @@ import _ from "underscore";
 import {getMatrixSize} from "./matrix";
 
 import type {PerseusStrings} from "../../strings";
-import type {PerseusScore} from "../../types";
+import type {ValidationResult} from "../../types";
 import type {
     PerseusMatrixUserInput,
     PerseusMatrixValidationData,
@@ -21,7 +21,7 @@ function validateMatrix(
     userInput: PerseusMatrixUserInput,
     validationData: PerseusMatrixValidationData,
     strings: PerseusStrings,
-): Extract<PerseusScore, {type: "invalid"}> | null {
+): ValidationResult {
     const supplied = userInput.answers;
     const suppliedSize = getMatrixSize(supplied);
 

--- a/packages/perseus/src/widgets/orderer/validate-orderer.ts
+++ b/packages/perseus/src/widgets/orderer/validate-orderer.ts
@@ -1,4 +1,4 @@
-import type {PerseusScore} from "../../types";
+import type {ValidationResult} from "../../types";
 import type {PerseusOrdererUserInput} from "../../validation.types";
 
 /**
@@ -7,9 +7,7 @@ import type {PerseusOrdererUserInput} from "../../validation.types";
  * @param userInput
  * @see `scoreOrderer` for more details.
  */
-function validateOrderer(
-    userInput: PerseusOrdererUserInput,
-): Extract<PerseusScore, {type: "invalid"}> | null {
+function validateOrderer(userInput: PerseusOrdererUserInput): ValidationResult {
     if (userInput.current.length === 0) {
         return {
             type: "invalid",

--- a/packages/perseus/src/widgets/plotter/validate-plotter.ts
+++ b/packages/perseus/src/widgets/plotter/validate-plotter.ts
@@ -1,6 +1,6 @@
 import Util from "../../util";
 
-import type {PerseusScore} from "../../types";
+import type {ValidationResult} from "../../types";
 import type {
     PerseusPlotterUserInput,
     PerseusPlotterValidationData,
@@ -17,7 +17,7 @@ const {deepEq} = Util;
 function validatePlotter(
     userInput: PerseusPlotterUserInput,
     validationData: PerseusPlotterValidationData,
-): Extract<PerseusScore, {type: "invalid"}> | null {
+): ValidationResult {
     if (deepEq(userInput, validationData.starting)) {
         return {
             type: "invalid",

--- a/packages/perseus/src/widgets/radio/validate-radio.ts
+++ b/packages/perseus/src/widgets/radio/validate-radio.ts
@@ -1,4 +1,4 @@
-import type {PerseusScore} from "../../types";
+import type {ValidationResult} from "../../types";
 import type {PerseusRadioUserInput} from "../../validation.types";
 
 /**
@@ -9,9 +9,7 @@ import type {PerseusRadioUserInput} from "../../validation.types";
  * @param userInput
  * @see `scoreRadio` for the additional validation logic and the scoring logic.
  */
-function validateRadio(
-    userInput: PerseusRadioUserInput,
-): Extract<PerseusScore, {type: "invalid"}> | null {
+function validateRadio(userInput: PerseusRadioUserInput): ValidationResult {
     const numSelected = userInput.choicesSelected.reduce((sum, selected) => {
         return sum + (selected ? 1 : 0);
     }, 0);

--- a/packages/perseus/src/widgets/sorter/validate-sorter.ts
+++ b/packages/perseus/src/widgets/sorter/validate-sorter.ts
@@ -1,4 +1,4 @@
-import type {PerseusScore} from "../../types";
+import type {ValidationResult} from "../../types";
 import type {PerseusSorterUserInput} from "../../validation.types";
 
 /**
@@ -8,9 +8,7 @@ import type {PerseusSorterUserInput} from "../../validation.types";
  * @see 'scoreSorter' in 'packages/perseus/src/widgets/sorter/score-sorter.ts'
  * for more details on how the sorter widget is scored.
  */
-function validateSorter(
-    userInput: PerseusSorterUserInput,
-): Extract<PerseusScore, {type: "invalid"}> | null {
+function validateSorter(userInput: PerseusSorterUserInput): ValidationResult {
     // If the sorter widget hasn't been changed yet, we treat it as "empty" which
     // prevents the "Check" button from becoming active. We want the user
     // to make a change before trying to move forward. This makes an

--- a/packages/perseus/src/widgets/table/validate-table.ts
+++ b/packages/perseus/src/widgets/table/validate-table.ts
@@ -1,11 +1,9 @@
 import {filterNonEmpty} from "./utils";
 
-import type {PerseusScore} from "../../types";
+import type {ValidationResult} from "../../types";
 import type {PerseusTableUserInput} from "../../validation.types";
 
-function validateTable(
-    userInput: PerseusTableUserInput,
-): Extract<PerseusScore, {type: "invalid"}> | null {
+function validateTable(userInput: PerseusTableUserInput): ValidationResult {
     const supplied = filterNonEmpty(userInput);
 
     const hasEmptyCell = supplied.some(function (row) {


### PR DESCRIPTION
## Summary:

This is a tiny PR to introduce a validation result which is a subset of the `PerseusScore`, but since we use it all over the validation code, it seemed useful to create a type for it. 

Issue: LEMS-2561

## Test plan:

`yarn typecheck`
`yarn test`