### PR TITLE
Remove unused rubric type for iFrame

### DIFF
--- a/.changeset/proud-ghosts-learn.md
+++ b/.changeset/proud-ghosts-learn.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Remove unused iframe rubric type

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -102,9 +102,6 @@ export type PerseusGrapherRubric = {
 
 export type PerseusGrapherUserInput = PerseusGrapherRubric["correct"];
 
-// TODO(LEMS-2440): Can possibly be removed during 2440; only userInput used
-export type PerseusIFrameRubric = Empty;
-
 export type PerseusIFrameUserInput = {
     status: UserInputStatus;
     message: string | null;
@@ -244,7 +241,6 @@ export type Rubric =
     | PerseusGradedGroupRubric
     | PerseusGradedGroupSetRubric
     | PerseusGrapherRubric
-    | PerseusIFrameRubric
     | PerseusInputNumberRubric
     | PerseusInteractiveGraphRubric
     | PerseusLabelImageRubric

--- a/packages/perseus/src/widgets/iframe/iframe.tsx
+++ b/packages/perseus/src/widgets/iframe/iframe.tsx
@@ -21,7 +21,6 @@ import {scoreIframe} from "./score-iframe";
 import type {PerseusIFrameWidgetOptions} from "../../perseus-types";
 import type {WidgetExports, WidgetProps, Widget} from "../../types";
 import type {
-    PerseusIFrameRubric,
     PerseusIFrameUserInput,
     UserInputStatus,
 } from "../../validation.types";
@@ -36,7 +35,7 @@ type RenderProps = PerseusIFrameWidgetOptions & {
     height: string;
 };
 
-type Props = WidgetProps<RenderProps, PerseusIFrameRubric>;
+type Props = WidgetProps<RenderProps>;
 
 type DefaultProps = {
     status: Props["status"];


### PR DESCRIPTION
## Summary:
The initial goal was to separate out answers from the userInput, but iFrame is a unique widget in that the answers aren't actually contained in what is sent to the scoring function. Scoring happens via the iFrame, and the scoring function is told if the user is correct, incorrect, and incomplete. It may be useful to change what this parameter is called as it is not actually the user's input either, but a summary of the results of checking the user's input. Additionally, validation happens after both types of scoring, so it most likely will not be possible to have a validation function for this widget either.

Issue: LEMS-2440

## Test plan:
- Confirm all checks pass
- Confirm widget still works as expected via a ZND (iframe tends not to be testable locally)