### PR TITLE
Remove unused rubric type for CS Program

### DIFF
--- a/.changeset/fifty-laws-hear.md
+++ b/.changeset/fifty-laws-hear.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Remove unused CS Program rubric type

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -63,12 +63,6 @@ export type PerseusCategorizerValidationData = {
     items: ReadonlyArray<string>;
 };
 
-// TODO(LEMS-2440): Can possibly be removed during 2440?
-// This is not used for grading at all. The only place it is used is to define
-// Props type in cs-program.tsx, but RenderProps already contains WidgetOptions
-// and is already included in the Props type.
-export type PerseusCSProgramRubric = Empty;
-
 export type PerseusCSProgramUserInput = {
     status: UserInputStatus;
     message: string | null;
@@ -237,7 +231,6 @@ export type PerseusTableUserInput = ReadonlyArray<ReadonlyArray<string>>;
 
 export type Rubric =
     | PerseusCategorizerScoringData
-    | PerseusCSProgramRubric
     | PerseusDropdownRubric
     | PerseusExpressionRubric
     | PerseusGroupRubric

--- a/packages/perseus/src/widgets/cs-program/cs-program.tsx
+++ b/packages/perseus/src/widgets/cs-program/cs-program.tsx
@@ -19,17 +19,14 @@ import scoreCSProgram from "./score-cs-program";
 
 import type {PerseusCSProgramWidgetOptions} from "../../perseus-types";
 import type {Widget, WidgetExports, WidgetProps} from "../../types";
-import type {
-    PerseusCSProgramRubric,
-    PerseusCSProgramUserInput,
-} from "../../validation.types";
+import type {PerseusCSProgramUserInput} from "../../validation.types";
 import type {UnsupportedWidgetPromptJSON} from "../../widget-ai-utils/unsupported-widget";
 
 const {updateQueryString} = Util;
 
 type RenderProps = PerseusCSProgramWidgetOptions & PerseusCSProgramUserInput;
 
-type Props = WidgetProps<RenderProps, PerseusCSProgramRubric>;
+type Props = WidgetProps<RenderProps>;
 
 type DefaultProps = {
     showEditor: Props["showEditor"];


### PR DESCRIPTION
## Summary:
This removes an unused rubric type. The iframe tells the widget if the user's input is correct or not, so a rubric is not needed.
Additionally, validation happens after scoring, so it won't be possible to create a validation function for this widget at this time either.

Issue: LEMS-2440

## Test plan:
- Confirm all checks pass
- Confirm widget still works as expected via a ZND (CS Program works via iFrame, which tens not to be testable locally)