### PR TITLE
SSS: Hook emptyWidgets() up to validation functions

### DIFF
--- a/.changeset/quiet-adults-look.md
+++ b/.changeset/quiet-adults-look.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Change empty widgets check in Renderer to depend only on data available (and not on scoring data)

--- a/packages/perseus/src/__testdata__/renderer.testdata.ts
+++ b/packages/perseus/src/__testdata__/renderer.testdata.ts
@@ -1,10 +1,28 @@
 import type {
     DropdownWidget,
+    ExpressionWidget,
     ImageWidget,
     NumericInputWidget,
     PerseusRenderer,
 } from "../perseus-types";
 import type {RenderProps} from "../widgets/radio";
+
+export const expressionWidget: ExpressionWidget = {
+    type: "expression",
+    options: {
+        answerForms: [
+            {
+                considered: "correct",
+                form: true,
+                simplify: true,
+                value: "1.0",
+            },
+        ],
+        buttonSets: ["basic"],
+        functions: [],
+        times: true,
+    },
+};
 
 export const dropdownWidget: DropdownWidget = {
     type: "dropdown",
@@ -94,6 +112,12 @@ export const question2: PerseusRenderer = {
             },
     },
     widgets: {"numeric-input 1": numericInputWidget},
+};
+
+export const question3: PerseusRenderer = {
+    content: "Enter $1.0$ in the input field: [[\u2603 expression 1]]\n\n\n\n",
+    images: {},
+    widgets: {"expression 1": expressionWidget},
 };
 
 export const definitionItem: PerseusRenderer = {

--- a/packages/perseus/src/__tests__/renderer.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.test.tsx
@@ -1,6 +1,6 @@
 import {describe, beforeAll, beforeEach, it} from "@jest/globals";
 import {Errors} from "@khanacademy/perseus-core";
-import {act, logRoles, screen, waitFor, within} from "@testing-library/react";
+import {act, screen, waitFor, within} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 

--- a/packages/perseus/src/__tests__/renderer.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.test.tsx
@@ -1,6 +1,6 @@
 import {describe, beforeAll, beforeEach, it} from "@jest/globals";
 import {Errors} from "@khanacademy/perseus-core";
-import {act, screen, waitFor, within} from "@testing-library/react";
+import {act, logRoles, screen, waitFor, within} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
@@ -15,6 +15,7 @@ import {
     definitionItem,
     mockedRandomItem,
     mockedShuffledRadioProps,
+    question3,
 } from "../__testdata__/renderer.testdata";
 import * as Dependencies from "../dependencies";
 import {registerWidget} from "../widgets";
@@ -1605,35 +1606,36 @@ describe("renderer", () => {
         it("should return all empty widgets", async () => {
             // Arrange
             const {renderer} = renderQuestion({
-                ...question2,
+                ...question3,
                 content:
-                    "Input 1: [[☃ numeric-input 1]]\n\n" +
-                    "Input 2: [[☃ numeric-input 2]]",
+                    "Input 1: [[☃ expression 1]]\n\n" +
+                    "Input 2: [[☃ expression 2]]",
                 widgets: {
-                    ...question2.widgets,
-                    "numeric-input 2": question2.widgets["numeric-input 1"],
+                    ...question3.widgets,
+                    "expression 2": question3.widgets["expression 1"],
                 },
             });
             await userEvent.type(screen.getAllByRole("textbox")[0], "150");
+            act(() => jest.runOnlyPendingTimers());
 
             // Act
             const emptyWidgets = renderer.emptyWidgets();
 
             // Assert
-            expect(emptyWidgets).toStrictEqual(["numeric-input 2"]);
+            expect(emptyWidgets).toStrictEqual(["expression 2"]);
         });
 
         it("should not return static widgets even if empty", () => {
             // Arrange
             const {renderer} = renderQuestion({
-                ...question2,
+                ...question3,
                 content:
-                    "Input 1: [[☃ numeric-input 1]]\n\n" +
-                    "Input 2: [[☃ numeric-input 2]]",
+                    "Input 1: [[☃ expression 1]]\n\n" +
+                    "Input 2: [[☃ expression 2]]",
                 widgets: {
-                    ...question2.widgets,
-                    "numeric-input 2": {
-                        ...question2.widgets["numeric-input 1"],
+                    ...question3.widgets,
+                    "expression 2": {
+                        ...question3.widgets["expression 1"],
                         static: true,
                     },
                 },
@@ -1643,7 +1645,7 @@ describe("renderer", () => {
             const emptyWidgets = renderer.emptyWidgets();
 
             // Assert
-            expect(emptyWidgets).toStrictEqual(["numeric-input 1"]);
+            expect(emptyWidgets).toStrictEqual(["expression 1"]);
         });
 
         it("should return widget ID for group with empty widget", () => {
@@ -1663,7 +1665,7 @@ describe("renderer", () => {
                 JSON.stringify(simpleGroupQuestion),
             );
             simpleGroupQuestionCopy.widgets["group 1"].options.widgets[
-                "numeric-input 1"
+                "expression 1"
             ].static = true;
             const {renderer} = renderQuestion(simpleGroupQuestionCopy);
 
@@ -1678,6 +1680,7 @@ describe("renderer", () => {
             // Arrange
             const {renderer} = renderQuestion(simpleGroupQuestion);
             await userEvent.type(screen.getByRole("textbox"), "99");
+            act(() => jest.runOnlyPendingTimers());
 
             // Act
             const emptyWidgets = renderer.emptyWidgets();

--- a/packages/perseus/src/renderer-util.ts
+++ b/packages/perseus/src/renderer-util.ts
@@ -1,12 +1,20 @@
 import {mapObject} from "./interactive2/objective_";
 import {scoreIsEmpty, flattenScores} from "./util/scoring";
 import {getWidgetIdsFromContent} from "./widget-type-utils";
-import {getWidgetScorer, upgradeWidgetInfoToLatestVersion} from "./widgets";
+import {
+    getWidgetScorer,
+    getWidgetValidator,
+    upgradeWidgetInfoToLatestVersion,
+} from "./widgets";
 
 import type {PerseusRenderer, PerseusWidgetsMap} from "./perseus-types";
 import type {PerseusStrings} from "./strings";
 import type {PerseusScore} from "./types";
-import type {UserInput, UserInputMap} from "./validation.types";
+import type {
+    UserInput,
+    UserInputMap,
+    ValidationDataMap,
+} from "./validation.types";
 
 export function getUpgradedWidgetOptions(
     oldWidgetOptions: PerseusWidgetsMap,
@@ -33,8 +41,13 @@ export function getUpgradedWidgetOptions(
     });
 }
 
+/**
+ * Checks the given user input to see if any answerable widgets have not been
+ * "filled in" (ie. if they're empty). Another way to think about this
+ * function is that its a check to see if we can score the provided input.
+ */
 export function emptyWidgetsFunctional(
-    widgets: PerseusWidgetsMap,
+    widgets: ValidationDataMap,
     // This is a port of old code, I'm not sure why
     // we need widgetIds vs the keys of the widgets object
     widgetIds: Array<string>,
@@ -42,22 +55,17 @@ export function emptyWidgetsFunctional(
     strings: PerseusStrings,
     locale: string,
 ): ReadonlyArray<string> {
-    const upgradedWidgets = getUpgradedWidgetOptions(widgets);
-
     return widgetIds.filter((id) => {
-        const widget = upgradedWidgets[id];
-        if (!widget || widget.static) {
+        const widget = widgets[id];
+        if (!widget || widget.static === true) {
             // Static widgets shouldn't count as empty
             return false;
         }
 
-        const scorer = getWidgetScorer(widget.type);
-        const score = scorer?.(
-            userInputMap[id] as UserInput,
-            widget.options,
-            strings,
-            locale,
-        );
+        const validator = getWidgetValidator(widget.type);
+        const userInput = userInputMap[id];
+        const validationData = widget.options;
+        const score = validator?.(userInput, validationData, strings, locale);
 
         if (score) {
             return scoreIsEmpty(score);

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -578,6 +578,13 @@ export type WidgetTransform = (
 
 export type ValidationResult = Extract<PerseusScore, {type: "invalid"}> | null;
 
+export type WidgetValidatorFunction = (
+    userInput: any, // STOPSHIP
+    validationData: any, // STOPHIP
+    strings: PerseusStrings,
+    locale: string,
+) => ValidationResult;
+
 export type WidgetScorerFunction = (
     // The user data needed to score
     userInput: UserInput,
@@ -631,6 +638,14 @@ export type WidgetExports<
      * static renders.
      */
     staticTransform?: WidgetTransform; // this is a function of some sort,
+
+    /**
+     * Validates the learner's guess to check if it's sufficient for scoring.
+     * Typically, this is basically an "emptiness" check, but for some widgets
+     * such as `interactive-graph` it is a check that the learner has made any
+     * edits (ie. the widget is not in it's origin state).
+     */
+    validator?: WidgetValidatorFunction;
 
     /**
      * A function that scores user input (the guess) for the widget.

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -13,6 +13,7 @@ import type {
     UserInput,
     UserInputArray,
     UserInputMap,
+    ValidationData,
 } from "./validation.types";
 import type {WidgetPromptJSON} from "./widget-ai-utils/prompt-types";
 import type {KeypadAPI} from "@khanacademy/math-input";
@@ -579,8 +580,8 @@ export type WidgetTransform = (
 export type ValidationResult = Extract<PerseusScore, {type: "invalid"}> | null;
 
 export type WidgetValidatorFunction = (
-    userInput: any, // STOPSHIP
-    validationData: any, // STOPHIP
+    userInput: UserInput,
+    validationData: ValidationData,
     strings: PerseusStrings,
     locale: string,
 ) => ValidationResult;

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -265,6 +265,7 @@ export type UserInput =
     | PerseusDropdownUserInput
     | PerseusExpressionUserInput
     | PerseusGrapherUserInput
+    | PerseusGroupUserInput
     | PerseusIFrameUserInput
     | PerseusInputNumberUserInput
     | PerseusInteractiveGraphUserInput
@@ -279,7 +280,7 @@ export type UserInput =
     | PerseusSorterUserInput
     | PerseusTableUserInput;
 
-export type UserInputMap = {[widgetId: string]: UserInput | UserInputMap};
+export type UserInputMap = {[widgetId: string]: UserInput};
 
 /**
  * deprecated prefer using UserInputMap
@@ -344,3 +345,8 @@ export type ValidationDataMap = {
         options: ValidationDataTypes[Property];
     };
 };
+
+/**
+ * A union type of all the different widget validation data types that exist.
+ */
+export type ValidationData = ValidationDataTypes[keyof ValidationDataTypes];

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -90,6 +90,7 @@ export type PerseusExpressionRubric = {
 export type PerseusExpressionUserInput = string;
 
 export type PerseusGroupRubric = PerseusGroupWidgetOptions;
+export type PerseusGroupValidationData = {widgets: ValidationDataMap};
 export type PerseusGroupUserInput = UserInputMap;
 
 export type PerseusGradedGroupRubric = PerseusGradedGroupWidgetOptions;
@@ -286,3 +287,60 @@ export type UserInputMap = {[widgetId: string]: UserInput | UserInputMap};
 export type UserInputArray = ReadonlyArray<
     UserInputArray | UserInput | null | undefined
 >;
+export interface ValidationDataTypes {
+    categorizer: PerseusCategorizerValidationData;
+    // "cs-program": PerseusCSProgramValidationData;
+    // definition: PerseusDefinitionValidationData;
+    // dropdown: PerseusDropdownRubric;
+    // explanation: PerseusExplanationValidationData;
+    // expression: PerseusExpressionValidationData;
+    // grapher: PerseusGrapherValidationData;
+    // "graded-group-set": PerseusGradedGroupSetValidationData;
+    // "graded-group": PerseusGradedGroupValidationData;
+    group: PerseusGroupValidationData;
+    // iframe: PerseusIFrameValidationData;
+    // image: PerseusImageValidationData;
+    // "input-number": PerseusInputNumberValidationData;
+    // interaction: PerseusInteractionValidationData;
+    // "interactive-graph": PerseusInteractiveGraphValidationData;
+    // "label-image": PerseusLabelImageValidationData;
+    // matcher: PerseusMatcherValidationData;
+    // matrix: PerseusMatrixValidationData;
+    // measurer: PerseusMeasurerValidationData;
+    // "molecule-renderer": PerseusMoleculeRendererValidationData;
+    // "number-line": PerseusNumberLineValidationData;
+    // "numeric-input": PerseusNumericInputValidationData;
+    // orderer: PerseusOrdererValidationData;
+    // "passage-ref-target": PerseusRefTargetValidationData;
+    // "passage-ref": PerseusPassageRefValidationData;
+    // passage: PerseusPassageValidationData;
+    // "phet-simulation": PerseusPhetSimulationValidationData;
+    // "python-program": PerseusPythonProgramValidationData;
+    plotter: PerseusPlotterValidationData;
+    // radio: PerseusRadioValidationData;
+    // sorter: PerseusSorterValidationData;
+    // table: PerseusTableValidationData;
+    // video: PerseusVideoValidationData;
+
+    // Deprecated widgets
+    // sequence: PerseusAutoCorrectValidationData;
+}
+
+/**
+ * A map of validation data, keyed by `widgetId`. This data is used to check if
+ * a question is answerable. This data represents the minimal intersection of
+ * data that's available in the client (widget options) and server (scoring
+ * data) and is represented by a group of types known as "validation data".
+ *
+ * NOTE:  The value in this map is intentionally a subset of WidgetOptions<T>.
+ * By using the same shape (minus any unneeded data), we are able to pass a
+ * `PerseusWidgetsMap` or ` into any function that accepts a
+ * `ValidationDataMap` without any mutation of data.
+ */
+export type ValidationDataMap = {
+    [Property in keyof ValidationDataTypes as `${Property} ${number}`]: {
+        type: Property;
+        static?: boolean;
+        options: ValidationDataTypes[Property];
+    };
+};

--- a/packages/perseus/src/widgets.ts
+++ b/packages/perseus/src/widgets.ts
@@ -12,6 +12,7 @@ import type {
     WidgetExports,
     WidgetTransform,
     WidgetScorerFunction,
+    WidgetValidatorFunction,
 } from "./types";
 import type * as React from "react";
 
@@ -135,6 +136,12 @@ export const getWidget = (
 
 export const getWidgetExport = (name: string): WidgetExports | null => {
     return widgets[name] ?? null;
+};
+
+export const getWidgetValidator = (
+    name: string,
+): WidgetValidatorFunction | null => {
+    return widgets[name]?.validator ?? null;
 };
 
 export const getWidgetScorer = (name: string): WidgetScorerFunction | null => {

--- a/packages/perseus/src/widgets/categorizer/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.tsx
@@ -329,5 +329,7 @@ export default {
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusCSProgramUserInput'.
     scorer: scoreCategorizer,
+    // TODO(LEMS-2656): remove TS suppression
+    // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusCSProgramUserInput'.
     validator: validateCategorizer,
 } satisfies WidgetExports<typeof Categorizer>;

--- a/packages/perseus/src/widgets/categorizer/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.tsx
@@ -17,6 +17,7 @@ import Util from "../../util";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/categorizer/categorizer-ai-utils";
 
 import scoreCategorizer from "./score-categorizer";
+import validateCategorizer from "./validate-categorizer";
 
 import type {PerseusCategorizerWidgetOptions} from "../../perseus-types";
 import type {Widget, WidgetExports, WidgetProps} from "../../types";
@@ -328,4 +329,5 @@ export default {
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusCSProgramUserInput'.
     scorer: scoreCategorizer,
+    validator: validateCategorizer,
 } satisfies WidgetExports<typeof Categorizer>;

--- a/packages/perseus/src/widgets/dropdown/dropdown.tsx
+++ b/packages/perseus/src/widgets/dropdown/dropdown.tsx
@@ -163,5 +163,7 @@ export default {
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusDropdownUserInput'.
     scorer: scoreDropdown,
+    // TODO(LEMS-2656): remove TS suppression
+    // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusDropdownUserInput'.
     validator: validateDropdown,
 } satisfies WidgetExports<typeof Dropdown>;

--- a/packages/perseus/src/widgets/dropdown/dropdown.tsx
+++ b/packages/perseus/src/widgets/dropdown/dropdown.tsx
@@ -9,6 +9,7 @@ import {ApiOptions} from "../../perseus-api";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/dropdown/dropdown-ai-utils";
 
 import scoreDropdown from "./score-dropdown";
+import validateDropdown from "./validate-dropdown";
 
 import type {PerseusDropdownWidgetOptions} from "../../perseus-types";
 import type {Widget, WidgetExports, WidgetProps} from "../../types";
@@ -162,4 +163,5 @@ export default {
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusDropdownUserInput'.
     scorer: scoreDropdown,
+    validator: validateDropdown,
 } satisfies WidgetExports<typeof Dropdown>;

--- a/packages/perseus/src/widgets/expression/expression.tsx
+++ b/packages/perseus/src/widgets/expression/expression.tsx
@@ -20,6 +20,7 @@ import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/expression/
 
 import getDecimalSeparator from "./get-decimal-separator";
 import scoreExpression from "./score-expression";
+import validateExpression from "./validate-expression";
 
 import type {DependenciesContext} from "../../dependencies";
 import type {PerseusExpressionWidgetOptions} from "../../perseus-types";
@@ -558,6 +559,7 @@ export default {
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusExpressionUserInput'.
     scorer: scoreExpression,
+    validator: validateExpression,
 
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type 'Rubric' is not assignable to type 'PerseusExpressionRubric'.

--- a/packages/perseus/src/widgets/expression/expression.tsx
+++ b/packages/perseus/src/widgets/expression/expression.tsx
@@ -115,6 +115,7 @@ export class Expression
     _isMounted = false;
 
     static getUserInputFromProps(props: Props): PerseusExpressionUserInput {
+        props; //?
         return normalizeTex(props.value);
     }
 

--- a/packages/perseus/src/widgets/expression/expression.tsx
+++ b/packages/perseus/src/widgets/expression/expression.tsx
@@ -115,7 +115,6 @@ export class Expression
     _isMounted = false;
 
     static getUserInputFromProps(props: Props): PerseusExpressionUserInput {
-        props; //?
         return normalizeTex(props.value);
     }
 
@@ -560,6 +559,8 @@ export default {
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusExpressionUserInput'.
     scorer: scoreExpression,
+    // TODO(LEMS-2656): remove TS suppression
+    // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusExpressionUserInput'.
     validator: validateExpression,
 
     // TODO(LEMS-2656): remove TS suppression

--- a/packages/perseus/src/widgets/group/group.testdata.ts
+++ b/packages/perseus/src/widgets/group/group.testdata.ts
@@ -159,32 +159,24 @@ export const simpleGroupQuestion: PerseusRenderer = {
         "group 1": {
             graded: true,
             options: {
-                content: "[[☃ numeric-input 1]]",
+                content: "[[☃ expression 1]]",
                 images: {},
                 widgets: {
-                    "numeric-input 1": {
-                        alignment: "default",
-                        graded: true,
+                    "expression 1": {
+                        type: "expression",
                         options: {
-                            answers: [
+                            answerForms: [
                                 {
-                                    maxError: null,
-                                    message: "",
-                                    simplify: "required",
-                                    status: "correct",
-                                    strict: false,
-                                    value: 230,
+                                    considered: "correct",
+                                    form: true,
+                                    simplify: true,
+                                    value: "1.0",
                                 },
                             ],
-                            coefficient: false,
-                            labelText: "value rounded to the nearest ten",
-                            rightAlign: false,
-                            size: "normal",
-                            static: false,
+                            buttonSets: ["basic"],
+                            functions: [],
+                            times: true,
                         },
-                        static: false,
-                        type: "numeric-input",
-                        version: {major: 0, minor: 0},
                     },
                 },
             },

--- a/packages/perseus/src/widgets/group/group.tsx
+++ b/packages/perseus/src/widgets/group/group.tsx
@@ -9,6 +9,7 @@ import Renderer from "../../renderer";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/group/group-ai-utils";
 
 import scoreGroup from "./score-group";
+import validateGroup from "./validate-group";
 
 import type {PerseusGroupWidgetOptions} from "../../perseus-types";
 import type {
@@ -207,6 +208,7 @@ export default {
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusCSProgramUserInput'.
     scorer: scoreGroup,
+    validator: validateGroup,
     hidden: true,
     isLintable: true,
 } satisfies WidgetExports<typeof Group>;

--- a/packages/perseus/src/widgets/group/group.tsx
+++ b/packages/perseus/src/widgets/group/group.tsx
@@ -206,8 +206,10 @@ export default {
     widget: Group,
     traverseChildWidgets: traverseChildWidgets,
     // TODO(LEMS-2656): remove TS suppression
-    // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusCSProgramUserInput'.
+    // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusGroupUserInput'.
     scorer: scoreGroup,
+    // TODO(LEMS-2656): remove TS suppression
+    // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusGroupUserInput'.
     validator: validateGroup,
     hidden: true,
     isLintable: true,

--- a/packages/perseus/src/widgets/group/validate-group.ts
+++ b/packages/perseus/src/widgets/group/validate-group.ts
@@ -1,5 +1,4 @@
-import {validateFunctional} from "../../renderer-util";
-import {flattenScores} from "../../util/scoring";
+import {emptyWidgetsFunctional} from "../../renderer-util";
 
 import type {PerseusStrings} from "../../strings";
 import type {ValidationResult} from "../../types";
@@ -14,14 +13,19 @@ function validateGroup(
     strings: PerseusStrings,
     locale: string,
 ): ValidationResult {
-    const result = validateFunctional(
-        userInput,
+    const emptyWidgets = emptyWidgetsFunctional(
         validationData.widgets,
+        Object.keys(validationData.widgets),
+        userInput,
         strings,
         locale,
     );
 
-    return flattenScores(result);
+    if (emptyWidgets.length === 0) {
+        return null;
+    }
+
+    return {type: "invalid", message: null};
 }
 
 export default validateGroup;

--- a/packages/perseus/src/widgets/group/validate-group.ts
+++ b/packages/perseus/src/widgets/group/validate-group.ts
@@ -1,0 +1,27 @@
+import {validateFunctional} from "../../renderer-util";
+import {flattenScores} from "../../util/scoring";
+
+import type {PerseusStrings} from "../../strings";
+import type {ValidationResult} from "../../types";
+import type {
+    PerseusGroupUserInput,
+    PerseusGroupValidationData,
+} from "../../validation.types";
+
+function validateGroup(
+    userInput: PerseusGroupUserInput,
+    validationData: PerseusGroupValidationData,
+    strings: PerseusStrings,
+    locale: string,
+): ValidationResult {
+    const result = validateFunctional(
+        userInput,
+        validationData.widgets,
+        strings,
+        locale,
+    );
+
+    return flattenScores(result);
+}
+
+export default validateGroup;

--- a/packages/perseus/src/widgets/matrix/matrix.tsx
+++ b/packages/perseus/src/widgets/matrix/matrix.tsx
@@ -601,5 +601,7 @@ export default {
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusMatrixUserInput'.
     scorer: scoreMatrix,
+    // TODO(LEMS-2656): remove TS suppression
+    // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusMatrixUserInput'.
     validator: validateMatrix,
 } satisfies WidgetExports<typeof Matrix>;

--- a/packages/perseus/src/widgets/matrix/matrix.tsx
+++ b/packages/perseus/src/widgets/matrix/matrix.tsx
@@ -16,6 +16,7 @@ import Util from "../../util";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/matrix/matrix-ai-utils";
 
 import scoreMatrix from "./score-matrix";
+import validateMatrix from "./validate-matrix";
 
 import type {
     PerseusMatrixWidgetAnswers,
@@ -600,4 +601,5 @@ export default {
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusMatrixUserInput'.
     scorer: scoreMatrix,
+    validator: validateMatrix,
 } satisfies WidgetExports<typeof Matrix>;

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -15,6 +15,7 @@ import KhanMath from "../../util/math";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/number-line/number-line-ai-utils";
 
 import scoreNumberLine from "./score-number-line";
+import validateNumberLine from "./validate-number-line";
 
 import type {ChangeableProps} from "../../mixins/changeable";
 import type {APIOptions, WidgetExports, FocusPath, Widget} from "../../types";
@@ -808,4 +809,5 @@ export default {
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusNumberLineUserInput'.
     scorer: scoreNumberLine,
+    validator: validateNumberLine,
 } satisfies WidgetExports<typeof NumberLine>;

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -809,5 +809,7 @@ export default {
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusNumberLineUserInput'.
     scorer: scoreNumberLine,
+    // TODO(LEMS-2656): remove TS suppression
+    // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusNumberLineUserInput'.
     validator: validateNumberLine,
 } satisfies WidgetExports<typeof NumberLine>;

--- a/packages/perseus/src/widgets/orderer/orderer.tsx
+++ b/packages/perseus/src/widgets/orderer/orderer.tsx
@@ -786,5 +786,7 @@ export default {
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type UserInput is not assignable to type PerseusOrdererUserInput
     scorer: scoreOrderer,
+    // TODO(LEMS-2656): remove TS suppression
+    // @ts-expect-error: Type UserInput is not assignable to type PerseusOrdererUserInput
     validator: validateOrderer,
 } satisfies WidgetExports<typeof Orderer>;

--- a/packages/perseus/src/widgets/orderer/orderer.tsx
+++ b/packages/perseus/src/widgets/orderer/orderer.tsx
@@ -15,6 +15,7 @@ import Util from "../../util";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/orderer/orderer-ai-utils";
 
 import {scoreOrderer} from "./score-orderer";
+import validateOrderer from "./validate-orderer";
 
 import type {PerseusOrdererWidgetOptions} from "../../perseus-types";
 import type {WidgetExports, WidgetProps, Widget} from "../../types";
@@ -785,4 +786,5 @@ export default {
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type UserInput is not assignable to type PerseusOrdererUserInput
     scorer: scoreOrderer,
+    validator: validateOrderer,
 } satisfies WidgetExports<typeof Orderer>;

--- a/packages/perseus/src/widgets/plotter/plotter.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.tsx
@@ -14,6 +14,7 @@ import KhanMath from "../../util/math";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/plotter/plotter-ai-utils";
 
 import scorePlotter from "./score-plotter";
+import validatePlotter from "./validate-plotter";
 
 import type {PerseusPlotterWidgetOptions} from "../../perseus-types";
 import type {Widget, WidgetExports, WidgetProps} from "../../types";
@@ -1182,4 +1183,5 @@ export default {
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type UserInput is not assignable to type PerseusPlotterUserInput
     scorer: scorePlotter,
+    validator: validatePlotter,
 } satisfies WidgetExports<typeof Plotter>;

--- a/packages/perseus/src/widgets/plotter/plotter.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.tsx
@@ -1183,5 +1183,7 @@ export default {
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type UserInput is not assignable to type PerseusPlotterUserInput
     scorer: scorePlotter,
+    // TODO(LEMS-2656): remove TS suppression
+    // @ts-expect-error: Type UserInput is not assignable to type PerseusPlotterUserInput
     validator: validatePlotter,
 } satisfies WidgetExports<typeof Plotter>;

--- a/packages/perseus/src/widgets/radio/radio.ts
+++ b/packages/perseus/src/widgets/radio/radio.ts
@@ -4,6 +4,7 @@ import Util from "../../util";
 
 import Radio from "./radio-component";
 import scoreRadio from "./score-radio";
+import validateRadio from "./validate-radio";
 
 import type {RenderProps, RadioChoiceWithMetadata} from "./radio-component";
 import type {PerseusRadioWidgetOptions} from "../../perseus-types";
@@ -155,4 +156,5 @@ export default {
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type UserInput is not assignable to type PerseusRadioUserInput
     scorer: scoreRadio,
+    validator: validateRadio,
 } satisfies WidgetExports<typeof Radio>;

--- a/packages/perseus/src/widgets/radio/radio.ts
+++ b/packages/perseus/src/widgets/radio/radio.ts
@@ -156,5 +156,7 @@ export default {
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type UserInput is not assignable to type PerseusRadioUserInput
     scorer: scoreRadio,
+    // TODO(LEMS-2656): remove TS suppression
+    // @ts-expect-error: Type UserInput is not assignable to type PerseusRadioUserInput
     validator: validateRadio,
 } satisfies WidgetExports<typeof Radio>;

--- a/packages/perseus/src/widgets/sorter/sorter.tsx
+++ b/packages/perseus/src/widgets/sorter/sorter.tsx
@@ -6,6 +6,7 @@ import Util from "../../util";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/sorter/sorter-ai-utils";
 
 import scoreSorter from "./score-sorter";
+import validateSorter from "./validate-sorter";
 
 import type {SortableOption} from "../../components/sortable";
 import type {PerseusSorterWidgetOptions} from "../../perseus-types";
@@ -136,4 +137,5 @@ export default {
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type UserInput is not assignable to type PerseusSorterUserInput
     scorer: scoreSorter,
+    validator: validateSorter,
 } satisfies WidgetExports<typeof Sorter>;

--- a/packages/perseus/src/widgets/sorter/sorter.tsx
+++ b/packages/perseus/src/widgets/sorter/sorter.tsx
@@ -137,5 +137,7 @@ export default {
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type UserInput is not assignable to type PerseusSorterUserInput
     scorer: scoreSorter,
+    // TODO(LEMS-2656): remove TS suppression
+    // @ts-expect-error: Type UserInput is not assignable to type PerseusSorterUserInput
     validator: validateSorter,
 } satisfies WidgetExports<typeof Sorter>;

--- a/packages/perseus/src/widgets/table/table.tsx
+++ b/packages/perseus/src/widgets/table/table.tsx
@@ -11,6 +11,7 @@ import Renderer from "../../renderer";
 import Util from "../../util";
 
 import scoreTable from "./score-table";
+import validateTable from "./validate-table";
 
 import type {ChangeableProps} from "../../mixins/changeable";
 import type {PerseusTableWidgetOptions} from "../../perseus-types";
@@ -327,4 +328,5 @@ export default {
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type UserInput is not assignable to type PerseusTableUserInput
     scorer: scoreTable,
+    validator: validateTable,
 } satisfies WidgetExports<typeof Table>;

--- a/packages/perseus/src/widgets/table/table.tsx
+++ b/packages/perseus/src/widgets/table/table.tsx
@@ -328,5 +328,7 @@ export default {
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type UserInput is not assignable to type PerseusTableUserInput
     scorer: scoreTable,
+    // TODO(LEMS-2656): remove TS suppression
+    // @ts-expect-error: Type UserInput is not assignable to type PerseusTableUserInput
     validator: validateTable,
 } satisfies WidgetExports<typeof Table>;


### PR DESCRIPTION
## Summary:

This PR begins connecting the validation functions that have been built to the existing `emptyWidgets()` function that already exists on the `Renderer` (as well as `emptyWidgesFunctional()`). This function powers the `APIOptions.answerableCallback` which is what the exercise chrome using Perseus uses to detect if a question is at a point where it can be scored. 

Note that some widget's "emptiness" checks depend on scoring data and so those checks are not included in the empty checking now. 
 

Issue: LEMS-2561

## Test plan:

yarn test
yarn typecheck