### PR TITLE
Rename usages of rubric to scoringData

### DIFF
--- a/.changeset/smooth-cheetahs-grin.md
+++ b/.changeset/smooth-cheetahs-grin.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Rename usages of rubric to scoringData

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -556,7 +556,7 @@ class Renderer
         const apiOptions = this.getApiOptions();
         const widgetProps = this.state.widgetProps[widgetId] || {};
 
-        // The widget needs access to its "rubric" at all times when in review
+        // The widget needs access to its "scoring data" at all times when in review
         // mode (which is really just part of its widget info).
         const widgetInfo = this.state.widgetInfo[widgetId];
         const reviewModeRubric =

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -637,7 +637,7 @@ export type WidgetExports<
      */
     scorer?: WidgetScorerFunction;
 
-    getOneCorrectAnswerFromRubric?: (
+    getOneCorrectAnswerFromScoringData?: (
         scoringData: ScoringData,
     ) => string | null | undefined;
 

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -9,7 +9,7 @@ import type {
 import type {PerseusStrings} from "./strings";
 import type {SizeClass} from "./util/sizing-utils";
 import type {
-    Rubric,
+    ScoringData,
     UserInput,
     UserInputArray,
     UserInputMap,
@@ -582,7 +582,7 @@ export type WidgetScorerFunction = (
     // The user data needed to score
     userInput: UserInput,
     // The scoring criteria to score against
-    rubric: Rubric,
+    scoringData: ScoringData,
     // Strings, for error messages in invalid widgets
     string?: PerseusStrings,
     // Locale, for math evaluation
@@ -638,7 +638,7 @@ export type WidgetExports<
     scorer?: WidgetScorerFunction;
 
     getOneCorrectAnswerFromRubric?: (
-        rubric: Rubric,
+        scoringData: ScoringData,
     ) => string | null | undefined;
 
     /**

--- a/packages/perseus/src/util/extract-perseus-data.ts
+++ b/packages/perseus/src/util/extract-perseus-data.ts
@@ -674,18 +674,18 @@ export const getAnswerFromUserInput = (widgetType: string, userInput: any) => {
 
 /* Returns the correct answer for a given widget ID and Perseus Item */
 // TODO (LEMS-1835): We should fix the resonse type from getWidget to be specific.
-// TODO (LEMS-1836): We should also consider adding the getOneCorrectAnswerFromRubric method to all widgets.
+// TODO (LEMS-1836): We should also consider adding the getOneCorrectAnswerFromScoringData method to all widgets.
 export const getCorrectAnswerForWidgetId = (
     widgetId: string,
     itemData: PerseusItem,
 ): string | null | undefined => {
-    const rubric = itemData.question.widgets[widgetId].options;
+    const scoringData = itemData.question.widgets[widgetId].options;
     const widgetMap = getWidgetsMapFromItemData(itemData);
     const widgetType = getWidgetTypeByWidgetId(widgetId, widgetMap) as string;
 
     const widget = Widgets.getWidgetExport(widgetType);
 
-    return widget?.getOneCorrectAnswerFromRubric?.(rubric);
+    return widget?.getOneCorrectAnswerFromScoringData?.(scoringData);
 };
 
 /* Verify if the widget ID exists in the content string of the Perseus Item */

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -97,11 +97,11 @@ export type PerseusGradedGroupScoringData = PerseusGradedGroupWidgetOptions;
 export type PerseusGradedGroupSetScoringData =
     PerseusGradedGroupSetWidgetOptions;
 
-export type PerseusGrapherRubric = {
+export type PerseusGrapherScoringData = {
     correct: GrapherAnswerTypes;
 };
 
-export type PerseusGrapherUserInput = PerseusGrapherRubric["correct"];
+export type PerseusGrapherUserInput = PerseusGrapherScoringData["correct"];
 
 // TODO(LEMS-2440): Can possibly be removed during 2440; only userInput used
 export type PerseusIFrameRubric = Empty;
@@ -244,7 +244,7 @@ export type Rubric =
     | PerseusGroupScoringData
     | PerseusGradedGroupScoringData
     | PerseusGradedGroupSetScoringData
-    | PerseusGrapherRubric
+    | PerseusGrapherScoringData
     | PerseusIFrameRubric
     | PerseusInputNumberRubric
     | PerseusInteractiveGraphRubric

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -94,7 +94,8 @@ export type PerseusGroupUserInput = UserInputMap;
 
 export type PerseusGradedGroupScoringData = PerseusGradedGroupWidgetOptions;
 
-export type PerseusGradedGroupSetRubric = PerseusGradedGroupSetWidgetOptions;
+export type PerseusGradedGroupSetScoringData =
+    PerseusGradedGroupSetWidgetOptions;
 
 export type PerseusGrapherRubric = {
     correct: GrapherAnswerTypes;
@@ -242,7 +243,7 @@ export type Rubric =
     | PerseusExpressionScoringData
     | PerseusGroupScoringData
     | PerseusGradedGroupScoringData
-    | PerseusGradedGroupSetRubric
+    | PerseusGradedGroupSetScoringData
     | PerseusGrapherRubric
     | PerseusIFrameRubric
     | PerseusInputNumberRubric

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -74,7 +74,7 @@ export type PerseusCSProgramUserInput = {
     message: string | null;
 };
 
-export type PerseusDropdownRubric = {
+export type PerseusDropdownScoringData = {
     choices: ReadonlyArray<PerseusDropdownChoice>;
 };
 
@@ -238,8 +238,8 @@ export type PerseusTableUserInput = ReadonlyArray<ReadonlyArray<string>>;
 export type Rubric =
     | PerseusCategorizerScoringData
     | PerseusCSProgramRubric
-    | PerseusDropdownRubric
     | PerseusExpressionRubric
+    | PerseusDropdownScoringData
     | PerseusGroupRubric
     | PerseusGradedGroupRubric
     | PerseusGradedGroupSetRubric

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -92,7 +92,7 @@ export type PerseusExpressionUserInput = string;
 export type PerseusGroupScoringData = PerseusGroupWidgetOptions;
 export type PerseusGroupUserInput = UserInputMap;
 
-export type PerseusGradedGroupRubric = PerseusGradedGroupWidgetOptions;
+export type PerseusGradedGroupScoringData = PerseusGradedGroupWidgetOptions;
 
 export type PerseusGradedGroupSetRubric = PerseusGradedGroupSetWidgetOptions;
 
@@ -241,7 +241,7 @@ export type Rubric =
     | PerseusDropdownScoringData
     | PerseusExpressionScoringData
     | PerseusGroupScoringData
-    | PerseusGradedGroupRubric
+    | PerseusGradedGroupScoringData
     | PerseusGradedGroupSetRubric
     | PerseusGrapherRubric
     | PerseusIFrameRubric

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -89,7 +89,7 @@ export type PerseusExpressionScoringData = {
 
 export type PerseusExpressionUserInput = string;
 
-export type PerseusGroupRubric = PerseusGroupWidgetOptions;
+export type PerseusGroupScoringData = PerseusGroupWidgetOptions;
 export type PerseusGroupUserInput = UserInputMap;
 
 export type PerseusGradedGroupRubric = PerseusGradedGroupWidgetOptions;
@@ -240,7 +240,7 @@ export type Rubric =
     | PerseusCSProgramRubric
     | PerseusDropdownScoringData
     | PerseusExpressionScoringData
-    | PerseusGroupRubric
+    | PerseusGroupScoringData
     | PerseusGradedGroupRubric
     | PerseusGradedGroupSetRubric
     | PerseusGrapherRubric

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -287,7 +287,7 @@ export interface ValidationDataTypes {
     categorizer: PerseusCategorizerValidationData;
     // "cs-program": PerseusCSProgramValidationData;
     // definition: PerseusDefinitionValidationData;
-    // dropdown: PerseusDropdownRubric;
+    // dropdown: PerseusDropdownValidationData;
     // explanation: PerseusExplanationValidationData;
     // expression: PerseusExpressionValidationData;
     // grapher: PerseusGrapherValidationData;

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -210,7 +210,7 @@ export type PerseusPlotterValidationData = {
 
 export type PerseusPlotterUserInput = ReadonlyArray<number>;
 
-export type PerseusRadioRubric = {
+export type PerseusRadioScoringData = {
     // The choices provided to the user.
     choices: ReadonlyArray<PerseusRadioChoice>;
 };
@@ -255,7 +255,7 @@ export type Rubric =
     | PerseusNumericInputScoringData
     | PerseusOrdererScoringData
     | PerseusPlotterScoringData
-    | PerseusRadioRubric
+    | PerseusRadioScoringData
     | PerseusSorterRubric
     | PerseusTableRubric;
 

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -181,7 +181,7 @@ export type PerseusNumberLineUserInput = {
     divisionRange: ReadonlyArray<number>;
 };
 
-export type PerseusNumericInputRubric = {
+export type PerseusNumericInputScoringData = {
     // A list of all the possible correct and incorrect answers
     answers: ReadonlyArray<PerseusNumericInputAnswer>;
     // A coefficient style number allows the student to use - for -1 and an empty string to mean 1.
@@ -252,7 +252,7 @@ export type Rubric =
     | PerseusMatcherScoringData
     | PerseusMatrixScoringData
     | PerseusNumberLineScoringData
-    | PerseusNumericInputRubric
+    | PerseusNumericInputScoringData
     | PerseusOrdererRubric
     | PerseusPlotterScoringData
     | PerseusRadioRubric

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -82,7 +82,7 @@ export type PerseusDropdownUserInput = {
     value: number;
 };
 
-export type PerseusExpressionRubric = {
+export type PerseusExpressionScoringData = {
     answerForms: ReadonlyArray<PerseusExpressionAnswerForm>;
     functions: ReadonlyArray<string>;
 };
@@ -238,8 +238,8 @@ export type PerseusTableUserInput = ReadonlyArray<ReadonlyArray<string>>;
 export type Rubric =
     | PerseusCategorizerScoringData
     | PerseusCSProgramRubric
-    | PerseusExpressionRubric
     | PerseusDropdownScoringData
+    | PerseusExpressionScoringData
     | PerseusGroupRubric
     | PerseusGradedGroupRubric
     | PerseusGradedGroupSetRubric

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -111,7 +111,7 @@ export type PerseusIFrameUserInput = {
     message: string | null;
 };
 
-export type PerseusInputNumberRubric = {
+export type PerseusInputNumberScoringData = {
     answerType?:
         | "number"
         | "decimal"
@@ -246,7 +246,7 @@ export type Rubric =
     | PerseusGradedGroupSetScoringData
     | PerseusGrapherScoringData
     | PerseusIFrameRubric
-    | PerseusInputNumberRubric
+    | PerseusInputNumberScoringData
     | PerseusInteractiveGraphRubric
     | PerseusLabelImageRubric
     | PerseusMatcherRubric

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -219,7 +219,7 @@ export type PerseusRadioUserInput = {
     choicesSelected: ReadonlyArray<boolean>;
 };
 
-export type PerseusSorterRubric = {
+export type PerseusSorterScoringData = {
     // Translatable Text; The correct answer (in the correct order). The user will see the cards in a randomized order.
     correct: ReadonlyArray<string>;
 };
@@ -256,7 +256,7 @@ export type Rubric =
     | PerseusOrdererScoringData
     | PerseusPlotterScoringData
     | PerseusRadioScoringData
-    | PerseusSorterRubric
+    | PerseusSorterScoringData
     | PerseusTableRubric;
 
 export type UserInput =

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -131,7 +131,7 @@ export type PerseusInputNumberUserInput = {
     currentValue: string;
 };
 
-export type PerseusInteractiveGraphRubric = {
+export type PerseusInteractiveGraphScoringData = {
     // TODO(LEMS-2344): make the type of `correct` more specific
     correct: PerseusGraphCorrectType;
     graph: PerseusGraphType;
@@ -247,7 +247,7 @@ export type Rubric =
     | PerseusGrapherScoringData
     | PerseusIFrameRubric
     | PerseusInputNumberScoringData
-    | PerseusInteractiveGraphRubric
+    | PerseusInteractiveGraphScoringData
     | PerseusLabelImageRubric
     | PerseusMatcherRubric
     | PerseusMatrixRubric

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -147,7 +147,7 @@ export type PerseusLabelImageUserInput = {
     markers: ReadonlyArray<InteractiveMarkerType>;
 };
 
-export type PerseusMatcherRubric = PerseusMatcherWidgetOptions;
+export type PerseusMatcherScoringData = PerseusMatcherWidgetOptions;
 
 export type PerseusMatcherUserInput = {
     left: ReadonlyArray<string>;
@@ -249,7 +249,7 @@ export type Rubric =
     | PerseusInputNumberScoringData
     | PerseusInteractiveGraphScoringData
     | PerseusLabelImageRubric
-    | PerseusMatcherRubric
+    | PerseusMatcherScoringData
     | PerseusMatrixRubric
     | PerseusNumberLineScoringData
     | PerseusNumericInputRubric

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -236,7 +236,7 @@ export type PerseusTableScoringData = {
 
 export type PerseusTableUserInput = ReadonlyArray<ReadonlyArray<string>>;
 
-export type Rubric =
+export type ScoringData =
     | PerseusCategorizerScoringData
     | PerseusCSProgramRubric
     | PerseusDropdownScoringData

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -229,7 +229,7 @@ export type PerseusSorterUserInput = {
     changed: boolean;
 };
 
-export type PerseusTableRubric = {
+export type PerseusTableScoringData = {
     // Translatable Text; A 2-dimensional array of text to populate the table with
     answers: ReadonlyArray<ReadonlyArray<string>>;
 };
@@ -257,7 +257,7 @@ export type Rubric =
     | PerseusPlotterScoringData
     | PerseusRadioScoringData
     | PerseusSorterScoringData
-    | PerseusTableRubric;
+    | PerseusTableScoringData;
 
 export type UserInput =
     | PerseusCategorizerUserInput

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -154,7 +154,7 @@ export type PerseusMatcherUserInput = {
     right: ReadonlyArray<string>;
 };
 
-export type PerseusMatrixRubric = {
+export type PerseusMatrixScoringData = {
     // A data matrix representing the "correct" answers to be entered into the matrix
     answers: PerseusMatrixWidgetAnswers;
 } & PerseusMatrixValidationData;
@@ -162,7 +162,7 @@ export type PerseusMatrixRubric = {
 export type PerseusMatrixValidationData = Empty;
 
 export type PerseusMatrixUserInput = {
-    answers: PerseusMatrixRubric["answers"];
+    answers: PerseusMatrixScoringData["answers"];
 };
 
 export type PerseusNumberLineScoringData = {
@@ -250,7 +250,7 @@ export type Rubric =
     | PerseusInteractiveGraphScoringData
     | PerseusLabelImageRubric
     | PerseusMatcherScoringData
-    | PerseusMatrixRubric
+    | PerseusMatrixScoringData
     | PerseusNumberLineScoringData
     | PerseusNumericInputRubric
     | PerseusOrdererRubric

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -192,7 +192,7 @@ export type PerseusNumericInputUserInput = {
     currentValue: string;
 };
 
-export type PerseusOrdererRubric = PerseusOrdererWidgetOptions;
+export type PerseusOrdererScoringData = PerseusOrdererWidgetOptions;
 
 export type PerseusOrdererUserInput = {
     current: ReadonlyArray<string>;
@@ -253,7 +253,7 @@ export type Rubric =
     | PerseusMatrixScoringData
     | PerseusNumberLineScoringData
     | PerseusNumericInputScoringData
-    | PerseusOrdererRubric
+    | PerseusOrdererScoringData
     | PerseusPlotterScoringData
     | PerseusRadioRubric
     | PerseusSorterRubric

--- a/packages/perseus/src/widgets/cs-program/score-cs-program.ts
+++ b/packages/perseus/src/widgets/cs-program/score-cs-program.ts
@@ -1,23 +1,23 @@
 import type {PerseusScore} from "../../types";
 import type {PerseusCSProgramUserInput} from "../../validation.types";
 
-function scoreCSProgram(state: PerseusCSProgramUserInput): PerseusScore {
+function scoreCSProgram(userInput: PerseusCSProgramUserInput): PerseusScore {
     // The iframe can tell us whether it's correct or incorrect,
     //  and pass an optional message
-    if (state.status === "correct") {
+    if (userInput.status === "correct") {
         return {
             type: "points",
             earned: 1,
             total: 1,
-            message: state.message || null,
+            message: userInput.message || null,
         };
     }
-    if (state.status === "incorrect") {
+    if (userInput.status === "incorrect") {
         return {
             type: "points",
             earned: 0,
             total: 1,
-            message: state.message || null,
+            message: userInput.message || null,
         };
     }
     return {

--- a/packages/perseus/src/widgets/dropdown/dropdown.tsx
+++ b/packages/perseus/src/widgets/dropdown/dropdown.tsx
@@ -13,12 +13,12 @@ import scoreDropdown from "./score-dropdown";
 import type {PerseusDropdownWidgetOptions} from "../../perseus-types";
 import type {Widget, WidgetExports, WidgetProps} from "../../types";
 import type {
-    PerseusDropdownRubric,
+    PerseusDropdownScoringData,
     PerseusDropdownUserInput,
 } from "../../validation.types";
 import type {DropdownPromptJSON} from "../../widget-ai-utils/dropdown/dropdown-ai-utils";
 
-type Props = WidgetProps<RenderProps, PerseusDropdownRubric> & {
+type Props = WidgetProps<RenderProps, PerseusDropdownScoringData> & {
     selected: number;
 };
 

--- a/packages/perseus/src/widgets/dropdown/score-dropdown.test.ts
+++ b/packages/perseus/src/widgets/dropdown/score-dropdown.test.ts
@@ -2,7 +2,7 @@ import {question1} from "./dropdown.testdata";
 import scoreDropdown from "./score-dropdown";
 
 import type {
-    PerseusDropdownRubric,
+    PerseusDropdownScoringData,
     PerseusDropdownUserInput,
 } from "../../validation.types";
 
@@ -12,12 +12,12 @@ describe("scoreDropdown", () => {
         const userInput: PerseusDropdownUserInput = {
             value: 1,
         };
-        const rubric: PerseusDropdownRubric = {
+        const scoringData: PerseusDropdownScoringData = {
             choices: question1.widgets["dropdown 1"].options.choices,
         };
 
         // Act
-        const score = scoreDropdown(userInput, rubric);
+        const score = scoreDropdown(userInput, scoringData);
 
         // Assert
         expect(score).toHaveBeenAnsweredIncorrectly();
@@ -28,12 +28,12 @@ describe("scoreDropdown", () => {
         const userInput: PerseusDropdownUserInput = {
             value: 2,
         };
-        const rubric: PerseusDropdownRubric = {
+        const scoringData: PerseusDropdownScoringData = {
             choices: question1.widgets["dropdown 1"].options.choices,
         };
 
         // Act
-        const score = scoreDropdown(userInput, rubric);
+        const score = scoreDropdown(userInput, scoringData);
 
         // Assert
         expect(score).toHaveBeenAnsweredCorrectly();

--- a/packages/perseus/src/widgets/dropdown/score-dropdown.ts
+++ b/packages/perseus/src/widgets/dropdown/score-dropdown.ts
@@ -2,19 +2,19 @@ import validateDropdown from "./validate-dropdown";
 
 import type {PerseusScore} from "../../types";
 import type {
-    PerseusDropdownRubric,
+    PerseusDropdownScoringData,
     PerseusDropdownUserInput,
 } from "../../validation.types";
 
 function scoreDropdown(
     userInput: PerseusDropdownUserInput,
-    rubric: PerseusDropdownRubric,
+    scoringData: PerseusDropdownScoringData,
 ): PerseusScore {
     const validationError = validateDropdown(userInput);
     if (validationError) {
         return validationError;
     }
-    const correct = rubric.choices[userInput.value - 1].correct;
+    const correct = scoringData.choices[userInput.value - 1].correct;
     return {
         type: "points",
         earned: correct ? 1 : 0,

--- a/packages/perseus/src/widgets/expression/expression.test.tsx
+++ b/packages/perseus/src/widgets/expression/expression.test.tsx
@@ -265,16 +265,16 @@ describe("Expression Widget", function () {
         });
     });
 
-    describe("getOneCorrectAnswerFromRubric", () => {
+    describe("getOneCorrectAnswerFromScoringData", () => {
         beforeEach(() => {
             jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
                 testDependencies,
             );
         });
 
-        it("should return undefined if rubric.value is null/undefined", () => {
+        it("should return undefined if scoringData.value is null/undefined", () => {
             // Arrange
-            const rubric = {
+            const scoringData = {
                 answerForms: [],
                 buttonSets: [],
                 functions: [],
@@ -283,7 +283,9 @@ describe("Expression Widget", function () {
 
             // Act
             const result =
-                ExpressionWidgetExport.getOneCorrectAnswerFromRubric?.(rubric);
+                ExpressionWidgetExport.getOneCorrectAnswerFromScoringData?.(
+                    scoringData,
+                );
 
             // Assert
             expect(result).toBeUndefined();
@@ -291,7 +293,7 @@ describe("Expression Widget", function () {
 
         it("returns a correct answer when there is one correct answer", () => {
             // Arrange
-            const rubric = {
+            const scoringData = {
                 answerForms: [
                     {
                         value: "123",
@@ -307,7 +309,9 @@ describe("Expression Widget", function () {
 
             // Act
             const result =
-                ExpressionWidgetExport.getOneCorrectAnswerFromRubric?.(rubric);
+                ExpressionWidgetExport.getOneCorrectAnswerFromScoringData?.(
+                    scoringData,
+                );
 
             // Assert
             expect(result).toEqual("123");
@@ -315,7 +319,7 @@ describe("Expression Widget", function () {
 
         it("returns the first correct answer when there are multiple correct answers", () => {
             // Arrange
-            const rubric = {
+            const scoringData = {
                 answerForms: [
                     {
                         value: "123",
@@ -337,7 +341,9 @@ describe("Expression Widget", function () {
 
             // Act
             const result =
-                ExpressionWidgetExport.getOneCorrectAnswerFromRubric?.(rubric);
+                ExpressionWidgetExport.getOneCorrectAnswerFromScoringData?.(
+                    scoringData,
+                );
 
             // Assert
             expect(result).toEqual("123");

--- a/packages/perseus/src/widgets/expression/expression.tsx
+++ b/packages/perseus/src/widgets/expression/expression.tsx
@@ -561,7 +561,7 @@ export default {
 
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type 'ScoringData' is not assignable to type 'PerseusExpressionScoringData'.
-    getOneCorrectAnswerFromRubric(
+    getOneCorrectAnswerFromScoringData(
         scoringData: PerseusExpressionScoringData,
     ): string | null | undefined {
         const correctAnswers = (scoringData.answerForms || []).filter(

--- a/packages/perseus/src/widgets/expression/expression.tsx
+++ b/packages/perseus/src/widgets/expression/expression.tsx
@@ -25,7 +25,7 @@ import type {DependenciesContext} from "../../dependencies";
 import type {PerseusExpressionWidgetOptions} from "../../perseus-types";
 import type {FocusPath, Widget, WidgetExports, WidgetProps} from "../../types";
 import type {
-    PerseusExpressionRubric,
+    PerseusExpressionScoringData,
     PerseusExpressionUserInput,
 } from "../../validation.types";
 import type {ExpressionPromptJSON} from "../../widget-ai-utils/expression/expression-ai-utils";
@@ -69,7 +69,7 @@ type RenderProps = {
     keypadConfiguration: ReturnType<typeof keypadConfigurationForProps>;
 };
 
-type ExternalProps = WidgetProps<RenderProps, PerseusExpressionRubric>;
+type ExternalProps = WidgetProps<RenderProps, PerseusExpressionScoringData>;
 
 export type Props = ExternalProps &
     Partial<React.ContextType<typeof DependenciesContext>> & {
@@ -560,11 +560,11 @@ export default {
     scorer: scoreExpression,
 
     // TODO(LEMS-2656): remove TS suppression
-    // @ts-expect-error: Type 'Rubric' is not assignable to type 'PerseusExpressionRubric'.
+    // @ts-expect-error: Type 'ScoringData' is not assignable to type 'PerseusExpressionScoringData'.
     getOneCorrectAnswerFromRubric(
-        rubric: PerseusExpressionRubric,
+        scoringData: PerseusExpressionScoringData,
     ): string | null | undefined {
-        const correctAnswers = (rubric.answerForms || []).filter(
+        const correctAnswers = (scoringData.answerForms || []).filter(
             (answerForm) => answerForm.considered === "correct",
         );
         if (correctAnswers.length === 0) {

--- a/packages/perseus/src/widgets/expression/score-expression.test.ts
+++ b/packages/perseus/src/widgets/expression/score-expression.test.ts
@@ -4,7 +4,7 @@ import {expressionItem3Options} from "./expression.testdata";
 import scoreExpression from "./score-expression";
 import * as ExpressionValidator from "./validate-expression";
 
-import type {PerseusExpressionRubric} from "../../validation.types";
+import type {PerseusExpressionScoringData} from "../../validation.types";
 
 describe("scoreExpression", () => {
     it("should be correctly answerable if validation passes", function () {
@@ -12,10 +12,11 @@ describe("scoreExpression", () => {
         const mockValidator = jest
             .spyOn(ExpressionValidator, "default")
             .mockReturnValue(null);
-        const rubric: PerseusExpressionRubric = expressionItem3Options;
+        const scoringData: PerseusExpressionScoringData =
+            expressionItem3Options;
 
         // Act
-        const score = scoreExpression("z+1", rubric, mockStrings, "en");
+        const score = scoreExpression("z+1", scoringData, mockStrings, "en");
 
         // Assert
         expect(mockValidator).toHaveBeenCalledWith("z+1");
@@ -27,10 +28,11 @@ describe("scoreExpression", () => {
         const mockValidator = jest
             .spyOn(ExpressionValidator, "default")
             .mockReturnValue({type: "invalid", message: null});
-        const rubric: PerseusExpressionRubric = expressionItem3Options;
+        const scoringData: PerseusExpressionScoringData =
+            expressionItem3Options;
 
         // Act
-        const score = scoreExpression("z+1", rubric, mockStrings, "en");
+        const score = scoreExpression("z+1", scoringData, mockStrings, "en");
 
         // Assert
         expect(mockValidator).toHaveBeenCalledWith("z+1");

--- a/packages/perseus/src/widgets/expression/score-expression.ts
+++ b/packages/perseus/src/widgets/expression/score-expression.ts
@@ -65,7 +65,7 @@ function scoreExpression(
             Log.error(
                 "Unable to parse solution answer for expression",
                 Errors.InvalidInput,
-                {loggedMetadata: {rubric: JSON.stringify(scoringData)}},
+                {loggedMetadata: {scoringData: JSON.stringify(scoringData)}},
             );
             return null;
         }

--- a/packages/perseus/src/widgets/expression/score-expression.ts
+++ b/packages/perseus/src/widgets/expression/score-expression.ts
@@ -13,7 +13,7 @@ import type {PerseusStrings} from "../../strings";
 import type {PerseusScore} from "../../types";
 import type {Score} from "../../util/answer-types";
 import type {
-    PerseusExpressionRubric,
+    PerseusExpressionScoringData,
     PerseusExpressionUserInput,
 } from "../../validation.types";
 
@@ -37,7 +37,7 @@ import type {
  */
 function scoreExpression(
     userInput: PerseusExpressionUserInput,
-    rubric: PerseusExpressionRubric,
+    scoringData: PerseusExpressionScoringData,
     strings: PerseusStrings,
     locale: string,
 ): PerseusScore {
@@ -46,7 +46,7 @@ function scoreExpression(
         return validationError;
     }
 
-    const options = _.clone(rubric);
+    const options = _.clone(scoringData);
     _.extend(options, {
         decimal_separator: getDecimalSeparator(locale),
     });
@@ -56,7 +56,7 @@ function scoreExpression(
         // solution answer, not the student answer, and we don't want a
         // solution to work if the student is using a different language
         // (different from the content creation language, ie. English).
-        const expression = KAS.parse(answer.value, rubric);
+        const expression = KAS.parse(answer.value, scoringData);
         // An answer may not be parsed if the expression was defined
         // incorrectly. For example if the answer is using a symbol defined
         // in the function variables list for the expression.
@@ -65,7 +65,7 @@ function scoreExpression(
             Log.error(
                 "Unable to parse solution answer for expression",
                 Errors.InvalidInput,
-                {loggedMetadata: {rubric: JSON.stringify(rubric)}},
+                {loggedMetadata: {rubric: JSON.stringify(scoringData)}},
             );
             return null;
         }
@@ -95,7 +95,7 @@ function scoreExpression(
     let matchMessage: string | undefined;
     let allEmpty = true;
     let firstUngradedResult: Score | undefined;
-    for (const answerForm of rubric.answerForms || []) {
+    for (const answerForm of scoringData.answerForms || []) {
         const validator = createValidator(answerForm);
         if (!validator) {
             continue;

--- a/packages/perseus/src/widgets/expression/validate-expression.ts
+++ b/packages/perseus/src/widgets/expression/validate-expression.ts
@@ -4,7 +4,7 @@ import type {PerseusExpressionUserInput} from "../../validation.types";
 /**
  * Checks user input from the expression widget to see if it is scorable.
  *
- * Note: Most of the expression widget's validation requires the Rubric because
+ * Note: Most of the expression widget's validation requires the ScoringData because
  * of its use of KhanAnswerTypes as a core part of scoring.
  *
  * @see `scoreExpression()` for more details.

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
@@ -25,7 +25,7 @@ import type {
     PerseusGradedGroupWidgetOptions,
 } from "../../perseus-types";
 import type {FocusPath, Widget, WidgetExports, WidgetProps} from "../../types";
-import type {PerseusGradedGroupSetRubric} from "../../validation.types";
+import type {PerseusGradedGroupSetScoringData} from "../../validation.types";
 import type {GradedGroupSetPromptJSON} from "../../widget-ai-utils/graded-group-set/graded-group-set-ai-utils";
 
 type IndicatorsProps = {
@@ -93,7 +93,7 @@ class Indicators extends React.Component<IndicatorsProps> {
 type RenderProps = PerseusGradedGroupSetWidgetOptions; // no transform
 
 type Props = Changeable.ChangeableProps &
-    WidgetProps<RenderProps, PerseusGradedGroupSetRubric> & {
+    WidgetProps<RenderProps, PerseusGradedGroupSetScoringData> & {
         trackInteraction: () => void;
     };
 

--- a/packages/perseus/src/widgets/graded-group/graded-group.tsx
+++ b/packages/perseus/src/widgets/graded-group/graded-group.tsx
@@ -35,7 +35,7 @@ import type {
     WidgetExports,
     WidgetProps,
 } from "../../types";
-import type {PerseusGradedGroupRubric} from "../../validation.types";
+import type {PerseusGradedGroupScoringData} from "../../validation.types";
 import type {GradedGroupPromptJSON} from "../../widget-ai-utils/graded-group/graded-group-ai-utils";
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
@@ -70,7 +70,7 @@ type RenderProps = PerseusGradedGroupWidgetOptions; // exports has no 'transform
 
 type Props = WidgetProps<
     RenderProps,
-    PerseusGradedGroupRubric,
+    PerseusGradedGroupScoringData,
     TrackingGradedGroupExtraArguments
 > & {
     inGradedGroupSet?: boolean; // Set by graded-group-set.jsx,
@@ -102,7 +102,7 @@ type State = {
 // via defaultProps.
 0 as any as WidgetProps<
     PerseusGradedGroupWidgetOptions,
-    PerseusGradedGroupRubric
+    PerseusGradedGroupScoringData
 > satisfies PropsFor<typeof GradedGroup>;
 
 // A Graded Group is more or less a Group widget that displays a check

--- a/packages/perseus/src/widgets/grapher/grapher.tsx
+++ b/packages/perseus/src/widgets/grapher/grapher.tsx
@@ -37,7 +37,7 @@ import type {PerseusGrapherWidgetOptions} from "../../perseus-types";
 import type {Widget, WidgetExports, WidgetProps} from "../../types";
 import type {GridDimensions} from "../../util";
 import type {
-    PerseusGrapherRubric,
+    PerseusGrapherScoringData,
     PerseusGrapherUserInput,
 } from "../../validation.types";
 import type {GrapherPromptJSON} from "../../widget-ai-utils/grapher/grapher-ai-utils";
@@ -349,7 +349,7 @@ type RenderProps = {
     plot?: any;
 };
 
-type ExternalProps = WidgetProps<RenderProps, PerseusGrapherRubric>;
+type ExternalProps = WidgetProps<RenderProps, PerseusGrapherScoringData>;
 
 type Props = ExternalProps & {
     // plot is always provided by default props

--- a/packages/perseus/src/widgets/grapher/score-grapher.test.ts
+++ b/packages/perseus/src/widgets/grapher/score-grapher.test.ts
@@ -2,12 +2,12 @@ import scoreGrapher from "./score-grapher";
 
 import type {Coord} from "../../interactive2/types";
 import type {
-    PerseusGrapherRubric,
+    PerseusGrapherScoringData,
     PerseusGrapherUserInput,
 } from "../../validation.types";
 
 describe("scoreGrapher", () => {
-    it("is incorrect when user input type doesn't match rubric type", () => {
+    it("is incorrect when user input type doesn't match scoring data type", () => {
         const asymptote: [Coord, Coord] = [
             [-10, -10],
             [10, 10],
@@ -24,7 +24,7 @@ describe("scoreGrapher", () => {
             coords,
         };
 
-        const rubric: PerseusGrapherRubric = {
+        const scoringData: PerseusGrapherScoringData = {
             correct: {
                 type: "logarithm",
                 asymptote,
@@ -33,7 +33,7 @@ describe("scoreGrapher", () => {
         };
 
         // Act
-        const result = scoreGrapher(userInput, rubric);
+        const result = scoreGrapher(userInput, scoringData);
 
         // Assert
         expect(result).toHaveBeenAnsweredIncorrectly();
@@ -59,7 +59,7 @@ describe("scoreGrapher", () => {
             coords: null,
         };
 
-        const rubric: PerseusGrapherRubric = {
+        const scoringData: PerseusGrapherScoringData = {
             correct: {
                 type: "exponential",
                 asymptote,
@@ -68,7 +68,7 @@ describe("scoreGrapher", () => {
         };
 
         // Act
-        const result = scoreGrapher(userInput, rubric);
+        const result = scoreGrapher(userInput, scoringData);
 
         // Assert
         expect(result).toHaveInvalidInput();
@@ -89,7 +89,7 @@ describe("scoreGrapher", () => {
             coords,
         };
 
-        const rubric: PerseusGrapherRubric = {
+        const scoringData: PerseusGrapherScoringData = {
             correct: {
                 type: "linear",
                 coords,
@@ -97,7 +97,7 @@ describe("scoreGrapher", () => {
         };
 
         // Act
-        const result = scoreGrapher(userInput, rubric);
+        const result = scoreGrapher(userInput, scoringData);
 
         // Assert
         expect(result).toHaveInvalidInput();
@@ -115,7 +115,7 @@ describe("scoreGrapher", () => {
             coords,
         };
 
-        const rubric: PerseusGrapherRubric = {
+        const scoringData: PerseusGrapherScoringData = {
             correct: {
                 type: "linear",
                 coords,
@@ -123,13 +123,13 @@ describe("scoreGrapher", () => {
         };
 
         // Act
-        const result = scoreGrapher(userInput, rubric);
+        const result = scoreGrapher(userInput, scoringData);
 
         // Assert
         expect(result).toHaveBeenAnsweredCorrectly();
     });
 
-    it("can be answered incorrectly when user input and rubric coords don't match", () => {
+    it("can be answered incorrectly when user input and scoring data coords don't match", () => {
         // Arrange
         const userInput: PerseusGrapherUserInput = {
             type: "linear",
@@ -139,7 +139,7 @@ describe("scoreGrapher", () => {
             ],
         };
 
-        const rubric: PerseusGrapherRubric = {
+        const scoringData: PerseusGrapherScoringData = {
             correct: {
                 type: "linear",
                 coords: [
@@ -150,7 +150,7 @@ describe("scoreGrapher", () => {
         };
 
         // Act
-        const result = scoreGrapher(userInput, rubric);
+        const result = scoreGrapher(userInput, scoringData);
 
         // Assert
         expect(result).toHaveBeenAnsweredIncorrectly();

--- a/packages/perseus/src/widgets/grapher/score-grapher.ts
+++ b/packages/perseus/src/widgets/grapher/score-grapher.ts
@@ -5,7 +5,7 @@ import {functionForType} from "./util";
 import type {GrapherAnswerTypes} from "../../perseus-types";
 import type {PerseusScore} from "../../types";
 import type {
-    PerseusGrapherRubric,
+    PerseusGrapherScoringData,
     PerseusGrapherUserInput,
 } from "../../validation.types";
 
@@ -31,9 +31,9 @@ function getCoefficientsByType(
 
 function scoreGrapher(
     userInput: PerseusGrapherUserInput,
-    rubric: PerseusGrapherRubric,
+    scoringData: PerseusGrapherScoringData,
 ): PerseusScore {
-    if (userInput.type !== rubric.correct.type) {
+    if (userInput.type !== scoringData.correct.type) {
         return {
             type: "points",
             earned: 0,
@@ -53,7 +53,7 @@ function scoreGrapher(
     // Get new function handler for grading
     const grader = functionForType(userInput.type);
     const guessCoeffs = getCoefficientsByType(userInput);
-    const correctCoeffs = getCoefficientsByType(rubric.correct);
+    const correctCoeffs = getCoefficientsByType(scoringData.correct);
 
     if (guessCoeffs == null || correctCoeffs == null) {
         return {

--- a/packages/perseus/src/widgets/group/group.tsx
+++ b/packages/perseus/src/widgets/group/group.tsx
@@ -19,11 +19,14 @@ import type {
     WidgetExports,
     WidgetProps,
 } from "../../types";
-import type {PerseusGroupRubric, UserInputArray} from "../../validation.types";
+import type {
+    PerseusGroupScoringData,
+    UserInputArray,
+} from "../../validation.types";
 import type {GroupPromptJSON} from "../../widget-ai-utils/group/group-ai-utils";
 
 type RenderProps = PerseusGroupWidgetOptions; // exports has no 'transform'
-type Props = WidgetProps<RenderProps, PerseusGroupRubric>;
+type Props = WidgetProps<RenderProps, PerseusGroupScoringData>;
 type DefaultProps = {
     content: Props["content"];
     widgets: Props["widgets"];

--- a/packages/perseus/src/widgets/group/score-group.ts
+++ b/packages/perseus/src/widgets/group/score-group.ts
@@ -4,7 +4,7 @@ import {flattenScores} from "../../util/scoring";
 import type {PerseusStrings} from "../../strings";
 import type {PerseusScore} from "../../types";
 import type {
-    PerseusGroupRubric,
+    PerseusGroupScoringData,
     PerseusGroupUserInput,
 } from "../../validation.types";
 
@@ -12,7 +12,7 @@ import type {
 // it. As such, scoring a group means scoring all widgets it contains.
 function scoreGroup(
     userInput: PerseusGroupUserInput,
-    options: PerseusGroupRubric,
+    options: PerseusGroupScoringData,
     strings: PerseusStrings,
     locale: string,
 ): PerseusScore {

--- a/packages/perseus/src/widgets/input-number/input-number.test.ts
+++ b/packages/perseus/src/widgets/input-number/input-number.test.ts
@@ -285,49 +285,52 @@ describe("invalid", function () {
     });
 });
 
-describe("getOneCorrectAnswerFromRubric", () => {
+describe("getOneCorrectAnswerFromScoringData", () => {
     beforeEach(() => {
         jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
             testDependencies,
         );
     });
 
-    it("should return undefined if rubric.value is null/undefined", () => {
+    it("should return undefined if scoringData.value is null/undefined", () => {
         // Arrange
-        const rubric: Record<string, any> = {};
+        const scoringData: Record<string, any> = {};
 
         // Act
-        const result = InputNumber.getOneCorrectAnswerFromRubric?.(rubric);
+        const result =
+            InputNumber.getOneCorrectAnswerFromScoringData?.(scoringData);
 
         // Assert
         expect(result).toBeUndefined();
     });
 
-    it("should return rubric.value if inexact is false", () => {
+    it("should return scoringData.value if inexact is false", () => {
         // Arrange
-        const rubric = {
+        const scoringData = {
             value: 0,
             maxError: 0.1,
             inexact: false,
         } as const;
 
         // Act
-        const result = InputNumber.getOneCorrectAnswerFromRubric?.(rubric);
+        const result =
+            InputNumber.getOneCorrectAnswerFromScoringData?.(scoringData);
 
         // Assert
         expect(result).toEqual("0");
     });
 
-    it("should return rubric.value with an error band if inexact is true", () => {
+    it("should return scoringData.value with an error band if inexact is true", () => {
         // Arrange
-        const rubric = {
+        const scoringData = {
             value: 0,
             maxError: 0.1,
             inexact: true,
         } as const;
 
         // Act
-        const result = InputNumber.getOneCorrectAnswerFromRubric?.(rubric);
+        const result =
+            InputNumber.getOneCorrectAnswerFromScoringData?.(scoringData);
 
         // Assert
         expect(result).toEqual("0 ± 0.1");

--- a/packages/perseus/src/widgets/input-number/input-number.tsx
+++ b/packages/perseus/src/widgets/input-number/input-number.tsx
@@ -16,7 +16,7 @@ import type {PerseusInputNumberWidgetOptions} from "../../perseus-types";
 import type {PerseusStrings} from "../../strings";
 import type {Path, Widget, WidgetExports, WidgetProps} from "../../types";
 import type {
-    PerseusInputNumberRubric,
+    PerseusInputNumberScoringData,
     PerseusInputNumberUserInput,
 } from "../../validation.types";
 import type {InputNumberPromptJSON} from "../../widget-ai-utils/input-number/input-number-ai-utils";
@@ -58,7 +58,7 @@ type RenderProps = {
     rightAlign: PerseusInputNumberWidgetOptions["rightAlign"];
 };
 
-type ExternalProps = WidgetProps<RenderProps, PerseusInputNumberRubric>;
+type ExternalProps = WidgetProps<RenderProps, PerseusInputNumberScoringData>;
 type Props = ExternalProps & {
     apiOptions: NonNullable<ExternalProps["apiOptions"]>;
     linterContext: NonNullable<ExternalProps["linterContext"]>;
@@ -67,7 +67,7 @@ type Props = ExternalProps & {
     currentValue: string;
     // NOTE(kevinb): This was the only default prop that is listed as
     // not-required in PerseusInputNumberWidgetOptions.
-    answerType: NonNullable<PerseusInputNumberRubric["answerType"]>;
+    answerType: NonNullable<PerseusInputNumberScoringData["answerType"]>;
 };
 
 type DefaultProps = {

--- a/packages/perseus/src/widgets/input-number/input-number.tsx
+++ b/packages/perseus/src/widgets/input-number/input-number.tsx
@@ -288,7 +288,7 @@ export default {
     // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusInputNumberUserInput'.
     scorer: scoreInputNumber,
 
-    getOneCorrectAnswerFromRubric(rubric: any): string | null | undefined {
+    getOneCorrectAnswerFromScoringData(rubric: any): string | null | undefined {
         if (rubric.value == null) {
             return;
         }

--- a/packages/perseus/src/widgets/input-number/input-number.tsx
+++ b/packages/perseus/src/widgets/input-number/input-number.tsx
@@ -288,13 +288,15 @@ export default {
     // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusInputNumberUserInput'.
     scorer: scoreInputNumber,
 
-    getOneCorrectAnswerFromScoringData(rubric: any): string | null | undefined {
-        if (rubric.value == null) {
+    getOneCorrectAnswerFromScoringData(
+        scoringData: any,
+    ): string | null | undefined {
+        if (scoringData.value == null) {
             return;
         }
-        let answerString = String(rubric.value);
-        if (rubric.inexact && rubric.maxError) {
-            answerString += " \u00B1 " + rubric.maxError;
+        let answerString = String(scoringData.value);
+        if (scoringData.inexact && scoringData.maxError) {
+            answerString += " \u00B1 " + scoringData.maxError;
         }
         return answerString;
     },

--- a/packages/perseus/src/widgets/input-number/score-input-number.test.ts
+++ b/packages/perseus/src/widgets/input-number/score-input-number.test.ts
@@ -2,11 +2,11 @@ import {mockStrings} from "../../strings";
 
 import scoreInputNumber from "./score-input-number";
 
-import type {PerseusInputNumberRubric} from "../../validation.types";
+import type {PerseusInputNumberScoringData} from "../../validation.types";
 
 describe("scoreInputNumber", () => {
     it("scores correct answer correctly", () => {
-        const rubric: PerseusInputNumberRubric = {
+        const rubric: PerseusInputNumberScoringData = {
             maxError: 0.1,
             inexact: false,
             value: 1,
@@ -24,7 +24,7 @@ describe("scoreInputNumber", () => {
     });
 
     it("scores incorrect answer correctly", () => {
-        const rubric: PerseusInputNumberRubric = {
+        const rubric: PerseusInputNumberScoringData = {
             maxError: 0.1,
             inexact: false,
             value: 1,
@@ -42,7 +42,7 @@ describe("scoreInputNumber", () => {
     });
 
     it("shows as invalid with a nonsense answer", () => {
-        const rubric: PerseusInputNumberRubric = {
+        const rubric: PerseusInputNumberScoringData = {
             maxError: 0.1,
             inexact: false,
             value: 1,
@@ -68,7 +68,7 @@ describe("scoreInputNumber", () => {
     // important to the test.
     // https://khanacademy.atlassian.net/browse/LC-691
     it("doesn't default to validating pi", () => {
-        const rubric: PerseusInputNumberRubric = {
+        const rubric: PerseusInputNumberScoringData = {
             maxError: 0.1,
             inexact: false,
             value: 241.90263432641407,
@@ -95,7 +95,7 @@ describe("scoreInputNumber", () => {
     });
 
     it("validates against pi if provided in answerType", () => {
-        const rubric: PerseusInputNumberRubric = {
+        const rubric: PerseusInputNumberScoringData = {
             maxError: 0.1,
             inexact: false,
             value: 241.90263432641407,

--- a/packages/perseus/src/widgets/input-number/score-input-number.test.ts
+++ b/packages/perseus/src/widgets/input-number/score-input-number.test.ts
@@ -6,7 +6,7 @@ import type {PerseusInputNumberScoringData} from "../../validation.types";
 
 describe("scoreInputNumber", () => {
     it("scores correct answer correctly", () => {
-        const rubric: PerseusInputNumberScoringData = {
+        const scoringData: PerseusInputNumberScoringData = {
             maxError: 0.1,
             inexact: false,
             value: 1,
@@ -18,13 +18,13 @@ describe("scoreInputNumber", () => {
             currentValue: "1",
         } as const;
 
-        const score = scoreInputNumber(useInput, rubric, mockStrings);
+        const score = scoreInputNumber(useInput, scoringData, mockStrings);
 
         expect(score).toHaveBeenAnsweredCorrectly();
     });
 
     it("scores incorrect answer correctly", () => {
-        const rubric: PerseusInputNumberScoringData = {
+        const scoringData: PerseusInputNumberScoringData = {
             maxError: 0.1,
             inexact: false,
             value: 1,
@@ -36,13 +36,13 @@ describe("scoreInputNumber", () => {
             currentValue: "2",
         } as const;
 
-        const score = scoreInputNumber(useInput, rubric, mockStrings);
+        const score = scoreInputNumber(useInput, scoringData, mockStrings);
 
         expect(score).toHaveBeenAnsweredIncorrectly();
     });
 
     it("shows as invalid with a nonsense answer", () => {
-        const rubric: PerseusInputNumberScoringData = {
+        const scoringData: PerseusInputNumberScoringData = {
             maxError: 0.1,
             inexact: false,
             value: 1,
@@ -54,7 +54,7 @@ describe("scoreInputNumber", () => {
             currentValue: "sadasdfas",
         } as const;
 
-        const score = scoreInputNumber(useInput, rubric, mockStrings);
+        const score = scoreInputNumber(useInput, scoringData, mockStrings);
 
         expect(score).toHaveInvalidInput(
             "We could not understand your answer. Please check your answer for extra text or symbols.",
@@ -68,7 +68,7 @@ describe("scoreInputNumber", () => {
     // important to the test.
     // https://khanacademy.atlassian.net/browse/LC-691
     it("doesn't default to validating pi", () => {
-        const rubric: PerseusInputNumberScoringData = {
+        const scoringData: PerseusInputNumberScoringData = {
             maxError: 0.1,
             inexact: false,
             value: 241.90263432641407,
@@ -82,7 +82,7 @@ describe("scoreInputNumber", () => {
             currentValue: "241.91",
         } as const;
 
-        const score = scoreInputNumber(userInput, rubric, mockStrings);
+        const score = scoreInputNumber(userInput, scoringData, mockStrings);
 
         expect(score.message).not.toBe(
             "Your answer is close, but yyou may " +
@@ -95,7 +95,7 @@ describe("scoreInputNumber", () => {
     });
 
     it("validates against pi if provided in answerType", () => {
-        const rubric: PerseusInputNumberScoringData = {
+        const scoringData: PerseusInputNumberScoringData = {
             maxError: 0.1,
             inexact: false,
             value: 241.90263432641407,
@@ -107,7 +107,7 @@ describe("scoreInputNumber", () => {
             currentValue: "77 pi",
         } as const;
 
-        const score = scoreInputNumber(userInput, rubric, mockStrings);
+        const score = scoreInputNumber(userInput, scoringData, mockStrings);
 
         expect(score).toHaveBeenAnsweredCorrectly();
     });

--- a/packages/perseus/src/widgets/input-number/score-input-number.ts
+++ b/packages/perseus/src/widgets/input-number/score-input-number.ts
@@ -3,7 +3,7 @@ import KhanAnswerTypes from "../../util/answer-types";
 
 import type {PerseusStrings} from "../../strings";
 import type {
-    PerseusInputNumberRubric,
+    PerseusInputNumberScoringData,
     PerseusInputNumberUserInput,
 } from "../../validation.types";
 import type {PerseusScore} from "@khanacademy/perseus";
@@ -47,7 +47,7 @@ export const answerTypes = {
 
 function scoreInputNumber(
     userInput: PerseusInputNumberUserInput,
-    rubric: PerseusInputNumberRubric,
+    rubric: PerseusInputNumberScoringData,
     strings: PerseusStrings,
 ): PerseusScore {
     if (rubric.answerType == null) {

--- a/packages/perseus/src/widgets/input-number/score-input-number.ts
+++ b/packages/perseus/src/widgets/input-number/score-input-number.ts
@@ -47,24 +47,24 @@ export const answerTypes = {
 
 function scoreInputNumber(
     userInput: PerseusInputNumberUserInput,
-    rubric: PerseusInputNumberScoringData,
+    scoringData: PerseusInputNumberScoringData,
     strings: PerseusStrings,
 ): PerseusScore {
-    if (rubric.answerType == null) {
-        rubric.answerType = "number";
+    if (scoringData.answerType == null) {
+        scoringData.answerType = "number";
     }
 
     // note(matthewc): this will get immediately parsed again by
     // `KhanAnswerTypes.number.convertToPredicate`, but a string is
     // expected here
-    const stringValue = `${rubric.value}`;
+    const stringValue = `${scoringData.value}`;
     const val = KhanAnswerTypes.number.createValidatorFunctional(
         stringValue,
         {
-            simplify: rubric.simplify,
-            inexact: rubric.inexact || undefined,
-            maxError: rubric.maxError,
-            forms: answerTypes[rubric.answerType].forms,
+            simplify: scoringData.simplify,
+            inexact: scoringData.inexact || undefined,
+            maxError: scoringData.maxError,
+            forms: answerTypes[scoringData.answerType].forms,
         },
         strings,
     );

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -55,7 +55,7 @@ import type {
     SineCoefficient,
 } from "../util/geometry";
 import type {
-    PerseusInteractiveGraphRubric,
+    PerseusInteractiveGraphScoringData,
     PerseusInteractiveGraphUserInput,
 } from "../validation.types";
 import type {InteractiveGraphPromptJSON} from "../widget-ai-utils/interactive-graph/interactive-graph-ai-utils";
@@ -219,7 +219,7 @@ type RenderProps = {
      */
     fullGraphAriaDescription?: string;
 }; // There's no transform function in exports
-type Props = WidgetProps<RenderProps, PerseusInteractiveGraphRubric>;
+type Props = WidgetProps<RenderProps, PerseusInteractiveGraphScoringData>;
 type State = any;
 type DefaultProps = {
     labels: ReadonlyArray<string>;
@@ -240,7 +240,7 @@ type DefaultProps = {
 // which receive defaults via defaultProps.
 0 as any as WidgetProps<
     PerseusInteractiveGraphWidgetOptions,
-    PerseusInteractiveGraphRubric
+    PerseusInteractiveGraphScoringData
 > satisfies PropsFor<typeof InteractiveGraph>;
 
 // TODO: there's another, very similar getSinusoidCoefficients function

--- a/packages/perseus/src/widgets/interactive-graphs/score-interactive-graph.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/score-interactive-graph.test.ts
@@ -5,12 +5,12 @@ import {clone} from "../../../../../testing/object-utils";
 import scoreInteractiveGraph from "./score-interactive-graph";
 
 import type {PerseusGraphType} from "../../perseus-types";
-import type {PerseusInteractiveGraphRubric} from "../../validation.types";
+import type {PerseusInteractiveGraphScoringData} from "../../validation.types";
 
 describe("InteractiveGraph scoring on a segment question", () => {
     it("marks the answer invalid if guess.coords is missing", () => {
         const guess: PerseusGraphType = {type: "segment"};
-        const rubric: PerseusInteractiveGraphRubric = {
+        const scoringData: PerseusInteractiveGraphScoringData = {
             graph: {
                 type: "segment",
             },
@@ -25,7 +25,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
             },
         };
 
-        const result = scoreInteractiveGraph(guess, rubric);
+        const result = scoreInteractiveGraph(guess, scoringData);
 
         expect(result).toHaveInvalidInput();
     });
@@ -41,7 +41,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
             ],
         };
 
-        const rubric: PerseusInteractiveGraphRubric = {
+        const scoringData: PerseusInteractiveGraphScoringData = {
             graph: {type: "segment"},
             correct: {
                 type: "segment",
@@ -54,7 +54,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
             },
         };
 
-        const result = scoreInteractiveGraph(guess, rubric);
+        const result = scoreInteractiveGraph(guess, scoringData);
 
         expect(result).toHaveBeenAnsweredIncorrectly();
     });
@@ -70,7 +70,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
             ],
         };
 
-        const rubric: PerseusInteractiveGraphRubric = {
+        const scoringData: PerseusInteractiveGraphScoringData = {
             graph: {type: "segment"},
             correct: {
                 type: "segment",
@@ -83,7 +83,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
             },
         };
 
-        const result = scoreInteractiveGraph(guess, rubric);
+        const result = scoreInteractiveGraph(guess, scoringData);
 
         expect(result).toHaveBeenAnsweredCorrectly();
     });
@@ -98,7 +98,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
                 ],
             ],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const scoringData: PerseusInteractiveGraphScoringData = {
             graph: {type: "segment"},
             correct: {
                 type: "segment",
@@ -111,7 +111,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
             },
         };
 
-        const result = scoreInteractiveGraph(guess, rubric);
+        const result = scoreInteractiveGraph(guess, scoringData);
 
         expect(result).toHaveBeenAnsweredCorrectly();
     });
@@ -127,7 +127,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
             ],
         };
 
-        const rubric: PerseusInteractiveGraphRubric = {
+        const scoringData: PerseusInteractiveGraphScoringData = {
             graph: {type: "segment"},
             correct: {
                 type: "segment",
@@ -140,7 +140,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
             },
         };
 
-        scoreInteractiveGraph(guess, rubric);
+        scoreInteractiveGraph(guess, scoringData);
 
         expect(guess.coords).toEqual([
             [
@@ -150,7 +150,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
         ]);
     });
 
-    it("does not modify the `rubric` data", () => {
+    it("does not modify `scoringData`", () => {
         const guess: PerseusGraphType = {
             type: "segment",
             coords: [
@@ -160,7 +160,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
                 ],
             ],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const scoringData: PerseusInteractiveGraphScoringData = {
             graph: {type: "segment"},
             correct: {
                 type: "segment",
@@ -173,12 +173,12 @@ describe("InteractiveGraph scoring on a segment question", () => {
             },
         };
 
-        scoreInteractiveGraph(guess, rubric);
+        scoreInteractiveGraph(guess, scoringData);
 
-        // Narrow the type of `rubric.correct` to segment graph; otherwise TS
+        // Narrow the type of `scoringData.correct` to segment graph; otherwise TS
         // thinks it might not have a `coords` property.
-        invariant(rubric.correct.type === "segment");
-        expect(rubric.correct.coords).toEqual([
+        invariant(scoringData.correct.type === "segment");
+        expect(scoringData.correct.coords).toEqual([
             [
                 [1, 1],
                 [0, 0],
@@ -190,7 +190,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
 describe("InteractiveGraph scoring on an angle question", () => {
     it("marks the answer invalid if guess.coords is missing", () => {
         const guess: PerseusGraphType = {type: "angle"};
-        const rubric: PerseusInteractiveGraphRubric = {
+        const scoringData: PerseusInteractiveGraphScoringData = {
             graph: {type: "angle"},
             correct: {
                 type: "angle",
@@ -204,7 +204,7 @@ describe("InteractiveGraph scoring on an angle question", () => {
             },
         };
 
-        const result = scoreInteractiveGraph(guess, rubric);
+        const result = scoreInteractiveGraph(guess, scoringData);
 
         expect(result).toHaveInvalidInput();
     });
@@ -213,7 +213,7 @@ describe("InteractiveGraph scoring on an angle question", () => {
 describe("InteractiveGraph scoring on a point question", () => {
     it("marks the answer invalid if guess.coords is missing", () => {
         const guess: PerseusGraphType = {type: "point"};
-        const rubric: PerseusInteractiveGraphRubric = {
+        const scoringData: PerseusInteractiveGraphScoringData = {
             graph: {type: "point"},
             correct: {
                 type: "point",
@@ -221,7 +221,7 @@ describe("InteractiveGraph scoring on a point question", () => {
             },
         };
 
-        const result = scoreInteractiveGraph(guess, rubric);
+        const result = scoreInteractiveGraph(guess, scoringData);
 
         expect(result).toHaveInvalidInput();
     });
@@ -234,17 +234,17 @@ describe("InteractiveGraph scoring on a point question", () => {
             coords: [[0, 0]],
         };
 
-        const rubric: PerseusInteractiveGraphRubric = {
+        const scoringData: PerseusInteractiveGraphScoringData = {
             graph: {
                 type: "point",
             },
-            // @ts-expect-error: Testing exception for invalid rubric
+            // @ts-expect-error: Testing exception for invalid scoringData
             correct: {
                 type: "point",
             },
         };
 
-        expect(() => scoreInteractiveGraph(guess, rubric)).toThrowError();
+        expect(() => scoreInteractiveGraph(guess, scoringData)).toThrowError();
     });
 
     it("does not award points if guess.coords is wrong", () => {
@@ -252,7 +252,7 @@ describe("InteractiveGraph scoring on a point question", () => {
             type: "point",
             coords: [[9, 9]],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const scoringData: PerseusInteractiveGraphScoringData = {
             graph: {type: "point"},
             correct: {
                 type: "point",
@@ -260,7 +260,7 @@ describe("InteractiveGraph scoring on a point question", () => {
             },
         };
 
-        const result = scoreInteractiveGraph(guess, rubric);
+        const result = scoreInteractiveGraph(guess, scoringData);
 
         expect(result).toHaveBeenAnsweredIncorrectly();
     });
@@ -270,7 +270,7 @@ describe("InteractiveGraph scoring on a point question", () => {
             type: "point",
             coords: [[7, 8]],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const scoringData: PerseusInteractiveGraphScoringData = {
             graph: {type: "point"},
             correct: {
                 type: "point",
@@ -278,7 +278,7 @@ describe("InteractiveGraph scoring on a point question", () => {
             },
         };
 
-        const result = scoreInteractiveGraph(guess, rubric);
+        const result = scoreInteractiveGraph(guess, scoringData);
 
         expect(result).toHaveBeenAnsweredCorrectly();
     });
@@ -291,7 +291,7 @@ describe("InteractiveGraph scoring on a point question", () => {
                 [5, 6],
             ],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const scoringData: PerseusInteractiveGraphScoringData = {
             graph: {type: "point"},
             correct: {
                 type: "point",
@@ -302,7 +302,7 @@ describe("InteractiveGraph scoring on a point question", () => {
             },
         };
 
-        const result = scoreInteractiveGraph(guess, rubric);
+        const result = scoreInteractiveGraph(guess, scoringData);
 
         expect(result).toHaveBeenAnsweredCorrectly();
     });
@@ -315,7 +315,7 @@ describe("InteractiveGraph scoring on a point question", () => {
                 [5, 6],
             ],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const scoringData: PerseusInteractiveGraphScoringData = {
             graph: {type: "point"},
             correct: {
                 type: "point",
@@ -328,12 +328,12 @@ describe("InteractiveGraph scoring on a point question", () => {
 
         const guessClone = clone(guess);
 
-        scoreInteractiveGraph(guess, rubric);
+        scoreInteractiveGraph(guess, scoringData);
 
         expect(guess).toEqual(guessClone);
     });
 
-    it("does not modify the `rubric` data", () => {
+    it("does not modify `scoringData`", () => {
         const guess: PerseusGraphType = {
             type: "point",
             coords: [
@@ -341,7 +341,7 @@ describe("InteractiveGraph scoring on a point question", () => {
                 [5, 6],
             ],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const scoringData: PerseusInteractiveGraphScoringData = {
             graph: {type: "point"},
             correct: {
                 type: "point",
@@ -352,10 +352,10 @@ describe("InteractiveGraph scoring on a point question", () => {
             },
         };
 
-        const rubricClone = clone(rubric);
+        const scoringDataClone = clone(scoringData);
 
-        scoreInteractiveGraph(guess, rubric);
+        scoreInteractiveGraph(guess, scoringData);
 
-        expect(rubric).toEqual(rubricClone);
+        expect(scoringData).toEqual(scoringDataClone);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/score-interactive-graph.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/score-interactive-graph.ts
@@ -16,7 +16,7 @@ import {getClockwiseAngle} from "./math/angles";
 
 import type {PerseusScore} from "../../types";
 import type {
-    PerseusInteractiveGraphRubric,
+    PerseusInteractiveGraphScoringData,
     PerseusInteractiveGraphUserInput,
 } from "../../validation.types";
 
@@ -25,10 +25,10 @@ const deepEq = Util.deepEq;
 
 function scoreInteractiveGraph(
     userInput: PerseusInteractiveGraphUserInput,
-    rubric: PerseusInteractiveGraphRubric,
+    scoringData: PerseusInteractiveGraphScoringData,
 ): PerseusScore {
     // None-type graphs are not graded
-    if (userInput.type === "none" && rubric.correct.type === "none") {
+    if (userInput.type === "none" && scoringData.correct.type === "none") {
         return {
             type: "points",
             earned: 0,
@@ -47,14 +47,14 @@ function scoreInteractiveGraph(
             (userInput.center && userInput.radius),
     );
 
-    if (userInput.type === rubric.correct.type && hasValue) {
+    if (userInput.type === scoringData.correct.type && hasValue) {
         if (
             userInput.type === "linear" &&
-            rubric.correct.type === "linear" &&
+            scoringData.correct.type === "linear" &&
             userInput.coords != null
         ) {
             const guess = userInput.coords;
-            const correct = rubric.correct.coords;
+            const correct = scoringData.correct.coords;
 
             // If both of the guess points are on the correct line, it's
             // correct.
@@ -71,11 +71,11 @@ function scoreInteractiveGraph(
             }
         } else if (
             userInput.type === "linear-system" &&
-            rubric.correct.type === "linear-system" &&
+            scoringData.correct.type === "linear-system" &&
             userInput.coords != null
         ) {
             const guess = userInput.coords;
-            const correct = rubric.correct.coords;
+            const correct = scoringData.correct.coords;
 
             if (
                 (collinear(correct[0][0], correct[0][1], guess[0][0]) &&
@@ -96,13 +96,13 @@ function scoreInteractiveGraph(
             }
         } else if (
             userInput.type === "quadratic" &&
-            rubric.correct.type === "quadratic" &&
+            scoringData.correct.type === "quadratic" &&
             userInput.coords != null
         ) {
             // If the parabola coefficients match, it's correct.
             const guessCoeffs = getQuadraticCoefficients(userInput.coords);
             const correctCoeffs = getQuadraticCoefficients(
-                rubric.correct.coords,
+                scoringData.correct.coords,
             );
             if (deepEq(guessCoeffs, correctCoeffs)) {
                 return {
@@ -114,12 +114,12 @@ function scoreInteractiveGraph(
             }
         } else if (
             userInput.type === "sinusoid" &&
-            rubric.correct.type === "sinusoid" &&
+            scoringData.correct.type === "sinusoid" &&
             userInput.coords != null
         ) {
             const guessCoeffs = getSinusoidCoefficients(userInput.coords);
             const correctCoeffs = getSinusoidCoefficients(
-                rubric.correct.coords,
+                scoringData.correct.coords,
             );
 
             const canonicalGuessCoeffs = canonicalSineCoefficients(guessCoeffs);
@@ -136,11 +136,11 @@ function scoreInteractiveGraph(
             }
         } else if (
             userInput.type === "circle" &&
-            rubric.correct.type === "circle"
+            scoringData.correct.type === "circle"
         ) {
             if (
-                deepEq(userInput.center, rubric.correct.center) &&
-                eq(userInput.radius, rubric.correct.radius)
+                deepEq(userInput.center, scoringData.correct.center) &&
+                eq(userInput.radius, scoringData.correct.radius)
             ) {
                 return {
                     type: "points",
@@ -151,12 +151,12 @@ function scoreInteractiveGraph(
             }
         } else if (
             userInput.type === "point" &&
-            rubric.correct.type === "point" &&
+            scoringData.correct.type === "point" &&
             userInput.coords != null
         ) {
-            let correct = rubric.correct.coords;
+            let correct = scoringData.correct.coords;
             if (correct == null) {
-                throw new Error("Point graph rubric has null coords");
+                throw new Error("Point graph scoringData has null coords");
             }
             const guess = userInput.coords.slice();
             correct = correct.slice();
@@ -177,18 +177,18 @@ function scoreInteractiveGraph(
             }
         } else if (
             userInput.type === "polygon" &&
-            rubric.correct.type === "polygon" &&
+            scoringData.correct.type === "polygon" &&
             userInput.coords != null
         ) {
             const guess = userInput.coords.slice();
-            const correct = rubric.correct.coords.slice();
+            const correct = scoringData.correct.coords.slice();
 
             let match;
-            if (rubric.correct.match === "similar") {
+            if (scoringData.correct.match === "similar") {
                 match = similar(guess, correct, Number.POSITIVE_INFINITY);
-            } else if (rubric.correct.match === "congruent") {
+            } else if (scoringData.correct.match === "congruent") {
                 match = similar(guess, correct, knumber.DEFAULT_TOLERANCE);
-            } else if (rubric.correct.match === "approx") {
+            } else if (scoringData.correct.match === "approx") {
                 match = similar(guess, correct, 0.1);
             } else {
                 /* exact */
@@ -207,11 +207,11 @@ function scoreInteractiveGraph(
             }
         } else if (
             userInput.type === "segment" &&
-            rubric.correct.type === "segment" &&
+            scoringData.correct.type === "segment" &&
             userInput.coords != null
         ) {
             let guess = Util.deepClone(userInput.coords);
-            let correct = Util.deepClone(rubric.correct.coords);
+            let correct = Util.deepClone(scoringData.correct.coords);
             guess = _.invoke(guess, "sort").sort();
             correct = _.invoke(correct, "sort").sort();
             if (deepEq(guess, correct)) {
@@ -224,11 +224,11 @@ function scoreInteractiveGraph(
             }
         } else if (
             userInput.type === "ray" &&
-            rubric.correct.type === "ray" &&
+            scoringData.correct.type === "ray" &&
             userInput.coords != null
         ) {
             const guess = userInput.coords;
-            const correct = rubric.correct.coords;
+            const correct = scoringData.correct.coords;
             if (
                 deepEq(guess[0], correct[0]) &&
                 collinear(correct[0], correct[1], guess[1])
@@ -242,14 +242,14 @@ function scoreInteractiveGraph(
             }
         } else if (
             userInput.type === "angle" &&
-            rubric.correct.type === "angle"
+            scoringData.correct.type === "angle"
         ) {
             const guess = userInput.coords;
-            const correct = rubric.correct.coords;
-            const allowReflexAngles = rubric.correct.allowReflexAngles;
+            const correct = scoringData.correct.coords;
+            const allowReflexAngles = scoringData.correct.allowReflexAngles;
 
             let match;
-            if (rubric.correct.match === "congruent") {
+            if (scoringData.correct.match === "congruent") {
                 const angles = _.map([guess, correct], function (coords) {
                     if (!coords) {
                         return false;
@@ -282,7 +282,7 @@ function scoreInteractiveGraph(
 
     // The input wasn't correct, so check if it's a blank input or if it's
     // actually just wrong
-    if (!hasValue || _.isEqual(userInput, rubric.graph)) {
+    if (!hasValue || _.isEqual(userInput, scoringData.graph)) {
         // We're where we started.
         return {
             type: "invalid",

--- a/packages/perseus/src/widgets/matcher/matcher.tsx
+++ b/packages/perseus/src/widgets/matcher/matcher.tsx
@@ -17,7 +17,7 @@ import type {SortableOption} from "../../components/sortable";
 import type {PerseusMatcherWidgetOptions} from "../../perseus-types";
 import type {WidgetExports, WidgetProps, Widget} from "../../types";
 import type {
-    PerseusMatcherRubric,
+    PerseusMatcherScoringData,
     PerseusMatcherUserInput,
 } from "../../validation.types";
 import type {MatcherPromptJSON} from "../../widget-ai-utils/matcher/matcher-ai-utils";
@@ -27,7 +27,7 @@ const HACKY_CSS_CLASSNAME = "perseus-widget-matcher";
 
 type RenderProps = PerseusMatcherWidgetOptions;
 
-type Props = WidgetProps<RenderProps, PerseusMatcherRubric>;
+type Props = WidgetProps<RenderProps, PerseusMatcherScoringData>;
 
 type DefaultProps = {
     left: Props["left"];

--- a/packages/perseus/src/widgets/matcher/score-matcher.test.ts
+++ b/packages/perseus/src/widgets/matcher/score-matcher.test.ts
@@ -1,7 +1,7 @@
 import scoreMatcher from "./score-matcher";
 
 import type {
-    PerseusMatcherRubric,
+    PerseusMatcherScoringData,
     PerseusMatcherUserInput,
 } from "../../validation.types";
 
@@ -13,7 +13,7 @@ describe("scoreMatcher", () => {
             right: ["cool", "beans"],
         };
 
-        const rubric: PerseusMatcherRubric = {
+        const scoringData: PerseusMatcherScoringData = {
             labels: ["One", "Two"],
             left: ["1", "0+1"],
             right: ["2", "0+2"],
@@ -22,7 +22,7 @@ describe("scoreMatcher", () => {
         };
 
         // Act
-        const result = scoreMatcher(userInput, rubric);
+        const result = scoreMatcher(userInput, scoringData);
 
         // Assert
         expect(result).toHaveBeenAnsweredIncorrectly();
@@ -30,7 +30,7 @@ describe("scoreMatcher", () => {
 
     it("can be answered correctly", () => {
         // Arrange
-        const rubric: PerseusMatcherRubric = {
+        const scoringData: PerseusMatcherScoringData = {
             labels: ["One", "Two"],
             left: ["1", "0+1"],
             right: ["2", "0+2"],
@@ -39,12 +39,12 @@ describe("scoreMatcher", () => {
         };
 
         const userInput: PerseusMatcherUserInput = {
-            left: [...rubric.left],
-            right: [...rubric.right],
+            left: [...scoringData.left],
+            right: [...scoringData.right],
         };
 
         // Act
-        const result = scoreMatcher(userInput, rubric);
+        const result = scoreMatcher(userInput, scoringData);
 
         // Assert
         expect(result).toHaveBeenAnsweredCorrectly();

--- a/packages/perseus/src/widgets/matcher/score-matcher.ts
+++ b/packages/perseus/src/widgets/matcher/score-matcher.ts
@@ -2,17 +2,17 @@ import _ from "underscore";
 
 import type {PerseusScore} from "../../types";
 import type {
-    PerseusMatcherRubric,
+    PerseusMatcherScoringData,
     PerseusMatcherUserInput,
 } from "../../validation.types";
 
 function scoreMatcher(
     state: PerseusMatcherUserInput,
-    rubric: PerseusMatcherRubric,
+    scoringData: PerseusMatcherScoringData,
 ): PerseusScore {
     const correct =
-        _.isEqual(state.left, rubric.left) &&
-        _.isEqual(state.right, rubric.right);
+        _.isEqual(state.left, scoringData.left) &&
+        _.isEqual(state.right, scoringData.right);
 
     return {
         type: "points",

--- a/packages/perseus/src/widgets/matcher/score-matcher.ts
+++ b/packages/perseus/src/widgets/matcher/score-matcher.ts
@@ -7,12 +7,12 @@ import type {
 } from "../../validation.types";
 
 function scoreMatcher(
-    state: PerseusMatcherUserInput,
+    userInput: PerseusMatcherUserInput,
     scoringData: PerseusMatcherScoringData,
 ): PerseusScore {
     const correct =
-        _.isEqual(state.left, scoringData.left) &&
-        _.isEqual(state.right, scoringData.right);
+        _.isEqual(userInput.left, scoringData.left) &&
+        _.isEqual(userInput.right, scoringData.right);
 
     return {
         type: "points",

--- a/packages/perseus/src/widgets/matrix/matrix.tsx
+++ b/packages/perseus/src/widgets/matrix/matrix.tsx
@@ -23,7 +23,7 @@ import type {
 } from "../../perseus-types";
 import type {WidgetExports, WidgetProps, Widget, FocusPath} from "../../types";
 import type {
-    PerseusMatrixRubric,
+    PerseusMatrixScoringData,
     PerseusMatrixUserInput,
 } from "../../validation.types";
 import type {MatrixPromptJSON} from "../../widget-ai-utils/matrix/matrix-ai-utils";
@@ -118,7 +118,7 @@ type ExternalProps = WidgetProps<
         // Whether this is meant to statically display the answers (true) or be used as an input field, graded against the answers
         static?: boolean | undefined;
     },
-    PerseusMatrixRubric
+    PerseusMatrixScoringData
 >;
 
 // Assert that the PerseusMatrixWidgetOptions parsed from JSON can be passed
@@ -129,7 +129,7 @@ type ExternalProps = WidgetProps<
 // defaultProps.
 0 as any as WidgetProps<
     PerseusMatrixWidgetOptions,
-    PerseusMatrixRubric
+    PerseusMatrixScoringData
 > satisfies PropsFor<typeof Matrix>;
 
 type Props = ExternalProps & {

--- a/packages/perseus/src/widgets/matrix/score-matrix.test.ts
+++ b/packages/perseus/src/widgets/matrix/score-matrix.test.ts
@@ -4,7 +4,7 @@ import scoreMatrix from "./score-matrix";
 import * as MatrixValidator from "./validate-matrix";
 
 import type {
-    PerseusMatrixRubric,
+    PerseusMatrixScoringData,
     PerseusMatrixUserInput,
 } from "../../validation.types";
 
@@ -15,7 +15,7 @@ describe("scoreMatrix", () => {
             .spyOn(MatrixValidator, "default")
             .mockReturnValue(null);
 
-        const rubric: PerseusMatrixRubric = {
+        const scoringData: PerseusMatrixScoringData = {
             answers: [
                 [0, 1, 2],
                 [3, 4, 5],
@@ -24,16 +24,16 @@ describe("scoreMatrix", () => {
         };
 
         const userInput: PerseusMatrixUserInput = {
-            answers: rubric.answers,
+            answers: scoringData.answers,
         };
 
         // Act
-        const score = scoreMatrix(userInput, rubric, mockStrings);
+        const score = scoreMatrix(userInput, scoringData, mockStrings);
 
         // Assert
         expect(mockValidator).toHaveBeenCalledWith(
             userInput,
-            rubric,
+            scoringData,
             mockStrings,
         );
         expect(score).toHaveBeenAnsweredCorrectly();
@@ -45,7 +45,7 @@ describe("scoreMatrix", () => {
             .spyOn(MatrixValidator, "default")
             .mockReturnValue({type: "invalid", message: null});
 
-        const rubric: PerseusMatrixRubric = {
+        const scoringData: PerseusMatrixScoringData = {
             answers: [
                 [0, 1, 2],
                 [3, 4, 5],
@@ -54,16 +54,16 @@ describe("scoreMatrix", () => {
         };
 
         const userInput: PerseusMatrixUserInput = {
-            answers: rubric.answers,
+            answers: scoringData.answers,
         };
 
         // Act
-        const score = scoreMatrix(userInput, rubric, mockStrings);
+        const score = scoreMatrix(userInput, scoringData, mockStrings);
 
         // Assert
         expect(mockValidator).toHaveBeenCalledWith(
             userInput,
-            rubric,
+            scoringData,
             mockStrings,
         );
         expect(score).toHaveInvalidInput();
@@ -71,7 +71,7 @@ describe("scoreMatrix", () => {
 
     it("can be answered correctly", () => {
         // Arrange
-        const rubric: PerseusMatrixRubric = {
+        const scoringData: PerseusMatrixScoringData = {
             answers: [
                 [0, 1, 2],
                 [3, 4, 5],
@@ -80,11 +80,11 @@ describe("scoreMatrix", () => {
         };
 
         const userInput: PerseusMatrixUserInput = {
-            answers: rubric.answers,
+            answers: scoringData.answers,
         };
 
         // Act
-        const result = scoreMatrix(userInput, rubric, mockStrings);
+        const result = scoreMatrix(userInput, scoringData, mockStrings);
 
         // Assert
         expect(result).toHaveBeenAnsweredCorrectly();
@@ -92,7 +92,7 @@ describe("scoreMatrix", () => {
 
     it("can be answered incorrectly", () => {
         // Arrange
-        const rubric: PerseusMatrixRubric = {
+        const scoringData: PerseusMatrixScoringData = {
             answers: [
                 [0, 1, 2],
                 [3, 4, 5],
@@ -109,7 +109,7 @@ describe("scoreMatrix", () => {
         };
 
         // Act
-        const result = scoreMatrix(userInput, rubric, mockStrings);
+        const result = scoreMatrix(userInput, scoringData, mockStrings);
 
         // Assert
         expect(result).toHaveBeenAnsweredIncorrectly();
@@ -117,7 +117,7 @@ describe("scoreMatrix", () => {
 
     it("is invalid when there's an empty cell: null", () => {
         // Arrange
-        const rubric: PerseusMatrixRubric = {
+        const scoringData: PerseusMatrixScoringData = {
             answers: [
                 [0, 1, 2],
                 [3, 4, 5],
@@ -137,7 +137,7 @@ describe("scoreMatrix", () => {
         };
 
         // Act
-        const result = scoreMatrix(userInput, rubric, mockStrings);
+        const result = scoreMatrix(userInput, scoringData, mockStrings);
 
         // Assert
         expect(result).toHaveInvalidInput();
@@ -145,7 +145,7 @@ describe("scoreMatrix", () => {
 
     it("is invalid when there's an empty cell: empty string", () => {
         // Arrange
-        const rubric: PerseusMatrixRubric = {
+        const scoringData: PerseusMatrixScoringData = {
             answers: [
                 [0, 1, 2],
                 [3, 4, 5],
@@ -165,7 +165,7 @@ describe("scoreMatrix", () => {
         };
 
         // Act
-        const result = scoreMatrix(userInput, rubric, mockStrings);
+        const result = scoreMatrix(userInput, scoringData, mockStrings);
 
         // Assert
         expect(result).toHaveInvalidInput();
@@ -173,7 +173,7 @@ describe("scoreMatrix", () => {
 
     it("is considered incorrect when the size is wrong", () => {
         // Arrange
-        const rubric: PerseusMatrixRubric = {
+        const scoringData: PerseusMatrixScoringData = {
             answers: [
                 [0, 1, 2],
                 [3, 4, 5],
@@ -182,7 +182,7 @@ describe("scoreMatrix", () => {
         };
 
         const correctUserInput: PerseusMatrixUserInput = {
-            answers: rubric.answers,
+            answers: scoringData.answers,
         };
 
         const incorrectUserInput: PerseusMatrixUserInput = {
@@ -190,18 +190,18 @@ describe("scoreMatrix", () => {
             // This is so we can check that it's considered incorrect
             // if it has the wrong length, even though it otherwise
             // would be a partial match.
-            answers: [...rubric.answers, [8, 6, 7]],
+            answers: [...scoringData.answers, [8, 6, 7]],
         };
 
         // Act
         const correctResult = scoreMatrix(
             correctUserInput,
-            rubric,
+            scoringData,
             mockStrings,
         );
         const incorrectResult = scoreMatrix(
             incorrectUserInput,
-            rubric,
+            scoringData,
             mockStrings,
         );
 

--- a/packages/perseus/src/widgets/matrix/score-matrix.ts
+++ b/packages/perseus/src/widgets/matrix/score-matrix.ts
@@ -8,21 +8,21 @@ import validateMatrix from "./validate-matrix";
 import type {PerseusStrings} from "../../strings";
 import type {PerseusScore} from "../../types";
 import type {
-    PerseusMatrixRubric,
+    PerseusMatrixScoringData,
     PerseusMatrixUserInput,
 } from "../../validation.types";
 
 function scoreMatrix(
     userInput: PerseusMatrixUserInput,
-    rubric: PerseusMatrixRubric,
+    scoringData: PerseusMatrixScoringData,
     strings: PerseusStrings,
 ): PerseusScore {
-    const validationResult = validateMatrix(userInput, rubric, strings);
+    const validationResult = validateMatrix(userInput, scoringData, strings);
     if (validationResult != null) {
         return validationResult;
     }
 
-    const solution = rubric.answers;
+    const solution = scoringData.answers;
     const supplied = userInput.answers;
     const solutionSize = getMatrixSize(solution);
     const suppliedSize = getMatrixSize(supplied);

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
@@ -166,7 +166,7 @@ describe("static function getOneCorrectAnswerFromScoringData", () => {
         );
     });
 
-    it("can get one correct answer from a rubric with multiple answers", () => {
+    it("can get one correct answer from scoring data with multiple answers", () => {
         const widget = multipleAnswersWithDecimals.widgets["numeric-input 1"];
         const widgetOptions = widget && widget.options;
         const answers: ReadonlyArray<any> =
@@ -180,7 +180,7 @@ describe("static function getOneCorrectAnswerFromScoringData", () => {
         expect(singleAnswer).toBe("12.2");
     });
 
-    it("can get one correct answer from a rubric with one answer", () => {
+    it("can get one correct answer from scoring data with one answer", () => {
         const widget = question1.widgets["numeric-input 1"];
         const widgetOptions = widget && widget.options;
         const answers: ReadonlyArray<any> =
@@ -193,7 +193,7 @@ describe("static function getOneCorrectAnswerFromScoringData", () => {
         expect(singleAnswer).toBe("1252");
     });
 
-    it("can not get a correct answer from a rubric with no answer", () => {
+    it("can not get a correct answer from scoring data with no answer", () => {
         const answers: Array<never> = [];
         const singleAnswer =
             NumericInputWidgetExport.getOneCorrectAnswerFromScoringData?.({

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
@@ -17,7 +17,7 @@ import {
     withCoefficient,
 } from "./numeric-input.testdata";
 
-import type {PerseusNumericInputRubric} from "../../validation.types";
+import type {PerseusNumericInputScoringData} from "../../validation.types";
 import type {UserEvent} from "@testing-library/user-event";
 
 describe("numeric-input widget", () => {
@@ -204,7 +204,7 @@ describe("static function getOneCorrectAnswerFromRubric", () => {
     });
 
     it("supports error bars", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const scoringData: PerseusNumericInputScoringData = {
             answers: [
                 {
                     status: "correct",
@@ -219,7 +219,9 @@ describe("static function getOneCorrectAnswerFromRubric", () => {
             coefficient: true,
         };
         const singleAnswer =
-            NumericInputWidgetExport.getOneCorrectAnswerFromRubric?.(rubric);
+            NumericInputWidgetExport.getOneCorrectAnswerFromRubric?.(
+                scoringData,
+            );
         expect(singleAnswer).toBe("1 ± 0.2");
     });
 });

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
@@ -159,7 +159,7 @@ describe("numeric-input widget", () => {
     });
 });
 
-describe("static function getOneCorrectAnswerFromRubric", () => {
+describe("static function getOneCorrectAnswerFromScoringData", () => {
     beforeEach(() => {
         jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
             testDependencies,
@@ -173,7 +173,7 @@ describe("static function getOneCorrectAnswerFromRubric", () => {
             (widgetOptions && widgetOptions.answers) || [];
 
         const singleAnswer =
-            NumericInputWidgetExport.getOneCorrectAnswerFromRubric?.({
+            NumericInputWidgetExport.getOneCorrectAnswerFromScoringData?.({
                 answers,
                 coefficient: false,
             });
@@ -186,7 +186,7 @@ describe("static function getOneCorrectAnswerFromRubric", () => {
         const answers: ReadonlyArray<any> =
             (widgetOptions && widgetOptions.answers) || [];
         const singleAnswer =
-            NumericInputWidgetExport.getOneCorrectAnswerFromRubric?.({
+            NumericInputWidgetExport.getOneCorrectAnswerFromScoringData?.({
                 answers,
                 coefficient: false,
             });
@@ -196,7 +196,7 @@ describe("static function getOneCorrectAnswerFromRubric", () => {
     it("can not get a correct answer from a rubric with no answer", () => {
         const answers: Array<never> = [];
         const singleAnswer =
-            NumericInputWidgetExport.getOneCorrectAnswerFromRubric?.({
+            NumericInputWidgetExport.getOneCorrectAnswerFromScoringData?.({
                 answers,
                 coefficient: false,
             });
@@ -219,7 +219,7 @@ describe("static function getOneCorrectAnswerFromRubric", () => {
             coefficient: true,
         };
         const singleAnswer =
-            NumericInputWidgetExport.getOneCorrectAnswerFromRubric?.(
+            NumericInputWidgetExport.getOneCorrectAnswerFromScoringData?.(
                 scoringData,
             );
         expect(singleAnswer).toBe("1 ± 0.2");

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
@@ -19,7 +19,7 @@ import type {
 import type {PerseusStrings} from "../../strings";
 import type {FocusPath, Widget, WidgetExports, WidgetProps} from "../../types";
 import type {
-    PerseusNumericInputRubric,
+    PerseusNumericInputScoringData,
     PerseusNumericInputUserInput,
 } from "../../validation.types";
 import type {NumericInputPromptJSON} from "../../widget-ai-utils/numeric-input/prompt-utils";
@@ -47,7 +47,7 @@ const formExamples: {
 
 type ExternalProps = WidgetProps<
     PerseusNumericInputWidgetOptions,
-    PerseusNumericInputRubric
+    PerseusNumericInputScoringData
 >;
 
 type Props = ExternalProps & {
@@ -80,7 +80,7 @@ type DefaultProps = {
 // via defaultProps.
 0 as any as WidgetProps<
     PerseusNumericInputWidgetOptions,
-    PerseusNumericInputRubric
+    PerseusNumericInputScoringData
 > satisfies PropsFor<typeof NumericInput>;
 
 type State = {
@@ -384,9 +384,9 @@ export default {
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type 'Rubric' is not assignable to type 'PerseusNumericInputRubric'
     getOneCorrectAnswerFromRubric(
-        rubric: PerseusNumericInputRubric,
+        scoringData: PerseusNumericInputScoringData,
     ): string | null | undefined {
-        const correctAnswers = rubric.answers.filter(
+        const correctAnswers = scoringData.answers.filter(
             (answer) => answer.status === "correct",
         );
         const answerStrings = correctAnswers.map((answer) => {

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
@@ -382,7 +382,7 @@ export default {
     scorer: scoreNumericInput,
 
     // TODO(LEMS-2656): remove TS suppression
-    // @ts-expect-error: Type 'Rubric' is not assignable to type 'PerseusNumericInputRubric'
+    // @ts-expect-error: Type 'ScoringData' is not assignable to type 'PerseusNumericInputScoringData'
     getOneCorrectAnswerFromScoringData(
         scoringData: PerseusNumericInputScoringData,
     ): string | null | undefined {

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
@@ -383,7 +383,7 @@ export default {
 
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type 'Rubric' is not assignable to type 'PerseusNumericInputRubric'
-    getOneCorrectAnswerFromRubric(
+    getOneCorrectAnswerFromScoringData(
         scoringData: PerseusNumericInputScoringData,
     ): string | null | undefined {
         const correctAnswers = scoringData.answers.filter(

--- a/packages/perseus/src/widgets/numeric-input/score-numeric-input.test.ts
+++ b/packages/perseus/src/widgets/numeric-input/score-numeric-input.test.ts
@@ -14,7 +14,7 @@ describe("scoreNumericInput", () => {
     });
 
     it("is correct when input is empty but answer is 1 and coefficient: true", () => {
-        const rubric: PerseusNumericInputScoringData = {
+        const scoringData: PerseusNumericInputScoringData = {
             answers: [
                 {
                     value: 1,
@@ -34,7 +34,7 @@ describe("scoreNumericInput", () => {
             currentValue: "",
         };
 
-        const score = scoreNumericInput(userInput, rubric, mockStrings);
+        const score = scoreNumericInput(userInput, scoringData, mockStrings);
 
         expect(score).toHaveBeenAnsweredCorrectly();
     });

--- a/packages/perseus/src/widgets/numeric-input/score-numeric-input.test.ts
+++ b/packages/perseus/src/widgets/numeric-input/score-numeric-input.test.ts
@@ -14,7 +14,7 @@ describe("scoreNumericInput", () => {
     });
 
     it("is correct when input is empty but answer is 1 and coefficient: true", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const rubric: PerseusNumericInputScoringData = {
             answers: [
                 {
                     value: 1,

--- a/packages/perseus/src/widgets/numeric-input/score-numeric-input.test.ts
+++ b/packages/perseus/src/widgets/numeric-input/score-numeric-input.test.ts
@@ -4,7 +4,7 @@ import {mockStrings} from "../../strings";
 
 import scoreNumericInput, {maybeParsePercentInput} from "./score-numeric-input";
 
-import type {PerseusNumericInputRubric} from "../../validation.types";
+import type {PerseusNumericInputScoringData} from "../../validation.types";
 
 describe("static function validate", () => {
     beforeEach(() => {
@@ -14,7 +14,7 @@ describe("static function validate", () => {
     });
 
     it("with a simple value", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const scoringData: PerseusNumericInputScoringData = {
             answers: [
                 {
                     value: 1,
@@ -32,13 +32,13 @@ describe("static function validate", () => {
             currentValue: "1",
         } as const;
 
-        const score = scoreNumericInput(userInput, rubric, mockStrings);
+        const score = scoreNumericInput(userInput, scoringData, mockStrings);
 
         expect(score).toHaveBeenAnsweredCorrectly();
     });
 
     it("with nonsense", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const scoringData: PerseusNumericInputScoringData = {
             answers: [
                 {
                     value: 1,
@@ -56,7 +56,7 @@ describe("static function validate", () => {
             currentValue: "sadasdfas",
         } as const;
 
-        const score = scoreNumericInput(userInput, rubric, mockStrings);
+        const score = scoreNumericInput(userInput, scoringData, mockStrings);
 
         expect(score).toHaveInvalidInput(
             "We could not understand your answer. Please check your answer for extra text or symbols.",
@@ -70,7 +70,7 @@ describe("static function validate", () => {
     // important to the test.
     // https://khanacademy.atlassian.net/browse/LC-691
     it("doesn't default to validating pi", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const scoringData: PerseusNumericInputScoringData = {
             answers: [
                 {
                     maxError: null,
@@ -91,7 +91,7 @@ describe("static function validate", () => {
             currentValue: "45.282",
         } as const;
 
-        const score = scoreNumericInput(userInput, rubric, mockStrings);
+        const score = scoreNumericInput(userInput, scoringData, mockStrings);
 
         expect(score.message).not.toBe(
             "Your answer is close, but you may " +
@@ -104,7 +104,7 @@ describe("static function validate", () => {
     });
 
     it("still validates against pi if provided in answerForms", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const scoringData: PerseusNumericInputScoringData = {
             answers: [
                 {
                     maxError: null,
@@ -123,13 +123,13 @@ describe("static function validate", () => {
             currentValue: "99 pi",
         } as const;
 
-        const score = scoreNumericInput(userInput, rubric, mockStrings);
+        const score = scoreNumericInput(userInput, scoringData, mockStrings);
 
         expect(score).toHaveBeenAnsweredCorrectly();
     });
 
     it("with a strict answer", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const scoringData: PerseusNumericInputScoringData = {
             answers: [
                 {
                     value: 1,
@@ -147,13 +147,13 @@ describe("static function validate", () => {
             currentValue: "1.0",
         } as const;
 
-        const score = scoreNumericInput(userInput, rubric, mockStrings);
+        const score = scoreNumericInput(userInput, scoringData, mockStrings);
 
         expect(score).toHaveBeenAnsweredCorrectly();
     });
 
     it("with a strict answer and max error is outside range", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const scoringData: PerseusNumericInputScoringData = {
             answers: [
                 {
                     value: 1,
@@ -171,13 +171,13 @@ describe("static function validate", () => {
             currentValue: "1.3",
         } as const;
 
-        const score = scoreNumericInput(userInput, rubric, mockStrings);
+        const score = scoreNumericInput(userInput, scoringData, mockStrings);
 
         expect(score).toHaveBeenAnsweredIncorrectly();
     });
 
     it("with a strict answer and max error is inside range", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const scoringData: PerseusNumericInputScoringData = {
             answers: [
                 {
                     value: 1,
@@ -195,14 +195,14 @@ describe("static function validate", () => {
             currentValue: "1.12",
         } as const;
 
-        const score = scoreNumericInput(userInput, rubric, mockStrings);
+        const score = scoreNumericInput(userInput, scoringData, mockStrings);
 
         expect(score).toHaveBeenAnsweredCorrectly();
     });
 
     it("respects the order of answer options when scoring", () => {
         // Arrange
-        const rubric: PerseusNumericInputRubric = {
+        const scoringData: PerseusNumericInputScoringData = {
             answers: [
                 // "4" is a wrong answer
                 {
@@ -230,7 +230,7 @@ describe("static function validate", () => {
         const wrongInput = {
             currentValue: "4",
         } as const;
-        let score = scoreNumericInput(wrongInput, rubric, mockStrings);
+        let score = scoreNumericInput(wrongInput, scoringData, mockStrings);
 
         // Assert - "wrong"
         expect(score).toHaveBeenAnsweredIncorrectly();
@@ -239,7 +239,7 @@ describe("static function validate", () => {
         const correctInput = {
             currentValue: "14",
         } as const;
-        score = scoreNumericInput(correctInput, rubric, mockStrings);
+        score = scoreNumericInput(correctInput, scoringData, mockStrings);
 
         // Assert - "correct"
         expect(score).toHaveBeenAnsweredCorrectly();
@@ -247,7 +247,7 @@ describe("static function validate", () => {
 
     it("defaults to 1 or -1 when user input is empty/incomplete", () => {
         // Arrange
-        const rubric: PerseusNumericInputRubric = {
+        const scoringData: PerseusNumericInputScoringData = {
             answers: [
                 {
                     value: 1,
@@ -273,7 +273,7 @@ describe("static function validate", () => {
         const emptyInput = {
             currentValue: "",
         } as const;
-        let score = scoreNumericInput(emptyInput, rubric, mockStrings);
+        let score = scoreNumericInput(emptyInput, scoringData, mockStrings);
 
         // Assert - "empty"
         expect(score).toHaveBeenAnsweredCorrectly();
@@ -282,14 +282,14 @@ describe("static function validate", () => {
         const incompleteInput = {
             currentValue: "-",
         } as const;
-        score = scoreNumericInput(incompleteInput, rubric, mockStrings);
+        score = scoreNumericInput(incompleteInput, scoringData, mockStrings);
 
         // Assert - "incomplete"
         expect(score).toHaveBeenAnsweredCorrectly();
     });
 
     it("rejects responses formatted as a percentage when any answer has no value field", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const scoringData: PerseusNumericInputScoringData = {
             answers: [
                 {
                     // This answer is missing its value field.
@@ -314,7 +314,7 @@ describe("static function validate", () => {
 
         const score = scoreNumericInput(
             {currentValue: "50%"},
-            rubric,
+            scoringData,
             mockStrings,
         );
 
@@ -322,7 +322,7 @@ describe("static function validate", () => {
     });
 
     it("converts a percentage input value to a decimal", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const scoringData: PerseusNumericInputScoringData = {
             answers: [
                 {
                     value: 0.2,
@@ -338,7 +338,7 @@ describe("static function validate", () => {
 
         const score = scoreNumericInput(
             {currentValue: "20%"},
-            rubric,
+            scoringData,
             mockStrings,
         );
 
@@ -349,7 +349,7 @@ describe("static function validate", () => {
         // TODO(benchristel): This seems like incorrect behavior. I've added
         // this test to characterize the current behavior. Feel free to
         // delete/change it if it's in your way.
-        const rubric: PerseusNumericInputRubric = {
+        const scoringData: PerseusNumericInputScoringData = {
             answers: [
                 {
                     value: 1.2,
@@ -365,7 +365,7 @@ describe("static function validate", () => {
 
         const score = scoreNumericInput(
             {currentValue: "120%"},
-            rubric,
+            scoringData,
             mockStrings,
         );
 
@@ -376,7 +376,7 @@ describe("static function validate", () => {
         // TODO(benchristel): This seems like incorrect behavior. I've added
         // this test to characterize the current behavior. Feel free to
         // delete/change it if it's in your way.
-        const rubric: PerseusNumericInputRubric = {
+        const scoringData: PerseusNumericInputScoringData = {
             answers: [
                 {
                     value: 1.1,
@@ -392,7 +392,7 @@ describe("static function validate", () => {
 
         const score = scoreNumericInput(
             {currentValue: "1.1%"},
-            rubric,
+            scoringData,
             mockStrings,
         );
 
@@ -400,7 +400,7 @@ describe("static function validate", () => {
     });
 
     it("rejects answers with an extra, incorrect percent sign if < 1", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const scoringData: PerseusNumericInputScoringData = {
             answers: [
                 {
                     value: 0.9,
@@ -416,7 +416,7 @@ describe("static function validate", () => {
 
         const score = scoreNumericInput(
             {currentValue: "0.9%"},
-            rubric,
+            scoringData,
             mockStrings,
         );
 

--- a/packages/perseus/src/widgets/numeric-input/score-numeric-input.ts
+++ b/packages/perseus/src/widgets/numeric-input/score-numeric-input.ts
@@ -6,7 +6,7 @@ import type {PerseusStrings} from "../../strings";
 import type {PerseusScore} from "../../types";
 import type {Score} from "../../util/answer-types";
 import type {
-    PerseusNumericInputRubric,
+    PerseusNumericInputScoringData,
     PerseusNumericInputUserInput,
 } from "../../validation.types";
 
@@ -67,7 +67,7 @@ export function maybeParsePercentInput(
 
 function scoreNumericInput(
     userInput: PerseusNumericInputUserInput,
-    rubric: PerseusNumericInputRubric,
+    scoringData: PerseusNumericInputScoringData,
     strings: PerseusStrings,
 ): PerseusScore {
     const defaultAnswerForms = answerFormButtons
@@ -109,7 +109,7 @@ function scoreNumericInput(
     // If `currentValue` is not TeX, this should be a no-op.
     const currentValue = ParseTex(userInput.currentValue);
 
-    const normalizedAnswerExpected = rubric.answers
+    const normalizedAnswerExpected = scoringData.answers
         .filter((answer) => answer.status === "correct")
         .every(
             (answer) =>
@@ -118,7 +118,7 @@ function scoreNumericInput(
 
     // The coefficient is an attribute of the widget
     let localValue: string | number = currentValue;
-    if (rubric.coefficient) {
+    if (scoringData.coefficient) {
         if (!localValue) {
             localValue = 1;
         } else if (localValue === "-") {
@@ -127,7 +127,7 @@ function scoreNumericInput(
     }
     const matchedAnswer:
         | (PerseusNumericInputAnswer & {score: Score})
-        | undefined = rubric.answers
+        | undefined = scoringData.answers
         .map((answer) => {
             const validateFn = createValidator(answer);
             const score = validateFn(

--- a/packages/perseus/src/widgets/orderer/orderer.tsx
+++ b/packages/perseus/src/widgets/orderer/orderer.tsx
@@ -19,7 +19,7 @@ import {scoreOrderer} from "./score-orderer";
 import type {PerseusOrdererWidgetOptions} from "../../perseus-types";
 import type {WidgetExports, WidgetProps, Widget} from "../../types";
 import type {
-    PerseusOrdererRubric,
+    PerseusOrdererScoringData,
     PerseusOrdererUserInput,
 } from "../../validation.types";
 import type {OrdererPromptJSON} from "../../widget-ai-utils/orderer/orderer-ai-utils";
@@ -299,7 +299,7 @@ type RenderProps = PerseusOrdererWidgetOptions & {
     current: any;
 };
 
-type OrdererProps = WidgetProps<RenderProps, PerseusOrdererRubric>;
+type OrdererProps = WidgetProps<RenderProps, PerseusOrdererScoringData>;
 
 type OrdererDefaultProps = {
     current: OrdererProps["current"];

--- a/packages/perseus/src/widgets/orderer/score-orderer.test.ts
+++ b/packages/perseus/src/widgets/orderer/score-orderer.test.ts
@@ -3,14 +3,14 @@ import {scoreOrderer} from "./score-orderer";
 import * as OrdererValidator from "./validate-orderer";
 
 import type {
-    PerseusOrdererRubric,
+    PerseusOrdererScoringData,
     PerseusOrdererUserInput,
 } from "../../validation.types";
 
 describe("scoreOrderer", () => {
-    it("is correct when the userInput is in the same order and is the same length as the rubric's correctOption content items", () => {
+    it("is correct when the userInput is in the same order and is the same length as the scoringData's correctOption content items", () => {
         // Arrange
-        const rubric: PerseusOrdererRubric =
+        const scoringData: PerseusOrdererScoringData =
             question1.widgets["orderer 1"].options;
 
         const userInput: PerseusOrdererUserInput = {
@@ -20,15 +20,15 @@ describe("scoreOrderer", () => {
         };
 
         // Act
-        const result = scoreOrderer(userInput, rubric);
+        const result = scoreOrderer(userInput, scoringData);
 
         // Assert
         expect(result).toHaveBeenAnsweredCorrectly();
     });
 
-    it("is incorrect when the userInput is not in the same order as the rubric's correctOption content items", () => {
+    it("is incorrect when the userInput is not in the same order as the scoringData's correctOption content items", () => {
         // Arrange
-        const rubric: PerseusOrdererRubric =
+        const scoringData: PerseusOrdererScoringData =
             question1.widgets["orderer 1"].options;
 
         const userInput: PerseusOrdererUserInput = {
@@ -36,15 +36,15 @@ describe("scoreOrderer", () => {
         };
 
         // Act
-        const result = scoreOrderer(userInput, rubric);
+        const result = scoreOrderer(userInput, scoringData);
 
         // Assert
         expect(result).toHaveBeenAnsweredIncorrectly();
     });
 
-    it("is incorrect when the userInput is not the same length as the rubric's correctOption content items", () => {
+    it("is incorrect when the userInput is not the same length as the scoringData's correctOption content items", () => {
         // Arrange
-        const rubric: PerseusOrdererRubric =
+        const scoringData: PerseusOrdererScoringData =
             question1.widgets["orderer 1"].options;
 
         const userInput: PerseusOrdererUserInput = {
@@ -52,7 +52,7 @@ describe("scoreOrderer", () => {
         };
 
         // Act
-        const result = scoreOrderer(userInput, rubric);
+        const result = scoreOrderer(userInput, scoringData);
 
         // Assert
         expect(result).toHaveBeenAnsweredIncorrectly();
@@ -64,7 +64,7 @@ describe("scoreOrderer", () => {
             .spyOn(OrdererValidator, "default")
             .mockReturnValue(null);
 
-        const rubric: PerseusOrdererRubric =
+        const scoringData: PerseusOrdererScoringData =
             question1.widgets["orderer 1"].options;
 
         const userInput: PerseusOrdererUserInput = {
@@ -73,7 +73,7 @@ describe("scoreOrderer", () => {
             ),
         };
         // Act
-        const result = scoreOrderer(userInput, rubric);
+        const result = scoreOrderer(userInput, scoringData);
 
         // Assert
         expect(mockValidator).toHaveBeenCalledWith(userInput);
@@ -89,7 +89,7 @@ describe("scoreOrderer", () => {
                 message: null,
             });
 
-        const rubric: PerseusOrdererRubric =
+        const scoringData: PerseusOrdererScoringData =
             question1.widgets["orderer 1"].options;
 
         const userInput: PerseusOrdererUserInput = {
@@ -97,7 +97,7 @@ describe("scoreOrderer", () => {
         };
 
         // Act
-        const result = scoreOrderer(userInput, rubric);
+        const result = scoreOrderer(userInput, scoringData);
 
         // Assert
         expect(mockValidator).toHaveBeenCalledWith(userInput);

--- a/packages/perseus/src/widgets/orderer/score-orderer.ts
+++ b/packages/perseus/src/widgets/orderer/score-orderer.ts
@@ -4,13 +4,13 @@ import validateOrderer from "./validate-orderer";
 
 import type {PerseusScore} from "../../types";
 import type {
-    PerseusOrdererRubric,
+    PerseusOrdererScoringData,
     PerseusOrdererUserInput,
 } from "../../validation.types";
 
 export function scoreOrderer(
     userInput: PerseusOrdererUserInput,
-    rubric: PerseusOrdererRubric,
+    scoringData: PerseusOrdererScoringData,
 ): PerseusScore {
     const validateError = validateOrderer(userInput);
     if (validateError) {
@@ -19,7 +19,7 @@ export function scoreOrderer(
 
     const correct = _.isEqual(
         userInput.current,
-        rubric.correctOptions.map((option) => option.content),
+        scoringData.correctOptions.map((option) => option.content),
     );
 
     return {

--- a/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
@@ -953,7 +953,7 @@ describe("Radio Widget", () => {
         /**
          * (LEMS-2435) We want to be sure that we're able to score shuffled
          * Radio widgets outside of the component which means `getUserInput`
-         * should return the same order that the rubric provides
+         * should return the same order that the scoring data provides
          */
         it("can be scored correctly when shuffled", async () => {
             // Arrange
@@ -966,8 +966,8 @@ describe("Radio Widget", () => {
 
             const userInput =
                 renderer.getUserInput()[0] as PerseusRadioUserInput;
-            const rubric = shuffledQuestion.widgets["radio 1"].options;
-            const widgetScore = scoreRadio(userInput, rubric, mockStrings);
+            const scoringData = shuffledQuestion.widgets["radio 1"].options;
+            const widgetScore = scoreRadio(userInput, scoringData, mockStrings);
             const rendererScore = scorePerseusItemTesting(
                 shuffledQuestion,
                 renderer.getUserInputMap(),
@@ -981,7 +981,7 @@ describe("Radio Widget", () => {
         /**
          * (LEMS-2435) We want to be sure that we're able to score shuffled
          * Radio widgets outside of the component which means `getUserInput`
-         * should return the same order that the rubric provides
+         * should return the same order that the scoring data provides
          */
         it("can be scored incorrectly when shuffled", async () => {
             // Arrange
@@ -994,8 +994,8 @@ describe("Radio Widget", () => {
 
             const userInput =
                 renderer.getUserInput()[0] as PerseusRadioUserInput;
-            const rubric = shuffledQuestion.widgets["radio 1"].options;
-            const widgetScore = scoreRadio(userInput, rubric, mockStrings);
+            const scoringData = shuffledQuestion.widgets["radio 1"].options;
+            const widgetScore = scoreRadio(userInput, scoringData, mockStrings);
             const rendererScore = scorePerseusItemTesting(
                 shuffledQuestion,
                 renderer.getUserInputMap(),
@@ -1009,7 +1009,7 @@ describe("Radio Widget", () => {
         /**
          * (LEMS-2435) We want to be sure that we're able to score shuffled
          * Radio widgets outside of the component which means `getUserInput`
-         * should return the same order that the rubric provides
+         * should return the same order that the scoring data provides
          */
         it("can be scored correctly when shuffled with none of the above", async () => {
             // Arrange
@@ -1022,8 +1022,8 @@ describe("Radio Widget", () => {
 
             const userInput =
                 renderer.getUserInput()[0] as PerseusRadioUserInput;
-            const rubric = shuffledNoneQuestion.widgets["radio 1"].options;
-            const widgetScore = scoreRadio(userInput, rubric, mockStrings);
+            const scoringData = shuffledNoneQuestion.widgets["radio 1"].options;
+            const widgetScore = scoreRadio(userInput, scoringData, mockStrings);
             const rendererScore = scorePerseusItemTesting(
                 shuffledNoneQuestion,
                 renderer.getUserInputMap(),
@@ -1037,7 +1037,7 @@ describe("Radio Widget", () => {
         /**
          * (LEMS-2435) We want to be sure that we're able to score shuffled
          * Radio widgets outside of the component which means `getUserInput`
-         * should return the same order that the rubric provides
+         * should return the same order that the scoring data provides
          */
         it("can be scored incorrectly when shuffled with none of the above", async () => {
             // Arrange
@@ -1050,8 +1050,8 @@ describe("Radio Widget", () => {
 
             const userInput =
                 renderer.getUserInput()[0] as PerseusRadioUserInput;
-            const rubric = shuffledNoneQuestion.widgets["radio 1"].options;
-            const widgetScore = scoreRadio(userInput, rubric, mockStrings);
+            const scoringData = shuffledNoneQuestion.widgets["radio 1"].options;
+            const widgetScore = scoreRadio(userInput, scoringData, mockStrings);
             const rendererScore = scorePerseusItemTesting(
                 shuffledQuestion,
                 renderer.getUserInputMap(),

--- a/packages/perseus/src/widgets/radio/radio-component.tsx
+++ b/packages/perseus/src/widgets/radio/radio-component.tsx
@@ -268,12 +268,12 @@ class Radio extends React.Component<Props> implements Widget {
      */
     showRationalesForCurrentlySelectedChoices: (
         arg1: PerseusRadioWidgetOptions,
-    ) => void = (rubric) => {
+    ) => void = (scoringData) => {
         const {choiceStates} = this.props;
         if (choiceStates) {
             const score = scoreRadio(
                 this.getUserInput(),
-                rubric,
+                scoringData,
                 this.context.strings,
             );
             const widgetCorrect =
@@ -417,7 +417,7 @@ class Radio extends React.Component<Props> implements Widget {
                     // Current versions of the radio widget always pass in the
                     // "correct" value through the choices. Old serialized state
                     // for radio widgets doesn't have this though, so we have to
-                    // pull the correctness out of the review mode rubric. This
+                    // pull the correctness out of the review mode scoring data. This
                     // only works because all of the places we use
                     // `restoreSerializedState()` also turn on reviewMode, but is
                     // fine for now.

--- a/packages/perseus/src/widgets/radio/radio-component.tsx
+++ b/packages/perseus/src/widgets/radio/radio-component.tsx
@@ -18,7 +18,7 @@ import type {
 } from "../../perseus-types";
 import type {WidgetProps, ChoiceState, Widget} from "../../types";
 import type {
-    PerseusRadioRubric,
+    PerseusRadioScoringData,
     PerseusRadioUserInput,
 } from "../../validation.types";
 import type {RadioPromptJSON} from "../../widget-ai-utils/radio/radio-ai-utils";
@@ -39,7 +39,7 @@ export type RenderProps = {
     values?: ReadonlyArray<boolean>;
 };
 
-type Props = WidgetProps<RenderProps, PerseusRadioRubric>;
+type Props = WidgetProps<RenderProps, PerseusRadioScoringData>;
 
 type DefaultProps = Required<
     Pick<

--- a/packages/perseus/src/widgets/radio/score-radio.test.ts
+++ b/packages/perseus/src/widgets/radio/score-radio.test.ts
@@ -3,7 +3,7 @@ import {mockStrings} from "../../strings";
 import scoreRadio from "./score-radio";
 
 import type {
-    PerseusRadioRubric,
+    PerseusRadioScoringData,
     PerseusRadioUserInput,
 } from "../../validation.types";
 
@@ -13,7 +13,7 @@ describe("scoreRadio", () => {
             choicesSelected: [true, false, false, false],
         };
 
-        const rubric: PerseusRadioRubric = {
+        const scoringData: PerseusRadioScoringData = {
             choices: [
                 {content: "Choice 1", correct: true},
                 {content: "Choice 2", correct: true},
@@ -22,7 +22,7 @@ describe("scoreRadio", () => {
             ],
         };
 
-        const score = scoreRadio(userInput, rubric, mockStrings);
+        const score = scoreRadio(userInput, scoringData, mockStrings);
 
         expect(score).toHaveInvalidInput();
     });
@@ -32,7 +32,7 @@ describe("scoreRadio", () => {
             choicesSelected: [true, false, false, false, true],
         };
 
-        const rubric: PerseusRadioRubric = {
+        const scoringData: PerseusRadioScoringData = {
             choices: [
                 {content: "Choice 1", correct: true},
                 {content: "Choice 2", correct: false},
@@ -46,7 +46,7 @@ describe("scoreRadio", () => {
             ],
         };
 
-        const score = scoreRadio(userInput, rubric, mockStrings);
+        const score = scoreRadio(userInput, scoringData, mockStrings);
 
         expect(score).toHaveInvalidInput();
     });
@@ -56,7 +56,7 @@ describe("scoreRadio", () => {
             choicesSelected: [true, false, false, false],
         };
 
-        const rubric: PerseusRadioRubric = {
+        const scoringData: PerseusRadioScoringData = {
             choices: [
                 {content: "Choice 1", correct: true},
                 {content: "Choice 2", correct: false},
@@ -65,7 +65,7 @@ describe("scoreRadio", () => {
             ],
         };
 
-        const score = scoreRadio(userInput, rubric, mockStrings);
+        const score = scoreRadio(userInput, scoringData, mockStrings);
 
         expect(score).toHaveBeenAnsweredCorrectly();
     });
@@ -75,7 +75,7 @@ describe("scoreRadio", () => {
             choicesSelected: [false, false, false, true],
         };
 
-        const rubric: PerseusRadioRubric = {
+        const scoringData: PerseusRadioScoringData = {
             choices: [
                 {content: "Choice 1", correct: true},
                 {content: "Choice 2", correct: false},
@@ -84,7 +84,7 @@ describe("scoreRadio", () => {
             ],
         };
 
-        const score = scoreRadio(userInput, rubric, mockStrings);
+        const score = scoreRadio(userInput, scoringData, mockStrings);
 
         expect(score).toHaveBeenAnsweredIncorrectly();
     });
@@ -94,7 +94,7 @@ describe("scoreRadio", () => {
             choicesSelected: [true, true, false, false],
         };
 
-        const rubric: PerseusRadioRubric = {
+        const scoringData: PerseusRadioScoringData = {
             choices: [
                 {content: "Choice 1", correct: true},
                 {content: "Choice 2", correct: true},
@@ -103,7 +103,7 @@ describe("scoreRadio", () => {
             ],
         };
 
-        const score = scoreRadio(userInput, rubric, mockStrings);
+        const score = scoreRadio(userInput, scoringData, mockStrings);
 
         expect(score).toHaveBeenAnsweredCorrectly();
     });
@@ -113,7 +113,7 @@ describe("scoreRadio", () => {
             choicesSelected: [true, false, false, true],
         };
 
-        const rubric: PerseusRadioRubric = {
+        const scoringData: PerseusRadioScoringData = {
             choices: [
                 {content: "Choice 1", correct: true},
                 {content: "Choice 2", correct: true},
@@ -122,7 +122,7 @@ describe("scoreRadio", () => {
             ],
         };
 
-        const score = scoreRadio(userInput, rubric, mockStrings);
+        const score = scoreRadio(userInput, scoringData, mockStrings);
 
         expect(score).toHaveBeenAnsweredIncorrectly();
     });
@@ -132,7 +132,7 @@ describe("scoreRadio", () => {
             choicesSelected: [false, false, false, false, true],
         };
 
-        const rubric: PerseusRadioRubric = {
+        const scoringData: PerseusRadioScoringData = {
             choices: [
                 {content: "Choice 1", correct: false},
                 {content: "Choice 2", correct: false},
@@ -142,7 +142,7 @@ describe("scoreRadio", () => {
             ],
         };
 
-        const score = scoreRadio(userInput, rubric, mockStrings);
+        const score = scoreRadio(userInput, scoringData, mockStrings);
 
         expect(score).toHaveBeenAnsweredCorrectly();
     });
@@ -152,7 +152,7 @@ describe("scoreRadio", () => {
             choicesSelected: [false, false, false, false, true],
         };
 
-        const rubric: PerseusRadioRubric = {
+        const scoringData: PerseusRadioScoringData = {
             choices: [
                 {content: "Choice 1", correct: true},
                 {content: "Choice 2", correct: false},
@@ -162,7 +162,7 @@ describe("scoreRadio", () => {
             ],
         };
 
-        const score = scoreRadio(userInput, rubric, mockStrings);
+        const score = scoreRadio(userInput, scoringData, mockStrings);
 
         expect(score).toHaveBeenAnsweredIncorrectly();
     });

--- a/packages/perseus/src/widgets/radio/score-radio.ts
+++ b/packages/perseus/src/widgets/radio/score-radio.ts
@@ -3,13 +3,13 @@ import validateRadio from "./validate-radio";
 import type {PerseusStrings} from "../../strings";
 import type {PerseusScore} from "../../types";
 import type {
-    PerseusRadioRubric,
+    PerseusRadioScoringData,
     PerseusRadioUserInput,
 } from "../../validation.types";
 
 function scoreRadio(
     userInput: PerseusRadioUserInput,
-    rubric: PerseusRadioRubric,
+    scoringData: PerseusRadioScoringData,
     strings: PerseusStrings,
 ): PerseusScore {
     const validationError = validateRadio(userInput);
@@ -21,9 +21,12 @@ function scoreRadio(
         return sum + (selected ? 1 : 0);
     }, 0);
 
-    const numCorrect: number = rubric.choices.reduce((sum, currentChoice) => {
-        return currentChoice.correct ? sum + 1 : sum;
-    }, 0);
+    const numCorrect: number = scoringData.choices.reduce(
+        (sum, currentChoice) => {
+            return currentChoice.correct ? sum + 1 : sum;
+        },
+        0,
+    );
 
     if (numCorrect > 1 && numSelected !== numCorrect) {
         return {
@@ -33,7 +36,7 @@ function scoreRadio(
         // If NOTA and some other answer are checked, ...
     }
 
-    const noneOfTheAboveSelected = rubric.choices.some(
+    const noneOfTheAboveSelected = scoringData.choices.some(
         (choice, index) =>
             choice.isNoneOfTheAbove && userInput.choicesSelected[index],
     );
@@ -47,12 +50,12 @@ function scoreRadio(
 
     const correct = userInput.choicesSelected.every((selected, i) => {
         let isCorrect: boolean;
-        if (rubric.choices[i].isNoneOfTheAbove) {
-            isCorrect = rubric.choices.every((choice, j) => {
+        if (scoringData.choices[i].isNoneOfTheAbove) {
+            isCorrect = scoringData.choices.every((choice, j) => {
                 return i === j || !choice.correct;
             });
         } else {
-            isCorrect = !!rubric.choices[i].correct;
+            isCorrect = !!scoringData.choices[i].correct;
         }
         return isCorrect === selected;
     });

--- a/packages/perseus/src/widgets/sorter/score-sorter.test.ts
+++ b/packages/perseus/src/widgets/sorter/score-sorter.test.ts
@@ -2,40 +2,40 @@ import scoreSorter from "./score-sorter";
 import * as SorterValidator from "./validate-sorter";
 
 import type {
-    PerseusSorterRubric,
+    PerseusSorterScoringData,
     PerseusSorterUserInput,
 } from "../../validation.types";
 
 describe("scoreSorter", () => {
-    it("is correct when the user input values are in the order defined in the rubric", () => {
+    it("is correct when the user input values are in the order defined in the scoringData", () => {
         // Arrange
         const userInput: PerseusSorterUserInput = {
             options: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],
             changed: true,
         };
-        const rubric: PerseusSorterRubric = {
+        const scoringData: PerseusSorterScoringData = {
             correct: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],
         };
 
         // Act
-        const result = scoreSorter(userInput, rubric);
+        const result = scoreSorter(userInput, scoringData);
 
         // Assert
         expect(result).toHaveBeenAnsweredCorrectly();
     });
 
-    it("is incorrect when the user input values are not in the order defined in the rubric", () => {
+    it("is incorrect when the user input values are not in the order defined in the scoringData", () => {
         // Arrange
         const userInput: PerseusSorterUserInput = {
             options: ["$15$ grams", "$55$ grams", "$0.005$ kilograms"],
             changed: true,
         };
-        const rubric: PerseusSorterRubric = {
+        const scoringData: PerseusSorterScoringData = {
             correct: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],
         };
 
         // Act
-        const result = scoreSorter(userInput, rubric);
+        const result = scoreSorter(userInput, scoringData);
 
         // Assert
         expect(result).toHaveBeenAnsweredIncorrectly();
@@ -52,12 +52,12 @@ describe("scoreSorter", () => {
             options: ["$15$ grams", "$55$ grams", "$0.005$ kilograms"],
             changed: false,
         };
-        const rubric: PerseusSorterRubric = {
+        const scoringData: PerseusSorterScoringData = {
             correct: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],
         };
 
         // Act
-        const result = scoreSorter(userInput, rubric);
+        const result = scoreSorter(userInput, scoringData);
 
         // Assert
         expect(mockValidate).toHaveBeenCalledWith(userInput);
@@ -75,12 +75,12 @@ describe("scoreSorter", () => {
             options: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],
             changed: true,
         };
-        const rubric: PerseusSorterRubric = {
+        const scoringData: PerseusSorterScoringData = {
             correct: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],
         };
 
         // Act
-        const result = scoreSorter(userInput, rubric);
+        const result = scoreSorter(userInput, scoringData);
 
         // Assert
         expect(mockValidate).toHaveBeenCalledWith(userInput);

--- a/packages/perseus/src/widgets/sorter/score-sorter.ts
+++ b/packages/perseus/src/widgets/sorter/score-sorter.ts
@@ -4,20 +4,20 @@ import validateSorter from "./validate-sorter";
 
 import type {PerseusScore} from "../../types";
 import type {
-    PerseusSorterRubric,
+    PerseusSorterScoringData,
     PerseusSorterUserInput,
 } from "../../validation.types";
 
 function scoreSorter(
     userInput: PerseusSorterUserInput,
-    rubric: PerseusSorterRubric,
+    scoringData: PerseusSorterScoringData,
 ): PerseusScore {
     const validationError = validateSorter(userInput);
     if (validationError) {
         return validationError;
     }
 
-    const correct = Util.deepEq(userInput.options, rubric.correct);
+    const correct = Util.deepEq(userInput.options, scoringData.correct);
     return {
         type: "points",
         earned: correct ? 1 : 0,

--- a/packages/perseus/src/widgets/sorter/sorter.tsx
+++ b/packages/perseus/src/widgets/sorter/sorter.tsx
@@ -11,7 +11,7 @@ import type {SortableOption} from "../../components/sortable";
 import type {PerseusSorterWidgetOptions} from "../../perseus-types";
 import type {Widget, WidgetExports, WidgetProps} from "../../types";
 import type {
-    PerseusSorterRubric,
+    PerseusSorterScoringData,
     PerseusSorterUserInput,
 } from "../../validation.types";
 import type {SorterPromptJSON} from "../../widget-ai-utils/sorter/sorter-ai-utils";
@@ -20,7 +20,7 @@ const {shuffle} = Util;
 
 type RenderProps = PerseusSorterWidgetOptions;
 
-type Props = WidgetProps<RenderProps, PerseusSorterRubric>;
+type Props = WidgetProps<RenderProps, PerseusSorterScoringData>;
 
 type DefaultProps = {
     correct: Props["correct"];

--- a/packages/perseus/src/widgets/table/score-table.test.ts
+++ b/packages/perseus/src/widgets/table/score-table.test.ts
@@ -4,7 +4,7 @@ import scoreTable from "./score-table";
 import * as TableValidator from "./validate-table";
 
 import type {
-    PerseusTableRubric,
+    PerseusTableScoringData,
     PerseusTableUserInput,
 } from "../../validation.types";
 
@@ -20,7 +20,7 @@ describe("scoreTable", () => {
             ["3", "4"],
         ];
 
-        const rubric: PerseusTableRubric = {
+        const scoringData: PerseusTableScoringData = {
             answers: [
                 ["1", "2"],
                 ["3", "4"],
@@ -28,7 +28,7 @@ describe("scoreTable", () => {
         };
 
         // Act
-        const score = scoreTable(userInput, rubric, mockStrings);
+        const score = scoreTable(userInput, scoringData, mockStrings);
 
         // Assert
         expect(mockValidator).toHaveBeenCalledWith(userInput);
@@ -46,7 +46,7 @@ describe("scoreTable", () => {
             ["3", "4"],
         ];
 
-        const rubric: PerseusTableRubric = {
+        const scoringData: PerseusTableScoringData = {
             answers: [
                 ["1", "2"],
                 ["3", "4"],
@@ -54,7 +54,7 @@ describe("scoreTable", () => {
         };
 
         // Act
-        const score = scoreTable(userInput, rubric, mockStrings);
+        const score = scoreTable(userInput, scoringData, mockStrings);
 
         // Assert
         expect(mockValidator).toHaveBeenCalledWith(userInput);
@@ -68,7 +68,7 @@ describe("scoreTable", () => {
             ["3", "4"],
         ];
 
-        const rubric: PerseusTableRubric = {
+        const scoringData: PerseusTableScoringData = {
             answers: [
                 ["1", "2"],
                 ["3", "4"],
@@ -76,7 +76,7 @@ describe("scoreTable", () => {
         };
 
         // Act
-        const result = scoreTable(userInput, rubric, mockStrings);
+        const result = scoreTable(userInput, scoringData, mockStrings);
 
         // Assert
         expect(result).toHaveInvalidInput();
@@ -90,7 +90,7 @@ describe("scoreTable", () => {
             ["5", "6"],
         ];
 
-        const rubric: PerseusTableRubric = {
+        const scoringData: PerseusTableScoringData = {
             answers: [
                 ["1", "2"],
                 ["3", "4"],
@@ -98,7 +98,7 @@ describe("scoreTable", () => {
         };
 
         // Act
-        const result = scoreTable(userInput, rubric, mockStrings);
+        const result = scoreTable(userInput, scoringData, mockStrings);
 
         // Assert
         expect(result).toHaveBeenAnsweredIncorrectly();
@@ -111,7 +111,7 @@ describe("scoreTable", () => {
             ["3", "5"],
         ];
 
-        const rubric: PerseusTableRubric = {
+        const scoringData: PerseusTableScoringData = {
             answers: [
                 ["1", "2"],
                 ["3", "4"],
@@ -119,7 +119,7 @@ describe("scoreTable", () => {
         };
 
         // Act
-        const result = scoreTable(userInput, rubric, mockStrings);
+        const result = scoreTable(userInput, scoringData, mockStrings);
 
         // Assert
         expect(result).toHaveBeenAnsweredIncorrectly();
@@ -132,7 +132,7 @@ describe("scoreTable", () => {
             ["3", "4"],
         ];
 
-        const rubric: PerseusTableRubric = {
+        const scoringData: PerseusTableScoringData = {
             answers: [
                 ["1", "2"],
                 ["3", "4"],
@@ -140,7 +140,7 @@ describe("scoreTable", () => {
         };
 
         // Act
-        const result = scoreTable(userInput, rubric, mockStrings);
+        const result = scoreTable(userInput, scoringData, mockStrings);
 
         // Assert
         expect(result).toHaveBeenAnsweredCorrectly();
@@ -153,7 +153,7 @@ describe("scoreTable", () => {
             ["3.0", "4.0"],
         ];
 
-        const rubric: PerseusTableRubric = {
+        const scoringData: PerseusTableScoringData = {
             answers: [
                 ["1", "2"],
                 ["3", "4"],
@@ -161,7 +161,7 @@ describe("scoreTable", () => {
         };
 
         // Act
-        const result = scoreTable(userInput, rubric, mockStrings);
+        const result = scoreTable(userInput, scoringData, mockStrings);
 
         // Assert
         expect(result).toHaveBeenAnsweredCorrectly();

--- a/packages/perseus/src/widgets/table/score-table.ts
+++ b/packages/perseus/src/widgets/table/score-table.ts
@@ -8,13 +8,13 @@ import validateTable from "./validate-table";
 import type {PerseusStrings} from "../../strings";
 import type {PerseusScore} from "../../types";
 import type {
-    PerseusTableRubric,
+    PerseusTableScoringData,
     PerseusTableUserInput,
 } from "../../validation.types";
 
 function scoreTable(
     userInput: PerseusTableUserInput,
-    rubric: PerseusTableRubric,
+    scoringData: PerseusTableScoringData,
     strings: PerseusStrings,
 ): PerseusScore {
     const validationResult = validateTable(userInput);
@@ -23,7 +23,7 @@ function scoreTable(
     }
 
     const supplied = filterNonEmpty(userInput);
-    const solution = filterNonEmpty(rubric.answers);
+    const solution = filterNonEmpty(scoringData.answers);
     if (supplied.length !== solution.length) {
         return {
             type: "points",

--- a/packages/perseus/src/widgets/table/table.tsx
+++ b/packages/perseus/src/widgets/table/table.tsx
@@ -16,7 +16,7 @@ import type {ChangeableProps} from "../../mixins/changeable";
 import type {PerseusTableWidgetOptions} from "../../perseus-types";
 import type {Widget, WidgetExports, WidgetProps} from "../../types";
 import type {
-    PerseusTableRubric,
+    PerseusTableScoringData,
     PerseusTableUserInput,
 } from "../../validation.types";
 
@@ -27,7 +27,8 @@ type RenderProps = PerseusTableWidgetOptions & {
     Editor: any;
 };
 
-type Props = ChangeableProps & WidgetProps<RenderProps, PerseusTableRubric>;
+type Props = ChangeableProps &
+    WidgetProps<RenderProps, PerseusTableScoringData>;
 
 type DefaultProps = {
     apiOptions: Props["apiOptions"];


### PR DESCRIPTION
## Summary:
This is to rename anything related to scoring that still uses rubric to scoringData instead to be more in alignment with the vocabulary for server side scoring.

Issue: LEMS-2657

## Test plan:
- Confirm all checks pass
- Confirm all checks pass in a webapp draft 
- Check for issues with widgets affected