### PR TITLE
[Unlimited Polygon] Fix for creating concave polygons.

### DIFF
--- a/.changeset/slow-rules-unite.md
+++ b/.changeset/slow-rules-unite.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fixing bug in creating concave shapes in unlimited polygons.

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -263,6 +263,14 @@ const UnlimitedPolygonGraph = (statefulProps: StatefulProps) => {
 
     return (
         <>
+            <Polyline
+                points={[...points]}
+                color="var(--movable-line-stroke-color)"
+                svgPolylineProps={{
+                    strokeWidth: "var(--movable-line-stroke-weight)",
+                    style: {fill: "transparent"},
+                }}
+            />
             {/* This rect is here to grab clicks so that new points can be added */}
             {/* It's important because it stops mouse events from propogating
                 when dragging a points around */}
@@ -287,14 +295,6 @@ const UnlimitedPolygonGraph = (statefulProps: StatefulProps) => {
                         graphConfig,
                     );
                     dispatch(actions.polygon.addPoint(graphCoordinates[0]));
-                }}
-            />
-            <Polyline
-                points={[...points]}
-                color="var(--movable-line-stroke-color)"
-                svgPolylineProps={{
-                    strokeWidth: "var(--movable-line-stroke-weight)",
-                    style: {fill: "transparent"},
                 }}
             />
             {coords.map((point, i) => (


### PR DESCRIPTION
## Summary:
Moving the Polygon component lower in the stack to ensure the rect component is on top. This is necessary to allow users to draw a polygon that is concaved, because the Polyline blocks the click events.

https://github.com/user-attachments/assets/181a987f-c0a2-4ff9-bc08-cbf57df44fe9

Issue: LEMS-2679

## Test plan:
Go to: http://localhost:6006/?path=/story/perseus-widgets-interactive-graph--unlimited-polygon-with-mafs.
Draw a polygon that is concave and notice it should allow you to draw it.