### PR TITLE
Fixing scoring for unlimited point to ensure there 1 or more points for it to be considered scorable.

### DIFF
--- a/.changeset/wet-bugs-sip.md
+++ b/.changeset/wet-bugs-sip.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fixing scoring for unlimited point to ensure there 1 or more points for it to be considered scorable.

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.stories.tsx
@@ -39,6 +39,7 @@ const enableMafs: APIOptions = {
             segment: true,
             polygon: true,
             "unlimited-polygon": true,
+            "unlimited-point": true,
             angle: true,
             "interactive-graph-locked-features-labels": true,
         },
@@ -69,6 +70,13 @@ export const LinearSystem = (args: StoryArgs): React.ReactElement => (
 
 export const Point = (args: StoryArgs): React.ReactElement => (
     <RendererWithDebugUI question={pointQuestion} />
+);
+
+export const PointWithMafs = (args: StoryArgs): React.ReactElement => (
+    <RendererWithDebugUI
+        apiOptions={{...enableMafs}}
+        question={pointQuestion}
+    />
 );
 
 export const Polygon = (args: StoryArgs): React.ReactElement => (

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
@@ -22,6 +22,22 @@ const defaultAngleState: InteractiveGraphState = {
     allowReflexAngles: false,
 };
 
+const defaultUnlimitedPointState: InteractiveGraphState = {
+    type: "point",
+    focusedPointIndex: 0,
+    coords: [[5, 0]],
+    numPoints: "unlimited",
+    hasBeenInteractedWith: true,
+    showRemovePointButton: false,
+    showKeyboardInteractionInvitation: false,
+    interactionMode: "mouse",
+    range: [
+        [-10, 10],
+        [-10, 10],
+    ],
+    snapStep: [1, 1],
+};
+
 const defaultUnlimitedPolygonState: InteractiveGraphState = {
     type: "polygon",
     closedPolygon: false,
@@ -136,6 +152,32 @@ describe("getGradableGraph", () => {
             [0, 0],
             [-5, -5],
         ]);
+    });
+
+    it("returns null coordinates if the unlimited point graph has an empty array of coordinates", () => {
+        const state: InteractiveGraphState = {
+            ...defaultUnlimitedPointState,
+            coords: [],
+        };
+        const initialGraph: PerseusGraphType = {
+            type: "point",
+        };
+        const result = getGradableGraph(state, initialGraph);
+        invariant(result.type === "point");
+        expect(result.coords).toEqual(null);
+    });
+
+    it("returns coordinates if the unlimited point graph is has at least one coordinate", () => {
+        const state: InteractiveGraphState = {
+            ...defaultUnlimitedPointState,
+            coords: [[1, 0]],
+        };
+        const initialGraph: PerseusGraphType = {
+            type: "point",
+        };
+        const result = getGradableGraph(state, initialGraph);
+        invariant(result.type === "point");
+        expect(result.coords).toEqual([[1, 0]]);
     });
 
     it("returns null coordinates if the unlimited polygon graph is open", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -59,6 +59,14 @@ export function getGradableGraph(
     }
 
     if (state.type === "point" && initialGraph.type === "point") {
+        // The unlimited point graph must have at least 1 coordinate or else it is not considered score-able.
+        if (state.numPoints === "unlimited" && state.coords.length === 0) {
+            return {
+                ...initialGraph,
+                coords: null,
+            };
+        }
+
         return {
             ...initialGraph,
             coords: state.coords,


### PR DESCRIPTION
## Summary:
Refining scoring behavior for unlimited point to ensure it treats an empty graph as unscorable.

Issue: LEMS-2682

## Test plan:
Go to http://localhost:6006/?path=/story/perseus-widgets-interactive-graph--point-with-mafs
Add a bunch of points and remove them until there is none left.
Check your answer and notice the score is defined as `invalid`.