### PR TITLE
[SR] Linear graph - add full graph aria label and description

### DIFF
--- a/.changeset/quick-apes-crash.md
+++ b/.changeset/quick-apes-crash.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[SR] Linear graph - add full graph aria label and description

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -183,6 +183,33 @@ export type PerseusStrings = {
         point4X: string;
         point4Y: string;
     }) => string;
+    srLinearGraph: string;
+    srLinearGraphPoints: ({
+        point1X,
+        point1Y,
+        point2X,
+        point2Y,
+    }: {
+        point1X: string;
+        point1Y: string;
+        point2X: string;
+        point2Y: string;
+    }) => string;
+    srLinearGraphSlopeIncreasing: string;
+    srLinearGraphSlopeDecreasing: string;
+    srLinearGraphSlopeHorizontal: string;
+    srLinearGraphSlopeVertical: string;
+    srLinearGraphXOnlyIntercept: ({xIntercept}: {xIntercept: string}) => string;
+    srLinearGraphYOnlyIntercept: ({yIntercept}: {yIntercept: string}) => string;
+    srLinearGraphBothIntercepts: ({
+        xIntercept,
+        yIntercept,
+    }: {
+        xIntercept: string;
+        yIntercept: string;
+    }) => string;
+    srLinearGraphOriginIntercept: string;
+
     // The above strings are used for interactive graph SR descriptions.
 };
 
@@ -400,6 +427,57 @@ export const strings: {
         message:
             "Points on the circle at %(point1X)s comma %(point1Y)s, %(point2X)s comma %(point2Y)s, %(point3X)s comma %(point3Y)s, %(point4X)s comma %(point4Y)s.",
     },
+    srLinearGraph: {
+        context: "Aria label for the linear graph as a whole.",
+        message: "A line on a coordinate plane.",
+    },
+    srLinearGraphPoints: {
+        context:
+            "Additional information about the points for the linear graph as a whole.",
+        message:
+            "The line has two points, point 1 at %(point1X)s comma %(point1Y)s and point 2 at %(point2X)s comma %(point2Y)s.",
+    },
+    srLinearGraphSlopeIncreasing: {
+        context:
+            "Screenreader-only description of a line's decreasing slope on a linear graph.",
+        message: "Its slope increases from left to right.",
+    },
+    srLinearGraphSlopeDecreasing: {
+        context:
+            "Screenreader-only description of a line's increasing slope on a linear graph.",
+        message: "Its slope decreases from left to right.",
+    },
+    srLinearGraphSlopeHorizontal: {
+        context:
+            "Screenreader-only description of a line's horizontal slope on a linear graph.",
+        message: "Its slope is zero.",
+    },
+    srLinearGraphSlopeVertical: {
+        context:
+            "Screenreader-only description of a line's vertical slope on a linear graph.",
+        message: "Its slope is undefined.",
+    },
+    srLinearGraphXOnlyIntercept: {
+        context:
+            "Screenreader-only description of a line's x-intercept on a linear graph when it only has an x intercept.",
+        message: "The line crosses the X-axis at %(xIntercept)s comma 0.",
+    },
+    srLinearGraphYOnlyIntercept: {
+        context:
+            "Screenreader-only description of a line's y-intercept on a linear graph when it only has a y intercept.",
+        message: "The line crosses the Y-axis at 0 comma %(yIntercept)s.",
+    },
+    srLinearGraphBothIntercepts: {
+        context:
+            "Screenreader-only description of a line's x and y intercepts on a linear graph when both intercepts are present.",
+        message:
+            "The line crosses the X-axis at %(xIntercept)s comma 0 and the Y-axis at 0 comma %(yIntercept)s.",
+    },
+    srLinearGraphOriginIntercept: {
+        context:
+            "Screenreader-only description of the line's intercept when the intercept is the graph's origin.",
+        message: "The line crosses the x and y axes at the graph's origin.",
+    },
     // The above strings are used for interactive graph SR descriptions.
 };
 
@@ -585,5 +663,20 @@ export const mockStrings: PerseusStrings = {
         point4Y,
     }) =>
         `Points on the circle at ${point1X} comma ${point1Y}, ${point2X} comma ${point2Y}, ${point3X} comma ${point3Y}, ${point4X} comma ${point4Y}.`,
+    srLinearGraph: "A line on a coordinate plane.",
+    srLinearGraphPoints: ({point1X, point1Y, point2X, point2Y}) =>
+        `The line has two points, point 1 at ${point1X} comma ${point1Y} and point 2 at ${point2X} comma ${point2Y}.`,
+    srLinearGraphSlopeIncreasing: "Its slope increases from left to right.",
+    srLinearGraphSlopeDecreasing: "Its slope decreases from left to right.",
+    srLinearGraphSlopeHorizontal: "Its slope is zero.",
+    srLinearGraphSlopeVertical: "Its slope is undefined.",
+    srLinearGraphXOnlyIntercept: ({xIntercept}) =>
+        `The line crosses the X-axis at ${xIntercept} comma 0.`,
+    srLinearGraphYOnlyIntercept: ({yIntercept}) =>
+        `The line crosses the Y-axis at 0 comma ${yIntercept}.`,
+    srLinearGraphBothIntercepts: ({xIntercept, yIntercept}) =>
+        `The line crosses the X-axis at ${xIntercept} comma 0 and the Y-axis at 0 comma ${yIntercept}.`,
+    srLinearGraphOriginIntercept:
+        "The line crosses the x and y axes at the graph's origin.",
     // The above strings are used for interactive graph SR descriptions.
 };

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -16,21 +16,21 @@ import {Vector} from "./vector";
 import type {Interval} from "mafs";
 
 type Props = {
+    points: Readonly<[vec.Vector2, vec.Vector2]>;
     ariaLabels?: {
         point1AriaLabel?: string;
         point2AriaLabel?: string;
     };
     // Extra graph information to be read by screen readers
     ariaDescribedBy?: string;
-    points: Readonly<[vec.Vector2, vec.Vector2]>;
-    onMovePoint?: (endpointIndex: number, destination: vec.Vector2) => unknown;
-    onMoveLine?: (delta: vec.Vector2) => unknown;
     color?: string;
     /* Extends the line to the edge of the graph with an arrow */
     extend?: {
         start: boolean;
         end: boolean;
     };
+    onMovePoint?: (endpointIndex: number, destination: vec.Vector2) => unknown;
+    onMoveLine?: (delta: vec.Vector2) => unknown;
 };
 
 export const MovableLine = (props: Props) => {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -16,6 +16,12 @@ import {Vector} from "./vector";
 import type {Interval} from "mafs";
 
 type Props = {
+    ariaLabels?: {
+        point1AriaLabel?: string;
+        point2AriaLabel?: string;
+    };
+    // Extra graph information to be read by screen readers
+    ariaDescribedBy?: string;
     points: Readonly<[vec.Vector2, vec.Vector2]>;
     onMovePoint?: (endpointIndex: number, destination: vec.Vector2) => unknown;
     onMoveLine?: (delta: vec.Vector2) => unknown;
@@ -29,6 +35,8 @@ type Props = {
 
 export const MovableLine = (props: Props) => {
     const {
+        ariaLabels,
+        ariaDescribedBy,
         onMoveLine = () => {},
         onMovePoint = () => {},
         color,
@@ -49,6 +57,8 @@ export const MovableLine = (props: Props) => {
     //   tab order for the entire page, which is not what we want.
     const {visiblePoint: visiblePoint1, focusableHandle: focusableHandle1} =
         useControlPoint({
+            ariaLabel: ariaLabels?.point1AriaLabel,
+            ariaDescribedBy: ariaDescribedBy,
             point: start,
             sequenceNumber: 1,
             color,
@@ -56,6 +66,8 @@ export const MovableLine = (props: Props) => {
         });
     const {visiblePoint: visiblePoint2, focusableHandle: focusableHandle2} =
         useControlPoint({
+            ariaLabel: ariaLabels?.point2AriaLabel,
+            ariaDescribedBy: ariaDescribedBy,
             point: end,
             sequenceNumber: 2,
             color,

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear.test.tsx
@@ -1,0 +1,155 @@
+import {render, screen} from "@testing-library/react";
+import * as React from "react";
+
+import {Dependencies} from "@khanacademy/perseus";
+
+import {testDependencies} from "../../../../../../testing/test-dependencies";
+import {MafsGraph} from "../mafs-graph";
+import {getBaseMafsGraphPropsForTests} from "../utils";
+
+import type {InteractiveGraphState} from "../types";
+
+const baseMafsGraphProps = getBaseMafsGraphPropsForTests();
+const baseLinearState: InteractiveGraphState = {
+    type: "linear",
+    coords: [
+        [-5, 5],
+        [5, 5],
+    ],
+    hasBeenInteractedWith: false,
+    range: [
+        [-10, 10],
+        [-10, 10],
+    ],
+    snapStep: [1, 1],
+};
+
+describe("Linear graph screen reader", () => {
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    test("should have aria label and describedby for overall linear graph", () => {
+        // Arrange
+        render(<MafsGraph {...baseMafsGraphProps} state={baseLinearState} />);
+
+        // Act
+        // eslint-disable-next-line testing-library/no-node-access
+        const linearGraphContainer = document.querySelector(
+            ".linear-graph-container",
+        );
+
+        // Assert
+        // Check aria-label for the overall linear graph.
+        expect(linearGraphContainer).toHaveAttribute(
+            "aria-label",
+            "A line on a coordinate plane.",
+        );
+        expect(linearGraphContainer).toHaveAttribute(
+            "aria-describedby",
+            ":r1:-points :r1:-intercept :r1:-slope",
+        );
+    });
+
+    test("should have aria labels for both points on the line", () => {
+        // Arrange
+        render(<MafsGraph {...baseMafsGraphProps} state={baseLinearState} />);
+
+        // Act
+        // eslint-disable-next-line testing-library/no-node-access
+        const points = screen.getAllByTestId("movable-point__focusable-handle");
+
+        // Assert
+        // Check aria-label for both points on the line.
+        expect(points[0]).toHaveAttribute(
+            "aria-label",
+            "Point 1 at -5 comma 5",
+        );
+        expect(points[1]).toHaveAttribute("aria-label", "Point 2 at 5 comma 5");
+    });
+
+    test("points description should include points info", () => {
+        // Arrange
+        render(<MafsGraph {...baseMafsGraphProps} state={baseLinearState} />);
+
+        // Act
+        const pointsDescription = screen.getByText(
+            "The line has two points, point 1 at -5 comma 5 and point 2 at 5 comma 5.",
+        );
+
+        // Assert
+        expect(pointsDescription).toBeInTheDocument();
+        // Check the text was found in the hidden points description.
+        // Check only the ID suffix after the variable unique ID prefix.
+        expect(pointsDescription.getAttribute("id")).toContain("-points");
+    });
+
+    test.each`
+        case                         | coords              | interceptDescription
+        ${"origin intercept"}        | ${[[1, 1], [2, 2]]} | ${"The line crosses the x and y axes at the graph's origin."}
+        ${"both x and y intercepts"} | ${[[4, 4], [7, 1]]} | ${"The line crosses the X-axis at 8 comma 0 and the Y-axis at 0 comma 8."}
+        ${"x intercept only"}        | ${[[5, 5], [5, 2]]} | ${"The line crosses the X-axis at 5 comma 0."}
+        ${"y intercept only"}        | ${[[5, 5], [2, 5]]} | ${"The line crosses the Y-axis at 0 comma 5."}
+    `(
+        `slope description should include slope info for $case`,
+        ({coords, interceptDescription}) => {
+            // Arrange
+            render(
+                <MafsGraph
+                    {...baseMafsGraphProps}
+                    state={{
+                        ...baseLinearState,
+                        coords,
+                    }}
+                />,
+            );
+
+            // Act
+            const interceptDescriptionElement =
+                screen.getByText(interceptDescription);
+
+            // Assert
+            expect(interceptDescriptionElement).toBeInTheDocument();
+            // Check the text was found in the hidden intercept description.
+            // Check only the ID suffix after the variable unique ID prefix.
+            expect(interceptDescriptionElement.getAttribute("id")).toContain(
+                "-intercept",
+            );
+        },
+    );
+
+    test.each`
+        case                 | coords              | slopeDescription
+        ${"positive slope"}  | ${[[1, 1], [3, 3]]} | ${"Its slope increases from left to right."}
+        ${"negative slope"}  | ${[[3, 3], [1, 6]]} | ${"Its slope decreases from left to right."}
+        ${"horizontal line"} | ${[[1, 1], [3, 1]]} | ${"Its slope is zero."}
+        ${"vertical line"}   | ${[[1, 1], [1, 3]]} | ${"Its slope is undefined."}
+    `(
+        `slope description should include slope info for $case`,
+        ({coords, slopeDescription}) => {
+            // Arrange
+            render(
+                <MafsGraph
+                    {...baseMafsGraphProps}
+                    state={{
+                        ...baseLinearState,
+                        coords,
+                    }}
+                />,
+            );
+
+            // Act
+            const slopeDescriptionElement = screen.getByText(slopeDescription);
+
+            // Assert
+            expect(slopeDescriptionElement).toBeInTheDocument();
+            // Check the text was found in the hidden slope description.
+            // Check only the ID suffix after the variable unique ID prefix.
+            expect(slopeDescriptionElement.getAttribute("id")).toContain(
+                "-slope",
+            );
+        },
+    );
+});

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear.test.tsx
@@ -24,6 +24,8 @@ const baseLinearState: InteractiveGraphState = {
     snapStep: [1, 1],
 };
 
+const overallGraphLabel = "A line on a coordinate plane.";
+
 describe("Linear graph screen reader", () => {
     beforeEach(() => {
         jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
@@ -36,18 +38,13 @@ describe("Linear graph screen reader", () => {
         render(<MafsGraph {...baseMafsGraphProps} state={baseLinearState} />);
 
         // Act
-        // eslint-disable-next-line testing-library/no-node-access
-        const linearGraphContainer = document.querySelector(
-            ".linear-graph-container",
+        const linearGraph = screen.getByLabelText(
+            "A line on a coordinate plane.",
         );
 
         // Assert
-        // Check aria-label for the overall linear graph.
-        expect(linearGraphContainer).toHaveAttribute(
-            "aria-label",
-            "A line on a coordinate plane.",
-        );
-        expect(linearGraphContainer).toHaveAttribute(
+        expect(linearGraph).toBeInTheDocument();
+        expect(linearGraph).toHaveAttribute(
             "aria-describedby",
             ":r1:-points :r1:-intercept :r1:-slope",
         );
@@ -75,15 +72,12 @@ describe("Linear graph screen reader", () => {
         render(<MafsGraph {...baseMafsGraphProps} state={baseLinearState} />);
 
         // Act
-        const pointsDescription = screen.getByText(
-            "The line has two points, point 1 at -5 comma 5 and point 2 at 5 comma 5.",
-        );
+        const linearGraph = screen.getByLabelText(overallGraphLabel);
 
         // Assert
-        expect(pointsDescription).toBeInTheDocument();
-        // Check the text was found in the hidden points description.
-        // Check only the ID suffix after the variable unique ID prefix.
-        expect(pointsDescription.getAttribute("id")).toContain("-points");
+        expect(linearGraph).toHaveTextContent(
+            "The line has two points, point 1 at -5 comma 5 and point 2 at 5 comma 5.",
+        );
     });
 
     test.each`
@@ -107,16 +101,10 @@ describe("Linear graph screen reader", () => {
             );
 
             // Act
-            const interceptDescriptionElement =
-                screen.getByText(interceptDescription);
+            const linearGraph = screen.getByLabelText(overallGraphLabel);
 
             // Assert
-            expect(interceptDescriptionElement).toBeInTheDocument();
-            // Check the text was found in the hidden intercept description.
-            // Check only the ID suffix after the variable unique ID prefix.
-            expect(interceptDescriptionElement.getAttribute("id")).toContain(
-                "-intercept",
-            );
+            expect(linearGraph).toHaveTextContent(interceptDescription);
         },
     );
 
@@ -141,15 +129,10 @@ describe("Linear graph screen reader", () => {
             );
 
             // Act
-            const slopeDescriptionElement = screen.getByText(slopeDescription);
+            const linearGraph = screen.getByLabelText(overallGraphLabel);
 
             // Assert
-            expect(slopeDescriptionElement).toBeInTheDocument();
-            // Check the text was found in the hidden slope description.
-            // Check only the ID suffix after the variable unique ID prefix.
-            expect(slopeDescriptionElement.getAttribute("id")).toContain(
-                "-slope",
-            );
+            expect(linearGraph).toHaveTextContent(slopeDescription);
         },
     );
 });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
@@ -1,8 +1,10 @@
 import * as React from "react";
 
+import {usePerseusI18n} from "../../../components/i18n-context";
 import {actions} from "../reducer/interactive-graph-action";
 
 import {MovableLine} from "./components/movable-line";
+import {srFormatNumber} from "./screenreader-text";
 
 import type {
     MafsGraphProps,
@@ -28,24 +30,102 @@ const LinearGraph = (props: LinearGraphProps, key: number) => {
     const {dispatch} = props;
     const {coords: line} = props.graphState;
 
+    const {strings, locale} = usePerseusI18n();
+    const id = React.useId();
+    const pointsDescriptionId = id + "-points";
+    const interceptDescriptionId = id + "-intercept";
+    const slopeDescriptionId = id + "-slope";
+
+    // Aria label strings
+    const linearGraphPointsDescription = strings.srLinearGraphPoints({
+        point1X: srFormatNumber(line[0][0], locale),
+        point1Y: srFormatNumber(line[0][1], locale),
+        point2X: srFormatNumber(line[1][0], locale),
+        point2Y: srFormatNumber(line[1][1], locale),
+    });
+
+    // Slope description
+    const slope = (line[1][1] - line[0][1]) / (line[1][0] - line[0][0]);
+    let slopeString = "";
+    if (slope === Infinity || slope === -Infinity) {
+        slopeString = strings.srLinearGraphSlopeVertical;
+    } else if (slope === 0) {
+        slopeString = strings.srLinearGraphSlopeHorizontal;
+    } else {
+        slopeString =
+            slope > 0
+                ? strings.srLinearGraphSlopeIncreasing
+                : strings.srLinearGraphSlopeDecreasing;
+    }
+
+    // Intersection description
+    const xIntercept = (0 - line[0][1]) / slope + line[0][0];
+    const yIntercept = line[0][1] - slope * line[0][0];
+    const hasXIntercept = xIntercept !== Infinity && xIntercept !== -Infinity;
+    const hasYIntercept = yIntercept !== Infinity && yIntercept !== -Infinity;
+    let interceptString;
+    if (hasXIntercept && hasYIntercept) {
+        // Describe both intercepts in the same sentence.
+        interceptString =
+            xIntercept === 0 && yIntercept === 0
+                ? strings.srLinearGraphOriginIntercept
+                : strings.srLinearGraphBothIntercepts({
+                      xIntercept: srFormatNumber(xIntercept, locale),
+                      yIntercept: srFormatNumber(yIntercept, locale),
+                  });
+    } else {
+        // Describe only one intercept.
+        interceptString = hasXIntercept
+            ? strings.srLinearGraphXOnlyIntercept({
+                  xIntercept: srFormatNumber(xIntercept, locale),
+              })
+            : strings.srLinearGraphYOnlyIntercept({
+                  yIntercept: srFormatNumber(yIntercept, locale),
+              });
+    }
+
     // Linear graphs only have one line
     // (LEMS-2050): Update the reducer so that we have a separate action for moving one line
     // and another action for moving multiple lines
     return (
-        <MovableLine
-            key={0}
-            points={line}
-            onMoveLine={(delta: vec.Vector2) => {
-                dispatch(actions.linear.moveLine(delta));
-            }}
-            extend={{
-                start: true,
-                end: true,
-            }}
-            onMovePoint={(endpointIndex: number, destination: vec.Vector2) =>
-                dispatch(actions.linear.movePoint(endpointIndex, destination))
-            }
-            color="var(--movable-line-stroke-color)"
-        />
+        <g
+            className="linear-graph-container"
+            // Outer line minimal description
+            aria-label={strings.srLinearGraph}
+            aria-describedby={`${pointsDescriptionId} ${interceptDescriptionId} ${slopeDescriptionId}`}
+        >
+            <MovableLine
+                key={0}
+                ariaDescribedBy={`${interceptDescriptionId} ${slopeDescriptionId}`}
+                points={line}
+                onMoveLine={(delta: vec.Vector2) => {
+                    dispatch(actions.linear.moveLine(delta));
+                }}
+                extend={{
+                    start: true,
+                    end: true,
+                }}
+                onMovePoint={(
+                    endpointIndex: number,
+                    destination: vec.Vector2,
+                ) =>
+                    dispatch(
+                        actions.linear.movePoint(endpointIndex, destination),
+                    )
+                }
+                color="var(--movable-line-stroke-color)"
+            />
+            {/* Hidden elements to provide the descriptions for the
+                circle and radius point's `aria-describedby` properties. */}
+            <g id={pointsDescriptionId} style={{display: "hidden"}}>
+                {linearGraphPointsDescription}
+            </g>
+            <g id={interceptDescriptionId} style={{display: "hidden"}}>
+                {interceptString}
+            </g>
+            <g id={slopeDescriptionId} style={{display: "hidden"}}>
+                {slopeString}
+            </g>
+        </g>
     );
 };


### PR DESCRIPTION
## Summary:
Add the full graph aria label and description for Linear graphs, based on the [SRUX doc](https://khanacademy.atlassian.net/wiki/spaces/LC/pages/3460366348/Linear).

This includes four different cases for the slope description, and
four different cases for the intercepts.
- increasing slope
- decreasing slope
- horizontal slope
- vertical slope
- origin intercept
- different x and y intercepts
- only x intercept
- only y intercept

Upcoming in a separate PR:
- focus, aria label, and aria live management for the movable middle part between the two points on the line

Issue: https://khanacademy.atlassian.net/browse/LEMS-1726

## Test plan:
`yarn jest packages/perseus/src/widgets/interactive-graphs/graphs/linear.test.tsx`

Storybook
- http://localhost:6006/iframe.html?id=perseuseditor-widgets-interactive-graph--interactive-graph-linear&viewMode=story
- Try all the different slopes and intercepts

https://github.com/user-attachments/assets/2e0c0a26-6cf5-40c4-a986-0207e6e8ea56

