### PR TITLE
Fix some naming discrepancies and simplify Matcher scoring type

### DIFF
--- a/.changeset/nine-planes-relax.md
+++ b/.changeset/nine-planes-relax.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-editor": minor
+---
+
+Fix some naming discrepancies related to validation and simplify Matcher ScoringData type

--- a/.changeset/nine-planes-relax.md
+++ b/.changeset/nine-planes-relax.md
@@ -1,6 +1,5 @@
 ---
 "@khanacademy/perseus": minor
-"@khanacademy/perseus-editor": minor
 ---
 
 Fix some naming discrepancies related to validation and simplify Matcher ScoringData type

--- a/packages/perseus/src/validation.types.ts
+++ b/packages/perseus/src/validation.types.ts
@@ -36,7 +36,6 @@ import type {
     PerseusGradedGroupWidgetOptions,
     PerseusGraphType,
     PerseusGroupWidgetOptions,
-    PerseusMatcherWidgetOptions,
     PerseusMatrixWidgetAnswers,
     PerseusNumericInputAnswer,
     PerseusOrdererWidgetOptions,
@@ -144,7 +143,12 @@ export type PerseusLabelImageUserInput = {
     }>;
 };
 
-export type PerseusMatcherScoringData = PerseusMatcherWidgetOptions;
+export type PerseusMatcherScoringData = {
+    // Translatable Text; Static concepts to show in the left column. e.g. ["Fruit", "Color", "Clothes"]
+    left: ReadonlyArray<string>;
+    // Translatable Markup; Values that represent the concepts to be correlated with the concepts.  e.g. ["Red", "Shirt", "Banana"]
+    right: ReadonlyArray<string>;
+};
 
 export type PerseusMatcherUserInput = {
     left: ReadonlyArray<string>;

--- a/packages/perseus/src/widgets/group/score-group.ts
+++ b/packages/perseus/src/widgets/group/score-group.ts
@@ -12,13 +12,13 @@ import type {
 // it. As such, scoring a group means scoring all widgets it contains.
 function scoreGroup(
     userInput: PerseusGroupUserInput,
-    options: PerseusGroupScoringData,
+    scoringData: PerseusGroupScoringData,
     strings: PerseusStrings,
     locale: string,
 ): PerseusScore {
     const scores = scoreWidgetsFunctional(
-        options.widgets,
-        Object.keys(options.widgets),
+        scoringData.widgets,
+        Object.keys(scoringData.widgets),
         userInput,
         strings,
         locale,

--- a/packages/perseus/src/widgets/matcher/score-matcher.test.ts
+++ b/packages/perseus/src/widgets/matcher/score-matcher.test.ts
@@ -14,11 +14,8 @@ describe("scoreMatcher", () => {
         };
 
         const scoringData: PerseusMatcherScoringData = {
-            labels: ["One", "Two"],
             left: ["1", "0+1"],
             right: ["2", "0+2"],
-            orderMatters: false,
-            padding: false,
         };
 
         // Act
@@ -31,11 +28,8 @@ describe("scoreMatcher", () => {
     it("can be answered correctly", () => {
         // Arrange
         const scoringData: PerseusMatcherScoringData = {
-            labels: ["One", "Two"],
             left: ["1", "0+1"],
             right: ["2", "0+2"],
-            orderMatters: false,
-            padding: false,
         };
 
         const userInput: PerseusMatcherUserInput = {

--- a/packages/perseus/src/widgets/matrix/score-matrix.ts
+++ b/packages/perseus/src/widgets/matrix/score-matrix.ts
@@ -17,9 +17,9 @@ function scoreMatrix(
     scoringData: PerseusMatrixScoringData,
     strings: PerseusStrings,
 ): PerseusScore {
-    const validationResult = validateMatrix(userInput, scoringData, strings);
-    if (validationResult != null) {
-        return validationResult;
+    const validationError = validateMatrix(userInput, scoringData, strings);
+    if (validationError != null) {
+        return validationError;
     }
 
     const solution = scoringData.answers;

--- a/packages/perseus/src/widgets/orderer/score-orderer.ts
+++ b/packages/perseus/src/widgets/orderer/score-orderer.ts
@@ -12,9 +12,9 @@ export function scoreOrderer(
     userInput: PerseusOrdererUserInput,
     scoringData: PerseusOrdererScoringData,
 ): PerseusScore {
-    const validateError = validateOrderer(userInput);
-    if (validateError) {
-        return validateError;
+    const validationError = validateOrderer(userInput);
+    if (validationError) {
+        return validationError;
     }
 
     const correct = _.isEqual(


### PR DESCRIPTION
## Summary:
Noticed some discrepanies in naming relating to calling the validation function and also noticed some scoring types still reference their widgetOptions. The scoring types for the group widgets still references widgetOptions, but here I updated the scoring type for Matcher to be more specific to what is actually used.

Issue: LEMS-2734

## Test plan:
- Confirm all checks pass
- Will do more manual testing after merging to the feature branch