### PR TITLE
docs(changeset): Bump versions to fix release

### DIFF
--- a/.changeset/friendly-carrots-move.md
+++ b/.changeset/friendly-carrots-move.md
@@ -1,0 +1,16 @@
+---
+"perseus-build-settings": patch
+"@khanacademy/perseus-dev-ui": patch
+"@khanacademy/kas": patch
+"@khanacademy/keypad-context": patch
+"@khanacademy/kmath": patch
+"@khanacademy/math-input": patch
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-core": patch
+"@khanacademy/perseus-editor": patch
+"@khanacademy/perseus-linter": patch
+"@khanacademy/pure-markdown": patch
+"@khanacademy/simple-markdown": patch
+---
+
+Bump versions to fix release


### PR DESCRIPTION
## Summary:
The work to try and block publishes of non-snapshot packages during a snapshot did not work. So we have to either delete packages off NPM or bump versions to fix the release. Bumping versions.

## Test plan:
No testing needed here.