### PR TITLE
fix(LEMS-2738): Convert Expression Editor Answer keys to strings

### DIFF
--- a/.changeset/red-bugs-build.md
+++ b/.changeset/red-bugs-build.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+fix for editor

--- a/packages/perseus-editor/src/widgets/__tests__/expression-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/expression-editor.test.tsx
@@ -235,7 +235,7 @@ describe("expression-editor", () => {
                     {
                         considered: "correct",
                         form: false,
-                        key: 0,
+                        key: "0",
                         simplify: false,
                         value: "",
                     },

--- a/packages/perseus-editor/src/widgets/expression-editor.tsx
+++ b/packages/perseus-editor/src/widgets/expression-editor.tsx
@@ -211,7 +211,13 @@ class ExpressionEditor extends React.Component<Props, State> {
     handleRemoveForm: (answerKey: number) => void = (i) => {
         const answerForms = this.props.answerForms.slice();
         answerForms.splice(i, 1);
-        this.change({answerForms});
+
+        const updatedAnswerForms = answerForms.map((form, index) => ({
+            ...form,
+            key: index,
+        }));
+
+        this.change({answerForms: updatedAnswerForms});
     };
 
     // This function is designed to update the answerForm property

--- a/packages/perseus-editor/src/widgets/expression-editor.tsx
+++ b/packages/perseus-editor/src/widgets/expression-editor.tsx
@@ -189,7 +189,7 @@ class ExpressionEditor extends React.Component<Props, State> {
     };
 
     _newEmptyAnswerForm: () => any = () => {
-        const newKey = _makeNewKey(this.props.answerForms)
+        const newKey = _makeNewKey(this.props.answerForms);
         return {
             considered: "correct",
             form: false,
@@ -212,8 +212,11 @@ class ExpressionEditor extends React.Component<Props, State> {
     handleRemoveForm: (answerKey: number) => void = (i) => {
         const answerForms = this.props.answerForms.slice();
         answerForms.splice(i, 1);
-
-        this.change({answerForms});
+        const updatedAnswerForms = answerForms.map((form, index) => ({
+            ...form,
+            key: `${index}`,
+        }));
+        this.change({answerForms: updatedAnswerForms});
     };
 
     // This function is designed to update the answerForm property
@@ -346,7 +349,7 @@ class ExpressionEditor extends React.Component<Props, State> {
 
     render(): React.ReactNode {
         const answerOptions: React.JSX.Element[] = this.props.answerForms.map(
-            (ans: AnswerForm) => {
+            (ans: AnswerForm, index: number) => {
                 const key = parseAnswerKey(ans);
 
                 const expressionProps: Partial<
@@ -378,7 +381,7 @@ class ExpressionEditor extends React.Component<Props, State> {
                         expressionProps={expressionProps}
                         form={ans.form}
                         simplify={ans.simplify}
-                        onDelete={() => this.handleRemoveForm(key)}
+                        onDelete={() => this.handleRemoveForm(index)}
                         onChangeSimplify={(simplify) =>
                             this.changeSimplify(key, simplify)
                         }
@@ -567,6 +570,7 @@ class AnswerOption extends React.Component<
 
     handleImSure = () => {
         this.props.onDelete();
+        this.handleCancelDelete();
     };
 
     handleCancelDelete = () => {

--- a/packages/perseus-editor/src/widgets/expression-editor.tsx
+++ b/packages/perseus-editor/src/widgets/expression-editor.tsx
@@ -206,6 +206,7 @@ class ExpressionEditor extends React.Component<Props, State> {
         const answerForms = this.props.answerForms.slice();
         answerForms.push(this._newEmptyAnswerForm());
         this.change({answerForms});
+        console.log("newAnswer", answerForms)
     };
 
     handleRemoveForm: (answerKey: number) => void = (i) => {
@@ -214,10 +215,11 @@ class ExpressionEditor extends React.Component<Props, State> {
 
         const updatedAnswerForms = answerForms.map((form, index) => ({
             ...form,
-            key: index,
+            key: `${index}`,
         }));
 
         this.change({answerForms: updatedAnswerForms});
+        console.log(answerForms)
     };
 
     // This function is designed to update the answerForm property

--- a/packages/perseus-editor/src/widgets/expression-editor.tsx
+++ b/packages/perseus-editor/src/widgets/expression-editor.tsx
@@ -189,13 +189,14 @@ class ExpressionEditor extends React.Component<Props, State> {
     };
 
     _newEmptyAnswerForm: () => any = () => {
+        const newKey = _makeNewKey(this.props.answerForms)
         return {
             considered: "correct",
             form: false,
 
             // note: the key means "n-th form created" - not "form in
             // position n" and will stay the same for the life of this form
-            key: _makeNewKey(this.props.answerForms),
+            key: `${newKey}`,
 
             simplify: false,
             value: "",
@@ -206,20 +207,13 @@ class ExpressionEditor extends React.Component<Props, State> {
         const answerForms = this.props.answerForms.slice();
         answerForms.push(this._newEmptyAnswerForm());
         this.change({answerForms});
-        console.log("newAnswer", answerForms)
     };
 
     handleRemoveForm: (answerKey: number) => void = (i) => {
         const answerForms = this.props.answerForms.slice();
         answerForms.splice(i, 1);
 
-        const updatedAnswerForms = answerForms.map((form, index) => ({
-            ...form,
-            key: `${index}`,
-        }));
-
-        this.change({answerForms: updatedAnswerForms});
-        console.log(answerForms)
+        this.change({answerForms});
     };
 
     // This function is designed to update the answerForm property


### PR DESCRIPTION
## Summary:
- Converts expression editor keys to strings
- Updates `onDelete` handler to use index instead of key

Issue: LEMS-2738

## Test plan:


https://github.com/user-attachments/assets/60424f5a-f654-4afc-901f-de47505e053c


