### PR TITLE
[🔥AUDIT🔥] docs(changeset): Version bump to verify release protections

### DIFF
--- a/.changeset/fluffy-needles-leave.md
+++ b/.changeset/fluffy-needles-leave.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Version bump to verify release protections


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
In order to verify our existing release protection, that prevents snapshot releases from releasing non-snapshot versions, and to verify the additional workflow change in #2044 that should fail the snapshot release if a main release is in progress, we need a new release to kick off.

This PR bumps a patch version to make that happen.

Issue: XXX-XXXX

## Test plan:

1. [THIS PR] ~Audit a version bump and land that~
2. Wait for the Version Packages PR to be ready
3. Merge Version Packages
4. Immediately update my two PRs (#2039 and #2044) to match main and kickstart their actions
   - `git pull && git merge --no-edit origin/main && git push && git switch snapshotsvsrelease.2 && git merge --no-edit origin/main && git push`
5. See what happens. With the fix, the script should error on pre-publish; and the new PR should fail the publish workflow - both should guard against the issue we saw.

If something doesn't prevent the publish, then a subsequent patch bump will be needed to correct that.