### PR TITLE
Update changesets' auto-commit feature to not suppress CI on commits

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@1.7.0/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config@2/schema.json",
   "changelog": ["@changesets/changelog-github", {"repo": "Khan/perseus"}],
-  "commit": true,
+  "commit": ["@changesets/cli/commit", { "skipCI": false }],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
## Summary:

I recently updated our Changesets config to auto-commit the `.md` file when using `yarn changset` to describe a set of changes. This broke our releases as the default behaviour is that Changesets adds `[skip ci]` to the commit created when running `yarn changesets version`. No CI on that PR/commit, meant that none of our release Github Actions ran!

So this PR fixes the config so that Changesets no longer adds `[skip ci]` to any commits, but still auto-commits them. 

### Similar PRs

  * Wonder-Blocks: https://github.com/Khan/wonder-blocks/pull/2409
  * Wonder-Stuff: https://github.com/Khan/wonder-stuff/pull/1100
  * Perseus: https://github.com/Khan/perseus/pull/2052 (this PR!)

Issue: "none"

## Test plan:

Land this PR
Merge `main` into an open Version Packages PR
Land that PR and ensure the release goes out