### PR TITLE
[SR] Circle - Add the interactive elements circle description to the whole graph container

### DIFF
--- a/.changeset/little-beds-tickle.md
+++ b/.changeset/little-beds-tickle.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[SR] Circle - Add interactive Circle element to full graph description

--- a/packages/perseus/src/components/i18n-context.tsx
+++ b/packages/perseus/src/components/i18n-context.tsx
@@ -10,7 +10,7 @@ import {mockStrings} from "../strings";
 
 import type {PerseusStrings} from "../strings";
 
-type I18nContextType = {
+export type I18nContextType = {
     strings: PerseusStrings;
     locale: string;
 };

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.test.tsx
@@ -5,8 +5,11 @@ import * as React from "react";
 import {Dependencies} from "@khanacademy/perseus";
 
 import {testDependencies} from "../../../../../../testing/test-dependencies";
+import {mockPerseusI18nContext} from "../../../components/i18n-context";
 import {MafsGraph} from "../mafs-graph";
 import {getBaseMafsGraphPropsForTests} from "../utils";
+
+import {describeCircleGraph} from "./circle";
 
 import type {InteractiveGraphState} from "../types";
 import type {UserEvent} from "@testing-library/user-event";
@@ -161,5 +164,59 @@ describe("Circle graph screen reader", () => {
 
         // Assert
         expect(radiusPoint).toHaveAttribute("aria-live", "off");
+    });
+});
+
+describe("describeCircleGraph", () => {
+    test("describes a default circle", () => {
+        // Arrange
+
+        // Act
+        const strings = describeCircleGraph(
+            baseCircleState,
+            mockPerseusI18nContext,
+        );
+
+        // Assert
+        expect(strings.srCircleGraph).toBe("A circle on a coordinate plane.");
+        expect(strings.srCircleShape).toBe(
+            "Circle. The center point is at 0 comma 0.",
+        );
+        expect(strings.srCircleRadiusPoint).toBe("Radius point at 1 comma 0.");
+        expect(strings.srCircleRadius).toBe("Circle radius is 1.");
+        expect(strings.srCircleOuterPoints).toBe(
+            "Points on the circle at 1 comma 0, 0 comma 1, -1 comma 0, 0 comma -1.",
+        );
+        expect(strings.srCircleInteractiveElement).toBe(
+            "Interactive elements: Circle. The center point is at 0 comma 0. Circle radius is 1.",
+        );
+    });
+
+    test("describes a circle with updated values", () => {
+        // Arrange
+
+        // Act
+        const strings = describeCircleGraph(
+            {
+                ...baseCircleState,
+                center: [2, 3],
+                radiusPoint: [7, 3],
+            },
+            mockPerseusI18nContext,
+        );
+
+        // Assert
+        expect(strings.srCircleGraph).toBe("A circle on a coordinate plane.");
+        expect(strings.srCircleShape).toBe(
+            "Circle. The center point is at 2 comma 3.",
+        );
+        expect(strings.srCircleRadiusPoint).toBe("Radius point at 7 comma 3.");
+        expect(strings.srCircleRadius).toBe("Circle radius is 5.");
+        expect(strings.srCircleOuterPoints).toBe(
+            "Points on the circle at 7 comma 3, 2 comma 8, -3 comma 3, 2 comma -2.",
+        );
+        expect(strings.srCircleInteractiveElement).toBe(
+            "Interactive elements: Circle. The center point is at 2 comma 3. Circle radius is 5.",
+        );
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -31,7 +31,9 @@ export function renderCircleGraph(
 ): InteractiveGraphElementSuite {
     return {
         graph: <CircleGraph graphState={state} dispatch={dispatch} />,
-        interactiveElementsDescription: CircleGraphDescription({state}),
+        interactiveElementsDescription: (
+            <CircleGraphDescription state={state} />
+        ),
     };
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -16,7 +16,7 @@ import {
     useTransformVectorsToPixels,
 } from "./use-transform";
 
-import type {PerseusStrings} from "../../../strings";
+import type {I18nContextType} from "../../../components/i18n-context";
 import type {
     AriaLive,
     CircleGraphState,
@@ -209,8 +209,9 @@ function crossProduct<A, B>(as: A[], bs: B[]): [A, B][] {
 }
 
 function CircleGraphDescription({state}: {state: CircleGraphState}) {
-    // CircleGraphDescription needs to the `usePerseusI18n`, hook so it has]
-    // to be a component rather than a function that simply returns a string.
+    // The reason that CircleGraphDescription is a component (rather than a
+    // function that returns a string) is because it needs to use a
+    // hook: `usePerseusI18n`.
     const i18n = usePerseusI18n();
     const strings = describeCircleGraph(state, i18n);
 
@@ -220,7 +221,7 @@ function CircleGraphDescription({state}: {state: CircleGraphState}) {
 // Exported for testing
 export function describeCircleGraph(
     state: CircleGraphState,
-    i18n: {strings: PerseusStrings; locale: string},
+    i18n: I18nContextType,
 ): Record<string, string> {
     const {strings, locale} = i18n;
     const {center, radiusPoint} = state;


### PR DESCRIPTION
## Summary:
Add the interactive Circle graph description to the full graph container.

This adds the "Interactive elements: Circle..." description to the outermost graph container.

Issue: https://khanacademy.atlassian.net/browse/LEMS-1706

## Test plan:
- Go to https://650db21c3f5d1b2f13c02952-iupnsmdbhn.chromatic.com/iframe.html?globals=&args=&id=perseuseditor-widgets-interactive-graph--interactive-graph-circle&viewMode=story
- Use a screen reader to get to the outermost graph container
- Confirm that it has the circle description after "Interactive elements:"