### PR TITLE
[SR][SR Tree] Add screen reader tree to interactive graph editor

### DIFF
--- a/.changeset/four-avocados-raise.md
+++ b/.changeset/four-avocados-raise.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+[SR][sr tree] Add screen reader tree to interactive graph editor

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.test.tsx
@@ -1,0 +1,230 @@
+import {render} from "@testing-library/react";
+import * as React from "react";
+
+import {fetchAriaLabels} from "./interactive-graph-sr-tree";
+
+describe("fetchAriaLabels", () => {
+    test("should return an empty array if the container is null", () => {
+        // Arrange
+        const container = undefined;
+        const expected = [];
+
+        // Act
+        const result = fetchAriaLabels(container);
+
+        // Assert
+        expect(result).toEqual(expected);
+    });
+
+    test("should return an array of labels", () => {
+        // Arrange
+        const container = render(
+            <div>
+                <div aria-label="label1" />
+                <div aria-label="label2" />
+            </div>,
+        );
+
+        // Act
+        const result = fetchAriaLabels(container.container);
+
+        // Assert
+        expect(result).toEqual([
+            {
+                role: "div",
+                values: [{name: "label", value: "label1"}],
+            },
+            {
+                role: "div",
+                values: [{name: "label", value: "label2"}],
+            },
+        ]);
+    });
+
+    test("should return an array with given roles", () => {
+        // Arrange
+        const container = render(
+            <div>
+                <div role="button" aria-label="aria-label1" />
+                <div role="button" aria-label="aria-label2" />
+            </div>,
+        );
+
+        // Act
+        const result = fetchAriaLabels(container.container);
+
+        // Assert
+        expect(result).toEqual([
+            {
+                role: "button",
+                values: [{name: "label", value: "aria-label1"}],
+            },
+            {
+                role: "button",
+                values: [{name: "label", value: "aria-label2"}],
+            },
+        ]);
+    });
+
+    test("should return an array with descriptions", () => {
+        // Arrange
+        const container = render(
+            <div>
+                <div aria-describedby="description1">label1</div>
+                <div aria-describedby="description2">label2</div>
+                <div id="description1">description1 content</div>
+                <div id="description2">description2 content</div>
+            </div>,
+        );
+
+        // Act
+        const result = fetchAriaLabels(container.container);
+
+        // Assert
+        expect(result).toEqual([
+            {
+                role: "div",
+                values: [{name: "description", value: "description1 content"}],
+            },
+            {
+                role: "div",
+                values: [{name: "description", value: "description2 content"}],
+            },
+        ]);
+    });
+
+    test("should return an array for element with multiple descriptions", () => {
+        // Arrange
+        const container = render(
+            <div>
+                <div aria-describedby="description1 description2">label1</div>
+                <div id="description1">description1 content</div>
+                <div id="description2">description2 content</div>
+            </div>,
+        );
+
+        // Act
+        const result = fetchAriaLabels(container.container);
+
+        // Assert
+        expect(result).toEqual([
+            {
+                role: "div",
+                values: [
+                    {name: "description", value: "description1 content"},
+                    {name: "description", value: "description2 content"},
+                ],
+            },
+        ]);
+    });
+
+    test("should not include descriptions that are not found", () => {
+        // Arrange
+        const container = render(
+            <div>
+                <div aria-describedby="description1 description2">label1</div>
+                <div id="description1">description1 content</div>
+            </div>,
+        );
+
+        // Act
+        const result = fetchAriaLabels(container.container);
+
+        // Assert
+        expect(result).toEqual([
+            {
+                role: "div",
+                values: [{name: "description", value: "description1 content"}],
+            },
+        ]);
+    });
+
+    test("should build attributes array with a variety of attributes", () => {
+        // Arrange
+        const container = render(
+            <div>
+                <div aria-label="label-only" />
+                <div aria-describedby="description-only" />
+                <div role="img" aria-label="label with role" />
+                <div
+                    role="button"
+                    aria-label="aria-label1"
+                    aria-describedby="description1"
+                />
+                <div
+                    role="button"
+                    aria-label="aria-label2"
+                    aria-describedby="description2"
+                />
+                <div id="description-only">description-only content </div>
+                <div id="description1">description1 content</div>
+                <div id="description2">description2 content</div>
+            </div>,
+        );
+
+        // Act
+        const result = fetchAriaLabels(container.container);
+
+        // Assert
+        expect(result).toEqual([
+            {
+                role: "div",
+                values: [{name: "label", value: "label-only"}],
+            },
+            {
+                role: "div",
+                values: [
+                    {name: "description", value: "description-only content "},
+                ],
+            },
+            {
+                role: "img",
+                values: [{name: "label", value: "label with role"}],
+            },
+            {
+                role: "button",
+                values: [
+                    {name: "label", value: "aria-label1"},
+                    {name: "description", value: "description1 content"},
+                ],
+            },
+            {
+                role: "button",
+                values: [
+                    {name: "label", value: "aria-label2"},
+                    {name: "description", value: "description2 content"},
+                ],
+            },
+        ]);
+    });
+
+    test("should not add element if descriptions are not found", () => {
+        // Arrange
+        const container = render(
+            <div>
+                <div aria-describedby="description1 description2">label1</div>
+            </div>,
+        );
+
+        // Act
+        const result = fetchAriaLabels(container.container);
+
+        // Assert
+        expect(result).toEqual([]);
+    });
+
+    test("should not add element if aria attributes are not found", () => {
+        // Arrange
+        const container = render(
+            <div>
+                <div />
+            </div>,
+        );
+
+        // Act
+        const result = fetchAriaLabels(container.container);
+
+        // Assert
+        expect(result).toEqual([]);
+    });
+});

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.tsx
@@ -1,0 +1,139 @@
+import Pill from "@khanacademy/wonder-blocks-pill";
+import * as React from "react";
+
+import Heading from "../../../components/heading";
+
+type Attribute = {
+    name: string;
+    value: string;
+};
+
+type AttributeMap = {
+    role: string;
+    values: Array<Attribute>;
+};
+
+function fetchAriaLabels(container: Element): AttributeMap[] {
+    const elementArias: Array<AttributeMap> = [];
+
+    if (!container) {
+        return elementArias;
+    }
+
+    container.querySelectorAll("*").forEach((element) => {
+        const elementAttributes: Array<Attribute> = [];
+        const attributes = element.attributes;
+
+        for (const attribute of attributes) {
+            if (attribute.name === "aria-label") {
+                elementAttributes.unshift({
+                    name: "label",
+                    value: attribute.value,
+                });
+            }
+            if (attribute.name === "aria-describedby") {
+                // Aria-description is a space-separated list of ids.
+                // Use the ids to get the actual description strings.
+                const descriptions = attribute.value.split(" ");
+                for (const description of descriptions) {
+                    const descriptionString =
+                        document.getElementById(description)?.textContent;
+
+                    if (descriptionString) {
+                        elementAttributes.push({
+                            name: "description",
+                            value: descriptionString,
+                        });
+                    }
+                }
+            }
+        }
+
+        if (elementAttributes.length > 0) {
+            elementArias.push({
+                role:
+                    element.getAttribute("role") ||
+                    element.tagName.toLowerCase(),
+                values: elementAttributes,
+            });
+        }
+    });
+
+    return elementArias;
+}
+
+type Props = {
+    elementArias: Array<AttributeMap>;
+};
+
+function SRTree(props: Props) {
+    const {elementArias} = props;
+
+    // Each list item of this ordered list is the role/rag of the element
+    // followed by an unordered list of its aria attributes.
+    return (
+        <ol style={{listStyle: "revert", marginLeft: 8}}>
+            {elementArias.map((ariaString, index) => (
+                <li key={index}>
+                    {ariaString.role}
+                    <ul style={{listStyle: "revert", marginLeft: 8}}>
+                        {ariaString.values.map((value, index) => (
+                            <li key={index}>
+                                <Pill
+                                    size="small"
+                                    kind={
+                                        value.name === "label"
+                                            ? "info"
+                                            : "neutral"
+                                    }
+                                >
+                                    {value.name}
+                                </Pill>{" "}
+                                {value.value}
+                            </li>
+                        ))}
+                    </ul>
+                </li>
+            ))}
+        </ol>
+    );
+}
+
+function InteractiveGraphSRTree({
+    correct,
+    fullGraphAriaLabel,
+    fullGraphAriaDescription,
+    lockedFigures,
+}) {
+    const [isExpanded, setIsExpanded] = React.useState(true);
+    const [elementArias, setElementArias] = React.useState<AttributeMap[]>([]);
+
+    const mafsGraphContainer = document.getElementsByClassName(
+        "mafs-graph-container",
+    )?.[0];
+
+    // Update the tree when the graph is updated.
+    React.useEffect(() => {
+        setElementArias(fetchAriaLabels(mafsGraphContainer));
+    }, [
+        correct,
+        fullGraphAriaLabel,
+        fullGraphAriaDescription,
+        lockedFigures,
+        mafsGraphContainer,
+    ]);
+
+    return (
+        <>
+            <Heading
+                title="Screen reader tree"
+                isOpen={isExpanded}
+                onToggle={setIsExpanded}
+                isCollapsible={true}
+            />
+            {isExpanded && <SRTree elementArias={elementArias} />}
+        </>
+    );
+}
+
+export default InteractiveGraphSRTree;

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.tsx
@@ -13,7 +13,8 @@ type AttributeMap = {
     values: Array<Attribute>;
 };
 
-function fetchAriaLabels(container: Element): AttributeMap[] {
+// Exported for testing
+export function fetchAriaLabels(container?: Element): AttributeMap[] {
     const elementArias: Array<AttributeMap> = [];
 
     if (!container) {
@@ -108,6 +109,8 @@ function InteractiveGraphSRTree({
     const [isExpanded, setIsExpanded] = React.useState(true);
     const [elementArias, setElementArias] = React.useState<AttributeMap[]>([]);
 
+    // TODO(nisha): Change this to use ref after the graph has a non-string
+    // ref and the InteractiveGraph component forwards refs.
     const mafsGraphContainer = document.getElementsByClassName(
         "mafs-graph-container",
     )?.[0];
@@ -116,6 +119,7 @@ function InteractiveGraphSRTree({
     React.useEffect(() => {
         setElementArias(fetchAriaLabels(mafsGraphContainer));
     }, [
+        // Update the tree when the "correct preview" graph is updated.
         correct,
         fullGraphAriaLabel,
         fullGraphAriaDescription,

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
@@ -25,6 +25,7 @@ import GraphTypeSelector from "./components/graph-type-selector";
 import {InteractiveGraphCorrectAnswer} from "./components/interactive-graph-correct-answer";
 import InteractiveGraphDescription from "./components/interactive-graph-description";
 import InteractiveGraphSettings from "./components/interactive-graph-settings";
+import InteractiveGraphSRTree from "./components/interactive-graph-sr-tree";
 import SegmentCountSelector from "./components/segment-count-selector";
 import LabeledRow from "./locked-figures/labeled-row";
 import LockedFiguresSection from "./locked-figures/locked-figures-section";
@@ -712,6 +713,14 @@ class InteractiveGraphEditor extends React.Component<Props> {
                             onChange={this.changeStartCoords}
                         />
                     )}
+                <InteractiveGraphSRTree
+                    correct={this.props.correct}
+                    fullGraphAriaLabel={this.props.fullGraphAriaLabel}
+                    fullGraphAriaDescription={
+                        this.props.fullGraphAriaDescription
+                    }
+                    lockedFigures={this.props.lockedFigures}
+                />
                 <InteractiveGraphSettings
                     box={getInteractiveBoxFromSizeClass(sizeClass)}
                     range={this.props.range}

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -153,7 +153,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                 disableKeyboardInteraction: readOnly || !!props.static,
             }}
         >
-            <View>
+            <View className="mafs-graph-container">
                 <View
                     className="mafs-graph"
                     style={{


### PR DESCRIPTION
## Summary:
To make it easier for content authors (and us devs while we're still
working on the screen reader experience) to build the screen reader
experience for an interactive graph without constantly having to
turn on the screen reader, add a screen reader tree directly into
the editor.

To do this, I used `querySelectorAll()` to get the mafs container
and all its children, and read their `aria-label` and
`aria-describedby` attributes.

After building an object with the elements, roles, and attributes,
display a tree showing these in the editor.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2714

## Test plan:
`yarn jest packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.test.tsx`

Storybook
- Go to http://localhost:6006/iframe.html?globals=&id=perseuseditor-widgets-interactive-graph--interactive-graph-circle&viewMode=story
- Update the whole graph aria label and description
- Update the correct graph
- Update the locked figures and their labels
- Confirm that the SR tree updates