### PR TITLE
Remove locked-figures-aria flag

### DIFF
--- a/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
+++ b/packages/perseus-editor/src/__stories__/flags-for-api-options.ts
@@ -17,7 +17,6 @@ export const flags = {
         none: true,
 
         // Locked figures flags
-        "locked-figures-aria": true,
         "locked-point-labels": true,
         "locked-line-labels": true,
         "locked-vector-labels": true,

--- a/packages/perseus-editor/src/__stories__/interactive-graph-editor.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/interactive-graph-editor.stories.tsx
@@ -161,7 +161,6 @@ export const MafsWithLockedFiguresCurrent = (): React.ReactElement => {
                 flags: {
                     mafs: {
                         ...flags.mafs,
-                        "locked-figures-aria": false,
                         "locked-point-labels": false,
                         "locked-line-labels": false,
                         "locked-vector-labels": false,

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-ellipse-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-ellipse-settings.tsx
@@ -245,20 +245,15 @@ const LockedEllipseSettings = (props: Props) => {
             />
 
             {/* Aria label */}
-            {flags?.["mafs"]?.["locked-figures-aria"] && (
-                <>
-                    <Strut size={spacing.small_12} />
-                    <View style={styles.horizontalRule} />
-
-                    <LockedFigureAria
-                        ariaLabel={ariaLabel}
-                        getPrepopulatedAriaLabel={getPrepopulatedAriaLabel}
-                        onChangeProps={(newProps) => {
-                            onChangeProps(newProps);
-                        }}
-                    />
-                </>
-            )}
+            <Strut size={spacing.small_12} />
+            <View style={styles.horizontalRule} />
+            <LockedFigureAria
+                ariaLabel={ariaLabel}
+                getPrepopulatedAriaLabel={getPrepopulatedAriaLabel}
+                onChangeProps={(newProps) => {
+                    onChangeProps(newProps);
+                }}
+            />
 
             {/* Visible Labels */}
             {flags?.["mafs"]?.["locked-ellipse-labels"] && (

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.tsx
@@ -326,20 +326,15 @@ const LockedFunctionSettings = (props: Props) => {
             </PerseusEditorAccordion>
 
             {/* Aria label */}
-            {flags?.["mafs"]?.["locked-figures-aria"] && (
-                <>
-                    <Strut size={spacing.small_12} />
-                    <View style={styles.horizontalRule} />
-
-                    <LockedFigureAria
-                        ariaLabel={ariaLabel}
-                        getPrepopulatedAriaLabel={getPrepopulatedAriaLabel}
-                        onChangeProps={(newProps) => {
-                            onChangeProps(newProps);
-                        }}
-                    />
-                </>
-            )}
+            <Strut size={spacing.small_12} />
+            <View style={styles.horizontalRule} />
+            <LockedFigureAria
+                ariaLabel={ariaLabel}
+                getPrepopulatedAriaLabel={getPrepopulatedAriaLabel}
+                onChangeProps={(newProps) => {
+                    onChangeProps(newProps);
+                }}
+            />
 
             {/* Visible Labels */}
             {flags?.["mafs"]?.["locked-function-labels"] && (

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-line-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-line-settings.tsx
@@ -271,20 +271,16 @@ const LockedLineSettings = (props: Props) => {
                 onChangeProps={(newProps) => handleChangePoint(newProps, 1)}
             />
 
-            {flags?.["mafs"]?.["locked-figures-aria"] && (
-                <>
-                    <Strut size={spacing.small_12} />
-                    <View style={styles.horizontalRule} />
-
-                    <LockedFigureAria
-                        ariaLabel={ariaLabel}
-                        getPrepopulatedAriaLabel={getPrepopulatedAriaLabel}
-                        onChangeProps={(newProps) => {
-                            onChangeProps(newProps);
-                        }}
-                    />
-                </>
-            )}
+            {/* Aria label */}
+            <Strut size={spacing.small_12} />
+            <View style={styles.horizontalRule} />
+            <LockedFigureAria
+                ariaLabel={ariaLabel}
+                getPrepopulatedAriaLabel={getPrepopulatedAriaLabel}
+                onChangeProps={(newProps) => {
+                    onChangeProps(newProps);
+                }}
+            />
 
             {flags?.["mafs"]?.["locked-line-labels"] && (
                 <>

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-point-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-point-settings.tsx
@@ -242,7 +242,7 @@ const LockedPointSettings = (props: Props) => {
                 </>
             )}
 
-            {!isDefiningPoint && flags?.["mafs"]?.["locked-figures-aria"] && (
+            {!isDefiningPoint && (
                 <>
                     <Strut size={spacing.small_12} />
                     <View style={styles.horizontalRule} />

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.tsx
@@ -338,20 +338,15 @@ const LockedPolygonSettings = (props: Props) => {
             </PerseusEditorAccordion>
 
             {/* Aria label */}
-            {flags?.["mafs"]?.["locked-figures-aria"] && (
-                <>
-                    <Strut size={spacing.small_12} />
-                    <View style={styles.horizontalRule} />
-
-                    <LockedFigureAria
-                        ariaLabel={ariaLabel}
-                        getPrepopulatedAriaLabel={getPrepopulatedAriaLabel}
-                        onChangeProps={(newProps) => {
-                            onChangeProps(newProps);
-                        }}
-                    />
-                </>
-            )}
+            <Strut size={spacing.small_12} />
+            <View style={styles.horizontalRule} />
+            <LockedFigureAria
+                ariaLabel={ariaLabel}
+                getPrepopulatedAriaLabel={getPrepopulatedAriaLabel}
+                onChangeProps={(newProps) => {
+                    onChangeProps(newProps);
+                }}
+            />
 
             {/* Visible Labels */}
             {flags?.["mafs"]?.["locked-polygon-labels"] && (

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-vector-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-vector-settings.tsx
@@ -209,20 +209,16 @@ const LockedVectorSettings = (props: Props) => {
                 />
             </PerseusEditorAccordion>
 
-            {flags?.["mafs"]?.["locked-figures-aria"] && (
-                <>
-                    <Strut size={spacing.small_12} />
-                    <View style={styles.horizontalRule} />
-
-                    <LockedFigureAria
-                        ariaLabel={ariaLabel}
-                        getPrepopulatedAriaLabel={getPrepopulatedAriaLabel}
-                        onChangeProps={(newProps) => {
-                            onChangeProps(newProps);
-                        }}
-                    />
-                </>
-            )}
+            {/* Aria label */}
+            <Strut size={spacing.small_12} />
+            <View style={styles.horizontalRule} />
+            <LockedFigureAria
+                ariaLabel={ariaLabel}
+                getPrepopulatedAriaLabel={getPrepopulatedAriaLabel}
+                onChangeProps={(newProps) => {
+                    onChangeProps(newProps);
+                }}
+            />
 
             {flags?.["mafs"]?.["locked-vector-labels"] && (
                 <>

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -210,12 +210,6 @@ export const MafsGraphTypeFlags = [
 
 export const InteractiveGraphLockedFeaturesFlags = [
     /**
-     * Enables/disables the aria labels associated with specific locked
-     * figures in the updated Interactive Graph widget.
-     */
-    "locked-figures-aria",
-
-    /**
      * Enables/disables the labels associated with locked points in the
      * updated Interactive Graph widget.
      */

--- a/packages/perseus/src/widgets/interactive-graphs/graph-locked-layer.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graph-locked-layer.tsx
@@ -9,28 +9,22 @@ import LockedPolygon from "./locked-figures/locked-polygon";
 import LockedVector from "./locked-figures/locked-vector";
 
 import type {LockedFigure} from "../../perseus-types";
-import type {APIOptions} from "../../types";
 import type {Interval} from "mafs";
 
 type Props = {
-    flags?: APIOptions["flags"];
     lockedFigures: ReadonlyArray<LockedFigure>;
     range: [x: Interval, y: Interval];
 };
 
 const GraphLockedLayer = (props: Props) => {
-    const {flags, lockedFigures} = props;
+    const {lockedFigures} = props;
     return (
         <>
             {lockedFigures.map((figure, index) => {
                 switch (figure.type) {
                     case "point":
                         return (
-                            <LockedPoint
-                                key={`point-${index}`}
-                                {...figure}
-                                flags={flags}
-                            />
+                            <LockedPoint key={`point-${index}`} {...figure} />
                         );
                     case "line":
                         return (
@@ -38,23 +32,17 @@ const GraphLockedLayer = (props: Props) => {
                                 key={`line-${index}`}
                                 range={props.range}
                                 {...figure}
-                                flags={flags}
                             />
                         );
                     case "vector":
                         return (
-                            <LockedVector
-                                key={`vector-${index}`}
-                                {...figure}
-                                flags={flags}
-                            />
+                            <LockedVector key={`vector-${index}`} {...figure} />
                         );
                     case "ellipse":
                         return (
                             <LockedEllipse
                                 key={`ellipse-${index}`}
                                 {...figure}
-                                flags={flags}
                             />
                         );
                     case "polygon":
@@ -62,7 +50,6 @@ const GraphLockedLayer = (props: Props) => {
                             <LockedPolygon
                                 key={`polygon-${index}`}
                                 {...figure}
-                                flags={flags}
                             />
                         );
                     case "function":
@@ -70,7 +57,6 @@ const GraphLockedLayer = (props: Props) => {
                             <LockedFunction
                                 key={`function-${index}`}
                                 {...figure}
-                                flags={flags}
                             />
                         );
                     case "label":

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
@@ -545,13 +545,7 @@ describe("Interactive Graph", function () {
             // Arrange
             const {container} = renderQuestion(
                 segmentWithLockedPointsWithColorQuestion,
-                {
-                    flags: {
-                        mafs: {
-                            segment: true,
-                        },
-                    },
-                },
+                apiOptions,
             );
 
             // Act
@@ -581,14 +575,7 @@ describe("Interactive Graph", function () {
                     .build();
             const {container} = renderQuestion(
                 lockedPointWithAriaLabelQuestion,
-                {
-                    flags: {
-                        mafs: {
-                            segment: true,
-                            "locked-figures-aria": true,
-                        },
-                    },
-                },
+                apiOptions,
             );
 
             // Act
@@ -604,13 +591,10 @@ describe("Interactive Graph", function () {
             const simpleLockedPointQuestion = interactiveGraphQuestionBuilder()
                 .addLockedPointAt(0, 0)
                 .build();
-            const {container} = renderQuestion(simpleLockedPointQuestion, {
-                flags: {
-                    mafs: {
-                        segment: true,
-                    },
-                },
-            });
+            const {container} = renderQuestion(
+                simpleLockedPointQuestion,
+                apiOptions,
+            );
 
             // Act
             // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
@@ -622,13 +606,10 @@ describe("Interactive Graph", function () {
 
         it("should render locked lines", () => {
             // Arrange
-            const {container} = renderQuestion(segmentWithLockedLineQuestion, {
-                flags: {
-                    mafs: {
-                        segment: true,
-                    },
-                },
-            });
+            const {container} = renderQuestion(
+                segmentWithLockedLineQuestion,
+                apiOptions,
+            );
 
             // Act
             // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
@@ -643,13 +624,10 @@ describe("Interactive Graph", function () {
 
         it("should render locked lines with styles", () => {
             // Arrange
-            const {container} = renderQuestion(segmentWithLockedLineQuestion, {
-                flags: {
-                    mafs: {
-                        segment: true,
-                    },
-                },
-            });
+            const {container} = renderQuestion(
+                segmentWithLockedLineQuestion,
+                apiOptions,
+            );
 
             // Act
             // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
@@ -666,13 +644,10 @@ describe("Interactive Graph", function () {
 
         it("should render locked lines with shown points", async () => {
             // Arrange
-            const {container} = renderQuestion(segmentWithLockedLineQuestion, {
-                flags: {
-                    mafs: {
-                        segment: true,
-                    },
-                },
-            });
+            const {container} = renderQuestion(
+                segmentWithLockedLineQuestion,
+                apiOptions,
+            );
 
             // Act
             // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
@@ -717,14 +692,7 @@ describe("Interactive Graph", function () {
                     .build();
             const {container} = renderQuestion(
                 lockedLineWithAriaLabelQuestion,
-                {
-                    flags: {
-                        mafs: {
-                            segment: true,
-                            "locked-figures-aria": true,
-                        },
-                    },
-                },
+                apiOptions,
             );
 
             // Act
@@ -740,13 +708,10 @@ describe("Interactive Graph", function () {
             const simpleLockedLinequestion = interactiveGraphQuestionBuilder()
                 .addLockedLine([0, 0], [2, 2])
                 .build();
-            const {container} = renderQuestion(simpleLockedLinequestion, {
-                flags: {
-                    mafs: {
-                        segment: true,
-                    },
-                },
-            });
+            const {container} = renderQuestion(
+                simpleLockedLinequestion,
+                apiOptions,
+            );
 
             // Act
             // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
@@ -758,13 +723,10 @@ describe("Interactive Graph", function () {
 
         it("should render locked vectors", async () => {
             // Arrange
-            const {container} = renderQuestion(segmentWithLockedVectors, {
-                flags: {
-                    mafs: {
-                        segment: true,
-                    },
-                },
-            });
+            const {container} = renderQuestion(
+                segmentWithLockedVectors,
+                apiOptions,
+            );
 
             // Act
             // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
@@ -816,14 +778,7 @@ describe("Interactive Graph", function () {
                     .build();
             const {container} = renderQuestion(
                 lockedVectorWithAriaLabelQuestion,
-                {
-                    flags: {
-                        mafs: {
-                            segment: true,
-                            "locked-figures-aria": true,
-                        },
-                    },
-                },
+                apiOptions,
             );
 
             // Act
@@ -839,13 +794,10 @@ describe("Interactive Graph", function () {
             const simpleLockedVectorquestion = interactiveGraphQuestionBuilder()
                 .addLockedVector([0, 0], [2, 2])
                 .build();
-            const {container} = renderQuestion(simpleLockedVectorquestion, {
-                flags: {
-                    mafs: {
-                        segment: true,
-                    },
-                },
-            });
+            const {container} = renderQuestion(
+                simpleLockedVectorquestion,
+                apiOptions,
+            );
 
             // Act
             // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
@@ -857,13 +809,10 @@ describe("Interactive Graph", function () {
 
         it("should render locked ellipses", async () => {
             // Arrange
-            const {container} = renderQuestion(segmentWithLockedEllipses, {
-                flags: {
-                    mafs: {
-                        segment: true,
-                    },
-                },
-            });
+            const {container} = renderQuestion(
+                segmentWithLockedEllipses,
+                apiOptions,
+            );
 
             // Act
             // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
@@ -887,13 +836,10 @@ describe("Interactive Graph", function () {
 
         it("should render locked ellipses with white fill", async () => {
             // Arrange
-            const {container} = renderQuestion(segmentWithLockedEllipseWhite, {
-                flags: {
-                    mafs: {
-                        segment: true,
-                    },
-                },
-            });
+            const {container} = renderQuestion(
+                segmentWithLockedEllipseWhite,
+                apiOptions,
+            );
 
             // Act
             // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
@@ -924,14 +870,7 @@ describe("Interactive Graph", function () {
                     .build();
             const {container} = renderQuestion(
                 lockedEllipseWithAriaLabelQuestion,
-                {
-                    flags: {
-                        mafs: {
-                            segment: true,
-                            "locked-figures-aria": true,
-                        },
-                    },
-                },
+                apiOptions,
             );
 
             // Act
@@ -948,13 +887,10 @@ describe("Interactive Graph", function () {
                 interactiveGraphQuestionBuilder()
                     .addLockedEllipse([0, 0], [2, 2])
                     .build();
-            const {container} = renderQuestion(simpleLockedEllipsequestion, {
-                flags: {
-                    mafs: {
-                        segment: true,
-                    },
-                },
-            });
+            const {container} = renderQuestion(
+                simpleLockedEllipsequestion,
+                apiOptions,
+            );
 
             // Act
             // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
@@ -966,13 +902,10 @@ describe("Interactive Graph", function () {
 
         it("should render locked polygons with style", async () => {
             // Arrange
-            const {container} = renderQuestion(segmentWithLockedPolygons, {
-                flags: {
-                    mafs: {
-                        segment: true,
-                    },
-                },
-            });
+            const {container} = renderQuestion(
+                segmentWithLockedPolygons,
+                apiOptions,
+            );
 
             // Act
             // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
@@ -998,13 +931,10 @@ describe("Interactive Graph", function () {
 
         it("should render locked polygons with white fill", async () => {
             // Arrange
-            const {container} = renderQuestion(segmentWithLockedPolygonWhite, {
-                flags: {
-                    mafs: {
-                        segment: true,
-                    },
-                },
-            });
+            const {container} = renderQuestion(
+                segmentWithLockedPolygonWhite,
+                apiOptions,
+            );
 
             // Act
             // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
@@ -1029,13 +959,10 @@ describe("Interactive Graph", function () {
 
         it("should render vertices of locked polygons with showVertices", async () => {
             // Arrange
-            const {container} = renderQuestion(segmentWithLockedPolygons, {
-                flags: {
-                    mafs: {
-                        segment: true,
-                    },
-                },
-            });
+            const {container} = renderQuestion(
+                segmentWithLockedPolygons,
+                apiOptions,
+            );
 
             // Act
             // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
@@ -1106,14 +1033,7 @@ describe("Interactive Graph", function () {
                     .build();
             const {container} = renderQuestion(
                 lockedPolygonWithAriaLabelQuestion,
-                {
-                    flags: {
-                        mafs: {
-                            segment: true,
-                            "locked-figures-aria": true,
-                        },
-                    },
-                },
+                apiOptions,
             );
 
             // Act
@@ -1134,13 +1054,10 @@ describe("Interactive Graph", function () {
                         [1, 1],
                     ])
                     .build();
-            const {container} = renderQuestion(simpleLockedPolygonQuestion, {
-                flags: {
-                    mafs: {
-                        segment: true,
-                    },
-                },
-            });
+            const {container} = renderQuestion(
+                simpleLockedPolygonQuestion,
+                apiOptions,
+            );
 
             // Act
             // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
@@ -1157,13 +1074,7 @@ describe("Interactive Graph", function () {
                     color: "green",
                     strokeStyle: "dashed",
                 }),
-                {
-                    flags: {
-                        mafs: {
-                            segment: true,
-                        },
-                    },
-                },
+                apiOptions,
             );
 
             // Act
@@ -1229,14 +1140,7 @@ describe("Interactive Graph", function () {
                     .build();
             const {container} = renderQuestion(
                 lockedFunctionWithAriaLabelQuestion,
-                {
-                    flags: {
-                        mafs: {
-                            segment: true,
-                            "locked-figures-aria": true,
-                        },
-                    },
-                },
+                apiOptions,
             );
 
             // Act
@@ -1253,13 +1157,10 @@ describe("Interactive Graph", function () {
                 interactiveGraphQuestionBuilder()
                     .addLockedFunction("x^2")
                     .build();
-            const {container} = renderQuestion(simpleLockedFunctionquestion, {
-                flags: {
-                    mafs: {
-                        segment: true,
-                    },
-                },
-            });
+            const {container} = renderQuestion(
+                simpleLockedFunctionquestion,
+                apiOptions,
+            );
 
             // Act
             // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
@@ -1271,13 +1172,10 @@ describe("Interactive Graph", function () {
 
         it("should render locked labels", async () => {
             // Arrange
-            const {container} = renderQuestion(segmentWithLockedLabels, {
-                flags: {
-                    mafs: {
-                        segment: true,
-                    },
-                },
-            });
+            const {container} = renderQuestion(
+                segmentWithLockedLabels,
+                apiOptions,
+            );
 
             // Act
             // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
@@ -1494,13 +1392,10 @@ describe("Interactive Graph", function () {
 
         it("should have an aria-label and description if they are provided", async () => {
             // Arrange
-            const {container} = renderQuestion(interactiveGraphWithAriaLabel, {
-                flags: {
-                    mafs: {
-                        segment: true,
-                    },
-                },
-            });
+            const {container} = renderQuestion(
+                interactiveGraphWithAriaLabel,
+                apiOptions,
+            );
 
             // Act
             // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
@@ -1516,13 +1411,7 @@ describe("Interactive Graph", function () {
 
         it("should not have an aria-label or description if they are not provided", async () => {
             // Arrange
-            const {container} = renderQuestion(segmentQuestion, {
-                flags: {
-                    mafs: {
-                        segment: true,
-                    },
-                },
-            });
+            const {container} = renderQuestion(segmentQuestion, apiOptions);
 
             // Act
             // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-ellipse.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-ellipse.tsx
@@ -15,18 +15,10 @@ type Props = LockedEllipseType & {
 };
 
 const LockedEllipse = (props: Props) => {
-    const {
-        center,
-        radius,
-        angle,
-        color,
-        fillStyle,
-        strokeStyle,
-        ariaLabel,
-        flags,
-    } = props;
+    const {center, radius, angle, color, fillStyle, strokeStyle, ariaLabel} =
+        props;
 
-    const hasAria = ariaLabel && flags?.["mafs"]?.["locked-figures-aria"];
+    const hasAria = !!ariaLabel;
 
     return (
         <g

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-ellipse.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-ellipse.tsx
@@ -8,13 +8,7 @@ import {
     type LockedEllipseType,
 } from "../../../perseus-types";
 
-import type {APIOptions} from "../../../types";
-
-type Props = LockedEllipseType & {
-    flags?: APIOptions["flags"];
-};
-
-const LockedEllipse = (props: Props) => {
+const LockedEllipse = (props: LockedEllipseType) => {
     const {center, radius, angle, color, fillStyle, strokeStyle, ariaLabel} =
         props;
 

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-function.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-function.tsx
@@ -28,8 +28,7 @@ const LockedFunction = (props: Props) => {
         domain,
     };
 
-    const hasAria =
-        props.ariaLabel && props.flags?.["mafs"]?.["locked-figures-aria"];
+    const hasAria = !!props.ariaLabel;
 
     useEffect(() => {
         // Parsing the equation in a "useEffect" hook saves about 2ms each frame

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-function.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-function.tsx
@@ -6,13 +6,8 @@ import {useState, useEffect} from "react";
 import {lockedFigureColors} from "../../../perseus-types";
 
 import type {LockedFunctionType} from "../../../perseus-types";
-import type {APIOptions} from "../../../types";
 
-type Props = LockedFunctionType & {
-    flags?: APIOptions["flags"];
-};
-
-const LockedFunction = (props: Props) => {
+const LockedFunction = (props: LockedFunctionType) => {
     type Equation = {
         [k: string]: any;
         eval: (number) => number;

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-line.tsx
@@ -27,12 +27,11 @@ const LockedLine = (props: Props) => {
         showPoint1,
         showPoint2,
         ariaLabel,
-        flags,
         range,
     } = props;
     const [point1, point2] = points;
 
-    const hasAria = ariaLabel && flags?.["mafs"]?.["locked-figures-aria"];
+    const hasAria = !!ariaLabel;
 
     let line;
 

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-line.tsx
@@ -10,11 +10,9 @@ import {getIntersectionOfRayWithBox} from "../graphs/utils";
 import {X, Y, calculateAngleInDegrees} from "../math";
 
 import type {LockedLineType} from "../../../perseus-types";
-import type {APIOptions} from "../../../types";
 import type {Interval} from "mafs";
 
 type Props = LockedLineType & {
-    flags?: APIOptions["flags"];
     range: [Interval, Interval];
 };
 

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-point.tsx
@@ -4,13 +4,7 @@ import * as React from "react";
 
 import {lockedFigureColors, type LockedPointType} from "../../../perseus-types";
 
-import type {APIOptions} from "../../../types";
-
-type Props = LockedPointType & {
-    flags?: APIOptions["flags"];
-};
-
-const LockedPoint = (props: Props) => {
+const LockedPoint = (props: LockedPointType) => {
     const {color, coord, filled, ariaLabel} = props;
     const [x, y] = coord;
 

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-point.tsx
@@ -11,10 +11,10 @@ type Props = LockedPointType & {
 };
 
 const LockedPoint = (props: Props) => {
-    const {flags, color, coord, filled, ariaLabel} = props;
+    const {color, coord, filled, ariaLabel} = props;
     const [x, y] = coord;
 
-    const hasAria = ariaLabel && flags?.["mafs"]?.["locked-figures-aria"];
+    const hasAria = !!ariaLabel;
 
     return (
         <g

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-polygon.tsx
@@ -18,8 +18,7 @@ type Props = LockedPolygonType & {
 const LockedPolygon = (props: Props) => {
     const {points, color, showVertices, fillStyle, strokeStyle} = props;
 
-    const hasAria =
-        props.ariaLabel && props.flags?.["mafs"]?.["locked-figures-aria"];
+    const hasAria = !!props.ariaLabel;
 
     return (
         <g

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-polygon.tsx
@@ -9,13 +9,8 @@ import {
 import {X, Y} from "../math";
 
 import type {LockedPolygonType} from "../../../perseus-types";
-import type {APIOptions} from "../../../types";
 
-type Props = LockedPolygonType & {
-    flags?: APIOptions["flags"];
-};
-
-const LockedPolygon = (props: Props) => {
+const LockedPolygon = (props: LockedPolygonType) => {
     const {points, color, showVertices, fillStyle, strokeStyle} = props;
 
     const hasAria = !!props.ariaLabel;

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-vector.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-vector.tsx
@@ -11,10 +11,10 @@ type Props = LockedVectorType & {
 };
 
 const LockedVector = (props: Props) => {
-    const {color, points, ariaLabel, flags} = props;
+    const {color, points, ariaLabel} = props;
     const [tail, tip] = points;
 
-    const hasAria = ariaLabel && flags?.["mafs"]?.["locked-figures-aria"];
+    const hasAria = !!ariaLabel;
 
     return (
         <g

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-vector.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-vector.tsx
@@ -4,13 +4,8 @@ import {lockedFigureColors} from "../../../perseus-types";
 import {Vector} from "../graphs/components/vector";
 
 import type {LockedVectorType} from "../../../perseus-types";
-import type {APIOptions} from "../../../types";
 
-type Props = LockedVectorType & {
-    flags?: APIOptions["flags"];
-};
-
-const LockedVector = (props: Props) => {
+const LockedVector = (props: LockedVectorType) => {
     const {color, points, ariaLabel} = props;
     const [tail, tip] = points;
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -263,7 +263,6 @@ export const MafsGraph = (props: MafsGraphProps) => {
                                 {/* Locked figures layer */}
                                 {props.lockedFigures && (
                                     <GraphLockedLayer
-                                        flags={props.flags}
                                         lockedFigures={props.lockedFigures}
                                         range={state.range}
                                     />


### PR DESCRIPTION
## Summary:
Remove the `locked-figures-aria` flag from the Perseus repo
now that the locked figures' aria labels have been out for
a while now.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2274

## Test plan:
`yarn jest`