### PR TITLE
Redesign discriminated union type parser

### DIFF
--- a/.changeset/many-cats-run.md
+++ b/.changeset/many-cats-run.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Redesign discriminated union type parser to have a simpler and more intuitive interface.

--- a/packages/perseus/src/util/parse-perseus-json/general-purpose-parsers/discriminated-union.typetest.ts
+++ b/packages/perseus/src/util/parse-perseus-json/general-purpose-parsers/discriminated-union.typetest.ts
@@ -1,0 +1,65 @@
+import {constant} from "./constant";
+import {discriminatedUnionOn} from "./discriminated-union";
+import {number} from "./number";
+import {object} from "./object";
+
+import type {Parser} from "../parser-types";
+
+type Figure =
+    | {shape: "circle"; radius: number}
+    | {shape: "rectangle"; width: number; height: number}
+    | {shape: "square"; sideLength: number};
+
+const parseCircle = object({
+    shape: constant("circle"),
+    radius: number,
+});
+
+const parseRectangle = object({
+    shape: constant("rectangle"),
+    width: number,
+    height: number,
+});
+
+const parseSquare = object({
+    shape: constant("square"),
+    sideLength: number,
+});
+
+// Test: parsed result is assignable to the union type
+{
+    const parser = discriminatedUnionOn("shape")
+        .withBranch("circle", parseCircle)
+        .withBranch("rectangle", parseRectangle)
+        .withBranch("square", parseSquare).parser;
+
+    parser satisfies Parser<Figure>;
+
+    // Guard against implicit 'any' type
+    // @ts-expect-error - Type '{ shape: "circle"; radius: number; }' is not assignable to type 'string'.
+    parser satisfies Parser<string>;
+}
+
+// Test: parse result with extra branches is not assignable to the union type
+{
+    const parser = discriminatedUnionOn("shape")
+        .withBranch("circle", parseCircle)
+        .withBranch("rectangle", parseRectangle)
+        .withBranch("square", parseSquare)
+        .withBranch("extra", object({shape: constant("extra")})).parser;
+
+    // @ts-expect-error - Type '{shape: "extra"}' is not assignable to type 'Figure'
+    parser satisfies Parser<Figure>;
+}
+
+// Test: each variant must contain the discriminant key
+{
+    // @ts-expect-error - property 'shape' is missing in type '{}'
+    discriminatedUnionOn("shape").withBranch("circle", object({}));
+}
+
+// Test: each variant must be an object
+{
+    // @ts-expect-error - Type 'number' is not assignable to type '{ shape: Primitive; }'.
+    discriminatedUnionOn("shape").withBranch("circle", number);
+}

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/grapher-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/grapher-widget.ts
@@ -11,7 +11,7 @@ import {
     string,
     union,
 } from "../general-purpose-parsers";
-import {discriminatedUnion} from "../general-purpose-parsers/discriminated-union";
+import {discriminatedUnionOn} from "../general-purpose-parsers/discriminated-union";
 
 import {parseWidget} from "./widget";
 
@@ -36,52 +36,53 @@ export const parseGrapherWidget: Parser<GrapherWidget> = parseWidget(
                 "tangent",
             ),
         ),
-        correct: discriminatedUnion(
-            object({type: constant("absolute_value")}),
-            object({
-                type: constant("absolute_value"),
-                coords: pairOfPoints,
-            }),
-        )
-            .or(
-                object({type: constant("exponential")}),
+        correct: discriminatedUnionOn("type")
+            .withBranch(
+                "absolute_value",
+                object({
+                    type: constant("absolute_value"),
+                    coords: pairOfPoints,
+                }),
+            )
+            .withBranch(
+                "exponential",
                 object({
                     type: constant("exponential"),
                     asymptote: pairOfPoints,
                     coords: pairOfPoints,
                 }),
             )
-            .or(
-                object({type: constant("linear")}),
+            .withBranch(
+                "linear",
                 object({
                     type: constant("linear"),
                     coords: pairOfPoints,
                 }),
             )
-            .or(
-                object({type: constant("logarithm")}),
+            .withBranch(
+                "logarithm",
                 object({
                     type: constant("logarithm"),
                     asymptote: pairOfPoints,
                     coords: pairOfPoints,
                 }),
             )
-            .or(
-                object({type: constant("quadratic")}),
+            .withBranch(
+                "quadratic",
                 object({
                     type: constant("quadratic"),
                     coords: pairOfPoints,
                 }),
             )
-            .or(
-                object({type: constant("sinusoid")}),
+            .withBranch(
+                "sinusoid",
                 object({
                     type: constant("sinusoid"),
                     coords: pairOfPoints,
                 }),
             )
-            .or(
-                object({type: constant("tangent")}),
+            .withBranch(
+                "tangent",
                 object({
                     type: constant("tangent"),
                     coords: pairOfPoints,

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/interaction-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/interaction-widget.ts
@@ -11,7 +11,7 @@ import {
     union,
 } from "../general-purpose-parsers";
 import {defaulted} from "../general-purpose-parsers/defaulted";
-import {discriminatedUnion} from "../general-purpose-parsers/discriminated-union";
+import {discriminatedUnionOn} from "../general-purpose-parsers/discriminated-union";
 
 import {parsePerseusImageBackground} from "./perseus-image-background";
 import {parseWidget} from "./widget";
@@ -184,24 +184,15 @@ export const parseInteractionWidget: Parser<InteractionWidget> = parseWidget(
             tickStep: pairOfNumbers,
         }),
         elements: array(
-            discriminatedUnion(
-                object({type: parseFunctionType}),
-                parseFunctionElement,
-            )
-                .or(object({type: parseLabelType}), parseLabelElement)
-                .or(object({type: parseLineType}), parseLineElement)
-                .or(
-                    object({type: parseMovableLineType}),
-                    parseMovableLineElement,
-                )
-                .or(
-                    object({type: parseMovablePointType}),
-                    parseMovablePointElement,
-                )
-                .or(object({type: parseParametricType}), parseParametricElement)
-                .or(object({type: parsePointType}), parsePointElement)
-                .or(object({type: parseRectangleType}), parseRectangleElement)
-                .parser,
+            discriminatedUnionOn("type")
+                .withBranch("function", parseFunctionElement)
+                .withBranch("label", parseLabelElement)
+                .withBranch("line", parseLineElement)
+                .withBranch("movable-line", parseMovableLineElement)
+                .withBranch("movable-point", parseMovablePointElement)
+                .withBranch("parametric", parseParametricElement)
+                .withBranch("point", parsePointElement)
+                .withBranch("rectangle", parseRectangleElement).parser,
         ),
     }),
 );


### PR DESCRIPTION
Previously, the `discriminatedUnion` parser required you to specify the
discriminant via an object parser, which was confusing and verbose. Now you only
have to specify the discriminant key once, and provide the values for each
branch.

Issue: LEMS-2582

## Test plan:

`yarn test`