### PR TITLE
Temporarily fixing pi-based strings for Numeric Input

### DIFF
--- a/.changeset/kind-jeans-move.md
+++ b/.changeset/kind-jeans-move.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Temporarily fixing pi-based strings for Numeric Input

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -283,8 +283,8 @@ export const strings: {
         "Your answer is close, but you may " +
         "have approximated pi. Enter your " +
         "answer as a multiple of pi, like " +
-        "$12$ pi or " +
-        "$2/3$ pi",
+        "12 pi or " +
+        "2/3 pi",
     EXTRA_SYMBOLS_ERROR:
         "We could not understand your " +
         "answer. Please check your answer for extra " +

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -283,8 +283,8 @@ export const strings: {
         "Your answer is close, but you may " +
         "have approximated pi. Enter your " +
         "answer as a multiple of pi, like " +
-        "<code>12\\\\ \\\\text{pi}</code> or " +
-        "<code>2/3\\\\ \\\\text{pi}</code>",
+        "$12$ pi or " +
+        "$2/3$ pi",
     EXTRA_SYMBOLS_ERROR:
         "We could not understand your " +
         "answer. Please check your answer for extra " +
@@ -334,8 +334,7 @@ export const strings: {
     mixedExample: "a mixed number, like $1\\\\ 3/4$",
     decimalExample: "an *exact* decimal, like $0.75$",
     percentExample: "a percent, like $12.34\\\\%$",
-    piExample:
-        "a multiple of pi, like $12\\\\ \\\\text{pi}$ or $2/3\\\\ \\\\text{pi}$",
+    piExample: "a multiple of pi, like $12$ pi or $2/3$ pi$",
     yourAnswer: "**Your answer should be** ",
     yourAnswerLabel: "Your answer:",
     addPoints: "Click to add points",

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -334,7 +334,7 @@ export const strings: {
     mixedExample: "a mixed number, like $1\\\\ 3/4$",
     decimalExample: "an *exact* decimal, like $0.75$",
     percentExample: "a percent, like $12.34\\\\%$",
-    piExample: "a multiple of pi, like $12$ pi or $2/3$ pi$",
+    piExample: "a multiple of pi, like $12$ pi or $2/3$ pi",
     yourAnswer: "**Your answer should be** ",
     yourAnswerLabel: "Your answer:",
     addPoints: "Click to add points",


### PR DESCRIPTION
## Summary:
There's a larger issue related to TeX commands (specifically `\\text{}`) in our Perseus strings. While we investigate this issue, I've proposed that we simply remove these calls from our strings. 

As a result, these string will no longer match translations, but that is preferable as a temporary solution to the current issues with broken rendering. Given that these will no longer match translations any way, I've removed the `<code>` tag from one of the strings to closer match the second one. The use of the code tag here was unnecessary.

While the TeX commands will likely need a fix, I believe it would be good to permanently remove the `\\text` commands from these strings, and to simply request new translations for them. 

## Test plan:
- manually tested in webapp for both strings