### PR TITLE
[Locked Figures Aria] Correct aria autogen for negative coords

### DIFF
--- a/.changeset/weak-geese-joke.md
+++ b/.changeset/weak-geese-joke.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Locked Figures Aria] Correct aria autogen for negative coords

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-ellipse-settings.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-ellipse-settings.test.tsx
@@ -8,6 +8,7 @@ import {flags} from "../../../__stories__/flags-for-api-options";
 import LockedEllipseSettings from "./locked-ellipse-settings";
 import {
     getDefaultFigureForType,
+    mockedGenerateSpokenMathDetailsForTests,
     mockedJoinLabelsAsSpokenMathForTests,
 } from "./util";
 
@@ -23,9 +24,11 @@ const defaultProps = {
 
 const defaultLabel = getDefaultFigureForType("label");
 
-// Mock the async function generateSpokenMathDetails
+// Mock the async functions
 jest.mock("./util", () => ({
     ...jest.requireActual("./util"),
+    generateSpokenMathDetails: (input) =>
+        mockedGenerateSpokenMathDetailsForTests(input),
     joinLabelsAsSpokenMath: (input) =>
         mockedJoinLabelsAsSpokenMathForTests(input),
 }));
@@ -387,7 +390,7 @@ describe("LockedEllipseSettings", () => {
             // Assert
             expect(onChangeProps).toHaveBeenCalledWith({
                 ariaLabel:
-                    "Circle with radius 2, centered at 0 comma 0. Appearance solid gray border, with no fill.",
+                    "Circle with radius 2, centered at spoken $0$ comma spoken $0$. Appearance solid gray border, with no fill.",
             });
         });
 
@@ -415,7 +418,7 @@ describe("LockedEllipseSettings", () => {
             // Assert
             expect(onChangeProps).toHaveBeenCalledWith({
                 ariaLabel:
-                    "Circle with radius 2, centered at 0 comma 0. Appearance solid gray border, with no fill.",
+                    "Circle with radius 2, centered at spoken $0$ comma spoken $0$. Appearance solid gray border, with no fill.",
             });
         });
 
@@ -442,7 +445,7 @@ describe("LockedEllipseSettings", () => {
             // Assert
             expect(onChangeProps).toHaveBeenCalledWith({
                 ariaLabel:
-                    "Ellipse with x radius 2 and y radius 3, centered at 0 comma 0. Appearance solid gray border, with no fill.",
+                    "Ellipse with x radius 2 and y radius 3, centered at spoken $0$ comma spoken $0$. Appearance solid gray border, with no fill.",
             });
         });
 
@@ -470,7 +473,7 @@ describe("LockedEllipseSettings", () => {
             // Assert
             expect(onChangeProps).toHaveBeenCalledWith({
                 ariaLabel:
-                    "Ellipse with x radius 2 and y radius 3, centered at 0 comma 0, rotated by 90 degrees. Appearance solid gray border, with no fill.",
+                    "Ellipse with x radius 2 and y radius 3, centered at spoken $0$ comma spoken $0$, rotated by spoken $90$ degrees. Appearance solid gray border, with no fill.",
             });
         });
 
@@ -502,7 +505,7 @@ describe("LockedEllipseSettings", () => {
             // Assert
             expect(onChangeProps).toHaveBeenCalledWith({
                 ariaLabel:
-                    "Circle spoken A with radius 2, centered at 0 comma 0. Appearance solid gray border, with no fill.",
+                    "Circle spoken A with radius 2, centered at spoken $0$ comma spoken $0$. Appearance solid gray border, with no fill.",
             });
         });
 
@@ -538,7 +541,7 @@ describe("LockedEllipseSettings", () => {
             // Assert
             expect(onChangeProps).toHaveBeenCalledWith({
                 ariaLabel:
-                    "Circle spoken A, spoken B with radius 2, centered at 0 comma 0. Appearance solid gray border, with no fill.",
+                    "Circle spoken A, spoken B with radius 2, centered at spoken $0$ comma spoken $0$. Appearance solid gray border, with no fill.",
             });
         });
     });

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-ellipse-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-ellipse-settings.tsx
@@ -22,6 +22,7 @@ import LockedFigureSettingsActions from "./locked-figure-settings-actions";
 import LockedLabelSettings from "./locked-label-settings";
 import {
     generateLockedFigureAppearanceDescription,
+    generateSpokenMathDetails,
     getDefaultFigureForType,
     joinLabelsAsSpokenMath,
 } from "./util";
@@ -67,7 +68,13 @@ const LockedEllipseSettings = (props: Props) => {
      * with the math details converted into spoken words.
      */
     async function getPrepopulatedAriaLabel() {
+        // Ensure negative values are read correctly within aria labels.
         const visiblelabel = await joinLabelsAsSpokenMath(labels);
+        const spokenCenterX = await generateSpokenMathDetails(`$${center[0]}$`);
+        const spokenCenterY = await generateSpokenMathDetails(`$${center[1]}$`);
+        const spokenRotation = await generateSpokenMathDetails(
+            `$${radianToDegree(angle)}$`,
+        );
 
         const isCircle = radius[0] === radius[1];
         let str = "";
@@ -78,10 +85,10 @@ const LockedEllipseSettings = (props: Props) => {
             str += `Ellipse${visiblelabel} with x radius ${radius[0]} and y radius ${radius[1]}`;
         }
 
-        str += `, centered at ${center[0]} comma ${center[1]}`;
+        str += `, centered at ${spokenCenterX} comma ${spokenCenterY}`;
 
         if (!isCircle && angle !== 0) {
-            str += `, rotated by ${radianToDegree(angle)} degrees`;
+            str += `, rotated by ${spokenRotation} degrees`;
         }
 
         const ellipseAppearance = generateLockedFigureAppearanceDescription(

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-line-settings.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-line-settings.test.tsx
@@ -8,6 +8,7 @@ import {flags} from "../../../__stories__/flags-for-api-options";
 import LockedLineSettings from "./locked-line-settings";
 import {
     getDefaultFigureForType,
+    mockedGenerateSpokenMathDetailsForTests,
     mockedJoinLabelsAsSpokenMathForTests,
 } from "./util";
 
@@ -29,9 +30,11 @@ const defaultProps = {
 
 const defaultLabel = getDefaultFigureForType("label");
 
-// Mock the async function generateSpokenMathDetails
+// Mock the async functions
 jest.mock("./util", () => ({
     ...jest.requireActual("./util"),
+    generateSpokenMathDetails: (input) =>
+        mockedGenerateSpokenMathDetailsForTests(input),
     joinLabelsAsSpokenMath: (input) =>
         mockedJoinLabelsAsSpokenMathForTests(input),
 }));
@@ -625,7 +628,7 @@ describe("LockedLineSettings", () => {
             // Assert
             expect(onChangeProps).toHaveBeenCalledWith({
                 ariaLabel:
-                    "Segment from point at 0 comma 0 to point at 2 comma 2. Appearance solid gray.",
+                    "Segment from point at spoken $0$ comma spoken $0$ to point at spoken $2$ comma spoken $2$. Appearance solid gray.",
             });
         });
 
@@ -651,7 +654,7 @@ describe("LockedLineSettings", () => {
             // Assert
             expect(onChangeProps).toHaveBeenCalledWith({
                 ariaLabel:
-                    "Line from point at 0 comma 0 to point at 2 comma 2. Appearance solid gray.",
+                    "Line from point at spoken $0$ comma spoken $0$ to point at spoken $2$ comma spoken $2$. Appearance solid gray.",
             });
         });
 
@@ -682,7 +685,7 @@ describe("LockedLineSettings", () => {
             // Assert
             expect(onChangeProps).toHaveBeenCalledWith({
                 ariaLabel:
-                    "Line spoken A from point at 0 comma 0 to point at 2 comma 2. Appearance solid gray.",
+                    "Line spoken A from point at spoken $0$ comma spoken $0$ to point at spoken $2$ comma spoken $2$. Appearance solid gray.",
             });
         });
 
@@ -717,7 +720,7 @@ describe("LockedLineSettings", () => {
             // Assert
             expect(onChangeProps).toHaveBeenCalledWith({
                 ariaLabel:
-                    "Line spoken A, spoken B from point at 0 comma 0 to point at 2 comma 2. Appearance solid gray.",
+                    "Line spoken A, spoken B from point at spoken $0$ comma spoken $0$ to point at spoken $2$ comma spoken $2$. Appearance solid gray.",
             });
         });
 
@@ -758,7 +761,7 @@ describe("LockedLineSettings", () => {
             // Assert
             expect(onChangeProps).toHaveBeenCalledWith({
                 ariaLabel:
-                    "Line spoken A from point spoken C at 0 comma 0 to point spoken D at 2 comma 2. Appearance solid gray.",
+                    "Line spoken A from point spoken C at spoken $0$ comma spoken $0$ to point spoken D at spoken $2$ comma spoken $2$. Appearance solid gray.",
             });
         });
 
@@ -809,7 +812,7 @@ describe("LockedLineSettings", () => {
             // Assert
             expect(onChangeProps).toHaveBeenCalledWith({
                 ariaLabel:
-                    "Line spoken A, spoken B from point spoken C, spoken C2 at 0 comma 0 to point spoken D, spoken D2 at 2 comma 2. Appearance solid gray.",
+                    "Line spoken A, spoken B from point spoken C, spoken C2 at spoken $0$ comma spoken $0$ to point spoken D, spoken D2 at spoken $2$ comma spoken $2$. Appearance solid gray.",
             });
         });
     });

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-line-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-line-settings.tsx
@@ -27,6 +27,7 @@ import LockedLabelSettings from "./locked-label-settings";
 import LockedPointSettings from "./locked-point-settings";
 import {
     generateLockedFigureAppearanceDescription,
+    generateSpokenMathDetails,
     getDefaultFigureForType,
     joinLabelsAsSpokenMath,
 } from "./util";
@@ -81,8 +82,21 @@ const LockedLineSettings = (props: Props) => {
         const visiblelabel = await joinLabelsAsSpokenMath(labels);
         const point1VisibleLabel = await joinLabelsAsSpokenMath(point1.labels);
         const point2VisibleLabel = await joinLabelsAsSpokenMath(point2.labels);
+        // Ensure negative values are read correctly within aria labels.
+        const spokenPoint1X = await generateSpokenMathDetails(
+            `$${point1.coord[0]}$`,
+        );
+        const spokenPoint1Y = await generateSpokenMathDetails(
+            `$${point1.coord[1]}$`,
+        );
+        const spokenPoint2X = await generateSpokenMathDetails(
+            `$${point2.coord[0]}$`,
+        );
+        const spokenPoint2Y = await generateSpokenMathDetails(
+            `$${point2.coord[1]}$`,
+        );
 
-        let str = `${capitalizeKind}${visiblelabel} from point${point1VisibleLabel} at ${point1.coord[0]} comma ${point1.coord[1]} to point${point2VisibleLabel} at ${point2.coord[0]} comma ${point2.coord[1]}`;
+        let str = `${capitalizeKind}${visiblelabel} from point${point1VisibleLabel} at ${spokenPoint1X} comma ${spokenPoint1Y} to point${point2VisibleLabel} at ${spokenPoint2X} comma ${spokenPoint2Y}`;
 
         const lineAppearance = generateLockedFigureAppearanceDescription(
             lineColor,

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-point-settings.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-point-settings.test.tsx
@@ -8,6 +8,7 @@ import {flags} from "../../../__stories__/flags-for-api-options";
 import LockedPointSettings from "./locked-point-settings";
 import {
     getDefaultFigureForType,
+    mockedGenerateSpokenMathDetailsForTests,
     mockedJoinLabelsAsSpokenMathForTests,
 } from "./util";
 
@@ -29,9 +30,11 @@ const defaultProps = {
 
 const defaultLabel = getDefaultFigureForType("label");
 
-// Mock the async function generateSpokenMathDetails
+// Mock the async functions
 jest.mock("./util", () => ({
     ...jest.requireActual("./util"),
+    generateSpokenMathDetails: (input) =>
+        mockedGenerateSpokenMathDetailsForTests(input),
     joinLabelsAsSpokenMath: (input) =>
         mockedJoinLabelsAsSpokenMathForTests(input),
 }));
@@ -422,7 +425,8 @@ describe("LockedPointSettings", () => {
         // generateSpokenMathDetails is mocked to return the input string
         // with "Spoken math details for " prepended.
         expect(onChangeProps).toHaveBeenCalledWith({
-            ariaLabel: "Point at 0 comma 0. Appearance solid gray.",
+            ariaLabel:
+                "Point at spoken $0$ comma spoken $0$. Appearance solid gray.",
         });
     });
 
@@ -451,10 +455,12 @@ describe("LockedPointSettings", () => {
         await userEvent.click(autoGenButton);
 
         // Assert
+        expect(onChangeProps).toHaveBeenCalled();
         // generateSpokenMathDetails is mocked to return the input string
         // with "Spoken math details for " prepended.
         expect(onChangeProps).toHaveBeenCalledWith({
-            ariaLabel: "Point spoken A at 0 comma 0. Appearance solid gray.",
+            ariaLabel:
+                "Point spoken A at spoken $0$ comma spoken $0$. Appearance solid gray.",
         });
     });
 
@@ -491,7 +497,7 @@ describe("LockedPointSettings", () => {
         // with "Spoken math details for " prepended.
         expect(onChangeProps).toHaveBeenCalledWith({
             ariaLabel:
-                "Point spoken A, spoken B at 0 comma 0. Appearance solid gray.",
+                "Point spoken A, spoken B at spoken $0$ comma spoken $0$. Appearance solid gray.",
         });
     });
 });

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-point-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-point-settings.tsx
@@ -23,6 +23,7 @@ import LockedFigureAria from "./locked-figure-aria";
 import LockedFigureSettingsActions from "./locked-figure-settings-actions";
 import LockedLabelSettings from "./locked-label-settings";
 import {
+    generateSpokenMathDetails,
     generateLockedFigureAppearanceDescription,
     getDefaultFigureForType,
     joinLabelsAsSpokenMath,
@@ -109,8 +110,11 @@ const LockedPointSettings = (props: Props) => {
      */
     async function getPrepopulatedAriaLabel() {
         const visiblelabel = await joinLabelsAsSpokenMath(labels);
+        // Ensure negative values are read correctly within aria labels.
+        const spokenX = await generateSpokenMathDetails(`$${coord[0]}$`);
+        const spokenY = await generateSpokenMathDetails(`$${coord[1]}$`);
 
-        let str = `Point${visiblelabel} at ${coord[0]} comma ${coord[1]}`;
+        let str = `Point${visiblelabel} at ${spokenX} comma ${spokenY}`;
 
         const pointAppearance =
             generateLockedFigureAppearanceDescription(pointColor);

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.test.tsx
@@ -8,6 +8,7 @@ import {flags} from "../../../__stories__/flags-for-api-options";
 import LockedPolygonSettings from "./locked-polygon-settings";
 import {
     getDefaultFigureForType,
+    mockedGenerateSpokenMathDetailsForTests,
     mockedJoinLabelsAsSpokenMathForTests,
 } from "./util";
 
@@ -30,9 +31,11 @@ const defaultProps = {
 
 const defaultLabel = getDefaultFigureForType("label");
 
-// Mock the async function generateSpokenMathDetails
+// Mock the async functions
 jest.mock("./util", () => ({
     ...jest.requireActual("./util"),
+    generateSpokenMathDetails: (input) =>
+        mockedGenerateSpokenMathDetailsForTests(input),
     joinLabelsAsSpokenMath: (input) =>
         mockedJoinLabelsAsSpokenMathForTests(input),
 }));
@@ -608,7 +611,7 @@ describe("LockedPolygonSettings", () => {
             // Assert
             expect(onChangeProps).toHaveBeenCalledWith({
                 ariaLabel:
-                    "Polygon with 3 sides, vertices at 0 comma 0, 0 comma 1, 1 comma 1. Appearance solid gray border, with no fill.",
+                    "Polygon with 3 sides, vertices at spoken $0$ comma spoken $0$, spoken $0$ comma spoken $1$, spoken $1$ comma spoken $1$. Appearance solid gray border, with no fill.",
             });
         });
 
@@ -644,7 +647,7 @@ describe("LockedPolygonSettings", () => {
             // Assert
             expect(onChangeProps).toHaveBeenCalledWith({
                 ariaLabel:
-                    "Polygon spoken A with 3 sides, vertices at 0 comma 0, 0 comma 1, 1 comma 1. Appearance solid gray border, with no fill.",
+                    "Polygon spoken A with 3 sides, vertices at spoken $0$ comma spoken $0$, spoken $0$ comma spoken $1$, spoken $1$ comma spoken $1$. Appearance solid gray border, with no fill.",
             });
         });
 
@@ -684,7 +687,7 @@ describe("LockedPolygonSettings", () => {
             // Assert
             expect(onChangeProps).toHaveBeenCalledWith({
                 ariaLabel:
-                    "Polygon spoken A, spoken B with 3 sides, vertices at 0 comma 0, 0 comma 1, 1 comma 1. Appearance solid gray border, with no fill.",
+                    "Polygon spoken A, spoken B with 3 sides, vertices at spoken $0$ comma spoken $0$, spoken $0$ comma spoken $1$, spoken $1$ comma spoken $1$. Appearance solid gray border, with no fill.",
             });
         });
     });

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.tsx
@@ -34,6 +34,7 @@ import LockedLabelSettings from "./locked-label-settings";
 import PolygonSwatch from "./polygon-swatch";
 import {
     generateLockedFigureAppearanceDescription,
+    generateSpokenMathDetails,
     getDefaultFigureForType,
     joinLabelsAsSpokenMath,
 } from "./util";
@@ -74,7 +75,15 @@ const LockedPolygonSettings = (props: Props) => {
         let str = `Polygon${visiblelabel} with ${points.length} sides, vertices at `;
 
         // Add the coordinates of each point to the aria label
-        str += points.map(([x, y]) => `${x} comma ${y}`).join(", ");
+        const pointsList = await Promise.all(
+            points.map(async ([x, y]) => {
+                // Ensure negative values are read correctly within aria labels.
+                const spokenX = await generateSpokenMathDetails(`$${x}$`);
+                const spokenY = await generateSpokenMathDetails(`$${y}$`);
+                return `${spokenX} comma ${spokenY}`;
+            }),
+        );
+        str += pointsList.join(", ");
 
         const polygonAppearance = generateLockedFigureAppearanceDescription(
             color,

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-vector-settings.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-vector-settings.test.tsx
@@ -8,6 +8,7 @@ import {flags} from "../../../__stories__/flags-for-api-options";
 import LockedVectorSettings from "./locked-vector-settings";
 import {
     getDefaultFigureForType,
+    mockedGenerateSpokenMathDetailsForTests,
     mockedJoinLabelsAsSpokenMathForTests,
 } from "./util";
 
@@ -30,9 +31,11 @@ const defaultProps = {
 
 const defaultLabel = getDefaultFigureForType("label");
 
-// Mock the async function generateSpokenMathDetails
+// Mock the async functions
 jest.mock("./util", () => ({
     ...jest.requireActual("./util"),
+    generateSpokenMathDetails: (input) =>
+        mockedGenerateSpokenMathDetailsForTests(input),
     joinLabelsAsSpokenMath: (input) =>
         mockedJoinLabelsAsSpokenMathForTests(input),
 }));
@@ -441,7 +444,7 @@ describe("Locked Vector Settings", () => {
             // Assert
             expect(onChangeProps).toHaveBeenCalledWith({
                 ariaLabel:
-                    "Vector from 0 comma 0 to 2 comma 2. Appearance solid gray.",
+                    "Vector from spoken $0$ comma spoken $0$ to spoken $2$ comma spoken $2$. Appearance solid gray.",
             });
         });
 
@@ -472,7 +475,7 @@ describe("Locked Vector Settings", () => {
             // Assert
             expect(onChangeProps).toHaveBeenCalledWith({
                 ariaLabel:
-                    "Vector spoken A from 0 comma 0 to 2 comma 2. Appearance solid gray.",
+                    "Vector spoken A from spoken $0$ comma spoken $0$ to spoken $2$ comma spoken $2$. Appearance solid gray.",
             });
         });
 
@@ -507,7 +510,7 @@ describe("Locked Vector Settings", () => {
             // Assert
             expect(onChangeProps).toHaveBeenCalledWith({
                 ariaLabel:
-                    "Vector spoken A, spoken B from 0 comma 0 to 2 comma 2. Appearance solid gray.",
+                    "Vector spoken A, spoken B from spoken $0$ comma spoken $0$ to spoken $2$ comma spoken $2$. Appearance solid gray.",
             });
         });
     });

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-vector-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-vector-settings.tsx
@@ -25,6 +25,7 @@ import LockedFigureSettingsActions from "./locked-figure-settings-actions";
 import LockedLabelSettings from "./locked-label-settings";
 import {
     generateLockedFigureAppearanceDescription,
+    generateSpokenMathDetails,
     getDefaultFigureForType,
     joinLabelsAsSpokenMath,
 } from "./util";
@@ -70,8 +71,13 @@ const LockedVectorSettings = (props: Props) => {
      */
     async function getPrepopulatedAriaLabel() {
         const visiblelabel = await joinLabelsAsSpokenMath(labels);
+        // Ensure negative values are read correctly within aria labels.
+        const spokenTailX = await generateSpokenMathDetails(`$${tail[0]}$`);
+        const spokenTailY = await generateSpokenMathDetails(`$${tail[1]}$`);
+        const spokenTipX = await generateSpokenMathDetails(`$${tip[0]}$`);
+        const spokenTipY = await generateSpokenMathDetails(`$${tip[1]}$`);
 
-        let str = `Vector${visiblelabel} from ${tail[0]} comma ${tail[1]} to ${tip[0]} comma ${tip[1]}`;
+        let str = `Vector${visiblelabel} from ${spokenTailX} comma ${spokenTailY} to ${spokenTipX} comma ${spokenTipY}`;
 
         const vectorAppearance =
             generateLockedFigureAppearanceDescription(lineColor);

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.ts
@@ -202,3 +202,7 @@ export function mockedJoinLabelsAsSpokenMathForTests(
     const jointMock = labels.map((input) => ` spoken ${input.text}`).join(",");
     return Promise.resolve(jointMock);
 }
+
+export function mockedGenerateSpokenMathDetailsForTests(mathString: string) {
+    return Promise.resolve(`spoken ${mathString}`);
+}


### PR DESCRIPTION
## Summary:
Right now, the speech rule engine is not being used to generate
the the aria labels for negative coordinates when pressing the
"auto-generate" button for Interactive Graph locked figures in
the editor.

This means that the coordinates are read as "minus [coord]"
rather than "negative [coord]"

To fix this, I'm calling the speech rule engine on the
coordinates as well. And also the rotation on an ellipse.

Issue: none

## Test plan:
`yarn jest packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-point-settings.test.tsx`
`yarn jest packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-line-settings.test.tsx`
`yarn jest packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-vector-settings.test.tsx`
`packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-ellipse-settings.test.tsx`
`packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.test.tsx`

Storybook
http://localhost:6006/iframe.html?globals=&args=&id=perseuseditor-widgets-interactive-graph--mafs-with-locked-figures&viewMode=story

| Before | After |
| --- | --- |
| <img width="326" alt="Screenshot 2025-01-07 at 4 25 42 PM" src="https://github.com/user-attachments/assets/13ff3d48-57e9-4fa9-938d-e263af246ede" /> | <img width="322" alt="Screenshot 2025-01-07 at 4 25 49 PM" src="https://github.com/user-attachments/assets/63682bc6-8b66-4e3c-9aa6-bac2c317e331" /> |
