### PR TITLE
Export Item and Article parsing functions from the 'perseus' package

### DIFF
--- a/.changeset/strange-buses-run.md
+++ b/.changeset/strange-buses-run.md
@@ -2,4 +2,4 @@
 "@khanacademy/perseus": minor
 ---
 
-Deprecates `parsePerseusItem()` in favor of typesafe `parseAndMigratePerseusItem() and`parseAndMigratePerseusArticle()` functions.
+Deprecates `parsePerseusItem()` in favor of typesafe `parseAndMigratePerseusItem()` and `parseAndMigratePerseusArticle()` functions.

--- a/.changeset/strange-buses-run.md
+++ b/.changeset/strange-buses-run.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Deprecates `parsePerseusItem()` in favor of typesafe `parseAndMigratePerseusItem() and`parseAndMigratePerseusArticle()` functions.

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -115,6 +115,7 @@ export {
     parseAndMigratePerseusItem,
     parseAndMigratePerseusArticle,
 } from "./util/parse-perseus-json";
+export {isSuccess, isFailure} from "./util/parse-perseus-json/result"
 export {
     generateTestPerseusItem,
     genericPerseusItemData,
@@ -195,6 +196,7 @@ export type {
     SharedRendererProps,
 } from "./types";
 export type {ParsedValue} from "./util";
+export type {Result, Success, Failure} from "./util/parse-perseus-json/result"
 export type {UserInputMap} from "./validation.types";
 export type {Coord} from "./interactive2/types";
 export type {Coords} from "./widgets/grapher/grapher-types";

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -115,7 +115,7 @@ export {
     parseAndMigratePerseusItem,
     parseAndMigratePerseusArticle,
 } from "./util/parse-perseus-json";
-export {isSuccess, isFailure} from "./util/parse-perseus-json/result"
+export {isSuccess, isFailure} from "./util/parse-perseus-json/result";
 export {
     generateTestPerseusItem,
     genericPerseusItemData,
@@ -196,7 +196,7 @@ export type {
     SharedRendererProps,
 } from "./types";
 export type {ParsedValue} from "./util";
-export type {Result, Success, Failure} from "./util/parse-perseus-json/result"
+export type {Result, Success, Failure} from "./util/parse-perseus-json/result";
 export type {UserInputMap} from "./validation.types";
 export type {Coord} from "./interactive2/types";
 export type {Coords} from "./widgets/grapher/grapher-types";

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -110,7 +110,11 @@ export {
     getAnswerFromUserInput,
     getImagesWithoutAltData,
 } from "./util/extract-perseus-data";
-export {parsePerseusItem} from "./util/parse-perseus-json";
+export {
+    parsePerseusItem,
+    parseAndMigratePerseusItem,
+    parseAndMigratePerseusArticle,
+} from "./util/parse-perseus-json";
 export {
     generateTestPerseusItem,
     genericPerseusItemData,

--- a/packages/perseus/src/util/parse-perseus-json/index.ts
+++ b/packages/perseus/src/util/parse-perseus-json/index.ts
@@ -6,6 +6,7 @@ import {parsePerseusItem as migrateAndTypecheckPerseusItem} from "./perseus-pars
 
 import type {Result} from "./result";
 import type {PerseusItem, PerseusArticle} from "@khanacademy/perseus-core";
+import {failure, isFailure} from "./result";
 
 /**
  * Helper to parse PerseusItem JSON
@@ -25,6 +26,19 @@ export function parsePerseusItem(json: string): PerseusItem {
     throw new Error("Something went wrong.");
 }
 
+export type ParseFailureDetail = {
+    /**
+     * A human-readable error message describing where in the object tree
+     * parsing failed.
+     */
+    message: string,
+    /**
+     * The raw result of parsing the input JSON, with no migrations applied.
+     * Use at your own risk.
+     */
+    invalidObject: unknown,
+}
+
 /**
  * Parses a PerseusItem from a JSON string, migrates old formats to the latest
  * schema, and runtime-typechecks the result. Use this to parse assessmentItem
@@ -37,10 +51,14 @@ export function parsePerseusItem(json: string): PerseusItem {
  */
 export function parseAndMigratePerseusItem(
     json: string,
-): Result<PerseusItem, string> {
+): Result<PerseusItem, ParseFailureDetail> {
     throwErrorIfCheatingDetected();
     const object: unknown = JSON.parse(json);
-    return parse(object, migrateAndTypecheckPerseusItem);
+    const result = parse(object, migrateAndTypecheckPerseusItem);
+    if (isFailure(result)) {
+        return failure({message: result.detail, invalidObject: object})
+    }
+    return result
 }
 
 /**
@@ -54,10 +72,14 @@ export function parseAndMigratePerseusItem(
  */
 export function parseAndMigratePerseusArticle(
     json: string,
-): Result<PerseusArticle, string> {
+): Result<PerseusArticle, ParseFailureDetail> {
     throwErrorIfCheatingDetected();
     const object: unknown = JSON.parse(json);
-    return parse(object, migrateAndTypecheckPerseusArticle);
+    const result = parse(object, migrateAndTypecheckPerseusArticle);
+    if (isFailure(result)) {
+        return failure({message: result.detail, invalidObject: object})
+    }
+    return result
 }
 
 /**

--- a/packages/perseus/src/util/parse-perseus-json/index.ts
+++ b/packages/perseus/src/util/parse-perseus-json/index.ts
@@ -3,10 +3,10 @@ import {isRealJSONParse} from "../is-real-json-parse";
 import {parse} from "./parse";
 import {parsePerseusArticle as migrateAndTypecheckPerseusArticle} from "./perseus-parsers/perseus-article";
 import {parsePerseusItem as migrateAndTypecheckPerseusItem} from "./perseus-parsers/perseus-item";
+import {failure, isFailure} from "./result";
 
 import type {Result} from "./result";
 import type {PerseusItem, PerseusArticle} from "@khanacademy/perseus-core";
-import {failure, isFailure} from "./result";
 
 /**
  * Helper to parse PerseusItem JSON
@@ -31,13 +31,13 @@ export type ParseFailureDetail = {
      * A human-readable error message describing where in the object tree
      * parsing failed.
      */
-    message: string,
+    message: string;
     /**
      * The raw result of parsing the input JSON, with no migrations applied.
      * Use at your own risk.
      */
-    invalidObject: unknown,
-}
+    invalidObject: unknown;
+};
 
 /**
  * Parses a PerseusItem from a JSON string, migrates old formats to the latest
@@ -56,9 +56,9 @@ export function parseAndMigratePerseusItem(
     const object: unknown = JSON.parse(json);
     const result = parse(object, migrateAndTypecheckPerseusItem);
     if (isFailure(result)) {
-        return failure({message: result.detail, invalidObject: object})
+        return failure({message: result.detail, invalidObject: object});
     }
-    return result
+    return result;
 }
 
 /**
@@ -77,9 +77,9 @@ export function parseAndMigratePerseusArticle(
     const object: unknown = JSON.parse(json);
     const result = parse(object, migrateAndTypecheckPerseusArticle);
     if (isFailure(result)) {
-        return failure({message: result.detail, invalidObject: object})
+        return failure({message: result.detail, invalidObject: object});
     }
-    return result
+    return result;
 }
 
 /**

--- a/packages/perseus/src/util/parse-perseus-json/parse-perseus-json.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/parse-perseus-json.test.ts
@@ -29,9 +29,16 @@ describe("parseAndMigratePerseusItem", () => {
         const result = parseAndMigratePerseusItem(`{"question": "bad value"}`);
 
         assertFailure(result);
-        expect(result.detail).toContain(
+        expect(result.detail.message).toContain(
             `At (root).question -- expected object, but got "bad value"`,
         );
+    });
+
+    it("returns the invalid object along with the error", () => {
+        const result = parseAndMigratePerseusItem(`{"question": "bad value"}`);
+
+        assertFailure(result);
+        expect(result.detail.invalidObject).toEqual({question: "bad value"});
     });
 
     it("throws an error given malformed JSON", () => {
@@ -78,10 +85,19 @@ describe("parseAndMigratePerseusArticle", () => {
 
     it("fails given invalid data", () => {
         const result = parseAndMigratePerseusArticle("[9]");
-        expect(result).toEqual(
-            failure("At (root)[0] -- expected object, but got 9"),
+
+        assertFailure(result)
+        expect(result.detail.message).toEqual(
+            "At (root)[0] -- expected object, but got 9",
         );
     });
+
+    it("returns the invalid object along with the error", () => {
+        const result = parseAndMigratePerseusArticle("[9]");
+
+        assertFailure(result);
+        expect(result.detail.invalidObject).toEqual([9])
+    })
 
     it("throws an error given malformed JSON", () => {
         expect(() => parseAndMigratePerseusArticle("")).toThrowError(

--- a/packages/perseus/src/util/parse-perseus-json/parse-perseus-json.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/parse-perseus-json.test.ts
@@ -1,6 +1,6 @@
 import {jest} from "@jest/globals";
 
-import {assertFailure, assertSuccess, failure, success} from "./result";
+import {assertFailure, assertSuccess, success} from "./result";
 
 import {parseAndMigratePerseusItem, parseAndMigratePerseusArticle} from ".";
 
@@ -86,7 +86,7 @@ describe("parseAndMigratePerseusArticle", () => {
     it("fails given invalid data", () => {
         const result = parseAndMigratePerseusArticle("[9]");
 
-        assertFailure(result)
+        assertFailure(result);
         expect(result.detail.message).toEqual(
             "At (root)[0] -- expected object, but got 9",
         );
@@ -96,8 +96,8 @@ describe("parseAndMigratePerseusArticle", () => {
         const result = parseAndMigratePerseusArticle("[9]");
 
         assertFailure(result);
-        expect(result.detail.invalidObject).toEqual([9])
-    })
+        expect(result.detail.invalidObject).toEqual([9]);
+    });
 
     it("throws an error given malformed JSON", () => {
         expect(() => parseAndMigratePerseusArticle("")).toThrowError(

--- a/packages/perseus/src/util/parse-perseus-json/parse-perseus-json.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/parse-perseus-json.test.ts
@@ -1,10 +1,12 @@
-import {assertFailure, assertSuccess} from "./result";
+import {jest} from "@jest/globals";
 
-import {parseAndTypecheckPerseusItem} from ".";
+import {assertFailure, assertSuccess, failure, success} from "./result";
 
-describe("parseAndTypecheckPerseusItem", () => {
+import {parseAndMigratePerseusItem, parseAndMigratePerseusArticle} from ".";
+
+describe("parseAndMigratePerseusItem", () => {
     it("should parse JSON", () => {
-        const result = parseAndTypecheckPerseusItem(
+        const result = parseAndMigratePerseusItem(
             `{
                 "itemDataVersion": { "major": 0, "minor": 0 },
                 "answerArea": {},
@@ -24,13 +26,75 @@ describe("parseAndTypecheckPerseusItem", () => {
     });
 
     it("returns an error given an invalid PerseusItem", () => {
-        const result = parseAndTypecheckPerseusItem(
-            `{"question": "bad value"}`,
-        );
+        const result = parseAndMigratePerseusItem(`{"question": "bad value"}`);
 
         assertFailure(result);
         expect(result.detail).toContain(
             `At (root).question -- expected object, but got "bad value"`,
         );
+    });
+
+    it("throws an error given malformed JSON", () => {
+        expect(() => parseAndMigratePerseusItem("")).toThrowError(
+            new SyntaxError("Unexpected end of JSON input"),
+        );
+    });
+
+    it("throws an error if JSON.parse is monkey-patched", () => {
+        // This is an attempt to make cheating more difficult.
+        const validItem = `{"question": ""}`;
+        jest.spyOn(JSON, "parse").mockReturnValue({question: ""});
+        expect(() => parseAndMigratePerseusItem(validItem)).toThrowError();
+    });
+});
+
+describe("parseAndMigratePerseusArticle", () => {
+    it("parses a single renderer", () => {
+        const result = parseAndMigratePerseusArticle(
+            `{"content": "", "widgets": {}}`,
+        );
+
+        expect(result).toEqual(
+            success({
+                content: "",
+                widgets: {},
+                images: {},
+                metadata: undefined,
+            }),
+        );
+    });
+
+    it("parses an array of renderers", () => {
+        const result = parseAndMigratePerseusArticle(
+            `[{"content": "one"}, {"content": "two"}]`,
+        );
+        expect(result).toEqual(
+            success([
+                {content: "one", widgets: {}, images: {}, metadata: undefined},
+                {content: "two", widgets: {}, images: {}, metadata: undefined},
+            ]),
+        );
+    });
+
+    it("fails given invalid data", () => {
+        const result = parseAndMigratePerseusArticle("[9]");
+        expect(result).toEqual(
+            failure("At (root)[0] -- expected object, but got 9"),
+        );
+    });
+
+    it("throws an error given malformed JSON", () => {
+        expect(() => parseAndMigratePerseusArticle("")).toThrowError(
+            new SyntaxError("Unexpected end of JSON input"),
+        );
+    });
+
+    it("throws an error if JSON.parse is monkey-patched", () => {
+        // This is an attempt to make cheating more difficult.
+        const validArticle = `{"content": "", "widgets": {}}`;
+        jest.spyOn(JSON, "parse").mockReturnValue({content: "", widgets: {}});
+        expect(() =>
+            parseAndMigratePerseusArticle(validArticle),
+        ).toThrowError();
     });
 });

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/perseus-article.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/perseus-article.ts
@@ -1,0 +1,10 @@
+import {array, union} from "../general-purpose-parsers";
+
+import {parsePerseusRenderer} from "./perseus-renderer";
+
+import type {Parser} from "../parser-types";
+import type {PerseusArticle} from "@khanacademy/perseus-core";
+
+export const parsePerseusArticle: Parser<PerseusArticle> = union(
+    parsePerseusRenderer,
+).or(array(parsePerseusRenderer)).parser;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/perseus-image-background.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/perseus-image-background.ts
@@ -10,8 +10,8 @@ import {
 import {convert} from "../general-purpose-parsers/convert";
 import {stringToNumber} from "../general-purpose-parsers/string-to-number";
 
-import type {PerseusImageBackground} from "@khanacademy/perseus-core";
 import type {Parser} from "../parser-types";
+import type {PerseusImageBackground} from "@khanacademy/perseus-core";
 
 function emptyToZero(x: string | number): string | number {
     return x === "" ? 0 : x;

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/perseus-image-background.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/perseus-image-background.ts
@@ -10,8 +10,8 @@ import {
 import {convert} from "../general-purpose-parsers/convert";
 import {stringToNumber} from "../general-purpose-parsers/string-to-number";
 
-import type {Parser} from "../parser-types";
 import type {PerseusImageBackground} from "@khanacademy/perseus-core";
+import type {Parser} from "../parser-types";
 
 function emptyToZero(x: string | number): string | number {
     return x === "" ? 0 : x;

--- a/packages/perseus/src/util/parse-perseus-json/regression-tests/parse-perseus-json-regression.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/regression-tests/parse-perseus-json-regression.test.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import {join} from "path";
 
-import {parseAndTypecheckPerseusItem} from "../index";
+import {parseAndMigratePerseusItem} from "../index";
 
 const dataFiles = fs.readdirSync(join(__dirname, "data"));
 
@@ -11,7 +11,7 @@ describe("parseAndTypecheckPerseusItem", () => {
             join(__dirname, "data", filename),
             "utf-8",
         );
-        const result = parseAndTypecheckPerseusItem(json);
+        const result = parseAndMigratePerseusItem(json);
 
         // This strange-looking assertion style results in the failure message
         // being printed if parsing fails, so the test is easier to debug.

--- a/packages/perseus/src/util/parse-perseus-json/regression-tests/parse-perseus-json-snapshot.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/regression-tests/parse-perseus-json-snapshot.test.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import {join} from "path";
 
-import {parseAndTypecheckPerseusItem} from "../index";
+import {parseAndMigratePerseusItem} from "../index";
 import {assertSuccess} from "../result";
 
 const dataFiles = fs.readdirSync(join(__dirname, "data"));
@@ -15,7 +15,7 @@ describe("parseAndTypecheckPerseusItem", () => {
             join(__dirname, "data", filename),
             "utf-8",
         );
-        const result = parseAndTypecheckPerseusItem(json);
+        const result = parseAndMigratePerseusItem(json);
         assertSuccess(result);
         expect(result.value).toMatchSnapshot();
     });


### PR DESCRIPTION
This is the public API for Perseus JSON parsing that we'll call in Webapp.
See [ADR 773][1] for context on why this is needed.

[1]: https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/3318349891/ADR+773+Validate+widget+data+on+input+in+Perseus

Issue: https://khanacademy.atlassian.net/browse/LEMS-2774

## Test plan:

`yarn test`