### PR TITLE
[SR][SR Tree] Update tree to use innerText

### DIFF
--- a/.changeset/chilly-experts-juggle.md
+++ b/.changeset/chilly-experts-juggle.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[SR][sr tree] Update tree to use innerText

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.test.tsx
@@ -340,34 +340,6 @@ describe("fetchAriaLabels", () => {
         ]);
     });
 
-    test("should include hidden descriptions", () => {
-        // Arrange
-        const {container} = render(
-            <div>
-                <div aria-describedby="description1 description2">label1</div>
-                <div id="description1">description1 content</div>
-                <div id="description2" style={{display: "hidden"}}>
-                    description2 content
-                </div>
-            </div>,
-        );
-
-        // Act
-        const result = getAccessibilityAttributes(container);
-
-        // Assert
-        expect(result).toEqual([
-            {
-                roleOrTag: "div",
-                className: "",
-                attributes: [
-                    {name: "description", value: "description1 content"},
-                    {name: "description", value: "description2 content"},
-                ],
-            },
-        ]);
-    });
-
     test("should not include descriptions that are not found", () => {
         // Arrange
         const {container} = render(

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.tsx
@@ -55,9 +55,7 @@ export function getAccessibilityAttributes(
             const descriptions = ariaDescribedby.split(/ +/);
             for (const description of descriptions) {
                 const descriptionString =
-                    // Use textContent instead of innerText to get the text
-                    // even if it is hidden.
-                    document.getElementById(description)?.textContent;
+                    document.getElementById(description)?.innerText;
 
                 if (descriptionString) {
                     elementAttributes.push({


### PR DESCRIPTION
## Summary:
Now that we're using `a11y.srOnly` styling for the hidden
aria descriptions, we don't need to use `textContent`, we
can just use `innerText`.

We also don't need the test for hidden content.

Issue: none

## Test plan:
`yarn jest packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.test.tsx`