### PR TITLE
[SR][SR Tree] Show the descriptions again

### DIFF
--- a/.changeset/cool-shrimps-grin.md
+++ b/.changeset/cool-shrimps-grin.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[SR][sr tree] Show descriptions again

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.tsx
@@ -55,7 +55,7 @@ export function getAccessibilityAttributes(
             const descriptions = ariaDescribedby.split(/ +/);
             for (const description of descriptions) {
                 const descriptionString =
-                    document.getElementById(description)?.innerText;
+                    document.getElementById(description)?.textContent;
 
                 if (descriptionString) {
                     elementAttributes.push({


### PR DESCRIPTION
## Summary:
By changing the text getting to `innerText` insted of
`textContent`, we actually stopped displaying the
descriptions.

Go back to using `textContent` so the descriptions
display again.

Issue: none

## Test plan:
Storybook
- http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--interactive-graph-linear
- check that the screen reader tree shows all the
  linear graph descriptions

| Before | After |
| --- | --- |
| ![Screenshot 2025-01-13 at 10 12 52 AM](https://github.com/user-attachments/assets/5d6f9ce7-f692-4225-bb94-e748db867f2e) | ![Screenshot 2025-01-13 at 10 16 24 AM](https://github.com/user-attachments/assets/80528e07-84fb-4262-bcfb-936f21deb501) |