### PR TITLE
Fix graded-group error message bug

### DIFF
--- a/.changeset/three-hats-melt.md
+++ b/.changeset/three-hats-melt.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Handle error codes better in Graded Group

--- a/packages/perseus/src/widgets/graded-group/graded-group.tsx
+++ b/packages/perseus/src/widgets/graded-group/graded-group.tsx
@@ -13,6 +13,7 @@ import {iconOk, iconRemove} from "../../icon-paths";
 import * as Changeable from "../../mixins/changeable";
 import {ApiOptions} from "../../perseus-api";
 import Renderer from "../../renderer";
+import {mapErrorToString} from "../../strings";
 import {
     gray68,
     gray76,
@@ -189,7 +190,7 @@ export class GradedGroup
             score.type === "points"
                 ? score.message || ""
                 : score.message
-                  ? `${INVALID_MESSAGE_PREFIX} ${score.message}`
+                  ? `${INVALID_MESSAGE_PREFIX} ${mapErrorToString(score.message)}`
                   : `${INVALID_MESSAGE_PREFIX} ${DEFAULT_INVALID_MESSAGE_1}${DEFAULT_INVALID_MESSAGE_2}`;
 
         this.setState({


### PR DESCRIPTION
## Summary:
In https://github.com/Khan/perseus/pull/2086 I started moving things into `perseus-score` which will not have access to translated strings. Instead we'll be returning error codes that can map to translated error messages. So far, I've only done this for KhanAnswerTypes so it's still an edge-case, but I found a place where we use error messages in https://github.com/Khan/perseus/pull/2102