### PR TITLE
Make `values` optional on `PerseusCategorizerWidgetOptions` type

### DIFF
--- a/.changeset/witty-suns-mate.md
+++ b/.changeset/witty-suns-mate.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-core": minor
+---
+
+Make `values` field optional on the `PerseusCategorizerWidgetOptions` type. This will allow us to remove `values` (which represents the correct answer) from the data sent to the client.

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -423,7 +423,7 @@ export type PerseusCategorizerWidgetOptions = {
     // Whether this widget is displayed with the results and immutable
     static: boolean;
     // The correct answers where index relates to the items and value relates to the category.  e.g. [0, 1, 0, 1, 2]
-    values: ReadonlyArray<number>;
+    values?: ReadonlyArray<number>;
     // Whether we should highlight i18n linter errors found on this widget
     highlightLint?: boolean;
     // Internal editor configuration. Can be ignored by consumers.

--- a/packages/perseus/src/util/extract-perseus-data.ts
+++ b/packages/perseus/src/util/extract-perseus-data.ts
@@ -59,9 +59,9 @@ function getAnswersFromWidgets(
                     categorizer.options?.items &&
                     categorizer.options?.values
                 ) {
-                    const categories = categorizer.options?.categories;
-                    const items = categorizer.options?.items;
-                    const values = categorizer.options?.values;
+                    const categories = categorizer.options.categories;
+                    const items = categorizer.options.items;
+                    const values = categorizer.options.values;
                     answers.push(
                         ...values.map(
                             (value, index) =>

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/categorizer-widget.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/categorizer-widget.test.ts
@@ -1,10 +1,9 @@
-import {
-    CategorizerWidget,
-    PerseusLinterContext
-} from "@khanacademy/perseus-core";
-import {parseCategorizerWidget} from "./categorizer-widget";
-import {success} from "../result";
 import {parse} from "../parse";
+import {success} from "../result";
+
+import {parseCategorizerWidget} from "./categorizer-widget";
+
+import type {CategorizerWidget} from "@khanacademy/perseus-core";
 
 describe("parseCategorizerWidget", () => {
     const baseWidget: CategorizerWidget = {
@@ -16,8 +15,8 @@ describe("parseCategorizerWidget", () => {
             categories: [],
             randomizeItems: false,
             static: false,
-        }
-    }
+        },
+    };
 
     it("allows `values` to be undefined", () => {
         const widget = {
@@ -28,6 +27,6 @@ describe("parseCategorizerWidget", () => {
             },
         };
         const result = parse(widget, parseCategorizerWidget);
-        expect(result).toEqual(success(widget))
+        expect(result).toEqual(success(widget));
     });
-})
+});

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/categorizer-widget.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/categorizer-widget.test.ts
@@ -1,0 +1,33 @@
+import {
+    CategorizerWidget,
+    PerseusLinterContext
+} from "@khanacademy/perseus-core";
+import {parseCategorizerWidget} from "./categorizer-widget";
+import {success} from "../result";
+import {parse} from "../parse";
+
+describe("parseCategorizerWidget", () => {
+    const baseWidget: CategorizerWidget = {
+        type: "categorizer",
+        version: {major: 0, minor: 0},
+        graded: true,
+        options: {
+            items: [],
+            categories: [],
+            randomizeItems: false,
+            static: false,
+        }
+    }
+
+    it("allows `values` to be undefined", () => {
+        const widget = {
+            ...baseWidget,
+            options: {
+                ...baseWidget.options,
+                values: undefined,
+            },
+        };
+        const result = parse(widget, parseCategorizerWidget);
+        expect(result).toEqual(success(widget))
+    });
+})

--- a/packages/perseus/src/util/parse-perseus-json/perseus-parsers/categorizer-widget.ts
+++ b/packages/perseus/src/util/parse-perseus-json/perseus-parsers/categorizer-widget.ts
@@ -21,7 +21,7 @@ export const parseCategorizerWidget: Parser<CategorizerWidget> = parseWidget(
         categories: array(string),
         randomizeItems: defaulted(boolean, () => false),
         static: defaulted(boolean, () => false),
-        values: array(defaulted(number, () => 0)),
+        values: optional(array(defaulted(number, () => 0))),
         highlightLint: optional(boolean),
         linterContext: optional(
             object({

--- a/packages/perseus/src/widgets/categorizer/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.tsx
@@ -28,13 +28,13 @@ import type {CategorizerPromptJSON} from "../../widget-ai-utils/categorizer/cate
 import type {PerseusCategorizerWidgetOptions} from "@khanacademy/perseus-core";
 
 type Props = WidgetProps<RenderProps, PerseusCategorizerScoringData> & {
-    values: ReadonlyArray<string>;
+    values: ReadonlyArray<number>;
 };
 
 type DefaultProps = {
     items: Props["items"];
     categories: Props["categories"];
-    values: Props["values"];
+    values: ReadonlyArray<number>;
     linterContext: Props["linterContext"];
 };
 
@@ -79,7 +79,6 @@ export class Categorizer
 
     onChange(itemNum, catNum) {
         const values = [...this.props.values];
-        // @ts-expect-error - TS2322 - Type 'number' is not assignable to type 'never'.
         values[itemNum] = catNum;
         this.change("values", values);
         this.props.trackInteraction();


### PR DESCRIPTION
This is a proof of concept of how we might change the WidgetOptions types so we
can avoid sending "private data" like hints and answers to the client.

Issue: LEMS-2562

## Test plan:

`yarn test`