### PR TITLE
Fix a React warning about non-unique component keys in the editor

### DIFF
--- a/.changeset/slimy-scissors-smash.md
+++ b/.changeset/slimy-scissors-smash.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Fix a React warning about non-unique component keys in the exercise editor.

--- a/packages/perseus-editor/src/__tests__/editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/editor.test.tsx
@@ -143,4 +143,26 @@ describe("Editor", () => {
             undefined,
         );
     });
+
+    it("should not log a warning given widget with an undefined key", () => {
+        const consoleErrorSpy = jest.spyOn(console, "error");
+
+        render(
+            <Harnessed
+                widgets={{
+                    "image 1": {
+                        type: "image",
+                        key: undefined,
+                        options: {
+                            backgroundImage: {
+                                url: "http://placekitten.com/200/300",
+                            },
+                        },
+                    },
+                }}
+            />,
+        );
+
+        expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
 });

--- a/packages/perseus-editor/src/__tests__/editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/editor.test.tsx
@@ -144,7 +144,7 @@ describe("Editor", () => {
         );
     });
 
-    it("should not log a warning given widget with an undefined key", () => {
+    it("should not log a warning given a widget with an undefined key", () => {
         const consoleErrorSpy = jest.spyOn(console, "error");
 
         render(

--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -250,6 +250,11 @@ class Editor extends React.Component<Props, State> {
         }
         return (
             <WidgetEditor
+                // The order of props matters here. We need to spread the
+                // widget data before specifying the `key` prop, to ensure the
+                // key overrides any `key` field on the widget (which might not
+                // be unique.
+                {...this.props.widgets[id]}
                 ref={id}
                 id={id}
                 key={id}
@@ -259,7 +264,6 @@ class Editor extends React.Component<Props, State> {
                 onRemove={this._handleWidgetEditorRemove.bind(this, id)}
                 apiOptions={this.props.apiOptions}
                 widgetIsOpen={this.props.widgetIsOpen}
-                {...this.props.widgets[id]}
             />
         );
     }


### PR DESCRIPTION
## Summary:
WidgetOptions has a `key` field (which appears to be unused, but that's
a different discussion) which is often not present in the JSON data.
This field, when absent from the JSON, was getting set to `undefined` by
`parseAndMigratePerseusItem()`. The `undefined` value then overrode the
`key` prop which we intended to set on the WidgetEditor component, which
caused React to log an error about non-unique keys.

I've changed the order of the props so the keys we want to set
explicitly will override any fields parsed out of the widget JSON. This
is what we want anyway, since the JSON might contain absolutely
anything, and we don't want it to be able to set arbitrary editor props.

I discovered this bug while hooking up `parseAndMigratePerseusItem` in
webapp (https://github.com/Khan/webapp/pull/28551)

Issue: https://khanacademy.atlassian.net/browse/LEMS-2774

Test plan:

`yarn test`