### PR TITLE
Don't add undefined values to objects when parsing JSON

### DIFF
--- a/.changeset/happy-pets-breathe.md
+++ b/.changeset/happy-pets-breathe.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Avoid adding undefined values to objects parsed from Perseus JSON when properties are missing.

--- a/packages/perseus/src/util/parse-perseus-json/general-purpose-parsers/object.test.ts
+++ b/packages/perseus/src/util/parse-perseus-json/general-purpose-parsers/object.test.ts
@@ -1,9 +1,10 @@
-import {assertFailure, success} from "../result";
+import {assertFailure, assertSuccess, success} from "../result";
 
 import {array} from "./array";
 import {defaulted} from "./defaulted";
 import {number} from "./number";
 import {object} from "./object";
+import {optional} from "./optional";
 import {string} from "./string";
 import {anyFailure, ctx, parseFailureWith} from "./test-helpers";
 
@@ -92,5 +93,20 @@ describe("object", () => {
         });
 
         expect(Train({}, ctx())).toEqual(success({boxcars: []}));
+    });
+
+    it("does not include fields not present on the original object", () => {
+        const Penguin = object({hat: optional(string)});
+        const result = Penguin({}, ctx());
+        assertSuccess(result);
+        expect(result.value).not.toHaveProperty("hat");
+    });
+
+    it("includes `undefined` fields from the original object", () => {
+        const Penguin = object({hat: optional(string)});
+        const result = Penguin({hat: undefined}, ctx());
+        assertSuccess(result);
+        expect(result.value).toHaveProperty("hat");
+        expect(result.value.hat).toBe(undefined);
     });
 });

--- a/packages/perseus/src/util/parse-perseus-json/general-purpose-parsers/object.ts
+++ b/packages/perseus/src/util/parse-perseus-json/general-purpose-parsers/object.ts
@@ -19,7 +19,9 @@ export function object<S extends ObjectSchema>(
         for (const [prop, propParser] of Object.entries(schema)) {
             const result = propParser(rawValue[prop], ctx.forSubtree(prop));
             if (isSuccess(result)) {
-                ret[prop] = result.value;
+                if (result.value !== undefined || prop in rawValue) {
+                    ret[prop] = result.value;
+                }
             } else {
                 mismatches.push(...result.detail);
             }

--- a/packages/perseus/src/util/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-snapshot.test.ts.snap
+++ b/packages/perseus/src/util/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-snapshot.test.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/categorizer-missing-randomizeItems.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -16,18 +15,14 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/categorizer-missing-
 
 [[☃ categorizer 1]]",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "categorizer 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "categories": [
             "Non-renewable Energy Sources",
             "Renewable Energy Sources",
           ],
-          "highlightLint": undefined,
           "items": [
             "Coal",
             "Wind",
@@ -37,7 +32,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/categorizer-missing-
             "Petroleum",
             "Solar",
           ],
-          "linterContext": undefined,
           "randomizeItems": false,
           "static": false,
           "values": [
@@ -50,7 +44,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/categorizer-missing-
             1,
           ],
         },
-        "static": undefined,
         "type": "categorizer",
         "version": {
           "major": 0,
@@ -64,7 +57,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/categorizer-missing-
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/categorizer-missing-static.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -78,30 +70,24 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/categorizer-missing-
 
 [[☃ categorizer 1]]",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "categorizer 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "categories": [
             "one",
             "two",
             "three",
           ],
-          "highlightLint": undefined,
           "items": [
             "this",
             "that",
             "other",
           ],
-          "linterContext": undefined,
           "randomizeItems": true,
           "static": false,
           "values": [],
         },
-        "static": undefined,
         "type": "categorizer",
         "version": {
           "major": 0,
@@ -115,7 +101,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/categorizer-missing-
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/categorizer-with-null-value.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
     "chi2Table": false,
@@ -133,19 +118,16 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/categorizer-with-nul
 
 [[☃ categorizer 1]]",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "categorizer 1": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "categories": [
             "Transparent",
             "Translucent",
             "Opaque",
           ],
-          "highlightLint": undefined,
           "items": [
             "Water",
             "Clean glass",
@@ -185,7 +167,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/categorizer-with-nul
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/cs-program-missing-static.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
     "periodicTable": false,
@@ -209,16 +190,13 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/cs-program-missing-s
         "width": 300,
       },
     },
-    "metadata": undefined,
     "widgets": {
       "cs-program 1": {
         "alignment": "block",
         "graded": true,
-        "key": undefined,
         "options": {
           "height": 400,
           "programID": "5900231381221376",
-          "programType": undefined,
           "settings": [
             {
               "name": "",
@@ -230,7 +208,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/cs-program-missing-s
           "static": false,
           "width": 400,
         },
-        "static": undefined,
         "type": "cs-program",
         "version": {
           "major": 0,
@@ -240,12 +217,9 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/cs-program-missing-s
       "numeric-input 1": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
-          "answerForms": undefined,
           "answers": [
             {
-              "answerForms": undefined,
               "maxError": 0.05,
               "message": "",
               "simplify": "required",
@@ -256,11 +230,9 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/cs-program-missing-s
           ],
           "coefficient": false,
           "labelText": "",
-          "rightAlign": undefined,
           "size": "normal",
           "static": false,
         },
-        "static": undefined,
         "type": "numeric-input",
         "version": {
           "major": 0,
@@ -274,32 +246,24 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/cs-program-missing-s
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/cs-program-with-null-width.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {},
   "hints": [],
-  "itemDataVersion": undefined,
   "question": {
     "content": "[[☃ cs-program 1]]",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "cs-program 1": {
         "alignment": "block",
-        "graded": undefined,
-        "key": undefined,
         "options": {
           "height": 250,
           "programID": "4545417404481536",
-          "programType": undefined,
           "settings": [],
           "showButtons": true,
           "showEditor": true,
           "static": false,
           "width": null,
         },
-        "static": undefined,
         "type": "cs-program",
-        "version": undefined,
       },
     },
   },
@@ -308,7 +272,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/cs-program-with-null
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/definition-missing-static.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
     "chi2Table": false,
@@ -330,19 +293,16 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/definition-missing-s
 
 ",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "categorizer 1": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "categories": [
             "Increases",
             "Decreases",
             "Stays constant",
           ],
-          "highlightLint": undefined,
           "items": [
             "Speed",
             "Acceleration",
@@ -368,15 +328,11 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/definition-missing-s
         },
       },
       "definition 1": {
-        "alignment": undefined,
-        "graded": undefined,
-        "key": undefined,
         "options": {
           "definition": "",
           "static": false,
           "togglePrompt": "",
         },
-        "static": undefined,
         "type": "definition",
         "version": {
           "major": 0,
@@ -390,7 +346,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/definition-missing-s
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/dropdown-missing-placeholder.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -400,19 +355,14 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/dropdown-missing-pla
 
 This is true whether the number is positive, negative, or $0$.",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
       "content": "$(x-x)=0$",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
   ],
-  "itemDataVersion": undefined,
   "question": {
     "content": "**Compare the two values using the number line below.**  
 
@@ -425,14 +375,10 @@ $\\qquad(x-x)$ [[☃ dropdown 1]] $0$
         "width": 460,
       },
     },
-    "metadata": undefined,
     "widgets": {
       "dropdown 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
-          "ariaLabel": undefined,
           "choices": [
             {
               "content": ">",
@@ -449,11 +395,8 @@ $\\qquad(x-x)$ [[☃ dropdown 1]] $0$
           ],
           "placeholder": "",
           "static": false,
-          "visibleLabel": undefined,
         },
-        "static": undefined,
         "type": "dropdown",
-        "version": undefined,
       },
     },
   },
@@ -462,7 +405,6 @@ $\\qquad(x-x)$ [[☃ dropdown 1]] $0$
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/dropdown-missing-version.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -470,23 +412,16 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/dropdown-missing-ver
     {
       "content": "While the Articles of Confederation did not provide for a federal executive, delegates to the Continental Congress did elect a president.",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
   ],
-  "itemDataVersion": undefined,
   "question": {
     "content": "**Under the Articles of Confederation[[☃ dropdown 1]] chose the president of the United States.** ",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "dropdown 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
-          "ariaLabel": undefined,
           "choices": [
             {
               "content": "state legislatures",
@@ -503,11 +438,8 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/dropdown-missing-ver
           ],
           "placeholder": "",
           "static": false,
-          "visibleLabel": undefined,
         },
-        "static": undefined,
         "type": "dropdown",
-        "version": undefined,
       },
     },
   },
@@ -516,7 +448,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/dropdown-missing-ver
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/explanation-missing-widgets-map.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
     "periodicTable": false,
@@ -525,8 +456,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/explanation-missing-
     {
       "content": "What times $a$ gives us $b$?",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
@@ -534,20 +463,14 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/explanation-missing-
 
 > $b=\\blue{0.25}a$",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
       "content": "The *constant of proportionality* $(r)$ in the equation $b=ra$ is $\\blue{0.25}$.",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {
         "explanation 1": {
-          "alignment": undefined,
           "graded": true,
-          "key": undefined,
           "options": {
             "explanation": "Let's check the values of $a$ and $b$ given in the table above.",
             "hidePrompt": "Okay, I'm convinced.",
@@ -555,7 +478,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/explanation-missing-
             "static": false,
             "widgets": {},
           },
-          "static": undefined,
           "type": "explanation",
           "version": {
             "major": 0,
@@ -582,17 +504,12 @@ $32$ | $8$
 
 $r =  $ [[☃ numeric-input 1]] ",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "numeric-input 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
-          "answerForms": undefined,
           "answers": [
             {
-              "answerForms": undefined,
               "maxError": null,
               "message": "",
               "simplify": "required",
@@ -603,11 +520,9 @@ $r =  $ [[☃ numeric-input 1]] ",
           ],
           "coefficient": false,
           "labelText": "",
-          "rightAlign": undefined,
           "size": "normal",
           "static": false,
         },
-        "static": undefined,
         "type": "numeric-input",
         "version": {
           "major": 0,
@@ -621,7 +536,6 @@ $r =  $ [[☃ numeric-input 1]] ",
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/expression-answerForm-missing-form.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
     "chi2Table": false,
@@ -641,12 +555,10 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/expression-answerFor
 
 [[☃ expression 1]]",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "expression 1": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "answerForms": [
             {
@@ -657,19 +569,16 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/expression-answerFor
               "value": "j<14",
             },
           ],
-          "ariaLabel": undefined,
           "buttonSets": [
             "basic",
             "basic relations",
             "advanced relations",
           ],
-          "buttonsVisible": undefined,
           "functions": [
             "f",
             "g",
           ],
           "times": false,
-          "visibleLabel": undefined,
         },
         "static": false,
         "type": "expression",
@@ -685,12 +594,10 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/expression-answerFor
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/expression-missing-buttonSets.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
   "hints": [],
-  "itemDataVersion": undefined,
   "question": {
     "content": " $ax + by = c$
 
@@ -703,12 +610,9 @@ $y=$ [[☃ expression 1]]",
         "width": 291,
       },
     },
-    "metadata": undefined,
     "widgets": {
       "expression 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "answerForms": [
             {
@@ -734,7 +638,6 @@ $y=$ [[☃ expression 1]]",
           "times": false,
           "visibleLabel": undefined,
         },
-        "static": undefined,
         "type": "expression",
         "version": {
           "major": 1,
@@ -748,7 +651,6 @@ $y=$ [[☃ expression 1]]",
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/expression-option-missing-value.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
     "periodicTable": false,
@@ -765,28 +667,22 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/expression-option-mi
 
 [[☃ expression 1]]",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "expression 1": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "answerForms": [],
-          "ariaLabel": undefined,
           "buttonSets": [
             "basic",
           ],
-          "buttonsVisible": undefined,
           "functions": [
             "f",
             "g",
             "h",
           ],
           "times": false,
-          "visibleLabel": undefined,
         },
-        "static": undefined,
         "type": "expression",
         "version": {
           "major": 1,
@@ -800,7 +696,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/expression-option-mi
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/expression-with-null-answer-key.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -815,8 +710,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/expression-with-null
           "width": 288,
         },
       },
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
@@ -826,8 +719,6 @@ $2 \\purple{b} = 6$
 
 $\\purple{b} = 3$",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
@@ -837,8 +728,6 @@ $3\\pink{\\varphi} = \\pi$
 
 $\\pink{\\varphi} = \\dfrac{\\pi}{3}$",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
@@ -846,8 +735,6 @@ $\\pink{\\varphi} = \\dfrac{\\pi}{3}$",
 
 $\\blue\\theta = \\dfrac{\\pi}{6}$",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
@@ -862,8 +749,6 @@ $\\begin{align} \\red{a}^2+ \\purple{b}^2 &= 6^2 \\\\
 
 ($\\red{a}$ is positive because it's a length.)",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
@@ -871,8 +756,6 @@ $\\begin{align} \\red{a}^2+ \\purple{b}^2 &= 6^2 \\\\
 
 $\\begin{align}\\sin (\\blue{\\theta})&=\\dfrac{3}{6}\\\\ &= \\frac{1}{2}\\end{align}$",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
@@ -890,8 +773,6 @@ $\\begin{align}\\sin (\\blue{\\theta})&=\\dfrac{3}{6}\\\\ &= \\frac{1}{2}\\end{a
 - $\\sin (\\blue{\\theta}) =\\dfrac{1}{2}$
 ",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
   ],
@@ -921,12 +802,9 @@ $\\qquad$![](https://ka-perseus-graphie.s3.amazonaws.com/bee05e004428ab4fb0d8af9
         "width": 288,
       },
     },
-    "metadata": undefined,
     "widgets": {
       "expression 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "answerForms": [
             {
@@ -937,21 +815,17 @@ $\\qquad$![](https://ka-perseus-graphie.s3.amazonaws.com/bee05e004428ab4fb0d8af9
               "value": "sqrt(3)*3",
             },
           ],
-          "ariaLabel": undefined,
           "buttonSets": [
             "basic",
             "prealgebra",
           ],
-          "buttonsVisible": undefined,
           "functions": [
             "f",
             "g",
             "h",
           ],
           "times": false,
-          "visibleLabel": undefined,
         },
-        "static": undefined,
         "type": "expression",
         "version": {
           "major": 1,
@@ -959,9 +833,7 @@ $\\qquad$![](https://ka-perseus-graphie.s3.amazonaws.com/bee05e004428ab4fb0d8af9
         },
       },
       "expression 2": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "answerForms": [
             {
@@ -972,21 +844,17 @@ $\\qquad$![](https://ka-perseus-graphie.s3.amazonaws.com/bee05e004428ab4fb0d8af9
               "value": "3",
             },
           ],
-          "ariaLabel": undefined,
           "buttonSets": [
             "basic",
             "prealgebra",
           ],
-          "buttonsVisible": undefined,
           "functions": [
             "f",
             "g",
             "h",
           ],
           "times": false,
-          "visibleLabel": undefined,
         },
-        "static": undefined,
         "type": "expression",
         "version": {
           "major": 1,
@@ -994,9 +862,7 @@ $\\qquad$![](https://ka-perseus-graphie.s3.amazonaws.com/bee05e004428ab4fb0d8af9
         },
       },
       "expression 3": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "answerForms": [
             {
@@ -1007,21 +873,17 @@ $\\qquad$![](https://ka-perseus-graphie.s3.amazonaws.com/bee05e004428ab4fb0d8af9
               "value": "pi/6",
             },
           ],
-          "ariaLabel": undefined,
           "buttonSets": [
             "basic",
             "prealgebra",
           ],
-          "buttonsVisible": undefined,
           "functions": [
             "f",
             "g",
             "h",
           ],
           "times": false,
-          "visibleLabel": undefined,
         },
-        "static": undefined,
         "type": "expression",
         "version": {
           "major": 1,
@@ -1029,9 +891,7 @@ $\\qquad$![](https://ka-perseus-graphie.s3.amazonaws.com/bee05e004428ab4fb0d8af9
         },
       },
       "expression 4": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "answerForms": [
             {
@@ -1049,21 +909,17 @@ $\\qquad$![](https://ka-perseus-graphie.s3.amazonaws.com/bee05e004428ab4fb0d8af9
               "value": "1/2",
             },
           ],
-          "ariaLabel": undefined,
           "buttonSets": [
             "basic",
             "prealgebra",
           ],
-          "buttonsVisible": undefined,
           "functions": [
             "f",
             "g",
             "h",
           ],
           "times": false,
-          "visibleLabel": undefined,
         },
-        "static": undefined,
         "type": "expression",
         "version": {
           "major": 1,
@@ -1077,7 +933,6 @@ $\\qquad$![](https://ka-perseus-graphie.s3.amazonaws.com/bee05e004428ab4fb0d8af9
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/graded-group-with-false-hint.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
     "chi2Table": false,
@@ -1095,13 +950,11 @@ To find entry $(i,j)$ of the resulting product matrix, we calculate the vector *
 
 ",
       "images": {},
-      "metadata": undefined,
       "replace": false,
       "widgets": {
         "explanation 1": {
           "alignment": "default",
           "graded": true,
-          "key": undefined,
           "options": {
             "explanation": "In general, vector dot product is an operation that takes two vectors of equal dimensions and returns a single real number.
 
@@ -1152,13 +1005,11 @@ The other entries of $\\text{H}$ can be found similarly.
           "width": 160,
         },
       },
-      "metadata": undefined,
       "replace": false,
       "widgets": {
         "graded-group 1": {
           "alignment": "default",
           "graded": true,
-          "key": undefined,
           "options": {
             "content": "**What is the appropriate calculation of $\\textbf{H}_{2,1}$?**
 
@@ -1168,44 +1019,30 @@ The other entries of $\\text{H}$ can be found similarly.
             "hasHint": false,
             "hint": null,
             "images": {},
-            "immutableWidgets": undefined,
             "title": "",
-            "widgetEnabled": undefined,
             "widgets": {
               "radio 1": {
                 "alignment": "default",
                 "graded": true,
-                "key": undefined,
                 "options": {
                   "choices": [
                     {
-                      "clue": undefined,
                       "content": "$1 \\cdot 4 + 3\\cdot 0 = 4$",
                       "correct": true,
-                      "isNoneOfTheAbove": undefined,
-                      "widgets": undefined,
                     },
                     {
-                      "clue": undefined,
                       "content": "$4 \\cdot 4 + 3\\cdot 3= 25$",
                       "correct": false,
-                      "isNoneOfTheAbove": undefined,
-                      "widgets": undefined,
                     },
                     {
-                      "clue": undefined,
                       "content": "$1 \\cdot 3 + 4\\cdot -1 = -1$",
-                      "correct": undefined,
                       "isNoneOfTheAbove": false,
-                      "widgets": undefined,
                     },
                   ],
-                  "countChoices": undefined,
                   "deselectEnabled": false,
                   "displayCount": null,
                   "hasNoneOfTheAbove": false,
                   "multipleSelect": false,
-                  "noneOfTheAbove": undefined,
                   "onePerLine": true,
                   "randomize": true,
                 },
@@ -1234,7 +1071,6 @@ After calculating all the remaining entries of $\\text{H}$, we get the following
 
 $ \\text{H}=\\left[\\begin{array}{rr}4 & -1 \\\\ 4 & 0\\end{array}\\right]$ ",
       "images": {},
-      "metadata": undefined,
       "replace": false,
       "widgets": {},
     },
@@ -1251,12 +1087,10 @@ $ \\text{H}=\\left[\\begin{array}{rr}4 & -1 \\\\ 4 & 0\\end{array}\\right]$ ",
 [[☃ matrix 1]]
 ",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "matrix 1": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "answers": [
             [
@@ -1294,7 +1128,6 @@ $ \\text{H}=\\left[\\begin{array}{rr}4 & -1 \\\\ 4 & 0\\end{array}\\right]$ ",
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/grapher-with-null-coords.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -1308,12 +1141,9 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/grapher-with-null-co
 
 ",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "grapher 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "availableTypes": [
             "linear",
@@ -1331,10 +1161,7 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/grapher-with-null-co
           },
           "graph": {
             "backgroundImage": {
-              "bottom": undefined,
               "height": 0,
-              "left": undefined,
-              "scale": undefined,
               "url": null,
               "width": 0,
             },
@@ -1370,7 +1197,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/grapher-with-null-co
             "rulerTicks": 10,
             "showProtractor": false,
             "showRuler": false,
-            "showTooltips": undefined,
             "snapStep": [
               1,
               1,
@@ -1382,7 +1208,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/grapher-with-null-co
             "valid": true,
           },
         },
-        "static": undefined,
         "type": "grapher",
         "version": {
           "major": 0,
@@ -1396,7 +1221,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/grapher-with-null-co
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/hint-missing-images.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
     "chi2Table": false,
@@ -1422,13 +1246,11 @@ If you haven't practiced [Systems of equations with elimination](/e/systems_of_e
 
 For more practice, go to [Systems of equations with elimination challenge](/e/systems_of_equations_with_elimination?getready=post).",
       "images": {},
-      "metadata": undefined,
       "replace": false,
       "widgets": {
         "graded-group-set 2": {
           "alignment": "default",
           "graded": true,
-          "key": undefined,
           "options": {
             "gradedGroups": [
               {
@@ -1443,7 +1265,6 @@ $\\begin{align}
 $x=$ [[☃ numeric-input 1]]
 
 $y=$ [[☃ numeric-input 2]]",
-                "hasHint": undefined,
                 "hint": {
                   "content": "Let's solve the system by using the *elimination method.* In order to eliminate one of the variables, we need to manipulate the equations so that variable has coefficients of the same size but opposite signs in each equation.
 
@@ -1477,7 +1298,6 @@ $\\begin{align}
 &y=-\\dfrac{1}{3}
 \\end{align}$",
                   "images": {},
-                  "metadata": undefined,
                   "widgets": {},
                 },
                 "images": {},
@@ -1488,12 +1308,9 @@ $\\begin{align}
                   "numeric-input 1": {
                     "alignment": "default",
                     "graded": true,
-                    "key": undefined,
                     "options": {
-                      "answerForms": undefined,
                       "answers": [
                         {
-                          "answerForms": undefined,
                           "maxError": null,
                           "message": "",
                           "simplify": "required",
@@ -1519,9 +1336,7 @@ $\\begin{align}
                   "numeric-input 2": {
                     "alignment": "default",
                     "graded": true,
-                    "key": undefined,
                     "options": {
-                      "answerForms": undefined,
                       "answers": [
                         {
                           "answerForms": [
@@ -1564,7 +1379,6 @@ $\\begin{align}
 $x=$ [[☃ numeric-input 1]]
 
 $y=$ [[☃ numeric-input 2]]",
-                "hasHint": undefined,
                 "hint": {
                   "content": "Let's solve the system by using the *elimination method.* In order to eliminate one of the variables, we need to manipulate the equations so that variable has coefficients of the same size but opposite signs in each equation.
 
@@ -1595,7 +1409,6 @@ $\\begin{align} {72x}-\\maroonD{40y} &= -440 \\\\\\\\
 
 When we solve the resulting equation we obtain that $x = -5$. Then, we can substitute this into one of the original equations and solve for $y$ to obtain $y=2$.",
                   "images": {},
-                  "metadata": undefined,
                   "widgets": {},
                 },
                 "images": {},
@@ -1606,12 +1419,9 @@ When we solve the resulting equation we obtain that $x = -5$. Then, we can subst
                   "numeric-input 1": {
                     "alignment": "default",
                     "graded": true,
-                    "key": undefined,
                     "options": {
-                      "answerForms": undefined,
                       "answers": [
                         {
-                          "answerForms": undefined,
                           "maxError": null,
                           "message": "",
                           "simplify": "required",
@@ -1637,12 +1447,9 @@ When we solve the resulting equation we obtain that $x = -5$. Then, we can subst
                   "numeric-input 2": {
                     "alignment": "default",
                     "graded": true,
-                    "key": undefined,
                     "options": {
-                      "answerForms": undefined,
                       "answers": [
                         {
-                          "answerForms": undefined,
                           "maxError": null,
                           "message": "",
                           "simplify": "required",
@@ -1683,7 +1490,6 @@ When we solve the resulting equation we obtain that $x = -5$. Then, we can subst
 
 It is possible to solve any system of linear equations using the substitution method as long as you're comfortable working with fractions in your equations.",
       "images": {},
-      "metadata": undefined,
       "replace": false,
       "widgets": {},
     },
@@ -1699,7 +1505,6 @@ Our strategic supplement version of algebra 1 is for students who are getting cl
 
 In case you would like a fuller experience, here is a taste of a skill you can learn in our full algebra 1 course.",
     "images": {},
-    "metadata": undefined,
     "widgets": {},
   },
 }
@@ -1707,7 +1512,6 @@ In case you would like a fuller experience, here is a taste of a skill you can l
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/iframe-missing-allowFullScreen.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -1717,21 +1521,12 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/iframe-missing-allow
 
 [[☃ image 1]]",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {
         "image 1": {
-          "alignment": undefined,
           "graded": true,
-          "key": undefined,
           "options": {
-            "alt": undefined,
             "backgroundImage": {
-              "bottom": undefined,
               "height": 215,
-              "left": undefined,
-              "scale": undefined,
-              "top": undefined,
               "url": "https://s3.amazonaws.com/ka-cs-algorithms/hanoi_exercise_step2_1.png",
               "width": 304,
             },
@@ -1739,7 +1534,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/iframe-missing-allow
               304,
               215,
             ],
-            "caption": undefined,
             "labels": [],
             "range": [
               [
@@ -1751,10 +1545,7 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/iframe-missing-allow
                 10,
               ],
             ],
-            "static": undefined,
-            "title": undefined,
           },
-          "static": undefined,
           "type": "image",
           "version": {
             "major": 0,
@@ -1773,15 +1564,11 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/iframe-missing-allow
 
 [[☃ iframe 1]]",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "iframe 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "allowFullScreen": false,
-          "allowTopNavigation": undefined,
           "height": "400",
           "settings": [
             {
@@ -1805,7 +1592,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/iframe-missing-allow
           "url": "4772835774169088",
           "width": 400,
         },
-        "static": undefined,
         "type": "iframe",
         "version": {
           "major": 0,
@@ -1819,31 +1605,22 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/iframe-missing-allow
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/iframe-missing-settings.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {},
   "hints": [],
-  "itemDataVersion": undefined,
   "question": {
     "content": "[[☃ iframe 1]]",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "iframe 1": {
         "alignment": "block",
-        "graded": undefined,
-        "key": undefined,
         "options": {
           "allowFullScreen": false,
-          "allowTopNavigation": undefined,
           "height": "550px",
-          "settings": undefined,
           "static": false,
           "url": "https://learnstorm.typeform.com/to/fnQ2tw?",
           "width": "100%",
         },
-        "static": undefined,
         "type": "iframe",
-        "version": undefined,
       },
     },
   },
@@ -1852,7 +1629,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/iframe-missing-setti
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/iframe-missing-static.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
     "periodicTable": false,
@@ -1863,16 +1639,11 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/iframe-missing-stati
 
 [[☃ iframe 1]]",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {
         "iframe 1": {
-          "alignment": undefined,
           "graded": true,
-          "key": undefined,
           "options": {
             "allowFullScreen": true,
-            "allowTopNavigation": undefined,
             "height": "235",
             "settings": [
               {
@@ -1884,7 +1655,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/iframe-missing-stati
             "url": "https://www.youtube.com/embed/qYD5iwhLzm8?enablejsapi=1&wmode=transparent&modestbranding=1&rel=0&frameborder='0'",
             "width": "425",
           },
-          "static": undefined,
           "type": "iframe",
           "version": {
             "major": 0,
@@ -1901,7 +1671,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/iframe-missing-stati
   "question": {
     "content": "This is a question.",
     "images": {},
-    "metadata": undefined,
     "widgets": {},
   },
 }
@@ -1909,7 +1678,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/iframe-missing-stati
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/input-number-with-boolean-value.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -1921,8 +1689,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/input-number-with-bo
  \\red{- 3|x - 5|}& && \\red{- 3|x - 5|} \\\\ \\\\
 & -3 &=& 1|x - 5| + 7 \\end{eqnarray} $",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
@@ -1932,8 +1698,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/input-number-with-bo
  \\red{- 7} && &\\red{- 7} \\\\ \\\\
  -10 &=& 1|x - 5| \\end{eqnarray} $",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
@@ -1941,15 +1705,11 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/input-number-with-bo
 
  $\\qquad -10 = |x - 5| $",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
       "content": "The absolute value cannot be negative. Therefore, there is no solution.",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
   ],
@@ -1964,23 +1724,17 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/input-number-with-bo
 
 [[☃ radio 1]]",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "input-number 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "answerType": "number",
-          "customKeypad": undefined,
           "inexact": false,
           "maxError": 0.1,
-          "rightAlign": undefined,
           "simplify": "required",
           "size": "small",
           "value": 0,
         },
-        "static": undefined,
         "type": "input-number",
         "version": {
           "major": 0,
@@ -1988,20 +1742,15 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/input-number-with-bo
         },
       },
       "input-number 2": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "answerType": "number",
-          "customKeypad": undefined,
           "inexact": false,
           "maxError": 0.1,
-          "rightAlign": undefined,
           "simplify": "required",
           "size": "small",
           "value": "true",
         },
-        "static": undefined,
         "type": "input-number",
         "version": {
           "major": 0,
@@ -2009,50 +1758,36 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/input-number-with-bo
         },
       },
       "radio 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "choices": [
             {
               "clue": "Absolute values cannot be negative.",
               "content": "$-5$",
               "correct": false,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
             {
               "clue": "Check your signs.",
               "content": " $5$",
               "correct": false,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
             {
               "clue": "You might have made a sign error.",
               "content": " $15$",
               "correct": false,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
             {
-              "clue": undefined,
               "content": "There are no solutions.",
               "correct": true,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
           ],
-          "countChoices": undefined,
           "deselectEnabled": false,
           "displayCount": null,
-          "hasNoneOfTheAbove": undefined,
           "multipleSelect": false,
           "noneOfTheAbove": false,
           "onePerLine": true,
           "randomize": false,
         },
-        "static": undefined,
         "type": "radio",
         "version": {
           "major": 0,
@@ -2066,7 +1801,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/input-number-with-bo
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/interaction-element-missing-constraints.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -2078,12 +1812,9 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/interaction-element-
   "question": {
     "content": "[[☃ interaction 1]]",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "interaction 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "elements": [
             {
@@ -2207,12 +1938,9 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/interaction-element-
           "graph": {
             "backgroundImage": {
               "bottom": 0,
-              "height": undefined,
               "left": 0,
               "scale": 1,
-              "top": undefined,
               "url": null,
-              "width": undefined,
             },
             "box": [
               400,
@@ -2257,7 +1985,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/interaction-element-
           },
           "static": false,
         },
-        "static": undefined,
         "type": "interaction",
         "version": {
           "major": 0,
@@ -2271,10 +1998,8 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/interaction-element-
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/interaction-element-missing-key.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {},
   "hints": [],
-  "itemDataVersion": undefined,
   "question": {
     "content": "# Functions introduction
 
@@ -2311,12 +2036,9 @@ Next, we'll look at some other representations of functions!",
         "width": 400,
       },
     },
-    "metadata": undefined,
     "widgets": {
       "interaction 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "elements": [
             {
@@ -2348,12 +2070,9 @@ Next, we'll look at some other representations of functions!",
           "graph": {
             "backgroundImage": {
               "bottom": 0,
-              "height": undefined,
               "left": 0,
               "scale": 1,
-              "top": undefined,
               "url": null,
-              "width": undefined,
             },
             "box": [
               400,
@@ -2402,7 +2121,6 @@ Next, we'll look at some other representations of functions!",
           },
           "static": false,
         },
-        "static": undefined,
         "type": "interaction",
         "version": {
           "major": 0,
@@ -2410,9 +2128,7 @@ Next, we'll look at some other representations of functions!",
         },
       },
       "interaction 2": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "elements": [
             {
@@ -2444,12 +2160,9 @@ Next, we'll look at some other representations of functions!",
           "graph": {
             "backgroundImage": {
               "bottom": 0,
-              "height": undefined,
               "left": 0,
               "scale": 1,
-              "top": undefined,
               "url": null,
-              "width": undefined,
             },
             "box": [
               400,
@@ -2498,7 +2211,6 @@ Next, we'll look at some other representations of functions!",
           },
           "static": false,
         },
-        "static": undefined,
         "type": "interaction",
         "version": {
           "major": 0,
@@ -2506,9 +2218,7 @@ Next, we'll look at some other representations of functions!",
         },
       },
       "interaction 3": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "elements": [
             {
@@ -2540,12 +2250,9 @@ Next, we'll look at some other representations of functions!",
           "graph": {
             "backgroundImage": {
               "bottom": 0,
-              "height": undefined,
               "left": 0,
               "scale": 1,
-              "top": undefined,
               "url": null,
-              "width": undefined,
             },
             "box": [
               400,
@@ -2594,7 +2301,6 @@ Next, we'll look at some other representations of functions!",
           },
           "static": false,
         },
-        "static": undefined,
         "type": "interaction",
         "version": {
           "major": 0,
@@ -2602,9 +2308,7 @@ Next, we'll look at some other representations of functions!",
         },
       },
       "interaction 4": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "elements": [
             {
@@ -2636,12 +2340,9 @@ Next, we'll look at some other representations of functions!",
           "graph": {
             "backgroundImage": {
               "bottom": 0,
-              "height": undefined,
               "left": 0,
               "scale": 1,
-              "top": undefined,
               "url": null,
-              "width": undefined,
             },
             "box": [
               400,
@@ -2690,7 +2391,6 @@ Next, we'll look at some other representations of functions!",
           },
           "static": false,
         },
-        "static": undefined,
         "type": "interaction",
         "version": {
           "major": 0,
@@ -2698,9 +2398,7 @@ Next, we'll look at some other representations of functions!",
         },
       },
       "interaction 5": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "elements": [
             {
@@ -2732,12 +2430,9 @@ Next, we'll look at some other representations of functions!",
           "graph": {
             "backgroundImage": {
               "bottom": 0,
-              "height": undefined,
               "left": 0,
               "scale": 1,
-              "top": undefined,
               "url": null,
-              "width": undefined,
             },
             "box": [
               400,
@@ -2786,7 +2481,6 @@ Next, we'll look at some other representations of functions!",
           },
           "static": false,
         },
-        "static": undefined,
         "type": "interaction",
         "version": {
           "major": 0,
@@ -2800,7 +2494,6 @@ Next, we'll look at some other representations of functions!",
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/interactive-graph-backgroundImage-with-empty-string-coordinates.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
     "periodicTable": false,
@@ -2815,8 +2508,6 @@ $\\qquad d=\\blue 6+5\\\\~~~~~~~~~~=\\red{11}.$
 
 So we place one point at $(\\blue 6,\\red{11})$.",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
@@ -2826,8 +2517,6 @@ $\\qquad d=\\blue{10}+5=\\red{15}$.
 
 So the second point is at $(\\blue{10},\\red{15})$.",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
@@ -2840,8 +2529,6 @@ So the second point is at $(\\blue{10},\\red{15})$.",
           "width": 425,
         },
       },
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
   ],
@@ -2869,24 +2556,20 @@ $3$ | $8$
 
 [[☃ interactive-graph 1]]",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "interactive-graph 1": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "backgroundImage": {
             "bottom": 0,
             "height": 0,
             "left": 0,
             "scale": 1,
-            "top": undefined,
             "url": null,
             "width": 0,
           },
           "correct": {
-            "coord": undefined,
             "coords": [
               [
                 6,
@@ -2898,16 +2581,10 @@ $3$ | $8$
               ],
             ],
             "numPoints": 2,
-            "startCoords": undefined,
             "type": "point",
           },
-          "fullGraphAriaDescription": undefined,
-          "fullGraphLabel": undefined,
           "graph": {
-            "coord": undefined,
-            "coords": undefined,
             "numPoints": 2,
-            "startCoords": undefined,
             "type": "point",
           },
           "gridStep": [
@@ -2918,7 +2595,6 @@ $3$ | $8$
             "w",
             "d",
           ],
-          "lockedFigures": undefined,
           "markings": "graph",
           "range": [
             [
@@ -2934,7 +2610,6 @@ $3$ | $8$
           "rulerTicks": 10,
           "showProtractor": false,
           "showRuler": false,
-          "showTooltips": undefined,
           "snapStep": [
             0.5,
             0.5,
@@ -2944,7 +2619,6 @@ $3$ | $8$
             1,
           ],
         },
-        "static": undefined,
         "type": "interactive-graph",
         "version": {
           "major": 0,
@@ -2958,10 +2632,8 @@ $3$ | $8$
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/interactive-graph-locked-line-missing-showPoint1.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {},
   "hints": [],
-  "itemDataVersion": undefined,
   "question": {
     "content": "Custom Axis Labels:
 [[☃ interactive-graph 1]]
@@ -2988,24 +2660,15 @@ Locked figures:
 [[☃ interactive-graph 8]]
 ",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "interactive-graph 1": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "backgroundImage": {
-            "bottom": undefined,
-            "height": undefined,
-            "left": undefined,
-            "scale": undefined,
-            "top": undefined,
             "url": null,
-            "width": undefined,
           },
           "correct": {
-            "coord": undefined,
             "coords": [
               [
                 [
@@ -3069,16 +2732,10 @@ Locked figures:
               ],
             ],
             "numSegments": 6,
-            "startCoords": undefined,
             "type": "segment",
           },
-          "fullGraphAriaDescription": undefined,
-          "fullGraphLabel": undefined,
           "graph": {
-            "coord": undefined,
-            "coords": undefined,
             "numSegments": 6,
-            "startCoords": undefined,
             "type": "segment",
           },
           "gridStep": [
@@ -3089,7 +2746,6 @@ Locked figures:
             "\\text{Re}",
             "\\text{Im}",
           ],
-          "lockedFigures": undefined,
           "markings": "graph",
           "range": [
             [
@@ -3101,10 +2757,7 @@ Locked figures:
               10,
             ],
           ],
-          "rulerLabel": undefined,
-          "rulerTicks": undefined,
           "showProtractor": false,
-          "showRuler": undefined,
           "showTooltips": false,
           "snapStep": [
             0.5,
@@ -3125,19 +2778,11 @@ Locked figures:
       "interactive-graph 2": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "backgroundImage": {
-            "bottom": undefined,
-            "height": undefined,
-            "left": undefined,
-            "scale": undefined,
-            "top": undefined,
             "url": null,
-            "width": undefined,
           },
           "correct": {
-            "coord": undefined,
             "coords": [
               [
                 [
@@ -3150,17 +2795,9 @@ Locked figures:
                 ],
               ],
             ],
-            "numSegments": undefined,
-            "startCoords": undefined,
             "type": "segment",
           },
-          "fullGraphAriaDescription": undefined,
-          "fullGraphLabel": undefined,
           "graph": {
-            "coord": undefined,
-            "coords": undefined,
-            "numSegments": undefined,
-            "startCoords": undefined,
             "type": "segment",
           },
           "gridStep": [
@@ -3171,7 +2808,6 @@ Locked figures:
             "x",
             "y",
           ],
-          "lockedFigures": undefined,
           "markings": "graph",
           "range": [
             [
@@ -3183,10 +2819,7 @@ Locked figures:
               100,
             ],
           ],
-          "rulerLabel": undefined,
-          "rulerTicks": undefined,
           "showProtractor": false,
-          "showRuler": undefined,
           "showTooltips": false,
           "snapStep": [
             0.5,
@@ -3207,31 +2840,16 @@ Locked figures:
       "interactive-graph 3": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "backgroundImage": {
-            "bottom": undefined,
             "height": 0,
-            "left": undefined,
-            "scale": undefined,
-            "top": undefined,
             "url": null,
             "width": 0,
           },
           "correct": {
-            "coord": undefined,
-            "coords": undefined,
-            "numSegments": undefined,
-            "startCoords": undefined,
             "type": "segment",
           },
-          "fullGraphAriaDescription": undefined,
-          "fullGraphLabel": undefined,
           "graph": {
-            "coord": undefined,
-            "coords": undefined,
-            "numSegments": undefined,
-            "startCoords": undefined,
             "type": "segment",
           },
           "gridStep": [
@@ -3242,7 +2860,6 @@ Locked figures:
             "x",
             "y",
           ],
-          "lockedFigures": undefined,
           "markings": "graph",
           "range": [
             [
@@ -3254,10 +2871,7 @@ Locked figures:
               10,
             ],
           ],
-          "rulerLabel": undefined,
-          "rulerTicks": undefined,
           "showProtractor": false,
-          "showRuler": undefined,
           "showTooltips": false,
           "snapStep": [
             2.5,
@@ -3278,31 +2892,14 @@ Locked figures:
       "interactive-graph 4": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "backgroundImage": {
-            "bottom": undefined,
-            "height": undefined,
-            "left": undefined,
-            "scale": undefined,
-            "top": undefined,
             "url": null,
-            "width": undefined,
           },
           "correct": {
-            "coord": undefined,
-            "coords": undefined,
-            "numSegments": undefined,
-            "startCoords": undefined,
             "type": "segment",
           },
-          "fullGraphAriaDescription": undefined,
-          "fullGraphLabel": undefined,
           "graph": {
-            "coord": undefined,
-            "coords": undefined,
-            "numSegments": undefined,
-            "startCoords": undefined,
             "type": "segment",
           },
           "gridStep": [
@@ -3313,7 +2910,6 @@ Locked figures:
             "x",
             "y",
           ],
-          "lockedFigures": undefined,
           "markings": "graph",
           "range": [
             [
@@ -3325,10 +2921,7 @@ Locked figures:
               3,
             ],
           ],
-          "rulerLabel": undefined,
-          "rulerTicks": undefined,
           "showProtractor": false,
-          "showRuler": undefined,
           "showTooltips": false,
           "snapStep": [
             0.25,
@@ -3349,31 +2942,14 @@ Locked figures:
       "interactive-graph 5": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "backgroundImage": {
-            "bottom": undefined,
-            "height": undefined,
-            "left": undefined,
-            "scale": undefined,
-            "top": undefined,
             "url": null,
-            "width": undefined,
           },
           "correct": {
-            "coord": undefined,
-            "coords": undefined,
-            "numSegments": undefined,
-            "startCoords": undefined,
             "type": "segment",
           },
-          "fullGraphAriaDescription": undefined,
-          "fullGraphLabel": undefined,
           "graph": {
-            "coord": undefined,
-            "coords": undefined,
-            "numSegments": undefined,
-            "startCoords": undefined,
             "type": "segment",
           },
           "gridStep": [
@@ -3384,7 +2960,6 @@ Locked figures:
             "x",
             "y",
           ],
-          "lockedFigures": undefined,
           "markings": "graph",
           "range": [
             [
@@ -3396,10 +2971,7 @@ Locked figures:
               10,
             ],
           ],
-          "rulerLabel": undefined,
-          "rulerTicks": undefined,
           "showProtractor": false,
-          "showRuler": undefined,
           "showTooltips": false,
           "snapStep": [
             1,
@@ -3420,31 +2992,14 @@ Locked figures:
       "interactive-graph 6": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "backgroundImage": {
-            "bottom": undefined,
-            "height": undefined,
-            "left": undefined,
-            "scale": undefined,
-            "top": undefined,
             "url": null,
-            "width": undefined,
           },
           "correct": {
-            "coord": undefined,
-            "coords": undefined,
-            "numSegments": undefined,
-            "startCoords": undefined,
             "type": "segment",
           },
-          "fullGraphAriaDescription": undefined,
-          "fullGraphLabel": undefined,
           "graph": {
-            "coord": undefined,
-            "coords": undefined,
-            "numSegments": undefined,
-            "startCoords": undefined,
             "type": "segment",
           },
           "gridStep": [
@@ -3455,7 +3010,6 @@ Locked figures:
             "x",
             "y",
           ],
-          "lockedFigures": undefined,
           "markings": "graph",
           "range": [
             [
@@ -3467,10 +3021,7 @@ Locked figures:
               5,
             ],
           ],
-          "rulerLabel": undefined,
-          "rulerTicks": undefined,
           "showProtractor": false,
-          "showRuler": undefined,
           "showTooltips": false,
           "snapStep": [
             0.25,
@@ -3491,31 +3042,14 @@ Locked figures:
       "interactive-graph 7": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "backgroundImage": {
-            "bottom": undefined,
-            "height": undefined,
-            "left": undefined,
-            "scale": undefined,
-            "top": undefined,
             "url": null,
-            "width": undefined,
           },
           "correct": {
-            "coord": undefined,
-            "coords": undefined,
-            "numSegments": undefined,
-            "startCoords": undefined,
             "type": "segment",
           },
-          "fullGraphAriaDescription": undefined,
-          "fullGraphLabel": undefined,
           "graph": {
-            "coord": undefined,
-            "coords": undefined,
-            "numSegments": undefined,
-            "startCoords": undefined,
             "type": "segment",
           },
           "gridStep": [
@@ -3526,7 +3060,6 @@ Locked figures:
             "x",
             "y",
           ],
-          "lockedFigures": undefined,
           "markings": "graph",
           "range": [
             [
@@ -3538,10 +3071,7 @@ Locked figures:
               5,
             ],
           ],
-          "rulerLabel": undefined,
-          "rulerTicks": undefined,
           "showProtractor": false,
-          "showRuler": undefined,
           "showTooltips": false,
           "snapStep": [
             1,
@@ -3562,19 +3092,11 @@ Locked figures:
       "interactive-graph 8": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "backgroundImage": {
-            "bottom": undefined,
-            "height": undefined,
-            "left": undefined,
-            "scale": undefined,
-            "top": undefined,
             "url": null,
-            "width": undefined,
           },
           "correct": {
-            "coord": undefined,
             "coords": [
               [
                 [
@@ -3589,7 +3111,6 @@ Locked figures:
             ],
             "hasBeenInteractedWith": true,
             "markings": "graph",
-            "numSegments": undefined,
             "range": [
               [
                 -10,
@@ -3604,16 +3125,9 @@ Locked figures:
               0.5,
               0.5,
             ],
-            "startCoords": undefined,
             "type": "segment",
           },
-          "fullGraphAriaDescription": undefined,
-          "fullGraphLabel": undefined,
           "graph": {
-            "coord": undefined,
-            "coords": undefined,
-            "numSegments": undefined,
-            "startCoords": undefined,
             "type": "segment",
           },
           "gridStep": [
@@ -3626,54 +3140,44 @@ Locked figures:
           ],
           "lockedFigures": [
             {
-              "ariaLabel": undefined,
               "color": "green",
               "coord": [
                 -1,
                 5,
               ],
               "filled": true,
-              "labels": undefined,
               "type": "point",
             },
             {
-              "ariaLabel": undefined,
               "color": "grayH",
               "coord": [
                 1,
                 5,
               ],
               "filled": false,
-              "labels": undefined,
               "type": "point",
             },
             {
-              "ariaLabel": undefined,
               "color": "grayH",
               "kind": "line",
-              "labels": undefined,
               "lineStyle": "solid",
               "points": [
                 {
-                  "ariaLabel": undefined,
                   "color": "grayH",
                   "coord": [
                     0,
                     1,
                   ],
                   "filled": true,
-                  "labels": undefined,
                   "type": "point",
                 },
                 {
-                  "ariaLabel": undefined,
                   "color": "grayH",
                   "coord": [
                     5,
                     2,
                   ],
                   "filled": true,
-                  "labels": undefined,
                   "type": "point",
                 },
               ],
@@ -3684,32 +3188,26 @@ Locked figures:
               "type": "line",
             },
             {
-              "ariaLabel": undefined,
               "color": "grayH",
               "kind": "line",
-              "labels": undefined,
               "lineStyle": "dashed",
               "points": [
                 {
-                  "ariaLabel": undefined,
                   "color": "grayH",
                   "coord": [
                     0,
                     0,
                   ],
                   "filled": true,
-                  "labels": undefined,
                   "type": "point",
                 },
                 {
-                  "ariaLabel": undefined,
                   "color": "grayH",
                   "coord": [
                     5,
                     1,
                   ],
                   "filled": false,
-                  "labels": undefined,
                   "type": "point",
                 },
               ],
@@ -3720,32 +3218,26 @@ Locked figures:
               "type": "line",
             },
             {
-              "ariaLabel": undefined,
               "color": "pink",
               "kind": "ray",
-              "labels": undefined,
               "lineStyle": "solid",
               "points": [
                 {
-                  "ariaLabel": undefined,
                   "color": "pink",
                   "coord": [
                     0,
                     -1,
                   ],
                   "filled": true,
-                  "labels": undefined,
                   "type": "point",
                 },
                 {
-                  "ariaLabel": undefined,
                   "color": "pink",
                   "coord": [
                     5,
                     0,
                   ],
                   "filled": true,
-                  "labels": undefined,
                   "type": "point",
                 },
               ],
@@ -3756,32 +3248,26 @@ Locked figures:
               "type": "line",
             },
             {
-              "ariaLabel": undefined,
               "color": "pink",
               "kind": "ray",
-              "labels": undefined,
               "lineStyle": "dashed",
               "points": [
                 {
-                  "ariaLabel": undefined,
                   "color": "purple",
                   "coord": [
                     0,
                     -2,
                   ],
                   "filled": true,
-                  "labels": undefined,
                   "type": "point",
                 },
                 {
-                  "ariaLabel": undefined,
                   "color": "pink",
                   "coord": [
                     5,
                     -1,
                   ],
                   "filled": false,
-                  "labels": undefined,
                   "type": "point",
                 },
               ],
@@ -3792,32 +3278,26 @@ Locked figures:
               "type": "line",
             },
             {
-              "ariaLabel": undefined,
               "color": "red",
               "kind": "segment",
-              "labels": undefined,
               "lineStyle": "solid",
               "points": [
                 {
-                  "ariaLabel": undefined,
                   "color": "red",
                   "coord": [
                     0,
                     -3,
                   ],
                   "filled": true,
-                  "labels": undefined,
                   "type": "point",
                 },
                 {
-                  "ariaLabel": undefined,
                   "color": "red",
                   "coord": [
                     5,
                     -2,
                   ],
                   "filled": true,
-                  "labels": undefined,
                   "type": "point",
                 },
               ],
@@ -3828,32 +3308,26 @@ Locked figures:
               "type": "line",
             },
             {
-              "ariaLabel": undefined,
               "color": "red",
               "kind": "segment",
-              "labels": undefined,
               "lineStyle": "dashed",
               "points": [
                 {
-                  "ariaLabel": undefined,
                   "color": "green",
                   "coord": [
                     0,
                     -4,
                   ],
                   "filled": true,
-                  "labels": undefined,
                   "type": "point",
                 },
                 {
-                  "ariaLabel": undefined,
                   "color": "red",
                   "coord": [
                     5,
                     -3,
                   ],
                   "filled": false,
-                  "labels": undefined,
                   "type": "point",
                 },
               ],
@@ -3885,10 +3359,7 @@ Locked figures:
               10,
             ],
           ],
-          "rulerLabel": undefined,
-          "rulerTicks": undefined,
           "showProtractor": false,
-          "showRuler": undefined,
           "showTooltips": false,
           "snapStep": [
             0.5,
@@ -3913,7 +3384,6 @@ Locked figures:
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/interactive-graph-missing-graph.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
     "chi2Table": false,
@@ -3929,7 +3399,6 @@ Let's remember what magnetic dip means. It is the angle that the magnetic field 
 
 *Tip: The **dip** angle is **positive** when the magnetic field **dips**!*",
       "images": {},
-      "metadata": undefined,
       "replace": false,
       "widgets": {},
     },
@@ -3942,21 +3411,15 @@ Here, the dip angle is **positive**, so the magnetic field is **below** the hori
 
 As we can see the direction of the vertical component is downwards $(\\downarrow)$, now let's find the magnitude.",
       "images": {},
-      "metadata": undefined,
       "replace": false,
       "widgets": {
         "image 1": {
           "alignment": "block",
           "graded": true,
-          "key": undefined,
           "options": {
             "alt": "",
             "backgroundImage": {
-              "bottom": undefined,
               "height": 151,
-              "left": undefined,
-              "scale": undefined,
-              "top": undefined,
               "url": "https://ka-perseus-images.s3.amazonaws.com/d36824c27f73d6263d9a1c548ead1fdac535243e.svg",
               "width": 255,
             },
@@ -3998,13 +3461,11 @@ $\\begin{align}
 
 [[☃ explanation 1]]",
       "images": {},
-      "metadata": undefined,
       "replace": false,
       "widgets": {
         "explanation 1": {
           "alignment": "default",
           "graded": true,
-          "key": undefined,
           "options": {
             "explanation": "We can move $\\purpleD {B_V}$ to the right in the diagram to get the right angle triangle as shown below.
 
@@ -4023,15 +3484,10 @@ $\\begin{align}
               "image 1": {
                 "alignment": "block",
                 "graded": true,
-                "key": undefined,
                 "options": {
                   "alt": "",
                   "backgroundImage": {
-                    "bottom": undefined,
                     "height": 156,
-                    "left": undefined,
-                    "scale": undefined,
-                    "top": undefined,
                     "url": "https://ka-perseus-images.s3.amazonaws.com/d3b512adb0f11756344a3838f91aa35eda75439b.svg",
                     "width": 255,
                   },
@@ -4062,36 +3518,21 @@ $\\begin{align}
                 },
               },
               "interactive-graph 1": {
-                "alignment": undefined,
-                "graded": undefined,
-                "key": undefined,
                 "options": {
                   "backgroundImage": {
-                    "bottom": undefined,
-                    "height": undefined,
-                    "left": undefined,
-                    "scale": undefined,
-                    "top": undefined,
                     "url": null,
-                    "width": undefined,
                   },
                   "correct": {
-                    "coord": undefined,
                     "coords": null,
-                    "startCoords": undefined,
                     "type": "linear",
                   },
-                  "fullGraphAriaDescription": undefined,
-                  "fullGraphLabel": undefined,
                   "graph": {
                     "type": "linear",
                   },
-                  "gridStep": undefined,
                   "labels": [
                     "x",
                     "y",
                   ],
-                  "lockedFigures": undefined,
                   "markings": "graph",
                   "range": [
                     [
@@ -4108,14 +3549,12 @@ $\\begin{align}
                   "showProtractor": false,
                   "showRuler": false,
                   "showTooltips": false,
-                  "snapStep": undefined,
                   "step": [
                     1,
                     1,
                   ],
                   "valid": true,
                 },
-                "static": undefined,
                 "type": "interactive-graph",
                 "version": {
                   "major": 0,
@@ -4139,7 +3578,6 @@ $\\begin{align}
 $B_E\\ \\sin{45\\degree}\\downarrow$
 ",
       "images": {},
-      "metadata": undefined,
       "replace": false,
       "widgets": {},
     },
@@ -4161,55 +3599,39 @@ $B_E\\ \\sin{45\\degree}\\downarrow$
         "width": 352,
       },
     },
-    "metadata": undefined,
     "widgets": {
       "radio 1": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "choices": [
             {
-              "clue": undefined,
               "content": "$B_E\\ \\cos{45\\degree} \\uparrow$",
               "correct": false,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
             {
-              "clue": undefined,
               "content": "$B_E\\ \\cos{45\\degree} \\downarrow$",
               "correct": false,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
             {
-              "clue": undefined,
               "content": "$B_E\\ \\sin{45\\degree} \\downarrow$",
               "correct": true,
               "isNoneOfTheAbove": false,
-              "widgets": undefined,
             },
             {
-              "clue": undefined,
               "content": "$B_E\\ \\sin{45\\degree}\\uparrow$",
               "correct": false,
               "isNoneOfTheAbove": false,
-              "widgets": undefined,
             },
             {
-              "clue": undefined,
               "content": "$B_E\\ \\tan {45\\degree} \\uparrow$",
               "correct": false,
               "isNoneOfTheAbove": false,
-              "widgets": undefined,
             },
             {
-              "clue": undefined,
               "content": "$B_E\\ \\tan {45\\degree} \\downarrow$",
               "correct": false,
               "isNoneOfTheAbove": false,
-              "widgets": undefined,
             },
           ],
           "countChoices": false,
@@ -4217,8 +3639,6 @@ $B_E\\ \\sin{45\\degree}\\downarrow$
           "displayCount": null,
           "hasNoneOfTheAbove": false,
           "multipleSelect": false,
-          "noneOfTheAbove": undefined,
-          "onePerLine": undefined,
           "randomize": false,
         },
         "static": false,
@@ -4235,7 +3655,6 @@ $B_E\\ \\sin{45\\degree}\\downarrow$
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/interactive-graph-missing-gridStep.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
     "chi2Table": false,
@@ -4255,43 +3674,26 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/interactive-graph-mi
 
 ",
       "images": {},
-      "metadata": undefined,
       "replace": false,
       "widgets": {
         "interactive-graph 1": {
           "alignment": "default",
           "graded": true,
-          "key": undefined,
           "options": {
             "backgroundImage": {
-              "bottom": undefined,
-              "height": undefined,
-              "left": undefined,
-              "scale": undefined,
-              "top": undefined,
               "url": null,
-              "width": undefined,
             },
             "correct": {
-              "coord": undefined,
               "coords": null,
-              "startCoords": undefined,
               "type": "linear",
             },
-            "fullGraphAriaDescription": undefined,
-            "fullGraphLabel": undefined,
             "graph": {
-              "coord": undefined,
-              "coords": undefined,
-              "startCoords": undefined,
               "type": "linear",
             },
-            "gridStep": undefined,
             "labels": [
               "x",
               "y",
             ],
-            "lockedFigures": undefined,
             "markings": "graph",
             "range": [
               [
@@ -4303,12 +3705,8 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/interactive-graph-mi
                 10,
               ],
             ],
-            "rulerLabel": undefined,
-            "rulerTicks": undefined,
             "showProtractor": false,
-            "showRuler": undefined,
             "showTooltips": false,
-            "snapStep": undefined,
             "step": [
               1,
               1,
@@ -4335,24 +3733,15 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/interactive-graph-mi
 
 [[☃ interactive-graph 2]]",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "interactive-graph 1": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "backgroundImage": {
-            "bottom": undefined,
-            "height": undefined,
-            "left": undefined,
-            "scale": undefined,
-            "top": undefined,
             "url": null,
-            "width": undefined,
           },
           "correct": {
-            "coord": undefined,
             "coords": [
               [
                 -3,
@@ -4378,23 +3767,15 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/interactive-graph-mi
               0.5,
               0.5,
             ],
-            "startCoords": undefined,
             "type": "linear",
           },
-          "fullGraphAriaDescription": undefined,
-          "fullGraphLabel": undefined,
           "graph": {
-            "coord": undefined,
-            "coords": undefined,
-            "startCoords": undefined,
             "type": "linear",
           },
-          "gridStep": undefined,
           "labels": [
             "x",
             "y",
           ],
-          "lockedFigures": undefined,
           "markings": "graph",
           "range": [
             [
@@ -4406,12 +3787,8 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/interactive-graph-mi
               10,
             ],
           ],
-          "rulerLabel": undefined,
-          "rulerTicks": undefined,
           "showProtractor": false,
-          "showRuler": undefined,
           "showTooltips": false,
-          "snapStep": undefined,
           "step": [
             1,
             1,
@@ -4427,19 +3804,11 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/interactive-graph-mi
       "interactive-graph 2": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "backgroundImage": {
-            "bottom": undefined,
-            "height": undefined,
-            "left": undefined,
-            "scale": undefined,
-            "top": undefined,
             "url": null,
-            "width": undefined,
           },
           "correct": {
-            "coord": undefined,
             "coords": [
               [
                 -3,
@@ -4465,23 +3834,15 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/interactive-graph-mi
               0.5,
               0.5,
             ],
-            "startCoords": undefined,
             "type": "linear",
           },
-          "fullGraphAriaDescription": undefined,
-          "fullGraphLabel": undefined,
           "graph": {
-            "coord": undefined,
-            "coords": undefined,
-            "startCoords": undefined,
             "type": "linear",
           },
-          "gridStep": undefined,
           "labels": [
             "x",
             "y",
           ],
-          "lockedFigures": undefined,
           "markings": "graph",
           "range": [
             [
@@ -4493,12 +3854,8 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/interactive-graph-mi
               10,
             ],
           ],
-          "rulerLabel": undefined,
-          "rulerTicks": undefined,
           "showProtractor": false,
-          "showRuler": undefined,
           "showTooltips": false,
-          "snapStep": undefined,
           "step": [
             1,
             1,
@@ -4518,7 +3875,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/interactive-graph-mi
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/interactive-graph-missing-labels.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -4530,8 +3886,6 @@ $R$ $(1,-3)$ is transformed into $R'$ $(4,4)$.
 
 ![](https://ka-perseus-graphie.s3.amazonaws.com/0450d707e93ac22809e8e4063f74b98bf35d079e.png)",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
@@ -4540,8 +3894,6 @@ $R$ $(1,-3)$ is transformed into $R'$ $(4,4)$.
 $G$ $(-3,-3)$ is transformed into $G'$ $(0,4)$.  
 $A$ $(1,0)$ is transformed into $A'$ $(4,7)$.  ",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
@@ -4550,35 +3902,27 @@ $A$ $(1,0)$ is transformed into $A'$ $(4,7)$.  ",
 ![](https://ka-perseus-graphie.s3.amazonaws.com/dcbfde322f50640db9f40bf4b79824ad9014d8db.png)
 ",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
   ],
-  "itemDataVersion": undefined,
   "question": {
     "content": "**Arrange the vertices of the movable triangle to construct the image of $\\triangle GAR$ after a translation by $\\langle3,7\\rangle$.**
 
 [[☃ interactive-graph 1]]",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "interactive-graph 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "backgroundImage": {
             "bottom": 0,
             "height": 425,
             "left": 0,
             "scale": 1,
-            "top": undefined,
             "url": "https://ka-perseus-graphie.s3.amazonaws.com/31eb6c4f83e061ca7e28bb4382469cb4d682f7b4.png",
             "width": 425,
           },
           "correct": {
-            "coord": undefined,
             "coords": [
               [
                 4,
@@ -4593,29 +3937,13 @@ $A$ $(1,0)$ is transformed into $A'$ $(4,7)$.  ",
                 4,
               ],
             ],
-            "match": undefined,
             "numSides": 3,
-            "showAngles": undefined,
-            "showSides": undefined,
-            "snapTo": undefined,
-            "startCoords": undefined,
             "type": "polygon",
           },
-          "fullGraphAriaDescription": undefined,
-          "fullGraphLabel": undefined,
           "graph": {
-            "coord": undefined,
-            "match": undefined,
             "numSides": 3,
-            "showAngles": undefined,
-            "showSides": undefined,
-            "snapTo": undefined,
-            "startCoords": undefined,
             "type": "polygon",
           },
-          "gridStep": undefined,
-          "labels": undefined,
-          "lockedFigures": undefined,
           "markings": "none",
           "range": [
             [
@@ -4627,20 +3955,13 @@ $A$ $(1,0)$ is transformed into $A'$ $(4,7)$.  ",
               10,
             ],
           ],
-          "rulerLabel": undefined,
-          "rulerTicks": undefined,
           "showProtractor": false,
-          "showRuler": undefined,
-          "showTooltips": undefined,
-          "snapStep": undefined,
           "step": [
             1,
             1,
           ],
         },
-        "static": undefined,
         "type": "interactive-graph",
-        "version": undefined,
       },
     },
   },
@@ -4649,7 +3970,6 @@ $A$ $(1,0)$ is transformed into $A'$ $(4,7)$.  ",
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/interactive-graph-polygon-with-exact-match.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -4664,8 +3984,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/interactive-graph-po
           "width": 425,
         },
       },
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
@@ -4680,8 +3998,6 @@ Plotting the remaining vertices at $(8,7)$ and $(5,3)$ gives the rhombus sides o
           "width": 425,
         },
       },
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
@@ -4695,8 +4011,6 @@ We end up with a rhombus that looks like this:
           "width": 425,
         },
       },
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
   ],
@@ -4713,24 +4027,17 @@ Draw the rhombus in the first quadrant.
 
 [[☃ interactive-graph 1]]",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "interactive-graph 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "backgroundImage": {
             "bottom": 0,
-            "height": undefined,
             "left": 0,
             "scale": 1,
-            "top": undefined,
             "url": null,
-            "width": undefined,
           },
           "correct": {
-            "coord": undefined,
             "coords": [
               [
                 3,
@@ -4751,22 +4058,14 @@ Draw the rhombus in the first quadrant.
             ],
             "match": "exact",
             "numSides": "unlimited",
-            "showAngles": undefined,
             "showSides": true,
             "snapTo": "grid",
-            "startCoords": undefined,
             "type": "polygon",
           },
-          "fullGraphAriaDescription": undefined,
-          "fullGraphLabel": undefined,
           "graph": {
-            "coord": undefined,
-            "match": undefined,
             "numSides": "unlimited",
-            "showAngles": undefined,
             "showSides": true,
             "snapTo": "grid",
-            "startCoords": undefined,
             "type": "polygon",
           },
           "gridStep": [
@@ -4777,7 +4076,6 @@ Draw the rhombus in the first quadrant.
             "x",
             "y",
           ],
-          "lockedFigures": undefined,
           "markings": "graph",
           "range": [
             [
@@ -4793,7 +4091,6 @@ Draw the rhombus in the first quadrant.
           "rulerTicks": 10,
           "showProtractor": false,
           "showRuler": false,
-          "showTooltips": undefined,
           "snapStep": [
             1,
             1,
@@ -4803,7 +4100,6 @@ Draw the rhombus in the first quadrant.
             1,
           ],
         },
-        "static": undefined,
         "type": "interactive-graph",
         "version": {
           "major": 0,
@@ -4817,7 +4113,6 @@ Draw the rhombus in the first quadrant.
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/interactive-graph-with-string-backgroundImage-left.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
     "chi2Table": false,
@@ -4840,24 +4135,20 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/interactive-graph-wi
 **How far along will Ally be in the race when she reaches her family?**  
 [[☃ radio 1]]",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "interactive-graph 1": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "backgroundImage": {
             "bottom": 4,
             "height": 0,
             "left": 0,
             "scale": 1,
-            "top": undefined,
             "url": "",
             "width": 0,
           },
           "correct": {
-            "coord": undefined,
             "coords": [
               [
                 4,
@@ -4873,16 +4164,10 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/interactive-graph-wi
               ],
             ],
             "numPoints": 3,
-            "startCoords": undefined,
             "type": "point",
           },
-          "fullGraphAriaDescription": undefined,
-          "fullGraphLabel": undefined,
           "graph": {
-            "coord": undefined,
-            "coords": undefined,
             "numPoints": 3,
-            "startCoords": undefined,
             "type": "point",
           },
           "gridStep": [
@@ -4893,7 +4178,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/interactive-graph-wi
             "x",
             "y",
           ],
-          "lockedFigures": undefined,
           "markings": "graph",
           "range": [
             [
@@ -4929,29 +4213,18 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/interactive-graph-wi
       "radio 1": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "choices": [
             {
-              "clue": undefined,
               "content": "Less than halfway through the race",
               "correct": false,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
             {
-              "clue": undefined,
               "content": "Halfway through the race",
               "correct": true,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
             {
-              "clue": undefined,
               "content": "More than halfway through the race",
-              "correct": undefined,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
           ],
           "countChoices": false,
@@ -4959,8 +4232,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/interactive-graph-wi
           "displayCount": null,
           "hasNoneOfTheAbove": false,
           "multipleSelect": false,
-          "noneOfTheAbove": undefined,
-          "onePerLine": undefined,
           "randomize": false,
         },
         "static": false,
@@ -4977,7 +4248,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/interactive-graph-wi
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/label-image-missing-static.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
     "chi2Table": false,
@@ -4995,14 +4265,12 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/label-image-missing-
 
 Non-renewable source can be exhausted with continuous use",
       "images": {},
-      "metadata": undefined,
       "replace": false,
       "widgets": {},
     },
     {
       "content": "Wind and solar energy are renewable, while oil and coal are non-renewable fossil fuels.",
       "images": {},
-      "metadata": undefined,
       "replace": false,
       "widgets": {},
     },
@@ -5017,18 +4285,15 @@ Non-renewable source can be exhausted with continuous use",
 [[☃ categorizer 1]]
 ",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "categorizer 1": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "categories": [
             "Renewable",
             "Non-renewable",
           ],
-          "highlightLint": undefined,
           "items": [
             "Wind",
             "Oil",
@@ -5058,11 +4323,7 @@ Non-renewable source can be exhausted with continuous use",
         },
       },
       "dropdown 1": {
-        "alignment": undefined,
-        "graded": undefined,
-        "key": undefined,
         "options": {
-          "ariaLabel": undefined,
           "choices": [
             {
               "content": "",
@@ -5071,9 +4332,7 @@ Non-renewable source can be exhausted with continuous use",
           ],
           "placeholder": "",
           "static": false,
-          "visibleLabel": undefined,
         },
-        "static": undefined,
         "type": "dropdown",
         "version": {
           "major": 0,
@@ -5081,9 +4340,6 @@ Non-renewable source can be exhausted with continuous use",
         },
       },
       "label-image 1": {
-        "alignment": undefined,
-        "graded": undefined,
-        "key": undefined,
         "options": {
           "choices": [],
           "hideChoicesFromInstructions": false,
@@ -5095,7 +4351,6 @@ Non-renewable source can be exhausted with continuous use",
           "multipleAnswers": false,
           "static": false,
         },
-        "static": undefined,
         "type": "label-image",
         "version": {
           "major": 0,
@@ -5103,9 +4358,6 @@ Non-renewable source can be exhausted with continuous use",
         },
       },
       "matcher 1": {
-        "alignment": undefined,
-        "graded": undefined,
-        "key": undefined,
         "options": {
           "labels": [
             "test",
@@ -5124,7 +4376,6 @@ Non-renewable source can be exhausted with continuous use",
             "$3$",
           ],
         },
-        "static": undefined,
         "type": "matcher",
         "version": {
           "major": 0,
@@ -5132,9 +4383,6 @@ Non-renewable source can be exhausted with continuous use",
         },
       },
       "sorter 1": {
-        "alignment": undefined,
-        "graded": undefined,
-        "key": undefined,
         "options": {
           "correct": [
             "$x$",
@@ -5144,7 +4392,6 @@ Non-renewable source can be exhausted with continuous use",
           "layout": "horizontal",
           "padding": true,
         },
-        "static": undefined,
         "type": "sorter",
         "version": {
           "major": 0,
@@ -5158,23 +4405,18 @@ Non-renewable source can be exhausted with continuous use",
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/lights-puzzle.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
   "hints": [],
-  "itemDataVersion": undefined,
   "question": {
     "content": "**Light up all the squares by clicking on them.** When you click on a square, it will turn on (if it's off), or off (if it's on), as will each of the squares next to it.
 
 [[☃ lights-puzzle 1]]",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "lights-puzzle 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "gradeIncompleteAsWrong": false,
           "startCells": [
@@ -5195,9 +4437,7 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/lights-puzzle.json 1
             ],
           ],
         },
-        "static": undefined,
         "type": "deprecated-standin",
-        "version": undefined,
       },
     },
   },
@@ -5206,7 +4446,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/lights-puzzle.json 1
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/matrix-missing-version.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -5216,8 +4455,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/matrix-missing-versi
 
  $ \\textbf A^{-1} = \\frac{1}{det(\\textbf A)}adj(\\textbf A) $",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
@@ -5227,8 +4464,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/matrix-missing-versi
 
  $ \\left[\\begin{array}{rrr}\\left|\\begin{array}{rr}1 & 1 \\\\ 1 & 1\\end{array}\\right| & \\left|\\begin{array}{rr}0 & 1 \\\\ 1 & 1\\end{array}\\right| & \\left|\\begin{array}{rr}0 & 1 \\\\ 1 & 1\\end{array}\\right| \\\\ \\left|\\begin{array}{rr}0 & 1 \\\\ 1 & 1\\end{array}\\right| & \\left|\\begin{array}{rr}2 & 1 \\\\ 1 & 1\\end{array}\\right| & \\left|\\begin{array}{rr}2 & 0 \\\\ 1 & 1\\end{array}\\right| \\\\ \\left|\\begin{array}{rr}0 & 1 \\\\ 1 & 1\\end{array}\\right| & \\left|\\begin{array}{rr}2 & 1 \\\\ 0 & 1\\end{array}\\right| & \\left|\\begin{array}{rr}2 & 0 \\\\ 0 & 1\\end{array}\\right|\\end{array}\\right] = \\left[\\begin{array}{rrr}0 & -1 & -1 \\\\ -1 & 1 & 2 \\\\ -1 & 2 & 2\\end{array}\\right] $",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
@@ -5238,8 +4473,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/matrix-missing-versi
 
  $ \\left[\\begin{array}{rrr}0 & 1 & -1 \\\\ 1 & 1 & -2 \\\\ -1 & -2 & 2\\end{array}\\right] $",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
@@ -5247,8 +4480,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/matrix-missing-versi
 
  $ adj(\\textbf A) = \\left[\\begin{array}{rrr}0 & 1 & -1 \\\\ 1 & 1 & -2 \\\\ -1 & -2 & 2\\end{array}\\right]^T = \\left[\\begin{array}{rrr}\\color{\\#6495ED}{0} & \\color{\\#6495ED}{1} & \\color{\\#6495ED}{-1} \\\\ \\color{\\#6495ED}{1} & \\color{\\#6495ED}{1} & \\color{\\#6495ED}{-2} \\\\ \\color{\\#6495ED}{-1} & \\color{\\#6495ED}{-2} & \\color{\\#6495ED}{2}\\end{array}\\right] $",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
@@ -5258,8 +4489,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/matrix-missing-versi
 
   $ det(\\textbf A) = \\left|\\begin{array}{rrr}2 & 0 & 1 \\\\ 0 & 1 & 1 \\\\ 1 & 1 & 1\\end{array}\\right|= \\color{\\#DF0030}{-1} $",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
@@ -5269,19 +4498,14 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/matrix-missing-versi
 
  $ \\textbf A^{-1} = \\frac{1}{\\color{\\#DF0030}{-1}} \\left[\\begin{array}{rrr}\\color{\\#6495ED}{0} & \\color{\\#6495ED}{1} & \\color{\\#6495ED}{-1} \\\\ \\color{\\#6495ED}{1} & \\color{\\#6495ED}{1} & \\color{\\#6495ED}{-2} \\\\ \\color{\\#6495ED}{-1} & \\color{\\#6495ED}{-2} & \\color{\\#6495ED}{2}\\end{array}\\right] $",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
       "content": "$ = \\left[\\begin{array}{rrr}0 & -1 & 1 \\\\ -1 & -1 & 2 \\\\ 1 & 2 & -2\\end{array}\\right]$",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
   ],
-  "itemDataVersion": undefined,
   "question": {
     "content": "$\\textbf A = \\left[\\begin{array}{rrr}2 & 0 & 1 \\\\ 0 & 1 & 1 \\\\ 1 & 1 & 1\\end{array}\\right]$
 
@@ -5289,12 +4513,8 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/matrix-missing-versi
 
 [[☃ matrix 1]]",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "matrix 1": {
-        "alignment": undefined,
-        "graded": undefined,
-        "key": undefined,
         "options": {
           "answers": [
             [
@@ -5313,18 +4533,12 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/matrix-missing-versi
               -2,
             ],
           ],
-          "cursorPosition": undefined,
           "matrixBoardSize": [
             3,
             3,
           ],
-          "prefix": undefined,
-          "static": undefined,
-          "suffix": undefined,
         },
-        "static": undefined,
         "type": "matrix",
-        "version": undefined,
       },
     },
   },
@@ -5333,7 +4547,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/matrix-missing-versi
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/matrix-with-nulls-in-answer.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
     "chi2Table": false,
@@ -5351,12 +4564,10 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/matrix-with-nulls-in
 
 [[☃ matrix 1]]",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "matrix 1": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "answers": [
             [
@@ -5401,7 +4612,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/matrix-with-nulls-in
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/matrix-with-string-answer-element.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": true,
     "chi2Table": false,
@@ -5422,13 +4632,11 @@ $x_1\\cdot\\vec{v_1}+x_2\\cdot\\vec{v_2}+...+x_n\\cdot\\vec{v_n}$
 
 [[☃ explanation 1]]",
       "images": {},
-      "metadata": undefined,
       "replace": false,
       "widgets": {
         "explanation 1": {
           "alignment": "default",
           "graded": true,
-          "key": undefined,
           "options": {
             "explanation": "We learned that for 2-dimensional matrices, the first column is the image of the unit vector $\\left[\\begin{array}{c}1\\\\\\\\0\\end{array}\\right]$ and the second column is the image of the unit vector $\\left[\\begin{array}{c}0\\\\\\\\1\\end{array}\\right]$.
 
@@ -5559,7 +4767,6 @@ $x_1\\cdot\\left[\\begin{array}{c}1\\\\\\\\0\\\\\\\\0\\\\\\\\0\\end{array}\\righ
 \\end{array}\\right]
 \\end{align}$",
       "images": {},
-      "metadata": undefined,
       "replace": false,
       "widgets": {},
     },
@@ -5592,7 +4799,6 @@ $\\left[\\begin{array}{c}
 -5
 \\end{array}\\right]$",
       "images": {},
-      "metadata": undefined,
       "replace": false,
       "widgets": {},
     },
@@ -5626,12 +4832,10 @@ $\\left[\\begin{array}{c}
 
 [[☃ matrix 1]]",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "matrix 1": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "answers": [
             [
@@ -5673,7 +4877,6 @@ $\\left[\\begin{array}{c}
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/measurer-missing-image.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -5681,37 +4884,26 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/measurer-missing-ima
     {
       "content": "crwdns2931741:0crwdne2931741:0",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
       "content": "crwdns2931695:0crwdne2931695:0",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
       "content": "crwdns2931679:0crwdne2931679:0",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
   ],
-  "itemDataVersion": undefined,
   "question": {
     "content": "crwdns3125767:0crwdne3125767:0",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "dropdown 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
-          "ariaLabel": undefined,
           "choices": [
             {
               "content": "crwdns2301760:0crwdne2301760:0",
@@ -5744,16 +4936,11 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/measurer-missing-ima
           ],
           "placeholder": "",
           "static": false,
-          "visibleLabel": undefined,
         },
-        "static": undefined,
         "type": "dropdown",
-        "version": undefined,
       },
       "measurer 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "box": [
             480,
@@ -5775,9 +4962,7 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/measurer-missing-ima
           "showRuler": false,
           "static": false,
         },
-        "static": undefined,
         "type": "measurer",
-        "version": undefined,
       },
     },
   },
@@ -5786,7 +4971,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/measurer-missing-ima
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/measurer-missing-static.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -5800,26 +4984,15 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/measurer-missing-sta
 
 ",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "measurer 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "box": [
             480,
             480,
           ],
-          "image": {
-            "bottom": undefined,
-            "height": undefined,
-            "left": undefined,
-            "scale": undefined,
-            "top": undefined,
-            "url": undefined,
-            "width": undefined,
-          },
+          "image": {},
           "rulerLabel": "",
           "rulerLength": 10,
           "rulerPixels": 40,
@@ -5828,7 +5001,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/measurer-missing-sta
           "showRuler": true,
           "static": false,
         },
-        "static": undefined,
         "type": "measurer",
         "version": {
           "major": 1,
@@ -5842,7 +5014,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/measurer-missing-sta
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/number-line-missing-snapDivisions.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
     "chi2Table": false,
@@ -5869,7 +5040,6 @@ This amount must be *greater than or equal to* $\\purpleC{13.50}$, so the inequa
 
 $\\blueD{3}+\\greenD{1.2c}\\maroonD{\\geq}\\purpleC{13.50}$",
       "images": {},
-      "metadata": undefined,
       "replace": false,
       "widgets": {},
     },
@@ -5888,7 +5058,6 @@ c &≥ 8.75
 
 Janie must do $8.75$ or more chores to have enough money to purchase the CD.",
       "images": {},
-      "metadata": undefined,
       "replace": false,
       "widgets": {},
     },
@@ -5899,7 +5068,6 @@ The solution  includes the point $c=8.75$, so we *fill in* the circle at $8.75$.
 
 Because the solution to the inequality says that $c\\geq 8.75$, this means that solutions are numbers to the *right* of $8.75$.",
       "images": {},
-      "metadata": undefined,
       "replace": false,
       "widgets": {},
     },
@@ -5917,13 +5085,11 @@ The graph of the solution of the inequality, $c ≥ 8.75$, looks like this:
           "width": 460,
         },
       },
-      "metadata": undefined,
       "replace": false,
       "widgets": {
         "number-line 3": {
           "alignment": "default",
           "graded": true,
-          "key": undefined,
           "options": {
             "correctRel": "ge",
             "correctX": 8.75,
@@ -5945,7 +5111,6 @@ The graph of the solution of the inequality, $c ≥ 8.75$, looks like this:
               5,
               10,
             ],
-            "showTooltip": undefined,
             "showTooltips": false,
             "snapDivisions": 2,
             "static": false,
@@ -5993,12 +5158,10 @@ The graph of the solution of the inequality, $c ≥ 8.75$, looks like this:
         "width": 460,
       },
     },
-    "metadata": undefined,
     "widgets": {
       "expression 1": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "answerForms": [
             {
@@ -6009,20 +5172,17 @@ The graph of the solution of the inequality, $c ≥ 8.75$, looks like this:
               "value": "1.2c+3\\ge13.5",
             },
           ],
-          "ariaLabel": undefined,
           "buttonSets": [
             "basic",
             "basic relations",
             "advanced relations",
           ],
-          "buttonsVisible": undefined,
           "functions": [
             "f",
             "g",
             "h",
           ],
           "times": false,
-          "visibleLabel": undefined,
         },
         "static": false,
         "type": "expression",
@@ -6034,7 +5194,6 @@ The graph of the solution of the inequality, $c ≥ 8.75$, looks like this:
       "number-line 1": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "correctRel": "ge",
           "correctX": 8.75,
@@ -6056,7 +5215,6 @@ The graph of the solution of the inequality, $c ≥ 8.75$, looks like this:
             5,
             10,
           ],
-          "showTooltip": undefined,
           "showTooltips": false,
           "snapDivisions": 2,
           "static": false,
@@ -6076,7 +5234,6 @@ The graph of the solution of the inequality, $c ≥ 8.75$, looks like this:
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/number-line-missing-static.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -6090,12 +5247,9 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/number-line-missing-
 
 ",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "number-line 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "correctRel": "eq",
           "correctX": 0.5,
@@ -6117,12 +5271,10 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/number-line-missing-
             0,
             1,
           ],
-          "showTooltip": undefined,
           "snapDivisions": 1,
           "static": false,
           "tickStep": null,
         },
-        "static": undefined,
         "type": "number-line",
         "version": {
           "major": 0,
@@ -6136,7 +5288,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/number-line-missing-
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/number-line-with-empty-strings-in-label-range.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -6154,15 +5305,11 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/number-line-with-emp
           "width": 460,
         },
       },
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
       "content": "On the number line, numbers to the left are less than numbers to the right.",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
@@ -6175,8 +5322,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/number-line-with-emp
           "width": 460,
         },
       },
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
   ],
@@ -6192,12 +5337,9 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/number-line-with-emp
 
 ",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "number-line 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "correctRel": "eq",
           "correctX": -0.375,
@@ -6218,12 +5360,10 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/number-line-with-emp
             -1,
             1,
           ],
-          "showTooltip": undefined,
           "snapDivisions": 2,
           "static": false,
           "tickStep": null,
         },
-        "static": undefined,
         "type": "number-line",
         "version": {
           "major": 0,
@@ -6231,43 +5371,29 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/number-line-with-emp
         },
       },
       "radio 2": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "choices": [
             {
-              "clue": undefined,
               "content": " $\\,-1\\,\\,\\,<\\,-10$",
               "correct": false,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
             {
-              "clue": undefined,
               "content": " $-10\\,\\,\\,<\\,\\,\\,1$",
               "correct": true,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
             {
-              "clue": undefined,
               "content": "  $\\,\\,\\,\\,\\,10\\,\\,\\,< \\,-1$",
               "correct": false,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
           ],
-          "countChoices": undefined,
           "deselectEnabled": false,
           "displayCount": null,
-          "hasNoneOfTheAbove": undefined,
           "multipleSelect": true,
           "noneOfTheAbove": false,
           "onePerLine": true,
           "randomize": true,
         },
-        "static": undefined,
         "type": "radio",
         "version": {
           "major": 0,
@@ -6281,7 +5407,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/number-line-with-emp
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/number-line-with-null-correctX.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -6292,22 +5417,16 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/number-line-with-nul
 
 $=(31-31) -8$",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
       "content": "$ =0-8$",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
       "content": "$=-8$",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
   ],
@@ -6320,12 +5439,9 @@ $=(31-31) -8$",
 
  [[☃ numeric-input 1]]",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "number-line 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "correctRel": "eq",
           "correctX": null,
@@ -6334,7 +5450,6 @@ $=(31-31) -8$",
             12,
           ],
           "initialX": null,
-          "isTickCtrl": undefined,
           "labelRange": [
             null,
             null,
@@ -6346,12 +5461,10 @@ $=(31-31) -8$",
             0,
             10,
           ],
-          "showTooltip": undefined,
           "snapDivisions": 2,
           "static": false,
           "tickStep": null,
         },
-        "static": undefined,
         "type": "number-line",
         "version": {
           "major": 0,
@@ -6359,14 +5472,10 @@ $=(31-31) -8$",
         },
       },
       "numeric-input 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
-          "answerForms": undefined,
           "answers": [
             {
-              "answerForms": undefined,
               "maxError": null,
               "message": "",
               "simplify": "required",
@@ -6376,12 +5485,9 @@ $=(31-31) -8$",
             },
           ],
           "coefficient": false,
-          "labelText": undefined,
-          "rightAlign": undefined,
           "size": "normal",
           "static": false,
         },
-        "static": undefined,
         "type": "numeric-input",
         "version": {
           "major": 0,
@@ -6395,7 +5501,6 @@ $=(31-31) -8$",
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-answer-with-null-value.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -6409,14 +5514,10 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-answer
 
 [[☃ numeric-input 1]]",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "numeric-input 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
-          "answerForms": undefined,
           "answers": [
             {
               "answerForms": [],
@@ -6429,12 +5530,9 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-answer
             },
           ],
           "coefficient": false,
-          "labelText": undefined,
-          "rightAlign": undefined,
           "size": "normal",
           "static": false,
         },
-        "static": undefined,
         "type": "numeric-input",
         "version": {
           "major": 0,
@@ -6448,7 +5546,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-answer
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-answer-with-simplify-true.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -6456,15 +5553,11 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-answer
     {
       "content": "$= \\dfrac{9 \\times 1}{2 \\times 4}$",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
       "content": "$= \\dfrac{9}{8}$",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
   ],
@@ -6477,17 +5570,13 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-answer
 
 [[☃ numeric-input 1]]",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "numeric-input 1": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
-          "answerForms": undefined,
           "answers": [
             {
-              "answerForms": undefined,
               "maxError": 0,
               "message": "",
               "simplify": "true",
@@ -6498,11 +5587,9 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-answer
           ],
           "coefficient": false,
           "labelText": "",
-          "rightAlign": undefined,
           "size": "normal",
           "static": false,
         },
-        "static": undefined,
         "type": "numeric-input",
         "version": {
           "major": 0,
@@ -6516,7 +5603,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-answer
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-answer-without-value.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
     "chi2Table": false,
@@ -6534,7 +5620,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-answer
 
 Let's perform this multiplication to find the answer.",
       "images": {},
-      "metadata": undefined,
       "replace": false,
       "widgets": {},
     },
@@ -6543,7 +5628,6 @@ Let's perform this multiplication to find the answer.",
 
 $\\dfrac{2}{3}\\times \\dfrac{2}{3}\\times\\dfrac{2}{3}=\\boxed{\\dfrac{8}{27}}$.",
       "images": {},
-      "metadata": undefined,
       "replace": false,
       "widgets": {},
     },
@@ -6555,12 +5639,10 @@ $\\dfrac{2}{3}\\times \\dfrac{2}{3}\\times\\dfrac{2}{3}=\\boxed{\\dfrac{8}{27}}$
   "question": {
     "content": "$\\bigg(\\dfrac{2}{3} \\bigg)^3 =$ [[☃ expression 1]]",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "expression 1": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "answerForms": [
             {
@@ -6587,11 +5669,9 @@ $\\dfrac{2}{3}\\times \\dfrac{2}{3}\\times\\dfrac{2}{3}=\\boxed{\\dfrac{8}{27}}$
               "value": "\\frac{8}{27}",
             },
           ],
-          "ariaLabel": undefined,
           "buttonSets": [
             "basic",
           ],
-          "buttonsVisible": undefined,
           "functions": [
             "f",
             "g",
@@ -6599,7 +5679,6 @@ $\\dfrac{2}{3}\\times \\dfrac{2}{3}\\times\\dfrac{2}{3}=\\boxed{\\dfrac{8}{27}}$
           ],
           "static": false,
           "times": false,
-          "visibleLabel": undefined,
         },
         "static": false,
         "type": "expression",
@@ -6611,9 +5690,7 @@ $\\dfrac{2}{3}\\times \\dfrac{2}{3}\\times\\dfrac{2}{3}=\\boxed{\\dfrac{8}{27}}$
       "numeric-input 1": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
-          "answerForms": undefined,
           "answers": [
             {
               "answerForms": [
@@ -6625,7 +5702,6 @@ $\\dfrac{2}{3}\\times \\dfrac{2}{3}\\times\\dfrac{2}{3}=\\boxed{\\dfrac{8}{27}}$
               "simplify": "required",
               "status": "correct",
               "strict": false,
-              "value": undefined,
             },
           ],
           "coefficient": false,
@@ -6649,7 +5725,6 @@ $\\dfrac{2}{3}\\times \\dfrac{2}{3}\\times\\dfrac{2}{3}=\\boxed{\\dfrac{8}{27}}$
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-missing-coefficient.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -6667,14 +5742,10 @@ What is the radius of the mattress when it is rolled up into a cylinder.
 
 [[☃ numeric-input 1]] ",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "numeric-input 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
-          "answerForms": undefined,
           "answers": [
             {
               "answerForms": [],
@@ -6687,12 +5758,9 @@ What is the radius of the mattress when it is rolled up into a cylinder.
             },
           ],
           "coefficient": false,
-          "labelText": undefined,
-          "rightAlign": undefined,
           "size": "normal",
           "static": false,
         },
-        "static": undefined,
         "type": "numeric-input",
         "version": {
           "major": 0,
@@ -6706,7 +5774,6 @@ What is the radius of the mattress when it is rolled up into a cylinder.
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-missing-labelText.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -6714,13 +5781,9 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-missin
     {
       "content": "Heart rate is measured in beats per minute: $\\dfrac{beats}{minutes}$",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {
         "expression 1": {
-          "alignment": undefined,
           "graded": true,
-          "key": undefined,
           "options": {
             "answerForms": [
               {
@@ -6743,7 +5806,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-missin
             "times": false,
             "visibleLabel": undefined,
           },
-          "static": undefined,
           "type": "expression",
           "version": {
             "major": 1,
@@ -6751,20 +5813,15 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-missin
           },
         },
         "input-number 1": {
-          "alignment": undefined,
           "graded": true,
-          "key": undefined,
           "options": {
             "answerType": "number",
-            "customKeypad": undefined,
             "inexact": false,
             "maxError": 0.1,
-            "rightAlign": undefined,
             "simplify": "required",
             "size": "normal",
             "value": 0,
           },
-          "static": undefined,
           "type": "input-number",
           "version": {
             "major": 0,
@@ -6772,9 +5829,7 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-missin
           },
         },
         "passage 1": {
-          "alignment": undefined,
           "graded": true,
-          "key": undefined,
           "options": {
             "footnotes": "",
             "passageText": "",
@@ -6782,7 +5837,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-missin
             "showLineNumbers": true,
             "static": false,
           },
-          "static": undefined,
           "type": "passage",
           "version": {
             "major": 0,
@@ -6796,13 +5850,9 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-missin
 
 ",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {
         "expression 1": {
-          "alignment": undefined,
           "graded": true,
-          "key": undefined,
           "options": {
             "answerForms": [
               {
@@ -6825,7 +5875,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-missin
             "times": false,
             "visibleLabel": undefined,
           },
-          "static": undefined,
           "type": "expression",
           "version": {
             "major": 1,
@@ -6833,17 +5882,10 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-missin
           },
         },
         "image 1": {
-          "alignment": undefined,
           "graded": true,
-          "key": undefined,
           "options": {
-            "alt": undefined,
             "backgroundImage": {
-              "bottom": undefined,
               "height": 0,
-              "left": undefined,
-              "scale": undefined,
-              "top": undefined,
               "url": null,
               "width": 0,
             },
@@ -6863,10 +5905,8 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-missin
                 10,
               ],
             ],
-            "static": undefined,
             "title": "",
           },
-          "static": undefined,
           "type": "image",
           "version": {
             "major": 0,
@@ -6885,36 +5925,26 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-missin
           "width": 342,
         },
       },
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
       "content": "From the previous calculation, we get 96 beats per minute as  Lance's active heart rate.",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
       "content": "To find the difference between the active and resting heart rate, subtract the resting heart rate from the active heart rate. The next hint shows this.",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
       "content": "$96$ $bpm$ $-$ $32$ $bpm$ $=$ $64$ $bpm$",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
       "content": "The difference between Lance Armstrong's  active and resting heart rate is $64$ $bpm$. ",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
   ],
@@ -6940,12 +5970,9 @@ Heart rate is described as the number of heart beats per minute.  The normal hum
         "width": 478,
       },
     },
-    "metadata": undefined,
     "widgets": {
       "expression 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "answerForms": [
             {
@@ -6968,7 +5995,6 @@ Heart rate is described as the number of heart beats per minute.  The normal hum
           "times": false,
           "visibleLabel": undefined,
         },
-        "static": undefined,
         "type": "expression",
         "version": {
           "major": 1,
@@ -6976,14 +6002,10 @@ Heart rate is described as the number of heart beats per minute.  The normal hum
         },
       },
       "numeric-input 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
-          "answerForms": undefined,
           "answers": [
             {
-              "answerForms": undefined,
               "maxError": null,
               "message": "",
               "simplify": "required",
@@ -6993,12 +6015,9 @@ Heart rate is described as the number of heart beats per minute.  The normal hum
             },
           ],
           "coefficient": false,
-          "labelText": undefined,
-          "rightAlign": undefined,
           "size": "normal",
           "static": false,
         },
-        "static": undefined,
         "type": "numeric-input",
         "version": {
           "major": 0,
@@ -7006,9 +6025,7 @@ Heart rate is described as the number of heart beats per minute.  The normal hum
         },
       },
       "sequence 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "json": [
             {
@@ -7018,7 +6035,6 @@ Heart rate is described as the number of heart beats per minute.  The normal hum
             },
           ],
         },
-        "static": undefined,
         "type": "deprecated-standin",
         "version": {
           "major": 0,
@@ -7032,7 +6048,6 @@ Heart rate is described as the number of heart beats per minute.  The normal hum
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-with-simplify-false.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
     "chi2Table": false,
@@ -7058,17 +6073,13 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-with-s
         "width": 285,
       },
     },
-    "metadata": undefined,
     "widgets": {
       "numeric-input 1": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
-          "answerForms": undefined,
           "answers": [
             {
-              "answerForms": undefined,
               "maxError": 0,
               "message": "",
               "simplify": "false",
@@ -7098,7 +6109,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/numeric-input-with-s
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/orderer-option-missing-images.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
     "chi2Table": false,
@@ -7115,13 +6125,11 @@ To **decompose** a number, we break it into smaller parts.
 
 A **unit fraction** is a fraction with a numerator of $1$. [[☃ explanation 2]]",
       "images": {},
-      "metadata": undefined,
       "replace": false,
       "widgets": {
         "explanation 1": {
           "alignment": "default",
           "graded": true,
-          "key": undefined,
           "options": {
             "explanation": "We can decompose $54$ into $50+4$.",
             "hidePrompt": "Okay, got it",
@@ -7139,7 +6147,6 @@ A **unit fraction** is a fraction with a numerator of $1$. [[☃ explanation 2]]
         "explanation 2": {
           "alignment": "default",
           "graded": true,
-          "key": undefined,
           "options": {
             "explanation": "$\\dfrac15$ is a unit fraction because the numerator (top number) is $1$.",
             "hidePrompt": "Okay, got it",
@@ -7175,13 +6182,11 @@ Let's decompose $\\dfrac59$ into unit fractions.
           "width": 400,
         },
       },
-      "metadata": undefined,
       "replace": false,
       "widgets": {
         "explanation 1": {
           "alignment": "default",
           "graded": true,
-          "key": undefined,
           "options": {
             "explanation": "
 
@@ -7203,76 +6208,61 @@ $\\dfrac59$ can be broken up into $\\dfrac19+\\dfrac19+\\dfrac19+\\dfrac19+\\dfr
         "graded-group 1": {
           "alignment": "default",
           "graded": true,
-          "key": undefined,
           "options": {
             "content": "**Drag the cards to create an expression that is equivalent to $\\dfrac59$.**
 
 [[☃ orderer 1]]",
-            "hasHint": undefined,
-            "hint": undefined,
             "images": {},
-            "immutableWidgets": undefined,
             "title": "",
-            "widgetEnabled": undefined,
             "widgets": {
               "orderer 1": {
                 "alignment": "default",
                 "graded": true,
-                "key": undefined,
                 "options": {
                   "correctOptions": [
                     {
                       "content": "$\\dfrac19$",
                       "images": {},
-                      "metadata": undefined,
                       "widgets": {},
                     },
                     {
                       "content": "$+$",
                       "images": {},
-                      "metadata": undefined,
                       "widgets": {},
                     },
                     {
                       "content": "$\\dfrac19$",
                       "images": {},
-                      "metadata": undefined,
                       "widgets": {},
                     },
                     {
                       "content": "$+$",
                       "images": {},
-                      "metadata": undefined,
                       "widgets": {},
                     },
                     {
                       "content": "$\\dfrac19$",
                       "images": {},
-                      "metadata": undefined,
                       "widgets": {},
                     },
                     {
                       "content": "$+$",
                       "images": {},
-                      "metadata": undefined,
                       "widgets": {},
                     },
                     {
                       "content": "$\\dfrac19$",
                       "images": {},
-                      "metadata": undefined,
                       "widgets": {},
                     },
                     {
                       "content": "$+$",
                       "images": {},
-                      "metadata": undefined,
                       "widgets": {},
                     },
                     {
                       "content": "$\\dfrac19$",
                       "images": {},
-                      "metadata": undefined,
                       "widgets": {},
                     },
                   ],
@@ -7282,13 +6272,11 @@ $\\dfrac59$ can be broken up into $\\dfrac19+\\dfrac19+\\dfrac19+\\dfrac19+\\dfr
                     {
                       "content": "$\\dfrac19$",
                       "images": {},
-                      "metadata": undefined,
                       "widgets": {},
                     },
                     {
                       "content": "$+$",
                       "images": {},
-                      "metadata": undefined,
                       "widgets": {},
                     },
                   ],
@@ -7332,13 +6320,11 @@ How can we decompose $\\dfrac38$?
           "width": 96,
         },
       },
-      "metadata": undefined,
       "replace": false,
       "widgets": {
         "explanation 1": {
           "alignment": "default",
           "graded": true,
-          "key": undefined,
           "options": {
             "explanation": "$\\dfrac18+\\dfrac18+\\dfrac18$
 
@@ -7358,7 +6344,6 @@ How can we decompose $\\dfrac38$?
         "graded-group 1": {
           "alignment": "default",
           "graded": true,
-          "key": undefined,
           "options": {
             "content": "**Write an expression decomposing $\\dfrac38$ into unit fractions.**
 
@@ -7367,17 +6352,12 @@ How can we decompose $\\dfrac38$?
 [[☃ expression 1]]
 
 ",
-            "hasHint": undefined,
-            "hint": undefined,
             "images": {},
-            "immutableWidgets": undefined,
             "title": "",
-            "widgetEnabled": undefined,
             "widgets": {
               "expression 1": {
                 "alignment": "default",
                 "graded": true,
-                "key": undefined,
                 "options": {
                   "answerForms": [
                     {
@@ -7388,18 +6368,15 @@ How can we decompose $\\dfrac38$?
                       "value": "\\frac{1}{8}+\\frac{1}{8}+\\frac{1}{8}",
                     },
                   ],
-                  "ariaLabel": undefined,
                   "buttonSets": [
                     "basic",
                   ],
-                  "buttonsVisible": undefined,
                   "functions": [
                     "f",
                     "g",
                     "h",
                   ],
                   "times": true,
-                  "visibleLabel": undefined,
                 },
                 "static": false,
                 "type": "expression",
@@ -7435,13 +6412,11 @@ How can we decompose $\\dfrac64$?
           "width": 410,
         },
       },
-      "metadata": undefined,
       "replace": false,
       "widgets": {
         "explanation 1": {
           "alignment": "default",
           "graded": true,
-          "key": undefined,
           "options": {
             "explanation": "$\\dfrac14+\\dfrac14+\\dfrac14+\\dfrac14+\\dfrac14+\\dfrac14$",
             "hidePrompt": "Hide solution",
@@ -7459,90 +6434,73 @@ How can we decompose $\\dfrac64$?
         "graded-group 1": {
           "alignment": "default",
           "graded": true,
-          "key": undefined,
           "options": {
             "content": "**Drag the cards to create an expression that is equivalent to $\\dfrac64$.**
 
 [[☃ orderer 1]]
 
 ",
-            "hasHint": undefined,
-            "hint": undefined,
             "images": {},
-            "immutableWidgets": undefined,
             "title": "",
-            "widgetEnabled": undefined,
             "widgets": {
               "orderer 1": {
                 "alignment": "default",
                 "graded": true,
-                "key": undefined,
                 "options": {
                   "correctOptions": [
                     {
                       "content": "$\\dfrac14$",
                       "images": {},
-                      "metadata": undefined,
                       "widgets": {},
                     },
                     {
                       "content": "$+$",
                       "images": {},
-                      "metadata": undefined,
                       "widgets": {},
                     },
                     {
                       "content": "$\\dfrac14$",
                       "images": {},
-                      "metadata": undefined,
                       "widgets": {},
                     },
                     {
                       "content": "$+$",
                       "images": {},
-                      "metadata": undefined,
                       "widgets": {},
                     },
                     {
                       "content": "$\\dfrac14$",
                       "images": {},
-                      "metadata": undefined,
                       "widgets": {},
                     },
                     {
                       "content": "$+$",
                       "images": {},
-                      "metadata": undefined,
                       "widgets": {},
                     },
                     {
                       "content": "$\\dfrac14$",
                       "images": {},
-                      "metadata": undefined,
                       "widgets": {},
                     },
                     {
                       "content": "$+$",
                       "images": {},
-                      "metadata": undefined,
                       "widgets": {},
                     },
                     {
                       "content": "$\\dfrac14$",
                       "images": {},
-                      "metadata": undefined,
                       "widgets": {},
                     },
                     {
                       "content": "$+$",
                       "images": {},
-                      "metadata": undefined,
                       "widgets": {},
                     },
                     {
                       "content": "$\\dfrac14$",
                       "images": {},
-                      "metadata": undefined,
                       "widgets": {},
                     },
                   ],
@@ -7552,13 +6510,11 @@ How can we decompose $\\dfrac64$?
                     {
                       "content": "$\\dfrac14$",
                       "images": {},
-                      "metadata": undefined,
                       "widgets": {},
                     },
                     {
                       "content": "$+$",
                       "images": {},
-                      "metadata": undefined,
                       "widgets": {},
                     },
                   ],
@@ -7613,13 +6569,11 @@ How can we decompose $\\dfrac64$?
 
 [[☃ explanation 4]]",
       "images": {},
-      "metadata": undefined,
       "replace": false,
       "widgets": {
         "explanation 1": {
           "alignment": "default",
           "graded": true,
-          "key": undefined,
           "options": {
             "explanation": "$\\dfrac29=\\dfrac19+\\dfrac19$",
             "hidePrompt": "Hide solution",
@@ -7637,7 +6591,6 @@ How can we decompose $\\dfrac64$?
         "explanation 2": {
           "alignment": "default",
           "graded": true,
-          "key": undefined,
           "options": {
             "explanation": "$\\dfrac13+\\dfrac13+\\dfrac13+\\dfrac13+\\dfrac13$",
             "hidePrompt": "Hide solution",
@@ -7655,7 +6608,6 @@ How can we decompose $\\dfrac64$?
         "explanation 3": {
           "alignment": "default",
           "graded": true,
-          "key": undefined,
           "options": {
             "explanation": "$\\dfrac16+\\dfrac16+\\dfrac16+\\dfrac16+\\dfrac16=\\dfrac56$
 ",
@@ -7674,7 +6626,6 @@ How can we decompose $\\dfrac64$?
         "explanation 4": {
           "alignment": "default",
           "graded": true,
-          "key": undefined,
           "options": {
             "explanation": "
 
@@ -7698,54 +6649,38 @@ $\\dfrac23$ | $\\dfrac13+\\dfrac13$",
         "graded-group 1": {
           "alignment": "default",
           "graded": true,
-          "key": undefined,
           "options": {
             "content": "**Which shows $\\dfrac29$ decomposed into unit fractions?**
 
 [[☃ radio 1]]
 
 ",
-            "hasHint": undefined,
-            "hint": undefined,
             "images": {},
-            "immutableWidgets": undefined,
             "title": "",
-            "widgetEnabled": undefined,
             "widgets": {
               "radio 1": {
                 "alignment": "default",
                 "graded": true,
-                "key": undefined,
                 "options": {
                   "choices": [
                     {
-                      "clue": undefined,
                       "content": "$\\dfrac19+\\dfrac19$",
                       "correct": true,
-                      "isNoneOfTheAbove": undefined,
-                      "widgets": undefined,
                     },
                     {
-                      "clue": undefined,
                       "content": "$\\dfrac12+\\dfrac12+\\dfrac12+\\dfrac12+\\dfrac12+\\dfrac12+\\dfrac12+\\dfrac12+\\dfrac12$",
                       "correct": false,
-                      "isNoneOfTheAbove": undefined,
-                      "widgets": undefined,
                     },
                     {
-                      "clue": undefined,
                       "content": "$\\dfrac19+\\dfrac29$",
                       "correct": false,
                       "isNoneOfTheAbove": false,
-                      "widgets": undefined,
                     },
                   ],
-                  "countChoices": undefined,
                   "deselectEnabled": false,
                   "displayCount": null,
                   "hasNoneOfTheAbove": false,
                   "multipleSelect": false,
-                  "noneOfTheAbove": undefined,
                   "onePerLine": true,
                   "randomize": false,
                 },
@@ -7768,7 +6703,6 @@ $\\dfrac23$ | $\\dfrac13+\\dfrac13$",
         "graded-group 2": {
           "alignment": "default",
           "graded": true,
-          "key": undefined,
           "options": {
             "content": "**Write an expression showing $\\dfrac53$ decomposed into unit fractions.**
 
@@ -7777,17 +6711,12 @@ $\\dfrac23$ | $\\dfrac13+\\dfrac13$",
 
 
 ",
-            "hasHint": undefined,
-            "hint": undefined,
             "images": {},
-            "immutableWidgets": undefined,
             "title": "",
-            "widgetEnabled": undefined,
             "widgets": {
               "expression 1": {
                 "alignment": "default",
                 "graded": true,
-                "key": undefined,
                 "options": {
                   "answerForms": [
                     {
@@ -7798,18 +6727,15 @@ $\\dfrac23$ | $\\dfrac13+\\dfrac13$",
                       "value": "\\frac{1}{3}+\\frac{1}{3}+\\frac{1}{3}+\\frac{1}{3}+\\frac{1}{3}",
                     },
                   ],
-                  "ariaLabel": undefined,
                   "buttonSets": [
                     "basic",
                   ],
-                  "buttonsVisible": undefined,
                   "functions": [
                     "f",
                     "g",
                     "h",
                   ],
                   "times": false,
-                  "visibleLabel": undefined,
                 },
                 "static": false,
                 "type": "expression",
@@ -7830,7 +6756,6 @@ $\\dfrac23$ | $\\dfrac13+\\dfrac13$",
         "graded-group 3": {
           "alignment": "default",
           "graded": true,
-          "key": undefined,
           "options": {
             "content": "**What fraction is equal to $\\dfrac16+\\dfrac16+\\dfrac16+\\dfrac16+\\dfrac16$?**
 
@@ -7839,19 +6764,13 @@ $\\dfrac23$ | $\\dfrac13+\\dfrac13$",
 
 
 ",
-            "hasHint": undefined,
-            "hint": undefined,
             "images": {},
-            "immutableWidgets": undefined,
             "title": "",
-            "widgetEnabled": undefined,
             "widgets": {
               "numeric-input 1": {
                 "alignment": "default",
                 "graded": true,
-                "key": undefined,
                 "options": {
-                  "answerForms": undefined,
                   "answers": [
                     {
                       "answerForms": [
@@ -7868,7 +6787,6 @@ $\\dfrac23$ | $\\dfrac13+\\dfrac13$",
                   ],
                   "coefficient": false,
                   "labelText": "",
-                  "rightAlign": undefined,
                   "size": "normal",
                   "static": false,
                 },
@@ -7891,7 +6809,6 @@ $\\dfrac23$ | $\\dfrac13+\\dfrac13$",
         "graded-group 4": {
           "alignment": "default",
           "graded": true,
-          "key": undefined,
           "options": {
             "content": "**Match each fraction to its equivalent expression.**
 
@@ -7900,17 +6817,12 @@ $\\dfrac23$ | $\\dfrac13+\\dfrac13$",
 
 
 ",
-            "hasHint": undefined,
-            "hint": undefined,
             "images": {},
-            "immutableWidgets": undefined,
             "title": "",
-            "widgetEnabled": undefined,
             "widgets": {
               "matcher 1": {
                 "alignment": "default",
                 "graded": true,
-                "key": undefined,
                 "options": {
                   "labels": [
                     "Fraction",
@@ -7955,7 +6867,6 @@ $\\dfrac23$ | $\\dfrac13+\\dfrac13$",
   "question": {
     "content": "",
     "images": {},
-    "metadata": undefined,
     "widgets": {},
   },
 }
@@ -7963,7 +6874,6 @@ $\\dfrac23$ | $\\dfrac13+\\dfrac13$",
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/orderer-option-missing-widgets.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -7972,19 +6882,14 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/orderer-option-missi
       "content": "Extinction is a natural process, and the rate of extinction can be determined by studying changes in biodiversity during the history of life on Earth.
 ",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {
         "orderer 1": {
-          "alignment": undefined,
           "graded": true,
-          "key": undefined,
           "options": {
             "correctOptions": [
               {
                 "content": "$x$",
                 "images": {},
-                "metadata": undefined,
                 "widgets": {},
               },
             ],
@@ -7994,13 +6899,11 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/orderer-option-missi
               {
                 "content": "$x$",
                 "images": {},
-                "metadata": undefined,
                 "widgets": {},
               },
               {
                 "content": "$y$",
                 "images": {},
-                "metadata": undefined,
                 "widgets": {},
               },
             ],
@@ -8008,12 +6911,10 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/orderer-option-missi
               {
                 "content": "$y$",
                 "images": {},
-                "metadata": undefined,
                 "widgets": {},
               },
             ],
           },
-          "static": undefined,
           "type": "orderer",
           "version": {
             "major": 0,
@@ -8025,8 +6926,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/orderer-option-missi
     {
       "content": "Humans are causing a current sixth mass extinction event, but are not the only reason species go extinct.",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
   ],
@@ -8046,53 +6945,35 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/orderer-option-missi
         "width": 396,
       },
     },
-    "metadata": undefined,
     "widgets": {
       "radio 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "choices": [
             {
-              "clue": undefined,
               "content": "a.	the rate of extinction that balances the rate of speciation",
               "correct": false,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
             {
-              "clue": undefined,
               "content": "b.	the average rate at which extinctions have occurred naturally in the geologic past, without human involvement",
               "correct": true,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
             {
-              "clue": undefined,
               "content": "c.	the rate of extinction that is currently occurring in protected areas like national parks and marine sanctuaries",
               "correct": false,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
             {
-              "clue": undefined,
               "content": "d.	the rate of extinction that can be determined by using Geiger counters and detecting radiation",
               "correct": false,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
           ],
-          "countChoices": undefined,
           "deselectEnabled": false,
           "displayCount": null,
-          "hasNoneOfTheAbove": undefined,
           "multipleSelect": false,
           "noneOfTheAbove": false,
           "onePerLine": true,
           "randomize": false,
         },
-        "static": undefined,
         "type": "radio",
         "version": {
           "major": 0,
@@ -8106,7 +6987,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/orderer-option-missi
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/orderer-with-invalid-height.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -8114,12 +6994,9 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/orderer-with-invalid
     {
       "content": "The doric is the oldest and simplest order, the Corinthian is the latest and most complex.",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
   ],
-  "itemDataVersion": undefined,
   "question": {
     "content": "Here is a doric, ionic and corinthian capital. Put these  in the chronological order of their development. [[☃ orderer 1]]
 
@@ -8132,30 +7009,23 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/orderer-with-invalid
 
 ",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "orderer 1": {
-        "alignment": undefined,
-        "graded": undefined,
-        "key": undefined,
         "options": {
           "correctOptions": [
             {
               "content": "![](https://ka-perseus-images.s3.amazonaws.com/a9387c1491bb743a0c76d2ab74c4dd145c964c7b.jpeg)",
               "images": {},
-              "metadata": undefined,
               "widgets": {},
             },
             {
               "content": "![](https://ka-perseus-images.s3.amazonaws.com/45ff66c9387dcb419651883677cfb11fbbf8e075.jpeg)",
               "images": {},
-              "metadata": undefined,
               "widgets": {},
             },
             {
               "content": "![](https://ka-perseus-images.s3.amazonaws.com/54ea9b0cf1a57bf2879772ea81f656264605d75e.jpeg)",
               "images": {},
-              "metadata": undefined,
               "widgets": {},
             },
           ],
@@ -8165,27 +7035,22 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/orderer-with-invalid
             {
               "content": "![](https://ka-perseus-images.s3.amazonaws.com/45ff66c9387dcb419651883677cfb11fbbf8e075.jpeg)",
               "images": {},
-              "metadata": undefined,
               "widgets": {},
             },
             {
               "content": "![](https://ka-perseus-images.s3.amazonaws.com/54ea9b0cf1a57bf2879772ea81f656264605d75e.jpeg)",
               "images": {},
-              "metadata": undefined,
               "widgets": {},
             },
             {
               "content": "![](https://ka-perseus-images.s3.amazonaws.com/a9387c1491bb743a0c76d2ab74c4dd145c964c7b.jpeg)",
               "images": {},
-              "metadata": undefined,
               "widgets": {},
             },
           ],
           "otherOptions": [],
         },
-        "static": undefined,
         "type": "orderer",
-        "version": undefined,
       },
     },
   },
@@ -8194,7 +7059,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/orderer-with-invalid
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/orderer-with-undefined-options.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
     "chi2Table": false,
@@ -8225,20 +7089,14 @@ A free body diagram of the **box** is shown below.
         "width": 400,
       },
     },
-    "metadata": undefined,
     "widgets": {
       "image 1": {
         "alignment": "block",
         "graded": true,
-        "key": undefined,
         "options": {
           "alt": "A woman places a box on a shelf and pushes it to the left, sliding it further onto the shelf.",
           "backgroundImage": {
-            "bottom": undefined,
             "height": 263,
-            "left": undefined,
-            "scale": undefined,
-            "top": undefined,
             "url": "https://cdn.kastatic.org/ka-content-images/89e2cabd1261ec9119c501bd6c9c0f541e09ab2f.png",
             "width": 400,
           },
@@ -8271,15 +7129,10 @@ A free body diagram of the **box** is shown below.
       "image 2": {
         "alignment": "block",
         "graded": true,
-        "key": undefined,
         "options": {
           "alt": "A model shows a square with four arrows pointing out of it. An arrow points down and is labelled F g. Another arrow points up and is labelled F N. Another arrow points left and is labelled F a. Another arrow points right and is labelled F f.",
           "backgroundImage": {
-            "bottom": undefined,
             "height": 306,
-            "left": undefined,
-            "scale": undefined,
-            "top": undefined,
             "url": "https://cdn.kastatic.org/ka-content-images/48c2597aa0e5a7ac27771cfc2e7c955c7cb14881.svg",
             "width": 300,
           },
@@ -8310,15 +7163,11 @@ A free body diagram of the **box** is shown below.
         },
       },
       "orderer 1": {
-        "alignment": undefined,
-        "graded": undefined,
-        "key": undefined,
         "options": {
           "correctOptions": [
             {
               "content": "$x$",
               "images": {},
-              "metadata": undefined,
               "widgets": {},
             },
           ],
@@ -8329,12 +7178,10 @@ A free body diagram of the **box** is shown below.
             {
               "content": "$y$",
               "images": {},
-              "metadata": undefined,
               "widgets": {},
             },
           ],
         },
-        "static": undefined,
         "type": "orderer",
         "version": {
           "major": 0,
@@ -8344,36 +7191,29 @@ A free body diagram of the **box** is shown below.
       "radio 1": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "choices": [
             {
               "clue": "$F_\\text{N}$ results from the box interacting with the shelf.",
               "content": "normal force $(F_\\text{N})$",
               "correct": true,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
             {
               "clue": "$F_\\text{g}$ results from the box interacting with Earth.",
               "content": "gravitational force $(F_\\text{g})$",
               "correct": true,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
             {
               "clue": "$F_\\text{a}$ results from the box interacting with the woman's hand.",
               "content": "applied force $(F_\\text{a})$",
               "correct": true,
               "isNoneOfTheAbove": false,
-              "widgets": undefined,
             },
             {
               "clue": "$F_\\text{f}$ results from the box interacting with the shelf.",
               "content": "frictional force $(F_\\text{f})$",
               "correct": true,
               "isNoneOfTheAbove": false,
-              "widgets": undefined,
             },
           ],
           "countChoices": false,
@@ -8381,8 +7221,6 @@ A free body diagram of the **box** is shown below.
           "displayCount": null,
           "hasNoneOfTheAbove": false,
           "multipleSelect": true,
-          "noneOfTheAbove": undefined,
-          "onePerLine": undefined,
           "randomize": true,
         },
         "static": false,
@@ -8395,7 +7233,6 @@ A free body diagram of the **box** is shown below.
       "sorter 1": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "correct": [
             "$x$",
@@ -8419,7 +7256,6 @@ A free body diagram of the **box** is shown below.
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/passage-missing-footnotes-and-title.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -8435,12 +7271,9 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/passage-missing-foot
 
 [[☃ passage-ref 1]]",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "passage 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "footnotes": "",
           "passageText": "a",
@@ -8448,7 +7281,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/passage-missing-foot
           "showLineNumbers": true,
           "static": false,
         },
-        "static": undefined,
         "type": "passage",
         "version": {
           "major": 0,
@@ -8456,15 +7288,11 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/passage-missing-foot
         },
       },
       "passage-ref 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "passageNumber": 1,
           "referenceNumber": 1,
-          "summaryText": undefined,
         },
-        "static": undefined,
         "type": "passage-ref",
         "version": {
           "major": 0,
@@ -8478,7 +7306,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/passage-missing-foot
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/passage-ref-missing-summaryText.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -8486,22 +7313,16 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/passage-ref-missing-
     {
       "content": "Anybody likely to need armor would certainly want to be wearing it. Armor was worn for sport, battle, civil defense, ceremony, and in some cases for hunting. This example—commissioned in 1591 by Sophie of Brandenburg as a Christmas gift for her husband, Christian I (reigned 1586–91)—is one of a set of twelve matching armors for the courtly sport of foot combat.",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
       "content": "Many medieval European cities, such as London, Paris, Frankfurt, Vienna, and Milan, actually required their citizens to own armor and weapons so that they would be able to defend the city in times of war.",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
       "content": "The answer is: All of the above. ",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
   ],
@@ -8519,20 +7340,12 @@ Anton Peffenhauser, *Foot-Combat Armor of Prince-Elector Christian I of Saxony (
 
 ",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "image 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
-          "alt": undefined,
           "backgroundImage": {
-            "bottom": undefined,
             "height": 571,
-            "left": undefined,
-            "scale": undefined,
-            "top": undefined,
             "url": "https://ka-perseus-images.s3.amazonaws.com/3d84aeb69c515789bba289f5118b1d6e2b796ca1.jpg",
             "width": 357,
           },
@@ -8552,11 +7365,9 @@ Anton Peffenhauser, *Foot-Combat Armor of Prince-Elector Christian I of Saxony (
               10,
             ],
           ],
-          "static": undefined,
           "title": "
 ",
         },
-        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -8564,17 +7375,10 @@ Anton Peffenhauser, *Foot-Combat Armor of Prince-Elector Christian I of Saxony (
         },
       },
       "image 2": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
-          "alt": undefined,
           "backgroundImage": {
-            "bottom": undefined,
             "height": 0,
-            "left": undefined,
-            "scale": undefined,
-            "top": undefined,
             "url": null,
             "width": 0,
           },
@@ -8594,10 +7398,8 @@ Anton Peffenhauser, *Foot-Combat Armor of Prince-Elector Christian I of Saxony (
               10,
             ],
           ],
-          "static": undefined,
           "title": "",
         },
-        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -8605,9 +7407,7 @@ Anton Peffenhauser, *Foot-Combat Armor of Prince-Elector Christian I of Saxony (
         },
       },
       "passage 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "footnotes": "",
           "passageText": "",
@@ -8615,7 +7415,6 @@ Anton Peffenhauser, *Foot-Combat Armor of Prince-Elector Christian I of Saxony (
           "showLineNumbers": true,
           "static": false,
         },
-        "static": undefined,
         "type": "passage",
         "version": {
           "major": 0,
@@ -8623,15 +7422,11 @@ Anton Peffenhauser, *Foot-Combat Armor of Prince-Elector Christian I of Saxony (
         },
       },
       "passage-ref 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "passageNumber": 1,
           "referenceNumber": 1,
-          "summaryText": undefined,
         },
-        "static": undefined,
         "type": "passage-ref",
         "version": {
           "major": 0,
@@ -8639,50 +7434,33 @@ Anton Peffenhauser, *Foot-Combat Armor of Prince-Elector Christian I of Saxony (
         },
       },
       "radio 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "choices": [
             {
-              "clue": undefined,
               "content": "Members of the high nobility and the wealthiest of the knightly class",
               "correct": false,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
             {
-              "clue": undefined,
               "content": "Soldiers, members of the civilian militia, and mercenaries",
               "correct": false,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
             {
-              "clue": undefined,
               "content": "Horses and dogs",
               "correct": false,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
             {
               "clue": "Armor (of different styles and quality) was worn by almost all levels of society: high nobility (emperors, dukes, and counts), knights, mercenaries, citizens, peasants, and even young boys. Horses and dogs could also be protected with armor. Price varied considerably based on materials, quality, and decoration.",
               "content": "All of the above",
               "correct": true,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
           ],
-          "countChoices": undefined,
-          "deselectEnabled": undefined,
           "displayCount": null,
-          "hasNoneOfTheAbove": undefined,
           "multipleSelect": false,
           "noneOfTheAbove": false,
           "onePerLine": true,
           "randomize": false,
         },
-        "static": undefined,
         "type": "radio",
         "version": {
           "major": 0,
@@ -8690,36 +7468,22 @@ Anton Peffenhauser, *Foot-Combat Armor of Prince-Elector Christian I of Saxony (
         },
       },
       "radio 2": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "choices": [
             {
-              "clue": undefined,
               "content": "",
-              "correct": undefined,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
             {
-              "clue": undefined,
               "content": "",
-              "correct": undefined,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
           ],
-          "countChoices": undefined,
-          "deselectEnabled": undefined,
           "displayCount": null,
-          "hasNoneOfTheAbove": undefined,
           "multipleSelect": false,
           "noneOfTheAbove": false,
           "onePerLine": true,
           "randomize": false,
         },
-        "static": undefined,
         "type": "radio",
         "version": {
           "major": 0,
@@ -8727,9 +7491,7 @@ Anton Peffenhauser, *Foot-Combat Armor of Prince-Elector Christian I of Saxony (
         },
       },
       "table 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "answers": [
             [
@@ -8751,7 +7513,6 @@ Anton Peffenhauser, *Foot-Combat Armor of Prince-Elector Christian I of Saxony (
           ],
           "rows": 4,
         },
-        "static": undefined,
         "type": "table",
         "version": {
           "major": 0,
@@ -8765,7 +7526,6 @@ Anton Peffenhauser, *Foot-Combat Armor of Prince-Elector Christian I of Saxony (
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/plotter-missing-scaleY-and-snapsPerLine.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -8782,15 +7542,11 @@ $$
 
 $\\green5 - \\red3= \\purple{2}$",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
       "content": "Michaela gjorde $\\purple{2}$ korgar mer än William.  ",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
   ],
@@ -8817,23 +7573,17 @@ $\\green5 - \\red3= \\purple{2}$",
         "width": 474,
       },
     },
-    "metadata": undefined,
     "widgets": {
       "input-number 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "answerType": "number",
-          "customKeypad": undefined,
           "inexact": false,
           "maxError": 0.1,
-          "rightAlign": undefined,
           "simplify": "required",
           "size": "normal",
           "value": 2,
         },
-        "static": undefined,
         "type": "input-number",
         "version": {
           "major": 0,
@@ -8841,9 +7591,6 @@ $\\green5 - \\red3= \\purple{2}$",
         },
       },
       "plotter 1": {
-        "alignment": undefined,
-        "graded": undefined,
-        "key": undefined,
         "options": {
           "categories": [
             "Calista",
@@ -8857,14 +7604,11 @@ $\\green5 - \\red3= \\purple{2}$",
             1,
             1,
           ],
-          "labelInterval": undefined,
           "labels": [
             "Child",
             "Baskets",
           ],
           "maxY": 5,
-          "picBoxHeight": undefined,
-          "picSize": undefined,
           "picUrl": "http://i.imgur.com/B8mGnxB.png",
           "plotDimensions": [
             380,
@@ -8880,9 +7624,7 @@ $\\green5 - \\red3= \\purple{2}$",
           ],
           "type": "pic",
         },
-        "static": undefined,
         "type": "plotter",
-        "version": undefined,
       },
     },
   },
@@ -8891,7 +7633,6 @@ $\\green5 - \\red3= \\purple{2}$",
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/plotter-with-undefined-plotDimensions.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -8899,13 +7640,9 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/plotter-with-undefin
     {
       "content": "If there is a 60° angle to the ground, this gives us a 30-60-90 triangle. ",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {
         "plotter 1": {
-          "alignment": undefined,
           "graded": true,
-          "key": undefined,
           "options": {
             "categories": [
               "",
@@ -8919,9 +7656,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/plotter-with-undefin
               "",
             ],
             "maxY": 10,
-            "picBoxHeight": undefined,
-            "picSize": undefined,
-            "picUrl": undefined,
             "plotDimensions": [
               380,
               300,
@@ -8933,7 +7667,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/plotter-with-undefin
             ],
             "type": "bar",
           },
-          "static": undefined,
           "type": "plotter",
           "version": {
             "major": 0,
@@ -8945,15 +7678,11 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/plotter-with-undefin
     {
       "content": "In this case, the horizontal component of force should be equal to the cos θ multiplied by the force of tension. ",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
     {
       "content": "Since we know θ=60, and T=30N, we can solve: 30cos60 = 15 N.",
       "images": {},
-      "metadata": undefined,
-      "replace": undefined,
       "widgets": {},
     },
   ],
@@ -8968,53 +7697,33 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/plotter-with-undefin
 
 ",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "radio 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "choices": [
             {
-              "clue": undefined,
               "content": "15 N",
               "correct": true,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
             {
-              "clue": undefined,
               "content": "30 N",
               "correct": false,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
             {
-              "clue": undefined,
               "content": "60 N",
-              "correct": undefined,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
             {
-              "clue": undefined,
               "content": "180 N",
-              "correct": undefined,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
           ],
-          "countChoices": undefined,
           "deselectEnabled": false,
           "displayCount": null,
-          "hasNoneOfTheAbove": undefined,
           "multipleSelect": false,
           "noneOfTheAbove": false,
           "onePerLine": true,
           "randomize": true,
         },
-        "static": undefined,
         "type": "radio",
         "version": {
           "major": 0,
@@ -9028,14 +7737,11 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/plotter-with-undefin
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/question-missing-content.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {},
   "hints": [],
-  "itemDataVersion": undefined,
   "question": {
     "content": "",
     "images": {},
-    "metadata": undefined,
     "widgets": {},
   },
 }
@@ -9043,7 +7749,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/question-missing-con
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/radio-choice-missing-content.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -9063,64 +7768,39 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/radio-choice-missing
 
 [[☃ group 4]]",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "group 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "content": "
 
 [[☃ radio 1]]",
           "images": {},
-          "metadata": undefined,
           "widgets": {
             "radio 1": {
-              "alignment": undefined,
               "graded": true,
-              "key": undefined,
               "options": {
                 "choices": [
                   {
-                    "clue": undefined,
                     "content": "",
-                    "correct": undefined,
-                    "isNoneOfTheAbove": undefined,
-                    "widgets": undefined,
                   },
                   {
-                    "clue": undefined,
                     "content": "",
-                    "correct": undefined,
-                    "isNoneOfTheAbove": undefined,
-                    "widgets": undefined,
                   },
                   {
-                    "clue": undefined,
                     "content": "",
-                    "correct": undefined,
-                    "isNoneOfTheAbove": undefined,
-                    "widgets": undefined,
                   },
                   {
-                    "clue": undefined,
                     "content": "",
-                    "correct": undefined,
-                    "isNoneOfTheAbove": undefined,
-                    "widgets": undefined,
                   },
                 ],
-                "countChoices": undefined,
                 "deselectEnabled": false,
                 "displayCount": null,
-                "hasNoneOfTheAbove": undefined,
                 "multipleSelect": false,
                 "noneOfTheAbove": false,
                 "onePerLine": true,
                 "randomize": false,
               },
-              "static": undefined,
               "type": "radio",
               "version": {
                 "major": 0,
@@ -9129,7 +7809,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/radio-choice-missing
             },
           },
         },
-        "static": undefined,
         "type": "group",
         "version": {
           "major": 0,
@@ -9137,61 +7816,37 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/radio-choice-missing
         },
       },
       "group 2": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "content": "
 
 [[☃ radio 1]]",
           "images": {},
-          "metadata": undefined,
           "widgets": {
             "radio 1": {
-              "alignment": undefined,
               "graded": true,
-              "key": undefined,
               "options": {
                 "choices": [
                   {
-                    "clue": undefined,
                     "content": "",
-                    "correct": undefined,
-                    "isNoneOfTheAbove": undefined,
-                    "widgets": undefined,
                   },
                   {
-                    "clue": undefined,
                     "content": "",
-                    "correct": undefined,
-                    "isNoneOfTheAbove": undefined,
-                    "widgets": undefined,
                   },
                   {
-                    "clue": undefined,
                     "content": "",
-                    "correct": undefined,
-                    "isNoneOfTheAbove": undefined,
-                    "widgets": undefined,
                   },
                   {
-                    "clue": undefined,
                     "content": "",
-                    "correct": undefined,
-                    "isNoneOfTheAbove": undefined,
-                    "widgets": undefined,
                   },
                 ],
-                "countChoices": undefined,
                 "deselectEnabled": false,
                 "displayCount": null,
-                "hasNoneOfTheAbove": undefined,
                 "multipleSelect": false,
                 "noneOfTheAbove": false,
                 "onePerLine": true,
                 "randomize": false,
               },
-              "static": undefined,
               "type": "radio",
               "version": {
                 "major": 0,
@@ -9200,7 +7855,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/radio-choice-missing
             },
           },
         },
-        "static": undefined,
         "type": "group",
         "version": {
           "major": 0,
@@ -9208,61 +7862,37 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/radio-choice-missing
         },
       },
       "group 3": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "content": "
 
 [[☃ radio 1]]",
           "images": {},
-          "metadata": undefined,
           "widgets": {
             "radio 1": {
-              "alignment": undefined,
               "graded": true,
-              "key": undefined,
               "options": {
                 "choices": [
                   {
-                    "clue": undefined,
                     "content": "",
-                    "correct": undefined,
-                    "isNoneOfTheAbove": undefined,
-                    "widgets": undefined,
                   },
                   {
-                    "clue": undefined,
                     "content": "",
-                    "correct": undefined,
-                    "isNoneOfTheAbove": undefined,
-                    "widgets": undefined,
                   },
                   {
-                    "clue": undefined,
                     "content": "",
-                    "correct": undefined,
-                    "isNoneOfTheAbove": undefined,
-                    "widgets": undefined,
                   },
                   {
-                    "clue": undefined,
                     "content": "",
-                    "correct": undefined,
-                    "isNoneOfTheAbove": undefined,
-                    "widgets": undefined,
                   },
                 ],
-                "countChoices": undefined,
                 "deselectEnabled": false,
                 "displayCount": null,
-                "hasNoneOfTheAbove": undefined,
                 "multipleSelect": false,
                 "noneOfTheAbove": false,
                 "onePerLine": true,
                 "randomize": false,
               },
-              "static": undefined,
               "type": "radio",
               "version": {
                 "major": 0,
@@ -9271,7 +7901,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/radio-choice-missing
             },
           },
         },
-        "static": undefined,
         "type": "group",
         "version": {
           "major": 0,
@@ -9279,61 +7908,37 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/radio-choice-missing
         },
       },
       "group 4": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "content": "
 
 [[☃ radio 1]]",
           "images": {},
-          "metadata": undefined,
           "widgets": {
             "radio 1": {
-              "alignment": undefined,
               "graded": true,
-              "key": undefined,
               "options": {
                 "choices": [
                   {
-                    "clue": undefined,
                     "content": "",
-                    "correct": undefined,
-                    "isNoneOfTheAbove": undefined,
-                    "widgets": undefined,
                   },
                   {
-                    "clue": undefined,
                     "content": "",
-                    "correct": undefined,
-                    "isNoneOfTheAbove": undefined,
-                    "widgets": undefined,
                   },
                   {
-                    "clue": undefined,
                     "content": "",
-                    "correct": undefined,
-                    "isNoneOfTheAbove": undefined,
-                    "widgets": undefined,
                   },
                   {
-                    "clue": undefined,
                     "content": "",
-                    "correct": undefined,
-                    "isNoneOfTheAbove": undefined,
-                    "widgets": undefined,
                   },
                 ],
-                "countChoices": undefined,
                 "deselectEnabled": false,
                 "displayCount": null,
-                "hasNoneOfTheAbove": undefined,
                 "multipleSelect": false,
                 "noneOfTheAbove": false,
                 "onePerLine": true,
                 "randomize": false,
               },
-              "static": undefined,
               "type": "radio",
               "version": {
                 "major": 0,
@@ -9342,7 +7947,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/radio-choice-missing
             },
           },
         },
-        "static": undefined,
         "type": "group",
         "version": {
           "major": 0,
@@ -9356,7 +7960,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/radio-choice-missing
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/radio-missing-noneOfTheAbove.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
     "chi2Table": false,
@@ -9380,27 +7983,19 @@ B &= \\{x: x \\text{ is a square in the plane P} \\}
 [[☃ radio 1]]
 ",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "radio 1": {
         "alignment": "default",
         "graded": true,
-        "key": undefined,
         "options": {
           "choices": [
             {
-              "clue": undefined,
               "content": "Yes",
               "correct": false,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
             {
-              "clue": undefined,
               "content": "No",
               "correct": true,
-              "isNoneOfTheAbove": undefined,
-              "widgets": undefined,
             },
           ],
           "countChoices": false,
@@ -9408,8 +8003,6 @@ B &= \\{x: x \\text{ is a square in the plane P} \\}
           "displayCount": null,
           "hasNoneOfTheAbove": false,
           "multipleSelect": false,
-          "noneOfTheAbove": undefined,
-          "onePerLine": undefined,
           "randomize": false,
         },
         "static": false,
@@ -9426,7 +8019,6 @@ B &= \\{x: x \\text{ is a square in the plane P} \\}
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/simulator-widget.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -9440,12 +8032,9 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/simulator-widget.jso
 
 ",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "simulator 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "numTrials": 100,
           "proportionLabel": "Underlying proportion",
@@ -9453,7 +8042,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/simulator-widget.jso
           "xAxisLabel": "Proportion (%)",
           "yAxisLabel": "Number of times seen",
         },
-        "static": undefined,
         "type": "deprecated-standin",
         "version": {
           "major": 0,
@@ -9461,9 +8049,7 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/simulator-widget.jso
         },
       },
       "sorter 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "correct": [
             "$x$",
@@ -9473,7 +8059,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/simulator-widget.jso
           "layout": "horizontal",
           "padding": true,
         },
-        "static": undefined,
         "type": "sorter",
         "version": {
           "major": 0,
@@ -9487,7 +8072,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/simulator-widget.jso
 
 exports[`parseAndTypecheckPerseusItem correctly parses data/transformer-widget.json 1`] = `
 {
-  "answer": undefined,
   "answerArea": {
     "calculator": false,
   },
@@ -9501,12 +8085,9 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/transformer-widget.j
 
 ",
     "images": {},
-    "metadata": undefined,
     "widgets": {
       "transformer 1": {
-        "alignment": undefined,
         "graded": true,
-        "key": undefined,
         "options": {
           "correct": {
             "shape": {
@@ -9641,7 +8222,6 @@ exports[`parseAndTypecheckPerseusItem correctly parses data/transformer-widget.j
           },
           "version": 1.2,
         },
-        "static": undefined,
         "type": "deprecated-standin",
         "version": {
           "major": 0,


### PR DESCRIPTION
## Summary:
Previously, when parsing typed objects from JSON, we would add
`[key]: undefined` for any fields that were specified in the parser schema but
were absent from the JSON. This was a difference from the behavior of
`JSON.parse()` that could cause bugs in some cases (e.g. if a parsed
object was spread into another object, it could overwrite existing
values with `undefined` when that was not intended).

Thus, to better match the behavior of `JSON.parse()`, we now omit
`undefined` values from the parsed object if they are not present on the
original object.

This PR was inspired by test failures on https://github.com/Khan/webapp/pull/28551.
I'm making this change out of an abundance of caution.

Issue: LEMS-2774

Test plan:

`yarn test`