### PR TITLE
[🔥AUDIT🔥] Align variable names in SR strings for interactive graph

### DIFF
--- a/.changeset/friendly-tables-confess.md
+++ b/.changeset/friendly-tables-confess.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix localized string templates for two the ray interactive graph type

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -535,8 +535,8 @@ export const strings = {
         "The endpoint is at %(point1X)s comma %(point1Y)s and the ray goes through point %(point2X)s comma %(point2Y)s.",
     srRayGrabHandle:
         "Ray with endpoint %(point1X)s comma %(point1Y)s going through point %(point2X)s comma %(point2Y)s.",
-    srRayEndpoint: "Endpoint at %(point1X)s comma %(point1Y)s.",
-    srRayTerminalPoint: "Through point at %(point2X)s comma %(point2Y)s.",
+    srRayEndpoint: "Endpoint at %(x)s comma %(y)s.",
+    srRayTerminalPoint: "Through point at %(x)s comma %(y)s.",
     // The above strings are used for interactive graph SR descriptions.
 } satisfies {
     [key in keyof PerseusStrings]:


### PR DESCRIPTION
## Summary:

Our localization infrastructure requires that the names of the placeholders in the `strings` variable (the object with the English strings) matches the variable names in the same-named string generator function that appears in the `PerseusStrings` type.

This PR fixes two new strings so that their placeholder variable names match: `srRayEndpoint` and `srRayTerminalPoint`.

Issue: "none"

## Test plan:

Do another release and integrate it again and rerun the localization script.