### PR TITLE
[its-a-numeric-story] Improving Numeric Input Storybook Stories

### DIFF
--- a/.changeset/six-cars-agree.md
+++ b/.changeset/six-cars-agree.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Cleanup of Numeric Input stories

--- a/packages/perseus-editor/src/__stories__/editor.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/editor.stories.tsx
@@ -4,7 +4,7 @@ import {action} from "@storybook/addon-actions";
 import * as React from "react";
 
 import {Editor} from "..";
-import SideBySide from "../../../../testing/side-by-side";
+import SplitView from "../../../../testing/side-by-side";
 import {question1} from "../__testdata__/numeric-input.testdata";
 import {registerAllWidgetsAndEditorsForTesting} from "../util/register-all-widgets-and-editors-for-testing";
 
@@ -85,9 +85,9 @@ export const DemoInteractiveGraph = (): React.ReactElement => {
         // class to be above it.
         // TODO: Refactor to aphrodite styles instead of scoped CSS in Less.
         <div className="framework-perseus">
-            <SideBySide
-                leftTitle="Editor"
-                left={
+            <SplitView
+                rendererTitle="Editor"
+                renderer={
                     <View style={{width: "360px", margin: "20px"}}>
                         <Editor
                             ref={editorRef}
@@ -128,7 +128,7 @@ export const DemoInteractiveGraph = (): React.ReactElement => {
                         />
                     </View>
                 }
-                rightTitle="Serialized Widget Options"
+                JSONTitle="Serialized Widget Options"
                 jsonObject={options}
             />
         </div>

--- a/packages/perseus-editor/src/__stories__/editor.stories.tsx
+++ b/packages/perseus-editor/src/__stories__/editor.stories.tsx
@@ -4,7 +4,7 @@ import {action} from "@storybook/addon-actions";
 import * as React from "react";
 
 import {Editor} from "..";
-import SplitView from "../../../../testing/side-by-side";
+import SplitView from "../../../../testing/split-view";
 import {question1} from "../__testdata__/numeric-input.testdata";
 import {registerAllWidgetsAndEditorsForTesting} from "../util/register-all-widgets-and-editors-for-testing";
 

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.stories.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.stories.tsx
@@ -11,6 +11,27 @@ import type {
 } from "@khanacademy/perseus-core";
 import type {Meta} from "@storybook/react";
 
+// We're using this format as storybook was not able to infer the type of the options.
+// It also gives us a lovely hover view of the JSON structure.
+const answerFormsArray: string = `[
+    {
+        simplify: string;
+        name: string;
+    }
+]`;
+
+const answersArray: string = `[
+    {
+        message: string;
+        value: number;
+        status: string;
+        answerForms: array<string>;
+        strict: boolean;
+        maxError: number;
+        simplify: string;
+    }
+]`;
+
 const meta: Meta<typeof NumericInput> = {
     component: NumericInput,
     title: "Perseus/Widgets/Numeric Input",
@@ -29,30 +50,23 @@ const meta: Meta<typeof NumericInput> = {
                 message: "",
             },
         ],
-        labelText: "What's the answer?",
-        answerForms: [],
+        answerForms: [
+            {simplify: "required", name: "decimal"},
+            {simplify: "required", name: "integer"},
+            {simplify: "required", name: "mixed"},
+            {simplify: "required", name: "percent"},
+            {simplify: "required", name: "pi"},
+        ],
     },
     argTypes: {
         answers: {
             control: {type: "object"},
             description:
                 "A list of all the possible correct and incorrect answers",
-            type: {
-                name: "array",
-                value: {
-                    name: "object",
-                    value: {
-                        message: {name: "string", required: true},
-                        value: {name: "number"},
-                        status: {name: "string", required: true},
-                        answerForms: {
-                            name: "array",
-                            value: {name: "string"},
-                        },
-                        strict: {name: "boolean", required: true},
-                        maxError: {name: "number"},
-                        simplify: {name: "string"},
-                    },
+            table: {
+                type: {
+                    summary: "array",
+                    detail: answersArray,
                 },
             },
         },
@@ -60,14 +74,10 @@ const meta: Meta<typeof NumericInput> = {
             control: {type: "object"},
             description:
                 "Used by examples, maybe not used and should be removed in the future",
-            type: {
-                name: "array",
-                value: {
-                    name: "object",
-                    value: {
-                        simplify: {name: "string"},
-                        name: {name: "string"},
-                    },
+            table: {
+                type: {
+                    summary: "array",
+                    detail: answerFormsArray,
                 },
             },
         },

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.stories.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.stories.tsx
@@ -66,6 +66,8 @@ const meta: Meta<typeof NumericInput> = {
             {simplify: "required", name: "mixed"},
             {simplify: "required", name: "percent"},
             {simplify: "required", name: "pi"},
+            {simplify: "required", name: "proper"},
+            {simplify: "required", name: "improper"},
         ],
     },
     argTypes: {

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.stories.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.stories.tsx
@@ -1,99 +1,178 @@
-import {action} from "@storybook/addon-actions";
 import * as React from "react";
 
 import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui";
 
 import {NumericInput} from "./numeric-input.class";
-import {question1} from "./numeric-input.testdata";
+import {decimalProblem, question1} from "./numeric-input.testdata";
 
-type StoryArgs = {
-    coefficient: boolean;
-    currentValue: string;
-    rightAlign: boolean;
-    size: "normal" | "small";
-};
+import type {
+    PerseusNumericInputWidgetOptions,
+    PerseusRenderer,
+} from "@khanacademy/perseus-core";
+import type {Meta} from "@storybook/react";
 
-function generateProps(overwrite) {
-    const base = {
-        alignment: "",
-        answers: [],
-        containerSizeClass: "medium",
-        isLastUsedWidget: true,
-        coefficient: false,
-        currentValue: "",
-        problemNum: 0,
-        rightAlign: false,
-        size: "normal",
-        static: false,
-        widgetId: "widgetId",
-        findWidgets: action("findWidgets"),
-        onBlur: action("onBlur"),
-        onChange: action("onChange"),
-        onFocus: action("onFocus"),
-        trackInteraction: action("trackInteraction"),
-    } as const;
-
-    return {...base, ...overwrite};
-}
-
-export default {
-    title: "Perseus/Widgets/NumericInput",
+const meta: Meta<typeof NumericInput> = {
+    component: NumericInput,
+    title: "Perseus/Widgets/Numeric Input",
     args: {
         coefficient: false,
-        currentValue: "8675309",
+        currentValue: "",
         rightAlign: false,
+        size: "normal",
+        answers: [
+            {
+                status: "correct",
+                maxError: null,
+                strict: false,
+                value: 1252,
+                simplify: "required",
+                message: "",
+            },
+        ],
+        labelText: "What's the answer?",
+        answerForms: [],
     },
     argTypes: {
+        answers: {
+            control: {type: "object"},
+            description:
+                "A list of all the possible correct and incorrect answers",
+            type: {
+                name: "array",
+                value: {
+                    name: "object",
+                    value: {
+                        message: {name: "string", required: true},
+                        value: {name: "number"},
+                        status: {name: "string", required: true},
+                        answerForms: {
+                            name: "array",
+                            value: {name: "string"},
+                        },
+                        strict: {name: "boolean", required: true},
+                        maxError: {name: "number"},
+                        simplify: {name: "string"},
+                    },
+                },
+            },
+        },
+        answerForms: {
+            control: {type: "object"},
+            description:
+                "Used by examples, maybe not used and should be removed in the future",
+            type: {
+                name: "array",
+                value: {
+                    name: "object",
+                    value: {
+                        simplify: {name: "string"},
+                        name: {name: "string"},
+                    },
+                },
+            },
+        },
+        currentValue: {
+            control: {type: "text"},
+            description: "The current value of the input field",
+            table: {
+                type: {summary: "string"},
+            },
+        },
+        coefficient: {
+            control: {type: "boolean"},
+            description:
+                "A coefficient style number allows the student to use - for -1 and an empty string to mean 1.",
+            table: {
+                type: {summary: "boolean"},
+            },
+        },
+        labelText: {
+            control: {type: "text"},
+            description:
+                " Translatable Text; Text to describe this input. This will be shown to users using screenreaders.",
+            value: "What's the answer?",
+            table: {
+                type: {summary: "string"},
+            },
+        },
+        rightAlign: {
+            control: {type: "boolean"},
+            description: "Whether to right-align the text or not",
+            table: {
+                type: {summary: "boolean"},
+            },
+        },
         size: {
             options: ["normal", "small"],
             control: {type: "radio"},
             defaultValue: "normal",
+            description:
+                "Use size 'Normal' for all text boxes, unless there are multiple text boxes in one line and the answer area is too narrow to fit them.",
+            table: {
+                type: {summary: "string"},
+                defaultValue: {summary: "normal"},
+            },
+        },
+        static: {
+            control: {type: "boolean"},
+            description: "Always false.  Not used for this widget",
+            table: {
+                type: {summary: "boolean"},
+            },
+        },
+        // ApiOptions and linterContext are large objects and not particularly applicable to this story,
+        // so we're hiding them from view to simplify the UI.
+        apiOptions: {
+            table: {
+                disable: true,
+            },
+        },
+        linterContext: {
+            table: {
+                disable: true,
+            },
         },
     },
 };
 
-export const Question1 = (): React.ReactElement => {
-    return <RendererWithDebugUI question={question1} />;
+export default meta;
+
+const updateWidgetOptions = (
+    question: PerseusRenderer,
+    widgetId: string,
+    options: PerseusNumericInputWidgetOptions,
+): PerseusRenderer => {
+    const widget = question.widgets[widgetId];
+    return {
+        ...question,
+        widgets: {
+            [widgetId]: {
+                ...widget,
+                options: {
+                    ...widget.options,
+                    ...options,
+                },
+            },
+        },
+    };
 };
 
-export const Interactive = (args: StoryArgs): React.ReactElement => {
-    const props = generateProps(args);
-
-    return <NumericInput {...props} />;
+export const Default = (
+    args: PerseusNumericInputWidgetOptions,
+): React.ReactElement => {
+    const question = updateWidgetOptions(question1, "numeric-input 1", args);
+    return <RendererWithDebugUI question={question} />;
 };
+Default.args = question1.widgets["numeric-input 1"].options;
 
-export const Sizes = (args: StoryArgs): React.ReactElement => {
-    const smallProps = generateProps({...args, size: "small"});
-    const normalProps = generateProps({...args, size: "normal"});
-
-    return (
-        <div>
-            <label>
-                Small:
-                <NumericInput {...smallProps} />
-            </label>
-            <label>
-                Normal:
-                <NumericInput {...normalProps} />
-            </label>
-        </div>
+export const WithExample = (
+    args: PerseusNumericInputWidgetOptions,
+): React.ReactElement => {
+    const question = updateWidgetOptions(
+        decimalProblem,
+        "numeric-input 1",
+        args,
     );
+    return <RendererWithDebugUI question={question} />;
 };
-
-export const TextAlignment = (args: StoryArgs): React.ReactElement => {
-    const leftProps = generateProps({...args, rightAlign: false});
-    const rightProps = generateProps({...args, rightAlign: true});
-
-    return (
-        <div>
-            <label>
-                Left:
-                <NumericInput {...leftProps} />
-            </label>
-            <label>
-                Right:
-                <NumericInput {...rightProps} />
-            </label>
-        </div>
-    );
-};
+WithExample.args = decimalProblem.widgets["numeric-input 1"].options;

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.stories.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.stories.tsx
@@ -3,7 +3,16 @@ import * as React from "react";
 import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui";
 
 import {NumericInput} from "./numeric-input.class";
-import {decimalProblem, question1} from "./numeric-input.testdata";
+import {
+    decimalProblem,
+    improperProblem,
+    integerProblem,
+    mixedProblem,
+    piProblem,
+    properProblem,
+    question1,
+    withCoefficient,
+} from "./numeric-input.testdata";
 
 import type {
     PerseusNumericInputWidgetOptions,
@@ -50,6 +59,7 @@ const meta: Meta<typeof NumericInput> = {
                 message: "",
             },
         ],
+        // We're including all the answer forms to make it easier to edit in storybook.
         answerForms: [
             {simplify: "required", name: "decimal"},
             {simplify: "required", name: "integer"},
@@ -174,8 +184,34 @@ export const Default = (
     return <RendererWithDebugUI question={question} />;
 };
 Default.args = question1.widgets["numeric-input 1"].options;
+Default.parameters = {
+    docs: {
+        description: {
+            story: "The default Numeric Input widget.",
+        },
+    },
+};
 
-export const WithExample = (
+export const IntegerExample = (
+    args: PerseusNumericInputWidgetOptions,
+): React.ReactElement => {
+    const question = updateWidgetOptions(
+        integerProblem,
+        "numeric-input 1",
+        args,
+    );
+    return <RendererWithDebugUI question={question} />;
+};
+IntegerExample.args = integerProblem.widgets["numeric-input 1"].options;
+IntegerExample.parameters = {
+    docs: {
+        description: {
+            story: "Numeric Input set to strictly integer mode will only accept integer answers.",
+        },
+    },
+};
+
+export const DecimalExample = (
     args: PerseusNumericInputWidgetOptions,
 ): React.ReactElement => {
     const question = updateWidgetOptions(
@@ -185,4 +221,98 @@ export const WithExample = (
     );
     return <RendererWithDebugUI question={question} />;
 };
-WithExample.args = decimalProblem.widgets["numeric-input 1"].options;
+DecimalExample.args = decimalProblem.widgets["numeric-input 1"].options;
+DecimalExample.parameters = {
+    docs: {
+        description: {
+            story: "Numeric Inputs set to strictly decimal mode will only accept decimal answers.",
+        },
+    },
+};
+
+export const ImproperExample = (
+    args: PerseusNumericInputWidgetOptions,
+): React.ReactElement => {
+    const question = updateWidgetOptions(
+        improperProblem,
+        "numeric-input 1",
+        args,
+    );
+    return <RendererWithDebugUI question={question} />;
+};
+ImproperExample.args = improperProblem.widgets["numeric-input 1"].options;
+ImproperExample.parameters = {
+    docs: {
+        description: {
+            story: "Numeric Inputs set to strictly improper mode will only accept improper fractions.",
+        },
+    },
+};
+
+export const ProperExample = (
+    args: PerseusNumericInputWidgetOptions,
+): React.ReactElement => {
+    const question = updateWidgetOptions(
+        properProblem,
+        "numeric-input 1",
+        args,
+    );
+    return <RendererWithDebugUI question={question} />;
+};
+ProperExample.args = properProblem.widgets["numeric-input 1"].options;
+ProperExample.parameters = {
+    docs: {
+        description: {
+            story: "Numeric Inputs set to strictly proper mode will only accept proper fractions. This example does not require simplifying.",
+        },
+    },
+};
+
+export const MixedExample = (
+    args: PerseusNumericInputWidgetOptions,
+): React.ReactElement => {
+    const question = updateWidgetOptions(mixedProblem, "numeric-input 1", args);
+    return <RendererWithDebugUI question={question} />;
+};
+MixedExample.args = mixedProblem.widgets["numeric-input 1"].options;
+MixedExample.parameters = {
+    docs: {
+        description: {
+            story: "Numeric Inputs set to strictly mixed mode will only accept mixed fractions.",
+        },
+    },
+};
+
+export const PiExample = (
+    args: PerseusNumericInputWidgetOptions,
+): React.ReactElement => {
+    const question = updateWidgetOptions(piProblem, "numeric-input 1", args);
+    return <RendererWithDebugUI question={question} />;
+};
+PiExample.args = piProblem.widgets["numeric-input 1"].options;
+PiExample.parameters = {
+    docs: {
+        description: {
+            story: "Numeric Inputs set to strictly pi mode will only accept answers in terms of π. Approximating pi will result in an incorrect answer and a hint.",
+        },
+    },
+};
+
+export const CoefficientExample = (
+    args: PerseusNumericInputWidgetOptions,
+): React.ReactElement => {
+    const question = updateWidgetOptions(
+        withCoefficient,
+        "numeric-input 1",
+        args,
+    );
+    return <RendererWithDebugUI question={question} />;
+};
+CoefficientExample.args = withCoefficient.widgets["numeric-input 1"].options;
+CoefficientExample.parameters = {
+    docs: {
+        description: {
+            story: "When Numeric Input is set to coefficient mode, it allows the student to use - for -1 and an empty string to mean 1.",
+        },
+    },
+};

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.testdata.ts
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.testdata.ts
@@ -38,7 +38,7 @@ export const question1: PerseusRenderer = {
 
 export const decimalProblem: PerseusRenderer = {
     // Added a floating question mark to keep enough space to show the examples.
-    content: "$12 + 0.52 =$ [[\u2603 numeric-input 1]] \n\n\n\n\n\n\n\n‎",
+    content: "$12 + 0.52 =$ [[\u2603 numeric-input 1]] \n\n‎",
     images: {},
     widgets: {
         "numeric-input 1": {
@@ -79,7 +79,7 @@ export const decimalProblem: PerseusRenderer = {
 
 export const integerProblem: PerseusRenderer = {
     // Added a floating question mark to keep enough space to show the examples.
-    content: "$5/5 + 10/10 =$ [[\u2603 numeric-input 1]] \n\n\n\n\n\n\n\n‎",
+    content: "$5/5 + 10/10 =$ [[\u2603 numeric-input 1]] \n\n‎",
     images: {},
     widgets: {
         "numeric-input 1": {
@@ -120,7 +120,7 @@ export const integerProblem: PerseusRenderer = {
 
 export const improperProblem: PerseusRenderer = {
     // Added a floating question mark to keep enough space to show the examples.
-    content: "$2/2 + 5/2 =$ [[\u2603 numeric-input 1]] \n\n\n\n\n\n\n\n‎",
+    content: "$2/2 + 5/2 =$ [[\u2603 numeric-input 1]] \n\n‎\n\n‎",
     images: {},
     widgets: {
         "numeric-input 1": {
@@ -162,7 +162,7 @@ export const improperProblem: PerseusRenderer = {
 export const piProblem: PerseusRenderer = {
     // Added a floating question mark to keep enough space to show the examples.
     content:
-        "$pi * 32 =$ [[\u2603 numeric-input 1]] \n\n\n\n\n\n\n\n‎\n\n\n Hint: Enter 100.53 to get an approx of pi error.",
+        "$pi * 32 =$ [[\u2603 numeric-input 1]] \n\n‎\n\n Hint: Enter 100.53 to get an approx of pi error.",
     images: {},
     widgets: {
         "numeric-input 1": {
@@ -203,7 +203,7 @@ export const piProblem: PerseusRenderer = {
 
 export const mixedProblem: PerseusRenderer = {
     // Added a floating question mark to keep enough space to show the examples.
-    content: "$2 + 2/10 =$ [[\u2603 numeric-input 1]] \n\n\n\n\n\n\n\n‎",
+    content: "$2 + 2/10 =$ [[\u2603 numeric-input 1]] \n\n‎",
     images: {},
     widgets: {
         "numeric-input 1": {
@@ -244,7 +244,7 @@ export const mixedProblem: PerseusRenderer = {
 
 export const properProblem: PerseusRenderer = {
     // Added a floating question mark to keep enough space to show the examples.
-    content: "$3/10 + 2/10 =$ [[\u2603 numeric-input 1]] \n\n\n\n\n\n\n\n‎",
+    content: "$3/10 + 2/10 =$ [[\u2603 numeric-input 1]] \n\n‎\n\n‎",
     images: {},
     widgets: {
         "numeric-input 1": {

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.testdata.ts
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.testdata.ts
@@ -38,7 +38,131 @@ export const question1: PerseusRenderer = {
 
 export const decimalProblem: PerseusRenderer = {
     // Added a floating question mark to keep enough space to show the examples.
-    content: "$12 + 0.52 =$ [[\u2603 numeric-input 1]] \n\n\n\n\n   ?",
+    content: "$12 + 0.52 =$ [[\u2603 numeric-input 1]] \n\n\n\n\n\n\n\n‎",
+    images: {},
+    widgets: {
+        "numeric-input 1": {
+            graded: true,
+            version: {
+                major: 0,
+                minor: 0,
+            },
+            static: false,
+            type: "numeric-input",
+            options: {
+                coefficient: false,
+                static: false,
+                answers: [
+                    {
+                        status: "correct",
+                        maxError: null,
+                        strict: true,
+                        value: 12.52,
+                        simplify: "required",
+                        message: "",
+                        answerForms: ["decimal"],
+                    },
+                ],
+                labelText: "",
+                size: "normal",
+                answerForms: [
+                    {
+                        simplify: "required",
+                        name: "decimal",
+                    },
+                ],
+            },
+            alignment: "default",
+        } as NumericInputWidget,
+    },
+};
+
+export const integerProblem: PerseusRenderer = {
+    // Added a floating question mark to keep enough space to show the examples.
+    content: "$5/5 + 10/10 =$ [[\u2603 numeric-input 1]] \n\n\n\n\n\n\n\n‎",
+    images: {},
+    widgets: {
+        "numeric-input 1": {
+            graded: true,
+            version: {
+                major: 0,
+                minor: 0,
+            },
+            static: false,
+            type: "numeric-input",
+            options: {
+                coefficient: false,
+                static: false,
+                answers: [
+                    {
+                        status: "correct",
+                        maxError: null,
+                        strict: true,
+                        value: 15,
+                        simplify: "required",
+                        message: "",
+                        answerForms: ["integer"],
+                    },
+                ],
+                labelText: "",
+                size: "normal",
+                answerForms: [
+                    {
+                        simplify: "required",
+                        name: "integer",
+                    },
+                ],
+            },
+            alignment: "default",
+        } as NumericInputWidget,
+    },
+};
+
+export const improperProblem: PerseusRenderer = {
+    // Added a floating question mark to keep enough space to show the examples.
+    content: "$2/2 + 5/2 =$ [[\u2603 numeric-input 1]] \n\n\n\n\n\n\n\n‎",
+    images: {},
+    widgets: {
+        "numeric-input 1": {
+            graded: true,
+            version: {
+                major: 0,
+                minor: 0,
+            },
+            static: false,
+            type: "numeric-input",
+            options: {
+                coefficient: false,
+                static: false,
+                answers: [
+                    {
+                        status: "correct",
+                        maxError: null,
+                        strict: true,
+                        value: 3.5,
+                        simplify: "optional",
+                        message: "",
+                        answerForms: ["improper"],
+                    },
+                ],
+                labelText: "",
+                size: "normal",
+                answerForms: [
+                    {
+                        simplify: "optional",
+                        name: "improper",
+                    },
+                ],
+            },
+            alignment: "default",
+        } as NumericInputWidget,
+    },
+};
+
+export const piProblem: PerseusRenderer = {
+    // Added a floating question mark to keep enough space to show the examples.
+    content:
+        "$pi * 32 =$ [[\u2603 numeric-input 1]] \n\n\n\n\n\n\n\n‎\n\n\n Hint: Enter 100.53 to get an approx of pi error.",
     images: {},
     widgets: {
         "numeric-input 1": {
@@ -57,10 +181,10 @@ export const decimalProblem: PerseusRenderer = {
                         status: "correct",
                         maxError: null,
                         strict: false,
-                        value: 12.52,
+                        value: 100.53096491487338,
                         simplify: "required",
                         message: "",
-                        answerForms: ["decimal"],
+                        answerForms: ["pi"],
                     },
                 ],
                 labelText: "",
@@ -68,7 +192,89 @@ export const decimalProblem: PerseusRenderer = {
                 answerForms: [
                     {
                         simplify: "required",
-                        name: "decimal",
+                        name: "pi",
+                    },
+                ],
+            },
+            alignment: "default",
+        } as NumericInputWidget,
+    },
+};
+
+export const mixedProblem: PerseusRenderer = {
+    // Added a floating question mark to keep enough space to show the examples.
+    content: "$2 + 2/10 =$ [[\u2603 numeric-input 1]] \n\n\n\n\n\n\n\n‎",
+    images: {},
+    widgets: {
+        "numeric-input 1": {
+            graded: true,
+            version: {
+                major: 0,
+                minor: 0,
+            },
+            static: false,
+            type: "numeric-input",
+            options: {
+                coefficient: false,
+                static: false,
+                answers: [
+                    {
+                        status: "correct",
+                        maxError: null,
+                        strict: true,
+                        value: 2.2,
+                        simplify: "optional",
+                        message: "",
+                        answerForms: ["mixed"],
+                    },
+                ],
+                labelText: "",
+                size: "normal",
+                answerForms: [
+                    {
+                        simplify: "optional",
+                        name: "mixed",
+                    },
+                ],
+            },
+            alignment: "default",
+        } as NumericInputWidget,
+    },
+};
+
+export const properProblem: PerseusRenderer = {
+    // Added a floating question mark to keep enough space to show the examples.
+    content: "$3/10 + 2/10 =$ [[\u2603 numeric-input 1]] \n\n\n\n\n\n\n\n‎",
+    images: {},
+    widgets: {
+        "numeric-input 1": {
+            graded: true,
+            version: {
+                major: 0,
+                minor: 0,
+            },
+            static: false,
+            type: "numeric-input",
+            options: {
+                coefficient: false,
+                static: false,
+                answers: [
+                    {
+                        status: "correct",
+                        maxError: null,
+                        strict: true,
+                        value: 0.5,
+                        simplify: "optional",
+                        message: "",
+                        answerForms: ["proper"],
+                    },
+                ],
+                labelText: "",
+                size: "normal",
+                answerForms: [
+                    {
+                        simplify: "optional",
+                        name: "proper",
                     },
                 ],
             },
@@ -245,7 +451,7 @@ export const duplicatedAnswers: PerseusRenderer = {
 };
 
 export const withCoefficient: PerseusRenderer = {
-    content: "$5008 \\div 4 =$ [[\u2603 numeric-input 1]] ",
+    content: "$1 =$ [[\u2603 numeric-input 1]] ",
     images: {},
     widgets: {
         "numeric-input 1": {

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.testdata.ts
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.testdata.ts
@@ -36,6 +36,47 @@ export const question1: PerseusRenderer = {
     },
 };
 
+export const decimalProblem: PerseusRenderer = {
+    // Added a floating question mark to keep enough space to show the examples.
+    content: "$12 + 0.52 =$ [[\u2603 numeric-input 1]] \n\n\n\n\n   ?",
+    images: {},
+    widgets: {
+        "numeric-input 1": {
+            graded: true,
+            version: {
+                major: 0,
+                minor: 0,
+            },
+            static: false,
+            type: "numeric-input",
+            options: {
+                coefficient: false,
+                static: false,
+                answers: [
+                    {
+                        status: "correct",
+                        maxError: null,
+                        strict: false,
+                        value: 12.52,
+                        simplify: "required",
+                        message: "",
+                        answerForms: ["decimal"],
+                    },
+                ],
+                labelText: "",
+                size: "normal",
+                answerForms: [
+                    {
+                        simplify: "required",
+                        name: "decimal",
+                    },
+                ],
+            },
+            alignment: "default",
+        } as NumericInputWidget,
+    },
+};
+
 export const percentageProblem: PerseusRenderer = {
     content: "$5008 \\div 4 =$ [[\u2603 numeric-input 1]] ",
     images: {},
@@ -134,6 +175,7 @@ export const multipleAnswersWithDecimals: PerseusRenderer = {
                         value: 12.2,
                         simplify: "required",
                         message: "",
+                        answerForms: ["decimal"],
                     },
                     {
                         status: "correct",
@@ -142,10 +184,17 @@ export const multipleAnswersWithDecimals: PerseusRenderer = {
                         value: 13.4,
                         simplify: "required",
                         message: "",
+                        answerForms: ["decimal"],
                     },
                 ],
                 labelText: "What's the answer?",
                 size: "normal",
+                answerforms: [
+                    {
+                        simplify: "required",
+                        name: "decimal",
+                    },
+                ],
             },
             alignment: "default",
         } as NumericInputWidget,

--- a/testing/renderer-with-debug-ui.tsx
+++ b/testing/renderer-with-debug-ui.tsx
@@ -14,7 +14,7 @@ import {scorePerseusItem} from "../packages/perseus/src/renderer-util";
 import {mockStrings} from "../packages/perseus/src/strings";
 import {registerAllWidgetsForTesting} from "../packages/perseus/src/util/register-all-widgets-for-testing";
 
-import SplitView from "./side-by-side";
+import SplitView from "./split-view";
 
 import type {PerseusRenderer} from "@khanacademy/perseus-core";
 import type {ComponentProps} from "react";

--- a/testing/renderer-with-debug-ui.tsx
+++ b/testing/renderer-with-debug-ui.tsx
@@ -14,7 +14,7 @@ import {scorePerseusItem} from "../packages/perseus/src/renderer-util";
 import {mockStrings} from "../packages/perseus/src/strings";
 import {registerAllWidgetsForTesting} from "../packages/perseus/src/util/register-all-widgets-for-testing";
 
-import SideBySide from "./side-by-side";
+import SplitView from "./side-by-side";
 
 import type {PerseusRenderer} from "@khanacademy/perseus-core";
 import type {ComponentProps} from "react";
@@ -47,8 +47,8 @@ export const RendererWithDebugUI = ({
     };
 
     return (
-        <SideBySide
-            leftTitle={
+        <SplitView
+            rendererTitle={
                 <View
                     style={{
                         flexDirection: "row",
@@ -66,7 +66,7 @@ export const RendererWithDebugUI = ({
                     </View>
                 </View>
             }
-            left={
+            renderer={
                 <View>
                     <View className={isMobile ? "perseus-mobile" : ""}>
                         <Renderer

--- a/testing/renderer-with-debug-ui.tsx
+++ b/testing/renderer-with-debug-ui.tsx
@@ -40,6 +40,12 @@ export const RendererWithDebugUI = ({
     const [isMobile, setIsMobile] = React.useState(false);
     const {strings} = usePerseusI18n();
 
+    const controlledAPIOptions = {
+        ...apiOptions,
+        isMobile,
+        customKeypad: isMobile, // Use the mobile keypad for mobile
+    };
+
     return (
         <SideBySide
             leftTitle={
@@ -70,7 +76,7 @@ export const RendererWithDebugUI = ({
                             images={question.images}
                             widgets={question.widgets}
                             problemNum={0}
-                            apiOptions={{...apiOptions, isMobile}}
+                            apiOptions={controlledAPIOptions}
                             reviewMode={reviewMode}
                             strings={strings}
                             {...rest}

--- a/testing/server-item-renderer-with-debug-ui.tsx
+++ b/testing/server-item-renderer-with-debug-ui.tsx
@@ -57,8 +57,8 @@ export const ServerItemRendererWithDebugUI = ({
 
     return (
         <SideBySide
-            leftTitle="Renderer"
-            left={
+            rendererTitle="Renderer"
+            renderer={
                 <>
                     <Perseus.ServerItemRenderer
                         ref={ref}

--- a/testing/server-item-renderer-with-debug-ui.tsx
+++ b/testing/server-item-renderer-with-debug-ui.tsx
@@ -8,7 +8,7 @@ import {mockStrings} from "../packages/perseus/src/strings";
 import {keScoreFromPerseusScore} from "../packages/perseus/src/util/scoring";
 
 import KEScoreUI from "./ke-score-ui";
-import SideBySide from "./side-by-side";
+import SideBySide from "./split-view";
 import {storybookDependenciesV2} from "./test-dependencies";
 
 import type {APIOptions} from "../packages/perseus/src/types";

--- a/testing/side-by-side.tsx
+++ b/testing/side-by-side.tsx
@@ -4,29 +4,27 @@ import {HeadingMedium} from "@khanacademy/wonder-blocks-typography";
 import * as React from "react";
 import ReactJson from "react-json-view";
 
-import {interactiveSizes} from "../packages/perseus/src/styles/constants";
-
 type Props = {
-    leftTitle: React.ReactNode;
-    left: React.ReactNode;
-    rightTitle?: string;
+    rendererTitle: React.ReactNode;
+    renderer: React.ReactNode;
+    JSONTitle?: string;
     jsonObject: any;
 };
 
-const SideBySide = ({
-    leftTitle = "Renderer",
-    left,
-    rightTitle = "Perseus JSON",
+const SplitView = ({
+    rendererTitle = "Renderer",
+    renderer,
+    JSONTitle = "Perseus JSON",
     jsonObject,
 }: Props): React.ReactElement => {
     return (
         <View style={styles.sideBySide}>
-            <View style={styles.leftPanel} className="framework-perseus">
-                <HeadingMedium>{leftTitle}</HeadingMedium>
-                {left}
+            <View className="framework-perseus">
+                <HeadingMedium>{rendererTitle}</HeadingMedium>
+                {renderer}
             </View>
-            <View style={styles.rightPanel}>
-                <HeadingMedium>{rightTitle}</HeadingMedium>
+            <View>
+                <HeadingMedium>{JSONTitle}</HeadingMedium>
                 <ReactJson
                     style={{marginTop: "10px"}}
                     quotesOnKeys={false}
@@ -43,18 +41,10 @@ const styles = {
     sideBySide: {
         display: "flex",
         flexWrap: "wrap",
-        flexDirection: "row",
+        flexDirection: "column",
         gap: spacing.large_24,
         padding: `0px ${spacing.large_24}px`,
     },
-    leftPanel: {
-        flexBasis: `${interactiveSizes.defaultBoxSize}px`,
-    },
-    rightPanel: {
-        flexGrow: 1,
-        flexBasis: `${interactiveSizes.defaultBoxSize}px`,
-        maxWidth: "50%",
-    },
 } as const;
 
-export default SideBySide;
+export default SplitView;

--- a/testing/side-by-side.tsx
+++ b/testing/side-by-side.tsx
@@ -31,7 +31,7 @@ const SideBySide = ({
                     style={{marginTop: "10px"}}
                     quotesOnKeys={false}
                     enableClipboard={false}
-                    collapsed={5}
+                    collapsed={true}
                     src={jsonObject}
                 />
             </View>

--- a/testing/split-view.tsx
+++ b/testing/split-view.tsx
@@ -11,6 +11,10 @@ type Props = {
     jsonObject: any;
 };
 
+/**
+ * This component is used in Storybook to render both the renderer and the JSON object in a split view.
+ * Currently, the renderer is displayed above the JSON object.
+ */
 const SplitView = ({
     rendererTitle = "Renderer",
     renderer,


### PR DESCRIPTION
## Summary:
This PR is part of the Numeric Input Project. 

The purpose of this PR is to improve our storybook setup for our Numeric Input Widget. This includes the following work:
- Modernizing story structure 
- Hooking up argTypes with descriptions 
- Updating RendererWithDebugUI to also set customKeypad to the same value as isMobile 
     - This allows us to ensure that our Widgets that use MathInput are properly updating when toggled into Mobile view
- Adjustments to SideBySide 
     - Automatically collapse the Perseus JSON view. 
     - Moved the PerseusJSON view below the Renderer View
     - Rename to SplitView to better encapsulate the new design 
     - Updated variable names to match

[Current (Live) Storybook Example](https://khan.github.io/perseus/?path=/docs/perseus-widgets-numericinput--docs) | [PR Storybook Example](https://650db21c3f5d1b2f13c02952-osexoxinde.chromatic.com/?path=/docs/perseus-widgets-numeric-input--docs)

Issue: LEMS-2449

## Video Example:
https://github.com/user-attachments/assets/69f6dbfb-1fda-445b-a06f-90a178f9dbeb

## Test plan:
- Ensure all tests pass + manual testing