### PR TITLE
[shifting-static] docs(changeset): Moving static function for Numeric

### DIFF
--- a/.changeset/gorgeous-dolls-promise.md
+++ b/.changeset/gorgeous-dolls-promise.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Moving static function for Numeric

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.class.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.class.tsx
@@ -11,7 +11,7 @@ import {ApiOptions} from "../../perseus-api";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/numeric-input/prompt-utils";
 
 import {NumericInputComponent} from "./numeric-input";
-import {unionAnswerForms} from "./utils";
+import {getUserInputFromProps, unionAnswerForms} from "./utils";
 
 import type InputWithExamples from "../../components/input-with-examples";
 import type SimpleKeypadInput from "../../components/simple-keypad-input";
@@ -88,14 +88,6 @@ export class NumericInput
         linterContext: linterContextDefault,
     };
 
-    static getUserInputFromProps(
-        props: NumericInputProps,
-    ): PerseusNumericInputUserInput {
-        return {
-            currentValue: props.currentValue,
-        };
-    }
-
     constructor(props: NumericInputProps) {
         super(props);
         // Create a ref that we can pass down to the input component so that we
@@ -140,7 +132,7 @@ export class NumericInput
      * Returns the value the user has currently input for this widget.
      */
     getUserInput(): PerseusNumericInputUserInput {
-        return NumericInput.getUserInputFromProps(this.props);
+        return getUserInputFromProps(this.props);
     }
 
     /**

--- a/packages/perseus/src/widgets/numeric-input/utils.ts
+++ b/packages/perseus/src/widgets/numeric-input/utils.ts
@@ -1,5 +1,7 @@
+import type {NumericInputProps} from "./numeric-input.class";
 import type {PerseusStrings} from "../../strings";
 import type {PerseusNumericInputAnswerForm} from "@khanacademy/perseus-core";
+import type {PerseusNumericInputUserInput} from "@khanacademy/perseus-score";
 
 /**
  * The full list of available strings for the numeric input widget,
@@ -118,4 +120,15 @@ export const unionAnswerForms: (
             formExampleKeys.indexOf(a.name) - formExampleKeys.indexOf(b.name)
         );
     });
+};
+
+/**
+ * Returns the value the user has currently input for this widget.
+ */
+export const getUserInputFromProps = (
+    props: NumericInputProps,
+): PerseusNumericInputUserInput => {
+    return {
+        currentValue: props.currentValue,
+    };
 };


### PR DESCRIPTION
## Summary:
This PR is part of the Numeric Input Project.

All this PR does is move a single static function to a util file. 

Note for Mark: I think I would recommend that we simply set this ticket to "Won't Do", as there's not a lot to be gained here anymore! We would need to essentially duplicate a single, very simple, function as it seems that `getUserInputFromProps` is also called from the renderer, even though `getUserInput` does the exact same thing. 

I'll keep the PR as-is for reference. 

Issue: LEMS-2444

## Test plan:
- tests pass 