### PR TITLE
Take 2: Grapher default widget options

### DIFF
--- a/.changeset/dry-fans-study.md
+++ b/.changeset/dry-fans-study.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-core": minor
+"@khanacademy/perseus-editor": patch
+---
+
+Move default widget options for Grapher to Perseus Core

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -48,6 +48,8 @@ export {default as gradedGroupLogic} from "./widgets/graded-group";
 export type {GradedGroupDefaultWidgetOptions} from "./widgets/graded-group";
 export {default as gradedGroupSetLogic} from "./widgets/graded-group-set";
 export type {GradedGroupSetDefaultWidgetOptions} from "./widgets/graded-group-set";
+export {default as grapherLogic} from "./widgets/grapher";
+export type {GrapherDefaultWidgetOptions} from "./widgets/grapher";
 export {default as groupLogic} from "./widgets/group";
 export type {GroupDefaultWidgetOptions} from "./widgets/group";
 export {default as iframeLogic} from "./widgets/iframe";

--- a/packages/perseus-core/src/widgets/grapher/index.ts
+++ b/packages/perseus-core/src/widgets/grapher/index.ts
@@ -1,0 +1,38 @@
+import type {PerseusGrapherWidgetOptions} from "../../data-schema";
+import type {WidgetLogic} from "../logic-export.types";
+
+export type GrapherDefaultWidgetOptions = Pick<
+    PerseusGrapherWidgetOptions,
+    "graph" | "correct" | "availableTypes"
+>;
+
+const defaultWidgetOptions: GrapherDefaultWidgetOptions = {
+    graph: {
+        labels: ["x", "y"],
+        range: [
+            [-10, 10],
+            [-10, 10],
+        ],
+        step: [1, 1],
+        backgroundImage: {
+            url: null,
+        },
+        markings: "graph",
+        rulerLabel: "",
+        rulerTicks: 10,
+        valid: true,
+        showTooltips: false,
+    },
+    correct: {
+        type: "linear",
+        coords: null,
+    },
+    availableTypes: ["linear"],
+};
+
+const grapherWidgetLogic: WidgetLogic = {
+    name: "grapher",
+    defaultWidgetOptions,
+};
+
+export default grapherWidgetLogic;

--- a/packages/perseus-editor/src/widgets/grapher-editor.tsx
+++ b/packages/perseus-editor/src/widgets/grapher-editor.tsx
@@ -7,21 +7,21 @@ import {
     containerSizeClass,
     getInteractiveBoxFromSizeClass,
 } from "@khanacademy/perseus";
-import {GrapherUtil as CoreGrapherUtil} from "@khanacademy/perseus-core";
+import {
+    GrapherUtil as CoreGrapherUtil,
+    grapherLogic,
+} from "@khanacademy/perseus-core";
 import * as React from "react";
 import _ from "underscore";
 
 import GraphSettings from "../components/graph-settings";
 
+import type {GrapherDefaultWidgetOptions} from "@khanacademy/perseus-core";
+
 const {InfoTip, MultiButtonGroup} = components;
 const Grapher = GrapherWidget.widget;
-const {
-    DEFAULT_GRAPHER_PROPS,
-    chooseType,
-    defaultPlotProps,
-    getEquationString,
-    typeToButton,
-} = GrapherUtil;
+const {chooseType, defaultPlotProps, getEquationString, typeToButton} =
+    GrapherUtil;
 
 type Props = any;
 
@@ -32,11 +32,8 @@ class GrapherEditor extends React.Component<Props> {
 
     static widgetName = "grapher" as const;
 
-    static defaultProps: Props = {
-        correct: DEFAULT_GRAPHER_PROPS.plot,
-        graph: DEFAULT_GRAPHER_PROPS.graph,
-        availableTypes: DEFAULT_GRAPHER_PROPS.availableTypes,
-    };
+    static defaultProps: GrapherDefaultWidgetOptions =
+        grapherLogic.defaultWidgetOptions;
 
     change: (arg1: any, arg2: any, arg3: any) => any = (...args) => {
         return Changeable.change.apply(this, args);

--- a/packages/perseus/src/widgets/grapher/util.tsx
+++ b/packages/perseus/src/widgets/grapher/util.tsx
@@ -172,6 +172,8 @@ export const DEFAULT_GRAPHER_PROPS: any = {
     availableTypes: [defaultPlot.type],
 };
 
+console.log(JSON.stringify(DEFAULT_GRAPHER_PROPS, null, 2));
+
 export const typeToButton = (type: FunctionTypeMappingKeys): any => {
     const capitalized = type.charAt(0).toUpperCase() + type.substring(1);
     const staticUrl = getDependencies().staticUrl;

--- a/packages/perseus/src/widgets/grapher/util.tsx
+++ b/packages/perseus/src/widgets/grapher/util.tsx
@@ -172,8 +172,6 @@ export const DEFAULT_GRAPHER_PROPS: any = {
     availableTypes: [defaultPlot.type],
 };
 
-console.log(JSON.stringify(DEFAULT_GRAPHER_PROPS, null, 2));
-
 export const typeToButton = (type: FunctionTypeMappingKeys): any => {
     const capitalized = type.charAt(0).toUpperCase() + type.substring(1);
     const staticUrl = getDependencies().staticUrl;


### PR DESCRIPTION
## Summary:
This is an alternative for: https://github.com/Khan/perseus/pull/2146

In #2146 I tried to a direct move of logic from `perseus` to `perseus-core` to get the default widget options for Grapher. That required `defaultPlotProps` which required `maybePointsFromNormalized` which eventually required `kmath`. It was gross for a number of reasons:

1. I had to move a lot of utilities
2. I had to give `perseus-core` a dependency on `kmath` (and `perseus-core` probably shouldn't have dependencies)
3. There was a lot of misdirection and logic all to make one static object

Whatever, I was okay hacking my way through that. _However_ we ended up with a circular dependency: `kmath` depends on `perseus-core` which was now depending on `kmath`.

At this point I reflected on my life choices and thought "why are we using all of these utilities just to compute an unchanging object? Why am I moving all this logic just to generate 2 properties?

So I just logged the default object and copied it to `perseus-core`.

Issue: LEMS-2737

## Test plan:
Nothing should change, just copy/pasta-ing code.