### PR TITLE
Re-export widget id support function: addWidget

### DIFF
--- a/.changeset/cool-cherries-vanish.md
+++ b/.changeset/cool-cherries-vanish.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": minor
+---
+
+Re-export widget id support function: addWidget

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -17,6 +17,7 @@ export {default as getMatrixSize} from "./utils/get-matrix-size";
 export {default as getDecimalSeparator} from "./utils/get-decimal-separator";
 export {approximateEqual, approximateDeepEqual} from "./utils/equality";
 export {
+    addWidget,
     getWidgetIdsFromContent,
     getWidgetIdsFromContentByType,
 } from "./utils/widget-id-utils";


### PR DESCRIPTION
## Summary:

As we've moved Perseus logic around, we moved `addWidget` into `perseus-core`. However, we didn't export it from the package. This function is used by hosting applications and needs to be exported. 

Issue: "none"

## Test plan:

Update host app and update import to import the function from `"@khanacademy/perseus-core"`.