### PR TITLE
Ensure that Numeric Input Examples only show for correct answers.

### DIFF
--- a/.changeset/rotten-kangaroos-fly.md
+++ b/.changeset/rotten-kangaroos-fly.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Bug fix to ensure that Numeric Examples only show for correct answers.

--- a/packages/perseus/src/widgets/numeric-input/__snapshots__/numeric-input.test.ts.snap
+++ b/packages/perseus/src/widgets/numeric-input/__snapshots__/numeric-input.test.ts.snap
@@ -421,6 +421,126 @@ a mixed number, like 1 and 3/4
 </div>
 `;
 
+exports[`numeric-input widget Should render tooltip using only correct answer formats: render tooltip only with correct answers 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="paragraph"
+      >
+        <span
+          style="white-space: nowrap;"
+        >
+          <span />
+          <span
+            class="mock-TeX"
+          >
+            5008 \\div 4 =
+          </span>
+          <span />
+        </span>
+         
+        <div
+          class="perseus-widget-container widget-nohighlight widget-inline-block"
+        >
+          <span>
+            <div>
+              <input
+                aria-describedby="aria-for-input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                aria-disabled="false"
+                aria-invalid="false"
+                aria-label="What's the answer?"
+                autocapitalize="off"
+                autocomplete="off"
+                autocorrect="off"
+                class="input_1ck1z8k-o_O-LabelMedium_1rew30o-o_O-default_53h0n9-o_O-defaultFocus_9n1kv3-o_O-inputWithExamples_1y6ajxo"
+                id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                type="text"
+                value=""
+              />
+              <span
+                id="aria-for-input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                style="display: none;"
+              >
+                Your answer should be 
+                   a simplified proper fraction, like 3/5
+              </span>
+            </div>
+            <div
+              style="position: relative; height: 0px; display: none;"
+            >
+              <div
+                class="tooltipContainer"
+                role="tooltip"
+                style="position: absolute; left: 0px;"
+              >
+                <div
+                  style="display: block; position: relative; visibility: visible; left: 0px; top: -1px; width: 12px; height: 11px; margin-top: -1px; margin-bottom: -2px; z-index: 10;"
+                >
+                  <div
+                    style="display: block; height: 0px; width: 0px; position: absolute; left: 0px; top: -1px; border-right: 12px solid transparent; border-bottom: 12px solid #ccc;"
+                  />
+                  <div
+                    style="display: block; height: 0px; width: 0px; position: absolute; left: 1px; top: 1px; border-right: 10px solid transparent; border-bottom: 10px solid white;"
+                  />
+                </div>
+                <div
+                  class="perseus-formats-tooltip preview-measure"
+                  style="position: relative; top: 0px; left: 0px; border: 1px solid #ccc; box-shadow: 0 1px 3px #ccc; z-index: 9;"
+                >
+                  <div
+                    id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                  >
+                    <div
+                      class="perseus-renderer perseus-renderer-responsive"
+                    >
+                      <div
+                        class="paragraph"
+                        data-perseus-paragraph-index="0"
+                      >
+                        <div
+                          class="paragraph"
+                        >
+                          <strong>
+                            Your answer should be
+                          </strong>
+                            a 
+                          <em>
+                            simplified proper
+                          </em>
+                           fraction, like 
+                          <span
+                            style="white-space: nowrap;"
+                          >
+                            <span />
+                            <span
+                              class="mock-TeX"
+                            >
+                              3/5
+                            </span>
+                            <span />
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </span>
+        </div>
+         
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`numeric-input widget Should render tooltip when format option is given: render with format tooltip 1`] = `
 <div>
   <div

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.class.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.class.tsx
@@ -174,14 +174,18 @@ const propsTransform = function (
     const {answers: _, ...rendererProps} = {
         ...widgetOptions,
         answerForms: unionAnswerForms(
-            widgetOptions.answers.map((answer) => {
-                return (answer.answerForms || []).map((form) => {
-                    return {
-                        simplify: answer.simplify,
-                        name: form,
-                    };
-                });
-            }),
+            // Filter out the correct answers and map them to the answer forms
+            // so that we can generate the examples for the widget.
+            widgetOptions.answers
+                .filter((answer) => answer.status === "correct")
+                .map((answer) => {
+                    return (answer.answerForms || []).map((form) => {
+                        return {
+                            simplify: answer.simplify,
+                            name: form,
+                        };
+                    });
+                }),
         ),
     };
 

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
@@ -15,6 +15,7 @@ import {
     question1,
     duplicatedAnswers,
     withCoefficient,
+    correctAndWrongAnswers,
 } from "./numeric-input.testdata";
 
 import type {PerseusNumericInputRubric} from "@khanacademy/perseus-score";
@@ -111,6 +112,16 @@ describe("numeric-input widget", () => {
 
         // Assert
         expect(container).toMatchSnapshot("render with format list tooltip");
+    });
+
+    it("Should render tooltip using only correct answer formats", async () => {
+        // Arrange
+        const {container} = renderQuestion(correctAndWrongAnswers);
+
+        // Assert
+        expect(container).toMatchSnapshot(
+            "render tooltip only with correct answers",
+        );
     });
 
     it("Should render an element with format options as text for use by assistive technologies", async () => {
@@ -372,5 +383,16 @@ describe("Numeric input widget", () => {
         expect(document.activeElement).not.toBe(
             screen.getByRole("textbox", {hidden: true}),
         );
+    });
+
+    it("only generates examples for correct answers", async () => {
+        const {renderer} = renderQuestion(question1);
+
+        // Act
+        const gotFocus = await act(() => renderer.focus());
+
+        // Assert
+        expect(gotFocus).toBe(true);
+        expect(screen.getByRole("textbox", {hidden: true})).toHaveFocus();
     });
 });

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
@@ -384,15 +384,4 @@ describe("Numeric input widget", () => {
             screen.getByRole("textbox", {hidden: true}),
         );
     });
-
-    it("only generates examples for correct answers", async () => {
-        const {renderer} = renderQuestion(question1);
-
-        // Act
-        const gotFocus = await act(() => renderer.focus());
-
-        // Assert
-        expect(gotFocus).toBe(true);
-        expect(screen.getByRole("textbox", {hidden: true})).toHaveFocus();
-    });
 });

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
@@ -18,6 +18,7 @@ import {
     correctAndWrongAnswers,
 } from "./numeric-input.testdata";
 
+import type {PerseusNumericInputWidgetOptions} from "@khanacademy/perseus-core";
 import type {PerseusNumericInputRubric} from "@khanacademy/perseus-score";
 import type {UserEvent} from "@testing-library/user-event";
 
@@ -383,5 +384,80 @@ describe("Numeric input widget", () => {
         expect(document.activeElement).not.toBe(
             screen.getByRole("textbox", {hidden: true}),
         );
+    });
+});
+
+describe("transform", () => {
+    it("removes the answers and extracts the answer forms", () => {
+        const transform = NumericInputWidgetExport.transform;
+        const widgetOptions: PerseusNumericInputWidgetOptions = {
+            coefficient: false,
+            static: false,
+            size: "normal",
+            answers: [
+                {
+                    status: "correct",
+                    maxError: null,
+                    strict: true,
+                    value: 0.5,
+                    simplify: "required",
+                    answerForms: ["proper"],
+                    message: "",
+                },
+            ],
+        };
+        const renderProps = transform(widgetOptions);
+        expect(renderProps).toEqual({
+            coefficient: false,
+            static: false,
+            size: "normal",
+            answerForms: [
+                {
+                    simplify: "required",
+                    name: "proper",
+                },
+            ],
+        });
+    });
+
+    it("only uses answer forms from correct answers", () => {
+        const transform = NumericInputWidgetExport.transform;
+        const widgetOptions: PerseusNumericInputWidgetOptions = {
+            coefficient: false,
+            static: false,
+            size: "normal",
+            answers: [
+                {
+                    status: "correct",
+                    maxError: null,
+                    strict: true,
+                    value: 0.5,
+                    simplify: "required",
+                    answerForms: ["proper"],
+                    message: "",
+                },
+                {
+                    status: "wrong",
+                    maxError: null,
+                    strict: true,
+                    value: 0.5,
+                    simplify: "required",
+                    answerForms: ["decimal"],
+                    message: "",
+                },
+            ],
+        };
+        const renderProps = transform(widgetOptions);
+        expect(renderProps).toEqual({
+            coefficient: false,
+            static: false,
+            size: "normal",
+            answerForms: [
+                {
+                    simplify: "required",
+                    name: "proper",
+                },
+            ],
+        });
     });
 });

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.testdata.ts
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.testdata.ts
@@ -111,6 +111,49 @@ export const multipleAnswers: PerseusRenderer = {
     },
 };
 
+export const correctAndWrongAnswers: PerseusRenderer = {
+    content: "$5008 \\div 4 =$ [[\u2603 numeric-input 1]] ",
+    images: {},
+    widgets: {
+        "numeric-input 1": {
+            graded: true,
+            version: {
+                major: 0,
+                minor: 0,
+            },
+            static: false,
+            type: "numeric-input",
+            options: {
+                coefficient: false,
+                static: false,
+                answers: [
+                    {
+                        status: "correct",
+                        maxError: null,
+                        strict: true,
+                        value: 0.5,
+                        simplify: "required",
+                        answerForms: ["proper"],
+                        message: "",
+                    },
+                    {
+                        status: "wrong",
+                        maxError: null,
+                        strict: true,
+                        value: 0.5,
+                        simplify: "required",
+                        answerForms: ["decimal"],
+                        message: "",
+                    },
+                ],
+                labelText: "What's the answer?",
+                size: "normal",
+            },
+            alignment: "default",
+        } as NumericInputWidget,
+    },
+};
+
 export const multipleAnswersWithDecimals: PerseusRenderer = {
     content: "$5008 \\div 4 =$ [[\u2603 numeric-input 1]] ",
     images: {},


### PR DESCRIPTION
## Summary:
This PR is part of the Numeric Input Project. 

This is a bug fix that ensures that the Examples Tooltip for the Numeric Input widget only displays examples from the _correct_ answers. 

Issue: LEMS-2803

## Test plan:
- Run tests 
- Creation of new snapshot test that verifies wrong answerFormats are not being provided. 