### PR TITLE
Fix 'repository' field in kmath's package.json

### DIFF
--- a/.changeset/curly-bikes-nail.md
+++ b/.changeset/curly-bikes-nail.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/kmath": patch
+---
+
+Update repository information

--- a/packages/kmath/package.json
+++ b/packages/kmath/package.json
@@ -9,7 +9,8 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/Khan/kmath.git"
+        "url": "https://github.com/Khan/perseus.git",
+        "directory": "packages/kmath"
     },
     "bugs": {
         "url": "https://github.com/Khan/perseus/issues"


### PR DESCRIPTION
## Summary:

While working on some automation, I noticed that this package still points to its old repository (before we moved everything into this monorepo)

Issue: "none"

## Test plan:

Review the change. Hpoe it's correct!