### PR TITLE
Remove deprecated exports from the `perseus` package

### DIFF
--- a/.changeset/poor-masks-return.md
+++ b/.changeset/poor-masks-return.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": major
+---
+
+Removes the following deprecated exports from `@khanacademy/perseus`: `parsePerseusItem`, `parseAndMigratePerseusItem`, `parseAndMigratePerseusArticle`, `isSuccess`, `isFailure`, `Result`, `Success`, `Failure`. Clients should import these from `@khanacademy/perseus-core` instead.

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -108,28 +108,6 @@ export {
     getAnswerFromUserInput,
     getImagesWithoutAltData,
 } from "./util/extract-perseus-data";
-export {
-    /**
-     * @deprecated - import this function from perseus-core instead
-     */
-    parsePerseusItem,
-    /**
-     * @deprecated - import this function from perseus-core instead
-     */
-    parseAndMigratePerseusItem,
-    /**
-     * @deprecated - import this function from perseus-core instead
-     */
-    parseAndMigratePerseusArticle,
-    /**
-     * @deprecated - import this function from perseus-core instead
-     */
-    isSuccess,
-    /**
-     * @deprecated - import this function from perseus-core instead
-     */
-    isFailure,
-} from "@khanacademy/perseus-core";
 
 export {
     generateTestPerseusItem,
@@ -203,20 +181,6 @@ export type {
     SharedRendererProps,
 } from "./types";
 export type {ParsedValue} from "./util";
-export type {
-    /**
-     * @deprecated - import this function from perseus-core instead
-     */
-    Result,
-    /**
-     * @deprecated - import this function from perseus-core instead
-     */
-    Success,
-    /**
-     * @deprecated - import this function from perseus-core instead
-     */
-    Failure,
-} from "@khanacademy/perseus-core";
 export type {Coord} from "./interactive2/types";
 export type {
     RendererPromptJSON,


### PR DESCRIPTION
## Summary:
They have been moved to `perseus-core`.

Issue: none

Test plan:

CI should be green.