### PR TITLE
Remove z-index tokens, constants, and classes that place SOME widgets above the doodlepad.

### DIFF
--- a/.changeset/tame-doors-itch.md
+++ b/.changeset/tame-doors-itch.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Removes explicit z-indexes from many widgets to fix long-standing bugs in consuming code.

--- a/packages/perseus/src/components/__tests__/__snapshots__/graph.test.tsx.snap
+++ b/packages/perseus/src/components/__tests__/__snapshots__/graph.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`graph should render 1`] = `
 <div>
   <div
-    class="graphie-container above-scratchpad"
+    class="graphie-container blank-background"
     style="width: 400px; height: 400px;"
   >
     <div

--- a/packages/perseus/src/components/__tests__/__snapshots__/sortable.test.tsx.snap
+++ b/packages/perseus/src/components/__tests__/__snapshots__/sortable.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`Sortable renders a spinner while waiting for the TeX renderer to load: 
     class="sortable_13d4756 perseus-sortable"
   >
     <li
-      class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
+      class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-sortable-draggable"
       style="position: static; margin: 0px 5px 0px 0px;"
     >
       <div
@@ -55,7 +55,7 @@ exports[`Sortable renders a spinner while waiting for the TeX renderer to load: 
       </div>
     </li>
     <li
-      class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
+      class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-sortable-draggable"
       style="position: static; margin: 0px 5px 0px 0px;"
     >
       <div
@@ -74,7 +74,7 @@ exports[`Sortable renders a spinner while waiting for the TeX renderer to load: 
       </div>
     </li>
     <li
-      class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
+      class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-sortable-draggable"
       style="position: static; margin: 0px;"
     >
       <div
@@ -102,7 +102,7 @@ exports[`Sortable should snapshot: first render 1`] = `
     class="sortable_13d4756 perseus-sortable"
   >
     <li
-      class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
+      class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-sortable-draggable"
       style="position: static; margin: 0px 5px 0px 0px;"
     >
       <div
@@ -121,7 +121,7 @@ exports[`Sortable should snapshot: first render 1`] = `
       </div>
     </li>
     <li
-      class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
+      class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-sortable-draggable"
       style="position: static; margin: 0px 5px 0px 0px;"
     >
       <div
@@ -140,7 +140,7 @@ exports[`Sortable should snapshot: first render 1`] = `
       </div>
     </li>
     <li
-      class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
+      class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-sortable-draggable"
       style="position: static; margin: 0px;"
     >
       <div

--- a/packages/perseus/src/components/__tests__/__snapshots__/sorter.test.tsx.snap
+++ b/packages/perseus/src/components/__tests__/__snapshots__/sorter.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`sorter widget should snapshot on mobile: first mobile render 1`] = `
               class="sortable_13d4756 perseus-sortable"
             >
               <li
-                class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
+                class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-sortable-draggable"
                 style="position: static; margin: 0px 8px 0px 0px;"
               >
                 <div
@@ -64,7 +64,7 @@ exports[`sorter widget should snapshot on mobile: first mobile render 1`] = `
                 </div>
               </li>
               <li
-                class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
+                class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-sortable-draggable"
                 style="position: static; margin: 0px 8px 0px 0px;"
               >
                 <div
@@ -94,7 +94,7 @@ exports[`sorter widget should snapshot on mobile: first mobile render 1`] = `
                 </div>
               </li>
               <li
-                class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
+                class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-sortable-draggable"
                 style="position: static; margin: 0px;"
               >
                 <div
@@ -166,7 +166,7 @@ exports[`sorter widget should snapshot: first render 1`] = `
               class="sortable_13d4756 perseus-sortable"
             >
               <li
-                class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
+                class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-sortable-draggable"
                 style="position: static; margin: 0px 5px 0px 0px;"
               >
                 <div
@@ -196,7 +196,7 @@ exports[`sorter widget should snapshot: first render 1`] = `
                 </div>
               </li>
               <li
-                class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
+                class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-sortable-draggable"
                 style="position: static; margin: 0px 5px 0px 0px;"
               >
                 <div
@@ -226,7 +226,7 @@ exports[`sorter widget should snapshot: first render 1`] = `
                 </div>
               </li>
               <li
-                class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-interactive perseus-sortable-draggable"
+                class="card_1s6cuhy-o_O-draggable_12to336-o_O-horizontalCard_9um937 perseus-sortable-draggable"
                 style="position: static; margin: 0px;"
               >
                 <div

--- a/packages/perseus/src/components/graph.tsx
+++ b/packages/perseus/src/components/graph.tsx
@@ -416,7 +416,7 @@ class Graph extends React.Component<Props> {
 
         return (
             <div
-                className="graphie-container above-scratchpad"
+                className="graphie-container blank-background"
                 style={{
                     width: this.props.box[0],
                     height: this.props.box[1],

--- a/packages/perseus/src/components/input-with-examples.tsx
+++ b/packages/perseus/src/components/input-with-examples.tsx
@@ -71,7 +71,7 @@ class InputWithExamples extends React.Component<Props, State> {
 
     _getInputClassName: () => string = () => {
         // Otherwise, we need to add these INPUT and FOCUSED tags here.
-        let className = ApiClassNames.INPUT + " " + ApiClassNames.INTERACTIVE;
+        let className = ApiClassNames.INPUT;
         if (this.state.focused) {
             className += " " + ApiClassNames.FOCUSED;
         }

--- a/packages/perseus/src/components/sortable.tsx
+++ b/packages/perseus/src/components/sortable.tsx
@@ -9,7 +9,6 @@ import ReactDOM from "react-dom";
 import _ from "underscore";
 
 import {getDependencies} from "../dependencies";
-import {ClassNames as ApiClassNames} from "../perseus-api";
 import Renderer from "../renderer";
 import Util from "../util";
 
@@ -351,8 +350,7 @@ class Draggable extends React.Component<DraggableProps, DraggableState> {
                 !includePadding && styles.unpaddedCard,
             ) +
             " " +
-            ApiClassNames.INTERACTIVE +
-            " perseus-sortable-draggable";
+            "perseus-sortable-draggable";
 
         if (!includePadding) {
             className += " perseus-sortable-draggable-unpadded";

--- a/packages/perseus/src/perseus-api.tsx
+++ b/packages/perseus/src/perseus-api.tsx
@@ -168,10 +168,6 @@ export const ClassNames = {
         SELECTED: "perseus-radio-selected",
         OPTION_CONTENT: "perseus-radio-option-content",
     },
-    /**
-     * @deprecated This used to add a z-index of 3. Now it does nothing.
-     */
-    INTERACTIVE: "perseus-interactive",
     CORRECT: "perseus-correct",
     INCORRECT: "perseus-incorrect",
     UNANSWERED: "perseus-unanswered",

--- a/packages/perseus/src/perseus-api.tsx
+++ b/packages/perseus/src/perseus-api.tsx
@@ -168,6 +168,9 @@ export const ClassNames = {
         SELECTED: "perseus-radio-selected",
         OPTION_CONTENT: "perseus-radio-option-content",
     },
+    /**
+     * @deprecated This used to add a z-index of 3. Now it does nothing.
+     */
     INTERACTIVE: "perseus-interactive",
     CORRECT: "perseus-correct",
     INCORRECT: "perseus-incorrect",

--- a/packages/perseus/src/styles/constants.ts
+++ b/packages/perseus/src/styles/constants.ts
@@ -30,8 +30,6 @@ export const pureMdMax = "1023px";
 export const pureLgMax = "1279px";
 // @tableBackgroundAccent: #f9f9f9; // for striping
 export const tableBackgroundAccent = "#F9F9F9";
-// @zIndexInteractiveComponent: 3;
-export const zIndexInteractiveComponent = 3;
 // @phoneMargin: 16px;
 export const phoneMargin = 16;
 

--- a/packages/perseus/src/styles/constants.ts
+++ b/packages/perseus/src/styles/constants.ts
@@ -30,9 +30,7 @@ export const pureMdMax = "1023px";
 export const pureLgMax = "1279px";
 // @tableBackgroundAccent: #f9f9f9; // for striping
 export const tableBackgroundAccent = "#F9F9F9";
-// @zIndexAboveScratchpad: @zIndexScratchPad + 1;
-export const zIndexAboveScratchpad = 2;
-// @zIndexInteractiveComponent: @zIndexAboveScratchpad + 1;
+// @zIndexInteractiveComponent: 3;
 export const zIndexInteractiveComponent = 3;
 // @phoneMargin: 16px;
 export const phoneMargin = 16;

--- a/packages/perseus/src/styles/perseus-renderer.less
+++ b/packages/perseus/src/styles/perseus-renderer.less
@@ -46,11 +46,6 @@
     .no-select;
 }
 
-.perseus-interactive {
-    position: relative;
-    z-index: @zIndexInteractiveComponent;
-}
-
 &,  // and moar specificity...
 #answercontent input[type=text],
 #answercontent input[type=number],

--- a/packages/perseus/src/styles/perseus-renderer.less
+++ b/packages/perseus/src/styles/perseus-renderer.less
@@ -37,20 +37,8 @@
     background-color: transparent;
 }
 
-.above-scratchpad {
+.relative {
     position: relative;
-    z-index: @zIndexAboveScratchpad;
-}
-
-// All graphie components placed above the scratchpad should have their
-// background wiped out.
-.graphie.above-scratchpad,
-.graphie-container.above-scratchpad {
-    .blank-background;
-}
-
-.perseus-mobile .graphie-container.above-scratchpad {
-    background: #ffffff;
 }
 
 // Selectable graphie components make for awkward touch experiences
@@ -58,8 +46,7 @@
     .no-select;
 }
 
-.perseus-interactive,
-.perseus-interactive.above-scratchpad {
+.perseus-interactive {
     position: relative;
     z-index: @zIndexInteractiveComponent;
 }

--- a/packages/perseus/src/styles/perseus-renderer.less
+++ b/packages/perseus/src/styles/perseus-renderer.less
@@ -37,10 +37,6 @@
     background-color: transparent;
 }
 
-.relative {
-    position: relative;
-}
-
 // Selectable graphie components make for awkward touch experiences
 .graphie {
     .no-select;

--- a/packages/perseus/src/styles/shared.ts
+++ b/packages/perseus/src/styles/shared.ts
@@ -6,7 +6,6 @@ import mediaQueries from "./media-queries";
 import type {StyleDeclaration} from "aphrodite";
 
 const {
-    zIndexAboveScratchpad,
     zIndexInteractiveComponent,
     radioBorderColor,
     checkedColor,
@@ -18,11 +17,6 @@ export default StyleSheet.create({
     perseusInteractive: {
         zIndex: zIndexInteractiveComponent,
         position: "relative",
-    },
-
-    aboveScratchpad: {
-        position: "relative",
-        zIndex: zIndexAboveScratchpad,
     },
 
     blankBackground: {

--- a/packages/perseus/src/styles/shared.ts
+++ b/packages/perseus/src/styles/shared.ts
@@ -5,20 +5,10 @@ import mediaQueries from "./media-queries";
 
 import type {StyleDeclaration} from "aphrodite";
 
-const {
-    zIndexInteractiveComponent,
-    radioBorderColor,
-    checkedColor,
-    circleSize,
-    radioMarginWidth,
-} = constants;
+const {radioBorderColor, checkedColor, circleSize, radioMarginWidth} =
+    constants;
 
 export default StyleSheet.create({
-    perseusInteractive: {
-        zIndex: zIndexInteractiveComponent,
-        position: "relative",
-    },
-
     blankBackground: {
         // TODO(emily): Use WB colors?
         backgroundColor: "#FDFDFD",

--- a/packages/perseus/src/styles/variables.less
+++ b/packages/perseus/src/styles/variables.less
@@ -40,7 +40,6 @@
 
 // TODO: Remove these; only handle stacking with DOM order
 // Layer variables
-@zIndexInteractiveComponent: 3;
 @zIndexCurrentlyDragging: 4;
 @zIndexCalculator: 5;
 

--- a/packages/perseus/src/styles/variables.less
+++ b/packages/perseus/src/styles/variables.less
@@ -38,12 +38,11 @@
 @pure-md-max: (@pure-lg-min - 1);
 @pure-lg-max: (@pure-xl-min - 1);
 
+// TODO: Remove these; only handle stacking with DOM order
 // Layer variables
-@zIndexScratchPad: 1;
-@zIndexAboveScratchpad: @zIndexScratchPad + 1;
-@zIndexInteractiveComponent: @zIndexAboveScratchpad + 1;
-@zIndexCurrentlyDragging: @zIndexInteractiveComponent + 1;
-@zIndexCalculator: @zIndexCurrentlyDragging + 1;
+@zIndexInteractiveComponent: 3;
+@zIndexCurrentlyDragging: 4;
+@zIndexCalculator: 5;
 
 // Responsive variables
 @phoneMargin: 16px;

--- a/packages/perseus/src/styles/widgets/categorizer.less
+++ b/packages/perseus/src/styles/widgets/categorizer.less
@@ -12,10 +12,6 @@
     table {
         min-width: 0;
     }
-
-    label {
-        .above-scratchpad;
-    }
 }
 
 // TODO(benkomalo): ughhh. kill or move this out of here :(

--- a/packages/perseus/src/styles/widgets/expression.less
+++ b/packages/perseus/src/styles/widgets/expression.less
@@ -17,7 +17,6 @@
         color: #fcc335;
         cursor: pointer;
         font-size: 20px;
-        .perseus-interactive;
     }
 
     .error-text {

--- a/packages/perseus/src/styles/widgets/orderer.less
+++ b/packages/perseus/src/styles/widgets/orderer.less
@@ -47,7 +47,6 @@
     }
 
     .card-wrap {
-        .perseus-interactive;
         width: auto;
     }
 

--- a/packages/perseus/src/styles/widgets/sortable.less
+++ b/packages/perseus/src/styles/widgets/sortable.less
@@ -14,13 +14,6 @@
         box-shadow: 0 1px 2px #ccc;
     }
 
-    // TODO(jack): Make this work for the orderer too.
-    // Right now don't do this for the orderer because it uses
-    // more complicated positioning that this would break
-    .cards-area {
-        .above-scratchpad;
-    }
-
     .card {
         .perseus-interactive;
 

--- a/packages/perseus/src/styles/widgets/sortable.less
+++ b/packages/perseus/src/styles/widgets/sortable.less
@@ -15,8 +15,6 @@
     }
 
     .card {
-        .perseus-interactive;
-
         background-color: #fff;
         border: 1px solid #b9b9b9;
         border-bottom-color: #939393;

--- a/packages/perseus/src/widget-container.tsx
+++ b/packages/perseus/src/widget-container.tsx
@@ -6,7 +6,6 @@ import ReactDOM from "react-dom";
 
 import {DependenciesContext} from "./dependencies";
 import ErrorBoundary from "./error-boundary";
-import {zIndexInteractiveComponent} from "./styles/constants";
 import {containerSizeClass, getClassFromWidth} from "./util/sizing-utils";
 import * as Widgets from "./widgets";
 
@@ -127,6 +126,7 @@ class WidgetContainer extends React.Component<Props, State> {
         // Hack to prevent interaction with static widgets: we overlay a big
         // div on top of the widget and overflow: hidden the container.
         // Ideally widgets themselves should know how to prevent interaction.
+        // UPDATE HTML5: `inert` on the underlying div would be better
         const isStatic = this.state.widgetProps.static || apiOptions.readOnly;
         const staticContainerStyles = {
             position: "relative",
@@ -138,7 +138,7 @@ class WidgetContainer extends React.Component<Props, State> {
             position: "absolute",
             top: 0,
             left: 0,
-            zIndex: zIndexInteractiveComponent,
+            zIndex: 3,
         } as const;
 
         // Some widgets may include strings of markdown that we may

--- a/packages/perseus/src/widgets/categorizer/__snapshots__/categorizer.test.ts.snap
+++ b/packages/perseus/src/widgets/categorizer/__snapshots__/categorizer.test.ts.snap
@@ -170,7 +170,6 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                   >
                     <div
                       aria-label="No relationship"
-                      class="perseus-interactive"
                       role="button"
                     >
                       <input
@@ -185,7 +184,6 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                   >
                     <div
                       aria-label="Positive linear relationship"
-                      class="perseus-interactive"
                       role="button"
                     >
                       <input
@@ -200,7 +198,6 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                   >
                     <div
                       aria-label="Negative linear relationship"
-                      class="perseus-interactive"
                       role="button"
                     >
                       <input
@@ -215,7 +212,6 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                   >
                     <div
                       aria-label="Nonlinear relationship"
-                      class="perseus-interactive"
                       role="button"
                     >
                       <input
@@ -259,7 +255,6 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                   >
                     <div
                       aria-label="No relationship"
-                      class="perseus-interactive"
                       role="button"
                     >
                       <input
@@ -274,7 +269,6 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                   >
                     <div
                       aria-label="Positive linear relationship"
-                      class="perseus-interactive"
                       role="button"
                     >
                       <input
@@ -289,7 +283,6 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                   >
                     <div
                       aria-label="Negative linear relationship"
-                      class="perseus-interactive"
                       role="button"
                     >
                       <input
@@ -304,7 +297,6 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                   >
                     <div
                       aria-label="Nonlinear relationship"
-                      class="perseus-interactive"
                       role="button"
                     >
                       <input
@@ -589,7 +581,6 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                   >
                     <div
                       aria-label="No relationship"
-                      class="perseus-interactive"
                       role="button"
                     >
                       <span
@@ -616,7 +607,6 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                   >
                     <div
                       aria-label="Positive linear relationship"
-                      class="perseus-interactive"
                       role="button"
                     >
                       <span
@@ -643,7 +633,6 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                   >
                     <div
                       aria-label="Negative linear relationship"
-                      class="perseus-interactive"
                       role="button"
                     >
                       <span
@@ -670,7 +659,6 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                   >
                     <div
                       aria-label="Nonlinear relationship"
-                      class="perseus-interactive"
                       role="button"
                     >
                       <span
@@ -726,7 +714,6 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                   >
                     <div
                       aria-label="No relationship"
-                      class="perseus-interactive"
                       role="button"
                     >
                       <span
@@ -753,7 +740,6 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                   >
                     <div
                       aria-label="Positive linear relationship"
-                      class="perseus-interactive"
                       role="button"
                     >
                       <span
@@ -780,7 +766,6 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                   >
                     <div
                       aria-label="Negative linear relationship"
-                      class="perseus-interactive"
                       role="button"
                     >
                       <span
@@ -807,7 +792,6 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                   >
                     <div
                       aria-label="Nonlinear relationship"
-                      class="perseus-interactive"
                       role="button"
                     >
                       <span

--- a/packages/perseus/src/widgets/categorizer/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.tsx
@@ -17,7 +17,6 @@ import {PerseusI18nContext} from "../../components/i18n-context";
 import InlineIcon from "../../components/inline-icon";
 import {iconCircle, iconCircleThin} from "../../icon-paths";
 import * as Changeable from "../../mixins/changeable";
-import {ClassNames as ApiClassNames} from "../../perseus-api";
 import Renderer from "../../renderer";
 import mediaQueries from "../../styles/media-queries";
 import sharedStyles from "../../styles/shared";
@@ -152,13 +151,7 @@ export class Categorizer
                                                 }
                                                 key={catNum}
                                             >
-                                                {/* a pseudo-label: toggle the
-                                value of the checkbox when this div or the
-                                checkbox is clicked */}
                                                 <div
-                                                    className={
-                                                        ApiClassNames.INTERACTIVE
-                                                    }
                                                     role="button"
                                                     aria-label={catName}
                                                     onClick={() =>

--- a/packages/perseus/src/widgets/expression/expression.tsx
+++ b/packages/perseus/src/widgets/expression/expression.tsx
@@ -21,7 +21,7 @@ import {PerseusI18nContext} from "../../components/i18n-context";
 import MathInput from "../../components/math-input";
 import {useDependencies} from "../../dependencies";
 import * as Changeable from "../../mixins/changeable";
-import {ApiOptions, ClassNames as ApiClassNames} from "../../perseus-api";
+import {ApiOptions} from "../../perseus-api";
 import a11y from "../../util/a11y";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/expression/expression-ai-utils";
 
@@ -380,7 +380,6 @@ export class Expression
                         <MathInput
                             // eslint-disable-next-line react/no-string-refs
                             ref="input"
-                            className={ApiClassNames.INTERACTIVE}
                             value={this.props.value}
                             onChange={this.changeAndTrack}
                             convertDotToTimes={this.props.times}

--- a/packages/perseus/src/widgets/graded-group/__snapshots__/graded-group.test.ts.snap
+++ b/packages/perseus/src/widgets/graded-group/__snapshots__/graded-group.test.ts.snap
@@ -135,7 +135,6 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                 >
                                   <div
                                     aria-label="True"
-                                    class="perseus-interactive"
                                     role="button"
                                   >
                                     <span
@@ -162,7 +161,6 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                 >
                                   <div
                                     aria-label="False"
-                                    class="perseus-interactive"
                                     role="button"
                                   >
                                     <span
@@ -207,7 +205,6 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                 >
                                   <div
                                     aria-label="True"
-                                    class="perseus-interactive"
                                     role="button"
                                   >
                                     <span
@@ -234,7 +231,6 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                 >
                                   <div
                                     aria-label="False"
-                                    class="perseus-interactive"
                                     role="button"
                                   >
                                     <span
@@ -279,7 +275,6 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                 >
                                   <div
                                     aria-label="True"
-                                    class="perseus-interactive"
                                     role="button"
                                   >
                                     <span
@@ -306,7 +301,6 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                 >
                                   <div
                                     aria-label="False"
-                                    class="perseus-interactive"
                                     role="button"
                                   >
                                     <span
@@ -351,7 +345,6 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                 >
                                   <div
                                     aria-label="True"
-                                    class="perseus-interactive"
                                     role="button"
                                   >
                                     <span
@@ -378,7 +371,6 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                 >
                                   <div
                                     aria-label="False"
-                                    class="perseus-interactive"
                                     role="button"
                                   >
                                     <span
@@ -575,7 +567,6 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                 >
                                   <div
                                     aria-label="True"
-                                    class="perseus-interactive"
                                     role="button"
                                   >
                                     <input
@@ -590,7 +581,6 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                 >
                                   <div
                                     aria-label="False"
-                                    class="perseus-interactive"
                                     role="button"
                                   >
                                     <input
@@ -623,7 +613,6 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                 >
                                   <div
                                     aria-label="True"
-                                    class="perseus-interactive"
                                     role="button"
                                   >
                                     <input
@@ -638,7 +627,6 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                 >
                                   <div
                                     aria-label="False"
-                                    class="perseus-interactive"
                                     role="button"
                                   >
                                     <input
@@ -671,7 +659,6 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                 >
                                   <div
                                     aria-label="True"
-                                    class="perseus-interactive"
                                     role="button"
                                   >
                                     <input
@@ -686,7 +673,6 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                 >
                                   <div
                                     aria-label="False"
-                                    class="perseus-interactive"
                                     role="button"
                                   >
                                     <input
@@ -719,7 +705,6 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                 >
                                   <div
                                     aria-label="True"
-                                    class="perseus-interactive"
                                     role="button"
                                   >
                                     <input
@@ -734,7 +719,6 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                 >
                                   <div
                                     aria-label="False"
-                                    class="perseus-interactive"
                                     role="button"
                                   >
                                     <input

--- a/packages/perseus/src/widgets/grapher/__snapshots__/grapher.test.ts.snap
+++ b/packages/perseus/src/widgets/grapher/__snapshots__/grapher.test.ts.snap
@@ -45,7 +45,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
               style="width: 400px; height: 400px; box-sizing: initial;"
             >
               <div
-                class="graphie-container above-scratchpad"
+                class="graphie-container blank-background"
                 style="width: 400px; height: 400px;"
               >
                 <div
@@ -1364,7 +1364,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
               style="width: 400px; height: 400px; box-sizing: initial;"
             >
               <div
-                class="graphie-container above-scratchpad"
+                class="graphie-container blank-background"
                 style="width: 400px; height: 400px;"
               >
                 <div
@@ -2603,7 +2603,6 @@ exports[`grapher widget should snapshot question with multiple graph types: init
               </div>
             </div>
             <div
-              class="above-scratchpad"
               style="padding: 5px 5px;"
             >
               <div

--- a/packages/perseus/src/widgets/grapher/grapher.tsx
+++ b/packages/perseus/src/widgets/grapher/grapher.tsx
@@ -325,7 +325,7 @@ class FunctionGrapher extends React.Component<FunctionGrapherProps> {
                 }}
             >
                 <div
-                    className="graphie-container"
+                    className="graphie-container blank-background"
                     style={{
                         width: box[0],
                         height: box[1],
@@ -556,7 +556,7 @@ class Grapher extends React.Component<Props> implements Widget {
         const asymptote = this.props.plot.asymptote;
 
         const typeSelector = (
-            <div style={typeSelectorStyle} className="blank-background">
+            <div style={typeSelectorStyle}>
                 <ButtonGroup
                     value={type}
                     allowEmpty={true}

--- a/packages/perseus/src/widgets/grapher/grapher.tsx
+++ b/packages/perseus/src/widgets/grapher/grapher.tsx
@@ -325,7 +325,7 @@ class FunctionGrapher extends React.Component<FunctionGrapherProps> {
                 }}
             >
                 <div
-                    className="graphie-container above-scratchpad"
+                    className="graphie-container"
                     style={{
                         width: box[0],
                         height: box[1],
@@ -556,7 +556,7 @@ class Grapher extends React.Component<Props> implements Widget {
         const asymptote = this.props.plot.asymptote;
 
         const typeSelector = (
-            <div style={typeSelectorStyle} className="above-scratchpad">
+            <div style={typeSelectorStyle} className="blank-background">
                 <ButtonGroup
                     value={type}
                     allowEmpty={true}

--- a/packages/perseus/src/widgets/group/__snapshots__/group.test.tsx.snap
+++ b/packages/perseus/src/widgets/group/__snapshots__/group.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`group widget should snapshot: initial render 1`] = `
                                 style="list-style: none;"
                               >
                                 <li
-                                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                                 >
                                   <div
                                     class="description description_psmgei"
@@ -240,7 +240,7 @@ exports[`group widget should snapshot: initial render 1`] = `
                                   </div>
                                 </li>
                                 <li
-                                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                                 >
                                   <div
                                     class="description description_psmgei"
@@ -354,7 +354,7 @@ exports[`group widget should snapshot: initial render 1`] = `
                                   </div>
                                 </li>
                                 <li
-                                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                                 >
                                   <div
                                     class="description description_psmgei"
@@ -468,7 +468,7 @@ exports[`group widget should snapshot: initial render 1`] = `
                                   </div>
                                 </li>
                                 <li
-                                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                                 >
                                   <div
                                     class="description description_psmgei"
@@ -582,7 +582,7 @@ exports[`group widget should snapshot: initial render 1`] = `
                                   </div>
                                 </li>
                                 <li
-                                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                                 >
                                   <div
                                     class="description description_psmgei"

--- a/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`Interactive Graph interactive-graph widget A none-type graph renders pr
             style="width: 400px; height: 400px;"
           >
             <div
-              class="graphie-container above-scratchpad"
+              class="graphie-container blank-background"
               style="width: 400px; height: 400px;"
             >
               <div
@@ -1161,7 +1161,7 @@ exports[`Interactive Graph interactive-graph widget question Should render predi
             style="width: 400px; height: 400px;"
           >
             <div
-              class="graphie-container above-scratchpad"
+              class="graphie-container blank-background"
               style="width: 400px; height: 400px;"
             >
               <div
@@ -1531,7 +1531,7 @@ exports[`Interactive Graph interactive-graph widget question Should render predi
             style="width: 400px; height: 400px;"
           >
             <div
-              class="graphie-container above-scratchpad"
+              class="graphie-container blank-background"
               style="width: 400px; height: 400px;"
             >
               <div
@@ -1942,7 +1942,7 @@ exports[`Interactive Graph interactive-graph widget question Should render predi
             style="width: 400px; height: 400px;"
           >
             <div
-              class="graphie-container above-scratchpad"
+              class="graphie-container blank-background"
               style="width: 400px; height: 400px;"
             >
               <div
@@ -2346,7 +2346,7 @@ exports[`Interactive Graph interactive-graph widget question Should render predi
             style="width: 400px; height: 400px;"
           >
             <div
-              class="graphie-container above-scratchpad"
+              class="graphie-container blank-background"
               style="width: 400px; height: 400px;"
             >
               <div
@@ -2857,7 +2857,7 @@ exports[`Interactive Graph interactive-graph widget question Should render predi
             style="width: 400px; height: 400px;"
           >
             <div
-              class="graphie-container above-scratchpad"
+              class="graphie-container blank-background"
               style="width: 400px; height: 400px;"
             >
               <div
@@ -3227,7 +3227,7 @@ exports[`Interactive Graph interactive-graph widget question Should render predi
             style="width: 400px; height: 400px;"
           >
             <div
-              class="graphie-container above-scratchpad"
+              class="graphie-container blank-background"
               style="width: 400px; height: 400px;"
             >
               <div
@@ -3638,7 +3638,7 @@ exports[`Interactive Graph interactive-graph widget question Should render predi
             style="width: 400px; height: 400px;"
           >
             <div
-              class="graphie-container above-scratchpad"
+              class="graphie-container blank-background"
               style="width: 400px; height: 400px;"
             >
               <div
@@ -3854,7 +3854,7 @@ exports[`Interactive Graph interactive-graph widget question Should render predi
             style="width: 400px; height: 400px;"
           >
             <div
-              class="graphie-container above-scratchpad"
+              class="graphie-container blank-background"
               style="width: 400px; height: 400px;"
             >
               <div

--- a/packages/perseus/src/widgets/matcher/__snapshots__/matcher.test.tsx.snap
+++ b/packages/perseus/src/widgets/matcher/__snapshots__/matcher.test.tsx.snap
@@ -85,7 +85,7 @@ exports[`matcher widget can reorder options: moved items 1`] = `
                     class="sortable_13d4756 perseus-sortable"
                   >
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-sortable-draggable"
                       style="position: static; margin: 0px 0px 5px 0px;"
                     >
                       <div
@@ -104,7 +104,7 @@ exports[`matcher widget can reorder options: moved items 1`] = `
                       </div>
                     </li>
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-sortable-draggable"
                       style="position: static; margin: 0px 0px 5px 0px;"
                     >
                       <div
@@ -123,7 +123,7 @@ exports[`matcher widget can reorder options: moved items 1`] = `
                       </div>
                     </li>
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-sortable-draggable"
                       style="position: static; margin: 0px 0px 5px 0px;"
                     >
                       <div
@@ -142,7 +142,7 @@ exports[`matcher widget can reorder options: moved items 1`] = `
                       </div>
                     </li>
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-sortable-draggable"
                       style="position: static; margin: 0px 0px 5px 0px;"
                     >
                       <div
@@ -161,7 +161,7 @@ exports[`matcher widget can reorder options: moved items 1`] = `
                       </div>
                     </li>
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-sortable-draggable"
                       style="position: static; margin: 0px;"
                     >
                       <div
@@ -188,7 +188,7 @@ exports[`matcher widget can reorder options: moved items 1`] = `
                     class="sortable_13d4756 perseus-sortable"
                   >
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-sortable-draggable"
                       style="position: static; margin: 0px 0px 5px 0px;"
                     >
                       <div
@@ -207,7 +207,7 @@ exports[`matcher widget can reorder options: moved items 1`] = `
                       </div>
                     </li>
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-sortable-draggable"
                       style="position: static; margin: 0px 0px 5px 0px;"
                     >
                       <div
@@ -226,7 +226,7 @@ exports[`matcher widget can reorder options: moved items 1`] = `
                       </div>
                     </li>
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-sortable-draggable"
                       style="position: static; margin: 0px 0px 5px 0px;"
                     >
                       <div
@@ -245,7 +245,7 @@ exports[`matcher widget can reorder options: moved items 1`] = `
                       </div>
                     </li>
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-sortable-draggable"
                       style="position: static; margin: 0px 0px 5px 0px;"
                     >
                       <div
@@ -264,7 +264,7 @@ exports[`matcher widget can reorder options: moved items 1`] = `
                       </div>
                     </li>
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-sortable-draggable"
                       style="position: static; margin: 0px;"
                     >
                       <div
@@ -379,7 +379,7 @@ exports[`matcher widget should snapshot on mobile: first mobile render 1`] = `
                     class="sortable_13d4756 perseus-sortable"
                   >
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-sortable-draggable"
                       style="position: static; margin: 0px 0px 8px 0px;"
                     >
                       <div
@@ -398,7 +398,7 @@ exports[`matcher widget should snapshot on mobile: first mobile render 1`] = `
                       </div>
                     </li>
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-sortable-draggable"
                       style="position: static; margin: 0px 0px 8px 0px;"
                     >
                       <div
@@ -417,7 +417,7 @@ exports[`matcher widget should snapshot on mobile: first mobile render 1`] = `
                       </div>
                     </li>
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-sortable-draggable"
                       style="position: static; margin: 0px 0px 8px 0px;"
                     >
                       <div
@@ -436,7 +436,7 @@ exports[`matcher widget should snapshot on mobile: first mobile render 1`] = `
                       </div>
                     </li>
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-sortable-draggable"
                       style="position: static; margin: 0px 0px 8px 0px;"
                     >
                       <div
@@ -455,7 +455,7 @@ exports[`matcher widget should snapshot on mobile: first mobile render 1`] = `
                       </div>
                     </li>
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-sortable-draggable"
                       style="position: static; margin: 0px;"
                     >
                       <div
@@ -482,7 +482,7 @@ exports[`matcher widget should snapshot on mobile: first mobile render 1`] = `
                     class="sortable_13d4756 perseus-sortable"
                   >
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-sortable-draggable"
                       style="position: static; margin: 0px 0px 8px 0px;"
                     >
                       <div
@@ -501,7 +501,7 @@ exports[`matcher widget should snapshot on mobile: first mobile render 1`] = `
                       </div>
                     </li>
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-sortable-draggable"
                       style="position: static; margin: 0px 0px 8px 0px;"
                     >
                       <div
@@ -520,7 +520,7 @@ exports[`matcher widget should snapshot on mobile: first mobile render 1`] = `
                       </div>
                     </li>
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-sortable-draggable"
                       style="position: static; margin: 0px 0px 8px 0px;"
                     >
                       <div
@@ -539,7 +539,7 @@ exports[`matcher widget should snapshot on mobile: first mobile render 1`] = `
                       </div>
                     </li>
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-sortable-draggable"
                       style="position: static; margin: 0px 0px 8px 0px;"
                     >
                       <div
@@ -558,7 +558,7 @@ exports[`matcher widget should snapshot on mobile: first mobile render 1`] = `
                       </div>
                     </li>
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-sortable-draggable"
                       style="position: static; margin: 0px;"
                     >
                       <div
@@ -673,7 +673,7 @@ exports[`matcher widget should snapshot: first render 1`] = `
                     class="sortable_13d4756 perseus-sortable"
                   >
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-sortable-draggable"
                       style="position: static; margin: 0px 0px 5px 0px;"
                     >
                       <div
@@ -692,7 +692,7 @@ exports[`matcher widget should snapshot: first render 1`] = `
                       </div>
                     </li>
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-sortable-draggable"
                       style="position: static; margin: 0px 0px 5px 0px;"
                     >
                       <div
@@ -711,7 +711,7 @@ exports[`matcher widget should snapshot: first render 1`] = `
                       </div>
                     </li>
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-sortable-draggable"
                       style="position: static; margin: 0px 0px 5px 0px;"
                     >
                       <div
@@ -730,7 +730,7 @@ exports[`matcher widget should snapshot: first render 1`] = `
                       </div>
                     </li>
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-sortable-draggable"
                       style="position: static; margin: 0px 0px 5px 0px;"
                     >
                       <div
@@ -749,7 +749,7 @@ exports[`matcher widget should snapshot: first render 1`] = `
                       </div>
                     </li>
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1-o_O-disabled_u0qq3k perseus-sortable-draggable"
                       style="position: static; margin: 0px;"
                     >
                       <div
@@ -776,7 +776,7 @@ exports[`matcher widget should snapshot: first render 1`] = `
                     class="sortable_13d4756 perseus-sortable"
                   >
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-sortable-draggable"
                       style="position: static; margin: 0px 0px 5px 0px;"
                     >
                       <div
@@ -795,7 +795,7 @@ exports[`matcher widget should snapshot: first render 1`] = `
                       </div>
                     </li>
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-sortable-draggable"
                       style="position: static; margin: 0px 0px 5px 0px;"
                     >
                       <div
@@ -814,7 +814,7 @@ exports[`matcher widget should snapshot: first render 1`] = `
                       </div>
                     </li>
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-sortable-draggable"
                       style="position: static; margin: 0px 0px 5px 0px;"
                     >
                       <div
@@ -833,7 +833,7 @@ exports[`matcher widget should snapshot: first render 1`] = `
                       </div>
                     </li>
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-sortable-draggable"
                       style="position: static; margin: 0px 0px 5px 0px;"
                     >
                       <div
@@ -852,7 +852,7 @@ exports[`matcher widget should snapshot: first render 1`] = `
                       </div>
                     </li>
                     <li
-                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-interactive perseus-sortable-draggable"
+                      class="card_1s6cuhy-o_O-draggable_12to336-o_O-verticalCard_1gw9js1 perseus-sortable-draggable"
                       style="position: static; margin: 0px;"
                     >
                       <div

--- a/packages/perseus/src/widgets/measurer/measurer.tsx
+++ b/packages/perseus/src/widgets/measurer/measurer.tsx
@@ -161,7 +161,7 @@ class Measurer extends React.Component<Props> implements Widget {
             <div
                 className={
                     "perseus-widget perseus-widget-measurer " +
-                    "graphie-container above-scratchpad"
+                    "graphie-container blank-background"
                 }
                 style={{width: this.props.box[0], height: this.props.box[1]}}
             >

--- a/packages/perseus/src/widgets/orderer/__snapshots__/orderer.test.ts.snap
+++ b/packages/perseus/src/widgets/orderer/__snapshots__/orderer.test.ts.snap
@@ -29,7 +29,7 @@ exports[`orderer widget should snapshot on mobile: first mobile render 1`] = `
           class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="draggy-boxy-thing orderer height-normal layout-horizontal above-scratchpad blank-background perseus-clearfix perseus-interactive"
+            class="draggy-boxy-thing orderer height-normal layout-horizontal blank-background perseus-clearfix perseus-interactive"
           >
             <div
               class="bank perseus-clearfix"
@@ -150,7 +150,7 @@ exports[`orderer widget should snapshot: first render 1`] = `
           class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="draggy-boxy-thing orderer height-normal layout-horizontal above-scratchpad blank-background perseus-clearfix perseus-interactive"
+            class="draggy-boxy-thing orderer height-normal layout-horizontal blank-background perseus-clearfix perseus-interactive"
           >
             <div
               class="bank perseus-clearfix"

--- a/packages/perseus/src/widgets/orderer/__snapshots__/orderer.test.ts.snap
+++ b/packages/perseus/src/widgets/orderer/__snapshots__/orderer.test.ts.snap
@@ -29,13 +29,13 @@ exports[`orderer widget should snapshot on mobile: first mobile render 1`] = `
           class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="draggy-boxy-thing orderer height-normal layout-horizontal blank-background perseus-clearfix perseus-interactive"
+            class="draggy-boxy-thing orderer height-normal layout-horizontal blank-background perseus-clearfix "
           >
             <div
               class="bank perseus-clearfix"
             >
               <div
-                class="card-wrap perseus-interactive"
+                class="card-wrap"
               >
                 <div
                   class="card stack"
@@ -57,7 +57,7 @@ exports[`orderer widget should snapshot on mobile: first mobile render 1`] = `
                 </div>
               </div>
               <div
-                class="card-wrap perseus-interactive"
+                class="card-wrap"
               >
                 <div
                   class="card stack"
@@ -79,7 +79,7 @@ exports[`orderer widget should snapshot on mobile: first mobile render 1`] = `
                 </div>
               </div>
               <div
-                class="card-wrap perseus-interactive"
+                class="card-wrap"
               >
                 <div
                   class="card stack"
@@ -105,7 +105,7 @@ exports[`orderer widget should snapshot on mobile: first mobile render 1`] = `
               class="perseus-clearfix draggable-box"
             >
               <div
-                class="card-wrap perseus-interactive"
+                class="card-wrap"
               >
                 <div
                   class="card drag-hint"
@@ -150,13 +150,13 @@ exports[`orderer widget should snapshot: first render 1`] = `
           class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="draggy-boxy-thing orderer height-normal layout-horizontal blank-background perseus-clearfix perseus-interactive"
+            class="draggy-boxy-thing orderer height-normal layout-horizontal blank-background perseus-clearfix "
           >
             <div
               class="bank perseus-clearfix"
             >
               <div
-                class="card-wrap perseus-interactive"
+                class="card-wrap"
               >
                 <div
                   class="card stack"
@@ -178,7 +178,7 @@ exports[`orderer widget should snapshot: first render 1`] = `
                 </div>
               </div>
               <div
-                class="card-wrap perseus-interactive"
+                class="card-wrap"
               >
                 <div
                   class="card stack"
@@ -200,7 +200,7 @@ exports[`orderer widget should snapshot: first render 1`] = `
                 </div>
               </div>
               <div
-                class="card-wrap perseus-interactive"
+                class="card-wrap"
               >
                 <div
                   class="card stack"
@@ -226,7 +226,7 @@ exports[`orderer widget should snapshot: first render 1`] = `
               class="perseus-clearfix draggable-box"
             >
               <div
-                class="card-wrap perseus-interactive"
+                class="card-wrap"
               >
                 <div
                   class="card drag-hint"

--- a/packages/perseus/src/widgets/orderer/orderer.tsx
+++ b/packages/perseus/src/widgets/orderer/orderer.tsx
@@ -761,7 +761,7 @@ class Orderer
                     "layout-" +
                     this.props.layout +
                     " " +
-                    "above-scratchpad blank-background " +
+                    "blank-background " +
                     "perseus-clearfix " +
                     ApiClassNames.INTERACTIVE
                 }

--- a/packages/perseus/src/widgets/orderer/orderer.tsx
+++ b/packages/perseus/src/widgets/orderer/orderer.tsx
@@ -10,7 +10,6 @@ import _ from "underscore";
 
 import {PerseusI18nContext} from "../../components/i18n-context";
 import {Log} from "../../logging/log";
-import {ClassNames as ApiClassNames} from "../../perseus-api";
 import Renderer from "../../renderer";
 import Util from "../../util";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/orderer/orderer-ai-utils";
@@ -33,7 +32,7 @@ class PlaceholderCard extends React.Component<PlaceholderCardProps> {
     render(): React.ReactNode {
         return (
             <div
-                className={"card-wrap " + ApiClassNames.INTERACTIVE}
+                className={"card-wrap"}
                 style={{width: this.props.width as number}}
             >
                 <div
@@ -48,7 +47,7 @@ class PlaceholderCard extends React.Component<PlaceholderCardProps> {
 class DragHintCard extends React.Component<any> {
     render(): React.ReactNode {
         return (
-            <div className={"card-wrap " + ApiClassNames.INTERACTIVE}>
+            <div className={"card-wrap"}>
                 <div className="card drag-hint" />
             </div>
         );
@@ -275,7 +274,7 @@ class Card extends React.Component<CardProps, CardState> {
 
         return (
             <div
-                className={"card-wrap " + ApiClassNames.INTERACTIVE}
+                className={"card-wrap"}
                 style={style}
                 onMouseDown={onMouseDown}
                 onTouchStart={onMouseDown}
@@ -762,8 +761,7 @@ class Orderer
                     this.props.layout +
                     " " +
                     "blank-background " +
-                    "perseus-clearfix " +
-                    ApiClassNames.INTERACTIVE
+                    "perseus-clearfix "
                 }
                 // eslint-disable-next-line react/no-string-refs
                 ref="orderer"

--- a/packages/perseus/src/widgets/plotter/plotter.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.tsx
@@ -9,7 +9,6 @@ import _ from "underscore";
 import {PerseusI18nContext} from "../../components/i18n-context";
 import Interactive2 from "../../interactive2";
 import WrappedLine from "../../interactive2/wrapped-line";
-import {ClassNames as ApiClassNames} from "../../perseus-api";
 import KhanColors from "../../util/colors";
 import GraphUtils from "../../util/graph-utils";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/plotter/plotter-ai-utils";
@@ -1157,10 +1156,7 @@ export class Plotter extends React.Component<Props, State> implements Widget {
 
         return (
             <div
-                className={
-                    "perseus-widget-plotter graphie " +
-                    ApiClassNames.INTERACTIVE
-                }
+                className={"perseus-widget-plotter graphie"}
                 // eslint-disable-next-line react/no-string-refs
                 ref="graphieDiv"
                 style={style}

--- a/packages/perseus/src/widgets/radio/__tests__/__snapshots__/radio.test.ts.snap
+++ b/packages/perseus/src/widgets/radio/__tests__/__snapshots__/radio.test.ts.snap
@@ -61,7 +61,7 @@ exports[`Radio Widget multi-choice question should snapshot the same when invali
                 style="list-style: none;"
               >
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd-o_O-selectedItem_p6cyk0 perseus-radio-option perseus-radio-selected"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd-o_O-selectedItem_p6cyk0 perseus-radio-option perseus-radio-selected"
                 >
                   <div
                     class="description description_psmgei"
@@ -175,7 +175,7 @@ exports[`Radio Widget multi-choice question should snapshot the same when invali
                   </div>
                 </li>
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                 >
                   <div
                     class="description description_psmgei"
@@ -289,7 +289,7 @@ exports[`Radio Widget multi-choice question should snapshot the same when invali
                   </div>
                 </li>
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                 >
                   <div
                     class="description description_psmgei"
@@ -403,7 +403,7 @@ exports[`Radio Widget multi-choice question should snapshot the same when invali
                   </div>
                 </li>
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                 >
                   <div
                     class="description description_psmgei"
@@ -617,7 +617,7 @@ exports[`Radio Widget single-choice question reviewMode: false should snapshot t
                 style="list-style: none;"
               >
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                 >
                   <div
                     class="description description_psmgei"
@@ -757,7 +757,7 @@ exports[`Radio Widget single-choice question reviewMode: false should snapshot t
                   </div>
                 </li>
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                 >
                   <div
                     class="description description_psmgei"
@@ -871,7 +871,7 @@ exports[`Radio Widget single-choice question reviewMode: false should snapshot t
                   </div>
                 </li>
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd-o_O-selectedItem_p6cyk0 perseus-radio-option perseus-radio-selected"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd-o_O-selectedItem_p6cyk0 perseus-radio-option perseus-radio-selected"
                 >
                   <div
                     class="description description_psmgei"
@@ -985,7 +985,7 @@ exports[`Radio Widget single-choice question reviewMode: false should snapshot t
                   </div>
                 </li>
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                 >
                   <div
                     class="description description_psmgei"
@@ -1185,7 +1185,7 @@ exports[`Radio Widget single-choice question reviewMode: false should snapshot t
                 style="list-style: none;"
               >
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd-o_O-selectedItem_p6cyk0 perseus-radio-option perseus-radio-selected"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd-o_O-selectedItem_p6cyk0 perseus-radio-option perseus-radio-selected"
                 >
                   <div
                     class="description description_psmgei"
@@ -1325,7 +1325,7 @@ exports[`Radio Widget single-choice question reviewMode: false should snapshot t
                   </div>
                 </li>
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                 >
                   <div
                     class="description description_psmgei"
@@ -1439,7 +1439,7 @@ exports[`Radio Widget single-choice question reviewMode: false should snapshot t
                   </div>
                 </li>
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                 >
                   <div
                     class="description description_psmgei"
@@ -1553,7 +1553,7 @@ exports[`Radio Widget single-choice question reviewMode: false should snapshot t
                   </div>
                 </li>
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                 >
                   <div
                     class="description description_psmgei"
@@ -1753,7 +1753,7 @@ exports[`Radio Widget single-choice question reviewMode: false should snapshot t
                 style="list-style: none;"
               >
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                 >
                   <div
                     class="description description_psmgei"
@@ -1893,7 +1893,7 @@ exports[`Radio Widget single-choice question reviewMode: false should snapshot t
                   </div>
                 </li>
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                 >
                   <div
                     class="description description_psmgei"
@@ -2007,7 +2007,7 @@ exports[`Radio Widget single-choice question reviewMode: false should snapshot t
                   </div>
                 </li>
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                 >
                   <div
                     class="description description_psmgei"
@@ -2121,7 +2121,7 @@ exports[`Radio Widget single-choice question reviewMode: false should snapshot t
                   </div>
                 </li>
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                 >
                   <div
                     class="description description_psmgei"
@@ -2321,7 +2321,7 @@ exports[`Radio Widget single-choice question reviewMode: true should snapshot th
                 style="list-style: none;"
               >
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                 >
                   <div
                     class="description description_psmgei"
@@ -2461,7 +2461,7 @@ exports[`Radio Widget single-choice question reviewMode: true should snapshot th
                   </div>
                 </li>
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                 >
                   <div
                     class="description description_psmgei"
@@ -2575,7 +2575,7 @@ exports[`Radio Widget single-choice question reviewMode: true should snapshot th
                   </div>
                 </li>
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd-o_O-selectedItem_p6cyk0 perseus-radio-option perseus-radio-selected"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd-o_O-selectedItem_p6cyk0 perseus-radio-option perseus-radio-selected"
                 >
                   <div
                     class="description description_psmgei"
@@ -2689,7 +2689,7 @@ exports[`Radio Widget single-choice question reviewMode: true should snapshot th
                   </div>
                 </li>
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                 >
                   <div
                     class="description description_psmgei"
@@ -2889,7 +2889,7 @@ exports[`Radio Widget single-choice question reviewMode: true should snapshot th
                 style="list-style: none;"
               >
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd-o_O-selectedItem_p6cyk0 perseus-radio-option perseus-radio-selected"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd-o_O-selectedItem_p6cyk0 perseus-radio-option perseus-radio-selected"
                 >
                   <div
                     class="description description_psmgei"
@@ -3029,7 +3029,7 @@ exports[`Radio Widget single-choice question reviewMode: true should snapshot th
                   </div>
                 </li>
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                 >
                   <div
                     class="description description_psmgei"
@@ -3143,7 +3143,7 @@ exports[`Radio Widget single-choice question reviewMode: true should snapshot th
                   </div>
                 </li>
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                 >
                   <div
                     class="description description_psmgei"
@@ -3257,7 +3257,7 @@ exports[`Radio Widget single-choice question reviewMode: true should snapshot th
                   </div>
                 </li>
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option"
                 >
                   <div
                     class="description description_psmgei"
@@ -3457,7 +3457,7 @@ exports[`Radio Widget single-choice question reviewMode: true should snapshot th
                 style="list-style: none;"
               >
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option perseus-incorrect"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option perseus-incorrect"
                 >
                   <div
                     class="description description_psmgei"
@@ -3676,7 +3676,7 @@ exports[`Radio Widget single-choice question reviewMode: true should snapshot th
                   </div>
                 </li>
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option perseus-incorrect"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option perseus-incorrect"
                 >
                   <div
                     class="description description_psmgei"
@@ -3853,7 +3853,7 @@ exports[`Radio Widget single-choice question reviewMode: true should snapshot th
                   </div>
                 </li>
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option perseus-correct"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option perseus-correct"
                 >
                   <div
                     class="description description_psmgei"
@@ -4025,7 +4025,7 @@ exports[`Radio Widget single-choice question reviewMode: true should snapshot th
                   </div>
                 </li>
                 <li
-                  class="aboveScratchpad_1x0jb4k-o_O-item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option perseus-incorrect"
+                  class="item_dswvvi-o_O-responsiveItem_85oyrd perseus-radio-option perseus-incorrect"
                 >
                   <div
                     class="description description_psmgei"

--- a/packages/perseus/src/widgets/radio/base-radio.tsx
+++ b/packages/perseus/src/widgets/radio/base-radio.tsx
@@ -10,7 +10,6 @@ import {usePerseusI18n} from "../../components/i18n-context";
 import {ClassNames as ApiClassNames} from "../../perseus-api";
 import * as styleConstants from "../../styles/constants";
 import mediaQueries from "../../styles/media-queries";
-import sharedStyles from "../../styles/shared";
 import Util from "../../util";
 import {scrollElementIntoView} from "../../util/scroll-utils";
 

--- a/packages/perseus/src/widgets/radio/base-radio.tsx
+++ b/packages/perseus/src/widgets/radio/base-radio.tsx
@@ -303,7 +303,6 @@ const BaseRadio = function ({
                         // Whether or not to show correctness borders
                         // for this choice and the next choice.
                         return css(
-                            sharedStyles.aboveScratchpad,
                             styles.item,
                             styles.responsiveItem,
                             checked && styles.selectedItem,

--- a/testing/side-by-side.tsx
+++ b/testing/side-by-side.tsx
@@ -48,11 +48,11 @@ const styles = {
         padding: `0px ${spacing.large_24}px`,
     },
     leftPanel: {
-        flexBasis: `${interactiveSizes.defaultBoxSize}px`,
+        flex: `1 0 ${interactiveSizes.defaultBoxSize}px`,
+        overflow: "auto",
     },
     rightPanel: {
-        flexGrow: 1,
-        flexBasis: `${interactiveSizes.defaultBoxSize}px`,
+        flex: `1 1 ${interactiveSizes.defaultBoxSizeSmall}px`,
         maxWidth: "50%",
     },
 } as const;


### PR DESCRIPTION
## Summary
I did this in two passes -- one commit to remove `above scratchpad`, and a second for `interactive`, which seems to be used for the same purpose. Both place widgets above the ~scratchpad~ doodlepad, which has long led to many bugs.
- **remove all references to "above scratchpad"**
- **remove z-index from more widgets**

Issue: TUT-1059