### PR TITLE
Add -all option to 'yarn clean' 

### DIFF
--- a/utils/clean.sh
+++ b/utils/clean.sh
@@ -13,7 +13,21 @@ MYPATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 # ROOT is the root directory of our project.
 ROOT="$MYPATH/.."
 
-pushd "$ROOT"
+pushd "$ROOT" >/dev/null 2>&1
+
+CLEAN_ALL=false
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -a|--all)
+      CLEAN_ALL=true
+      shift # past argument
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
 
 rm -rf packages/*/dist
 rm -rf .nyc_output/
@@ -21,3 +35,8 @@ rm -rf coverage/
 rm -rf cypress/
 rm -rf packages/*/*.tsbuildinfo
 rm -rf storybook-static/
+
+if [[ "$CLEAN_ALL" == "true" ]]; then
+    echo "Removing node_modules directories. You'll need to 'yarn install' after this."
+    find . -name node_modules -and -type d -prune -exec rm -rf '{}' \;
+fi

--- a/utils/clean.sh
+++ b/utils/clean.sh
@@ -15,20 +15,6 @@ ROOT="$MYPATH/.."
 
 pushd "$ROOT" >/dev/null 2>&1
 
-CLEAN_ALL=false
-while [[ $# -gt 0 ]]; do
-  case $1 in
-    -a|--all)
-      CLEAN_ALL=true
-      shift # past argument
-      ;;
-    *)
-      echo "Unknown option: $1"
-      exit 1
-      ;;
-  esac
-done
-
 rm -rf packages/*/dist
 rm -rf .nyc_output/
 rm -rf coverage/
@@ -36,7 +22,6 @@ rm -rf cypress/
 rm -rf packages/*/*.tsbuildinfo
 rm -rf storybook-static/
 
-if [[ "$CLEAN_ALL" == "true" ]]; then
-    echo "Removing node_modules directories. You'll need to 'yarn install' after this."
-    find . -name node_modules -and -type d -prune -exec rm -rf '{}' \;
-fi
+echo "Removing node_modules directories. You'll need to 'yarn install' after this."
+find . -name node_modules -and -type d -prune -exec rm -rf '{}' \;
+


### PR DESCRIPTION
## Summary:

We've had instances where folks' local repo gets into a bad state. It's assumed that `yarn clean` will resolve this, but it hasn't in all cases because it doesn't delete `node_modules`.

This PR adds a `--all` option to `yarn clean` to demolish all `node_modules` folders in the local repo.

Issue: "none" 

## Test plan:

`yarn`
`yarn clean`
`ls node_modules` # still exists
`yarn clean --all`
`find . -name node_modules -and -type d` # no results!