### PR TITLE
Add a function to get the public options for a cs-program widget

### DIFF
--- a/.changeset/nasty-rockets-end.md
+++ b/.changeset/nasty-rockets-end.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-core": minor
+---
+
+Create a function to get the public widget options for a CS widget.

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -116,6 +116,7 @@ export type * from "./widgets/logic-export.types";
 
 export {default as getOrdererPublicWidgetOptions} from "./widgets/orderer/orderer-util";
 export {default as getCategorizerPublicWidgetOptions} from "./widgets/categorizer/categorizer-util";
+export {default as getCSProgramPublicWidgetOptions} from "./widgets/cs-program/cs-program-util";
 export {default as getExpressionPublicWidgetOptions} from "./widgets/expression/expression-util";
 export {default as getLabelImagePublicWidgetOptions} from "./widgets/label-image/label-image-util";
 export {default as getSorterPublicWidgetOptions} from "./widgets/sorter/sorter-util";

--- a/packages/perseus-core/src/widgets/cs-program/cs-program-util.ts
+++ b/packages/perseus-core/src/widgets/cs-program/cs-program-util.ts
@@ -1,0 +1,7 @@
+import type {PerseusCSProgramWidgetOptions} from "../../data-schema";
+
+export default function getCSProgramPublicWidgetOptions(
+    options: PerseusCSProgramWidgetOptions,
+): PerseusCSProgramWidgetOptions {
+    return options;
+}

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -15,6 +15,7 @@ import type {
     WidgetOptionsUpgradeMap,
     getOrdererPublicWidgetOptions,
     getCategorizerPublicWidgetOptions,
+    getCSProgramPublicWidgetOptions,
     getExpressionPublicWidgetOptions,
     getSorterPublicWidgetOptions,
     getDropdownPublicWidgetOptions,
@@ -551,7 +552,8 @@ export type PublicWidgetOptionsFunction =
     | typeof getOrdererPublicWidgetOptions
     | typeof getExpressionPublicWidgetOptions
     | typeof getLabelImagePublicWidgetOptions
-    | typeof getSorterPublicWidgetOptions;
+    | typeof getSorterPublicWidgetOptions
+    | typeof getCSProgramPublicWidgetOptions;
 
 export type WidgetExports<
     T extends React.ComponentType<any> & Widget = React.ComponentType<any>,

--- a/packages/perseus/src/widgets/cs-program/cs-program.tsx
+++ b/packages/perseus/src/widgets/cs-program/cs-program.tsx
@@ -2,6 +2,7 @@
  * This widget is for embedding Khan Academy CS programs.
  */
 
+import {getCSProgramPublicWidgetOptions} from "@khanacademy/perseus-core";
 import {scoreCSProgram} from "@khanacademy/perseus-score";
 import {StyleSheet, css} from "aphrodite";
 import $ from "jquery";
@@ -204,4 +205,5 @@ export default {
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type 'UserInput' is not assignable to type 'PerseusCSProgramUserInput'.
     scorer: scoreCSProgram,
+    getPublicWidgetOptions: getCSProgramPublicWidgetOptions,
 } satisfies WidgetExports<typeof CSProgram>;


### PR DESCRIPTION
CSProgram doesn't have any private options, so this is just the identity
function.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2770

## Test plan:

`yarn test`