### PR TITLE
Restore deprecated exports of `@khanacademy/perseus`

### DIFF
--- a/.changeset/great-cameras-play.md
+++ b/.changeset/great-cameras-play.md
@@ -1,0 +1,8 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Restores the following deprecated exports to `@khanacademy/perseus`:
+`parsePerseusItem`, `parseAndMigratePerseusItem`,
+`parseAndMigratePerseusArticle`, `isSuccess`, `isFailure`, `Result`, `Success`,
+`Failure`.

--- a/.changeset/poor-masks-return.md
+++ b/.changeset/poor-masks-return.md
@@ -1,5 +1,0 @@
----
-"@khanacademy/perseus": major
----
-
-Removes the following deprecated exports from `@khanacademy/perseus`: `parsePerseusItem`, `parseAndMigratePerseusItem`, `parseAndMigratePerseusArticle`, `isSuccess`, `isFailure`, `Result`, `Success`, `Failure`. Clients should import these from `@khanacademy/perseus-core` instead.

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -108,6 +108,28 @@ export {
     getAnswerFromUserInput,
     getImagesWithoutAltData,
 } from "./util/extract-perseus-data";
+export {
+    /**
+     * @deprecated - import this function from perseus-core instead
+     */
+    parsePerseusItem,
+    /**
+     * @deprecated - import this function from perseus-core instead
+     */
+    parseAndMigratePerseusItem,
+    /**
+     * @deprecated - import this function from perseus-core instead
+     */
+    parseAndMigratePerseusArticle,
+    /**
+     * @deprecated - import this function from perseus-core instead
+     */
+    isSuccess,
+    /**
+     * @deprecated - import this function from perseus-core instead
+     */
+    isFailure,
+} from "@khanacademy/perseus-core";
 
 export {
     generateTestPerseusItem,
@@ -181,6 +203,20 @@ export type {
     SharedRendererProps,
 } from "./types";
 export type {ParsedValue} from "./util";
+export type {
+    /**
+     * @deprecated - import this function from perseus-core instead
+     */
+    Result,
+    /**
+     * @deprecated - import this function from perseus-core instead
+     */
+    Success,
+    /**
+     * @deprecated - import this function from perseus-core instead
+     */
+    Failure,
+} from "@khanacademy/perseus-core";
 export type {Coord} from "./interactive2/types";
 export type {
     RendererPromptJSON,


### PR DESCRIPTION
The removal of these functions was causing problems for people who wanted to
use a dev build of Perseus in webapp, because webapp is still importing them.
We need to update webapp to import these functions from perseus-core instead,
and then we can remove them from perseus.

Issue: none

## Test plan:

`yarn test`