### PR TITLE
[SR] Polygon (unlimited) - Add screen reader experience

### DIFF
--- a/.changeset/eighty-bananas-sell.md
+++ b/.changeset/eighty-bananas-sell.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[SR] Polygon (unlimited) - Add screen reader experience

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -427,7 +427,9 @@ export type PerseusStrings = {
     srPolygonGraph: string;
     srPolygonGraphCoordinatePlane: string;
     srPolygonGraphPointsNum: ({num}: {num: number}) => string;
+    srPolygonGraphPointsOne: string;
     srPolygonElementsNum: ({num}: {num: number}) => string;
+    srPolygonElementsOne: string;
     srPolygonPointAngleApprox: ({angle}: {angle: string}) => string;
     srPolygonPointAngle: ({angle}: {angle: number}) => string;
     srPolygonSideLength: ({
@@ -444,6 +446,7 @@ export type PerseusStrings = {
         pointNum: number;
         length: string;
     }) => string;
+    srUnlimitedPolygonEmpty: string;
     // The above strings are used for interactive graph SR descriptions.
 };
 
@@ -706,7 +709,9 @@ export const strings = {
     srPolygonGraph: "A polygon.",
     srPolygonGraphCoordinatePlane: "A polygon on a coordinate plane.",
     srPolygonGraphPointsNum: "The polygon has %(num)s points.",
+    srPolygonGraphPointsOne: "The polygon has 1 point.",
     srPolygonElementsNum: "A polygon with %(num)s points.",
+    srPolygonElementsOne: "A polygon with 1 point.",
     srPolygonPointAngleApprox:
         "Angle approximately equal to %(angle)s degrees.",
     srPolygonPointAngle: "Angle equal to %(angle)s degrees.",
@@ -714,6 +719,7 @@ export const strings = {
         "A line segment, length equal to %(length)s units, connects to point %(pointNum)s.",
     srPolygonSideLengthApprox:
         "A line segment, length approximately equal to %(length)s units, connects to point %(pointNum)s.",
+    srUnlimitedPolygonEmpty: "An empty coordinate plane.",
     // The above strings are used for interactive graph SR descriptions.
 } satisfies {
     [key in keyof PerseusStrings]:
@@ -1005,7 +1011,9 @@ export const mockStrings: PerseusStrings = {
     srPolygonGraph: "A polygon.",
     srPolygonGraphCoordinatePlane: "A polygon on a coordinate plane.",
     srPolygonGraphPointsNum: ({num}) => `The polygon has ${num} points.`,
+    srPolygonGraphPointsOne: "The polygon has 1 point.",
     srPolygonElementsNum: ({num}) => `A polygon with ${num} points.`,
+    srPolygonElementsOne: "A polygon with 1 point.",
     srPolygonPointAngleApprox: ({angle}) =>
         `Angle approximately equal to ${angle} degrees.`,
     srPolygonPointAngle: ({angle}) => `Angle equal to ${angle} degrees.`,
@@ -1013,6 +1021,7 @@ export const mockStrings: PerseusStrings = {
         `A line segment, length equal to ${length} units, connects to point ${pointNum}.`,
     srPolygonSideLengthApprox: ({pointNum, length}) =>
         `A line segment, length approximately equal to ${length} units, connects to point ${pointNum}.`,
+    srUnlimitedPolygonEmpty: "An empty coordinate plane.",
     // The above strings are used for interactive graph SR descriptions.
 };
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
@@ -278,6 +278,7 @@ export function getAngleFromPoints(points: Coord[], i: number) {
 export function getSideLengthsFromPoints(
     points: Coord[],
     i: number,
+    isPolygonOpen?: boolean,
 ): Array<{
     pointIndex: number;
     sideLength: number;
@@ -298,11 +299,14 @@ export function getSideLengthsFromPoints(
     // If this point is the first point, then side 1 is the
     // last point in the list.
     const point1Index = i === 0 ? points.length - 1 : i - 1;
+
     const point1 = points[point1Index];
     // Make sure the previous point is not the same
     // as the current point.
     const side1 = i !== point1Index ? vec.dist(point, point1) : null;
-    if (side1) {
+    // The first side of the first point does not exist if
+    // the polygon is open.
+    if (side1 && !(isPolygonOpen && i === 0)) {
         returnArray.push({pointIndex: point1Index, sideLength: side1});
     }
 
@@ -315,7 +319,9 @@ export function getSideLengthsFromPoints(
         i !== point2Index && point2Index !== point1Index
             ? vec.dist(point, point2)
             : null;
-    if (side2) {
+    // The second side of the last point does not exist if
+    // the polygon is open.
+    if (side2 && !(isPolygonOpen && i === points.length - 1)) {
         returnArray.push({pointIndex: point2Index, sideLength: side2});
     }
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -180,7 +180,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                         interactiveElementsDescription &&
                             interactiveElementsDescriptionId,
                         isUnlimitedGraphState(state) &&
-                            "unlimited-graph-keyboard-prompt",
+                            unlimitedGraphKeyboardPromptId,
                     )}
                     ref={graphRef}
                     tabIndex={0}


### PR DESCRIPTION
## Summary:
Add the aria labels and descriptions for the full graph and interactive elements in the Unlimited Polygon graph, based on the [SRUX doc](https://khanacademy.atlassian.net/wiki/spaces/LC/pages/3455713294/Unlimited+Polygon).

Issue: https://khanacademy.atlassian.net/browse/LEMS-2487

## Test plan:
`packages/perseus/src/widgets/interactive-graphs/graphs/polygon.test.tsx`

Storybook
http://localhost:6006/iframe.html?globals=&args=&id=perseuseditor-widgets-interactive-graph--interactive-graph-unlimited-polygon&viewMode=story