### PR TITLE
Extend initial a11y config for eslint

### DIFF
--- a/.changeset/twenty-pianos-impress.md
+++ b/.changeset/twenty-pianos-impress.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Update internal addStyle variable name to address aphrodite-add-style-variable-name linting rule

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,6 +49,7 @@ function banImportExtension(extension) {
 module.exports = {
     extends: [
         "@khanacademy",
+        "@khanacademy/eslint-config/a11y",
         "plugin:react/recommended",
         // This config includes rules from storybook to enforce story best
         // practices

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "@cypress/code-coverage": "^3.12.24",
         "@cypress/react": "^8.0.0",
         "@jest/globals": "^29.7.0",
-        "@khanacademy/eslint-config": "^5.0.1",
+        "@khanacademy/eslint-config": "^5.1.0",
         "@khanacademy/eslint-plugin": "^3.1.1",
         "@khanacademy/mathjax-renderer": "^2.1.1",
         "@khanacademy/wonder-blocks-button": "7.0.5",

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.tsx
@@ -9,7 +9,7 @@ import * as React from "react";
 
 import Heading from "../../../components/heading";
 
-const StyledUL = addStyle("ul");
+const StyledUl = addStyle("ul");
 
 type Attribute = {
     name: string;
@@ -110,7 +110,7 @@ function SRTree(props: Props) {
                         </Pill>
                     )}
                     {aria.className}
-                    <StyledUL style={styles.indentListLeft}>
+                    <StyledUl style={styles.indentListLeft}>
                         {aria.attributes.map((value, index) => (
                             <li key={index}>
                                 <Pill
@@ -127,7 +127,7 @@ function SRTree(props: Props) {
                                 {value.value}
                             </li>
                         ))}
-                    </StyledUL>
+                    </StyledUl>
                 </li>
             ))}
         </ol>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2424,10 +2424,10 @@
   resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.4.0.tgz#08d6c5e20cf7e4cc02fd181c4b0c225cd31dbb60"
   integrity sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==
 
-"@khanacademy/eslint-config@^5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@khanacademy/eslint-config/-/eslint-config-5.0.1.tgz#430d4151d8d145b05ae8e55e838ea6acbfaadf27"
-  integrity sha512-2cOthcTwYxXGSfdrXEz98pg297L12kJ5DpCGy5AtaVqY1gGYDh0B9W8farPPmTzwi4tGM4p5aE+ESFxJvaWT/Q==
+"@khanacademy/eslint-config@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@khanacademy/eslint-config/-/eslint-config-5.1.0.tgz#86fa8e3f130aec77de1fa540d04ce6a986146a0e"
+  integrity sha512-JY5XUjeiOLKRwJQc6ssLsFdcnGspDvo9ZiJml5GdPG3H+56Hka4hbdR6l0YBg94qlTeHbvRhrPDzEPPIf5BdWg==
 
 "@khanacademy/eslint-plugin@^3.1.1":
   version "3.1.1"


### PR DESCRIPTION
## Summary:
This work is part of the implementation of [ADR#781 Enabling more lint rules for accessibility](https://khanacademy.atlassian.net/wiki/x/IoBVyg)

These changes includes:
- Updated dev dependency: `@khanacademy/eslint-config`
- Extending `@khanacademy/eslint-config/a11y` config in project's eslint config
  - Currently, the a11y config enables the `aphrodite-add-style-variable-name` rule from `@khanacademy/eslint-plugin`. This is the first step to adding more a11y linting rules so that the naming convention for html elements is more predictable for [custom component mapping](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y#component-mapping) for `eslint-plugin-jsx-a11y` (see [rule docs](https://github.com/Khan/wonder-stuff/blob/main/packages/eslint-plugin-khan/docs/aphrodite-add-style-variable-name.md) for more details).
  - `@khanacademy/eslint-config/a11y` will be updated in another PR to include config for `eslint-plugin-jsx-a11y` 
- Addressing lint errors from the aphrodite-add-style-variable-name rule

Issue: FEI-6050

Implementation Plan:
- https://github.com/Khan/wonder-stuff/pull/1114 Set up eslint a11y config and enable aphrodite-add-style-variable-name 
- (includes this PR) Use this new config in WB, perseus, webapp and address lint errors from the aphrodite-add-style-variable-name rule
- Update the a11y.js config with the config based on the accessibility linting rules ADR
- Use the updated config in projects and address existing errors by disabling the rules per line. Teams can address existing errors as they work in the area and new errors can be prevented with these lint rules!

## Test plan:
- Run `yarn lint` and make sure there are no linting errors.
- Some variables were renamed internally, there should be no functional changes