### PR TITLE
[SR] Segment - fix 2 strings with typos

### DIFF
--- a/.changeset/warm-olives-greet.md
+++ b/.changeset/warm-olives-greet.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[SR] Segment - fix 2 strings with typos

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -663,9 +663,9 @@ export const strings = {
     srMultipleSegmentGraphAriaLabel:
         "%(countOfSegments)s line segments on a coordinate plane.",
     srMultipleSegmentIndividualLabel:
-        "Segment %(indexOfSegment)s: Endpoint 1 at %(point1X)s comma %(point1Y)s. Endpoint 2 %(point2X)s comma %(point2Y)s.",
+        "Segment %(indexOfSegment)s: Endpoint 1 at %(point1X)s comma %(point1Y)s. Endpoint 2 at %(point2X)s comma %(point2Y)s.",
     srSingleSegmentLabel:
-        "Endpoint 1 at %(point1X)s comma %(point1Y)s. Endpoint 2 %(point2X)s comma %(point2Y)s.",
+        "Endpoint 1 at %(point1X)s comma %(point1Y)s. Endpoint 2 at %(point2X)s comma %(point2Y)s.",
     srSegmentLength: "Segment length %(length)s units.",
     srSingleSegmentGraphEndpointAriaLabel:
         "Endpoint %(endpointNumber)s at %(x)s comma %(y)s.",


### PR DESCRIPTION
## Summary:
Two segment strings are missing the word "at"

Fixing them here.

Issue: none

## Test plan:
N/A - will have to confirm on the webapp PR.