### PR TITLE
[whole-fraction-fix] Ensure that whole numbers are not accepted answers for Numeric Inputs that require Improper fractions.

### DIFF
--- a/.changeset/chilled-mugs-greet.md
+++ b/.changeset/chilled-mugs-greet.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-score": minor
+---
+
+Bugfix to ensure that Numerics that require Improper fractions don't accept whole numbers.

--- a/packages/perseus-score/src/util/answer-types.ts
+++ b/packages/perseus-score/src/util/answer-types.ts
@@ -245,8 +245,10 @@ const KhanAnswerTypes = {
                     // to check for the existence of a fraction in the input before
                     // validating the answer. If no fraction is found, we consider
                     // the answer to be incorrect.
-                    const fractionExists =
-                        text.match(/\//) && !text.match(/\\(d?frac)/);
+                    const fractionExists: boolean =
+                        text.includes("/") ||
+                        text.includes("\\") || // be nice in case the user uses the wrong slash.
+                        text.match(/\\(d?frac)/);
 
                     if (!fractionExists) {
                         return [];

--- a/packages/perseus-score/src/util/answer-types.ts
+++ b/packages/perseus-score/src/util/answer-types.ts
@@ -246,9 +246,7 @@ const KhanAnswerTypes = {
                     // validating the answer. If no fraction is found, we consider
                     // the answer to be incorrect.
                     const fractionExists: boolean =
-                        text.includes("/") ||
-                        text.includes("\\") || // be nice in case the user uses the wrong slash.
-                        text.match(/\\(d?frac)/);
+                        text.includes("/") || text.match(/\\(d?frac)/);
 
                     if (!fractionExists) {
                         return [];

--- a/packages/perseus-score/src/util/answer-types.ts
+++ b/packages/perseus-score/src/util/answer-types.ts
@@ -241,6 +241,17 @@ const KhanAnswerTypes = {
 
                 // an improper fraction
                 improper: function (text) {
+                    // As our answer keys are always in simplest form, we need
+                    // to check for the existence of a fraction in the input before
+                    // validating the answer. If no fraction is found, we consider
+                    // the answer to be incorrect.
+                    const fractionExists =
+                        text.match(/\//) && !text.match(/\\(d?frac)/);
+
+                    if (!fractionExists) {
+                        return [];
+                    }
+
                     return $.map(fractionTransformer(text), function (o) {
                         // All fractions that are greater than 1
                         if (Math.abs(o.value) >= 1) {

--- a/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.test.ts
+++ b/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.test.ts
@@ -214,6 +214,56 @@ describe("scoreNumericInput", () => {
         expect(score).toHaveBeenAnsweredCorrectly();
     });
 
+    it("rejects a strict improper and whole number answer", () => {
+        const rubric: PerseusNumericInputRubric = {
+            answers: [
+                {
+                    value: 3,
+                    status: "correct",
+                    maxError: 0.2,
+                    simplify: "optional",
+                    strict: true,
+                    answerForms: ["improper"],
+                    message: "",
+                },
+            ],
+            coefficient: true,
+        };
+
+        const userInput = {
+            currentValue: "3",
+        } as const;
+
+        const score = scoreNumericInput(userInput, rubric);
+
+        expect(score).toHaveBeenAnsweredIncorrectly();
+    });
+
+    it("accepts a strict improper answer and tex", () => {
+        const rubric: PerseusNumericInputRubric = {
+            answers: [
+                {
+                    value: 3,
+                    status: "correct",
+                    maxError: 0.2,
+                    simplify: "optional",
+                    strict: true,
+                    answerForms: ["improper"],
+                    message: "",
+                },
+            ],
+            coefficient: true,
+        };
+
+        const userInput = {
+            currentValue: "\\frac{9}{3}",
+        } as const;
+
+        const score = scoreNumericInput(userInput, rubric);
+
+        expect(score).toHaveBeenAnsweredCorrectly();
+    });
+
     it("respects the order of answer options when scoring", () => {
         // Arrange
         const rubric: PerseusNumericInputRubric = {

--- a/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.test.ts
+++ b/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.test.ts
@@ -214,7 +214,7 @@ describe("scoreNumericInput", () => {
         expect(score).toHaveBeenAnsweredCorrectly();
     });
 
-    it("rejects a strict improper and whole number answer", () => {
+    it("rejects a strict improper with whole number answer", () => {
         const rubric: PerseusNumericInputRubric = {
             answers: [
                 {
@@ -239,7 +239,7 @@ describe("scoreNumericInput", () => {
         expect(score).toHaveBeenAnsweredIncorrectly();
     });
 
-    it("accepts a strict improper answer and tex", () => {
+    it("accepts a strict improper answer with tex answer", () => {
         const rubric: PerseusNumericInputRubric = {
             answers: [
                 {
@@ -257,6 +257,31 @@ describe("scoreNumericInput", () => {
 
         const userInput = {
             currentValue: "\\frac{9}{3}",
+        } as const;
+
+        const score = scoreNumericInput(userInput, rubric);
+
+        expect(score).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("accepts a strict improper answer with simple text answer", () => {
+        const rubric: PerseusNumericInputRubric = {
+            answers: [
+                {
+                    value: 3,
+                    status: "correct",
+                    maxError: 0.2,
+                    simplify: "optional",
+                    strict: true,
+                    answerForms: ["improper"],
+                    message: "",
+                },
+            ],
+            coefficient: true,
+        };
+
+        const userInput = {
+            currentValue: "9/3",
         } as const;
 
         const score = scoreNumericInput(userInput, rubric);


### PR DESCRIPTION
## Summary:
This PR is part of the Numeric Input project. 

This small addition ensures that users cannot be marked correctly for entering whole numbers when required to enter Improper fractions. 

Issue: LEMS-2802

## Test plan:
- Tests pass 
- Creation of two new tests to ensure bug fix works, and there's no regressions for tex 