### PR TITLE
[SR Tree] Handle SR Tree when multiple editors are on the page

### DIFF
--- a/.changeset/soft-onions-dream.md
+++ b/.changeset/soft-onions-dream.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[SR Tree] Handle SR Tree when multiple editors are on the page

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-correct-answer.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-correct-answer.tsx
@@ -9,6 +9,7 @@ import * as React from "react";
 import Heading from "../../../components/heading";
 
 type Props = {
+    id: string;
     equationString: string;
     children: React.ReactNode;
 };
@@ -20,7 +21,7 @@ export function InteractiveGraphCorrectAnswer(props: Props) {
                 isOpen={true}
                 isCollapsible={false}
             />
-            <View>
+            <View id={props.id}>
                 <View>
                     <LabelXSmall
                         style={{

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.test.tsx
@@ -19,6 +19,7 @@ describe("InteractiveGraphSRTree", () => {
     test("should show the heading and the switch even if empty", () => {
         // Arrange
         const defaultProps = {
+            graphId: "test-id",
             correct: {},
             fullGraphAriaLabel: "full graph aria label",
             fullGraphAriaDescription: "full graph description",
@@ -40,6 +41,7 @@ describe("InteractiveGraphSRTree", () => {
     test("should have an empty list if mafs graph is not found", () => {
         // Arrange
         const defaultProps = {
+            graphId: "test-id",
             correct: {},
             fullGraphAriaLabel: "full graph aria label",
             fullGraphAriaDescription: "full graph description",
@@ -57,6 +59,7 @@ describe("InteractiveGraphSRTree", () => {
     test("should show the tree with the correct aria attributes", () => {
         // Arrange
         const defaultProps = {
+            graphId: "test-id",
             correct: {},
             fullGraphAriaLabel: "full graph aria label",
             fullGraphAriaDescription: "full graph description",
@@ -65,7 +68,7 @@ describe("InteractiveGraphSRTree", () => {
 
         // Act
         render(
-            <View>
+            <View id="test-id">
                 <View className="mafs-graph-container">
                     <View
                         className="mafs-graph-inner"
@@ -89,13 +92,14 @@ describe("InteractiveGraphSRTree", () => {
     test("should show the tree with the roles/tags when toggled", async () => {
         // Arrange
         const defaultProps = {
+            graphId: "test-id",
             correct: {},
             fullGraphAriaLabel: "full graph aria label",
             fullGraphAriaDescription: "full graph description",
             lockedFigures: [],
         };
         render(
-            <View>
+            <View id={"test-id"}>
                 <View className="mafs-graph-container">
                     <View
                         className="inner-div-1"
@@ -136,13 +140,12 @@ describe("InteractiveGraphSRTree", () => {
 });
 
 describe("fetchAriaLabels", () => {
-    test("should return an empty array if the container is null", () => {
+    test("should return an empty array if the container is not found", () => {
         // Arrange
-        const container = undefined;
         const expected = [];
 
         // Act
-        const result = getAccessibilityAttributes(container);
+        const result = getAccessibilityAttributes("something");
 
         // Assert
         expect(result).toEqual(expected);
@@ -150,15 +153,15 @@ describe("fetchAriaLabels", () => {
 
     test("should return an array of labels", () => {
         // Arrange
-        const {container} = render(
-            <div>
+        render(
+            <div id="test-id">
                 <div aria-label="label1" />
                 <div aria-label="label2" />
             </div>,
         );
 
         // Act
-        const result = getAccessibilityAttributes(container);
+        const result = getAccessibilityAttributes("test-id");
 
         // Assert
         expect(result).toEqual([
@@ -177,15 +180,15 @@ describe("fetchAriaLabels", () => {
 
     test("should return an array with given roles", () => {
         // Arrange
-        const {container} = render(
-            <div>
+        render(
+            <div id="test-id">
                 <div role="button" aria-label="aria-label1" />
                 <div role="button" aria-label="aria-label2" />
             </div>,
         );
 
         // Act
-        const result = getAccessibilityAttributes(container);
+        const result = getAccessibilityAttributes("test-id");
 
         // Assert
         expect(result).toEqual([
@@ -204,15 +207,15 @@ describe("fetchAriaLabels", () => {
 
     test("should include provided class", () => {
         // Arrange
-        const {container} = render(
-            <div>
+        render(
+            <div id="test-id">
                 <div className="class1" aria-label="label1" />
                 <div className="class2" aria-label="label2" />
             </div>,
         );
 
         // Act
-        const result = getAccessibilityAttributes(container);
+        const result = getAccessibilityAttributes("test-id");
 
         // Assert
         expect(result).toEqual([
@@ -231,8 +234,8 @@ describe("fetchAriaLabels", () => {
 
     test("should return last class if multiple classes are provided", () => {
         // Arrange
-        const {container} = render(
-            <div>
+        render(
+            <div id="test-id">
                 <div
                     className="class1 class2 class3 class4"
                     aria-label="label1"
@@ -241,7 +244,7 @@ describe("fetchAriaLabels", () => {
         );
 
         // Act
-        const result = getAccessibilityAttributes(container);
+        const result = getAccessibilityAttributes("test-id");
 
         // Assert
         expect(result).toEqual([
@@ -255,8 +258,8 @@ describe("fetchAriaLabels", () => {
 
     test("should return an array with descriptions", () => {
         // Arrange
-        const {container} = render(
-            <div>
+        render(
+            <div id="test-id">
                 <div aria-describedby="description1">label1</div>
                 <div aria-describedby="description2">label2</div>
                 <div id="description1">description1 content</div>
@@ -265,7 +268,7 @@ describe("fetchAriaLabels", () => {
         );
 
         // Act
-        const result = getAccessibilityAttributes(container);
+        const result = getAccessibilityAttributes("test-id");
 
         // Assert
         expect(result).toEqual([
@@ -288,8 +291,8 @@ describe("fetchAriaLabels", () => {
 
     test("should return an array for element with multiple descriptions", () => {
         // Arrange
-        const {container} = render(
-            <div>
+        render(
+            <div id="test-id">
                 <div aria-describedby="description1 description2">label1</div>
                 <div id="description1">description1 content</div>
                 <div id="description2">description2 content</div>
@@ -297,7 +300,7 @@ describe("fetchAriaLabels", () => {
         );
 
         // Act
-        const result = getAccessibilityAttributes(container);
+        const result = getAccessibilityAttributes("test-id");
 
         // Assert
         expect(result).toEqual([
@@ -314,8 +317,8 @@ describe("fetchAriaLabels", () => {
 
     test("should return an array for element with multiple descriptions with multiple spaces", () => {
         // Arrange
-        const {container} = render(
-            <div>
+        render(
+            <div id="test-id">
                 <div aria-describedby="description1     description2">
                     label1
                 </div>
@@ -325,7 +328,7 @@ describe("fetchAriaLabels", () => {
         );
 
         // Act
-        const result = getAccessibilityAttributes(container);
+        const result = getAccessibilityAttributes("test-id");
 
         // Assert
         expect(result).toEqual([
@@ -342,15 +345,15 @@ describe("fetchAriaLabels", () => {
 
     test("should not include descriptions that are not found", () => {
         // Arrange
-        const {container} = render(
-            <div>
+        render(
+            <div id="test-id">
                 <div aria-describedby="description1 description2">label1</div>
                 <div id="description1">description1 content</div>
             </div>,
         );
 
         // Act
-        const result = getAccessibilityAttributes(container);
+        const result = getAccessibilityAttributes("test-id");
 
         // Assert
         expect(result).toEqual([
@@ -366,8 +369,8 @@ describe("fetchAriaLabels", () => {
 
     test("should build attributes array with a variety of attributes", () => {
         // Arrange
-        const {container} = render(
-            <div>
+        render(
+            <div id="test-id">
                 <div aria-label="label-only" />
                 <div aria-describedby="description-only" />
                 <div role="img" aria-label="label with role" />
@@ -388,7 +391,7 @@ describe("fetchAriaLabels", () => {
         );
 
         // Act
-        const result = getAccessibilityAttributes(container);
+        const result = getAccessibilityAttributes("test-id");
 
         // Assert
         expect(result).toEqual([
@@ -430,14 +433,14 @@ describe("fetchAriaLabels", () => {
 
     test("should not add element if descriptions are not found", () => {
         // Arrange
-        const {container} = render(
-            <div>
+        render(
+            <div id="test-id">
                 <div aria-describedby="description1 description2">label1</div>
             </div>,
         );
 
         // Act
-        const result = getAccessibilityAttributes(container);
+        const result = getAccessibilityAttributes("test-id");
 
         // Assert
         expect(result).toEqual([]);
@@ -445,14 +448,14 @@ describe("fetchAriaLabels", () => {
 
     test("should not add element if aria attributes are not found", () => {
         // Arrange
-        const {container} = render(
-            <div>
+        render(
+            <div id="test-id">
                 <div />
             </div>,
         );
 
         // Act
-        const result = getAccessibilityAttributes(container);
+        const result = getAccessibilityAttributes("test-id");
 
         // Assert
         expect(result).toEqual([]);

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.test.tsx
@@ -99,7 +99,7 @@ describe("InteractiveGraphSRTree", () => {
             lockedFigures: [],
         };
         render(
-            <View id={"test-id"}>
+            <View id="test-id">
                 <View className="mafs-graph-container">
                     <View
                         className="inner-div-1"

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.tsx
@@ -23,10 +23,12 @@ type AttributeMap = {
 };
 
 // Exported for testing
-export function getAccessibilityAttributes(
-    container?: Element,
-): AttributeMap[] {
+export function getAccessibilityAttributes(graphId: string): AttributeMap[] {
     const elementArias: Array<AttributeMap> = [];
+
+    // TODO(nisha): Change this to use ref after the graph has a non-string
+    // ref and the InteractiveGraph component forwards refs.
+    const container = document.getElementById(graphId);
 
     if (!container) {
         return elementArias;
@@ -135,6 +137,10 @@ function SRTree(props: Props) {
 }
 
 function InteractiveGraphSRTree({
+    // The graph whos accessibility tree we want to display.
+    // This is necessary when there are multiple graphs on the editor
+    // page, such as when there are also hints.
+    graphId,
     correct,
     fullGraphAriaLabel,
     fullGraphAriaDescription,
@@ -145,22 +151,16 @@ function InteractiveGraphSRTree({
     const [elementArias, setElementArias] = React.useState<AttributeMap[]>([]);
     const switchId = React.useId();
 
-    // TODO(nisha): Change this to use ref after the graph has a non-string
-    // ref and the InteractiveGraph component forwards refs.
-    const mafsGraphContainer = document.getElementsByClassName(
-        "mafs-graph-container",
-    )?.[0];
-
     // Update the tree when the graph is updated.
     React.useEffect(() => {
-        setElementArias(getAccessibilityAttributes(mafsGraphContainer));
+        setElementArias(getAccessibilityAttributes(graphId));
     }, [
         // Update the tree when the "correct preview" graph is updated.
         correct,
         fullGraphAriaLabel,
         fullGraphAriaDescription,
+        graphId,
         lockedFigures,
-        mafsGraphContainer,
     ]);
 
     return (

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
@@ -16,7 +16,7 @@ import {
     type InteractiveGraphDefaultWidgetOptions,
     interactiveGraphLogic,
 } from "@khanacademy/perseus-core";
-import {View} from "@khanacademy/wonder-blocks-core";
+import {Id, View} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
@@ -344,495 +344,559 @@ class InteractiveGraphEditor extends React.Component<Props> {
         }
 
         return (
-            <View>
-                <LabeledRow label="Answer type:">
-                    <GraphTypeSelector
-                        graphType={
-                            this.props.graph?.type ??
-                            InteractiveGraph.defaultProps.graph.type
-                        }
-                        // TODO(LEMS-2656): remove TS suppression
-                        onChange={
-                            ((
-                                type: Required<InteractiveGraphProps>["graph"]["type"],
-                            ) => {
-                                this.props.onChange({
-                                    graph: {type},
-                                    correct: {type},
-                                });
-                            }) as any
-                        }
-                    />
-                </LabeledRow>
-                <InteractiveGraphDescription
-                    ariaLabelValue={this.props.fullGraphAriaLabel ?? ""}
-                    ariaDescriptionValue={
-                        this.props.fullGraphAriaDescription ?? ""
-                    }
-                    onChange={this.props.onChange}
-                />
-                <InteractiveGraphCorrectAnswer equationString={equationString}>
-                    {graph}
-                </InteractiveGraphCorrectAnswer>
-                {this.props.correct?.type === "point" && (
-                    <LabeledRow label="Number of Points:">
-                        <GraphPointsCountSelector
-                            numPoints={this.props.correct?.numPoints}
-                            onChange={(points) => {
-                                this.props.onChange({
-                                    correct: {
-                                        type: "point",
-                                        numPoints: points,
-                                    },
-                                    graph: {
-                                        type: "point",
-                                        numPoints: points,
-                                    },
-                                });
-                            }}
+            <Id>
+                {(graphId) => (
+                    <View>
+                        <LabeledRow label="Answer type:">
+                            <GraphTypeSelector
+                                graphType={
+                                    this.props.graph?.type ??
+                                    InteractiveGraph.defaultProps.graph.type
+                                }
+                                // TODO(LEMS-2656): remove TS suppression
+                                onChange={
+                                    ((
+                                        type: Required<InteractiveGraphProps>["graph"]["type"],
+                                    ) => {
+                                        this.props.onChange({
+                                            graph: {type},
+                                            correct: {type},
+                                        });
+                                    }) as any
+                                }
+                            />
+                        </LabeledRow>
+                        <InteractiveGraphDescription
+                            ariaLabelValue={this.props.fullGraphAriaLabel ?? ""}
+                            ariaDescriptionValue={
+                                this.props.fullGraphAriaDescription ?? ""
+                            }
+                            onChange={this.props.onChange}
                         />
-                    </LabeledRow>
-                )}
-                {this.props.correct?.type === "angle" && (
-                    <>
-                        <View style={styles.row}>
-                            <Checkbox
-                                label={
-                                    <LabelSmall>Show angle measures</LabelSmall>
-                                }
-                                checked={
-                                    // Don't show indeterminate checkbox state
-                                    !!this.props.correct?.showAngles
-                                }
-                                onChange={(newValue) => {
-                                    if (this.props.graph?.type === "angle") {
-                                        invariant(
-                                            this.props.correct.type === "angle",
-                                            `Expected graph type to be angle, but got ${this.props.correct.type}`,
-                                        );
+                        <InteractiveGraphCorrectAnswer
+                            id={graphId}
+                            equationString={equationString}
+                        >
+                            {graph}
+                        </InteractiveGraphCorrectAnswer>
+                        {this.props.correct?.type === "point" && (
+                            <LabeledRow label="Number of Points:">
+                                <GraphPointsCountSelector
+                                    numPoints={this.props.correct?.numPoints}
+                                    onChange={(points) => {
                                         this.props.onChange({
                                             correct: {
-                                                ...this.props.correct,
-                                                showAngles: newValue,
+                                                type: "point",
+                                                numPoints: points,
                                             },
                                             graph: {
-                                                ...this.props.graph,
-                                                showAngles: newValue,
+                                                type: "point",
+                                                numPoints: points,
                                             },
                                         });
+                                    }}
+                                />
+                            </LabeledRow>
+                        )}
+                        {this.props.correct?.type === "angle" && (
+                            <>
+                                <View style={styles.row}>
+                                    <Checkbox
+                                        label={
+                                            <LabelSmall>
+                                                Show angle measures
+                                            </LabelSmall>
+                                        }
+                                        checked={
+                                            // Don't show indeterminate checkbox state
+                                            !!this.props.correct?.showAngles
+                                        }
+                                        onChange={(newValue) => {
+                                            if (
+                                                this.props.graph?.type ===
+                                                "angle"
+                                            ) {
+                                                invariant(
+                                                    this.props.correct.type ===
+                                                        "angle",
+                                                    `Expected graph type to be angle, but got ${this.props.correct.type}`,
+                                                );
+                                                this.props.onChange({
+                                                    correct: {
+                                                        ...this.props.correct,
+                                                        showAngles: newValue,
+                                                    },
+                                                    graph: {
+                                                        ...this.props.graph,
+                                                        showAngles: newValue,
+                                                    },
+                                                });
+                                            }
+                                        }}
+                                    />
+                                    <InfoTip>
+                                        <p>
+                                            Displays the interior angle
+                                            measures.
+                                        </p>
+                                    </InfoTip>
+                                </View>
+                                <View style={styles.row}>
+                                    <Checkbox
+                                        label={
+                                            <LabelSmall>
+                                                Allow reflex angles
+                                            </LabelSmall>
+                                        }
+                                        checked={
+                                            // Don't show indeterminate checkbox state
+                                            !!this.props.correct
+                                                ?.allowReflexAngles
+                                        }
+                                        onChange={(newValue) => {
+                                            invariant(
+                                                this.props.correct.type ===
+                                                    "angle",
+                                                `Expected graph type to be angle, but got ${this.props.correct.type}`,
+                                            );
+                                            invariant(
+                                                this.props.graph?.type ===
+                                                    "angle",
+                                                `Expected graph type to be angle, but got ${this.props.graph?.type}`,
+                                            );
+
+                                            const update = {
+                                                allowReflexAngles: newValue,
+                                            };
+
+                                            this.props.onChange({
+                                                correct: {
+                                                    ...this.props.correct,
+                                                    ...update,
+                                                },
+                                                graph: {
+                                                    ...this.props.graph,
+                                                    ...update,
+                                                },
+                                            });
+                                        }}
+                                    />
+                                    <InfoTip>
+                                        <p>
+                                            Allow students to be able to create
+                                            reflex angles.
+                                        </p>
+                                    </InfoTip>
+                                </View>
+                            </>
+                        )}
+                        {this.props.correct?.type === "polygon" && (
+                            <>
+                                <LabeledRow label="Number of sides:">
+                                    <SingleSelect
+                                        key="polygon-select"
+                                        selectedValue={
+                                            this.props.correct?.numSides
+                                                ? `${this.props.correct.numSides}`
+                                                : "3"
+                                        }
+                                        placeholder=""
+                                        onChange={(newValue) => {
+                                            invariant(
+                                                this.props.graph?.type ===
+                                                    "polygon",
+                                            );
+                                            const updates = {
+                                                numSides:
+                                                    parsePointCount(newValue),
+                                                coords: null,
+                                                // reset the snap for UNLIMITED, which
+                                                // only supports "grid"
+                                                // From: D6578
+                                                snapTo: "grid",
+                                            } as const;
+
+                                            this.props.onChange({
+                                                correct: {
+                                                    ...this.props.correct,
+                                                    ...updates,
+                                                },
+                                                graph: {
+                                                    ...this.props.graph,
+                                                    ...updates,
+                                                },
+                                            });
+                                        }}
+                                        style={styles.singleSelectShort}
+                                    >
+                                        {[
+                                            ...POLYGON_SIDES,
+                                            <OptionItem
+                                                key="unlimited"
+                                                value="unlimited"
+                                                label="unlimited sides"
+                                            />,
+                                        ]}
+                                    </SingleSelect>
+                                </LabeledRow>
+                                <LabeledRow label="Snap to:">
+                                    <SingleSelect
+                                        selectedValue={
+                                            this.props.correct?.snapTo || "grid"
+                                        }
+                                        // Never uses placeholder, always has value
+                                        placeholder=""
+                                        onChange={(newValue) => {
+                                            invariant(
+                                                this.props.correct.type ===
+                                                    "polygon",
+                                                `Expected correct answer type to be polygon, but got ${this.props.correct.type}`,
+                                            );
+                                            invariant(
+                                                this.props.graph?.type ===
+                                                    "polygon",
+                                                `Expected graph type to be polygon, but got ${this.props.graph?.type}`,
+                                            );
+
+                                            const updates = {
+                                                snapTo: newValue as PerseusGraphTypePolygon["snapTo"],
+                                                coords: null,
+                                            } as const;
+
+                                            this.props.onChange({
+                                                correct: {
+                                                    ...this.props.correct,
+                                                    ...updates,
+                                                },
+                                                graph: {
+                                                    ...this.props.graph,
+                                                    ...updates,
+                                                },
+                                            });
+                                        }}
+                                        style={styles.singleSelectShort}
+                                    >
+                                        <OptionItem value="grid" label="grid" />
+                                        {this.props.correct?.numSides !==
+                                            "unlimited" && (
+                                            <OptionItem
+                                                value="angles"
+                                                label="interior angles"
+                                            />
+                                        )}
+                                        {this.props.correct?.numSides !==
+                                            "unlimited" && (
+                                            <OptionItem
+                                                value="sides"
+                                                label="side measures"
+                                            />
+                                        )}
+                                    </SingleSelect>
+                                    <InfoTip>
+                                        <p>
+                                            These options affect the movement of
+                                            the vertex points. The grid option
+                                            will guide the points to the nearest
+                                            half step along the grid.
+                                        </p>
+                                        <p>
+                                            The interior angle and side measure
+                                            options guide the points to the
+                                            nearest whole angle or side measure
+                                            respectively.
+                                        </p>
+                                    </InfoTip>
+                                </LabeledRow>
+                                <View style={styles.row}>
+                                    <Checkbox
+                                        label={
+                                            <LabelSmall>
+                                                Show angle measures
+                                            </LabelSmall>
+                                        }
+                                        checked={
+                                            // Don't show indeterminate checkbox state
+                                            !!this.props.correct?.showAngles
+                                        }
+                                        onChange={() => {
+                                            if (
+                                                this.props.graph?.type ===
+                                                "polygon"
+                                            ) {
+                                                invariant(
+                                                    this.props.correct.type ===
+                                                        "polygon",
+                                                    `Expected graph type to be polygon, but got ${this.props.correct.type}`,
+                                                );
+                                                this.props.onChange({
+                                                    correct: {
+                                                        ...this.props.correct,
+                                                        showAngles:
+                                                            !this.props.correct
+                                                                .showAngles,
+                                                    },
+                                                    graph: {
+                                                        ...this.props.graph,
+                                                        showAngles:
+                                                            !this.props.graph
+                                                                .showAngles,
+                                                    },
+                                                });
+                                            }
+                                        }}
+                                    />
+                                    <InfoTip>
+                                        <p>
+                                            Displays the interior angle
+                                            measures.
+                                        </p>
+                                    </InfoTip>
+                                </View>
+                                <View style={styles.row}>
+                                    <Checkbox
+                                        label={
+                                            <LabelSmall>
+                                                Show side measures
+                                            </LabelSmall>
+                                        }
+                                        checked={
+                                            // Don't show indeterminate checkbox state
+                                            !!this.props.correct?.showSides
+                                        }
+                                        onChange={() => {
+                                            if (
+                                                this.props.graph?.type ===
+                                                    "polygon" &&
+                                                this.props.correct.type ===
+                                                    "polygon"
+                                            ) {
+                                                this.props.onChange({
+                                                    correct: {
+                                                        ...this.props.correct,
+                                                        showSides:
+                                                            !this.props.correct
+                                                                .showSides,
+                                                    },
+                                                    graph: {
+                                                        ...this.props.graph,
+                                                        showSides:
+                                                            !this.props.graph
+                                                                .showSides,
+                                                    },
+                                                });
+                                            }
+                                        }}
+                                    />
+                                    <InfoTip>
+                                        <p>Displays the side lengths.</p>
+                                    </InfoTip>
+                                </View>
+                            </>
+                        )}
+                        {this.props.correct?.type === "segment" && (
+                            <LabeledRow label="Number of segments:">
+                                <SegmentCountSelector
+                                    numSegments={
+                                        this.props.correct?.numSegments
                                     }
-                                }}
-                            />
-                            <InfoTip>
-                                <p>Displays the interior angle measures.</p>
-                            </InfoTip>
-                        </View>
-                        <View style={styles.row}>
-                            <Checkbox
-                                label={
-                                    <LabelSmall>Allow reflex angles</LabelSmall>
-                                }
-                                checked={
-                                    // Don't show indeterminate checkbox state
-                                    !!this.props.correct?.allowReflexAngles
-                                }
-                                onChange={(newValue) => {
-                                    invariant(
-                                        this.props.correct.type === "angle",
-                                        `Expected graph type to be angle, but got ${this.props.correct.type}`,
-                                    );
-                                    invariant(
-                                        this.props.graph?.type === "angle",
-                                        `Expected graph type to be angle, but got ${this.props.graph?.type}`,
-                                    );
-
-                                    const update = {
-                                        allowReflexAngles: newValue,
-                                    };
-
-                                    this.props.onChange({
-                                        correct: {
-                                            ...this.props.correct,
-                                            ...update,
-                                        },
-                                        graph: {
-                                            ...this.props.graph,
-                                            ...update,
-                                        },
-                                    });
-                                }}
-                            />
-                            <InfoTip>
-                                <p>
-                                    Allow students to be able to create reflex
-                                    angles.
-                                </p>
-                            </InfoTip>
-                        </View>
-                    </>
-                )}
-                {this.props.correct?.type === "polygon" && (
-                    <>
-                        <LabeledRow label="Number of sides:">
-                            <SingleSelect
-                                key="polygon-select"
-                                selectedValue={
-                                    this.props.correct?.numSides
-                                        ? `${this.props.correct.numSides}`
-                                        : "3"
-                                }
-                                placeholder=""
-                                onChange={(newValue) => {
-                                    invariant(
-                                        this.props.graph?.type === "polygon",
-                                    );
-                                    const updates = {
-                                        numSides: parsePointCount(newValue),
-                                        coords: null,
-                                        // reset the snap for UNLIMITED, which
-                                        // only supports "grid"
-                                        // From: D6578
-                                        snapTo: "grid",
-                                    } as const;
-
-                                    this.props.onChange({
-                                        correct: {
-                                            ...this.props.correct,
-                                            ...updates,
-                                        },
-                                        graph: {
-                                            ...this.props.graph,
-                                            ...updates,
-                                        },
-                                    });
-                                }}
-                                style={styles.singleSelectShort}
-                            >
-                                {[
-                                    ...POLYGON_SIDES,
-                                    <OptionItem
-                                        key="unlimited"
-                                        value="unlimited"
-                                        label="unlimited sides"
-                                    />,
-                                ]}
-                            </SingleSelect>
-                        </LabeledRow>
-                        <LabeledRow label="Snap to:">
-                            <SingleSelect
-                                selectedValue={
-                                    this.props.correct?.snapTo || "grid"
-                                }
-                                // Never uses placeholder, always has value
-                                placeholder=""
-                                onChange={(newValue) => {
-                                    invariant(
-                                        this.props.correct.type === "polygon",
-                                        `Expected correct answer type to be polygon, but got ${this.props.correct.type}`,
-                                    );
-                                    invariant(
-                                        this.props.graph?.type === "polygon",
-                                        `Expected graph type to be polygon, but got ${this.props.graph?.type}`,
-                                    );
-
-                                    const updates = {
-                                        snapTo: newValue as PerseusGraphTypePolygon["snapTo"],
-                                        coords: null,
-                                    } as const;
-
-                                    this.props.onChange({
-                                        correct: {
-                                            ...this.props.correct,
-                                            ...updates,
-                                        },
-                                        graph: {
-                                            ...this.props.graph,
-                                            ...updates,
-                                        },
-                                    });
-                                }}
-                                style={styles.singleSelectShort}
-                            >
-                                <OptionItem value="grid" label="grid" />
-                                {this.props.correct?.numSides !==
-                                    "unlimited" && (
-                                    <OptionItem
-                                        value="angles"
-                                        label="interior angles"
-                                    />
-                                )}
-                                {this.props.correct?.numSides !==
-                                    "unlimited" && (
-                                    <OptionItem
-                                        value="sides"
-                                        label="side measures"
-                                    />
-                                )}
-                            </SingleSelect>
-                            <InfoTip>
-                                <p>
-                                    These options affect the movement of the
-                                    vertex points. The grid option will guide
-                                    the points to the nearest half step along
-                                    the grid.
-                                </p>
-                                <p>
-                                    The interior angle and side measure options
-                                    guide the points to the nearest whole angle
-                                    or side measure respectively.
-                                </p>
-                            </InfoTip>
-                        </LabeledRow>
-                        <View style={styles.row}>
-                            <Checkbox
-                                label={
-                                    <LabelSmall>Show angle measures</LabelSmall>
-                                }
-                                checked={
-                                    // Don't show indeterminate checkbox state
-                                    !!this.props.correct?.showAngles
-                                }
-                                onChange={() => {
-                                    if (this.props.graph?.type === "polygon") {
+                                    onChange={(sides) => {
+                                        this.props.onChange({
+                                            correct: {
+                                                type: "segment",
+                                                numSegments: sides,
+                                                coords: null,
+                                            },
+                                            graph: {
+                                                type: "segment",
+                                                numSegments: sides,
+                                            },
+                                        });
+                                    }}
+                                />
+                            </LabeledRow>
+                        )}
+                        {this.props.graph?.type &&
+                            shouldShowStartCoordsUI(
+                                this.props.graph,
+                                this.props.static,
+                            ) && (
+                                <StartCoordsSettings
+                                    {...this.props.graph}
+                                    range={this.props.range}
+                                    step={this.props.step}
+                                    onChange={this.changeStartCoords}
+                                />
+                            )}
+                        <InteractiveGraphSRTree
+                            graphId={graphId}
+                            correct={this.props.correct}
+                            fullGraphAriaLabel={this.props.fullGraphAriaLabel}
+                            fullGraphAriaDescription={
+                                this.props.fullGraphAriaDescription
+                            }
+                            lockedFigures={this.props.lockedFigures}
+                        />
+                        <InteractiveGraphSettings
+                            box={getInteractiveBoxFromSizeClass(sizeClass)}
+                            range={this.props.range}
+                            labels={this.props.labels}
+                            step={this.props.step}
+                            gridStep={gridStep}
+                            snapStep={snapStep}
+                            valid={this.props.valid}
+                            backgroundImage={this.props.backgroundImage}
+                            markings={this.props.markings}
+                            showProtractor={this.props.showProtractor}
+                            showTooltips={this.props.showTooltips}
+                            onChange={this.props.onChange}
+                        />
+                        {this.props.correct.type === "polygon" && (
+                            <LabeledRow label="Student answer must">
+                                <SingleSelect
+                                    selectedValue={
+                                        this.props.correct.match || "exact"
+                                    }
+                                    onChange={(newValue) => {
                                         invariant(
                                             this.props.correct.type ===
                                                 "polygon",
                                             `Expected graph type to be polygon, but got ${this.props.correct.type}`,
                                         );
-                                        this.props.onChange({
-                                            correct: {
-                                                ...this.props.correct,
-                                                showAngles:
-                                                    !this.props.correct
-                                                        .showAngles,
-                                            },
-                                            graph: {
-                                                ...this.props.graph,
-                                                showAngles:
-                                                    !this.props.graph
-                                                        .showAngles,
-                                            },
-                                        });
-                                    }
-                                }}
-                            />
-                            <InfoTip>
-                                <p>Displays the interior angle measures.</p>
-                            </InfoTip>
-                        </View>
-                        <View style={styles.row}>
-                            <Checkbox
-                                label={
-                                    <LabelSmall>Show side measures</LabelSmall>
-                                }
-                                checked={
-                                    // Don't show indeterminate checkbox state
-                                    !!this.props.correct?.showSides
-                                }
-                                onChange={() => {
-                                    if (
-                                        this.props.graph?.type === "polygon" &&
-                                        this.props.correct.type === "polygon"
-                                    ) {
-                                        this.props.onChange({
-                                            correct: {
-                                                ...this.props.correct,
-                                                showSides:
-                                                    !this.props.correct
-                                                        .showSides,
-                                            },
-                                            graph: {
-                                                ...this.props.graph,
-                                                showSides:
-                                                    !this.props.graph.showSides,
-                                            },
-                                        });
-                                    }
-                                }}
-                            />
-                            <InfoTip>
-                                <p>Displays the side lengths.</p>
-                            </InfoTip>
-                        </View>
-                    </>
-                )}
-                {this.props.correct?.type === "segment" && (
-                    <LabeledRow label="Number of segments:">
-                        <SegmentCountSelector
-                            numSegments={this.props.correct?.numSegments}
-                            onChange={(sides) => {
-                                this.props.onChange({
-                                    correct: {
-                                        type: "segment",
-                                        numSegments: sides,
-                                        coords: null,
-                                    },
-                                    graph: {
-                                        type: "segment",
-                                        numSegments: sides,
-                                    },
-                                });
-                            }}
-                        />
-                    </LabeledRow>
-                )}
-                {this.props.graph?.type &&
-                    shouldShowStartCoordsUI(
-                        this.props.graph,
-                        this.props.static,
-                    ) && (
-                        <StartCoordsSettings
-                            {...this.props.graph}
-                            range={this.props.range}
-                            step={this.props.step}
-                            onChange={this.changeStartCoords}
-                        />
-                    )}
-                <InteractiveGraphSRTree
-                    correct={this.props.correct}
-                    fullGraphAriaLabel={this.props.fullGraphAriaLabel}
-                    fullGraphAriaDescription={
-                        this.props.fullGraphAriaDescription
-                    }
-                    lockedFigures={this.props.lockedFigures}
-                />
-                <InteractiveGraphSettings
-                    box={getInteractiveBoxFromSizeClass(sizeClass)}
-                    range={this.props.range}
-                    labels={this.props.labels}
-                    step={this.props.step}
-                    gridStep={gridStep}
-                    snapStep={snapStep}
-                    valid={this.props.valid}
-                    backgroundImage={this.props.backgroundImage}
-                    markings={this.props.markings}
-                    showProtractor={this.props.showProtractor}
-                    showTooltips={this.props.showTooltips}
-                    onChange={this.props.onChange}
-                />
-                {this.props.correct.type === "polygon" && (
-                    <LabeledRow label="Student answer must">
-                        <SingleSelect
-                            selectedValue={this.props.correct.match || "exact"}
-                            onChange={(newValue) => {
-                                invariant(
-                                    this.props.correct.type === "polygon",
-                                    `Expected graph type to be polygon, but got ${this.props.correct.type}`,
-                                );
-                                const correct = {
-                                    ...this.props.correct,
-                                    // TODO(benchristel): this cast is necessary
-                                    // because "exact" is not actually a valid
-                                    // value for `match`; a value of undefined
-                                    // means exact matching. The code happens
-                                    // to work because "exact" falls through
-                                    // to the correct else branch when scoring
-                                    match: newValue as PerseusGraphTypePolygon["match"],
-                                };
-                                this.props.onChange({correct});
-                            }}
-                            // Never uses placeholder, always has value
-                            placeholder=""
-                            style={styles.singleSelectShort}
-                        >
-                            <OptionItem value="exact" label="match exactly" />
-                            <OptionItem
-                                value="congruent"
-                                label="be congruent"
-                            />
-                            <OptionItem
-                                value="approx"
-                                label="be approximately congruent"
-                            />
-                            <OptionItem value="similar" label="be similar" />
-                        </SingleSelect>
+                                        const correct = {
+                                            ...this.props.correct,
+                                            // TODO(benchristel): this cast is necessary
+                                            // because "exact" is not actually a valid
+                                            // value for `match`; a value of undefined
+                                            // means exact matching. The code happens
+                                            // to work because "exact" falls through
+                                            // to the correct else branch when scoring
+                                            match: newValue as PerseusGraphTypePolygon["match"],
+                                        };
+                                        this.props.onChange({correct});
+                                    }}
+                                    // Never uses placeholder, always has value
+                                    placeholder=""
+                                    style={styles.singleSelectShort}
+                                >
+                                    <OptionItem
+                                        value="exact"
+                                        label="match exactly"
+                                    />
+                                    <OptionItem
+                                        value="congruent"
+                                        label="be congruent"
+                                    />
+                                    <OptionItem
+                                        value="approx"
+                                        label="be approximately congruent"
+                                    />
+                                    <OptionItem
+                                        value="similar"
+                                        label="be similar"
+                                    />
+                                </SingleSelect>
 
-                        <InfoTip>
-                            <ul>
-                                <li>
+                                <InfoTip>
+                                    <ul>
+                                        <li>
+                                            <p>
+                                                <b>Match Exactly:</b> Match
+                                                exactly in size, orientation,
+                                                and location on the grid even if
+                                                it is not shown in the
+                                                background.
+                                            </p>
+                                        </li>
+                                        <li>
+                                            <p>
+                                                <b>Be Congruent:</b> Be
+                                                congruent in size and shape, but
+                                                can be located anywhere on the
+                                                grid.
+                                            </p>
+                                        </li>
+                                        <li>
+                                            <p>
+                                                <b>
+                                                    Be Approximately Congruent:
+                                                </b>{" "}
+                                                Be exactly similar, and
+                                                congruent in size and shape to
+                                                within 0.1 units, but can be
+                                                located anywhere on the grid.{" "}
+                                                <em>
+                                                    Use this with snapping to
+                                                    angle measure.
+                                                </em>
+                                            </p>
+                                        </li>
+                                        <li>
+                                            <p>
+                                                <b>Be Similar:</b> Be similar
+                                                with matching interior angles,
+                                                and side measures that are
+                                                matching or a multiple of the
+                                                correct side measures. The
+                                                figure can be located anywhere
+                                                on the grid.
+                                            </p>
+                                        </li>
+                                    </ul>
+                                </InfoTip>
+                            </LabeledRow>
+                        )}
+                        {this.props.correct.type === "angle" && (
+                            <LabeledRow label="Student answer must">
+                                <SingleSelect
+                                    selectedValue={
+                                        this.props.correct.match || "exact"
+                                    }
+                                    onChange={(newValue) => {
+                                        this.props.onChange({
+                                            correct: {
+                                                ...this.props.correct,
+                                                // TODO(benchristel): this cast is necessary
+                                                // because "exact" is not actually a valid
+                                                // value for `match`; a value of undefined
+                                                // means exact matching. The code happens
+                                                // to work because "exact" falls through
+                                                // to the correct else branch when scoring
+                                                match: newValue as PerseusGraphTypeAngle["match"],
+                                            },
+                                        });
+                                    }}
+                                    // Never uses placeholder, always has value
+                                    placeholder=""
+                                    style={styles.singleSelectShort}
+                                >
+                                    <OptionItem
+                                        value="exact"
+                                        label="match exactly"
+                                    />
+                                    <OptionItem
+                                        value="congruent"
+                                        label="be congruent"
+                                    />
+                                </SingleSelect>
+                                <InfoTip>
                                     <p>
-                                        <b>Match Exactly:</b> Match exactly in
-                                        size, orientation, and location on the
-                                        grid even if it is not shown in the
-                                        background.
+                                        Congruency requires only that the angle
+                                        measures are the same. An exact match
+                                        implies congruency, but also requires
+                                        that the angles have the same
+                                        orientation and that the vertices are in
+                                        the same position.
                                     </p>
-                                </li>
-                                <li>
-                                    <p>
-                                        <b>Be Congruent:</b> Be congruent in
-                                        size and shape, but can be located
-                                        anywhere on the grid.
-                                    </p>
-                                </li>
-                                <li>
-                                    <p>
-                                        <b>Be Approximately Congruent:</b> Be
-                                        exactly similar, and congruent in size
-                                        and shape to within 0.1 units, but can
-                                        be located anywhere on the grid.{" "}
-                                        <em>
-                                            Use this with snapping to angle
-                                            measure.
-                                        </em>
-                                    </p>
-                                </li>
-                                <li>
-                                    <p>
-                                        <b>Be Similar:</b> Be similar with
-                                        matching interior angles, and side
-                                        measures that are matching or a multiple
-                                        of the correct side measures. The figure
-                                        can be located anywhere on the grid.
-                                    </p>
-                                </li>
-                            </ul>
-                        </InfoTip>
-                    </LabeledRow>
+                                </InfoTip>
+                            </LabeledRow>
+                        )}
+                        <LockedFiguresSection
+                            figures={this.props.lockedFigures}
+                            onChange={this.props.onChange}
+                        />
+                    </View>
                 )}
-                {this.props.correct.type === "angle" && (
-                    <LabeledRow label="Student answer must">
-                        <SingleSelect
-                            selectedValue={this.props.correct.match || "exact"}
-                            onChange={(newValue) => {
-                                this.props.onChange({
-                                    correct: {
-                                        ...this.props.correct,
-                                        // TODO(benchristel): this cast is necessary
-                                        // because "exact" is not actually a valid
-                                        // value for `match`; a value of undefined
-                                        // means exact matching. The code happens
-                                        // to work because "exact" falls through
-                                        // to the correct else branch when scoring
-                                        match: newValue as PerseusGraphTypeAngle["match"],
-                                    },
-                                });
-                            }}
-                            // Never uses placeholder, always has value
-                            placeholder=""
-                            style={styles.singleSelectShort}
-                        >
-                            <OptionItem value="exact" label="match exactly" />
-                            <OptionItem
-                                value="congruent"
-                                label="be congruent"
-                            />
-                        </SingleSelect>
-                        <InfoTip>
-                            <p>
-                                Congruency requires only that the angle measures
-                                are the same. An exact match implies congruency,
-                                but also requires that the angles have the same
-                                orientation and that the vertices are in the
-                                same position.
-                            </p>
-                        </InfoTip>
-                    </LabeledRow>
-                )}
-                <LockedFiguresSection
-                    figures={this.props.lockedFigures}
-                    onChange={this.props.onChange}
-                />
-            </View>
+            </Id>
         );
     }
 }


### PR DESCRIPTION
## Summary:
Right now, the SR Tree just gets the first mafs-graph container on the page and renders its SR content.
However, this does not work if there are also hint editors on the page. The hints will just show the
SR content for the first graph instead of reflecting their respective graph.

To fix this, I added a unique ID to the editor and passed that into the graph container and the SR Tree.
And SR Tree now finds by this unique ID rather than just the first graph on the page.

Issue: none

## Test plan:
`yarn jest packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.test.tsx`

Storybook
- Go to http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--interactive-graph-ray
- Click "Add a hint" at the bottom
- Copy the interactive graph question
- Paste into the hint editor
- Confirm that the ray SR tree shows ray info
- Change the hint graph type
- Confirm that the hint SR tree no longer shows ray info

### Screenshots of the SR tree for a HINT none-type graph
| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/77f7211a-837a-48af-86f0-479174b83766) | <img width="344" alt="Screenshot 2025-02-06 at 12 32 07 PM" src="https://github.com/user-attachments/assets/26135a5c-7b0d-45cd-8bcf-924f5c0b03a9" /> |

