### PR TITLE
[SR] Angle - Add the "interactive elements" overall graph description

### DIFF
--- a/.changeset/calm-cats-ring.md
+++ b/.changeset/calm-cats-ring.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[SR] Refactor - Update graphs to pass in i18n context

--- a/.changeset/neat-beds-smash.md
+++ b/.changeset/neat-beds-smash.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[SR] Angle - Add the "interactive elements" overall graph description

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -260,6 +260,21 @@ export type PerseusStrings = {
         endingSideX: string;
         endingSideY: string;
     }) => string;
+    srAngleInteractiveElements: ({
+        vertexX,
+        vertexY,
+        startingSideX,
+        startingSideY,
+        endingSideX,
+        endingSideY,
+    }: {
+        vertexX: string;
+        vertexY: string;
+        startingSideX: string;
+        startingSideY: string;
+        endingSideX: string;
+        endingSideY: string;
+    }) => string;
     srSingleSegmentGraphAriaLabel: string;
     srMultipleSegmentGraphAriaLabel: ({
         countOfSegments,
@@ -662,6 +677,8 @@ export const strings = {
     srAngleGraphAriaLabel: "An angle on a coordinate plane.",
     srAngleGraphAriaDescription:
         "The angle measure is %(angleMeasure)s degrees with a vertex at %(vertexX)s comma %(vertexY)s, a point on the starting side at %(startingSideX)s comma %(startingSideY)s and a point on the ending side at %(endingSideX)s comma %(endingSideY)s",
+    srAngleInteractiveElements:
+        "An angle formed by 3 points. The vertex is at %(vertexX)s comma %(vertexY)s. The starting side point is at %(startingSideX)s comma %(startingSideY)s. The ending side point is at %(endingSideX)s comma %(endingSideY)s.",
     srSingleSegmentGraphAriaLabel: "A line segment on a coordinate plane.",
     srMultipleSegmentGraphAriaLabel:
         "%(countOfSegments)s line segments on a coordinate plane.",
@@ -942,6 +959,15 @@ export const mockStrings: PerseusStrings = {
         endingSideY,
     }) =>
         `The angle measure is ${angleMeasure} degrees with a vertex at ${vertexX} comma ${vertexY}, a point on the starting side at ${startingSideX} comma ${startingSideY} and a point on the ending side at ${endingSideX} comma ${endingSideY}.`,
+    srAngleInteractiveElements: ({
+        vertexX,
+        vertexY,
+        startingSideX,
+        startingSideY,
+        endingSideX,
+        endingSideY,
+    }) =>
+        `An angle formed by 3 points. The vertex is at ${vertexX} comma ${vertexY}. The starting side point is at ${startingSideX} comma ${startingSideY}. The ending side point is at ${endingSideX} comma ${endingSideY}.`,
     srSingleSegmentGraphAriaLabel: "A line segment on a coordinate plane.",
     srMultipleSegmentGraphAriaLabel: ({countOfSegments}) =>
         `${countOfSegments} segments on a coordinate plane.`,

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/angle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/angle.tsx
@@ -18,6 +18,7 @@ import {srFormatNumber} from "./screenreader-text";
 import {useTransformVectorsToPixels} from "./use-transform";
 import {getIntersectionOfRayWithBox} from "./utils";
 
+import type {I18nContextType} from "../../../components/i18n-context";
 import type {Segment} from "../math/geometry";
 import type {
     AngleGraphState,
@@ -34,10 +35,11 @@ type AngleGraphProps = MafsGraphProps<AngleGraphState>;
 export function renderAngleGraph(
     state: AngleGraphState,
     dispatch: Dispatch,
+    i18n: I18nContextType,
 ): InteractiveGraphElementSuite {
     return {
         graph: <AngleGraph graphState={state} dispatch={dispatch} />,
-        interactiveElementsDescription: null,
+        interactiveElementsDescription: getAngleGraphDescription(state, i18n),
     };
 }
 
@@ -224,6 +226,25 @@ function AngleGraph(props: AngleGraphProps) {
             </g>
         </g>
     );
+}
+
+function getAngleGraphDescription(
+    state: AngleGraphState,
+    i18n: I18nContextType,
+): string {
+    const {strings, locale} = i18n;
+    const {coords} = state;
+
+    return strings.srInteractiveElements({
+        elements: strings.srAngleInteractiveElements({
+            vertexX: srFormatNumber(coords[1][X], locale),
+            vertexY: srFormatNumber(coords[1][Y], locale),
+            startingSideX: srFormatNumber(coords[2][X], locale),
+            startingSideY: srFormatNumber(coords[2][Y], locale),
+            endingSideX: srFormatNumber(coords[0][X], locale),
+            endingSideY: srFormatNumber(coords[0][Y], locale),
+        }),
+    });
 }
 
 const positiveX: vec.Vector2 = [1, 0];

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -29,12 +29,11 @@ import type {
 export function renderCircleGraph(
     state: CircleGraphState,
     dispatch: Dispatch,
+    i18n: I18nContextType,
 ): InteractiveGraphElementSuite {
     return {
         graph: <CircleGraph graphState={state} dispatch={dispatch} />,
-        interactiveElementsDescription: (
-            <CircleGraphDescription state={state} />
-        ),
+        interactiveElementsDescription: getCircleGraphDescription(state, i18n),
     };
 }
 
@@ -211,13 +210,11 @@ function crossProduct<A, B>(as: A[], bs: B[]): [A, B][] {
     return result;
 }
 
-function CircleGraphDescription({state}: {state: CircleGraphState}) {
-    // The reason that CircleGraphDescription is a component (rather than a
-    // function that returns a string) is because it needs to use a
-    // hook: `usePerseusI18n`.
-    const i18n = usePerseusI18n();
+function getCircleGraphDescription(
+    state: CircleGraphState,
+    i18n: I18nContextType,
+) {
     const strings = describeCircleGraph(state, i18n);
-
     return strings.srCircleInteractiveElement;
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.test.tsx
@@ -9,7 +9,7 @@ import {mockPerseusI18nContext} from "../../../components/i18n-context";
 import {MafsGraph} from "../mafs-graph";
 import {getBaseMafsGraphPropsForTests} from "../utils";
 
-import {describeLinearSystemGraph} from "./linear-system";
+import {getLinearSystemGraphDescription} from "./linear-system";
 
 import type {InteractiveGraphState} from "../types";
 import type {UserEvent} from "@testing-library/user-event";
@@ -256,12 +256,12 @@ describe("Linear System graph screen reader", () => {
     });
 });
 
-describe(describeLinearSystemGraph, () => {
+describe("getLinearSystemGraphDescription", () => {
     test("describes a default linear system graph", () => {
         // Arrange
 
         // Act
-        const linearSystemGraphDescription = describeLinearSystemGraph(
+        const linearSystemGraphDescription = getLinearSystemGraphDescription(
             baseLinearSystemState,
             mockPerseusI18nContext,
         );
@@ -276,7 +276,7 @@ describe(describeLinearSystemGraph, () => {
         // Arrange
 
         // Act
-        const linearSystemGraphDescription = describeLinearSystemGraph(
+        const linearSystemGraphDescription = getLinearSystemGraphDescription(
             {
                 ...baseLinearSystemState,
                 coords: [

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.tsx
@@ -20,11 +20,13 @@ import type {vec} from "mafs";
 export function renderLinearSystemGraph(
     state: LinearSystemGraphState,
     dispatch: Dispatch,
+    i18n: I18nContextType,
 ): InteractiveGraphElementSuite {
     return {
         graph: <LinearSystemGraph graphState={state} dispatch={dispatch} />,
-        interactiveElementsDescription: (
-            <LinearSystemGraphDescription state={state} />
+        interactiveElementsDescription: getLinearSystemGraphDescription(
+            state,
+            i18n,
         ),
     };
 }
@@ -153,21 +155,8 @@ const LinearSystemGraph = (props: LinearSystemGraphProps) => {
     );
 };
 
-function LinearSystemGraphDescription({
-    state,
-}: {
-    state: LinearSystemGraphState;
-}) {
-    // The reason that LinearSystemGraphDescription is a component (rather
-    // than a function that returns a string) is because it needs to use a
-    // hook: `usePerseusI18n`.
-    const i18n = usePerseusI18n();
-
-    return describeLinearSystemGraph(state, i18n);
-}
-
 // Exported for testing
-export function describeLinearSystemGraph(
+export function getLinearSystemGraphDescription(
     state: LinearSystemGraphState,
     i18n: I18nContextType,
 ): string {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
@@ -20,12 +20,11 @@ import type {vec} from "mafs";
 export function renderLinearGraph(
     state: LinearGraphState,
     dispatch: Dispatch,
+    i18n: I18nContextType,
 ): InteractiveGraphElementSuite {
     return {
         graph: <LinearGraph graphState={state} dispatch={dispatch} />,
-        interactiveElementsDescription: (
-            <LinearGraphDescription state={state} />
-        ),
+        interactiveElementsDescription: getLinearGraphDescription(state, i18n),
     };
 }
 
@@ -96,11 +95,10 @@ const LinearGraph = (props: LinearGraphProps, key: number) => {
     );
 };
 
-function LinearGraphDescription({state}: {state: LinearGraphState}) {
-    // The reason that LinearGraphDescription is a component (rather than a
-    // function that returns a string) is because it needs to use a
-    // hook: `usePerseusI18n`.
-    const i18n = usePerseusI18n();
+function getLinearGraphDescription(
+    state: LinearGraphState,
+    i18n: I18nContextType,
+) {
     const strings = describeLinearGraph(state, i18n);
 
     return strings.srLinearInteractiveElement;

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.test.ts
@@ -1,10 +1,10 @@
 import {mockPerseusI18nContext} from "../../../components/i18n-context";
 
-import {describePointGraph} from "./point";
+import {getPointGraphDescription} from "./point";
 
 import type {PointGraphState} from "../types";
 
-describe("describePointGraph", () => {
+describe("getPointGraphDescription", () => {
     const baseState: PointGraphState = {
         type: "point",
         coords: [],
@@ -22,14 +22,14 @@ describe("describePointGraph", () => {
 
     it(`returns "No interactive elements" for a graph with no points`, () => {
         const state: PointGraphState = {...baseState, coords: []};
-        expect(describePointGraph(state, mockPerseusI18nContext)).toBe(
+        expect(getPointGraphDescription(state, mockPerseusI18nContext)).toBe(
             "No interactive elements",
         );
     });
 
     it("describes one point", () => {
         const state: PointGraphState = {...baseState, coords: [[3, 5]]};
-        expect(describePointGraph(state, mockPerseusI18nContext)).toBe(
+        expect(getPointGraphDescription(state, mockPerseusI18nContext)).toBe(
             "Interactive elements: Point 1 at 3 comma 5.",
         );
     });
@@ -42,7 +42,7 @@ describe("describePointGraph", () => {
                 [2, 4],
             ],
         };
-        expect(describePointGraph(state, mockPerseusI18nContext)).toBe(
+        expect(getPointGraphDescription(state, mockPerseusI18nContext)).toBe(
             "Interactive elements: Point 1 at 3 comma 5. Point 2 at 2 comma 4.",
         );
     });
@@ -52,7 +52,7 @@ describe("describePointGraph", () => {
             ...baseState,
             coords: [[-1.1234, 3.5678]],
         };
-        expect(describePointGraph(state, mockPerseusI18nContext)).toBe(
+        expect(getPointGraphDescription(state, mockPerseusI18nContext)).toBe(
             "Interactive elements: Point 1 at -1.123 comma 3.568.",
         );
     });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 
-import {usePerseusI18n} from "../../../components/i18n-context";
 import {actions} from "../reducer/interactive-graph-action";
 import useGraphConfig from "../reducer/use-graph-config";
 
@@ -8,6 +7,7 @@ import {MovablePoint} from "./components/movable-point";
 import {srFormatNumber} from "./screenreader-text";
 import {useTransformVectorsToPixels, pixelsToVectors} from "./use-transform";
 
+import type {I18nContextType} from "../../../components/i18n-context";
 import type {PerseusStrings} from "../../../strings";
 import type {GraphConfig} from "../reducer/use-graph-config";
 import type {
@@ -20,10 +20,11 @@ import type {
 export function renderPointGraph(
     state: PointGraphState,
     dispatch: Dispatch,
+    i18n: I18nContextType,
 ): InteractiveGraphElementSuite {
     return {
         graph: <PointGraph graphState={state} dispatch={dispatch} />,
-        interactiveElementsDescription: <PointGraphDescription state={state} />,
+        interactiveElementsDescription: getPointGraphDescription(state, i18n),
     };
 }
 
@@ -148,15 +149,8 @@ function UnlimitedPointGraph(statefulProps: StatefulProps) {
     );
 }
 
-function PointGraphDescription({state}: {state: PointGraphState}) {
-    // PointGraphDescription needs to `usePerseusI18n`, so it has to be a
-    // component rather than a function that simply returns a string.
-    const i18n = usePerseusI18n();
-    return describePointGraph(state, i18n);
-}
-
 // Exported for testing
-export function describePointGraph(
+export function getPointGraphDescription(
     state: PointGraphState,
     i18n: {strings: PerseusStrings; locale: string},
 ): string {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/ray.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/ray.tsx
@@ -19,10 +19,11 @@ import type {vec} from "mafs";
 export function renderRayGraph(
     state: RayGraphState,
     dispatch: Dispatch,
+    i18n: I18nContextType,
 ): InteractiveGraphElementSuite {
     return {
         graph: <RayGraph graphState={state} dispatch={dispatch} />,
-        interactiveElementsDescription: <RayGraphDescription state={state} />,
+        interactiveElementsDescription: getRayGraphDescription(state, i18n),
     };
 }
 
@@ -80,13 +81,8 @@ const RayGraph = (props: Props) => {
     );
 };
 
-function RayGraphDescription({state}: {state: RayGraphState}) {
-    // The reason that RayGraphDescription is a component (rather than a
-    // function that returns a string) is because it needs to use a
-    // hook: `usePerseusI18n`.
-    const i18n = usePerseusI18n();
+function getRayGraphDescription(state: RayGraphState, i18n: I18nContextType) {
     const strings = describeRayGraph(state, i18n);
-
     return strings.srRayInteractiveElement;
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/segment.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/segment.test.tsx
@@ -9,7 +9,7 @@ import {mockPerseusI18nContext} from "../../../components/i18n-context";
 import {MafsGraph} from "../mafs-graph";
 import {getBaseMafsGraphPropsForTests} from "../utils";
 
-import {describeSegmentGraph} from "./segment";
+import {getSegmentGraphDescription} from "./segment";
 
 import type {InteractiveGraphState} from "../types";
 import type {UserEvent} from "@testing-library/user-event";
@@ -338,12 +338,12 @@ describe("Segment graph screen reader", () => {
     );
 });
 
-describe("describeSegmentGraph", () => {
+describe("getSegmentGraphDescription", () => {
     test("describes a single segment", () => {
         // Arrange
 
         // Act
-        const interactiveElementsString = describeSegmentGraph(
+        const interactiveElementsString = getSegmentGraphDescription(
             baseSingleSegmentState,
             mockPerseusI18nContext,
         );
@@ -358,7 +358,7 @@ describe("describeSegmentGraph", () => {
         // Arrange
 
         // Act
-        const interactiveElementsString = describeSegmentGraph(
+        const interactiveElementsString = getSegmentGraphDescription(
             baseMultipleSegmentState,
             mockPerseusI18nContext,
         );
@@ -373,7 +373,7 @@ describe("describeSegmentGraph", () => {
         // Arrange
 
         // Act
-        const interactiveElementsString = describeSegmentGraph(
+        const interactiveElementsString = getSegmentGraphDescription(
             {
                 ...baseSingleSegmentState,
                 coords: [
@@ -396,7 +396,7 @@ describe("describeSegmentGraph", () => {
         // Arrange
 
         // Act
-        const interactiveElementsString = describeSegmentGraph(
+        const interactiveElementsString = getSegmentGraphDescription(
             {
                 ...baseMultipleSegmentState,
                 coords: [

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
@@ -22,12 +22,11 @@ import type {vec} from "mafs";
 export function renderSegmentGraph(
     state: SegmentGraphState,
     dispatch: Dispatch,
+    i18n: I18nContextType,
 ): InteractiveGraphElementSuite {
     return {
         graph: <SegmentGraph graphState={state} dispatch={dispatch} />,
-        interactiveElementsDescription: (
-            <SegmentGraphDescription state={state} />
-        ),
+        interactiveElementsDescription: getSegmentGraphDescription(state, i18n),
     };
 }
 
@@ -171,16 +170,8 @@ function getLengthOfSegment(segment: PairOfPoints) {
     return kpoint.distanceToPoint(...segment);
 }
 
-function SegmentGraphDescription({state}: {state: SegmentGraphState}) {
-    // The reason that SegmentGraphDescription is a component (rather than a
-    // function that returns a string) is because it needs to use a
-    // hook: `usePerseusI18n`.
-    const i18n = usePerseusI18n();
-    return describeSegmentGraph(state, i18n);
-}
-
 // Exported for testing
-export function describeSegmentGraph(
+export function getSegmentGraphDescription(
     state: SegmentGraphState,
     i18n: I18nContextType,
 ): string {

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -510,6 +510,39 @@ describe("MafsGraph", () => {
         expectLabelInDoc("Point 3, initial side at 0 comma 6");
     });
 
+    it("renders ARIA label for the interactive elements on an angle graph", () => {
+        const state: InteractiveGraphState = {
+            type: "angle",
+            hasBeenInteractedWith: true,
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            snapStep: [0.5, 0.5],
+            coords: [
+                [-1, 1],
+                [0, 0],
+                [1, 1],
+            ],
+            allowReflexAngles: true,
+            showAngles: true,
+        };
+
+        const {container} = render(
+            <MafsGraph
+                {...getBaseMafsGraphPropsForTests()}
+                state={state}
+                dispatch={() => {}}
+            />,
+        );
+
+        // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+        const angleGraph = container.querySelector(".mafs-graph");
+        const expectedDescription =
+            "Interactive elements: An angle formed by 3 points. The vertex is at 0 comma 0. The starting side point is at 1 comma 1. The ending side point is at -1 comma 1.";
+        expect(angleGraph).toHaveAccessibleDescription(expectedDescription);
+    });
+
     it("renders ARIA label for whole angle graph", () => {
         const state: InteractiveGraphState = {
             type: "angle",

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -692,19 +692,19 @@ const renderGraphElements = (props: {
         case "angle":
             return renderAngleGraph(state, dispatch);
         case "segment":
-            return renderSegmentGraph(state, dispatch);
+            return renderSegmentGraph(state, dispatch, i18n);
         case "linear-system":
-            return renderLinearSystemGraph(state, dispatch);
+            return renderLinearSystemGraph(state, dispatch, i18n);
         case "linear":
-            return renderLinearGraph(state, dispatch);
+            return renderLinearGraph(state, dispatch, i18n);
         case "ray":
-            return renderRayGraph(state, dispatch);
+            return renderRayGraph(state, dispatch, i18n);
         case "polygon":
             return renderPolygonGraph(state, dispatch, i18n, markings);
         case "point":
-            return renderPointGraph(state, dispatch);
+            return renderPointGraph(state, dispatch, i18n);
         case "circle":
-            return renderCircleGraph(state, dispatch);
+            return renderCircleGraph(state, dispatch, i18n);
         case "quadratic":
             return renderQuadraticGraph(state, dispatch, i18n);
         case "sinusoid":

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -690,7 +690,7 @@ const renderGraphElements = (props: {
     const {type} = state;
     switch (type) {
         case "angle":
-            return renderAngleGraph(state, dispatch);
+            return renderAngleGraph(state, dispatch, i18n);
         case "segment":
             return renderSegmentGraph(state, dispatch, i18n);
         case "linear-system":


### PR DESCRIPTION
## Summary:
This got missed when doing the angle SR work. We have to add the “interactive elements” description to the overall graph.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2839

## Test plan:
`yarn jest packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx`

Storybook
- Go to http://localhost:6006/iframe.html?globals=&id=perseuseditor-widgets-interactive-graph--interactive-graph-angle&viewMode=story
- Confirm that the "Interactive elements: ..." section is there in the screen reader tree.
- Change the values of the correct graph and confirm that the SR tree updates to reflect them in the interactive elements.

<img width="424" alt="image" src="https://github.com/user-attachments/assets/d3160281-c49d-4cd5-95a5-fed02ae0ffd5" />
