### PR TITLE
Create helper to build public widget options for Plotter

### DIFF
--- a/.changeset/nice-donuts-jump.md
+++ b/.changeset/nice-donuts-jump.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-core": minor
+---
+
+Implement a widget export function to filter out rubric data from widget options for the Plotter widget

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -135,3 +135,4 @@ export {default as getNumberLinePublicWidgetOptions} from "./widgets/number-line
 export {default as getRadioPublicWidgetOptions} from "./widgets/radio/radio-util";
 export {default as getTablePublicWidgetOptions} from "./widgets/table/table-util";
 export {default as getIFramePublicWidgetOptions} from "./widgets/iframe/iframe-util";
+export {default as getPlotterPublicWidgetOptions} from "./widgets/plotter/plotter-util";

--- a/packages/perseus-core/src/widgets/plotter/plotter-util.test.ts
+++ b/packages/perseus-core/src/widgets/plotter/plotter-util.test.ts
@@ -1,0 +1,43 @@
+import getPlotterPublicWidgetOptions from "./plotter-util";
+
+import type {PerseusPlotterWidgetOptions} from "../../data-schema";
+
+describe("getPlotterPublicWidgetOptions", () => {
+    it("should return the correct public options without any answer data", () => {
+        // Arrange
+        const options: PerseusPlotterWidgetOptions = {
+            labels: ["X Label", "Y Label"],
+            categories: [">0", ">6", ">12", ">18"],
+            type: "bar",
+            maxY: 10,
+            scaleY: 10,
+            labelInterval: 2,
+            snapsPerLine: 2,
+            starting: [1, 2, 3, 4],
+            correct: [5, 6, 7, 8],
+            picUrl: "test.png",
+            picSize: 2,
+            picBoxHeight: 2,
+            plotDimensions: [10, 10],
+        };
+
+        // Act
+        const publicWidgetOptions = getPlotterPublicWidgetOptions(options);
+
+        // Assert
+        expect(publicWidgetOptions).toEqual({
+            labels: ["X Label", "Y Label"],
+            categories: [">0", ">6", ">12", ">18"],
+            type: "bar",
+            maxY: 10,
+            scaleY: 10,
+            labelInterval: 2,
+            snapsPerLine: 2,
+            starting: [1, 2, 3, 4],
+            picUrl: "test.png",
+            picSize: 2,
+            picBoxHeight: 2,
+            plotDimensions: [10, 10],
+        });
+    });
+});

--- a/packages/perseus-core/src/widgets/plotter/plotter-util.ts
+++ b/packages/perseus-core/src/widgets/plotter/plotter-util.ts
@@ -1,0 +1,20 @@
+import type {PerseusPlotterWidgetOptions} from "@khanacademy/perseus-core";
+
+/**
+ * For details on the individual options, see the
+ * PerseusPlotterWidgetOptions type
+ */
+type PlotterPublicWidgetOptions = Omit<PerseusPlotterWidgetOptions, "correct">;
+
+/**
+ * Given a PerseusPlotterWidgetOptions object, return a new object with only
+ * the public options that should be exposed to the client.
+ */
+function getPlotterPublicWidgetOptions(
+    options: PerseusPlotterWidgetOptions,
+): PlotterPublicWidgetOptions {
+    const {correct: _, ...publicOptions} = options;
+    return publicOptions;
+}
+
+export default getPlotterPublicWidgetOptions;

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -25,6 +25,7 @@ import type {
     getRadioPublicWidgetOptions,
     getTablePublicWidgetOptions,
     getIFramePublicWidgetOptions,
+    getPlotterPublicWidgetOptions,
 } from "@khanacademy/perseus-core";
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
 import type {
@@ -482,6 +483,7 @@ export type WidgetTransform = (
  * A union type of all the functions that provide public widget options.
  */
 export type PublicWidgetOptionsFunction =
+    | typeof getPlotterPublicWidgetOptions
     | typeof getIFramePublicWidgetOptions
     | typeof getRadioPublicWidgetOptions
     | typeof getNumericInputPublicWidgetOptions

--- a/packages/perseus/src/widgets/plotter/plotter.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/no-unsafe */
 import {KhanMath} from "@khanacademy/kmath";
+import {getPlotterPublicWidgetOptions} from "@khanacademy/perseus-core";
 import $ from "jquery";
 import * as React from "react";
 import ReactDOM from "react-dom";
@@ -1173,4 +1174,5 @@ export default {
     hidden: true,
     widget: Plotter,
     staticTransform: staticTransform,
+    getPublicWidgetOptions: getPlotterPublicWidgetOptions,
 } satisfies WidgetExports<typeof Plotter>;


### PR DESCRIPTION
## Summary:
Adds a function that takes Plotters full widget options and filters out answer data. It also adds this function to Plotter's widget export and adds a test confirming the function works as intended.

Issue: LEMS-2764

## Test plan:
- Confirm all checks pass
- Confirm Plotter still works as expected