### PR TITLE
[LEMS-2190] Move coord reverse logic into scoring logic

### DIFF
--- a/.changeset/slow-shoes-march.md
+++ b/.changeset/slow-shoes-march.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-core": minor
+"@khanacademy/perseus-score": minor
+---
+
+Move coord reverse logic for Angle graphs into scoring logic

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -1017,7 +1017,7 @@ export type PerseusGraphTypeRay = {
 type AngleGraphCorrect = {
     type: "angle";
     allowReflexAngles: boolean;
-    match: "congruent";
+    match?: "congruent";
     coords: [Coord, Coord, Coord];
 };
 

--- a/packages/perseus-score/src/widgets/interactive-graph/score-interactive-graph.test.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/score-interactive-graph.test.ts
@@ -358,3 +358,131 @@ describe("InteractiveGraph scoring on a point question", () => {
         expect(rubric).toEqual(rubricClone);
     });
 });
+
+describe("InteractiveGraph scoring on an angle question", () => {
+    it("marks the answer invalid if guess.coords is missing", () => {
+        // Arrange
+        const guess: PerseusGraphType = {type: "angle"};
+        const rubric: PerseusInteractiveGraphRubric = {
+            graph: {
+                type: "angle",
+            },
+            correct: {
+                type: "angle",
+                allowReflexAngles: false,
+                coords: [
+                    [-5, 0],
+                    [0, 0],
+                    [5, 5],
+                ],
+            },
+        };
+
+        // Act
+        const result = scoreInteractiveGraph(guess, rubric);
+
+        // Assert
+        expect(result).toHaveInvalidInput();
+    });
+
+    it("properly reverses coordinates if angle graph is reflexive when not allowed", () => {
+        // Arrange
+        const guess: PerseusGraphType = {
+            type: "angle",
+            coords: [
+                [-5, 0],
+                [0, 0],
+                [5, 5],
+            ],
+        };
+        const rubric: PerseusInteractiveGraphRubric = {
+            graph: {
+                type: "angle",
+            },
+            correct: {
+                type: "angle",
+                allowReflexAngles: false,
+                coords: [
+                    [5, 5],
+                    [0, 0],
+                    [-5, 0],
+                ],
+            },
+        };
+
+        // Act
+        const result = scoreInteractiveGraph(guess, rubric);
+
+        // Assert
+        expect(result).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("does not reverse coordinates when angle is not reflexive", () => {
+        // Arrange
+        const guess: PerseusGraphType = {
+            type: "angle",
+            coords: [
+                [5, 0],
+                [0, 0],
+                [5, 5],
+            ],
+        };
+        const rubric: PerseusInteractiveGraphRubric = {
+            graph: {
+                type: "angle",
+            },
+            correct: {
+                type: "angle",
+                allowReflexAngles: false,
+                coords: [
+                    [5, 0],
+                    [0, 0],
+                    [5, 5],
+                ],
+            },
+        };
+
+        // Act
+        const result = scoreInteractiveGraph(guess, rubric);
+
+        // Assert
+        expect(result).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("does not reverse coordinates if the angle graph is allowed to be reflexive", () => {
+        // Arrange
+        const guess: PerseusGraphType = {
+            type: "angle",
+            coords: [
+                [5, 0],
+                [0, 0],
+                [-5, -5],
+            ],
+        };
+        const rubric: PerseusInteractiveGraphRubric = {
+            graph: {
+                type: "angle",
+                coords: [
+                    [5, 0],
+                    [0, 0],
+                    [-5, -5],
+                ],
+            },
+            correct: {
+                type: "angle",
+                allowReflexAngles: true,
+                coords: [
+                    [5, 0],
+                    [0, 0],
+                    [-5, -5],
+                ],
+            },
+        };
+
+        // Act
+        const result = scoreInteractiveGraph(guess, rubric);
+
+        // Assert
+        expect(result).toHaveBeenAnsweredCorrectly();
+    });
+});

--- a/packages/perseus-score/src/widgets/interactive-graph/score-interactive-graph.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/score-interactive-graph.ts
@@ -254,6 +254,8 @@ function scoreInteractiveGraph(
 
             // While the angle graph should always have 3 points, our types
             // technically allow for null values. We'll check for that here.
+            // TODO: (LEMS-2857) We would like to update the type of coords
+            // to be non-nullable, as the graph should always have 3 points.
             if (!coords) {
                 return {
                     type: "invalid",

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.test.ts
@@ -5,23 +5,6 @@ import {getGradableGraph} from "./interactive-graph-state";
 import type {InteractiveGraphState} from "../types";
 import type {PerseusGraphType} from "@khanacademy/perseus-core";
 
-const defaultAngleState: InteractiveGraphState = {
-    type: "angle",
-    coords: [
-        [5, 0],
-        [0, 0],
-        [5, 5],
-    ],
-    hasBeenInteractedWith: true,
-    range: [
-        [-10, 10],
-        [-10, 10],
-    ],
-    snapStep: [1, 1],
-    showAngles: true,
-    allowReflexAngles: false,
-};
-
 const defaultUnlimitedPointState: InteractiveGraphState = {
     type: "point",
     focusedPointIndex: 0,
@@ -82,76 +65,6 @@ describe("getGradableGraph", () => {
         const result = getGradableGraph(state, initialGraph);
 
         expect(result).toEqual(initialGraph);
-    });
-
-    // (LEMS-2190): This test is to ensure that the new Mafs graph is reversing coordinates when the angle graph
-    // is reflexive in a clockwise direction in order to temporarily maintain the same angle scoring with the
-    // legacy graph. This logic (& the tests) should be moved to the scoring function after removing the legacy graph.
-    it("returns reversed coordinates if the angle graph is reflexive when not allowed", () => {
-        const state: InteractiveGraphState = {
-            ...defaultAngleState,
-            coords: [
-                [-5, 0],
-                [0, 0],
-                [5, 5],
-            ],
-            hasBeenInteractedWith: true,
-        };
-        const initialGraph: PerseusGraphType = {
-            type: "angle",
-        };
-        const result = getGradableGraph(state, initialGraph);
-        invariant(result.type === "angle");
-        expect(result.coords).toEqual([
-            [5, 5],
-            [0, 0],
-            [-5, 0],
-        ]);
-    });
-
-    it("does not reverse coordinates if the angle graph is not reflexive", () => {
-        const state: InteractiveGraphState = {
-            ...defaultAngleState,
-            coords: [
-                [5, 0],
-                [0, 0],
-                [5, 5],
-            ],
-            hasBeenInteractedWith: true,
-        };
-        const initialGraph: PerseusGraphType = {
-            type: "angle",
-        };
-        const result = getGradableGraph(state, initialGraph);
-        invariant(result.type === "angle");
-        expect(result.coords).toEqual([
-            [5, 0],
-            [0, 0],
-            [5, 5],
-        ]);
-    });
-
-    it("does not reverse coordinates if the angle graph is allowed to be reflexive", () => {
-        const state: InteractiveGraphState = {
-            ...defaultAngleState,
-            coords: [
-                [5, 0],
-                [0, 0],
-                [-5, -5],
-            ],
-            hasBeenInteractedWith: true,
-            allowReflexAngles: true,
-        };
-        const initialGraph: PerseusGraphType = {
-            type: "angle",
-        };
-        const result = getGradableGraph(state, initialGraph);
-        invariant(result.type === "angle");
-        expect(result.coords).toEqual([
-            [5, 0],
-            [0, 0],
-            [-5, -5],
-        ]);
     });
 
     it("returns null coordinates if the unlimited point graph has an empty array of coordinates", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -1,10 +1,5 @@
-import {geometry} from "@khanacademy/kmath";
-
-import type {Coord} from "../../../interactive2/types";
 import type {CircleGraphState, InteractiveGraphState} from "../types";
 import type {PerseusGraphType} from "@khanacademy/perseus-core";
-
-const {clockwise} = geometry;
 
 export function getGradableGraph(
     state: InteractiveGraphState,
@@ -98,24 +93,9 @@ export function getGradableGraph(
     }
 
     if (state.type === "angle" && initialGraph.type === "angle") {
-        // We're going to reverse the coords for scoring if the angle is clockwise and
-        // we don't allow reflex angles. This is because the angle is largely defined
-        // by the order of the points in the coords array, and we want to maintain
-        // the same angle scoring with the legacy graph (which had a bug).
-        // (LEMS-2190): When we remove the legacy graph, move this logic to the scoring function.
-        const areClockwise = clockwise([
-            state.coords[0],
-            state.coords[2],
-            state.coords[1],
-        ]);
-        const shouldReverseCoords = areClockwise && !state.allowReflexAngles;
-        const coords: [Coord, Coord, Coord] = shouldReverseCoords
-            ? (state.coords.slice().reverse() as [Coord, Coord, Coord])
-            : state.coords;
-
         return {
             ...initialGraph,
-            coords,
+            coords: state.coords,
             allowReflexAngles: state.allowReflexAngles,
         };
     }


### PR DESCRIPTION
## Summary:
This PR is part of the Interactive Graph project. 

It contains the work required to move the coordinate reversal logic from the `getGradeableGraph` function and move it directly into our scoring logic. This logic was initially left in `getGradeableGraph` while we waited for the legacy Angle graph to no longer be in use. 

The reason for this was that there were 2 conflicting bugs in the Angle graph previously:

1.  Bug 1 allowed graphs to be reflexive if the bottom coordinate was moved, even if `allowReflexiveAngles` was false.
2. Bug 2 failed to properly reverse the coordinates in the same situation, resulting in the answer being marked as incorrect. 

Unfortunately, the combination of these bugs meant that we we needed to keep the scoring logic unchanged until the feature flags for the new Angle graph were removed. 

Issue: LEMS-2190

## Test plan:
- moved tests to new location 
- tests pass 