### PR TITLE
[put-down-tools] docs(changeset): Ensure Numeric Input Tooltips display under the input.

### DIFF
--- a/.changeset/dirty-seahorses-sneeze.md
+++ b/.changeset/dirty-seahorses-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Ensure Numeric Input Tooltips display under the input.

--- a/packages/perseus/src/widgets/numeric-input/input-with-examples.tsx
+++ b/packages/perseus/src/widgets/numeric-input/input-with-examples.tsx
@@ -180,7 +180,11 @@ const InputWithExamples = forwardRef<
     const showExamplesTooltip = shouldShowExamples && inputFocused;
 
     return (
-        <Tooltip content={getTooltipContent()} opened={showExamplesTooltip}>
+        <Tooltip
+            content={getTooltipContent()}
+            opened={showExamplesTooltip}
+            placement="bottom"
+        >
             {_renderInput()}
         </Tooltip>
     );


### PR DESCRIPTION
## Summary:
[put-down-tools] Ensure tooltip displays below input

Issue: LEMS-2856

## Test plan: