### PR TITLE
[SR] Stop graph from exposing random empty image to screen readers

### DIFF
--- a/.changeset/funny-jeans-bake.md
+++ b/.changeset/funny-jeans-bake.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[SR] Stop graph from exposing random empty image to screen readers

--- a/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
@@ -993,14 +993,6 @@ exports[`Interactive Graph interactive-graph widget A none-type graph renders pr
                         />
                       </g>
                     </g>
-                    <svg
-                      height="400"
-                      preserveAspectRatio="xMidYMin"
-                      viewBox="-200 -200 400 400"
-                      width="400"
-                      x="-200"
-                      y="-200"
-                    />
                   </svg>
                 </div>
                 <div
@@ -1143,14 +1135,6 @@ exports[`Interactive Graph interactive-graph widget question Should render predi
                         />
                       </filter>
                     </defs>
-                    <svg
-                      height="400"
-                      preserveAspectRatio="xMidYMin"
-                      viewBox="-57.142857142857146 -342.85714285714283 400 400"
-                      width="400"
-                      x="-57.142857142857146"
-                      y="-342.85714285714283"
-                    />
                     <svg
                       height="400"
                       preserveAspectRatio="xMidYMin"
@@ -1583,14 +1567,6 @@ exports[`Interactive Graph interactive-graph widget question Should render predi
                       x="-200"
                       y="-200"
                     />
-                    <svg
-                      height="400"
-                      preserveAspectRatio="xMidYMin"
-                      viewBox="-200 -200 400 400"
-                      width="400"
-                      x="-200"
-                      y="-200"
-                    />
                   </svg>
                 </div>
                 <div
@@ -1992,14 +1968,6 @@ exports[`Interactive Graph interactive-graph widget question Should render predi
                       x="-200"
                       y="-200"
                     />
-                    <svg
-                      height="400"
-                      preserveAspectRatio="xMidYMin"
-                      viewBox="-200 -200 400 400"
-                      width="400"
-                      x="-200"
-                      y="-200"
-                    />
                   </svg>
                 </div>
                 <div
@@ -2240,14 +2208,6 @@ exports[`Interactive Graph interactive-graph widget question Should render predi
                       x="-200"
                       y="-266.66666666666663"
                     />
-                    <svg
-                      height="400"
-                      preserveAspectRatio="xMidYMin"
-                      viewBox="-200 -266.66666666666663 400 400"
-                      width="400"
-                      x="-200"
-                      y="-266.66666666666663"
-                    />
                   </svg>
                 </div>
                 <div
@@ -2441,14 +2401,6 @@ exports[`Interactive Graph interactive-graph widget question Should render predi
                         />
                       </filter>
                     </defs>
-                    <svg
-                      height="400"
-                      preserveAspectRatio="xMidYMin"
-                      viewBox="-57.142857142857146 -342.85714285714283 400 400"
-                      width="400"
-                      x="-57.142857142857146"
-                      y="-342.85714285714283"
-                    />
                     <svg
                       height="400"
                       preserveAspectRatio="xMidYMin"
@@ -2881,14 +2833,6 @@ exports[`Interactive Graph interactive-graph widget question Should render predi
                       x="-200"
                       y="-200"
                     />
-                    <svg
-                      height="400"
-                      preserveAspectRatio="xMidYMin"
-                      viewBox="-200 -200 400 400"
-                      width="400"
-                      x="-200"
-                      y="-200"
-                    />
                   </svg>
                 </div>
                 <div
@@ -3290,14 +3234,6 @@ exports[`Interactive Graph interactive-graph widget question Should render predi
                       x="-200"
                       y="-200"
                     />
-                    <svg
-                      height="400"
-                      preserveAspectRatio="xMidYMin"
-                      viewBox="-200 -200 400 400"
-                      width="400"
-                      x="-200"
-                      y="-200"
-                    />
                   </svg>
                 </div>
                 <div
@@ -3530,14 +3466,6 @@ exports[`Interactive Graph interactive-graph widget question Should render predi
                         />
                       </filter>
                     </defs>
-                    <svg
-                      height="400"
-                      preserveAspectRatio="xMidYMin"
-                      viewBox="-200 -266.66666666666663 400 400"
-                      width="400"
-                      x="-200"
-                      y="-266.66666666666663"
-                    />
                     <svg
                       height="400"
                       preserveAspectRatio="xMidYMin"

--- a/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
@@ -44,956 +44,961 @@ exports[`Interactive Graph interactive-graph widget A none-type graph renders pr
                   </span>
                 </span>
                 <div
-                  class="MafsView"
-                  style="width: 400px; height: 400px;"
-                  tabindex="-1"
+                  aria-hidden="true"
+                  class="default_xu2jcg"
                 >
-                  <svg
-                    height="400"
-                    preserveAspectRatio="xMidYMin"
-                    style="width: 400px; --mafs-view-transform: matrix(20, 0, 0, -20, 0, 0); --mafs-user-transform: translate(0, 0);"
-                    viewBox="-200 -200 400 400"
-                    width="400"
+                  <div
+                    class="MafsView"
+                    style="width: 400px; height: 400px;"
+                    tabindex="-1"
                   >
-                    <defs>
-                      <filter
-                        height="100%"
-                        id="background"
-                        width="110%"
-                        x="-5%"
-                        y="0%"
-                      >
-                        <feflood
-                          flood-color="#FFF"
-                          flood-opacity="0.64"
-                        />
-                        <fecomposite
-                          in="SourceGraphic"
-                          operator="over"
-                        />
-                      </filter>
-                    </defs>
                     <svg
                       height="400"
                       preserveAspectRatio="xMidYMin"
+                      style="width: 400px; --mafs-view-transform: matrix(20, 0, 0, -20, 0, 0); --mafs-user-transform: translate(0, 0);"
                       viewBox="-200 -200 400 400"
                       width="400"
-                      x="-200"
-                      y="-200"
                     >
-                      <g
-                        fill="none"
+                      <defs>
+                        <filter
+                          height="100%"
+                          id="background"
+                          width="110%"
+                          x="-5%"
+                          y="0%"
+                        >
+                          <feflood
+                            flood-color="#FFF"
+                            flood-opacity="0.64"
+                          />
+                          <fecomposite
+                            in="SourceGraphic"
+                            operator="over"
+                          />
+                        </filter>
+                      </defs>
+                      <svg
+                        height="400"
+                        preserveAspectRatio="xMidYMin"
+                        viewBox="-200 -200 400 400"
+                        width="400"
+                        x="-200"
+                        y="-200"
                       >
-                        <pattern
-                          height="20"
-                          id="cartesian-0"
-                          patternUnits="userSpaceOnUse"
-                          width="20"
-                          x="0"
-                          y="0"
+                        <g
+                          fill="none"
                         >
                           <pattern
                             height="20"
-                            id="cartesian-0-subdivision"
+                            id="cartesian-0"
                             patternUnits="userSpaceOnUse"
                             width="20"
+                            x="0"
+                            y="0"
                           >
-                            <g
-                              stroke="var(--grid-line-subdivision-color)"
+                            <pattern
+                              height="20"
+                              id="cartesian-0-subdivision"
+                              patternUnits="userSpaceOnUse"
+                              width="20"
+                            >
+                              <g
+                                stroke="var(--grid-line-subdivision-color)"
+                              />
+                            </pattern>
+                            <rect
+                              fill="url(#cartesian-0-subdivision)"
+                              height="20"
+                              width="20"
                             />
+                            <g
+                              stroke="var(--mafs-line-color)"
+                            >
+                              <line
+                                x1="0"
+                                x2="20"
+                                y1="0"
+                                y2="0"
+                              />
+                              <line
+                                x1="0"
+                                x2="20"
+                                y1="20"
+                                y2="20"
+                              />
+                              <line
+                                x1="0"
+                                x2="0"
+                                y1="0"
+                                y2="20"
+                              />
+                              <line
+                                x1="20"
+                                x2="20"
+                                y1="0"
+                                y2="20"
+                              />
+                            </g>
                           </pattern>
                           <rect
-                            fill="url(#cartesian-0-subdivision)"
-                            height="20"
-                            width="20"
+                            fill="url(#cartesian-0)"
+                            height="640"
+                            width="640"
+                            x="-320"
+                            y="-320"
                           />
                           <g
-                            stroke="var(--mafs-line-color)"
+                            stroke="var(--mafs-origin-color)"
+                            stroke-width="var(--mafs-axis-stroke-width)"
                           >
                             <line
-                              x1="0"
-                              x2="20"
+                              x1="-320"
+                              x2="320"
                               y1="0"
                               y2="0"
                             />
                             <line
                               x1="0"
-                              x2="20"
+                              x2="0"
+                              y1="320"
+                              y2="-320"
+                            />
+                          </g>
+                          <g
+                            class="mafs-shadow"
+                          />
+                        </g>
+                      </svg>
+                      <g
+                        class="axis-ticks"
+                        role="presentation"
+                      >
+                        <g
+                          class="y-axis-ticks"
+                        >
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="-5"
+                              x2="5"
+                              y1="-20"
+                              y2="-20"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="end"
+                              x="-15.400000000000002"
+                              y="-16.5"
+                            >
+                              1
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="-5"
+                              x2="5"
+                              y1="-40"
+                              y2="-40"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="end"
+                              x="-15.400000000000002"
+                              y="-36.5"
+                            >
+                              2
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="-5"
+                              x2="5"
+                              y1="-60"
+                              y2="-60"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="end"
+                              x="-15.400000000000002"
+                              y="-56.5"
+                            >
+                              3
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="-5"
+                              x2="5"
+                              y1="-80"
+                              y2="-80"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="end"
+                              x="-15.400000000000002"
+                              y="-76.5"
+                            >
+                              4
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="-5"
+                              x2="5"
+                              y1="-100"
+                              y2="-100"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="end"
+                              x="-15.400000000000002"
+                              y="-96.5"
+                            >
+                              5
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="-5"
+                              x2="5"
+                              y1="-120"
+                              y2="-120"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="end"
+                              x="-15.400000000000002"
+                              y="-116.5"
+                            >
+                              6
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="-5"
+                              x2="5"
+                              y1="-140"
+                              y2="-140"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="end"
+                              x="-15.400000000000002"
+                              y="-136.5"
+                            >
+                              7
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="-5"
+                              x2="5"
+                              y1="-160"
+                              y2="-160"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="end"
+                              x="-15.400000000000002"
+                              y="-156.5"
+                            >
+                              8
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="-5"
+                              x2="5"
+                              y1="-180"
+                              y2="-180"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="end"
+                              x="-15.400000000000002"
+                              y="-176.5"
+                            >
+                              9
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="-5"
+                              x2="5"
                               y1="20"
                               y2="20"
                             />
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
                             <line
-                              x1="0"
-                              x2="0"
-                              y1="0"
-                              y2="20"
+                              class="axis-tick"
+                              x1="-5"
+                              x2="5"
+                              y1="40"
+                              y2="40"
                             />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="end"
+                              x="-15.400000000000002"
+                              y="43.5"
+                            >
+                              -2
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
                             <line
+                              class="axis-tick"
+                              x1="-5"
+                              x2="5"
+                              y1="60"
+                              y2="60"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="end"
+                              x="-15.400000000000002"
+                              y="63.5"
+                            >
+                              -3
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="-5"
+                              x2="5"
+                              y1="80"
+                              y2="80"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="end"
+                              x="-15.400000000000002"
+                              y="83.5"
+                            >
+                              -4
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="-5"
+                              x2="5"
+                              y1="100"
+                              y2="100"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="end"
+                              x="-15.400000000000002"
+                              y="103.5"
+                            >
+                              -5
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="-5"
+                              x2="5"
+                              y1="120"
+                              y2="120"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="end"
+                              x="-15.400000000000002"
+                              y="123.5"
+                            >
+                              -6
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="-5"
+                              x2="5"
+                              y1="140"
+                              y2="140"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="end"
+                              x="-15.400000000000002"
+                              y="143.5"
+                            >
+                              -7
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="-5"
+                              x2="5"
+                              y1="160"
+                              y2="160"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="end"
+                              x="-15.400000000000002"
+                              y="163.5"
+                            >
+                              -8
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="-5"
+                              x2="5"
+                              y1="180"
+                              y2="180"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="end"
+                              x="-15.400000000000002"
+                              y="183.5"
+                            >
+                              -9
+                            </text>
+                          </g>
+                        </g>
+                        <g
+                          class="x-axis-ticks"
+                        >
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
                               x1="20"
                               x2="20"
-                              y1="0"
-                              y2="20"
+                              y1="5"
+                              y2="-5"
                             />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="middle"
+                              x="20"
+                              y="24.5"
+                            >
+                              1
+                            </text>
                           </g>
-                        </pattern>
-                        <rect
-                          fill="url(#cartesian-0)"
-                          height="640"
-                          width="640"
-                          x="-320"
-                          y="-320"
-                        />
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="40"
+                              x2="40"
+                              y1="5"
+                              y2="-5"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="middle"
+                              x="40"
+                              y="24.5"
+                            >
+                              2
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="60"
+                              x2="60"
+                              y1="5"
+                              y2="-5"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="middle"
+                              x="60"
+                              y="24.5"
+                            >
+                              3
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="80"
+                              x2="80"
+                              y1="5"
+                              y2="-5"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="middle"
+                              x="80"
+                              y="24.5"
+                            >
+                              4
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="100"
+                              x2="100"
+                              y1="5"
+                              y2="-5"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="middle"
+                              x="100"
+                              y="24.5"
+                            >
+                              5
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="120"
+                              x2="120"
+                              y1="5"
+                              y2="-5"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="middle"
+                              x="120"
+                              y="24.5"
+                            >
+                              6
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="140"
+                              x2="140"
+                              y1="5"
+                              y2="-5"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="middle"
+                              x="140"
+                              y="24.5"
+                            >
+                              7
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="160"
+                              x2="160"
+                              y1="5"
+                              y2="-5"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="middle"
+                              x="160"
+                              y="24.5"
+                            >
+                              8
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="180"
+                              x2="180"
+                              y1="5"
+                              y2="-5"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="middle"
+                              x="180"
+                              y="24.5"
+                            >
+                              9
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="-20"
+                              x2="-20"
+                              y1="5"
+                              y2="-5"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="middle"
+                              x="-22"
+                              y="24.5"
+                            >
+                              -1
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="-40"
+                              x2="-40"
+                              y1="5"
+                              y2="-5"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="middle"
+                              x="-42"
+                              y="24.5"
+                            >
+                              -2
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="-60"
+                              x2="-60"
+                              y1="5"
+                              y2="-5"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="middle"
+                              x="-62"
+                              y="24.5"
+                            >
+                              -3
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="-80"
+                              x2="-80"
+                              y1="5"
+                              y2="-5"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="middle"
+                              x="-82"
+                              y="24.5"
+                            >
+                              -4
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="-100"
+                              x2="-100"
+                              y1="5"
+                              y2="-5"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="middle"
+                              x="-102"
+                              y="24.5"
+                            >
+                              -5
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="-120"
+                              x2="-120"
+                              y1="5"
+                              y2="-5"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="middle"
+                              x="-122"
+                              y="24.5"
+                            >
+                              -6
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="-140"
+                              x2="-140"
+                              y1="5"
+                              y2="-5"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="middle"
+                              x="-142"
+                              y="24.5"
+                            >
+                              -7
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="-160"
+                              x2="-160"
+                              y1="5"
+                              y2="-5"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="middle"
+                              x="-162"
+                              y="24.5"
+                            >
+                              -8
+                            </text>
+                          </g>
+                          <g
+                            aria-hidden="true"
+                            class="tick"
+                          >
+                            <line
+                              class="axis-tick"
+                              x1="-180"
+                              x2="-180"
+                              y1="5"
+                              y2="-5"
+                            />
+                            <text
+                              class="axis-tick-label"
+                              style="font-size: 14px;"
+                              text-anchor="middle"
+                              x="-182"
+                              y="24.5"
+                            >
+                              -9
+                            </text>
+                          </g>
+                        </g>
+                      </g>
+                      <g
+                        class="interactive-graph-arrowhead"
+                        transform="translate(-200 0) rotate(180)"
+                      >
                         <g
-                          stroke="var(--mafs-origin-color)"
-                          stroke-width="var(--mafs-axis-stroke-width)"
+                          transform="translate(-1.5)"
                         >
-                          <line
-                            x1="-320"
-                            x2="320"
-                            y1="0"
-                            y2="0"
-                          />
-                          <line
-                            x1="0"
-                            x2="0"
-                            y1="320"
-                            y2="-320"
+                          <path
+                            d="M-4.199999999999999 5.6C-3.8499999999999996 3.5 0 0.35 1.0499999999999998 0C0 -0.35 -3.8499999999999996 -3.5 -4.199999999999999 -5.6"
+                            fill="none"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2px"
+                            style="stroke: var(--mafs-fg);"
                           />
                         </g>
+                      </g>
+                      <g
+                        class="interactive-graph-arrowhead"
+                        transform="translate(200 0) rotate(0)"
+                      >
                         <g
-                          class="mafs-shadow"
-                        />
+                          transform="translate(-1.5)"
+                        >
+                          <path
+                            d="M-4.199999999999999 5.6C-3.8499999999999996 3.5 0 0.35 1.0499999999999998 0C0 -0.35 -3.8499999999999996 -3.5 -4.199999999999999 -5.6"
+                            fill="none"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2px"
+                            style="stroke: var(--mafs-fg);"
+                          />
+                        </g>
+                      </g>
+                      <g
+                        class="interactive-graph-arrowhead"
+                        transform="translate(0 200) rotate(90)"
+                      >
+                        <g
+                          transform="translate(-1.5)"
+                        >
+                          <path
+                            d="M-4.199999999999999 5.6C-3.8499999999999996 3.5 0 0.35 1.0499999999999998 0C0 -0.35 -3.8499999999999996 -3.5 -4.199999999999999 -5.6"
+                            fill="none"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2px"
+                            style="stroke: var(--mafs-fg);"
+                          />
+                        </g>
+                      </g>
+                      <g
+                        class="interactive-graph-arrowhead"
+                        transform="translate(0 -200) rotate(270)"
+                      >
+                        <g
+                          transform="translate(-1.5)"
+                        >
+                          <path
+                            d="M-4.199999999999999 5.6C-3.8499999999999996 3.5 0 0.35 1.0499999999999998 0C0 -0.35 -3.8499999999999996 -3.5 -4.199999999999999 -5.6"
+                            fill="none"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2px"
+                            style="stroke: var(--mafs-fg);"
+                          />
+                        </g>
                       </g>
                     </svg>
-                    <g
-                      class="axis-ticks"
-                      role="presentation"
-                    >
-                      <g
-                        class="y-axis-ticks"
-                      >
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-5"
-                            x2="5"
-                            y1="-20"
-                            y2="-20"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="end"
-                            x="-15.400000000000002"
-                            y="-16.5"
-                          >
-                            1
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-5"
-                            x2="5"
-                            y1="-40"
-                            y2="-40"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="end"
-                            x="-15.400000000000002"
-                            y="-36.5"
-                          >
-                            2
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-5"
-                            x2="5"
-                            y1="-60"
-                            y2="-60"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="end"
-                            x="-15.400000000000002"
-                            y="-56.5"
-                          >
-                            3
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-5"
-                            x2="5"
-                            y1="-80"
-                            y2="-80"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="end"
-                            x="-15.400000000000002"
-                            y="-76.5"
-                          >
-                            4
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-5"
-                            x2="5"
-                            y1="-100"
-                            y2="-100"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="end"
-                            x="-15.400000000000002"
-                            y="-96.5"
-                          >
-                            5
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-5"
-                            x2="5"
-                            y1="-120"
-                            y2="-120"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="end"
-                            x="-15.400000000000002"
-                            y="-116.5"
-                          >
-                            6
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-5"
-                            x2="5"
-                            y1="-140"
-                            y2="-140"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="end"
-                            x="-15.400000000000002"
-                            y="-136.5"
-                          >
-                            7
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-5"
-                            x2="5"
-                            y1="-160"
-                            y2="-160"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="end"
-                            x="-15.400000000000002"
-                            y="-156.5"
-                          >
-                            8
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-5"
-                            x2="5"
-                            y1="-180"
-                            y2="-180"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="end"
-                            x="-15.400000000000002"
-                            y="-176.5"
-                          >
-                            9
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-5"
-                            x2="5"
-                            y1="20"
-                            y2="20"
-                          />
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-5"
-                            x2="5"
-                            y1="40"
-                            y2="40"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="end"
-                            x="-15.400000000000002"
-                            y="43.5"
-                          >
-                            -2
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-5"
-                            x2="5"
-                            y1="60"
-                            y2="60"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="end"
-                            x="-15.400000000000002"
-                            y="63.5"
-                          >
-                            -3
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-5"
-                            x2="5"
-                            y1="80"
-                            y2="80"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="end"
-                            x="-15.400000000000002"
-                            y="83.5"
-                          >
-                            -4
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-5"
-                            x2="5"
-                            y1="100"
-                            y2="100"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="end"
-                            x="-15.400000000000002"
-                            y="103.5"
-                          >
-                            -5
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-5"
-                            x2="5"
-                            y1="120"
-                            y2="120"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="end"
-                            x="-15.400000000000002"
-                            y="123.5"
-                          >
-                            -6
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-5"
-                            x2="5"
-                            y1="140"
-                            y2="140"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="end"
-                            x="-15.400000000000002"
-                            y="143.5"
-                          >
-                            -7
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-5"
-                            x2="5"
-                            y1="160"
-                            y2="160"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="end"
-                            x="-15.400000000000002"
-                            y="163.5"
-                          >
-                            -8
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-5"
-                            x2="5"
-                            y1="180"
-                            y2="180"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="end"
-                            x="-15.400000000000002"
-                            y="183.5"
-                          >
-                            -9
-                          </text>
-                        </g>
-                      </g>
-                      <g
-                        class="x-axis-ticks"
-                      >
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="20"
-                            x2="20"
-                            y1="5"
-                            y2="-5"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="middle"
-                            x="20"
-                            y="24.5"
-                          >
-                            1
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="40"
-                            x2="40"
-                            y1="5"
-                            y2="-5"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="middle"
-                            x="40"
-                            y="24.5"
-                          >
-                            2
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="60"
-                            x2="60"
-                            y1="5"
-                            y2="-5"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="middle"
-                            x="60"
-                            y="24.5"
-                          >
-                            3
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="80"
-                            x2="80"
-                            y1="5"
-                            y2="-5"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="middle"
-                            x="80"
-                            y="24.5"
-                          >
-                            4
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="100"
-                            x2="100"
-                            y1="5"
-                            y2="-5"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="middle"
-                            x="100"
-                            y="24.5"
-                          >
-                            5
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="120"
-                            x2="120"
-                            y1="5"
-                            y2="-5"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="middle"
-                            x="120"
-                            y="24.5"
-                          >
-                            6
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="140"
-                            x2="140"
-                            y1="5"
-                            y2="-5"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="middle"
-                            x="140"
-                            y="24.5"
-                          >
-                            7
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="160"
-                            x2="160"
-                            y1="5"
-                            y2="-5"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="middle"
-                            x="160"
-                            y="24.5"
-                          >
-                            8
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="180"
-                            x2="180"
-                            y1="5"
-                            y2="-5"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="middle"
-                            x="180"
-                            y="24.5"
-                          >
-                            9
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-20"
-                            x2="-20"
-                            y1="5"
-                            y2="-5"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="middle"
-                            x="-22"
-                            y="24.5"
-                          >
-                            -1
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-40"
-                            x2="-40"
-                            y1="5"
-                            y2="-5"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="middle"
-                            x="-42"
-                            y="24.5"
-                          >
-                            -2
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-60"
-                            x2="-60"
-                            y1="5"
-                            y2="-5"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="middle"
-                            x="-62"
-                            y="24.5"
-                          >
-                            -3
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-80"
-                            x2="-80"
-                            y1="5"
-                            y2="-5"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="middle"
-                            x="-82"
-                            y="24.5"
-                          >
-                            -4
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-100"
-                            x2="-100"
-                            y1="5"
-                            y2="-5"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="middle"
-                            x="-102"
-                            y="24.5"
-                          >
-                            -5
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-120"
-                            x2="-120"
-                            y1="5"
-                            y2="-5"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="middle"
-                            x="-122"
-                            y="24.5"
-                          >
-                            -6
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-140"
-                            x2="-140"
-                            y1="5"
-                            y2="-5"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="middle"
-                            x="-142"
-                            y="24.5"
-                          >
-                            -7
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-160"
-                            x2="-160"
-                            y1="5"
-                            y2="-5"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="middle"
-                            x="-162"
-                            y="24.5"
-                          >
-                            -8
-                          </text>
-                        </g>
-                        <g
-                          aria-hidden="true"
-                          class="tick"
-                        >
-                          <line
-                            class="axis-tick"
-                            x1="-180"
-                            x2="-180"
-                            y1="5"
-                            y2="-5"
-                          />
-                          <text
-                            class="axis-tick-label"
-                            style="font-size: 14px;"
-                            text-anchor="middle"
-                            x="-182"
-                            y="24.5"
-                          >
-                            -9
-                          </text>
-                        </g>
-                      </g>
-                    </g>
-                    <g
-                      class="interactive-graph-arrowhead"
-                      transform="translate(-200 0) rotate(180)"
-                    >
-                      <g
-                        transform="translate(-1.5)"
-                      >
-                        <path
-                          d="M-4.199999999999999 5.6C-3.8499999999999996 3.5 0 0.35 1.0499999999999998 0C0 -0.35 -3.8499999999999996 -3.5 -4.199999999999999 -5.6"
-                          fill="none"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2px"
-                          style="stroke: var(--mafs-fg);"
-                        />
-                      </g>
-                    </g>
-                    <g
-                      class="interactive-graph-arrowhead"
-                      transform="translate(200 0) rotate(0)"
-                    >
-                      <g
-                        transform="translate(-1.5)"
-                      >
-                        <path
-                          d="M-4.199999999999999 5.6C-3.8499999999999996 3.5 0 0.35 1.0499999999999998 0C0 -0.35 -3.8499999999999996 -3.5 -4.199999999999999 -5.6"
-                          fill="none"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2px"
-                          style="stroke: var(--mafs-fg);"
-                        />
-                      </g>
-                    </g>
-                    <g
-                      class="interactive-graph-arrowhead"
-                      transform="translate(0 200) rotate(90)"
-                    >
-                      <g
-                        transform="translate(-1.5)"
-                      >
-                        <path
-                          d="M-4.199999999999999 5.6C-3.8499999999999996 3.5 0 0.35 1.0499999999999998 0C0 -0.35 -3.8499999999999996 -3.5 -4.199999999999999 -5.6"
-                          fill="none"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2px"
-                          style="stroke: var(--mafs-fg);"
-                        />
-                      </g>
-                    </g>
-                    <g
-                      class="interactive-graph-arrowhead"
-                      transform="translate(0 -200) rotate(270)"
-                    >
-                      <g
-                        transform="translate(-1.5)"
-                      >
-                        <path
-                          d="M-4.199999999999999 5.6C-3.8499999999999996 3.5 0 0.35 1.0499999999999998 0C0 -0.35 -3.8499999999999996 -3.5 -4.199999999999999 -5.6"
-                          fill="none"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2px"
-                          style="stroke: var(--mafs-fg);"
-                        />
-                      </g>
-                    </g>
-                  </svg>
+                  </div>
                 </div>
                 <div
                   class="default_xu2jcg-o_O-inlineStyles_ay4wjb"
@@ -1106,44 +1111,49 @@ exports[`Interactive Graph interactive-graph widget question Should render predi
                 class="default_xu2jcg-o_O-inlineStyles_16155wj"
               >
                 <div
-                  class="MafsView"
-                  style="width: 400px; height: 400px;"
-                  tabindex="-1"
+                  aria-hidden="true"
+                  class="default_xu2jcg"
                 >
-                  <svg
-                    height="400"
-                    preserveAspectRatio="xMidYMin"
-                    style="width: 400px; --mafs-view-transform: matrix(57.14286, 0, 0, -57.14286, 0, 0); --mafs-user-transform: translate(0, 0);"
-                    viewBox="-57.1428571429 -342.8571428571 400 400"
-                    width="400"
+                  <div
+                    class="MafsView"
+                    style="width: 400px; height: 400px;"
+                    tabindex="-1"
                   >
-                    <defs>
-                      <filter
-                        height="100%"
-                        id="background"
-                        width="110%"
-                        x="-5%"
-                        y="0%"
-                      >
-                        <feflood
-                          flood-color="#FFF"
-                          flood-opacity="0.64"
-                        />
-                        <fecomposite
-                          in="SourceGraphic"
-                          operator="over"
-                        />
-                      </filter>
-                    </defs>
                     <svg
                       height="400"
                       preserveAspectRatio="xMidYMin"
-                      viewBox="-57.142857142857146 -342.85714285714283 400 400"
+                      style="width: 400px; --mafs-view-transform: matrix(57.14286, 0, 0, -57.14286, 0, 0); --mafs-user-transform: translate(0, 0);"
+                      viewBox="-57.1428571429 -342.8571428571 400 400"
                       width="400"
-                      x="-57.142857142857146"
-                      y="-342.85714285714283"
-                    />
-                  </svg>
+                    >
+                      <defs>
+                        <filter
+                          height="100%"
+                          id="background"
+                          width="110%"
+                          x="-5%"
+                          y="0%"
+                        >
+                          <feflood
+                            flood-color="#FFF"
+                            flood-opacity="0.64"
+                          />
+                          <fecomposite
+                            in="SourceGraphic"
+                            operator="over"
+                          />
+                        </filter>
+                      </defs>
+                      <svg
+                        height="400"
+                        preserveAspectRatio="xMidYMin"
+                        viewBox="-57.142857142857146 -342.85714285714283 400 400"
+                        width="400"
+                        x="-57.142857142857146"
+                        y="-342.85714285714283"
+                      />
+                    </svg>
+                  </div>
                 </div>
                 <div
                   class="default_xu2jcg-o_O-inlineStyles_ay4wjb"
@@ -1530,44 +1540,49 @@ exports[`Interactive Graph interactive-graph widget question Should render predi
                 class="default_xu2jcg-o_O-inlineStyles_16155wj"
               >
                 <div
-                  class="MafsView"
-                  style="width: 400px; height: 400px;"
-                  tabindex="-1"
+                  aria-hidden="true"
+                  class="default_xu2jcg"
                 >
-                  <svg
-                    height="400"
-                    preserveAspectRatio="xMidYMin"
-                    style="width: 400px; --mafs-view-transform: matrix(25, 0, 0, -25, 0, 0); --mafs-user-transform: translate(0, 0);"
-                    viewBox="-200 -200 400 400"
-                    width="400"
+                  <div
+                    class="MafsView"
+                    style="width: 400px; height: 400px;"
+                    tabindex="-1"
                   >
-                    <defs>
-                      <filter
-                        height="100%"
-                        id="background"
-                        width="110%"
-                        x="-5%"
-                        y="0%"
-                      >
-                        <feflood
-                          flood-color="#FFF"
-                          flood-opacity="0.64"
-                        />
-                        <fecomposite
-                          in="SourceGraphic"
-                          operator="over"
-                        />
-                      </filter>
-                    </defs>
                     <svg
                       height="400"
                       preserveAspectRatio="xMidYMin"
+                      style="width: 400px; --mafs-view-transform: matrix(25, 0, 0, -25, 0, 0); --mafs-user-transform: translate(0, 0);"
                       viewBox="-200 -200 400 400"
                       width="400"
-                      x="-200"
-                      y="-200"
-                    />
-                  </svg>
+                    >
+                      <defs>
+                        <filter
+                          height="100%"
+                          id="background"
+                          width="110%"
+                          x="-5%"
+                          y="0%"
+                        >
+                          <feflood
+                            flood-color="#FFF"
+                            flood-opacity="0.64"
+                          />
+                          <fecomposite
+                            in="SourceGraphic"
+                            operator="over"
+                          />
+                        </filter>
+                      </defs>
+                      <svg
+                        height="400"
+                        preserveAspectRatio="xMidYMin"
+                        viewBox="-200 -200 400 400"
+                        width="400"
+                        x="-200"
+                        y="-200"
+                      />
+                    </svg>
+                  </div>
                 </div>
                 <div
                   class="default_xu2jcg-o_O-inlineStyles_ay4wjb"
@@ -1931,44 +1946,49 @@ exports[`Interactive Graph interactive-graph widget question Should render predi
                 class="default_xu2jcg-o_O-inlineStyles_16155wj"
               >
                 <div
-                  class="MafsView"
-                  style="width: 400px; height: 400px;"
-                  tabindex="-1"
+                  aria-hidden="true"
+                  class="default_xu2jcg"
                 >
-                  <svg
-                    height="400"
-                    preserveAspectRatio="xMidYMin"
-                    style="width: 400px; --mafs-view-transform: matrix(50, 0, 0, -50, 0, 0); --mafs-user-transform: translate(0, 0);"
-                    viewBox="-200 -200 400 400"
-                    width="400"
+                  <div
+                    class="MafsView"
+                    style="width: 400px; height: 400px;"
+                    tabindex="-1"
                   >
-                    <defs>
-                      <filter
-                        height="100%"
-                        id="background"
-                        width="110%"
-                        x="-5%"
-                        y="0%"
-                      >
-                        <feflood
-                          flood-color="#FFF"
-                          flood-opacity="0.64"
-                        />
-                        <fecomposite
-                          in="SourceGraphic"
-                          operator="over"
-                        />
-                      </filter>
-                    </defs>
                     <svg
                       height="400"
                       preserveAspectRatio="xMidYMin"
+                      style="width: 400px; --mafs-view-transform: matrix(50, 0, 0, -50, 0, 0); --mafs-user-transform: translate(0, 0);"
                       viewBox="-200 -200 400 400"
                       width="400"
-                      x="-200"
-                      y="-200"
-                    />
-                  </svg>
+                    >
+                      <defs>
+                        <filter
+                          height="100%"
+                          id="background"
+                          width="110%"
+                          x="-5%"
+                          y="0%"
+                        >
+                          <feflood
+                            flood-color="#FFF"
+                            flood-opacity="0.64"
+                          />
+                          <fecomposite
+                            in="SourceGraphic"
+                            operator="over"
+                          />
+                        </filter>
+                      </defs>
+                      <svg
+                        height="400"
+                        preserveAspectRatio="xMidYMin"
+                        viewBox="-200 -200 400 400"
+                        width="400"
+                        x="-200"
+                        y="-200"
+                      />
+                    </svg>
+                  </div>
                 </div>
                 <div
                   class="default_xu2jcg-o_O-inlineStyles_ay4wjb"
@@ -2171,44 +2191,49 @@ exports[`Interactive Graph interactive-graph widget question Should render predi
                 class="default_xu2jcg-o_O-inlineStyles_16155wj"
               >
                 <div
-                  class="MafsView"
-                  style="width: 400px; height: 400px;"
-                  tabindex="-1"
+                  aria-hidden="true"
+                  class="default_xu2jcg"
                 >
-                  <svg
-                    height="400"
-                    preserveAspectRatio="xMidYMin"
-                    style="width: 400px; --mafs-view-transform: matrix(16.66667, 0, 0, -16.66667, 0, 0); --mafs-user-transform: translate(0, 0);"
-                    viewBox="-200 -266.6666666667 400 400"
-                    width="400"
+                  <div
+                    class="MafsView"
+                    style="width: 400px; height: 400px;"
+                    tabindex="-1"
                   >
-                    <defs>
-                      <filter
-                        height="100%"
-                        id="background"
-                        width="110%"
-                        x="-5%"
-                        y="0%"
-                      >
-                        <feflood
-                          flood-color="#FFF"
-                          flood-opacity="0.64"
-                        />
-                        <fecomposite
-                          in="SourceGraphic"
-                          operator="over"
-                        />
-                      </filter>
-                    </defs>
                     <svg
                       height="400"
                       preserveAspectRatio="xMidYMin"
-                      viewBox="-200 -266.66666666666663 400 400"
+                      style="width: 400px; --mafs-view-transform: matrix(16.66667, 0, 0, -16.66667, 0, 0); --mafs-user-transform: translate(0, 0);"
+                      viewBox="-200 -266.6666666667 400 400"
                       width="400"
-                      x="-200"
-                      y="-266.66666666666663"
-                    />
-                  </svg>
+                    >
+                      <defs>
+                        <filter
+                          height="100%"
+                          id="background"
+                          width="110%"
+                          x="-5%"
+                          y="0%"
+                        >
+                          <feflood
+                            flood-color="#FFF"
+                            flood-opacity="0.64"
+                          />
+                          <fecomposite
+                            in="SourceGraphic"
+                            operator="over"
+                          />
+                        </filter>
+                      </defs>
+                      <svg
+                        height="400"
+                        preserveAspectRatio="xMidYMin"
+                        viewBox="-200 -266.66666666666663 400 400"
+                        width="400"
+                        x="-200"
+                        y="-266.66666666666663"
+                      />
+                    </svg>
+                  </div>
                 </div>
                 <div
                   class="default_xu2jcg-o_O-inlineStyles_ay4wjb"
@@ -2372,44 +2397,49 @@ exports[`Interactive Graph interactive-graph widget question Should render predi
                 class="default_xu2jcg-o_O-inlineStyles_16155wj"
               >
                 <div
-                  class="MafsView"
-                  style="width: 400px; height: 400px;"
-                  tabindex="-1"
+                  aria-hidden="true"
+                  class="default_xu2jcg"
                 >
-                  <svg
-                    height="400"
-                    preserveAspectRatio="xMidYMin"
-                    style="width: 400px; --mafs-view-transform: matrix(57.14286, 0, 0, -57.14286, 0, 0); --mafs-user-transform: translate(0, 0);"
-                    viewBox="-57.1428571429 -342.8571428571 400 400"
-                    width="400"
+                  <div
+                    class="MafsView"
+                    style="width: 400px; height: 400px;"
+                    tabindex="-1"
                   >
-                    <defs>
-                      <filter
-                        height="100%"
-                        id="background"
-                        width="110%"
-                        x="-5%"
-                        y="0%"
-                      >
-                        <feflood
-                          flood-color="#FFF"
-                          flood-opacity="0.64"
-                        />
-                        <fecomposite
-                          in="SourceGraphic"
-                          operator="over"
-                        />
-                      </filter>
-                    </defs>
                     <svg
                       height="400"
                       preserveAspectRatio="xMidYMin"
-                      viewBox="-57.142857142857146 -342.85714285714283 400 400"
+                      style="width: 400px; --mafs-view-transform: matrix(57.14286, 0, 0, -57.14286, 0, 0); --mafs-user-transform: translate(0, 0);"
+                      viewBox="-57.1428571429 -342.8571428571 400 400"
                       width="400"
-                      x="-57.142857142857146"
-                      y="-342.85714285714283"
-                    />
-                  </svg>
+                    >
+                      <defs>
+                        <filter
+                          height="100%"
+                          id="background"
+                          width="110%"
+                          x="-5%"
+                          y="0%"
+                        >
+                          <feflood
+                            flood-color="#FFF"
+                            flood-opacity="0.64"
+                          />
+                          <fecomposite
+                            in="SourceGraphic"
+                            operator="over"
+                          />
+                        </filter>
+                      </defs>
+                      <svg
+                        height="400"
+                        preserveAspectRatio="xMidYMin"
+                        viewBox="-57.142857142857146 -342.85714285714283 400 400"
+                        width="400"
+                        x="-57.142857142857146"
+                        y="-342.85714285714283"
+                      />
+                    </svg>
+                  </div>
                 </div>
                 <div
                   class="default_xu2jcg-o_O-inlineStyles_ay4wjb"
@@ -2796,44 +2826,49 @@ exports[`Interactive Graph interactive-graph widget question Should render predi
                 class="default_xu2jcg-o_O-inlineStyles_16155wj"
               >
                 <div
-                  class="MafsView"
-                  style="width: 400px; height: 400px;"
-                  tabindex="-1"
+                  aria-hidden="true"
+                  class="default_xu2jcg"
                 >
-                  <svg
-                    height="400"
-                    preserveAspectRatio="xMidYMin"
-                    style="width: 400px; --mafs-view-transform: matrix(25, 0, 0, -25, 0, 0); --mafs-user-transform: translate(0, 0);"
-                    viewBox="-200 -200 400 400"
-                    width="400"
+                  <div
+                    class="MafsView"
+                    style="width: 400px; height: 400px;"
+                    tabindex="-1"
                   >
-                    <defs>
-                      <filter
-                        height="100%"
-                        id="background"
-                        width="110%"
-                        x="-5%"
-                        y="0%"
-                      >
-                        <feflood
-                          flood-color="#FFF"
-                          flood-opacity="0.64"
-                        />
-                        <fecomposite
-                          in="SourceGraphic"
-                          operator="over"
-                        />
-                      </filter>
-                    </defs>
                     <svg
                       height="400"
                       preserveAspectRatio="xMidYMin"
+                      style="width: 400px; --mafs-view-transform: matrix(25, 0, 0, -25, 0, 0); --mafs-user-transform: translate(0, 0);"
                       viewBox="-200 -200 400 400"
                       width="400"
-                      x="-200"
-                      y="-200"
-                    />
-                  </svg>
+                    >
+                      <defs>
+                        <filter
+                          height="100%"
+                          id="background"
+                          width="110%"
+                          x="-5%"
+                          y="0%"
+                        >
+                          <feflood
+                            flood-color="#FFF"
+                            flood-opacity="0.64"
+                          />
+                          <fecomposite
+                            in="SourceGraphic"
+                            operator="over"
+                          />
+                        </filter>
+                      </defs>
+                      <svg
+                        height="400"
+                        preserveAspectRatio="xMidYMin"
+                        viewBox="-200 -200 400 400"
+                        width="400"
+                        x="-200"
+                        y="-200"
+                      />
+                    </svg>
+                  </div>
                 </div>
                 <div
                   class="default_xu2jcg-o_O-inlineStyles_ay4wjb"
@@ -3197,44 +3232,49 @@ exports[`Interactive Graph interactive-graph widget question Should render predi
                 class="default_xu2jcg-o_O-inlineStyles_16155wj"
               >
                 <div
-                  class="MafsView"
-                  style="width: 400px; height: 400px;"
-                  tabindex="-1"
+                  aria-hidden="true"
+                  class="default_xu2jcg"
                 >
-                  <svg
-                    height="400"
-                    preserveAspectRatio="xMidYMin"
-                    style="width: 400px; --mafs-view-transform: matrix(50, 0, 0, -50, 0, 0); --mafs-user-transform: translate(0, 0);"
-                    viewBox="-200 -200 400 400"
-                    width="400"
+                  <div
+                    class="MafsView"
+                    style="width: 400px; height: 400px;"
+                    tabindex="-1"
                   >
-                    <defs>
-                      <filter
-                        height="100%"
-                        id="background"
-                        width="110%"
-                        x="-5%"
-                        y="0%"
-                      >
-                        <feflood
-                          flood-color="#FFF"
-                          flood-opacity="0.64"
-                        />
-                        <fecomposite
-                          in="SourceGraphic"
-                          operator="over"
-                        />
-                      </filter>
-                    </defs>
                     <svg
                       height="400"
                       preserveAspectRatio="xMidYMin"
+                      style="width: 400px; --mafs-view-transform: matrix(50, 0, 0, -50, 0, 0); --mafs-user-transform: translate(0, 0);"
                       viewBox="-200 -200 400 400"
                       width="400"
-                      x="-200"
-                      y="-200"
-                    />
-                  </svg>
+                    >
+                      <defs>
+                        <filter
+                          height="100%"
+                          id="background"
+                          width="110%"
+                          x="-5%"
+                          y="0%"
+                        >
+                          <feflood
+                            flood-color="#FFF"
+                            flood-opacity="0.64"
+                          />
+                          <fecomposite
+                            in="SourceGraphic"
+                            operator="over"
+                          />
+                        </filter>
+                      </defs>
+                      <svg
+                        height="400"
+                        preserveAspectRatio="xMidYMin"
+                        viewBox="-200 -200 400 400"
+                        width="400"
+                        x="-200"
+                        y="-200"
+                      />
+                    </svg>
+                  </div>
                 </div>
                 <div
                   class="default_xu2jcg-o_O-inlineStyles_ay4wjb"
@@ -3437,44 +3477,49 @@ exports[`Interactive Graph interactive-graph widget question Should render predi
                 class="default_xu2jcg-o_O-inlineStyles_16155wj"
               >
                 <div
-                  class="MafsView"
-                  style="width: 400px; height: 400px;"
-                  tabindex="-1"
+                  aria-hidden="true"
+                  class="default_xu2jcg"
                 >
-                  <svg
-                    height="400"
-                    preserveAspectRatio="xMidYMin"
-                    style="width: 400px; --mafs-view-transform: matrix(16.66667, 0, 0, -16.66667, 0, 0); --mafs-user-transform: translate(0, 0);"
-                    viewBox="-200 -266.6666666667 400 400"
-                    width="400"
+                  <div
+                    class="MafsView"
+                    style="width: 400px; height: 400px;"
+                    tabindex="-1"
                   >
-                    <defs>
-                      <filter
-                        height="100%"
-                        id="background"
-                        width="110%"
-                        x="-5%"
-                        y="0%"
-                      >
-                        <feflood
-                          flood-color="#FFF"
-                          flood-opacity="0.64"
-                        />
-                        <fecomposite
-                          in="SourceGraphic"
-                          operator="over"
-                        />
-                      </filter>
-                    </defs>
                     <svg
                       height="400"
                       preserveAspectRatio="xMidYMin"
-                      viewBox="-200 -266.66666666666663 400 400"
+                      style="width: 400px; --mafs-view-transform: matrix(16.66667, 0, 0, -16.66667, 0, 0); --mafs-user-transform: translate(0, 0);"
+                      viewBox="-200 -266.6666666667 400 400"
                       width="400"
-                      x="-200"
-                      y="-266.66666666666663"
-                    />
-                  </svg>
+                    >
+                      <defs>
+                        <filter
+                          height="100%"
+                          id="background"
+                          width="110%"
+                          x="-5%"
+                          y="0%"
+                        >
+                          <feflood
+                            flood-color="#FFF"
+                            flood-opacity="0.64"
+                          />
+                          <fecomposite
+                            in="SourceGraphic"
+                            operator="over"
+                          />
+                        </filter>
+                      </defs>
+                      <svg
+                        height="400"
+                        preserveAspectRatio="xMidYMin"
+                        viewBox="-200 -266.66666666666663 400 400"
+                        width="400"
+                        x="-200"
+                        y="-266.66666666666663"
+                      />
+                    </svg>
+                  </div>
                 </div>
                 <div
                   class="default_xu2jcg-o_O-inlineStyles_ay4wjb"

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -262,16 +262,16 @@ export const MafsGraph = (props: MafsGraphProps) => {
                                     </>
                                 )
                             }
-                            {/* Locked & Interactive elements nested an SVG to lock to graph bounds*/}
-                            <svg {...nestedSVGAttributes}>
-                                {/* Locked figures layer */}
-                                {props.lockedFigures && (
-                                    <GraphLockedLayer
-                                        lockedFigures={props.lockedFigures}
-                                        range={state.range}
-                                    />
+                            {/* Locked figures layer nested in SVG to lock to graph bounds*/}
+                            {props.lockedFigures &&
+                                props.lockedFigures.length > 0 && (
+                                    <svg {...nestedSVGAttributes}>
+                                        <GraphLockedLayer
+                                            lockedFigures={props.lockedFigures}
+                                            range={state.range}
+                                        />
+                                    </svg>
                                 )}
-                            </svg>
                         </Mafs>
                         {props.lockedFigures && (
                             <GraphLockedLabelsLayer

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -224,55 +224,75 @@ export const MafsGraph = (props: MafsGraphProps) => {
                                 <AxisLabels />
                             </>
                         )}
-                        <Mafs
-                            preserveAspectRatio={false}
-                            viewBox={{
-                                x: state.range[X],
-                                y: state.range[Y],
-                                padding: 0,
-                            }}
-                            pan={false}
-                            zoom={false}
-                            width={width}
-                            height={height}
-                        >
-                            {/* Svg definitions to render only once */}
-                            <SvgDefs />
-                            {/* Cartesian grid nested in an SVG to lock to graph bounds */}
-                            <svg {...nestedSVGAttributes}>
-                                <Grid
-                                    gridStep={props.gridStep}
-                                    range={state.range}
-                                    containerSizeClass={
-                                        props.containerSizeClass
-                                    }
-                                    markings={props.markings}
-                                    width={width}
-                                    height={height}
-                                />
-                            </svg>
-                            {/* Axis Ticks, Labels, and Arrows */}
-                            {
-                                // Only render the axis ticks and arrows if the markings are set to a full "graph"
-                                (props.markings === "graph" ||
-                                    props.markings === "axes") && (
-                                    <>
-                                        <AxisTicks />
-                                        <AxisArrows />
-                                    </>
-                                )
+                        <View
+                            // If we have locked figures, we set aria-hidden
+                            // to false so that screen readers can read the
+                            // locked figures. If we don't have any locked
+                            // figures, we need to set aria-hidden to true so
+                            // that screen readers don't read this Mafs element
+                            // as an empty image.
+                            // Note: Adding this in a wrapping View element
+                            // so that `aria-hidden` is a valid property.
+                            // It does not work on `Mafs` or svg elements.
+                            aria-hidden={
+                                props.lockedFigures &&
+                                props.lockedFigures.length > 0
+                                    ? false
+                                    : true
                             }
-                            {/* Locked figures layer nested in SVG to lock to graph bounds*/}
-                            {props.lockedFigures &&
-                                props.lockedFigures.length > 0 && (
-                                    <svg {...nestedSVGAttributes}>
-                                        <GraphLockedLayer
-                                            lockedFigures={props.lockedFigures}
-                                            range={state.range}
-                                        />
-                                    </svg>
-                                )}
-                        </Mafs>
+                        >
+                            <Mafs
+                                preserveAspectRatio={false}
+                                viewBox={{
+                                    x: state.range[X],
+                                    y: state.range[Y],
+                                    padding: 0,
+                                }}
+                                pan={false}
+                                zoom={false}
+                                width={width}
+                                height={height}
+                            >
+                                {/* Svg definitions to render only once */}
+                                <SvgDefs />
+                                {/* Cartesian grid nested in an SVG to lock to graph bounds */}
+                                <svg {...nestedSVGAttributes}>
+                                    <Grid
+                                        gridStep={props.gridStep}
+                                        range={state.range}
+                                        containerSizeClass={
+                                            props.containerSizeClass
+                                        }
+                                        markings={props.markings}
+                                        width={width}
+                                        height={height}
+                                    />
+                                </svg>
+                                {/* Axis Ticks, Labels, and Arrows */}
+                                {
+                                    // Only render the axis ticks and arrows if the markings are set to a full "graph"
+                                    (props.markings === "graph" ||
+                                        props.markings === "axes") && (
+                                        <>
+                                            <AxisTicks />
+                                            <AxisArrows />
+                                        </>
+                                    )
+                                }
+                                {/* Locked figures layer nested in SVG to lock to graph bounds*/}
+                                {props.lockedFigures &&
+                                    props.lockedFigures.length > 0 && (
+                                        <svg {...nestedSVGAttributes}>
+                                            <GraphLockedLayer
+                                                lockedFigures={
+                                                    props.lockedFigures
+                                                }
+                                                range={state.range}
+                                            />
+                                        </svg>
+                                    )}
+                            </Mafs>
+                        </View>
                         {props.lockedFigures && (
                             <GraphLockedLabelsLayer
                                 lockedFigures={props.lockedFigures}


### PR DESCRIPTION
## Summary:
When using a screen reader in the interactive graph widget, it would read
an empty image after the axis labels. This is bad practice, as it can be
confusing to screen reader users to hear random elements with no context.

To remove this, I had to wrap the Mafs graph in a `View` and add the
`aria-hidden` property, but only when the graph doesn't have locked figures.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2721

## Test plan:
Storybook
- On Chrome or Firefox, go to http://localhost:6006/iframe.html?globals=&args=&id=perseuseditor-widgets-interactive-graph--interactive-graph-segment&viewMode=story
- Use a screen reader to go through an interactive graph
- Note that after reading "x, math" and "y, math" (the axis labels), it does NOT read an empty image.

- On Chrome or Firefox, go to http://localhost:6006/iframe.html?globals=&args=&id=perseuseditor-widgets-interactive-graph--locked-figures&viewMode=story
- Use a screen reader to go through an interactive graph
- Note that it still reads all the locked figure aria labels