### PR TITLE
[SR] Add aria-labels for x- and y-axis labels

### DIFF
--- a/.changeset/slimy-schools-brake.md
+++ b/.changeset/slimy-schools-brake.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[SR] Add aria-labels for x- and y-axis labels

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -134,6 +134,8 @@ export type PerseusStrings = {
     simulationLocaleWarning: string;
     selectAnAnswer: string;
     // The following strings are used for interactive graph SR descriptions.
+    xAxisPrefix: string;
+    yAxisPrefix: string;
     addPoint: string;
     removePoint: string;
     graphKeyboardPrompt: string;
@@ -630,6 +632,8 @@ export const strings = {
     // translation tickets after all interactive graph SR strings have
     // been finalized. Remove this comment after the tickets have been
     // created.
+    xAxisPrefix: "X-axis",
+    yAxisPrefix: "Y-axis",
     srPointAtCoordinates: "Point %(num)s at %(x)s comma %(y)s.",
     srCircleGraph: "A circle on a coordinate plane.",
     srCircleShape:
@@ -885,6 +889,8 @@ export const mockStrings: PerseusStrings = {
     selectAnAnswer: "Select an answer",
 
     // The following strings are used for interactive graph SR descriptions.
+    xAxisPrefix: "X-axis",
+    yAxisPrefix: "Y-axis",
     graphKeyboardPrompt: "Press Shift + Enter to interact with the graph",
     addPoint: "Add Point",
     removePoint: "Remove Point",

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -134,8 +134,8 @@ export type PerseusStrings = {
     simulationLocaleWarning: string;
     selectAnAnswer: string;
     // The following strings are used for interactive graph SR descriptions.
-    xAxisPrefix: string;
-    yAxisPrefix: string;
+    xAxis: string;
+    yAxis: string;
     addPoint: string;
     removePoint: string;
     graphKeyboardPrompt: string;
@@ -632,8 +632,8 @@ export const strings = {
     // translation tickets after all interactive graph SR strings have
     // been finalized. Remove this comment after the tickets have been
     // created.
-    xAxisPrefix: "X-axis",
-    yAxisPrefix: "Y-axis",
+    xAxis: "X-axis",
+    yAxis: "Y-axis",
     srPointAtCoordinates: "Point %(num)s at %(x)s comma %(y)s.",
     srCircleGraph: "A circle on a coordinate plane.",
     srCircleShape:
@@ -889,8 +889,8 @@ export const mockStrings: PerseusStrings = {
     selectAnAnswer: "Select an answer",
 
     // The following strings are used for interactive graph SR descriptions.
-    xAxisPrefix: "X-axis",
-    yAxisPrefix: "Y-axis",
+    xAxis: "X-axis",
+    yAxis: "Y-axis",
     graphKeyboardPrompt: "Press Shift + Enter to interact with the graph",
     addPoint: "Add Point",
     removePoint: "Remove Point",

--- a/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`Interactive Graph interactive-graph widget A none-type graph renders pr
                 class="default_xu2jcg-o_O-inlineStyles_16155wj"
               >
                 <span
+                  aria-label="X-axis"
                   style="position: absolute; left: 400px; top: 200px; font-size: 14px; transform: translate(7px, -50%);"
                 >
                   <span
@@ -35,6 +36,7 @@ exports[`Interactive Graph interactive-graph widget A none-type graph renders pr
                   </span>
                 </span>
                 <span
+                  aria-label="Y-axis"
                   style="position: absolute; left: 200px; top: -24px; font-size: 14px; transform: translate(-50%, 0px);"
                 >
                   <span

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.tsx
@@ -37,7 +37,7 @@ export default function AxisLabels({i18n}: {i18n: I18nContextType}) {
     return (
         <>
             <span
-                aria-label={strings.xAxisPrefix}
+                aria-label={strings.xAxis}
                 style={{
                     position: "absolute",
                     left: x1,
@@ -49,7 +49,7 @@ export default function AxisLabels({i18n}: {i18n: I18nContextType}) {
                 <TeX>{replaceOutsideTeX(xAxisLabelText)}</TeX>
             </span>
             <span
-                aria-label={strings.yAxisPrefix}
+                aria-label={strings.yAxis}
                 style={{
                     position: "absolute",
                     left: x2,

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.tsx
@@ -7,10 +7,12 @@ import {MAX, X, Y} from "../math";
 import useGraphConfig from "../reducer/use-graph-config";
 import {replaceOutsideTeX} from "../utils";
 
+import type {I18nContextType} from "../../../components/i18n-context";
 import type {GraphDimensions} from "../types";
 
-export default function AxisLabels() {
+export default function AxisLabels({i18n}: {i18n: I18nContextType}) {
     const {range, labels, width, height} = useGraphConfig();
+    const {strings} = i18n;
 
     const yAxisLabelLocation: vec.Vector2 = [0, range[Y][MAX]];
     const xAxisLabelLocation: vec.Vector2 = [range[X][MAX], 0];
@@ -35,6 +37,7 @@ export default function AxisLabels() {
     return (
         <>
             <span
+                aria-label={strings.xAxisPrefix}
                 style={{
                     position: "absolute",
                     left: x1,
@@ -46,6 +49,7 @@ export default function AxisLabels() {
                 <TeX>{replaceOutsideTeX(xAxisLabelText)}</TeX>
             </span>
             <span
+                aria-label={strings.yAxisPrefix}
                 style={{
                     position: "absolute",
                     left: x2,

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -17,6 +17,8 @@ import type {InteractiveGraphState} from "./types";
 import type {GraphRange} from "@khanacademy/perseus-core";
 import type {UserEvent} from "@testing-library/user-event";
 
+const baseMafsProps = getBaseMafsGraphPropsForTests();
+
 function expectLabelInDoc(label: string) {
     expect(screen.getByLabelText(label)).toBeInTheDocument();
 }
@@ -84,7 +86,7 @@ describe("MafsGraph", () => {
             ],
         };
 
-        const baseMafsGraphProps = getBaseMafsGraphPropsForTests();
+        const baseMafsGraphProps = baseMafsProps;
 
         render(
             <MafsGraph
@@ -109,7 +111,7 @@ describe("MafsGraph", () => {
 
     it("renders TeX in axis Labels", () => {
         const basePropsWithTexLabels = {
-            ...getBaseMafsGraphPropsForTests(),
+            ...baseMafsProps,
             labels: ["$1/2$", "$3/4$"],
         };
 
@@ -120,13 +122,27 @@ describe("MafsGraph", () => {
 
     it("renders plain text in axis Labels", () => {
         const basePropsWithTexLabels = {
-            ...getBaseMafsGraphPropsForTests(),
+            ...baseMafsProps,
             labels: ["4/5", "5/6"],
         };
 
         render(<MafsGraph {...basePropsWithTexLabels} />);
         expect(screen.getByText("\\text{4/5}")).toBeInTheDocument();
         expect(screen.getByText("\\text{5/6}")).toBeInTheDocument();
+    });
+
+    it("includes aria-labels for the axes labels", () => {
+        const basePropsWithTexLabels = {
+            ...baseMafsProps,
+        };
+
+        render(<MafsGraph {...basePropsWithTexLabels} />);
+
+        const xAxisLabel = screen.getByLabelText("X-axis");
+        const yAxisLabel = screen.getByLabelText("Y-axis");
+
+        expect(xAxisLabel).toBeInTheDocument();
+        expect(yAxisLabel).toBeInTheDocument();
     });
 
     it("renders ARIA labels for each point (segment)", () => {
@@ -147,11 +163,7 @@ describe("MafsGraph", () => {
         };
 
         render(
-            <MafsGraph
-                {...getBaseMafsGraphPropsForTests()}
-                state={state}
-                dispatch={() => {}}
-            />,
+            <MafsGraph {...baseMafsProps} state={state} dispatch={() => {}} />,
         );
 
         expectLabelInDoc("Endpoint 1 at 0 comma 0.");
@@ -180,11 +192,7 @@ describe("MafsGraph", () => {
         };
 
         render(
-            <MafsGraph
-                {...getBaseMafsGraphPropsForTests()}
-                state={state}
-                dispatch={() => {}}
-            />,
+            <MafsGraph {...baseMafsProps} state={state} dispatch={() => {}} />,
         );
 
         expectLabelInDoc("Endpoint 1 on segment 1 at 0 comma 0.");
@@ -209,11 +217,7 @@ describe("MafsGraph", () => {
         };
 
         render(
-            <MafsGraph
-                {...getBaseMafsGraphPropsForTests()}
-                state={state}
-                dispatch={() => {}}
-            />,
+            <MafsGraph {...baseMafsProps} state={state} dispatch={() => {}} />,
         );
 
         expectLabelInDoc("Point 1 at 0 comma 0.");
@@ -242,11 +246,7 @@ describe("MafsGraph", () => {
         };
 
         render(
-            <MafsGraph
-                {...getBaseMafsGraphPropsForTests()}
-                state={state}
-                dispatch={() => {}}
-            />,
+            <MafsGraph {...baseMafsProps} state={state} dispatch={() => {}} />,
         );
 
         expectLabelInDoc("Point 1 on line 1 at 0 comma 0.");
@@ -271,11 +271,7 @@ describe("MafsGraph", () => {
         };
 
         render(
-            <MafsGraph
-                {...getBaseMafsGraphPropsForTests()}
-                state={state}
-                dispatch={() => {}}
-            />,
+            <MafsGraph {...baseMafsProps} state={state} dispatch={() => {}} />,
         );
 
         expectLabelInDoc("Endpoint at 0 comma 0.");
@@ -296,11 +292,7 @@ describe("MafsGraph", () => {
         };
 
         render(
-            <MafsGraph
-                {...getBaseMafsGraphPropsForTests()}
-                state={state}
-                dispatch={() => {}}
-            />,
+            <MafsGraph {...baseMafsProps} state={state} dispatch={() => {}} />,
         );
 
         // Circle's radius point has a special label
@@ -324,11 +316,7 @@ describe("MafsGraph", () => {
         };
 
         render(
-            <MafsGraph
-                {...getBaseMafsGraphPropsForTests()}
-                state={state}
-                dispatch={() => {}}
-            />,
+            <MafsGraph {...baseMafsProps} state={state} dispatch={() => {}} />,
         );
 
         const points = screen.getAllByRole("button");
@@ -361,11 +349,7 @@ describe("MafsGraph", () => {
         };
 
         render(
-            <MafsGraph
-                {...getBaseMafsGraphPropsForTests()}
-                state={state}
-                dispatch={() => {}}
-            />,
+            <MafsGraph {...baseMafsProps} state={state} dispatch={() => {}} />,
         );
 
         expectLabelInDoc("Point 1 at -1 comma 1.");
@@ -393,11 +377,7 @@ describe("MafsGraph", () => {
         };
 
         render(
-            <MafsGraph
-                {...getBaseMafsGraphPropsForTests()}
-                state={state}
-                dispatch={() => {}}
-            />,
+            <MafsGraph {...baseMafsProps} state={state} dispatch={() => {}} />,
         );
 
         expectLabelInDoc("Point 1 at -1 comma 1.");
@@ -429,11 +409,7 @@ describe("MafsGraph", () => {
         };
 
         render(
-            <MafsGraph
-                {...getBaseMafsGraphPropsForTests()}
-                state={state}
-                dispatch={() => {}}
-            />,
+            <MafsGraph {...baseMafsProps} state={state} dispatch={() => {}} />,
         );
 
         expectLabelInDoc("Point 1 at -1 comma 1.");
@@ -463,11 +439,7 @@ describe("MafsGraph", () => {
         };
 
         render(
-            <MafsGraph
-                {...getBaseMafsGraphPropsForTests()}
-                state={state}
-                dispatch={() => {}}
-            />,
+            <MafsGraph {...baseMafsProps} state={state} dispatch={() => {}} />,
         );
 
         expectLabelInDoc("Point 1, terminal side at -1 comma 1");
@@ -498,11 +470,7 @@ describe("MafsGraph", () => {
         };
 
         render(
-            <MafsGraph
-                {...getBaseMafsGraphPropsForTests()}
-                state={state}
-                dispatch={() => {}}
-            />,
+            <MafsGraph {...baseMafsProps} state={state} dispatch={() => {}} />,
         );
 
         expectLabelInDoc("Point 1, terminal side at 7 comma 0");
@@ -529,11 +497,7 @@ describe("MafsGraph", () => {
         };
 
         render(
-            <MafsGraph
-                {...getBaseMafsGraphPropsForTests()}
-                state={state}
-                dispatch={() => {}}
-            />,
+            <MafsGraph {...baseMafsProps} state={state} dispatch={() => {}} />,
         );
         const angleGraph = screen.getByLabelText(
             "An angle on a coordinate plane.",
@@ -563,11 +527,7 @@ describe("MafsGraph", () => {
         };
 
         render(
-            <MafsGraph
-                {...getBaseMafsGraphPropsForTests()}
-                state={state}
-                dispatch={() => {}}
-            />,
+            <MafsGraph {...baseMafsProps} state={state} dispatch={() => {}} />,
         );
 
         const angleGraph = screen.getByLabelText(
@@ -599,11 +559,7 @@ describe("MafsGraph", () => {
         };
 
         render(
-            <MafsGraph
-                {...getBaseMafsGraphPropsForTests()}
-                state={state}
-                dispatch={() => {}}
-            />,
+            <MafsGraph {...baseMafsProps} state={state} dispatch={() => {}} />,
         );
 
         expect(
@@ -635,7 +591,7 @@ describe("MafsGraph", () => {
             coords: [[2, 2]],
         };
 
-        const baseMafsGraphProps = getBaseMafsGraphPropsForTests();
+        const baseMafsGraphProps = baseMafsProps;
 
         const {rerender} = render(
             <MafsGraph
@@ -698,7 +654,7 @@ describe("MafsGraph", () => {
             initialState,
         );
 
-        const baseMafsGraphProps = getBaseMafsGraphPropsForTests();
+        const baseMafsGraphProps = baseMafsProps;
 
         render(
             <MafsGraph
@@ -749,7 +705,7 @@ describe("MafsGraph", () => {
             initialState,
         );
 
-        const baseMafsGraphProps = getBaseMafsGraphPropsForTests();
+        const baseMafsGraphProps = baseMafsProps;
 
         render(
             <MafsGraph
@@ -800,7 +756,7 @@ describe("MafsGraph", () => {
             initialState,
         );
 
-        const baseMafsGraphProps = getBaseMafsGraphPropsForTests();
+        const baseMafsGraphProps = baseMafsProps;
 
         render(
             <MafsGraph
@@ -851,7 +807,7 @@ describe("MafsGraph", () => {
             initialState,
         );
 
-        const baseMafsGraphProps = getBaseMafsGraphPropsForTests();
+        const baseMafsGraphProps = baseMafsProps;
 
         render(
             <MafsGraph
@@ -895,7 +851,7 @@ describe("MafsGraph", () => {
             };
 
             const baseMafsGraphProps: MafsGraphProps = {
-                ...getBaseMafsGraphPropsForTests(),
+                ...baseMafsProps,
                 markings: "none",
             };
 
@@ -937,7 +893,7 @@ describe("MafsGraph", () => {
             };
 
             const baseMafsGraphProps: MafsGraphProps = {
-                ...getBaseMafsGraphPropsForTests(),
+                ...baseMafsProps,
                 markings: "none",
             };
 
@@ -975,7 +931,7 @@ describe("MafsGraph", () => {
             };
 
             const baseMafsGraphProps: MafsGraphProps = {
-                ...getBaseMafsGraphPropsForTests(),
+                ...baseMafsProps,
                 markings: "none",
             };
 
@@ -1021,7 +977,7 @@ describe("MafsGraph", () => {
             };
 
             const baseMafsGraphProps: MafsGraphProps = {
-                ...getBaseMafsGraphPropsForTests(),
+                ...baseMafsProps,
                 markings: "none",
             };
 
@@ -1071,7 +1027,7 @@ describe("MafsGraph", () => {
             };
 
             const baseMafsGraphProps: MafsGraphProps = {
-                ...getBaseMafsGraphPropsForTests(),
+                ...baseMafsProps,
                 markings: "none",
             };
 
@@ -1122,7 +1078,7 @@ describe("MafsGraph", () => {
             };
 
             const baseMafsGraphProps: MafsGraphProps = {
-                ...getBaseMafsGraphPropsForTests(),
+                ...baseMafsProps,
                 markings: "none",
             };
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -221,7 +221,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                         {(props.markings === "graph" ||
                             props.markings === "axes") && (
                             <>
-                                <AxisLabels />
+                                <AxisLabels i18n={i18n} />
                             </>
                         )}
                         <View


### PR DESCRIPTION
## Summary:
Right now if a person using a screen reader traverses through the graph, they hear "x, math" and "y, math" for the axis labels, or whatever the x and y labels are updated to by the content authors.

We need to add a description for this so people know what x and y are referring to.

- Added "X-axis" and "Y-axis" strings as `aria-label`s for the `AxisLabel` elements.
- This means that it reads the actual label as a child of this axis label group
- This is my preferred approach so that it already handles math speech wehen reading the
  TeX label, and we don't have to manually use the speech rule engine again redundantly

Issue: https://khanacademy.atlassian.net/browse/LEMS-2844

## Test plan:
`yarn jest packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx`

Storybook
- Go to any interactive graph editor story (http://localhost:6006/iframe.html?globals=&args=&id=perseuseditor-widgets-interactive-graph--interactive-graph-segment&viewMode=story)
- Use the screen reader to confirm that the axis labels now say "X-axis, group"
- Continue using the screen reader and make sure that the actual axis label is read
- Update the x and y labels to have some kind of math TeX like `\frac{1}{2}`
- Repeat the above steps and confirm that the screen reader reads the math correctly