### PR TITLE
[SR] Add screen reader support for pi-based numbers

### DIFF
--- a/.changeset/chatty-spoons-laugh.md
+++ b/.changeset/chatty-spoons-laugh.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+[SR] Add screen reader support for pi-based numbers

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.test.ts
@@ -1,4 +1,4 @@
-import {srFormatNumber} from "./screenreader-text";
+import {getPiMultiple, srFormatNumber} from "./screenreader-text";
 
 describe("srFormatNumber", () => {
     it("trivially converts small integers to strings", () => {
@@ -28,4 +28,61 @@ describe("srFormatNumber", () => {
     it("uses a locale-appropriate decimal separator", () => {
         expect(srFormatNumber(1.5, "de")).toBe("1,5");
     });
+
+    it("uses pi format when the number is a multiple of pi", () => {
+        expect(srFormatNumber(Math.PI, "en")).toBe("π");
+    });
+});
+
+describe("getPiMultiple", () => {
+    test.each`
+        num
+        ${0}
+        ${1e12}
+        ${1e27}
+        ${3.14}
+        ${3.14159265}
+        ${2 * 3.14159265}
+        ${1}
+        ${-1}
+        ${-3.14}
+        ${Math.PI / 7}
+        ${Math.PI / 8}
+    `(
+        "returns null for non-pi-based numbers or non-approved divisors: $num",
+        ({num}) => {
+            expect(getPiMultiple(num)).toBe(null);
+        },
+    );
+
+    test.each`
+        num                   | expectedString
+        ${Math.PI}            | ${"π"}
+        ${-Math.PI}           | ${"-π"}
+        ${2 * Math.PI}        | ${"2π"}
+        ${-2 * Math.PI}       | ${"-2π"}
+        ${10 * Math.PI}       | ${"10π"}
+        ${-10 * Math.PI}      | ${"-10π"}
+        ${Math.PI / 2}        | ${"π/2"}
+        ${Math.PI / 3}        | ${"π/3"}
+        ${Math.PI / 4}        | ${"π/4"}
+        ${Math.PI / 6}        | ${"π/6"}
+        ${Math.PI / -2}       | ${"-π/2"}
+        ${Math.PI / -3}       | ${"-π/3"}
+        ${Math.PI / -4}       | ${"-π/4"}
+        ${Math.PI / -6}       | ${"-π/6"}
+        ${(7 * Math.PI) / 2}  | ${"7π/2"}
+        ${(2 * Math.PI) / 3}  | ${"2π/3"}
+        ${(3 * Math.PI) / 4}  | ${"3π/4"}
+        ${(5 * Math.PI) / 6}  | ${"5π/6"}
+        ${(-7 * Math.PI) / 2} | ${"-7π/2"}
+        ${(-2 * Math.PI) / 3} | ${"-2π/3"}
+        ${(-3 * Math.PI) / 4} | ${"-3π/4"}
+        ${(-5 * Math.PI) / 6} | ${"-5π/6"}
+    `(
+        "returns a string showing the number as a multiple of pi: $expectedString",
+        ({num, expectedString}) => {
+            expect(getPiMultiple(num)).toBe(expectedString);
+        },
+    );
 });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.ts
@@ -3,9 +3,90 @@ export function srFormatNumber(
     locale: string,
     maximumFractionDigits?: number,
 ): string {
+    const piBasedNumber = getPiMultiple(a);
+    if (piBasedNumber) {
+        return piBasedNumber;
+    }
+
     // adding zero here converts negative zero to positive zero.
     return (0 + a).toLocaleString(locale, {
         maximumFractionDigits: maximumFractionDigits ?? 3,
         useGrouping: false, // no thousands separators
     });
+}
+
+// Exported for testing
+export function getPiMultiple(a: number): string | null {
+    // - Save some calculations by checking if this is an integer first.
+    //   If a is an integer, it's definitely not a multiple of π.
+    // - 0 should not be presented as a multiple of π.
+    // - If a is greater than 1e12, then it thinks that it's always a
+    //   multiple of π even when it's not, due to rounding errors.
+    if (Number.isInteger(a) || a === 0 || a > 1e12) {
+        return null;
+    }
+
+    // Figure out the coefficient before the π.
+    // Example: If a = π/2, then piCoefficient = 0.5
+    // Example: If a = 2π, then piCoefficient = 2
+    const piCoefficient = a / Math.PI;
+    // Truncate the coefficient to account for floating point errors.
+    // π calculations are only accurate up to precision of 1e-12.
+    const truncatedCoefficient = parseFloat(piCoefficient.toFixed(12));
+
+    // If the coefficient is already an integer, then the number
+    // is a multiple of π. Return it here.
+    // Example: If a = 2π, then truncatedCoefficient = 2, so return "2π"
+    if (Number.isInteger(truncatedCoefficient)) {
+        // Return "π" rather than "1π".
+        if (truncatedCoefficient === 1) {
+            return "π";
+        }
+
+        // Return "-π" rather than "-1π".
+        if (truncatedCoefficient === -1) {
+            return "-π";
+        }
+
+        return truncatedCoefficient + "π";
+    }
+
+    // If the coefficient is not an integer, then we need to
+    // check if it's a multiple of π/2, π/3, π/4, or π/6.
+    // These are π-based values on a unit circle.
+    const acceptableDivisors = [2, 3, 4, 6];
+
+    // Loop through the acceptable divisors and check if the
+    // coefficient is a multiple of (1/divisor).
+    // Example: If a = 5π/6, the coeff is 5/6, which is a multiple of 1/6.
+    // So we return "5π/6".
+    for (const divisor of acceptableDivisors) {
+        // Check if the coefficient is a multiple of (1/divisor) by
+        // multiplying the coefficient by the divisor and checking if
+        // the result is an integer.
+        // Example: If a = 5π/6, then piCoefficient = 5/6. We multiply
+        // by 6 (divisor) to get 5, which is an integer.
+        const coefficientNumerator = parseFloat(
+            // π calculations are only accurate up to precision of 1e-12.
+            (piCoefficient * divisor).toFixed(12),
+        );
+
+        if (Number.isInteger(coefficientNumerator)) {
+            // Handle the case where the coefficient numberator is just 1.
+            // We don't want to write "π/6" as "1π/6"
+            if (coefficientNumerator === 1) {
+                return "π/" + divisor;
+            }
+
+            // Handle the case where the coefficient numberator is just -1.
+            // We don't want to write "π/6" as "-1π/6"
+            if (coefficientNumerator === -1) {
+                return "-π/" + divisor;
+            }
+
+            return coefficientNumerator + "π/" + divisor;
+        }
+    }
+
+    return null;
 }


### PR DESCRIPTION
## Summary:
The Sinusoid interactive graph type often uses pi-based ticks. We have support for this
visually, but the screen reader still reads out these numbers as decimal points.

Adding support for the screen reader to read pi-based numbers here in the `srFormatNumber()`
function, through which all coordinates should already be passed.

NOTE: The screen reader unfortunately does not read this with the math speech rule engine,
but that adds another layer of complexity that we may want to come back to later.
As is, it's not ideal, but it's workable. Sub-note: Manually adding the words for these
specific cases would be a nightmare for translations.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2484

## Test plan:
`yarn jest packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.test.ts`

Storybook
http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--interactive-graph-sinusoid-with-pi-ticks