### PR TITLE
[unlimited-focus] [Bug Fix] Ensure that Unlimited Graphs move focus properly when deleting points out of order.

### DIFF
--- a/.changeset/shiny-elephants-allow.md
+++ b/.changeset/shiny-elephants-allow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Bugfixes to ensure that focus is handled correctly on unlimited point/polygon graphs.

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
@@ -52,7 +52,12 @@ function PointGraph(props: Props) {
         if (focusedIndex != null) {
             pointsRef.current[focusedIndex]?.focus();
         }
-    }, [props.graphState.focusedPointIndex, pointsRef]);
+    }, [
+        props.graphState.focusedPointIndex,
+        // Ensure that we re-focus if a point is deleted.
+        props.graphState.coords.length,
+        pointsRef,
+    ]);
 
     const statefulProps = {
         ...props,

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -122,7 +122,12 @@ const PolygonGraph = (props: Props) => {
         if (focusedIndex != null) {
             pointsRef.current[focusedIndex]?.focus();
         }
-    }, [props.graphState.focusedPointIndex, pointsRef]);
+    }, [
+        props.graphState.focusedPointIndex,
+        // Ensure that we re-focus if a point is deleted.
+        props.graphState.coords.length,
+        pointsRef,
+    ]);
 
     // If the unlimited polygon is rendered with 3 or more coordinates
     // Close the polygon, but only on first render.

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -1430,7 +1430,7 @@ describe("doAddPoint", () => {
             [0, 0],
         ]);
         expect(updated.hasBeenInteractedWith).toBeTruthy();
-        expect(updated.showRemovePointButton).toBeFalsy();
+        expect(updated.showRemovePointButton).toBeTruthy();
         expect(updated.focusedPointIndex).toBe(1);
     });
 
@@ -1478,12 +1478,11 @@ describe("doRemovePoint", () => {
 
         invariant(updated.type === "point");
         expect(updated.coords).toMatchObject([[2, -2]]);
-        expect(updated.showRemovePointButton).toBeFalsy();
+        expect(updated.showRemovePointButton).toBeTruthy();
         expect(updated.focusedPointIndex).toBe(0);
-        expect(updated.showRemovePointButton).toBeFalsy();
     });
 
-    it("focusedPointIndex is set to null if interaction mode is in mouse", () => {
+    it("focusedPointIndex is set for mouse interaction mode", () => {
         const state: InteractiveGraphState = {
             ...baseUnlimitedPointGraphState,
             interactionMode: "mouse",
@@ -1501,9 +1500,8 @@ describe("doRemovePoint", () => {
 
         invariant(updated.type === "point");
         expect(updated.coords).toMatchObject([[2, -2]]);
-        expect(updated.showRemovePointButton).toBeFalsy();
-        expect(updated.focusedPointIndex).toBe(null);
-        expect(updated.showRemovePointButton).toBeFalsy();
+        expect(updated.showRemovePointButton).toBeTruthy();
+        expect(updated.focusedPointIndex).toBe(0);
     });
 });
 

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -722,19 +722,14 @@ function doRemovePoint(
         return state;
     }
 
-    let nextFocusedPointIndex: number | null;
-    if (state.interactionMode === "mouse") {
-        nextFocusedPointIndex = null;
-    } else {
-        nextFocusedPointIndex =
-            state.coords.length > 1 ? state.coords.length - 2 : null;
-    }
+    const nextFocusedPointIndex: number | null =
+        state.coords.length > 1 ? state.coords.length - 2 : null;
 
     return {
         ...state,
         coords: state.coords.filter((_, i) => i !== action.index),
         focusedPointIndex: nextFocusedPointIndex,
-        showRemovePointButton: false,
+        showRemovePointButton: nextFocusedPointIndex !== null ? true : false,
     };
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -709,7 +709,7 @@ function doAddPoint(
         ...state,
         hasBeenInteractedWith: true,
         coords: newCoords,
-        showRemovePointButton: false,
+        showRemovePointButton: true,
         focusedPointIndex: newCoords.length - 1,
     };
 }


### PR DESCRIPTION
## Summary:
This PR is part of the Interactive Graph Project.

While recreating LEMS-2551, it was discovered that focus was not being set for mouse-based interaction. This PR fixes both that issue, and the issue from LEMS-2551 where deleting the points out of order would eventually result in a failure to move the focus to the next point.

## Video example:
https://github.com/user-attachments/assets/acf582ff-e564-4950-a997-204c01b75e5a

Issue: LEMS-2551

## Test plan:
tests pass