### PR TITLE
[Interactive Graph] Replace string-based function call with switch statement

### DIFF
--- a/.changeset/spotty-humans-prove.md
+++ b/.changeset/spotty-humans-prove.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+[Interactive Graph] Replace string-based function call with switch statement

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
@@ -808,4 +808,34 @@ describe("InteractiveGraphEditor", () => {
         await userEvent.click(dropdown);
         expect(screen.getByRole("option", {name: "None"})).toBeInTheDocument();
     });
+
+    test.each`
+        graphType          | expectedNumber | correctAnswer
+        ${"linear"}        | ${1}           | ${"y = 5.000"}
+        ${"quadratic"}     | ${2}           | ${"y = 0.400x^2 + 0.000x + -5.000"}
+        ${"sinusoid"}      | ${2}           | ${"y = 2.000sin(0.524x - 0.000) + 0.000"}
+        ${"circle"}        | ${1}           | ${"center (0, 0), radius 2"}
+        ${"linear-system"} | ${1}           | ${"y = 0.000x + 5.000 y = 0.000x + -5.000 Lines are parallel"}
+        ${"point"}         | ${1}           | ${"(0, 0)"}
+        ${"segment"}       | ${1}           | ${"[(-5, 5) (5, 5)]"}
+        ${"ray"}           | ${1}           | ${"y = 5.000 (for x >= -5.000)"}
+        ${"polygon"}       | ${1}           | ${"(3, -2) (0, 4) (-3, -2)"}
+        ${"angle"}         | ${2}           | ${"20° angle at (0, 0)"}
+    `(
+        "Should show 'correct answer' box for $graphType graph",
+        ({graphType, expectedNumber, correctAnswer}) => {
+            render(
+                <InteractiveGraphEditor
+                    {...baseProps}
+                    graph={{type: graphType}}
+                    correct={{type: graphType}}
+                />,
+            );
+
+            const correctAnswerBoxes = screen.getAllByText(correctAnswer);
+            // Quadratic, Sinusoid, and Angle also have a second answer box
+            // in the "Start coordinates" section.
+            expect(correctAnswerBoxes).toHaveLength(expectedNumber);
+        },
+    );
 });

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -6,6 +6,7 @@ import {
     getInteractiveGraphPublicWidgetOptions,
     PerseusError,
 } from "@khanacademy/perseus-core";
+import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
 import * as React from "react";
 import _ from "underscore";
 
@@ -55,12 +56,6 @@ const UNLIMITED = "unlimited" as const;
 
 // Sample background image:
 // https://ka-perseus-graphie.s3.amazonaws.com/29c1b0fcd17fe63df0f148fe357044d5d5c7d0bb.png
-
-function capitalize(str) {
-    return str.replace(/(?:^|-)(.)/g, function (match, letter) {
-        return letter.toUpperCase();
-    });
-}
 
 function numSteps(range: Range, step: number) {
     return Math.floor((range[1] - range[0]) / step);
@@ -586,8 +581,32 @@ class InteractiveGraph extends React.Component<Props, State> {
 
     static getEquationString(props: Props): string {
         const type = props.graph.type;
-        const funcName = "get" + capitalize(type) + "EquationString";
-        return InteractiveGraph[funcName](props);
+        switch (type) {
+            case "none":
+                return InteractiveGraph.getNoneEquationString();
+            case "linear":
+                return InteractiveGraph.getLinearEquationString(props);
+            case "quadratic":
+                return InteractiveGraph.getQuadraticEquationString(props);
+            case "sinusoid":
+                return InteractiveGraph.getSinusoidEquationString(props);
+            case "circle":
+                return InteractiveGraph.getCircleEquationString(props);
+            case "linear-system":
+                return InteractiveGraph.getLinearSystemEquationString(props);
+            case "point":
+                return InteractiveGraph.getPointEquationString(props);
+            case "segment":
+                return InteractiveGraph.getSegmentEquationString(props);
+            case "ray":
+                return InteractiveGraph.getRayEquationString(props);
+            case "polygon":
+                return InteractiveGraph.getPolygonEquationString(props);
+            case "angle":
+                return InteractiveGraph.getAngleEquationString(props);
+            default:
+                throw new UnreachableCaseError(type);
+        }
     }
 
     static pointsFromNormalized(


### PR DESCRIPTION
## Summary:
There's a part in the interactive graph code where the equation string
getter function is called by a code that concatonates a string together
and uses that string as a function name to call.

For the sake of type safety and the wellbeing of our engineers, updating
this to a switch statement.

Issue: none

## Test plan:
`yarn jest packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx`

Storybook
- http://localhost:6006/?path=/story/perseuseditor-editorpage--demo