### PR TITLE
[SR] Update Circle strings

### DIFF
--- a/.changeset/smart-files-pump.md
+++ b/.changeset/smart-files-pump.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[SR] Update Circle strings

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -162,7 +162,14 @@ export type PerseusStrings = {
         centerX: string;
         centerY: string;
     }) => string;
-    srCircleRadiusPoint: ({
+    srCircleRadiusPointRight: ({
+        radiusPointX,
+        radiusPointY,
+    }: {
+        radiusPointX: string;
+        radiusPointY: string;
+    }) => string;
+    srCircleRadiusPointLeft: ({
         radiusPointX,
         radiusPointY,
     }: {
@@ -676,8 +683,10 @@ export const strings = {
     srCircleGraph: "A circle on a coordinate plane.",
     srCircleShape:
         "Circle. The center point is at %(centerX)s comma %(centerY)s.",
-    srCircleRadiusPoint:
-        "Radius point at %(radiusPointX)s comma %(radiusPointY)s.",
+    srCircleRadiusPointRight:
+        "Right radius endpoint at %(radiusPointX)s comma %(radiusPointY)s.",
+    srCircleRadiusPointLeft:
+        "Left radius endpoint at %(radiusPointX)s comma %(radiusPointY)s.",
     srCircleRadius: "Circle radius is %(radius)s.",
     srCircleOuterPoints:
         "Points on the circle at %(point1X)s comma %(point1Y)s, %(point2X)s comma %(point2Y)s, %(point3X)s comma %(point3Y)s, %(point4X)s comma %(point4Y)s.",
@@ -955,8 +964,10 @@ export const mockStrings: PerseusStrings = {
     srCircleGraph: "A circle on a coordinate plane.",
     srCircleShape: ({centerX, centerY}) =>
         `Circle. The center point is at ${centerX} comma ${centerY}.`,
-    srCircleRadiusPoint: ({radiusPointX, radiusPointY}) =>
-        `Radius point at ${radiusPointX} comma ${radiusPointY}.`,
+    srCircleRadiusPointRight: ({radiusPointX, radiusPointY}) =>
+        `Right radius endpoint at ${radiusPointX} comma ${radiusPointY}.`,
+    srCircleRadiusPointLeft: ({radiusPointX, radiusPointY}) =>
+        `Left radius endpoint at ${radiusPointX} comma ${radiusPointY}.`,
     srCircleRadius: ({radius}) => `Circle radius is ${radius}.`,
     srCircleOuterPoints: ({
         point1X,

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.test.tsx
@@ -210,7 +210,7 @@ describe("Circle graph screen reader", () => {
 
         expect(radiusPoint).toHaveAttribute(
             "aria-label",
-            "Radius point at 1 comma 0. Circle radius is 1.",
+            "Right radius endpoint at 1 comma 0. Circle radius is 1.",
         );
         expect(radiusPoint).toHaveAccessibleDescription(
             "Points on the circle at 1 comma 0, 0 comma 1, -1 comma 0, 0 comma -1.",
@@ -251,9 +251,41 @@ describe("Circle graph screen reader", () => {
         );
         expect(radiusPoint).toHaveAttribute(
             "aria-label",
-            "Radius point at 7 comma 3. Circle radius is 5.",
+            "Right radius endpoint at 7 comma 3. Circle radius is 5.",
         );
     });
+
+    test.each`
+        side       | point
+        ${"Right"} | ${[2, 0]}
+        ${"Left"}  | ${[-2, 0]}
+    `(
+        "radius aria-label reflects its side relative to the center",
+        ({side, point}) => {
+            // Arrange
+
+            // Act
+            render(
+                <MafsGraph
+                    {...baseMafsGraphProps}
+                    state={{
+                        ...baseCircleState,
+                        center: [0, 0],
+                        radiusPoint: point,
+                    }}
+                />,
+            );
+            const radiusPoint = screen.getByTestId(
+                "movable-point__focusable-handle",
+            );
+
+            // Assert
+            expect(radiusPoint).toHaveAttribute(
+                "aria-label",
+                `${side} radius endpoint at ${point[0]} comma ${point[1]}. Circle radius is 2.`,
+            );
+        },
+    );
 
     test("radius point has aria-live off by default", async () => {
         // Arrange
@@ -325,7 +357,9 @@ describe("describeCircleGraph", () => {
         expect(strings.srCircleShape).toBe(
             "Circle. The center point is at 0 comma 0.",
         );
-        expect(strings.srCircleRadiusPoint).toBe("Radius point at 1 comma 0.");
+        expect(strings.srCircleRadiusPoint).toBe(
+            "Right radius endpoint at 1 comma 0.",
+        );
         expect(strings.srCircleRadius).toBe("Circle radius is 1.");
         expect(strings.srCircleOuterPoints).toBe(
             "Points on the circle at 1 comma 0, 0 comma 1, -1 comma 0, 0 comma -1.",
@@ -353,7 +387,9 @@ describe("describeCircleGraph", () => {
         expect(strings.srCircleShape).toBe(
             "Circle. The center point is at 2 comma 3.",
         );
-        expect(strings.srCircleRadiusPoint).toBe("Radius point at 7 comma 3.");
+        expect(strings.srCircleRadiusPoint).toBe(
+            "Right radius endpoint at 7 comma 3.",
+        );
         expect(strings.srCircleRadius).toBe("Circle radius is 5.");
         expect(strings.srCircleOuterPoints).toBe(
             "Points on the circle at 7 comma 3, 2 comma 8, -3 comma 3, 2 comma -2.",

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -241,6 +241,7 @@ export function describeCircleGraph(
     const {strings, locale} = i18n;
     const {center, radiusPoint} = state;
     const radius = getRadius(state);
+    const isRadiusOnRight = radiusPoint[X] >= center[X];
 
     // Aria label strings
     const srCircleGraph = strings.srCircleGraph;
@@ -248,10 +249,15 @@ export function describeCircleGraph(
         centerX: srFormatNumber(center[0], locale),
         centerY: srFormatNumber(center[1], locale),
     });
-    const srCircleRadiusPoint = strings.srCircleRadiusPoint({
-        radiusPointX: srFormatNumber(radiusPoint[0], locale),
-        radiusPointY: srFormatNumber(radiusPoint[1], locale),
-    });
+    const srCircleRadiusPoint = isRadiusOnRight
+        ? strings.srCircleRadiusPointRight({
+              radiusPointX: srFormatNumber(radiusPoint[0], locale),
+              radiusPointY: srFormatNumber(radiusPoint[1], locale),
+          })
+        : strings.srCircleRadiusPointLeft({
+              radiusPointX: srFormatNumber(radiusPoint[0], locale),
+              radiusPointY: srFormatNumber(radiusPoint[1], locale),
+          });
     const srCircleRadius = strings.srCircleRadius({
         radius,
     });

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -355,7 +355,9 @@ describe("MafsGraph", () => {
         );
 
         // Circle's radius point has a special label
-        expectLabelInDoc("Radius point at 2 comma 0. Circle radius is 2.");
+        expectLabelInDoc(
+            "Right radius endpoint at 2 comma 0. Circle radius is 2.",
+        );
     });
 
     it("renders ARIA labels for each point (quadratic)", () => {


### PR DESCRIPTION
## Summary:
We're doing a final pass on strings now at the end of the phase 1
interactive graph screen reader work.

- Update the circle radius point’s label to “<Right/Left> radius endpoint at <coordinates>."

Issue: https://khanacademy.atlassian.net/browse/LEMS-2782

## Test plan:
`yarn jest packages/perseus/src/widgets/interactive-graphs/graphs/circle.test.tsx`

Storybook
- http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--interactive-graph-circle