### PR TITLE
[SR] Update Linear strings

### DIFF
--- a/.changeset/fair-humans-tie.md
+++ b/.changeset/fair-humans-tie.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[SR] Update Linear strings

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -697,7 +697,7 @@ export const strings = {
     srLinearGraphOriginIntercept:
         "The line crosses the x and y axes at the graph's origin.",
     srLinearGrabHandle:
-        "Line from %(point1X)s comma %(point1Y)s to %(point2X)s comma %(point2Y)s.",
+        "Line going through point %(point1X)s comma %(point1Y)s and point %(point2X)s comma %(point2Y)s.",
     srAngleStartingSide: "Point 3, starting side at %(x)s comma %(y)s.",
     srAngleEndingSide: "Point 2, ending side at %(x)s comma %(y)s.",
     srAngleVertex: "Point 1, vertex at %(x)s comma %(y)s.",
@@ -985,7 +985,7 @@ export const mockStrings: PerseusStrings = {
     srLinearGraphOriginIntercept:
         "The line crosses the x and y axes at the graph's origin.",
     srLinearGrabHandle: ({point1X, point1Y, point2X, point2Y}) =>
-        `Line from ${point1X} comma ${point1Y} to ${point2X} comma ${point2Y}.`,
+        `Line going through point ${point1X} comma ${point1Y} and point ${point2X} comma ${point2Y}.`,
     srAngleStartingSide: ({x, y}) =>
         `Point 3, starting side at ${x} comma ${y}.`,
     srAngleEndingSide: ({x, y}) => `Point 2, ending side at ${x} comma ${y}.`,

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear.test.tsx
@@ -61,7 +61,7 @@ describe("Linear graph screen reader", () => {
     test.each`
         element         | index | expectedValue
         ${"point1"}     | ${0}  | ${"Point 1 at -5 comma 5."}
-        ${"grabHandle"} | ${1}  | ${"Line from -5 comma 5 to 5 comma 5."}
+        ${"grabHandle"} | ${1}  | ${"Line going through point -5 comma 5 and point 5 comma 5."}
         ${"point2"}     | ${2}  | ${"Point 2 at 5 comma 5."}
     `(
         "should have aria label for $element on the line",
@@ -203,7 +203,7 @@ describe("Linear graph screen reader", () => {
         expect(point1).toHaveAttribute("aria-label", "Point 1 at -2 comma 3.");
         expect(grabHandle).toHaveAttribute(
             "aria-label",
-            "Line from -2 comma 3 to 3 comma 3.",
+            "Line going through point -2 comma 3 and point 3 comma 3.",
         );
         expect(point2).toHaveAttribute("aria-label", "Point 2 at 3 comma 3.");
     });
@@ -258,7 +258,7 @@ describe("describeLinearGraph", () => {
             "The line has two points, point 1 at -5 comma 5 and point 2 at 5 comma 5.",
         );
         expect(strings.srLinearGrabHandle).toBe(
-            "Line from -5 comma 5 to 5 comma 5.",
+            "Line going through point -5 comma 5 and point 5 comma 5.",
         );
         expect(strings.slopeString).toBe("Its slope is zero.");
         expect(strings.interceptString).toBe(
@@ -290,7 +290,7 @@ describe("describeLinearGraph", () => {
             "The line has two points, point 1 at -1 comma 2 and point 2 at 3 comma 4.",
         );
         expect(strings.srLinearGrabHandle).toBe(
-            "Line from -1 comma 2 to 3 comma 4.",
+            "Line going through point -1 comma 2 and point 3 comma 4.",
         );
         expect(strings.slopeString).toBe(
             "Its slope increases from left to right.",


### PR DESCRIPTION
## Summary:
We're doing a final pass on strings now at the end of the phase 1
interactive graph screen reader work.

- Update the linear graph's grab handle to say it's going through
  the points, rather than it being from one point to the other
  (as that would make it a line segment instead).

Issue: https://khanacademy.atlassian.net/browse/LEMS-2782

## Test plan:
`yarn jest packages/perseus/src/widgets/interactive-graphs/graphs/linear.test.tsx`

Storybook
- http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--interactive-graph-linear