### PR TITLE
[SR] Update sinusoid strings

### DIFF
--- a/.changeset/modern-ducks-cough.md
+++ b/.changeset/modern-ducks-cough.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[SR] Update sinusoid strings

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -460,7 +460,9 @@ export type PerseusStrings = {
     srUnlimitedPolygonEmpty: string;
     srSinusoidGraph: string;
     srSinusoidRootPoint: ({x, y}: {x: string; y: string}) => string;
-    srSinusoidPeakPoint: ({x, y}: {x: string; y: string}) => string;
+    srSinusoidMaxPoint: ({x, y}: {x: string; y: string}) => string;
+    srSinusoidMinPoint: ({x, y}: {x: string; y: string}) => string;
+    srSinusoidFlatPoint: ({x, y}: {x: string; y: string}) => string;
     srSinusoidDescription: ({
         minValue,
         maxValue,
@@ -768,7 +770,9 @@ export const strings = {
     srUnlimitedPolygonEmpty: "An empty coordinate plane.",
     srSinusoidGraph: "A sinusoid function on a coordinate plane.",
     srSinusoidRootPoint: "Midline intersection at %(x)s comma %(y)s.",
-    srSinusoidPeakPoint: "Extremum point at %(x)s comma %(y)s.",
+    srSinusoidMaxPoint: "Maximum point at %(x)s comma %(y)s.",
+    srSinusoidMinPoint: "Minimum point at %(x)s comma %(y)s.",
+    srSinusoidFlatPoint: "Line through point at %(x)s comma %(y)s.",
     srSinusoidDescription:
         "The graph shows a wave with a minimum value of %(minValue)s and a maximum value of %(maxValue)s. The wave completes a full cycle from %(cycleStart)s to %(cycleEnd)s.",
     srSinusoidInteractiveElements:
@@ -1094,7 +1098,9 @@ export const mockStrings: PerseusStrings = {
     srUnlimitedPolygonEmpty: "An empty coordinate plane.",
     srSinusoidGraph: "A sinusoid function on a coordinate plane.",
     srSinusoidRootPoint: ({x, y}) => `Midline intersection at ${x} comma ${y}.`,
-    srSinusoidPeakPoint: ({x, y}) => `Extremum point at ${x} comma ${y}.`,
+    srSinusoidMaxPoint: ({x, y}) => `Maximum point at ${x} comma ${y}.`,
+    srSinusoidMinPoint: ({x, y}) => `Minimum point at ${x} comma ${y}.`,
+    srSinusoidFlatPoint: ({x, y}) => `Line through point at ${x} comma ${y}.`,
     srSinusoidDescription: ({minValue, maxValue, cycleStart, cycleEnd}) =>
         `The graph shows a wave with a minimum value of ${minValue} and a maximum value of ${maxValue}. The wave completes a full cycle from ${cycleStart} to ${cycleEnd}.`,
     srSinusoidInteractiveElements: ({point1X, point1Y, point2X, point2Y}) =>

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.test.tsx
@@ -86,7 +86,7 @@ describe("Sinusoid graph screen reader", () => {
 
         // Assert
         expect(root).toHaveAccessibleName("Midline intersection at 0 comma 0.");
-        expect(peak).toHaveAccessibleName("Extremum point at 2 comma 2.");
+        expect(peak).toHaveAccessibleName("Maximum point at 2 comma 2.");
     });
 
     test("should have aria labels for sinusoid graph points with updated values", () => {
@@ -112,8 +112,40 @@ describe("Sinusoid graph screen reader", () => {
         expect(root).toHaveAccessibleName(
             "Midline intersection at -1 comma -1.",
         );
-        expect(peak).toHaveAccessibleName("Extremum point at 3 comma 2.");
+        expect(peak).toHaveAccessibleName("Maximum point at 3 comma 2.");
     });
+
+    test.each`
+        case               | extremum    | expectedLabel
+        ${"max on right"}  | ${[2, 2]}   | ${"Maximum point at 2 comma 2."}
+        ${"max on left"}   | ${[-2, 2]}  | ${"Maximum point at -2 comma 2."}
+        ${"min on right"}  | ${[2, -2]}  | ${"Minimum point at 2 comma -2."}
+        ${"min on left"}   | ${[-2, -2]} | ${"Minimum point at -2 comma -2."}
+        ${"flat on right"} | ${[2, 0]}   | ${"Line through point at 2 comma 0."}
+        ${"flat on left"}  | ${[-2, 0]}  | ${"Line through point at -2 comma 0."}
+    `(
+        "Should have aria label reflecting where the extremum point is relative to the midline ($case)",
+        ({extremum, expectedLabel}) => {
+            // Arrange
+            render(
+                <MafsGraph
+                    {...baseMafsGraphProps}
+                    state={{
+                        ...baseSinusoidState,
+                        coords: [[0, 0], extremum],
+                    }}
+                />,
+            );
+
+            // Act
+            const buttons = screen.getAllByRole("button");
+            // First button is the midline intersection, second is the extremum.
+            const extremumPoint = buttons[1];
+
+            // Assert
+            expect(extremumPoint).toHaveAccessibleName(expectedLabel);
+        },
+    );
 
     test("overall graph description should include interactive elements", () => {
         // Arrange

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
@@ -154,6 +154,15 @@ function describeSinusoidGraph(
     const diffX = Math.abs(peak[X] - root[X]);
     const diffY = Math.abs(peak[Y] - root[Y]);
 
+    const formattedRoot = {
+        x: srFormatNumber(root[X], locale),
+        y: srFormatNumber(root[Y], locale),
+    };
+    const formattedPeak = {
+        x: srFormatNumber(peak[X], locale),
+        y: srFormatNumber(peak[Y], locale),
+    };
+
     const srSinusoidGraph = strings.srSinusoidGraph;
     const srSinusoidDescription = strings.srSinusoidDescription({
         minValue: srFormatNumber(root[Y] - diffY, locale),
@@ -161,14 +170,13 @@ function describeSinusoidGraph(
         cycleStart: srFormatNumber(root[X] - 2 * diffX, locale),
         cycleEnd: srFormatNumber(root[X] + 2 * diffX, locale),
     });
-    const srSinusoidRootPoint = strings.srSinusoidRootPoint({
-        x: srFormatNumber(root[X], locale),
-        y: srFormatNumber(root[Y], locale),
-    });
-    const srSinusoidPeakPoint = strings.srSinusoidPeakPoint({
-        x: srFormatNumber(peak[X], locale),
-        y: srFormatNumber(peak[Y], locale),
-    });
+    const srSinusoidRootPoint = strings.srSinusoidRootPoint(formattedRoot);
+    const srSinusoidPeakPoint =
+        peak[Y] === root[Y]
+            ? strings.srSinusoidFlatPoint(formattedPeak)
+            : peak[Y] > root[Y]
+              ? strings.srSinusoidMaxPoint(formattedPeak)
+              : strings.srSinusoidMinPoint(formattedPeak);
     const srSinusoidInteractiveElements = strings.srInteractiveElements({
         elements: strings.srSinusoidInteractiveElements({
             point1X: srFormatNumber(root[X], locale),

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -417,7 +417,7 @@ describe("MafsGraph", () => {
         expect(point1).toHaveAccessibleName(
             "Midline intersection at -1 comma 1.",
         );
-        expect(point2).toHaveAccessibleName("Extremum point at 0 comma 0.");
+        expect(point2).toHaveAccessibleName("Minimum point at 0 comma 0.");
     });
 
     it("renders ARIA labels for each point (point)", () => {


### PR DESCRIPTION
## Summary:
We're doing a final pass on strings now at the end of the phase 1
interactive graph screen reader work.

- Update the Sinusoid graph's extremum point string to convey whether
  it's a minimum point, a maximum point, or straight line.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2782

## Test plan:
`yarn jest packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx`