### PR TITLE
[mr-right] Fix issue related to Marathi Language in getDecimalSeparator

### DIFF
--- a/.changeset/empty-lobsters-wash.md
+++ b/.changeset/empty-lobsters-wash.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": patch
+---
+
+Bug fix for Marathi language support in getDecimalSeparator

--- a/packages/perseus-core/src/utils/get-decimal-separator.test.ts
+++ b/packages/perseus-core/src/utils/get-decimal-separator.test.ts
@@ -1,0 +1,19 @@
+import getDecimalSeparator from "./get-decimal-separator";
+
+describe("getDecimalSeparator", () => {
+    it("gets the default decimal separator", () => {
+        expect(getDecimalSeparator("en")).toBe(".");
+    });
+    // Ensure that commas are being returned when expected.
+    it("gets the decimal separator for the fr locale", () => {
+        expect(getDecimalSeparator("fr")).toBe(",");
+    });
+    // Edge case: Chrome does not support the ka locale properly.
+    it("gets the decimal separator for the ka locale", () => {
+        expect(getDecimalSeparator("ka")).toBe(",");
+    });
+    // Edge case: Marathi returns non-Arabic numerals.
+    it("gets the decimal separator for the mr locale", () => {
+        expect(getDecimalSeparator("mr")).toBe(".");
+    });
+});

--- a/packages/perseus-core/src/utils/get-decimal-separator.test.ts
+++ b/packages/perseus-core/src/utils/get-decimal-separator.test.ts
@@ -16,4 +16,8 @@ describe("getDecimalSeparator", () => {
     it("gets the decimal separator for the mr locale", () => {
         expect(getDecimalSeparator("mr")).toBe(".");
     });
+    // Edge case: Bangala returns non-Arabic numerals.
+    it("gets the decimal separator for the bn locale", () => {
+        expect(getDecimalSeparator("bn")).toBe(".");
+    });
 });

--- a/packages/perseus-core/src/utils/get-decimal-separator.test.ts
+++ b/packages/perseus-core/src/utils/get-decimal-separator.test.ts
@@ -16,7 +16,7 @@ describe("getDecimalSeparator", () => {
     it("gets the decimal separator for the mr locale", () => {
         expect(getDecimalSeparator("mr")).toBe(".");
     });
-    // Edge case: Bangala returns non-Arabic numerals.
+    // Edge case: Bengali/Bangla returns non-Arabic numerals.
     it("gets the decimal separator for the bn locale", () => {
         expect(getDecimalSeparator("bn")).toBe(".");
     });

--- a/packages/perseus-core/src/utils/get-decimal-separator.ts
+++ b/packages/perseus-core/src/utils/get-decimal-separator.ts
@@ -20,7 +20,8 @@ const getDecimalSeparator = (locale: string): string => {
                 .format(numberWithDecimalSeparator)
                 // 0x661 is ARABIC-INDIC DIGIT ONE
                 // 0x6F1 is EXTENDED ARABIC-INDIC DIGIT ONE
-                .match(/[^\d\u0661\u06F1]/);
+                // 0x967 is DEVANAGARI DIGIT ONE
+                .match(/[^\d\u0661\u06F1\u0967]/);
             return match?.[0] ?? ".";
     }
 };

--- a/packages/perseus-core/src/utils/get-decimal-separator.ts
+++ b/packages/perseus-core/src/utils/get-decimal-separator.ts
@@ -21,7 +21,7 @@ const getDecimalSeparator = (locale: string): string => {
                 // 0x661 is ARABIC-INDIC DIGIT ONE
                 // 0x6F1 is EXTENDED ARABIC-INDIC DIGIT ONE
                 // 0x967 is DEVANAGARI DIGIT ONE
-                .match(/[^\d\u0661\u06F1\u0967]/);
+                .match(/[^\d\u0661\u06F1\u0967\u09e7]/);
             return match?.[0] ?? ".";
     }
 };

--- a/packages/perseus-core/src/utils/get-decimal-separator.ts
+++ b/packages/perseus-core/src/utils/get-decimal-separator.ts
@@ -21,6 +21,7 @@ const getDecimalSeparator = (locale: string): string => {
                 // 0x661 is ARABIC-INDIC DIGIT ONE
                 // 0x6F1 is EXTENDED ARABIC-INDIC DIGIT ONE
                 // 0x967 is DEVANAGARI DIGIT ONE
+                // 0x9e7 is BENGALI/BANGLA DIGIT ONE
                 .match(/[^\d\u0661\u06F1\u0967\u09e7]/);
             return match?.[0] ?? ".";
     }


### PR DESCRIPTION
## Summary:
Marathi returns non-Arabic digits when using `Intl.NumberFormat(locale)`, which was resulting in our keypad typing the wrong character.

This has been fixed by adding the Devanagari digit to the match logic. I've run a local test with all of our supported languages to ensure no other languages are facing a similar issue.

I have also added some new tests for this function to help cover the main edge cases. I could be persuaded to add a list of the supported locales and expected outcomes, but that seemed like overkill and something that would be hard to keep "up to date" should the upstream standard change, or KA add more languages.

Issue: LEMS-2878

## Test plan:
- Tests Pass
- New Tests
- Manual Testing