### PR TITLE
[SR Tree] Add infotip with explanation about SR Tree

### DIFF
--- a/.changeset/sixty-singers-turn.md
+++ b/.changeset/sixty-singers-turn.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[SR Tree] Add infotip with explanation about SR Tree

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.tsx
@@ -1,5 +1,6 @@
+import {components} from "@khanacademy/perseus";
 import {addStyle, View} from "@khanacademy/wonder-blocks-core";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
+import {Spring, Strut} from "@khanacademy/wonder-blocks-layout";
 import Pill from "@khanacademy/wonder-blocks-pill";
 import Switch from "@khanacademy/wonder-blocks-switch";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
@@ -9,6 +10,7 @@ import * as React from "react";
 
 import Heading from "../../../components/heading";
 
+const {InfoTip} = components;
 const StyledUl = addStyle("ul");
 
 type Attribute = {
@@ -183,6 +185,12 @@ function InteractiveGraphSRTree({
                         <LabelSmall tag="label" htmlFor={switchId}>
                             Show HTML roles/tags
                         </LabelSmall>
+                        <Spring />
+                        <InfoTip>
+                            This screen reader tree shows the ARIA labels and
+                            descriptions for elements within the "correct
+                            answer" Interactive Graph widget displayed above.
+                        </InfoTip>
                     </View>
                     <SRTree elementArias={elementArias} showTags={showTags} />
                 </>


### PR DESCRIPTION
## Summary:
It was a little unclear which graph the SR Tree was for.

Add a clarifying InfoTip explaning that it's for the
"correct answer" graph.

Issue: none

## Test plan:
Storybook
- http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--interactive-graph-with-aria-label

<img width="868" alt="image" src="https://github.com/user-attachments/assets/699d3a04-f1cd-43a6-a2f7-fb04c6ff5887" />
