### PR TITLE
Fix Cypress so it runs properly on Github Actions

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -164,12 +164,24 @@ jobs:
             - uses: actions/cache@v4
               with:
                   path: ~/.cache/Cypress
-                  key: cypress-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+                  # Generate a new cache whenever the lock file changes
+                  key: ${{ runner.os }}-cypress-${{ hashFiles('**/pnpm-lock.yaml') }}
+                  # If source files changed, rebuild from a prior cache.
+                  restore-keys: |
+                    ${{ runner.os }}-cypress-
 
             - name: Install & cache node_modules
               uses: ./.github/actions/shared-node-cache
               with:
                   node-version: ${{ matrix.node-version }}
+
+            - name: Install Cypress
+              shell: bash
+              working-directory: services/static
+              run: |
+                if [ ! -d "$HOME/.cache/Cypress" ]; then
+                  pnpm exec cypress install
+                fi
 
             - name: Run tests
               run: pnpm cypress:ci

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -175,13 +175,13 @@ jobs:
               with:
                   node-version: ${{ matrix.node-version }}
 
+            # We _should_ have a valid Cypress binary in place at this point,
+            # but we _could_ have had a cache miss on `~/.cache/Cypress` but a
+            # cache hit on `node_modules` leaving us in a state where the
+            # Cypress binary isn't available. This step ensures that the
+            # Cypress binary is in place
             - name: Install Cypress
-              shell: bash
-              working-directory: services/static
-              run: |
-                if [ ! -d "$HOME/.cache/Cypress" ]; then
-                  pnpm exec cypress install
-                fi
+              run: pnpm exec cypress install
 
             - name: Run tests
               run: pnpm cypress:ci

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -168,7 +168,7 @@ jobs:
                   key: ${{ runner.os }}-cypress-${{ hashFiles('**/pnpm-lock.yaml') }}
                   # If source files changed, rebuild from a prior cache.
                   restore-keys: |
-                    ${{ runner.os }}-cypress-
+                      ${{ runner.os }}-cypress-
 
             - name: Install & cache node_modules
               uses: ./.github/actions/shared-node-cache


### PR DESCRIPTION
## Summary:

When we migrated to pnpm, I thought i'd properly set up the Cypress install for CI (by caching `~/.cache/Cypress`). However, after landing that PR to `main`, I see that in some cases we can have a cache miss on that step but a cache hit on our `node_modules` folder. This leaves us with the Cypress npm package installed, but the Cypress binary missing.

This PR fixes it so that we ask Cypress to install, which will download the Cypres binary if it doesn't exist yet. 

Issue: LEMS-2825

## Test plan:

Delete the Cypress cache in Github actions and then re-run the Cypress tests. They should pass and there should be a cache miss for the `~/.cache/Cypress` step but a hit for `node_modules`.

_UPDATE_: Confirmed the [test plan worked](https://github.com/Khan/perseus/actions/runs/13439890181/job/37551792130?pr=2260). I deleted the Cypress cache (but not the node_modules cache) and re-ran the Cypress testing action. 

| Replay ... |
| --- |
| It failed to restore the Cypress cache... |
| <img width="429" alt="image" src="https://github.com/user-attachments/assets/cd085d44-465f-40e0-b31e-7be518a3d66a" /> |
| --- |
| ...restored node_modules... |
| <img width="442" alt="image" src="https://github.com/user-attachments/assets/b5c9d219-a505-490a-8ef1-35865bec1ae3" /> |
| --- |
| ...and then the Cypress install step correctly installed the binary...|
|<img width="423" alt="image" src="https://github.com/user-attachments/assets/0ac0aa4a-976b-43ae-b800-ff8c06735bc0" />|
| --- |
| ...and tests passed!|
| <img width="751" alt="image" src="https://github.com/user-attachments/assets/8ddd89bd-aff0-4391-b068-819d86c999ec" />|
