### PR TITLE
[i-like-to-move-it] Ensure that keyboard users can move points across invalid locations for all graphs. (#2264)

### DIFF
--- a/.changeset/slimy-mirrors-sneeze.md
+++ b/.changeset/slimy-mirrors-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Ensure that keyboard users can move points across invalid locations for all graphs.

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.test.tsx
@@ -11,12 +11,17 @@ import {MafsGraph} from "../mafs-graph";
 import * as ReducerGraphConfig from "../reducer/use-graph-config";
 import {getBaseMafsGraphPropsForTests} from "../utils";
 
-import {CircleGraph, describeCircleGraph} from "./circle";
+import {
+    CircleGraph,
+    describeCircleGraph,
+    getCircleKeyboardConstraint,
+} from "./circle";
 import * as UseDraggableModule from "./use-draggable";
 
 import type {GraphConfig} from "../reducer/use-graph-config";
 import type {InteractiveGraphState} from "../types";
 import type {UserEvent} from "@testing-library/user-event";
+import type {vec} from "mafs";
 
 const baseMafsGraphProps = getBaseMafsGraphPropsForTests();
 const baseCircleState: InteractiveGraphState = {
@@ -361,5 +366,26 @@ describe("describeCircleGraph", () => {
         expect(strings.srCircleInteractiveElement).toBe(
             "Interactive elements: Circle. The center point is at 2 comma 3. Circle radius is 5.",
         );
+    });
+});
+
+describe("getCircleKeyboardConstraint", () => {
+    it("should snap to the snapStep and avoid putting points on a vertical line", () => {
+        const radiusPoint: vec.Vector2 = [0, 0];
+        const center: vec.Vector2 = [1, 0];
+        const snapStep: vec.Vector2 = [1, 1];
+
+        const constraint = getCircleKeyboardConstraint(
+            center,
+            radiusPoint,
+            snapStep,
+        );
+
+        expect(constraint).toEqual({
+            up: [0, 1],
+            down: [0, -1],
+            left: [-1, 0],
+            right: [2, 0], // Avoids overlapping the points
+        });
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -249,13 +249,13 @@ export const getCircleKeyboardConstraint = (
     right: vec.Vector2;
 } => {
     // Create a helper function that moves the point and then checks
-    // if it overlaps with the other point in the line after the move.
+    // if it overlaps with the center point after the move.
     const movePointWithConstraint = (
         moveFunc: (coord: vec.Vector2) => vec.Vector2,
     ): vec.Vector2 => {
         // Move the point
         let movedCoord = moveFunc(radiusPoint);
-        // If the moved point overlaps with the other point in the line,
+        // If the moved point overlaps with the center point,
         // move the point again.
         if (vec.dist(movedCoord, center) === 0) {
             movedCoord = moveFunc(movedCoord);
@@ -263,9 +263,9 @@ export const getCircleKeyboardConstraint = (
         return movedCoord;
     };
 
-    // Check if the new point is on the same vertical line as the other point.
-    // If it is, we need to snap the point to the left or right an additional
-    // snapStep to avoid overlap.
+    // Check if the new point overlaps the center point.
+    // If it does, we need to snap the point to the left
+    //  or right an additional snapStep to avoid the overlap.
     return {
         up: movePointWithConstraint((coord) =>
             vec.add(coord, [0, snapStep[1]]),

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -43,7 +43,7 @@ type CircleGraphProps = MafsGraphProps<CircleGraphState>;
 // Exported for testing
 export function CircleGraph(props: CircleGraphProps) {
     const {dispatch, graphState} = props;
-    const {center, radiusPoint} = graphState;
+    const {center, radiusPoint, snapStep} = graphState;
 
     const {strings, locale} = usePerseusI18n();
     const [radiusPointAriaLive, setRadiusPointAriaLive] =
@@ -102,6 +102,11 @@ export function CircleGraph(props: CircleGraphProps) {
                     setRadiusPointAriaLive("polite");
                     dispatch(actions.circle.moveRadiusPoint(newRadiusPoint));
                 }}
+                constrain={getCircleKeyboardConstraint(
+                    center,
+                    radiusPoint,
+                    snapStep,
+                )}
             />
             {/* Hidden elements to provide the descriptions for the
                 circle and radius point's `aria-describedby` properties. */}
@@ -232,6 +237,50 @@ function getCircleGraphDescription(
     const strings = describeCircleGraph(state, i18n);
     return strings.srCircleInteractiveElement;
 }
+
+export const getCircleKeyboardConstraint = (
+    center: vec.Vector2,
+    radiusPoint: vec.Vector2,
+    snapStep: vec.Vector2,
+): {
+    up: vec.Vector2;
+    down: vec.Vector2;
+    left: vec.Vector2;
+    right: vec.Vector2;
+} => {
+    // Create a helper function that moves the point and then checks
+    // if it overlaps with the other point in the line after the move.
+    const movePointWithConstraint = (
+        moveFunc: (coord: vec.Vector2) => vec.Vector2,
+    ): vec.Vector2 => {
+        // Move the point
+        let movedCoord = moveFunc(radiusPoint);
+        // If the moved point overlaps with the other point in the line,
+        // move the point again.
+        if (vec.dist(movedCoord, center) === 0) {
+            movedCoord = moveFunc(movedCoord);
+        }
+        return movedCoord;
+    };
+
+    // Check if the new point is on the same vertical line as the other point.
+    // If it is, we need to snap the point to the left or right an additional
+    // snapStep to avoid overlap.
+    return {
+        up: movePointWithConstraint((coord) =>
+            vec.add(coord, [0, snapStep[1]]),
+        ),
+        down: movePointWithConstraint((coord) =>
+            vec.sub(coord, [0, snapStep[1]]),
+        ),
+        left: movePointWithConstraint((coord) =>
+            vec.sub(coord, [snapStep[0], 0]),
+        ),
+        right: movePointWithConstraint((coord) =>
+            vec.add(coord, [snapStep[0], 0]),
+        ),
+    };
+};
 
 // Exported for testing
 export function describeCircleGraph(

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.test.tsx
@@ -4,7 +4,11 @@ import React from "react";
 
 import * as UseDraggableModule from "../use-draggable";
 
-import {MovableLine, trimRange} from "./movable-line";
+import {
+    getMovableLineKeyboardConstraint,
+    MovableLine,
+    trimRange,
+} from "./movable-line";
 
 import type {Interval, vec} from "mafs";
 
@@ -168,5 +172,24 @@ describe("Rendering", () => {
         // eslint-disable-next-line testing-library/no-container,testing-library/no-node-access
         line = container.querySelector("[data-testid='movable-line__line']");
         expect(line?.classList).toContain("movable-dragging");
+    });
+});
+describe("getMovableLineKeyboardConstraint", () => {
+    it("should snap to the snapStep and avoid putting points on a vertical line", () => {
+        const line: [vec.Vector2, vec.Vector2] = [
+            [0, 0],
+            [1, 0],
+        ];
+        const snapStep: vec.Vector2 = [1, 1];
+
+        // We're moving the first point
+        const constraint = getMovableLineKeyboardConstraint(line, snapStep, 0);
+
+        expect(constraint).toEqual({
+            up: [0, 1],
+            down: [0, -1],
+            left: [-1, 0],
+            right: [2, 0], // Avoids overlapping the points
+        });
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.test.tsx
@@ -328,7 +328,7 @@ describe("getQuadraticCoefficients", () => {
 });
 
 describe("getQuadraticKeyboardConstraint", () => {
-    it("should snap to the grid and avoid putting points on a vertical line", () => {
+    it("should snap to the snapStep and avoid putting points on a vertical line", () => {
         const coords: QuadraticGraphState["coords"] = [
             [0, 0],
             [1, 1],

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.test.tsx
@@ -8,9 +8,14 @@ import {mockPerseusI18nContext} from "../../../components/i18n-context";
 import {MafsGraph} from "../mafs-graph";
 import {getBaseMafsGraphPropsForTests} from "../utils";
 
-import {describeQuadraticGraph, getQuadraticCoefficients} from "./quadratic";
+import {
+    describeQuadraticGraph,
+    getQuadraticCoefficients,
+    getQuadraticKeyboardConstraint,
+} from "./quadratic";
 
 import type {QuadraticGraphState, InteractiveGraphState} from "../types";
+import type {vec} from "mafs";
 
 const baseMafsGraphProps = getBaseMafsGraphPropsForTests();
 const baseQuadraticState: InteractiveGraphState = {
@@ -72,10 +77,7 @@ describe("Quadratic graph screen reader", () => {
             render(
                 <MafsGraph
                     {...baseMafsGraphProps}
-                    state={{
-                        ...baseQuadraticState,
-                        coords: points,
-                    }}
+                    state={{...baseQuadraticState, coords: points}}
                 />,
             );
 
@@ -95,9 +97,7 @@ describe("Quadratic graph screen reader", () => {
         render(
             <MafsGraph
                 {...baseMafsGraphProps}
-                state={{
-                    ...baseQuadraticState,
-                }}
+                state={{...baseQuadraticState}}
             />,
         );
 
@@ -125,9 +125,7 @@ describe("Quadratic graph screen reader", () => {
         render(
             <MafsGraph
                 {...baseMafsGraphProps}
-                state={{
-                    ...baseQuadraticState,
-                }}
+                state={{...baseQuadraticState}}
             />,
         );
 
@@ -259,37 +257,6 @@ describe("Quadratic graph screen reader", () => {
     });
 });
 
-describe("QuadraticGraph", () => {
-    it("should accurately calculate coefficients", () => {
-        const coords: QuadraticGraphState["coords"] = [
-            [-5, 5],
-            [0, -5],
-            [4, 5],
-        ];
-        const expected: [number, number, number] = [0.5, 0.5, -5];
-        expect(getQuadraticCoefficients(coords)).toEqual(expected);
-    });
-
-    it("should accurately calculate coefficients regardless of the provided order", () => {
-        const coords: QuadraticGraphState["coords"] = [
-            [-5, 5],
-            [4, 5],
-            [0, -5],
-        ];
-        const expected: [number, number, number] = [0.5, 0.5, -5];
-        expect(getQuadraticCoefficients(coords)).toEqual(expected);
-    });
-
-    it("should return undefined when the coefficients are invalid", () => {
-        const coords: QuadraticGraphState["coords"] = [
-            [0, 0],
-            [0, 0],
-            [0, 0],
-        ];
-        expect(getQuadraticCoefficients(coords)).toBe(undefined);
-    });
-});
-
 describe("describedQuadraticGraph interactive elements", () => {
     test("describes interactive elements on a default quadratic graph", () => {
         // Arrange
@@ -326,5 +293,76 @@ describe("describedQuadraticGraph interactive elements", () => {
         expect(strings.srQuadraticInteractiveElements).toBe(
             "Interactive elements: Parabola with points at -1 comma 2, 3 comma 4, and 5 comma 5.",
         );
+    });
+});
+
+describe("getQuadraticCoefficients", () => {
+    it("should accurately calculate coefficients", () => {
+        const coords: QuadraticGraphState["coords"] = [
+            [-5, 5],
+            [0, -5],
+            [4, 5],
+        ];
+        const expected: [number, number, number] = [0.5, 0.5, -5];
+        expect(getQuadraticCoefficients(coords)).toEqual(expected);
+    });
+
+    it("should accurately calculate coefficients regardless of the provided order", () => {
+        const coords: QuadraticGraphState["coords"] = [
+            [-5, 5],
+            [4, 5],
+            [0, -5],
+        ];
+        const expected: [number, number, number] = [0.5, 0.5, -5];
+        expect(getQuadraticCoefficients(coords)).toEqual(expected);
+    });
+
+    it("should return undefined when the coefficients are invalid", () => {
+        const coords: QuadraticGraphState["coords"] = [
+            [0, 0],
+            [0, 0],
+            [0, 0],
+        ];
+        expect(getQuadraticCoefficients(coords)).toBe(undefined);
+    });
+});
+
+describe("getQuadraticKeyboardConstraint", () => {
+    it("should snap to the grid and avoid putting points on a vertical line", () => {
+        const coords: QuadraticGraphState["coords"] = [
+            [0, 0],
+            [1, 1],
+            [3, 3],
+        ];
+        const snapStep: vec.Vector2 = [1, 1];
+
+        // We're moving the first point
+        const constraint = getQuadraticKeyboardConstraint(coords, snapStep, 0);
+
+        expect(constraint).toEqual({
+            up: [0, 1],
+            down: [0, -1],
+            left: [-1, 0],
+            right: [2, 0], // Avoids putting the point on a vertical line
+        });
+    });
+
+    it("should avoid vertical alignment even when all points are one snapStep apart", () => {
+        const coords: QuadraticGraphState["coords"] = [
+            [0, 0],
+            [1, 1],
+            [2, 2],
+        ];
+        const snapStep: vec.Vector2 = [1, 1];
+
+        // We're moving the first point
+        const constraint = getQuadraticKeyboardConstraint(coords, snapStep, 0);
+
+        expect(constraint).toEqual({
+            up: [0, 1],
+            down: [0, -1],
+            left: [-1, 0],
+            right: [3, 0], // Avoids putting the point on a vertical line
+        });
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
@@ -290,7 +290,7 @@ export const getQuadraticKeyboardConstraint = (
         // Otherwise, if the new coordinates are still invalid, we need to move the point one final snapStep.
         // This is to support the edge case where all of the points are each exactly one snapStep away
         // from each other.
-        // Eg. [0, 0], [1, 0], [2, 0] where snapStep = [1, 0] and we're moving point1 to the right.
+        // Eg. When coords = [[0, 0], [1, 0], [2, 0]], snapStep = [1, 1], and we're moving coords[0] to the right.
         return moveFunc(movedCoord);
     };
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
@@ -265,7 +265,9 @@ export const getQuadraticKeyboardConstraint = (
     const coordToBeMoved = newCoords[pointMoved];
 
     // Create a function to validate and adjust the movement of the point
-    const getValidMovement = (moveFunc: (coord: Coord) => Coord): Coord => {
+    const movePointWithConstraint = (
+        moveFunc: (coord: Coord) => Coord,
+    ): Coord => {
         // Move the point the desired direction
         let movedCoord = moveFunc(coordToBeMoved);
         newCoords[pointMoved] = movedCoord;
@@ -292,19 +294,16 @@ export const getQuadraticKeyboardConstraint = (
         return moveFunc(movedCoord);
     };
 
-    // Determine the new coord positions for left and right movement
-    const leftCoordMove = getValidMovement((coord) =>
-        vec.sub(coord, [snapStep[0], 0]),
-    );
-    const rightCoordMove = getValidMovement((coord) =>
-        vec.add(coord, [snapStep[0], 0]),
-    );
-
     return {
         up: vec.add(coordToBeMoved, [0, snapStep[1]]),
         down: vec.sub(coordToBeMoved, [0, snapStep[1]]),
-        left: leftCoordMove,
-        right: rightCoordMove,
+        // For horizontal movement, we need to ensure that the points are not on the same vertical line.
+        left: movePointWithConstraint((coord) =>
+            vec.sub(coord, [snapStep[0], 0]),
+        ),
+        right: movePointWithConstraint((coord) =>
+            vec.add(coord, [snapStep[0], 0]),
+        ),
     };
 };
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.test.tsx
@@ -7,9 +7,14 @@ import {testDependencies} from "../../../../../../testing/test-dependencies";
 import {MafsGraph} from "../mafs-graph";
 import {getBaseMafsGraphPropsForTests} from "../utils";
 
-import {computeSine, getSinusoidCoefficients} from "./sinusoid";
+import {
+    computeSine,
+    getSinusoidCoefficients,
+    getSinusoidKeyboardConstraint,
+} from "./sinusoid";
 
 import type {InteractiveGraphState, SinusoidGraphState} from "../types";
+import type {vec} from "mafs";
 
 const baseMafsGraphProps = getBaseMafsGraphPropsForTests();
 const baseSinusoidState: InteractiveGraphState = {
@@ -193,5 +198,23 @@ describe("SinusoidGraph", () => {
             [0, 0],
         ];
         expect(getSinusoidCoefficients(coords)).toBe(undefined);
+    });
+});
+
+describe("getSinusoidKeyboardConstraint", () => {
+    it("should snap to the grid and avoid putting points on a vertical line", () => {
+        const coords: SinusoidGraphState["coords"] = [
+            [0, 0],
+            [1, 1],
+        ];
+        const snapStep: vec.Vector2 = [1, 1];
+        const constraint = getSinusoidKeyboardConstraint(coords, snapStep, 0);
+
+        expect(constraint).toEqual({
+            up: [0, 1],
+            down: [0, -1],
+            left: [-1, 0],
+            right: [2, 0], // Avoids putting the point on a vertical line
+        });
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
@@ -117,8 +117,9 @@ export const getSinusoidKeyboardConstraint = (
     const coordToBeMoved = coords[pointIndex];
     const otherPoint = coords[1 - pointIndex];
 
-    // Create a helper function that moves the point and then checks
-    // if it overlaps with the other point in the line after the move.
+    // Create a helper function that checks if the new point is on the same
+    // vertical line as the other point. If it is, we need to move the point
+    // an additional snapStep.
     const movePointWithConstraint = (
         moveFunc: (coord: vec.Vector2) => vec.Vector2,
     ): vec.Vector2 => {
@@ -132,9 +133,6 @@ export const getSinusoidKeyboardConstraint = (
         return movedCoord;
     };
 
-    // Check if the new point is on the same vertical line as the other point.
-    // If it is, we need to snap the point to the left or right an additional
-    // snapStep to avoid overlap.
     return {
         up: movePointWithConstraint((coord) =>
             vec.add(coord, [0, snapStep[1]]),

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
@@ -117,24 +117,37 @@ export const getSinusoidKeyboardConstraint = (
     const coordToBeMoved = coords[pointIndex];
     const otherPoint = coords[1 - pointIndex];
 
-    // Determine if left or right movement is allowed
-    const left = vec.sub(coordToBeMoved, [snapStep[0], 0]);
-    const right = vec.add(coordToBeMoved, [snapStep[0], 0]);
+    // Create a helper function that moves the point and then checks
+    // if it overlaps with the other point in the line after the move.
+    const movePointWithConstraint = (
+        moveFunc: (coord: vec.Vector2) => vec.Vector2,
+    ): vec.Vector2 => {
+        // Move the point
+        let movedCoord = moveFunc(coordToBeMoved);
+        // If the moved point overlaps with the other point in the line,
+        // move the point again.
+        if (movedCoord[X] === otherPoint[X]) {
+            movedCoord = moveFunc(movedCoord);
+        }
+        return movedCoord;
+    };
 
     // Check if the new point is on the same vertical line as the other point.
     // If it is, we need to snap the point to the left or right an additional
-    // snapStep to avoid creating an invalid sine graph.
-    if (left[X] === otherPoint[X]) {
-        left[X] -= snapStep[X];
-    }
-    if (right[X] === otherPoint[X]) {
-        right[X] += snapStep[X];
-    }
+    // snapStep to avoid overlap.
     return {
-        up: vec.add(coordToBeMoved, [0, snapStep[1]]),
-        down: vec.sub(coordToBeMoved, [0, snapStep[1]]),
-        left: left,
-        right: right,
+        up: movePointWithConstraint((coord) =>
+            vec.add(coord, [0, snapStep[1]]),
+        ),
+        down: movePointWithConstraint((coord) =>
+            vec.sub(coord, [0, snapStep[1]]),
+        ),
+        left: movePointWithConstraint((coord) =>
+            vec.sub(coord, [snapStep[0], 0]),
+        ),
+        right: movePointWithConstraint((coord) =>
+            vec.add(coord, [snapStep[0], 0]),
+        ),
     };
 };
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -191,9 +191,7 @@ describe("MafsGraph", () => {
     });
 
     it("includes aria-labels for the axes labels", () => {
-        const basePropsWithTexLabels = {
-            ...baseMafsProps,
-        };
+        const basePropsWithTexLabels = {...baseMafsProps};
 
         render(<MafsGraph {...basePropsWithTexLabels} />);
 
@@ -768,6 +766,102 @@ describe("MafsGraph", () => {
         expect(state.coords).toEqual(expectedCoords);
     });
 
+    it("Quadratic moves points over invalid locations on keystroke", async () => {
+        const initialState: InteractiveGraphState = {
+            type: "quadratic",
+            hasBeenInteractedWith: true,
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            snapStep: [1, 1],
+            coords: [
+                [0, 0],
+                [1, 1],
+                [2, 2],
+            ],
+        };
+
+        const expectedCoords = [
+            [3, 0],
+            [1, 1],
+            [2, 2],
+        ];
+
+        const {dispatch, getState} = createFakeStore(
+            interactiveGraphReducer,
+            initialState,
+        );
+
+        const baseMafsGraphProps = baseMafsProps;
+
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={getState()}
+                dispatch={dispatch}
+            />,
+        );
+
+        const group = screen.getAllByTestId("movable-point__focusable-handle");
+        group[0].focus();
+        await userEvent.keyboard("{arrowright}");
+
+        const state = getState();
+        invariant(
+            state.type === "quadratic",
+            `state type must be quadratic but was ${state.type}`,
+        );
+        expect(state.coords).toEqual(expectedCoords);
+    });
+
+    it("Sinusoid moves points over invalid locations on keystroke", async () => {
+        const initialState: InteractiveGraphState = {
+            type: "sinusoid",
+            hasBeenInteractedWith: true,
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            snapStep: [1, 1],
+            coords: [
+                [0, 0],
+                [1, 1],
+            ],
+        };
+
+        const expectedCoords = [
+            [2, 0],
+            [1, 1],
+        ];
+
+        const {dispatch, getState} = createFakeStore(
+            interactiveGraphReducer,
+            initialState,
+        );
+
+        const baseMafsGraphProps = baseMafsProps;
+
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={getState()}
+                dispatch={dispatch}
+            />,
+        );
+
+        const group = screen.getAllByTestId("movable-point__focusable-handle");
+        group[0].focus();
+        await userEvent.keyboard("{arrowright}");
+
+        const state = getState();
+        invariant(
+            state.type === "sinusoid",
+            `state type must be sinusoid but was ${state.type}`,
+        );
+        expect(state.coords).toEqual(expectedCoords);
+    });
+
     describe("with an unlimited graph", () => {
         it("point - shows a remove point button when a point is focused", async () => {
             // Arrange
@@ -1054,10 +1148,7 @@ describe("calculateNestedSVGCoords", () => {
             graphSize[1],
         );
 
-        expect(result).toEqual({
-            viewboxX: -200,
-            viewboxY: -200,
-        });
+        expect(result).toEqual({viewboxX: -200, viewboxY: -200});
     });
     it("calculates nested SVG coordinates for an off center graph", () => {
         const range: GraphRange = [
@@ -1072,9 +1163,6 @@ describe("calculateNestedSVGCoords", () => {
             graphSize[1],
         );
 
-        expect(result).toEqual({
-            viewboxX: 400,
-            viewboxY: -200,
-        });
+        expect(result).toEqual({viewboxX: 400, viewboxY: -200});
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -862,6 +862,99 @@ describe("MafsGraph", () => {
         expect(state.coords).toEqual(expectedCoords);
     });
 
+    it("Circle moves the radius point over the center point on keystroke", async () => {
+        const initialState: InteractiveGraphState = {
+            type: "circle",
+            hasBeenInteractedWith: true,
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            snapStep: [1, 1],
+            center: [1, 0],
+            radiusPoint: [0, 0],
+        };
+
+        const expectedRadiusPoint = [2, 0];
+
+        const {dispatch, getState} = createFakeStore(
+            interactiveGraphReducer,
+            initialState,
+        );
+
+        const baseMafsGraphProps = baseMafsProps;
+
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={getState()}
+                dispatch={dispatch}
+            />,
+        );
+
+        const group = screen.getAllByTestId("movable-point__focusable-handle");
+        group[0].focus();
+        await userEvent.keyboard("{arrowright}");
+
+        const state = getState();
+        invariant(
+            state.type === "circle",
+            `state type must be sinusoid but was ${state.type}`,
+        );
+        expect(state.radiusPoint).toEqual(expectedRadiusPoint);
+    });
+
+    it("Graphs using MovableLine move points over invalid locations on keystroke", async () => {
+        const initialState: InteractiveGraphState = {
+            type: "segment",
+            hasBeenInteractedWith: true,
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            snapStep: [1, 1],
+            coords: [
+                [
+                    [0, 0],
+                    [1, 0],
+                ],
+            ],
+        };
+
+        const expectedCoords = [
+            [
+                [2, 0],
+                [1, 0],
+            ],
+        ];
+
+        const {dispatch, getState} = createFakeStore(
+            interactiveGraphReducer,
+            initialState,
+        );
+
+        const baseMafsGraphProps = baseMafsProps;
+
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={getState()}
+                dispatch={dispatch}
+            />,
+        );
+
+        const group = screen.getAllByTestId("movable-point__focusable-handle");
+        group[0].focus();
+        await userEvent.keyboard("{arrowright}");
+
+        const state = getState();
+        invariant(
+            state.type === "segment",
+            `state type must be segment but was ${state.type}`,
+        );
+        expect(state.coords).toEqual(expectedCoords);
+    });
+
     describe("with an unlimited graph", () => {
         it("point - shows a remove point button when a point is focused", async () => {
             // Arrange

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -150,7 +150,10 @@ function doFocusPoint(
     switch (state.type) {
         case "polygon":
         case "point":
-            return {...state, focusedPointIndex: action.index};
+            return {
+                ...state,
+                focusedPointIndex: action.index,
+            };
         default:
             return state;
     }
@@ -163,7 +166,10 @@ function doBlurPoint(
     switch (state.type) {
         case "polygon":
         case "point":
-            const nextState = {...state, showRemovePointButton: false};
+            const nextState = {
+                ...state,
+                showRemovePointButton: false,
+            };
 
             if (state.interactionMode === "mouse") {
                 nextState.focusedPointIndex = null;
@@ -198,7 +204,11 @@ function doClosePolygon(state: InteractiveGraphState): InteractiveGraphState {
         //     LOOKS correct, even if two of the points are at the same coords.
         const noDupedPoints = getArrayWithoutDuplicates(state.coords);
 
-        return {...state, coords: noDupedPoints, closedPolygon: true};
+        return {
+            ...state,
+            coords: noDupedPoints,
+            closedPolygon: true,
+        };
     }
 
     return state;
@@ -206,7 +216,10 @@ function doClosePolygon(state: InteractiveGraphState): InteractiveGraphState {
 
 function doOpenPolygon(state: InteractiveGraphState): InteractiveGraphState {
     if (isUnlimitedGraphState(state) && state.type === "polygon") {
-        return {...state, closedPolygon: false};
+        return {
+            ...state,
+            closedPolygon: false,
+        };
     }
 
     return state;
@@ -268,7 +281,11 @@ function doMovePointInFigure(
             if (coordsOverlap(coordsToCheck)) {
                 return state;
             }
-            return {...state, hasBeenInteractedWith: true, coords: newCoords};
+            return {
+                ...state,
+                hasBeenInteractedWith: true,
+                coords: newCoords,
+            };
         }
         case "linear":
         case "ray": {
@@ -278,7 +295,11 @@ function doMovePointInFigure(
                 newValue: boundAndSnapToGrid(action.destination, state),
             });
 
-            return {...state, hasBeenInteractedWith: true, coords: newCoords};
+            return {
+                ...state,
+                hasBeenInteractedWith: true,
+                coords: newCoords,
+            };
         }
         case "angle":
         case "circle":
@@ -390,7 +411,11 @@ function doMoveAll(
                     snap(snapStep, vec.add(point, change)),
                 );
             }
-            return {...state, hasBeenInteractedWith: true, coords: newCoords};
+            return {
+                ...state,
+                hasBeenInteractedWith: true,
+                coords: newCoords,
+            };
         }
         default:
             // MoveAll is not supported for other state types; just ignore it.
@@ -473,7 +498,11 @@ function doMovePoint(
                 return state;
             }
 
-            return {...state, hasBeenInteractedWith: true, coords: newCoords};
+            return {
+                ...state,
+                hasBeenInteractedWith: true,
+                coords: newCoords,
+            };
         case "point": {
             return {
                 ...state,
@@ -633,7 +662,10 @@ function doChangeSnapStep(
         return state;
     }
 
-    return {...state, snapStep: action.snapStep};
+    return {
+        ...state,
+        snapStep: action.snapStep,
+    };
 }
 
 function doChangeRange(
@@ -647,7 +679,10 @@ function doChangeRange(
         return state;
     }
 
-    return {...state, range: action.range};
+    return {
+        ...state,
+        range: action.range,
+    };
 }
 
 function doAddPoint(
@@ -926,7 +961,13 @@ function angleSidePointsTooCloseToVertex(state: AngleGraphState): boolean {
 
 function boundAndSnapToPolygonAngle(
     destinationPoint: vec.Vector2,
-    {range, coords}: {range: [Interval, Interval]; coords: Coord[]},
+    {
+        range,
+        coords,
+    }: {
+        range: [Interval, Interval];
+        coords: Coord[];
+    },
     index: number,
 ) {
     const startingPoint = coords[index];

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -150,10 +150,7 @@ function doFocusPoint(
     switch (state.type) {
         case "polygon":
         case "point":
-            return {
-                ...state,
-                focusedPointIndex: action.index,
-            };
+            return {...state, focusedPointIndex: action.index};
         default:
             return state;
     }
@@ -166,10 +163,7 @@ function doBlurPoint(
     switch (state.type) {
         case "polygon":
         case "point":
-            const nextState = {
-                ...state,
-                showRemovePointButton: false,
-            };
+            const nextState = {...state, showRemovePointButton: false};
 
             if (state.interactionMode === "mouse") {
                 nextState.focusedPointIndex = null;
@@ -204,11 +198,7 @@ function doClosePolygon(state: InteractiveGraphState): InteractiveGraphState {
         //     LOOKS correct, even if two of the points are at the same coords.
         const noDupedPoints = getArrayWithoutDuplicates(state.coords);
 
-        return {
-            ...state,
-            coords: noDupedPoints,
-            closedPolygon: true,
-        };
+        return {...state, coords: noDupedPoints, closedPolygon: true};
     }
 
     return state;
@@ -216,10 +206,7 @@ function doClosePolygon(state: InteractiveGraphState): InteractiveGraphState {
 
 function doOpenPolygon(state: InteractiveGraphState): InteractiveGraphState {
     if (isUnlimitedGraphState(state) && state.type === "polygon") {
-        return {
-            ...state,
-            closedPolygon: false,
-        };
+        return {...state, closedPolygon: false};
     }
 
     return state;
@@ -281,11 +268,7 @@ function doMovePointInFigure(
             if (coordsOverlap(coordsToCheck)) {
                 return state;
             }
-            return {
-                ...state,
-                hasBeenInteractedWith: true,
-                coords: newCoords,
-            };
+            return {...state, hasBeenInteractedWith: true, coords: newCoords};
         }
         case "linear":
         case "ray": {
@@ -295,11 +278,7 @@ function doMovePointInFigure(
                 newValue: boundAndSnapToGrid(action.destination, state),
             });
 
-            return {
-                ...state,
-                hasBeenInteractedWith: true,
-                coords: newCoords,
-            };
+            return {...state, hasBeenInteractedWith: true, coords: newCoords};
         }
         case "angle":
         case "circle":
@@ -411,11 +390,7 @@ function doMoveAll(
                     snap(snapStep, vec.add(point, change)),
                 );
             }
-            return {
-                ...state,
-                hasBeenInteractedWith: true,
-                coords: newCoords,
-            };
+            return {...state, hasBeenInteractedWith: true, coords: newCoords};
         }
         default:
             // MoveAll is not supported for other state types; just ignore it.
@@ -498,11 +473,7 @@ function doMovePoint(
                 return state;
             }
 
-            return {
-                ...state,
-                hasBeenInteractedWith: true,
-                coords: newCoords,
-            };
+            return {...state, hasBeenInteractedWith: true, coords: newCoords};
         case "point": {
             return {
                 ...state,
@@ -662,10 +633,7 @@ function doChangeSnapStep(
         return state;
     }
 
-    return {
-        ...state,
-        snapStep: action.snapStep,
-    };
+    return {...state, snapStep: action.snapStep};
 }
 
 function doChangeRange(
@@ -679,10 +647,7 @@ function doChangeRange(
         return state;
     }
 
-    return {
-        ...state,
-        range: action.range,
-    };
+    return {...state, range: action.range};
 }
 
 function doAddPoint(
@@ -961,13 +926,7 @@ function angleSidePointsTooCloseToVertex(state: AngleGraphState): boolean {
 
 function boundAndSnapToPolygonAngle(
     destinationPoint: vec.Vector2,
-    {
-        range,
-        coords,
-    }: {
-        range: [Interval, Interval];
-        coords: Coord[];
-    },
+    {range, coords}: {range: [Interval, Interval]; coords: Coord[]},
     index: number,
 ) {
     const startingPoint = coords[index];


### PR DESCRIPTION
## Summary:
This PR is part of the Interactive Graph Project! 

The work in this PR ensures that users can move points across invalid locations for all graph types. This required updates to the following Interactive Graph types:

- Quadratic 
- Sinsoid
- Circle
- All Graphs that use Movable Line
  - Segment
  - Linear 
  - Linear System
  - Ray

NOTE: This PR does not change the functionality of the Polygon or Angle Graphs as I believe both have custom implementations that have already been implemented. 

 Issue: LEMS-2014 

## Video:
https://github.com/user-attachments/assets/317d5263-7fe9-450b-b2a9-8a5b19e17134

## Storybook Link:
https://650db21c3f5d1b2f13c02952-ehxlgsxqwf.chromatic.com/

Issue: LEMS-2014

## Test plan:
- All current tests pass
- New tests 
- Manual testing in Storybook

Author: SonicScrewdriver

Reviewers: SonicScrewdriver, nishasy, catandthemachines

Required Reviewers:

Approved By: nishasy

Checks: ✅ Check for .changeset entries for all changed files (ubuntu-latest, 20.x), ✅ Cypress (ubuntu-latest, 20.x), ✅ Publish npm snapshot (ubuntu-latest, 20.x), ✅ Check builds for changes in size (ubuntu-latest, 20.x), ✅ Lint, Typecheck, Format, and Test (ubuntu-latest, 20.x), ✅ Publish Storybook to Chromatic (ubuntu-latest, 20.x)

Pull Request URL: https://github.com/Khan/perseus/pull/2264