### PR TITLE
Export the ContentPreview component from perseus-editor

### DIFF
--- a/.changeset/tricky-shoes-walk.md
+++ b/.changeset/tricky-shoes-walk.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+Export the ContentPreview component from perseus-editor

--- a/packages/perseus-editor/src/index.ts
+++ b/packages/perseus-editor/src/index.ts
@@ -8,13 +8,13 @@ export {default as ItemDiff} from "./diffs/item-diff";
 export {default as EditorPage} from "./editor-page";
 export {default as Editor} from "./editor";
 export {default as IframeContentRenderer} from "./iframe-content-renderer";
+export {default as ContentPreview} from "./content-preview";
 
 import "./styles/perseus-editor.less";
 
 // eslint-disable-next-line import/order
 import {Widgets, widgets} from "@khanacademy/perseus";
 import AllEditors from "./all-editors";
-import ContentPreview from "./content-preview";
 
 Widgets.registerEditors(AllEditors);
 Widgets.registerWidgets(widgets);
@@ -22,4 +22,4 @@ Widgets.registerWidgets(widgets);
 Widgets.replaceDeprecatedWidgets();
 Widgets.replaceDeprecatedEditors();
 
-export {AllEditors, widgets, ContentPreview};
+export {AllEditors, widgets};

--- a/packages/perseus-editor/src/index.ts
+++ b/packages/perseus-editor/src/index.ts
@@ -14,6 +14,7 @@ import "./styles/perseus-editor.less";
 // eslint-disable-next-line import/order
 import {Widgets, widgets} from "@khanacademy/perseus";
 import AllEditors from "./all-editors";
+import ContentPreview from "./content-preview";
 
 Widgets.registerEditors(AllEditors);
 Widgets.registerWidgets(widgets);
@@ -21,4 +22,4 @@ Widgets.registerWidgets(widgets);
 Widgets.replaceDeprecatedWidgets();
 Widgets.replaceDeprecatedEditors();
 
-export {AllEditors, widgets};
+export {AllEditors, widgets, ContentPreview};


### PR DESCRIPTION
## Summary:
The ContentPreview component was created previously during our work to try to remove the iframe-based preview system. That work did not roll out, but access has been requested to this component for other work. As such, we are now exporting the component from the perseus-editor package.

Issue: LEMS-2886

## Test plan:
- Confirm all tests and checks pass