### PR TITLE
[LEMS-2777] Bugfix: KAS handling functions around plain numbers

### DIFF
--- a/.changeset/quick-dodos-warn.md
+++ b/.changeset/quick-dodos-warn.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/kas": patch
+"@khanacademy/perseus-score": patch
+---
+
+Bugfix: KAS handling functions around plain numbers

--- a/packages/kas/src/__tests__/comparing.test.ts
+++ b/packages/kas/src/__tests__/comparing.test.ts
@@ -273,6 +273,10 @@ describe("comparing", () => {
         expect("f(g(x))").toEqualExpr("f(g(x))");
         expect("sin(f(3x-x))/cos(f(x+x))").toEqualExpr("tan(f(2x))");
         expect("f(x) = sin(x + 2pi)").toEqualExpr("f(x) = sin(x)");
+        // partial reversal
+        expect("f(2) = f(3) + 4").toEqualExpr("f(2) = 4 + f(3)");
+        // full reversal
+        expect("f(2) = f(3) + 4").toEqualExpr("f(3) + 4 = f(2)");
         // NOTE(kevinb): This test is flaky, because Expr.prototype.compare
         // is non-deterministic.  When comparing expressions this normally
         // wouldn't be an issue because we could just evaluate the different

--- a/packages/kas/src/__tests__/comparing.test.ts
+++ b/packages/kas/src/__tests__/comparing.test.ts
@@ -273,10 +273,7 @@ describe("comparing", () => {
         expect("f(g(x))").toEqualExpr("f(g(x))");
         expect("sin(f(3x-x))/cos(f(x+x))").toEqualExpr("tan(f(2x))");
         expect("f(x) = sin(x + 2pi)").toEqualExpr("f(x) = sin(x)");
-        // partial reversal
-        expect("f(2) = f(3) + 4").toEqualExpr("f(2) = 4 + f(3)");
-        // full reversal
-        expect("f(2) = f(3) + 4").toEqualExpr("f(3) + 4 = f(2)");
+
         // NOTE(kevinb): This test is flaky, because Expr.prototype.compare
         // is non-deterministic.  When comparing expressions this normally
         // wouldn't be an issue because we could just evaluate the different
@@ -292,6 +289,20 @@ describe("comparing", () => {
         // before comparing expressions on the other side.
         // expect("f(x) = sin^2(x)+cos^2(x)").toEqualExpr("f(x) = 1");
         expect("f(x) = ln|x|+c").toEqualExpr("f(x)-ln|x|-c = 0");
+
+        // LEMS-2777: we were having issues with functions calling integers
+        // (as opposed to working with variables which always seemed to work)
+        // which I believe was due to treating `f(7)` as a Rational
+        // due to it not having a variable
+        //
+        // completely incorrect (previously considered correct erroneously)
+        expect("f(5) = f(7) + 4").not.toEqualExpr("f(2) = f(3) + 4");
+        // exactly correct
+        expect("f(2) = f(3) + 4").toEqualExpr("f(2) = f(3) + 4");
+        // partial reversal
+        expect("f(2) = f(3) + 4").toEqualExpr("f(2) = 4 + f(3)");
+        // full reversal
+        expect("f(2) = f(3) + 4").toEqualExpr("f(3) + 4 = f(2)");
     });
 
     test("evaluating and comparing form", () => {

--- a/packages/kas/src/nodes.ts
+++ b/packages/kas/src/nodes.ts
@@ -425,11 +425,6 @@ abstract class Expr {
             );
         };
 
-        // if no variables, only need to evaluate once
-        if (!varList.length && !this.has(Unit) && !other.has(Unit)) {
-            return equalNumbers(this.eval(), other.eval());
-        }
-
         // collect here to avoid sometimes dividing by zero, and sometimes not
         // it is better to be deterministic, e.g. x/x -> 1
         // TODO(alex): may want to keep track of assumptions as they're made

--- a/packages/kas/src/nodes.ts
+++ b/packages/kas/src/nodes.ts
@@ -425,6 +425,19 @@ abstract class Expr {
             );
         };
 
+        // If no variables, only need to evaluate once.
+        // note(matthew) Seems to be an optimization for simple cases like `2+2=4`
+        // where there are no variables / functions.
+        // Ran into issues with it in LEMS-2777 and found that tests pass
+        // with this removed, but keeping a modified version out of caution.
+        const varAndFuncList = _.union(
+            this.getVars(/* excludeFunc */ false),
+            other.getVars(/* excludeFunc */ false),
+        );
+        if (!varAndFuncList.length && !this.has(Unit) && !other.has(Unit)) {
+            return equalNumbers(this.eval(), other.eval());
+        }
+
         // collect here to avoid sometimes dividing by zero, and sometimes not
         // it is better to be deterministic, e.g. x/x -> 1
         // TODO(alex): may want to keep track of assumptions as they're made

--- a/packages/perseus-score/src/widgets/expression/score-expression.test.ts
+++ b/packages/perseus-score/src/widgets/expression/score-expression.test.ts
@@ -56,7 +56,7 @@ describe("scoreExpression", () => {
 
     it("regression LEMS-2777: equivalent to correct answer", function () {
         // Arrange
-
+        const incorrect = "f(5) = f(7) + 4";
         const correct = "f(2) = f(3) + 4";
         const partialReversed = "f(2) = 4 + f(3)";
         const fullyReversed = "f(3) + 4 = f(2)";
@@ -80,6 +80,9 @@ describe("scoreExpression", () => {
 
         // Act
         // Assert
+        expect(
+            scoreExpression(incorrect, item, "en"),
+        ).toHaveBeenAnsweredIncorrectly();
         expect(
             scoreExpression(correct, item, "en"),
         ).toHaveBeenAnsweredCorrectly();

--- a/packages/perseus-score/src/widgets/expression/score-expression.test.ts
+++ b/packages/perseus-score/src/widgets/expression/score-expression.test.ts
@@ -1,6 +1,8 @@
 import scoreExpression from "./score-expression";
 import {expressionItem3Options} from "./score-expression.testdata";
 
+import type {PerseusExpressionWidgetOptions} from "@khanacademy/perseus-core";
+
 describe("scoreExpression", () => {
     it("should handle defined ungraded answer case with no error callback", function () {
         const err = scoreExpression("x+1", expressionItem3Options, "en");
@@ -50,5 +52,42 @@ describe("scoreExpression", () => {
     it("should handle incorrect answers with period decimal separator", function () {
         const result = scoreExpression("z+1,0", expressionItem3Options, "en");
         expect(result).toHaveInvalidInput();
+    });
+
+    it("regression LEMS-2777: equivalent to correct answer", function () {
+        // Arrange
+
+        const correct = "f(2) = f(3) + 4";
+        const partialReversed = "f(2) = 4 + f(3)";
+        const fullyReversed = "f(3) + 4 = f(2)";
+
+        const item: PerseusExpressionWidgetOptions = {
+            answerForms: [
+                {
+                    considered: "correct",
+                    form: false,
+                    simplify: false,
+                    value: correct,
+                },
+            ],
+            times: false,
+            buttonSets: ["basic"],
+            functions: ["f"],
+            buttonsVisible: "focused",
+            visibleLabel: "Visible",
+            ariaLabel: "Aria",
+        };
+
+        // Act
+        // Assert
+        expect(
+            scoreExpression(correct, item, "en"),
+        ).toHaveBeenAnsweredCorrectly();
+        expect(
+            scoreExpression(partialReversed, item, "en"),
+        ).toHaveBeenAnsweredCorrectly();
+        expect(
+            scoreExpression(fullyReversed, item, "en"),
+        ).toHaveBeenAnsweredCorrectly();
     });
 });


### PR DESCRIPTION
## Summary:
See the ticket for the full break-down of the issue.

What I think was happening:
- KAS saw `f(2)`
- KAS looked for a variable, which it doesn't have (`f` is a function)
- KAS said "cool, I'll take a shortcut and just treat this as a number then"
- It tried to do math on `f(2)` like it was a Rational

I just removed the part of the code that was trying to take a shortcut.

Issue: LEMS-2777

## Test plan:
- Added unit tests
- Repro steps for the UI are in the ticket