### PR TITLE
Convert null to undefined in the `replace` field of hints

### DIFF
--- a/.changeset/selfish-kangaroos-lie.md
+++ b/.changeset/selfish-kangaroos-lie.md
@@ -1,0 +1,8 @@
+---
+"@khanacademy/perseus-core": patch
+---
+
+Bugfix: Convert null to undefined in the `replace` field of hints.
+
+This fixes a parser error observed in production. `replace` is null in some assessment
+items.

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/hint.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/hint.ts
@@ -1,9 +1,4 @@
-import {
-    any,
-    boolean,
-    object,
-    string,
-} from "../general-purpose-parsers";
+import {any, boolean, object, string} from "../general-purpose-parsers";
 import {defaulted} from "../general-purpose-parsers/defaulted";
 
 import {parseImages} from "./images-map";

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/hint.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/hint.ts
@@ -2,7 +2,6 @@ import {
     any,
     boolean,
     object,
-    optional,
     string,
 } from "../general-purpose-parsers";
 import {defaulted} from "../general-purpose-parsers/defaulted";
@@ -14,7 +13,7 @@ import type {Hint} from "../../data-schema";
 import type {Parser} from "../parser-types";
 
 export const parseHint: Parser<Hint> = object({
-    replace: optional(boolean),
+    replace: defaulted(boolean, () => undefined),
     content: string,
     widgets: defaulted(parseWidgetsMap, () => ({})),
     images: parseImages,

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
@@ -2256,6 +2256,97 @@ In case you would like a fuller experience, here is a taste of a skill you can l
 }
 `;
 
+exports[`parseAndMigratePerseusItem given hint-with-null-replace.json returns the same result as before 1`] = `
+{
+  "_multi": null,
+  "answer": null,
+  "answerArea": {
+    "calculator": false,
+    "chi2Table": false,
+    "financialCalculatorMonthlyPayment": false,
+    "financialCalculatorTimeToPayOff": false,
+    "financialCalculatorTotalAmount": false,
+    "periodicTable": false,
+    "periodicTableWithKey": false,
+    "tTable": false,
+    "zTable": false,
+  },
+  "hints": [
+    {
+      "content": "crwdns3438995:0$944544$crwdnd3438995:0$10$crwdnd3438995:0$10$crwdne3438995:0",
+      "images": {},
+      "metadata": null,
+      "replace": undefined,
+      "widgets": {},
+    },
+    {
+      "content": "crwdns3439031:0$10$crwdnd3439031:0$0$crwdne3439031:0",
+      "images": {},
+      "metadata": null,
+      "replace": undefined,
+      "widgets": {},
+    },
+    {
+      "content": "crwdns3439065:0$944544$crwdnd3439065:0$4$crwdnd3439065:0$944544$crwdnd3439065:0$10$crwdne3439065:0",
+      "images": {},
+      "metadata": null,
+      "replace": undefined,
+      "widgets": {},
+    },
+  ],
+  "itemDataVersion": {
+    "major": 0,
+    "minor": 1,
+  },
+  "question": {
+    "content": "crwdns3439028:0{944544}crwdnd3439028:0$10$crwdne3439028:0",
+    "images": {},
+    "metadata": null,
+    "replace": null,
+    "widgets": {
+      "radio 1": {
+        "alignment": "default",
+        "graded": true,
+        "id": null,
+        "key": null,
+        "options": {
+          "choices": [
+            {
+              "clue": "",
+              "content": "crwdns2693864:0crwdne2693864:0",
+              "correct": false,
+              "isNoneOfTheAbove": false,
+              "widgets": {},
+            },
+            {
+              "clue": "",
+              "content": "crwdns2693863:0crwdne2693863:0",
+              "correct": true,
+              "isNoneOfTheAbove": false,
+              "widgets": {},
+            },
+          ],
+          "countChoices": false,
+          "deselectEnabled": false,
+          "displayCount": null,
+          "hasNoneOfTheAbove": false,
+          "multipleSelect": false,
+          "noneOfTheAbove": false,
+          "onePerLine": true,
+          "randomize": false,
+        },
+        "static": false,
+        "type": "radio",
+        "version": {
+          "major": 1,
+          "minor": 0,
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`parseAndMigratePerseusItem given iframe-missing-allowFullScreen.json returns the same result as before 1`] = `
 {
   "answerArea": {

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/hint-with-null-replace.json
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/hint-with-null-replace.json
@@ -1,0 +1,96 @@
+{
+  "question": {
+    "content": "crwdns3439028:0{944544}crwdnd3439028:0$10$crwdne3439028:0",
+    "widgets": {
+      "radio 1": {
+        "type": "radio",
+        "static": false,
+        "graded": true,
+        "alignment": "default",
+        "id": null,
+        "key": null,
+        "version": {
+          "major": 1,
+          "minor": 0
+        },
+        "options": {
+          "choices": [
+            {
+              "content": "crwdns2693864:0crwdne2693864:0",
+              "clue": "",
+              "correct": false,
+              "isNoneOfTheAbove": false,
+              "widgets": {}
+            },
+            {
+              "content": "crwdns2693863:0crwdne2693863:0",
+              "clue": "",
+              "correct": true,
+              "isNoneOfTheAbove": false,
+              "widgets": {}
+            }
+          ],
+          "noneOfTheAbove": false,
+          "hasNoneOfTheAbove": false,
+          "countChoices": false,
+          "deselectEnabled": false,
+          "randomize": false,
+          "multipleSelect": false,
+          "onePerLine": true,
+          "displayCount": null
+        }
+      }
+    },
+    "replace": null,
+    "metadata": null,
+    "images": {}
+  },
+  "hints": [
+    {
+      "content": "crwdns3438995:0$944544$crwdnd3438995:0$10$crwdnd3438995:0$10$crwdne3438995:0",
+      "widgets": {},
+      "replace": null,
+      "metadata": null,
+      "images": {}
+    },
+    {
+      "content": "crwdns3439031:0$10$crwdnd3439031:0$0$crwdne3439031:0",
+      "widgets": {},
+      "replace": null,
+      "metadata": null,
+      "images": {}
+    },
+    {
+      "content": "crwdns3439065:0$944544$crwdnd3439065:0$4$crwdnd3439065:0$944544$crwdnd3439065:0$10$crwdne3439065:0",
+      "widgets": {},
+      "replace": null,
+      "metadata": null,
+      "images": {}
+    }
+  ],
+  "answerArea": {
+    "type": "",
+    "static": false,
+    "graded": false,
+    "alignment": "",
+    "id": null,
+    "key": null,
+    "version": null,
+    "zTable": false,
+    "chi2Table": false,
+    "tTable": false,
+    "calculator": false,
+    "periodicTable": false,
+    "periodicTableWithKey": false,
+    "financialCalculatorMonthlyPayment": false,
+    "financialCalculatorTotalAmount": false,
+    "financialCalculatorTimeToPayOff": false,
+    "options": null
+  },
+  "_multi": null,
+  "itemDataVersion": {
+    "major": 0,
+    "minor": 1
+  },
+  "answer": null
+}


### PR DESCRIPTION
This fixes a Perseus JSON parser error observed in production. `replace` is
null in some assessment items.

Issue: none

## Test plan:

`yarn test`