### PR TITLE
[numeric-refactor-feedback-cleanup] Numeric Input Refector Feedback

### DIFF
--- a/.changeset/flat-carrots-reply.md
+++ b/.changeset/flat-carrots-reply.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-score": patch
+---
+
+Minor dev improvements for Numeric Input after Refactor changes.

--- a/packages/perseus-score/src/util/answer-types.test.ts
+++ b/packages/perseus-score/src/util/answer-types.test.ts
@@ -8,6 +8,14 @@ const validateFraction = (correctAnswer: string, guess: string) => {
     return validator(guess);
 };
 
+const validateImproperFraction = (correctAnswer: string, guess: string) => {
+    const validator = khanAnswerTypes.number.createValidatorFunctional(
+        correctAnswer,
+        {forms: ["improper"], strict: true, simplify: "optional"},
+    );
+    return validator(guess);
+};
+
 /**
  * Mobile keypad inputs submits fractions as for e.g. "\frac{1}{4}" to represent
  * "1/4". Whereas desktop browsers submits them as "1/4".
@@ -75,6 +83,14 @@ describe("For mobile keypad input", () => {
             expect(validateFraction("0.25", ".08").correct).toBe(false);
         });
     });
+
+    describe("when validator function is invoked with improper form", () => {
+        it("accepts a strict improper answer with tex answer", () => {
+            expect(validateImproperFraction("3", "\\frac{9}{3}").correct).toBe(
+                true,
+            );
+        });
+    });
 });
 
 describe("For desktop browser based inputs", () => {
@@ -109,6 +125,16 @@ describe("For desktop browser based inputs", () => {
 
         it("should fail incorrect guess", () => {
             expect(validateFraction("0.25", ".08").correct).toBe(false);
+        });
+    });
+
+    describe("when validator function is invoked with improper form", () => {
+        it("rejects a strict improper with whole number answer", () => {
+            expect(validateImproperFraction("3", "3").correct).toBe(false);
+        });
+
+        it("accepts a strict improper answer with simple text answer", () => {
+            expect(validateImproperFraction("3", "9/3").correct).toBe(true);
         });
     });
 });

--- a/packages/perseus/src/components/simple-keypad-input.tsx
+++ b/packages/perseus/src/components/simple-keypad-input.tsx
@@ -21,12 +21,7 @@ export default class SimpleKeypadInput extends React.Component<any> {
     static contextType = KeypadContext;
     declare context: React.ContextType<typeof KeypadContext>;
     _isMounted = false;
-    inputRef: React.RefObject<KeypadInput>;
-
-    constructor(props: any) {
-        super(props);
-        this.inputRef = React.createRef<KeypadInput>();
-    }
+    inputRef = React.createRef<KeypadInput>();
 
     componentDidMount() {
         // TODO(scottgrant): This is a hack to remove the deprecated call to

--- a/packages/perseus/src/components/text-input.tsx
+++ b/packages/perseus/src/components/text-input.tsx
@@ -105,6 +105,10 @@ class TextInput extends React.Component<Props> {
 
         const formattedValue = value === null ? "" : value.toString();
 
+        // Some of our content was saved with empty strings as the label text,
+        // and we don't want to render an empty aria-label attribute.
+        const ariaLabel = labelText || undefined;
+
         return (
             <TextField
                 ref={this.inputRef}
@@ -113,7 +117,7 @@ class TextInput extends React.Component<Props> {
                 id={this.id}
                 value={formattedValue}
                 type="text"
-                aria-label={labelText}
+                aria-label={ariaLabel}
                 aria-describedby={this.props["aria-describedby"]}
                 onChange={(value) => this.props.onChange(value)}
                 placeholder={placeholder}

--- a/packages/perseus/src/components/text-input.tsx
+++ b/packages/perseus/src/components/text-input.tsx
@@ -113,7 +113,7 @@ class TextInput extends React.Component<Props> {
                 id={this.id}
                 value={formattedValue}
                 type="text"
-                aria-label={labelText || undefined}
+                aria-label={labelText}
                 aria-describedby={this.props["aria-describedby"]}
                 onChange={(value) => this.props.onChange(value)}
                 placeholder={placeholder}

--- a/packages/perseus/src/widgets/graded-group-set/__snapshots__/graded-group-set-jipt.test.ts.snap
+++ b/packages/perseus/src/widgets/graded-group-set/__snapshots__/graded-group-set-jipt.test.ts.snap
@@ -67,13 +67,13 @@ exports[`graded-group-set should render all graded groups 1`] = `
                         autocomplete="off"
                         autocorrect="off"
                         class="input_1ck1z8k-o_O-LabelMedium_1rew30o-o_O-default_1tc7wjm-o_O-defaultFocus_lrnqlz-o_O-inputWithExamples_1y6ajxo"
-                        id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                        id=":r0:"
                         tabindex="0"
                         type="text"
                         value=""
                       />
                       <span
-                        id="aria-for-input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                        id="aria-for-input-with-examples-:r0:"
                         style="display: none;"
                       />
                     </div>
@@ -144,13 +144,13 @@ exports[`graded-group-set should render all graded groups 1`] = `
                         autocomplete="off"
                         autocorrect="off"
                         class="input_1ck1z8k-o_O-LabelMedium_1rew30o-o_O-default_1tc7wjm-o_O-defaultFocus_lrnqlz-o_O-inputWithExamples_1y6ajxo"
-                        id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                        id=":r3:"
                         tabindex="0"
                         type="text"
                         value=""
                       />
                       <span
-                        id="aria-for-input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                        id="aria-for-input-with-examples-:r3:"
                         style="display: none;"
                       />
                     </div>
@@ -221,13 +221,13 @@ exports[`graded-group-set should render all graded groups 1`] = `
                         autocomplete="off"
                         autocorrect="off"
                         class="input_1ck1z8k-o_O-LabelMedium_1rew30o-o_O-default_1tc7wjm-o_O-defaultFocus_lrnqlz-o_O-inputWithExamples_1y6ajxo"
-                        id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                        id=":r6:"
                         tabindex="0"
                         type="text"
                         value=""
                       />
                       <span
-                        id="aria-for-input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                        id="aria-for-input-with-examples-:r6:"
                         style="display: none;"
                       />
                     </div>

--- a/packages/perseus/src/widgets/graded-group-set/__snapshots__/graded-group-set-jipt.test.ts.snap
+++ b/packages/perseus/src/widgets/graded-group-set/__snapshots__/graded-group-set-jipt.test.ts.snap
@@ -73,7 +73,7 @@ exports[`graded-group-set should render all graded groups 1`] = `
                         value=""
                       />
                       <span
-                        id="aria-for-input-with-examples-:r0:"
+                        id="aria-for-:r0:"
                         style="display: none;"
                       />
                     </div>
@@ -150,7 +150,7 @@ exports[`graded-group-set should render all graded groups 1`] = `
                         value=""
                       />
                       <span
-                        id="aria-for-input-with-examples-:r3:"
+                        id="aria-for-:r3:"
                         style="display: none;"
                       />
                     </div>
@@ -227,7 +227,7 @@ exports[`graded-group-set should render all graded groups 1`] = `
                         value=""
                       />
                       <span
-                        id="aria-for-input-with-examples-:r6:"
+                        id="aria-for-:r6:"
                         style="display: none;"
                       />
                     </div>

--- a/packages/perseus/src/widgets/graded-group-set/__snapshots__/graded-group-set.test.ts.snap
+++ b/packages/perseus/src/widgets/graded-group-set/__snapshots__/graded-group-set.test.ts.snap
@@ -133,13 +133,13 @@ exports[`graded group widget should snapshot 1`] = `
                         autocomplete="off"
                         autocorrect="off"
                         class="input_1ck1z8k-o_O-LabelMedium_1rew30o-o_O-default_1tc7wjm-o_O-defaultFocus_lrnqlz-o_O-inputWithExamples_1y6ajxo"
-                        id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                        id=":r0:"
                         tabindex="0"
                         type="text"
                         value=""
                       />
                       <span
-                        id="aria-for-input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                        id="aria-for-input-with-examples-:r0:"
                         style="display: none;"
                       />
                     </div>

--- a/packages/perseus/src/widgets/graded-group-set/__snapshots__/graded-group-set.test.ts.snap
+++ b/packages/perseus/src/widgets/graded-group-set/__snapshots__/graded-group-set.test.ts.snap
@@ -139,7 +139,7 @@ exports[`graded group widget should snapshot 1`] = `
                         value=""
                       />
                       <span
-                        id="aria-for-input-with-examples-:r0:"
+                        id="aria-for-:r0:"
                         style="display: none;"
                       />
                     </div>

--- a/packages/perseus/src/widgets/group/__snapshots__/group.test.tsx.snap
+++ b/packages/perseus/src/widgets/group/__snapshots__/group.test.tsx.snap
@@ -756,13 +756,13 @@ exports[`group widget should snapshot: initial render 1`] = `
                             autocomplete="off"
                             autocorrect="off"
                             class="input_1ck1z8k-o_O-LabelMedium_1rew30o-o_O-default_1tc7wjm-o_O-defaultFocus_lrnqlz-o_O-inputWithExamples_1y6ajxo"
-                            id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                            id=":r0:"
                             tabindex="0"
                             type="text"
                             value=""
                           />
                           <span
-                            id="aria-for-input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+                            id="aria-for-input-with-examples-:r0:"
                             style="display: none;"
                           />
                         </div>
@@ -812,13 +812,13 @@ exports[`group widget should snapshot: initial render 1`] = `
                             autocomplete="off"
                             autocorrect="off"
                             class="input_1ck1z8k-o_O-LabelMedium_1rew30o-o_O-default_1tc7wjm-o_O-defaultFocus_lrnqlz-o_O-inputWithExamples_1y6ajxo"
-                            id="input-with-examples-bnVtZXJpYy1pbnB1dCAy"
+                            id=":r3:"
                             tabindex="0"
                             type="text"
                             value=""
                           />
                           <span
-                            id="aria-for-input-with-examples-bnVtZXJpYy1pbnB1dCAy"
+                            id="aria-for-input-with-examples-:r3:"
                             style="display: none;"
                           />
                         </div>

--- a/packages/perseus/src/widgets/group/__snapshots__/group.test.tsx.snap
+++ b/packages/perseus/src/widgets/group/__snapshots__/group.test.tsx.snap
@@ -762,7 +762,7 @@ exports[`group widget should snapshot: initial render 1`] = `
                             value=""
                           />
                           <span
-                            id="aria-for-input-with-examples-:r0:"
+                            id="aria-for-:r0:"
                             style="display: none;"
                           />
                         </div>
@@ -818,7 +818,7 @@ exports[`group widget should snapshot: initial render 1`] = `
                             value=""
                           />
                           <span
-                            id="aria-for-input-with-examples-:r3:"
+                            id="aria-for-:r3:"
                             style="display: none;"
                           />
                         </div>

--- a/packages/perseus/src/widgets/numeric-input/__snapshots__/numeric-input.test.ts.snap
+++ b/packages/perseus/src/widgets/numeric-input/__snapshots__/numeric-input.test.ts.snap
@@ -106,7 +106,7 @@ exports[`numeric-input widget Should render predictably: after interaction 1`] =
             value="1252"
           />
           <span
-            id="aria-for-input-with-examples-:r6:"
+            id="aria-for-:r6:"
             style="display: none;"
           />
         </div>
@@ -158,7 +158,7 @@ exports[`numeric-input widget Should render predictably: first render 1`] = `
             value=""
           />
           <span
-            id="aria-for-input-with-examples-:r6:"
+            id="aria-for-:r6:"
             style="display: none;"
           />
         </div>
@@ -197,7 +197,7 @@ exports[`numeric-input widget Should render tooltip as list when multiple format
           class="perseus-widget-container widget-nohighlight widget-inline-block"
         >
           <input
-            aria-describedby="aria-for-input-with-examples-:rf:"
+            aria-describedby="aria-for-:rf:"
             aria-disabled="false"
             aria-invalid="false"
             aria-required="false"
@@ -211,7 +211,7 @@ exports[`numeric-input widget Should render tooltip as list when multiple format
             value=""
           />
           <span
-            id="aria-for-input-with-examples-:rf:"
+            id="aria-for-:rf:"
             style="display: none;"
           >
             Your answer should be 
@@ -255,7 +255,7 @@ exports[`numeric-input widget Should render tooltip using only correct answer fo
           class="perseus-widget-container widget-nohighlight widget-inline-block"
         >
           <input
-            aria-describedby="aria-for-input-with-examples-:ri:"
+            aria-describedby="aria-for-:ri:"
             aria-disabled="false"
             aria-invalid="false"
             aria-label="What's the answer?"
@@ -270,7 +270,7 @@ exports[`numeric-input widget Should render tooltip using only correct answer fo
             value=""
           />
           <span
-            id="aria-for-input-with-examples-:ri:"
+            id="aria-for-:ri:"
             style="display: none;"
           >
             Your answer should be 
@@ -312,7 +312,7 @@ exports[`numeric-input widget Should render tooltip when format option is given:
           class="perseus-widget-container widget-nohighlight widget-inline-block"
         >
           <input
-            aria-describedby="aria-for-input-with-examples-:r9:"
+            aria-describedby="aria-for-:r9:"
             aria-disabled="false"
             aria-invalid="false"
             aria-required="false"
@@ -326,7 +326,7 @@ exports[`numeric-input widget Should render tooltip when format option is given:
             value=""
           />
           <span
-            id="aria-for-input-with-examples-:r9:"
+            id="aria-for-:r9:"
             style="display: none;"
           >
             Your answer should be 

--- a/packages/perseus/src/widgets/numeric-input/__snapshots__/numeric-input.test.ts.snap
+++ b/packages/perseus/src/widgets/numeric-input/__snapshots__/numeric-input.test.ts.snap
@@ -100,13 +100,13 @@ exports[`numeric-input widget Should render predictably: after interaction 1`] =
             autocomplete="off"
             autocorrect="off"
             class="input_1ck1z8k-o_O-LabelMedium_1rew30o-o_O-default_1tc7wjm-o_O-defaultFocus_lrnqlz-o_O-inputWithExamples_ylhnsi"
-            id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+            id=":r6:"
             tabindex="0"
             type="text"
             value="1252"
           />
           <span
-            id="aria-for-input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+            id="aria-for-input-with-examples-:r6:"
             style="display: none;"
           />
         </div>
@@ -152,13 +152,13 @@ exports[`numeric-input widget Should render predictably: first render 1`] = `
             autocomplete="off"
             autocorrect="off"
             class="input_1ck1z8k-o_O-LabelMedium_1rew30o-o_O-default_1tc7wjm-o_O-defaultFocus_lrnqlz-o_O-inputWithExamples_1y6ajxo"
-            id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+            id=":r6:"
             tabindex="0"
             type="text"
             value=""
           />
           <span
-            id="aria-for-input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+            id="aria-for-input-with-examples-:r6:"
             style="display: none;"
           />
         </div>
@@ -197,7 +197,7 @@ exports[`numeric-input widget Should render tooltip as list when multiple format
           class="perseus-widget-container widget-nohighlight widget-inline-block"
         >
           <input
-            aria-describedby="aria-for-input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+            aria-describedby="aria-for-input-with-examples-:rf:"
             aria-disabled="false"
             aria-invalid="false"
             aria-required="false"
@@ -205,13 +205,13 @@ exports[`numeric-input widget Should render tooltip as list when multiple format
             autocomplete="off"
             autocorrect="off"
             class="input_1ck1z8k-o_O-LabelMedium_1rew30o-o_O-default_1tc7wjm-o_O-defaultFocus_lrnqlz-o_O-inputWithExamples_1y6ajxo"
-            id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+            id=":rf:"
             tabindex="0"
             type="text"
             value=""
           />
           <span
-            id="aria-for-input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+            id="aria-for-input-with-examples-:rf:"
             style="display: none;"
           >
             Your answer should be 
@@ -255,7 +255,7 @@ exports[`numeric-input widget Should render tooltip using only correct answer fo
           class="perseus-widget-container widget-nohighlight widget-inline-block"
         >
           <input
-            aria-describedby="aria-for-input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+            aria-describedby="aria-for-input-with-examples-:ri:"
             aria-disabled="false"
             aria-invalid="false"
             aria-label="What's the answer?"
@@ -264,13 +264,13 @@ exports[`numeric-input widget Should render tooltip using only correct answer fo
             autocomplete="off"
             autocorrect="off"
             class="input_1ck1z8k-o_O-LabelMedium_1rew30o-o_O-default_1tc7wjm-o_O-defaultFocus_lrnqlz-o_O-inputWithExamples_1y6ajxo"
-            id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+            id=":ri:"
             tabindex="0"
             type="text"
             value=""
           />
           <span
-            id="aria-for-input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+            id="aria-for-input-with-examples-:ri:"
             style="display: none;"
           >
             Your answer should be 
@@ -312,7 +312,7 @@ exports[`numeric-input widget Should render tooltip when format option is given:
           class="perseus-widget-container widget-nohighlight widget-inline-block"
         >
           <input
-            aria-describedby="aria-for-input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+            aria-describedby="aria-for-input-with-examples-:r9:"
             aria-disabled="false"
             aria-invalid="false"
             aria-required="false"
@@ -320,13 +320,13 @@ exports[`numeric-input widget Should render tooltip when format option is given:
             autocomplete="off"
             autocorrect="off"
             class="input_1ck1z8k-o_O-LabelMedium_1rew30o-o_O-default_1tc7wjm-o_O-defaultFocus_lrnqlz-o_O-inputWithExamples_1y6ajxo"
-            id="input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+            id=":r9:"
             tabindex="0"
             type="text"
             value=""
           />
           <span
-            id="aria-for-input-with-examples-bnVtZXJpYy1pbnB1dCAx"
+            id="aria-for-input-with-examples-:r9:"
             style="display: none;"
           >
             Your answer should be 

--- a/packages/perseus/src/widgets/numeric-input/input-with-examples.tsx
+++ b/packages/perseus/src/widgets/numeric-input/input-with-examples.tsx
@@ -1,7 +1,7 @@
 import * as PerseusLinter from "@khanacademy/perseus-linter";
 import Tooltip, {TooltipContent} from "@khanacademy/wonder-blocks-tooltip";
 import * as React from "react";
-import {forwardRef, useImperativeHandle} from "react";
+import {forwardRef, useId, useImperativeHandle} from "react";
 import _ from "underscore";
 
 import {PerseusI18nContext} from "../../components/i18n-context";
@@ -60,6 +60,7 @@ const InputWithExamples = forwardRef<
     const context = React.useContext(PerseusI18nContext);
     const inputRef = React.useRef<TextInput>(null);
     const [inputFocused, setInputFocused] = React.useState<boolean>(false);
+    const id = useId();
 
     useImperativeHandle(ref, () => ({
         current: inputRef.current,
@@ -75,11 +76,7 @@ const InputWithExamples = forwardRef<
         },
     }));
 
-    const _getUniqueId = () => {
-        return `input-with-examples-${btoa(props.id).replace(/=/g, "")}`;
-    };
-
-    const _getInputClassName = () => {
+    const getInputClassName = () => {
         let inputClassName = ApiClassNames.INPUT;
         if (inputFocused) {
             inputClassName += " " + ApiClassNames.FOCUSED;
@@ -90,9 +87,22 @@ const InputWithExamples = forwardRef<
         return inputClassName;
     };
 
-    const _renderInput = () => {
-        const id = _getUniqueId();
-        const ariaId = `aria-for-${id}`;
+    const handleFocus = () => {
+        onFocus();
+        setInputFocused(true);
+    };
+
+    const handleBlur = () => {
+        onBlur();
+        setInputFocused(false);
+    };
+
+    const getUniqueId = () => {
+        return `input-with-examples-${id}`;
+    };
+
+    const renderInput = () => {
+        const ariaId = `aria-for-${getUniqueId()}`;
 
         // Generate the provided examples in simple language for screen readers.
         const examplesAria = props.shouldShowExamples
@@ -110,11 +120,11 @@ const InputWithExamples = forwardRef<
             // If we have examples, we want to provide the aria-describedby attribute
             "aria-describedby": props.shouldShowExamples ? ariaId : undefined,
             ref: inputRef,
-            className: _getInputClassName(),
+            className: getInputClassName(),
             labelText: props.labelText,
             value: props.value,
-            onFocus: _handleFocus,
-            onBlur: _handleBlur,
+            onFocus: handleFocus,
+            onBlur: handleBlur,
             disabled: disabled,
             style: props.style,
             onChange: props.onChange,
@@ -134,23 +144,10 @@ const InputWithExamples = forwardRef<
         );
     };
 
-    const _handleFocus = () => {
-        onFocus();
-        setInputFocused(true);
-    };
-
-    const _handleBlur = () => {
-        onBlur();
-        setInputFocused(false);
-    };
-
-    const getTooltipContent = () => {
+    const renderTooltipContent = () => {
         return (
             <TooltipContent>
-                <div
-                    id={_getUniqueId()}
-                    className="input-with-examples-tooltip"
-                >
+                <div id={id} className="input-with-examples-tooltip">
                     <Renderer
                         content={examplesContent}
                         linterContext={PerseusLinter.pushContextStack(
@@ -181,11 +178,11 @@ const InputWithExamples = forwardRef<
 
     return (
         <Tooltip
-            content={getTooltipContent()}
+            content={renderTooltipContent()}
             opened={showExamplesTooltip}
             placement="bottom"
         >
-            {_renderInput()}
+            {renderInput()}
         </Tooltip>
     );
 });

--- a/packages/perseus/src/widgets/numeric-input/input-with-examples.tsx
+++ b/packages/perseus/src/widgets/numeric-input/input-with-examples.tsx
@@ -61,6 +61,7 @@ const InputWithExamples = forwardRef<
     const inputRef = React.useRef<TextInput>(null);
     const [inputFocused, setInputFocused] = React.useState<boolean>(false);
     const id = useId();
+    const ariaId = `aria-for-${id}`;
 
     useImperativeHandle(ref, () => ({
         current: inputRef.current,
@@ -97,13 +98,7 @@ const InputWithExamples = forwardRef<
         setInputFocused(false);
     };
 
-    const getUniqueId = () => {
-        return `input-with-examples-${id}`;
-    };
-
     const renderInput = () => {
-        const ariaId = `aria-for-${getUniqueId()}`;
-
         // Generate the provided examples in simple language for screen readers.
         const examplesAria = props.shouldShowExamples
             ? `${props.examples[0]}

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.class.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.class.tsx
@@ -22,7 +22,6 @@ import type {
     PerseusNumericInputUserInput,
 } from "@khanacademy/perseus-score";
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
-import type {RefObject} from "react";
 
 type ExternalProps = WidgetProps<
     PerseusNumericInputWidgetOptions,
@@ -40,15 +39,25 @@ export type NumericInputProps = ExternalProps & {
     currentValue: string;
 };
 
-type DefaultProps = {
-    currentValue: NumericInputProps["currentValue"];
-    size: NumericInputProps["size"];
-    rightAlign: NumericInputProps["rightAlign"];
-    apiOptions: NumericInputProps["apiOptions"];
-    coefficient: NumericInputProps["coefficient"];
-    answerForms: NumericInputProps["answerForms"];
-    labelText: NumericInputProps["labelText"];
-    linterContext: NumericInputProps["linterContext"];
+type DefaultProps = Pick<
+    NumericInputProps,
+    | "currentValue"
+    | "size"
+    | "rightAlign"
+    | "apiOptions"
+    | "coefficient"
+    | "answerForms"
+    | "labelText"
+    | "linterContext"
+>;
+
+type RenderProps = {
+    answerForms: ReadonlyArray<PerseusNumericInputAnswerForm>;
+    labelText?: string;
+    size: string;
+    coefficient: boolean;
+    rightAlign?: boolean;
+    static: boolean;
 };
 
 // Assert that the PerseusNumericInputWidgetOptions parsed from JSON can be passed
@@ -74,7 +83,7 @@ export class NumericInput
     extends React.Component<NumericInputProps>
     implements Widget
 {
-    inputRef: RefObject<SimpleKeypadInput | typeof InputWithExamples>;
+    inputRef = React.createRef<SimpleKeypadInput | typeof InputWithExamples>();
 
     static defaultProps: DefaultProps = {
         currentValue: "",
@@ -93,15 +102,6 @@ export class NumericInput
         return {
             currentValue: props.currentValue,
         };
-    }
-
-    constructor(props: NumericInputProps) {
-        super(props);
-        // Create a ref that we can pass down to the input component so that we
-        // can call focus on it when necessary.
-        this.inputRef = React.createRef<
-            SimpleKeypadInput | typeof InputWithExamples
-        >();
     }
 
     focus: () => boolean = () => {
@@ -154,16 +154,6 @@ export class NumericInput
         return <NumericInputComponent {...this.props} ref={this.inputRef} />;
     }
 }
-
-type RenderProps = {
-    answerForms: ReadonlyArray<PerseusNumericInputAnswerForm>;
-    labelText?: string;
-    size: string;
-    coefficient: boolean;
-    rightAlign?: boolean;
-    static: boolean;
-};
-
 // Transforms the widget options to the props used to render the widget.
 const propsTransform = function (
     widgetOptions: PerseusNumericInputWidgetOptions,

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.stories.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.stories.tsx
@@ -57,17 +57,18 @@ const meta: Meta<typeof NumericInput> = {
                 value: 1252,
                 simplify: "required",
                 message: "",
+                // We're including all the answer forms to make it easier to edit in storybook.
+                // Note: that setting all of the answer forms results in the example tooltip being hidden,
+                // which mimics our default behaviour for the widget.
+                answerForms: [
+                    "decimal",
+                    "integer",
+                    "mixed",
+                    "pi",
+                    "proper",
+                    "improper",
+                ],
             },
-        ],
-        // We're including all the answer forms to make it easier to edit in storybook.
-        answerForms: [
-            {simplify: "required", name: "decimal"},
-            {simplify: "required", name: "integer"},
-            {simplify: "required", name: "mixed"},
-            {simplify: "required", name: "percent"},
-            {simplify: "required", name: "pi"},
-            {simplify: "required", name: "proper"},
-            {simplify: "required", name: "improper"},
         ],
     },
     argTypes: {

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
@@ -189,10 +189,10 @@ describe("numeric-input widget", () => {
         const fractionsContainer = renderQuestion(
             questionWithFormatOptions,
         ).container;
-        // eslint-disable-next-line testing-library/no-node-access
-        const fractionTextContainer = fractionsContainer.querySelector(
-            "[id*='aria-for-input-with-examples-']",
-        );
+
+        const fractionTextContainer =
+            // eslint-disable-next-line testing-library/no-node-access
+            fractionsContainer.querySelector("[id*='aria-for-']");
 
         // Assert
         expect(fractionTextContainer).toHaveTextContent(
@@ -212,10 +212,10 @@ describe("numeric-input widget", () => {
         const othersContainer = renderQuestion(
             questionWithFormatOptions,
         ).container;
-        // eslint-disable-next-line testing-library/no-node-access
-        const othersTextContainer = othersContainer.querySelector(
-            "[id*='aria-for-input-with-examples-']",
-        );
+
+        const othersTextContainer =
+            // eslint-disable-next-line testing-library/no-node-access
+            othersContainer.querySelector("[id*='aria-for-']");
 
         // Assert
         expect(othersTextContainer).toHaveTextContent("an integer");

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.testdata.ts
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.testdata.ts
@@ -10,10 +10,6 @@ export const question1: PerseusRenderer = {
     widgets: {
         "numeric-input 1": {
             graded: true,
-            version: {
-                major: 0,
-                minor: 0,
-            },
             static: false,
             type: "numeric-input",
             options: {
@@ -32,7 +28,6 @@ export const question1: PerseusRenderer = {
                 labelText: "",
                 size: "normal",
             },
-            alignment: "default",
         } as NumericInputWidget,
     },
 };
@@ -44,10 +39,6 @@ export const defaultQuestion: PerseusRenderer = {
     widgets: {
         "numeric-input 1": {
             graded: true,
-            version: {
-                major: 0,
-                minor: 0,
-            },
             static: false,
             type: "numeric-input",
             options: {
@@ -84,7 +75,6 @@ export const defaultQuestion: PerseusRenderer = {
                 labelText: "",
                 size: "normal",
             },
-            alignment: "default",
         } as NumericInputWidget,
     },
 };
@@ -96,10 +86,6 @@ export const decimalProblem: PerseusRenderer = {
     widgets: {
         "numeric-input 1": {
             graded: true,
-            version: {
-                major: 0,
-                minor: 0,
-            },
             static: false,
             type: "numeric-input",
             options: {
@@ -125,7 +111,6 @@ export const decimalProblem: PerseusRenderer = {
                     },
                 ],
             },
-            alignment: "default",
         } as NumericInputWidget,
     },
 };
@@ -137,10 +122,6 @@ export const integerProblem: PerseusRenderer = {
     widgets: {
         "numeric-input 1": {
             graded: true,
-            version: {
-                major: 0,
-                minor: 0,
-            },
             static: false,
             type: "numeric-input",
             options: {
@@ -166,7 +147,6 @@ export const integerProblem: PerseusRenderer = {
                     },
                 ],
             },
-            alignment: "default",
         } as NumericInputWidget,
     },
 };
@@ -178,10 +158,6 @@ export const improperProblem: PerseusRenderer = {
     widgets: {
         "numeric-input 1": {
             graded: true,
-            version: {
-                major: 0,
-                minor: 0,
-            },
             static: false,
             type: "numeric-input",
             options: {
@@ -207,7 +183,6 @@ export const improperProblem: PerseusRenderer = {
                     },
                 ],
             },
-            alignment: "default",
         } as NumericInputWidget,
     },
 };
@@ -220,10 +195,6 @@ export const piProblem: PerseusRenderer = {
     widgets: {
         "numeric-input 1": {
             graded: true,
-            version: {
-                major: 0,
-                minor: 0,
-            },
             static: false,
             type: "numeric-input",
             options: {
@@ -249,7 +220,6 @@ export const piProblem: PerseusRenderer = {
                     },
                 ],
             },
-            alignment: "default",
         } as NumericInputWidget,
     },
 };
@@ -290,7 +260,6 @@ export const mixedProblem: PerseusRenderer = {
                     },
                 ],
             },
-            alignment: "default",
         } as NumericInputWidget,
     },
 };
@@ -302,10 +271,6 @@ export const properProblem: PerseusRenderer = {
     widgets: {
         "numeric-input 1": {
             graded: true,
-            version: {
-                major: 0,
-                minor: 0,
-            },
             static: false,
             type: "numeric-input",
             options: {
@@ -331,7 +296,6 @@ export const properProblem: PerseusRenderer = {
                     },
                 ],
             },
-            alignment: "default",
         } as NumericInputWidget,
     },
 };
@@ -343,10 +307,6 @@ export const percentageProblem: PerseusRenderer = {
         // @ts-expect-error - TS2352 - Conversion of type '{ graded: true; version: { major: number; minor: number; }; static: false; type: "numeric-input"; options: { coefficient: false; static: false; answers: { status: string; maxError: null; strict: false; value: string; simplify: string; message: string; }[]; labelText: string; size: string; }; alignment: string; }' to type 'NumericInputWidget' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
         "numeric-input 1": {
             graded: true,
-            version: {
-                major: 0,
-                minor: 0,
-            },
             static: false,
             type: "numeric-input",
             options: {
@@ -365,7 +325,6 @@ export const percentageProblem: PerseusRenderer = {
                 labelText: "What's the answer?",
                 size: "normal",
             },
-            alignment: "default",
         } as NumericInputWidget,
     },
 };
@@ -376,10 +335,6 @@ export const multipleAnswers: PerseusRenderer = {
     widgets: {
         "numeric-input 1": {
             graded: true,
-            version: {
-                major: 0,
-                minor: 0,
-            },
             static: false,
             type: "numeric-input",
             options: {
@@ -406,7 +361,6 @@ export const multipleAnswers: PerseusRenderer = {
                 labelText: "What's the answer?",
                 size: "normal",
             },
-            alignment: "default",
         } as NumericInputWidget,
     },
 };
@@ -417,10 +371,6 @@ export const correctAndWrongAnswers: PerseusRenderer = {
     widgets: {
         "numeric-input 1": {
             graded: true,
-            version: {
-                major: 0,
-                minor: 0,
-            },
             static: false,
             type: "numeric-input",
             options: {
@@ -449,7 +399,6 @@ export const correctAndWrongAnswers: PerseusRenderer = {
                 labelText: "What's the answer?",
                 size: "normal",
             },
-            alignment: "default",
         } as NumericInputWidget,
     },
 };
@@ -460,10 +409,6 @@ export const multipleAnswersWithDecimals: PerseusRenderer = {
     widgets: {
         "numeric-input 1": {
             graded: true,
-            version: {
-                major: 0,
-                minor: 0,
-            },
             static: false,
             type: "numeric-input",
             options: {
@@ -498,7 +443,6 @@ export const multipleAnswersWithDecimals: PerseusRenderer = {
                     },
                 ],
             },
-            alignment: "default",
         } as NumericInputWidget,
     },
 };
@@ -509,10 +453,6 @@ export const duplicatedAnswers: PerseusRenderer = {
     widgets: {
         "numeric-input 1": {
             graded: true,
-            version: {
-                major: 0,
-                minor: 0,
-            },
             static: false,
             type: "numeric-input",
             options: {
@@ -541,7 +481,6 @@ export const duplicatedAnswers: PerseusRenderer = {
                 labelText: "What's the answer?",
                 size: "normal",
             },
-            alignment: "default",
         } as NumericInputWidget,
     },
 };
@@ -552,10 +491,6 @@ export const withCoefficient: PerseusRenderer = {
     widgets: {
         "numeric-input 1": {
             graded: true,
-            version: {
-                major: 0,
-                minor: 0,
-            },
             static: false,
             type: "numeric-input",
             options: {
@@ -574,7 +509,6 @@ export const withCoefficient: PerseusRenderer = {
                 labelText: "What's the answer?",
                 size: "normal",
             },
-            alignment: "default",
         } as NumericInputWidget,
     },
 };

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.testdata.ts
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.testdata.ts
@@ -52,25 +52,18 @@ export const defaultQuestion: PerseusRenderer = {
                         value: 1252,
                         simplify: "required",
                         message: "",
-                        // We don't include proper as otherwise
-                        // the tooltip will hide the examples.
+                        // We're including all the answer forms to make it easier to edit in storybook.
+                        // Note: that setting all of the answer forms results in the example tooltip being hidden,
+                        // which mimics our default behaviour for the widget.
                         answerForms: [
                             "integer",
                             "mixed",
                             "improper",
+                            "proper",
                             "decimal",
                             "pi",
                         ],
                     },
-                ],
-                answerForms: [
-                    // We don't include proper as otherwise
-                    // the tooltip will hide the examples.
-                    {simplify: "required", name: "integer"},
-                    {simplify: "required", name: "mixed"},
-                    {simplify: "required", name: "improper"},
-                    {simplify: "required", name: "decimal"},
-                    {simplify: "required", name: "pi"},
                 ],
                 labelText: "",
                 size: "normal",
@@ -104,12 +97,6 @@ export const decimalProblem: PerseusRenderer = {
                 ],
                 labelText: "",
                 size: "normal",
-                answerForms: [
-                    {
-                        simplify: "required",
-                        name: "decimal",
-                    },
-                ],
             },
         } as NumericInputWidget,
     },
@@ -140,12 +127,6 @@ export const integerProblem: PerseusRenderer = {
                 ],
                 labelText: "",
                 size: "normal",
-                answerForms: [
-                    {
-                        simplify: "required",
-                        name: "integer",
-                    },
-                ],
             },
         } as NumericInputWidget,
     },
@@ -176,12 +157,6 @@ export const improperProblem: PerseusRenderer = {
                 ],
                 labelText: "",
                 size: "normal",
-                answerForms: [
-                    {
-                        simplify: "optional",
-                        name: "improper",
-                    },
-                ],
             },
         } as NumericInputWidget,
     },
@@ -213,12 +188,6 @@ export const piProblem: PerseusRenderer = {
                 ],
                 labelText: "",
                 size: "normal",
-                answerForms: [
-                    {
-                        simplify: "required",
-                        name: "pi",
-                    },
-                ],
             },
         } as NumericInputWidget,
     },
@@ -253,12 +222,6 @@ export const mixedProblem: PerseusRenderer = {
                 ],
                 labelText: "",
                 size: "normal",
-                answerForms: [
-                    {
-                        simplify: "optional",
-                        name: "mixed",
-                    },
-                ],
             },
         } as NumericInputWidget,
     },
@@ -289,12 +252,6 @@ export const properProblem: PerseusRenderer = {
                 ],
                 labelText: "",
                 size: "normal",
-                answerForms: [
-                    {
-                        simplify: "optional",
-                        name: "proper",
-                    },
-                ],
             },
         } as NumericInputWidget,
     },
@@ -436,12 +393,6 @@ export const multipleAnswersWithDecimals: PerseusRenderer = {
                 ],
                 labelText: "What's the answer?",
                 size: "normal",
-                answerforms: [
-                    {
-                        simplify: "required",
-                        name: "decimal",
-                    },
-                ],
             },
         } as NumericInputWidget,
     },

--- a/packages/perseus/src/widgets/numeric-input/utils.test.ts
+++ b/packages/perseus/src/widgets/numeric-input/utils.test.ts
@@ -132,7 +132,7 @@ describe("shouldShowExamples", () => {
         expect(result).toBe(false);
     });
 
-    it("returns false when no forms are accepted", () => {
+    it("returns false when no forms are provided", () => {
         // Arrange
         const answerForms = [];
 

--- a/packages/perseus/src/widgets/numeric-input/utils.ts
+++ b/packages/perseus/src/widgets/numeric-input/utils.ts
@@ -11,18 +11,18 @@ export const NumericExampleStrings: {
         strings: PerseusStrings,
     ) => string;
 } = {
-    integer: (form, strings: PerseusStrings) => strings.integerExample,
-    proper: (form, strings: PerseusStrings) =>
+    integer: (form, strings) => strings.integerExample,
+    proper: (form, strings) =>
         form.simplify === "optional"
             ? strings.properExample
             : strings.simplifiedProperExample,
-    improper: (form, strings: PerseusStrings) =>
+    improper: (form, strings) =>
         form.simplify === "optional"
             ? strings.improperExample
             : strings.simplifiedImproperExample,
-    mixed: (form, strings: PerseusStrings) => strings.mixedExample,
-    decimal: (form, strings: PerseusStrings) => strings.decimalExample,
-    pi: (form, strings: PerseusStrings) => strings.piExample,
+    mixed: (form, strings) => strings.mixedExample,
+    decimal: (form, strings) => strings.decimalExample,
+    pi: (form, strings) => strings.piExample,
 };
 
 /**


### PR DESCRIPTION
## Summary:
This is a little PR that addresses some additional feedback points from the Numeric Input Refactor. 

This includes:
- Using useId() for generating ids in InputWithExamples 
- Removing underscores from InputWithExamples after it was converted to a functional component as part of the Numeric Input Refactor work. 
- Removing unnecessary constructors 
- Rename of `getTooltipContent` to `renderTooltipContent`
- Moving RenderProps to top of file for numeric-input.class.tsx 
- Removing unnecessary data from test data 
- Updating test name in utils.test.ts 
- Simplifying types from `NumericExampleStrings` after they were moved into the util file. 
- Commenting the reason for the `ariaLabel` setting to `undefined`.
- New tests in answer-types

## Test plan:
- Tests Pass
- Manual testing in Storybook (Link to ZND here) 