### PR TITLE
Default nulls to +/-Infinity when parsing the domain of a locked function

### DIFF
--- a/.changeset/beige-spoons-shave.md
+++ b/.changeset/beige-spoons-shave.md
@@ -2,4 +2,4 @@
 "@khanacademy/perseus-core": patch
 ---
 
-Bugfix: Allow null values when parsing the domain of a locked function on an Interactive Graph widget. A null value for the upper or lower bound means infinity/unbounded.
+Bugfix: Allow null values when parsing the domain of a locked function on an Interactive Graph widget, converting them to +/-Infinity. Note that Infinity is serialized to JSON as `null`, so this preserves the existing persisted data format.

--- a/.changeset/beige-spoons-shave.md
+++ b/.changeset/beige-spoons-shave.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": patch
+---
+
+Bugfix: Allow null values when parsing the domain of a locked function on an Interactive Graph widget. A null value for the upper or lower bound means infinity/unbounded.

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -874,7 +874,7 @@ export type LockedFunctionType = {
     strokeStyle: LockedLineStyle;
     equation: string; // This is the user-defined equation (as it was typed)
     directionalAxis: "x" | "y";
-    domain?: [min: number | null, max: number | null];
+    domain: [min: number | null, max: number | null];
     labels?: LockedLabelType[];
     ariaLabel?: string;
 };

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -872,9 +872,20 @@ export type LockedFunctionType = {
     type: "function";
     color: LockedFigureColor;
     strokeStyle: LockedLineStyle;
-    equation: string; // This is the user-defined equation (as it was typed)
+    /**
+     * This is the user-defined equation (as it was typed)
+     */
+    equation: string;
+    /**
+     * The independent variable of this function
+     */
     directionalAxis: "x" | "y";
-    domain: [min: number | null, max: number | null];
+    /**
+     * The minimum and maximum values along the `directionalAxis` at which
+     * this function should be graphed. Values of -Infinity and Infinity are
+     * allowed. Note that infinite values are serialized as `null` in JSON.
+     */
+    domain: [min: number, max: number];
     labels?: LockedLabelType[];
     ariaLabel?: string;
 };

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.test.ts
@@ -1,0 +1,47 @@
+import {anyFailure} from "../general-purpose-parsers/test-helpers";
+import {parse} from "../parse";
+import {success} from "../result";
+
+import {parseLockedFunctionDomain} from "./interactive-graph-widget";
+
+describe("parseLockedFunctionDomain", () => {
+    it("preserves finite numbers", () => {
+        const result = parse([-7, 42], parseLockedFunctionDomain);
+        expect(result).toEqual(success([-7, 42]));
+    });
+
+    it("rejects arrays with too many elements", () => {
+        const result = parse([1, 2, 3], parseLockedFunctionDomain);
+        expect(result).toEqual(anyFailure);
+    });
+
+    it("rejects arrays with too few elements", () => {
+        const result = parse([1], parseLockedFunctionDomain);
+        expect(result).toEqual(anyFailure);
+    });
+
+    it("defaults undefined to an unbounded domain [-Infinity, Infinity]", () => {
+        const result = parse(undefined, parseLockedFunctionDomain);
+        expect(result).toEqual(success([-Infinity, Infinity]));
+    });
+
+    it("defaults null to an unbounded domain [-Infinity, Infinity]", () => {
+        const result = parse(null, parseLockedFunctionDomain);
+        expect(result).toEqual(success([-Infinity, Infinity]));
+    });
+
+    it("converts a null minimum value to -Infinity", () => {
+        const result = parse([null, 0], parseLockedFunctionDomain);
+        expect(result).toEqual(success([-Infinity, 0]));
+    });
+
+    it("converts a null maximum value to Infinity", () => {
+        const result = parse([0, null], parseLockedFunctionDomain);
+        expect(result).toEqual(success([0, Infinity]));
+    });
+
+    it("defaults the min and max if both are null", () => {
+        const result = parse([null, null], parseLockedFunctionDomain);
+        expect(result).toEqual(success([-Infinity, Infinity]));
+    });
+});

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -253,16 +253,22 @@ const parseLockedPolygonType: Parser<LockedPolygonType> = object({
     ariaLabel: optional(string),
 });
 
+// Exported for testing.
+export const parseLockedFunctionDomain = defaulted(
+    pair(
+        defaulted(number, () => -Infinity),
+        defaulted(number, () => Infinity),
+    ),
+    (): [number, number] => [-Infinity, Infinity],
+);
+
 const parseLockedFunctionType: Parser<LockedFunctionType> = object({
     type: constant("function"),
     color: parseLockedFigureColor,
     strokeStyle: parseLockedLineStyle,
     equation: string,
     directionalAxis: enumeration("x", "y"),
-    domain: defaulted(
-        pair(nullable(number), nullable(number)),
-        (): [null, null] => [null, null],
-    ),
+    domain: parseLockedFunctionDomain,
     // TODO(benchristel): default labels to empty array?
     labels: optional(array(parseLockedLabelType)),
     ariaLabel: optional(string),

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -259,7 +259,8 @@ const parseLockedFunctionType: Parser<LockedFunctionType> = object({
     strokeStyle: parseLockedLineStyle,
     equation: string,
     directionalAxis: enumeration("x", "y"),
-    domain: optional(pairOfNumbers),
+    // TODO(benchristel): default domain to [null, null]?
+    domain: optional(pair(nullable(number), nullable(number))),
     // TODO(benchristel): default labels to empty array?
     labels: optional(array(parseLockedLabelType)),
     ariaLabel: optional(string),

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -259,8 +259,10 @@ const parseLockedFunctionType: Parser<LockedFunctionType> = object({
     strokeStyle: parseLockedLineStyle,
     equation: string,
     directionalAxis: enumeration("x", "y"),
-    // TODO(benchristel): default domain to [null, null]?
-    domain: optional(pair(nullable(number), nullable(number))),
+    domain: defaulted(
+        pair(nullable(number), nullable(number)),
+        () => [null, null] as [null, null],
+    ),
     // TODO(benchristel): default labels to empty array?
     labels: optional(array(parseLockedLabelType)),
     ariaLabel: optional(string),

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -261,7 +261,7 @@ const parseLockedFunctionType: Parser<LockedFunctionType> = object({
     directionalAxis: enumeration("x", "y"),
     domain: defaulted(
         pair(nullable(number), nullable(number)),
-        () => [null, null] as [null, null],
+        (): [null, null] => [null, null],
     ),
     // TODO(benchristel): default labels to empty array?
     labels: optional(array(parseLockedLabelType)),

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
@@ -3771,8 +3771,8 @@ exports[`parseAndMigratePerseusItem given interactive-graph-locked-function-with
               "color": "grayH",
               "directionalAxis": "x",
               "domain": [
-                null,
-                null,
+                -Infinity,
+                Infinity,
               ],
               "equation": "x^2",
               "strokeStyle": "solid",

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
@@ -3724,6 +3724,92 @@ $3$ | $8$
 }
 `;
 
+exports[`parseAndMigratePerseusItem given interactive-graph-locked-function-with-null-domain-element.json returns the same result as before 1`] = `
+{
+  "answerArea": {
+    "calculator": false,
+    "chi2Table": false,
+    "financialCalculatorMonthlyPayment": false,
+    "financialCalculatorTimeToPayOff": false,
+    "financialCalculatorTotalAmount": false,
+    "periodicTable": false,
+    "periodicTableWithKey": false,
+    "tTable": false,
+    "zTable": false,
+  },
+  "hints": [],
+  "itemDataVersion": {
+    "major": 0,
+    "minor": 1,
+  },
+  "question": {
+    "content": "[[☃ interactive-graph 1]]
+
+",
+    "images": {},
+    "widgets": {
+      "interactive-graph 1": {
+        "alignment": "default",
+        "graded": true,
+        "options": {
+          "backgroundImage": {
+            "url": null,
+          },
+          "correct": {
+            "coords": null,
+            "type": "linear",
+          },
+          "graph": {
+            "type": "linear",
+          },
+          "labels": [
+            "x",
+            "y",
+          ],
+          "lockedFigures": [
+            {
+              "color": "grayH",
+              "directionalAxis": "x",
+              "domain": [
+                null,
+                null,
+              ],
+              "equation": "x^2",
+              "strokeStyle": "solid",
+              "type": "function",
+            },
+          ],
+          "markings": "graph",
+          "range": [
+            [
+              -10,
+              10,
+            ],
+            [
+              -10,
+              10,
+            ],
+          ],
+          "showProtractor": false,
+          "showTooltips": false,
+          "step": [
+            1,
+            1,
+          ],
+          "valid": true,
+        },
+        "static": false,
+        "type": "interactive-graph",
+        "version": {
+          "major": 0,
+          "minor": 0,
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`parseAndMigratePerseusItem given interactive-graph-locked-line-missing-showPoint1.json returns the same result as before 1`] = `
 {
   "answerArea": {

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/interactive-graph-locked-function-with-null-domain-element.json
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/interactive-graph-locked-function-with-null-domain-element.json
@@ -1,0 +1,81 @@
+{
+  "question": {
+    "content": "[[☃ interactive-graph 1]]\n\n",
+    "images": {},
+    "widgets": {
+      "interactive-graph 1": {
+        "options": {
+          "labels": [
+            "x",
+            "y"
+          ],
+          "range": [
+            [
+              -10,
+              10
+            ],
+            [
+              -10,
+              10
+            ]
+          ],
+          "step": [
+            1,
+            1
+          ],
+          "backgroundImage": {
+            "url": null
+          },
+          "markings": "graph",
+          "showTooltips": false,
+          "showProtractor": false,
+          "graph": {
+            "type": "linear"
+          },
+          "correct": {
+            "type": "linear",
+            "coords": null
+          },
+          "valid": true,
+          "lockedFigures": [
+            {
+              "type": "function",
+              "color": "grayH",
+              "strokeStyle": "solid",
+              "equation": "x^2",
+              "directionalAxis": "x",
+              "domain": [
+                null,
+                null
+              ]
+            }
+          ]
+        },
+        "type": "interactive-graph",
+        "version": {
+          "major": 0,
+          "minor": 0
+        },
+        "graded": true,
+        "alignment": "default",
+        "static": false
+      }
+    }
+  },
+  "answerArea": {
+    "calculator": false,
+    "chi2Table": false,
+    "financialCalculatorMonthlyPayment": false,
+    "financialCalculatorTotalAmount": false,
+    "financialCalculatorTimeToPayOff": false,
+    "periodicTable": false,
+    "periodicTableWithKey": false,
+    "tTable": false,
+    "zTable": false
+  },
+  "hints": [],
+  "itemDataVersion": {
+    "major": 0,
+    "minor": 1
+  }
+}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.test.tsx
@@ -92,38 +92,6 @@ describe("Locked Function Settings", () => {
             // eslint-disable-next-line testing-library/no-node-access
             .querySelector("input");
         expect(inputField?.value).toEqual("");
-
-        // Act (max domain not defined)
-        cleanup();
-        render(
-            <LockedFunctionSettings {...defaultProps} domain={[0, null]} />,
-            {
-                wrapper: RenderStateRoot,
-            },
-        );
-
-        // Assert
-        inputField = screen
-            .getByLabelText("domain max")
-            // eslint-disable-next-line testing-library/no-node-access
-            .querySelector("input");
-        expect(inputField?.value).toEqual("");
-
-        // Act (min domain not defined)
-        cleanup();
-        render(
-            <LockedFunctionSettings {...defaultProps} domain={[null, 0]} />,
-            {
-                wrapper: RenderStateRoot,
-            },
-        );
-
-        // Assert
-        inputField = screen
-            .getByText("domain min")
-            // eslint-disable-next-line testing-library/no-node-access
-            .querySelector("input");
-        expect(inputField?.value).toEqual("");
     });
 
     describe("Header interactions", () => {
@@ -819,32 +787,6 @@ describe("Locked Function Settings", () => {
                         ariaLabel={undefined}
                         onChangeProps={onChangeProps}
                         domain={[-Infinity, Infinity]}
-                    />,
-                    {wrapper: RenderStateRoot},
-                );
-
-                // Act
-                const autoGenButton = screen.getByRole("button", {
-                    name: "Auto-generate",
-                });
-                await userEvent.click(autoGenButton);
-
-                // Assert
-                expect(onChangeProps).toHaveBeenCalledWith({
-                    ariaLabel:
-                        "Function with equation y=x^2. Appearance solid gray.",
-                });
-            });
-
-            test("aria label does not auto-generate with domain when both values are null", async () => {
-                // Arrange
-                const onChangeProps = jest.fn();
-                render(
-                    <LockedFunctionSettings
-                        {...defaultProps}
-                        ariaLabel={undefined}
-                        onChangeProps={onChangeProps}
-                        domain={[null, null]}
                     />,
                     {wrapper: RenderStateRoot},
                 );

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.test.tsx
@@ -808,8 +808,6 @@ describe("Locked Function Settings", () => {
                 domainValue       | domainAria
                 ${[1, Infinity]}  | ${"1 to Infinity"}
                 ${[-Infinity, 2]} | ${"-Infinity to 2"}
-                ${[1, null]}      | ${"1 to Infinity"}
-                ${[null, 2]}      | ${"-Infinity to 2"}
             `(
                 "aria label auto-generates with partial domain info: $domainValue",
                 async ({domainValue, domainAria}) => {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.tsx
@@ -129,9 +129,7 @@ const LockedFunctionSettings = (props: Props) => {
         const newDomainEntries: [string, string] = [...domainEntries];
         newDomainEntries[limitIndex] = newValueString;
         setDomainEntries(newDomainEntries);
-        const newDomain: [min: number | null, max: number | null] = domain
-            ? [...domain]
-            : [-Infinity, Infinity];
+        const newDomain: [min: number, max: number] = [...domain];
 
         let newValue = parseFloat(newValueString);
         if (newValueString === "" && limitIndex === 0) {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.tsx
@@ -97,10 +97,8 @@ const LockedFunctionSettings = (props: Props) => {
 
         // Add the domain/range constraints to the aria label
         // if they are not the default values.
-        const domainMin = Number.isFinite(domain[0]) ? domain[0] : "-Infinity";
-        const domainMax = Number.isFinite(domain[1]) ? domain[1] : "Infinity";
         if (Number.isFinite(domain[0]) || Number.isFinite(domain[1])) {
-            str += `, domain from ${domainMin} to ${domainMax}`;
+            str += `, domain from ${domain[0]} to ${domain[1]}`;
         }
 
         const functionAppearance = generateLockedFigureAppearanceDescription(

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.tsx
@@ -70,8 +70,8 @@ const LockedFunctionSettings = (props: Props) => {
     // This variable is used when specifying the values of the input fields.
     const getDomainStringValues = (domain): [string, string] => {
         return [
-            domain && Number.isFinite(domain[0]) ? domain[0].toString() : "",
-            domain && Number.isFinite(domain[1]) ? domain[1].toString() : "",
+            Number.isFinite(domain[0]) ? domain[0].toString() : "",
+            Number.isFinite(domain[1]) ? domain[1].toString() : "",
         ];
     };
 
@@ -97,14 +97,9 @@ const LockedFunctionSettings = (props: Props) => {
 
         // Add the domain/range constraints to the aria label
         // if they are not the default values.
-        const domainMin =
-            domain && Number.isFinite(domain[0]) ? domain[0] : "-Infinity";
-        const domainMax =
-            domain && Number.isFinite(domain[1]) ? domain[1] : "Infinity";
-        if (
-            domain &&
-            (Number.isFinite(domain[0]) || Number.isFinite(domain[1]))
-        ) {
+        const domainMin = Number.isFinite(domain[0]) ? domain[0] : "-Infinity";
+        const domainMax = Number.isFinite(domain[1]) ? domain[1] : "Infinity";
+        if (Number.isFinite(domain[0]) || Number.isFinite(domain[1])) {
             str += `, domain from ${domainMin} to ${domainMax}`;
         }
 

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.test.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.test.ts
@@ -98,6 +98,7 @@ describe("getDefaultFigureForType", () => {
             strokeStyle: "solid",
             equation: "x^2",
             directionalAxis: "x",
+            domain: [-Infinity, Infinity],
         });
     });
 

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.ts
@@ -89,7 +89,7 @@ export function getDefaultFigureForType(type: LockedFigureType): LockedFigure {
                 color: DEFAULT_COLOR,
                 strokeStyle: "solid",
                 equation: "x^2",
-                domain: [null, null],
+                domain: [-Infinity, Infinity],
                 directionalAxis: "x",
             };
         case "label":

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.ts
@@ -89,6 +89,7 @@ export function getDefaultFigureForType(type: LockedFigureType): LockedFigure {
                 color: DEFAULT_COLOR,
                 strokeStyle: "solid",
                 equation: "x^2",
+                domain: [null, null],
                 directionalAxis: "x",
             };
         case "label":

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
@@ -1247,6 +1247,7 @@ describe("InteractiveGraphQuestionBuilder", () => {
                 color: "grayH",
                 strokeStyle: "solid",
                 directionalAxis: "x",
+                domain: [-Infinity, Infinity],
             },
         ]);
     });
@@ -1301,6 +1302,7 @@ describe("InteractiveGraphQuestionBuilder", () => {
                 color: "grayH",
                 strokeStyle: "solid",
                 directionalAxis: "x",
+                domain: [-Infinity, Infinity],
                 labels: [
                     {
                         type: "label",

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -24,7 +24,7 @@ export type LockedFunctionOptions = {
     color?: LockedFigureColor;
     strokeStyle?: LockedLineStyle;
     directionalAxis?: "x" | "y";
-    domain?: [min: number | null, max: number | null];
+    domain?: [min: number, max: number];
     labels?: LockedFigureLabelOptions[];
     ariaLabel?: string;
 };
@@ -450,7 +450,7 @@ class InteractiveGraphQuestionBuilder {
             color: "grayH",
             strokeStyle: "solid",
             directionalAxis: "x",
-            domain: [null, null],
+            domain: [-Infinity, Infinity],
             ...options,
             labels: options?.labels?.map(
                 (label) =>

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -450,6 +450,7 @@ class InteractiveGraphQuestionBuilder {
             color: "grayH",
             strokeStyle: "solid",
             directionalAxis: "x",
+            domain: [null, null],
             ...options,
             labels: options?.labels?.map(
                 (label) =>

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
@@ -1062,15 +1062,6 @@ describe("Interactive Graph", function () {
         });
 
         describe("Locked Functions", () => {
-            // const domain = (
-            //     min: number | null,
-            //     max: number | null,
-            // ): [number | null, number | null] => {
-            //     return [min, max];
-            // };
-
-            // type domain = [min: number | null, max: number | null];
-
             it("should NOT render when an invalid equation is specified", () => {
                 // Arrange
                 const {container} = renderQuestion(

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
@@ -1169,41 +1169,6 @@ describe("Interactive Graph", function () {
                 );
             });
 
-            it.each`
-                domainSupplied                                            | domainExpected
-                ${[-2, null] as [min: number | null, max: number | null]} | ${[-2, Infinity]}
-                ${[null, 3] as [min: number | null, max: number | null]}  | ${[-Infinity, 3]}
-            `(
-                "plots the equation with partially supplied domain: $domainSupplied",
-                ({domainSupplied, domainExpected}) => {
-                    // Arrange
-                    const PlotOfXMock = jest
-                        .spyOn(Plot, "OfX")
-                        .mockReturnValue(<div>OfX</div>);
-                    const expectedParameters = {
-                        color: "#3B3D45",
-                        style: "solid",
-                    };
-
-                    // Act - no upper limit specified
-                    renderQuestion(
-                        segmentWithLockedFunction("x^2", {
-                            domain: domainSupplied,
-                        }),
-                        blankOptions,
-                    );
-
-                    // Assert
-                    expect(PlotOfXMock).toHaveBeenCalledWith(
-                        expect.objectContaining({
-                            ...expectedParameters,
-                            domain: domainExpected,
-                        }),
-                        {},
-                    );
-                },
-            );
-
             it("should render locked function with aria label when one is provided", () => {
                 // Arrange
                 const lockedFunctionWithAriaLabelQuestion =

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-function.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-function.tsx
@@ -16,16 +16,14 @@ const LockedFunction = (props: LockedFunctionType) => {
         React.Dispatch<React.SetStateAction<Equation | undefined>>,
     ] = useState();
     const {color, strokeStyle, directionalAxis} = props;
-    const domain: [min: number, max: number] | undefined = props.domain
-        ? [
-              Number.isFinite(props.domain[0])
-                  ? (props.domain[0] as number)
-                  : -Infinity,
-              Number.isFinite(props.domain[1])
-                  ? (props.domain[1] as number)
-                  : Infinity,
-          ]
-        : undefined;
+    const domain: [min: number, max: number] = [
+        Number.isFinite(props.domain[0])
+            ? (props.domain[0] as number)
+            : -Infinity,
+        Number.isFinite(props.domain[1])
+            ? (props.domain[1] as number)
+            : Infinity,
+    ];
     const plotProps = {
         color: lockedFigureColors[color],
         style: strokeStyle,

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-function.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-function.tsx
@@ -15,15 +15,7 @@ const LockedFunction = (props: LockedFunctionType) => {
         Equation | undefined,
         React.Dispatch<React.SetStateAction<Equation | undefined>>,
     ] = useState();
-    const {color, strokeStyle, directionalAxis} = props;
-    const domain: [min: number, max: number] = [
-        Number.isFinite(props.domain[0])
-            ? (props.domain[0] as number)
-            : -Infinity,
-        Number.isFinite(props.domain[1])
-            ? (props.domain[1] as number)
-            : Infinity,
-    ];
+    const {color, strokeStyle, directionalAxis, domain} = props;
     const plotProps = {
         color: lockedFigureColors[color],
         style: strokeStyle,


### PR DESCRIPTION
This fixes a Perseus JSON parser error observed in production. A null value for
in the JSON the upper or lower bound means infinity/unbounded, so we now convert nulls
to infinities during parsing. Note that the infinite values are converted back to
`null` when the JSON is serialized, so this preserves behavior.

Issue: none

## Test plan:

`pnpm test`

Verify that locked functions with a domain of `[null, null]` display correctly
by running `pnpm storybook` and visiting the [locked function docs page][1].

Test that when you edit the domain of a locked function the correct JSON is
generated, and the graph displays correctly.

[1]: http://localhost:6006/?path=/docs/perseus-widgets-interactive-graph-locked-functions--docs