### PR TITLE
[Interactive Graph] Polygon side snapping is keyboard accessible.

### DIFF
--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -179,7 +179,6 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
         showSides,
         range,
         snapTo = "grid",
-        coords,
     } = statefulProps.graphState;
     const {disableKeyboardInteraction} = graphConfig;
     const {strings, locale} = usePerseusI18n();
@@ -329,7 +328,7 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
                             point={point}
                             sequenceNumber={i + 1}
                             onMove={(destination: vec.Vector2) => {
-                                console.log("Movement!");
+                                //console.log("Movement!");
 
                                 const now = Date.now();
                                 const targetFPS = 40;

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -183,7 +183,6 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
         showSides,
         range,
         snapTo = "grid",
-        snapStep,
     } = statefulProps.graphState;
     const {disableKeyboardInteraction} = graphConfig;
     const {strings, locale} = usePerseusI18n();
@@ -332,12 +331,7 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
                             constrain={
                                 snapTo === "grid"
                                     ? constrain
-                                    : getSideSnapConstraint(
-                                          points,
-                                          i,
-                                          snapStep,
-                                          range,
-                                      )
+                                    : getSideSnapConstraint(points, i, range)
                             }
                             point={point}
                             sequenceNumber={i + 1}
@@ -699,7 +693,6 @@ function describePolygonGraph(
 export function getSideSnapConstraint(
     points: ReadonlyArray<Coord>,
     index: number,
-    snapStep: vec.Vector2,
     range: [Interval, Interval],
 ): {
     up: vec.Vector2;
@@ -734,7 +727,6 @@ export function getSideSnapConstraint(
                 destinationAttempt,
                 range,
                 newPoints,
-                snapStep,
                 index,
                 pointToBeMoved,
             );
@@ -749,21 +741,9 @@ export function getSideSnapConstraint(
     // Determine if we want to keep to align with snap steps or keep with
     // whole units.
     return {
-        up: movePointWithConstraint((coord) =>
-            //vec.add(coord, [0, snapStep[1]]),
-            vec.add(coord, [0, 1]),
-        ),
-        down: movePointWithConstraint((coord) =>
-            //vec.sub(coord, [0, snapStep[1]]),
-            vec.sub(coord, [0, 1]),
-        ),
-        left: movePointWithConstraint((coord) =>
-            //vec.sub(coord, [snapStep[0], 0]),
-            vec.sub(coord, [1, 0]),
-        ),
-        right: movePointWithConstraint((coord) =>
-            //vec.add(coord, [snapStep[0], 0]),
-            vec.add(coord, [1, 0]),
-        ),
+        up: movePointWithConstraint((coord) => vec.add(coord, [0, 1])),
+        down: movePointWithConstraint((coord) => vec.sub(coord, [0, 1])),
+        left: movePointWithConstraint((coord) => vec.sub(coord, [1, 0])),
+        right: movePointWithConstraint((coord) => vec.add(coord, [1, 0])),
     };
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -104,18 +104,6 @@ const PolygonGraph = (props: Props) => {
     const dragReferencePoint = points[0];
     const constrain: KeyboardMovementConstraint = (p) => snap(snapStep, p);
 
-    // switch (snapTo) {
-    //     case "sides":
-    //         // Values are BS, need to fix.
-    //         constrain = getSideSnapConstraint(snapStep, coords[0], 12);
-    //         break;
-    //     case "angles":
-    //     case "grid":
-    //     default:
-    //         constrain = (p) => snap(snapStep, p);
-    //         break;
-    // }
-
     const {dragging} = useDraggable({
         gestureTarget: polygonRef,
         point: dragReferencePoint,
@@ -356,8 +344,6 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
                             point={point}
                             sequenceNumber={i + 1}
                             onMove={(destination: vec.Vector2) => {
-                                //console.log("Movement!");
-
                                 const now = Date.now();
                                 const targetFPS = 40;
                                 const moveThresholdTime = 1000 / targetFPS;
@@ -744,15 +730,8 @@ export function getSideSnapConstraint(
         // The new point we're moving to.
         let newPoint = pointToBeMoved;
 
-        // Move the point
-        // Will need to tell it to stop if we're beyond the bounds.
-        // Initial thoughts, much better keyboard movement.
-        // Mouse movement is janky and flashing. Gross!!
-        // The aggressive janking is the fact that even the smallest
-        // Movement gets this function called again on mouse, and because it's
-        // the same point it tries to find another one. Dang it.
-        // Maybe there's a ways I can turn off this functionality if it's a keyboard
-        // vs a mouse user....
+        // Move the point and keep trying until we are at the boarder
+        // of the graph.
         while (
             newPoint[0] === pointToBeMoved[0] &&
             newPoint[1] === pointToBeMoved[1] &&
@@ -834,11 +813,10 @@ export function getSideSnapConstraint(
 
             newPoint = kvector.add(newPoints[rel(-1)], offset) as vec.Vector2;
 
-            // Set the initial destination attempt to the destination point.
+            // Increment the destinationAttempt.
             // For every time it does not work increment the direction for x and y.
             destinationAttempt = moveFunc(destinationAttempt);
         }
-
         return newPoint;
     };
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -746,18 +746,24 @@ export function getSideSnapConstraint(
         return newPoint;
     };
 
+    // Determine if we want to keep to align with snap steps or keep with
+    // whole units.
     return {
         up: movePointWithConstraint((coord) =>
-            vec.add(coord, [0, snapStep[1]]),
+            //vec.add(coord, [0, snapStep[1]]),
+            vec.add(coord, [0, 1]),
         ),
         down: movePointWithConstraint((coord) =>
-            vec.sub(coord, [0, snapStep[1]]),
+            //vec.sub(coord, [0, snapStep[1]]),
+            vec.sub(coord, [0, 1]),
         ),
         left: movePointWithConstraint((coord) =>
-            vec.sub(coord, [snapStep[0], 0]),
+            //vec.sub(coord, [snapStep[0], 0]),
+            vec.sub(coord, [1, 0]),
         ),
         right: movePointWithConstraint((coord) =>
-            vec.add(coord, [snapStep[0], 0]),
+            //vec.add(coord, [snapStep[0], 0]),
+            vec.add(coord, [1, 0]),
         ),
     };
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -74,7 +74,7 @@ type StatefulProps = MafsGraphProps<PolygonGraphState> & {
 
 const PolygonGraph = (props: Props) => {
     const {dispatch} = props;
-    const {numSides, coords, snapStep, snapTo = "grid"} = props.graphState;
+    const {numSides, coords, snapStep} = props.graphState;
     const graphConfig = useGraphConfig();
 
     // Ref to implement the dragging behavior on a Limited/Closed Polygon.
@@ -96,9 +96,7 @@ const PolygonGraph = (props: Props) => {
 
     // Logic to build the dragging experience. Primarily used by Limited Polygon.
     const dragReferencePoint = points[0];
-    const constrain = ["angles", "sides"].includes(snapTo)
-        ? (p) => p
-        : (p) => snap(snapStep, p);
+    const constrain = (p) => snap(snapStep, p);
 
     const {dragging} = useDraggable({
         gestureTarget: polygonRef,
@@ -181,6 +179,7 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
         showSides,
         range,
         snapTo = "grid",
+        coords,
     } = statefulProps.graphState;
     const {disableKeyboardInteraction} = graphConfig;
     const {strings, locale} = usePerseusI18n();
@@ -258,7 +257,7 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
                     return (
                         <TextLabel key={"side-" + i} x={x} y={y}>
                             {isApprox
-                                ? `≈ ${length.toFixed(snapTo === "sides" ? 0 : 1)}`
+                                ? `≈ ${length.toFixed(snapTo === "sides" ? 1 : 1)}`
                                 : length}
                         </TextLabel>
                     );
@@ -330,6 +329,9 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
                             point={point}
                             sequenceNumber={i + 1}
                             onMove={(destination: vec.Vector2) => {
+                                console.log(`current: ${coords[i]}`);
+                                console.log(`destination: ${destination}`);
+
                                 const now = Date.now();
                                 const targetFPS = 40;
                                 const moveThresholdTime = 1000 / targetFPS;

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -329,8 +329,7 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
                             point={point}
                             sequenceNumber={i + 1}
                             onMove={(destination: vec.Vector2) => {
-                                console.log(`current: ${coords[i]}`);
-                                console.log(`destination: ${destination}`);
+                                console.log("Movement!");
 
                                 const now = Date.now();
                                 const targetFPS = 40;

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -150,7 +150,7 @@ export const polygonQuestion: PerseusRenderer =
         .withGridStep(0.5, 0.5)
         .withSnapStep(0.25, 0.25)
         .withTickStep(0.5, 0.5)
-        .withMarkings("none")
+        .withMarkings("graph")
         .withXRange(-1, 6)
         .withYRange(-1, 6)
         .withPolygon("grid", {
@@ -217,7 +217,7 @@ export const polygonWithAnglesQuestion: PerseusRenderer =
         .withGridStep(0.5, 0.5)
         .withSnapStep(0.25, 0.25)
         .withTickStep(0.5, 0.5)
-        .withMarkings("none")
+        .withMarkings("graph")
         .withXRange(-1, 6)
         .withYRange(-1, 6)
         .withPolygon("grid", {
@@ -240,7 +240,7 @@ export const polygonWithAnglesAndAnglesSnapToQuestion: PerseusRenderer =
         .withGridStep(0.5, 0.5)
         .withSnapStep(0.25, 0.25)
         .withTickStep(0.5, 0.5)
-        .withMarkings("none")
+        .withMarkings("graph")
         .withXRange(-1, 6)
         .withYRange(-1, 6)
         .withPolygon("angles", {
@@ -302,7 +302,7 @@ export const polygonWithFourSidesSnappingQuestion: PerseusRenderer =
         .withGridStep(0.5, 0.5)
         .withSnapStep(0.25, 0.25)
         .withTickStep(0.5, 0.5)
-        .withMarkings("none")
+        .withMarkings("graph")
         .withXRange(-1, 6)
         .withYRange(-1, 6)
         .withPolygon("sides", {

--- a/packages/perseus/src/widgets/interactive-graphs/math/snap.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/snap.ts
@@ -12,3 +12,15 @@ export function snap(snapStep: vec.Vector2, point: vec.Vector2): vec.Vector2 {
         Math.round(requestedY / snapY) * snapY,
     ];
 }
+
+export function snapToSidesPolygonKeyboard(
+    snapStep: vec.Vector2,
+    point: vec.Vector2,
+): vec.Vector2 {
+    const [requestedX, requestedY] = point;
+    const [snapX, snapY] = snapStep;
+    return [
+        Math.round(requestedX / snapX) * snapX,
+        Math.round(requestedY / snapY) * snapY,
+    ];
+}

--- a/packages/perseus/src/widgets/interactive-graphs/math/snap.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/math/snap.ts
@@ -12,15 +12,3 @@ export function snap(snapStep: vec.Vector2, point: vec.Vector2): vec.Vector2 {
         Math.round(requestedY / snapY) * snapY,
     ];
 }
-
-export function snapToSidesPolygonKeyboard(
-    snapStep: vec.Vector2,
-    point: vec.Vector2,
-): vec.Vector2 {
-    const [requestedX, requestedY] = point;
-    const [snapX, snapY] = snapStep;
-    return [
-        Math.round(requestedX / snapX) * snapX,
-        Math.round(requestedY / snapY) * snapY,
-    ];
-}

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -1069,6 +1069,9 @@ function boundAndSnapToSides(
     index: number,
 ) {
     const startingPoint = coords[index];
+
+    // Needed to prevent updating the original coords before the checks for
+    // degenerate triangles and overlapping sides
     const coordsCopy = [...coords];
 
     return calculateSideSnap(
@@ -1085,17 +1088,17 @@ export function calculateSideSnap(
     destinationPoint: vec.Vector2,
     range: [Interval, Interval],
     coords: Coord[],
-    snapStep: vec.Vector2,
+    // undo underscore when determining if we want to keep this.
+    _snapStep: vec.Vector2,
     index: number,
     startingPoint: vec.Vector2,
 ) {
     // Takes the destination point and makes sure it is within the bounds of the graph
     coords[index] = bound({
-        snapStep: snapStep,
+        snapStep: [0, 0], //snapStep: snapStep,
         range,
         point: destinationPoint,
     });
-    //console.log(`bound: ${coordsCopy[index]}`);
 
     // Gets the relative index of a point
     const rel = (j): number => {
@@ -1117,8 +1120,9 @@ export function calculateSideSnap(
     _.each([0, 1], function (j) {
         // The snap length should be determined by the snapSteps to ensure
         // successful snapping for all graphs.
-        const lowestValue = Math.min(snapStep[0], snapStep[1]);
-        sides[j] = Math.round(sides[j] / lowestValue) * lowestValue;
+        //const lowestValue = Math.min(snapStep[0], snapStep[1]);
+        //sides[j] = Math.round(sides[j] / lowestValue) * lowestValue;
+        sides[j] = Math.round(sides[j]);
     });
 
     // Avoid degenerate triangles

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -1078,7 +1078,6 @@ function boundAndSnapToSides(
         destinationPoint,
         range,
         coordsCopy,
-        snapStep,
         index,
         startingPoint,
     ) as vec.Vector2;
@@ -1088,14 +1087,12 @@ export function calculateSideSnap(
     destinationPoint: vec.Vector2,
     range: [Interval, Interval],
     coords: Coord[],
-    // undo underscore when determining if we want to keep this.
-    _snapStep: vec.Vector2,
     index: number,
     startingPoint: vec.Vector2,
 ) {
     // Takes the destination point and makes sure it is within the bounds of the graph
     coords[index] = bound({
-        snapStep: [0, 0], //snapStep: snapStep,
+        snapStep: [0, 0],
         range,
         point: destinationPoint,
     });
@@ -1118,10 +1115,6 @@ export function calculateSideSnap(
 
     // Round the sides to left and right of the current point
     _.each([0, 1], function (j) {
-        // The snap length should be determined by the snapSteps to ensure
-        // successful snapping for all graphs.
-        //const lowestValue = Math.min(snapStep[0], snapStep[1]);
-        //sides[j] = Math.round(sides[j] / lowestValue) * lowestValue;
         sides[j] = Math.round(sides[j]);
     });
 

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -1061,7 +1061,11 @@ function boundAndSnapToPolygonAngle(
 
 function boundAndSnapToSides(
     destinationPoint: vec.Vector2,
-    {range, coords}: {range: [Interval, Interval]; coords: Coord[]},
+    {
+        range,
+        coords,
+        snapStep,
+    }: {range: [Interval, Interval]; coords: Coord[]; snapStep: vec.Vector2},
     index: number,
 ) {
     const startingPoint = coords[index];
@@ -1071,9 +1075,8 @@ function boundAndSnapToSides(
     const coordsCopy = [...coords];
 
     // Takes the destination point and makes sure it is within the bounds of the graph
-    // SnapStep is [0, 0] because we don't want to snap to the grid
     coordsCopy[index] = bound({
-        snapStep: [0, 0],
+        snapStep: snapStep,
         range,
         point: destinationPoint,
     });
@@ -1096,7 +1099,10 @@ function boundAndSnapToSides(
 
     // Round the sides to left and right of the current point
     _.each([0, 1], function (j) {
-        sides[j] = Math.round(sides[j]);
+        // The snap length should be determined by the snapSteps to ensure
+        // successful snapping for all graphs.
+        const lowestValue = Math.min(snapStep[0], snapStep[1]);
+        sides[j] = Math.round(sides[j] / lowestValue) * lowestValue;
     });
 
     // Avoid degenerate triangles

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -1061,7 +1061,11 @@ function boundAndSnapToPolygonAngle(
 
 function boundAndSnapToSides(
     destinationPoint: vec.Vector2,
-    {range, coords}: {range: [Interval, Interval]; coords: Coord[]},
+    {
+        range,
+        coords,
+        snapStep,
+    }: {range: [Interval, Interval]; coords: Coord[]; snapStep: vec.Vector2},
     index: number,
 ) {
     const startingPoint = coords[index];
@@ -1071,12 +1075,12 @@ function boundAndSnapToSides(
     const coordsCopy = [...coords];
 
     // Takes the destination point and makes sure it is within the bounds of the graph
-    // SnapStep is [0, 0] because we don't want to snap to the grid
     coordsCopy[index] = bound({
-        snapStep: [0, 0],
+        snapStep: snapStep,
         range,
         point: destinationPoint,
     });
+    console.log(`bound: ${coordsCopy[index]}`);
 
     // Gets the relative index of a point
     const rel = (j): number => {
@@ -1096,7 +1100,10 @@ function boundAndSnapToSides(
 
     // Round the sides to left and right of the current point
     _.each([0, 1], function (j) {
-        sides[j] = Math.round(sides[j]);
+        // The snap length should be determined by the snapSteps to ensure
+        // successful snapping for all graphs.
+        const lowestValue = Math.min(snapStep[0], snapStep[1]);
+        sides[j] = Math.round(sides[j] / lowestValue) * lowestValue;
     });
 
     // Avoid degenerate triangles

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -1094,7 +1094,7 @@ function boundAndSnapToSides(
         newPoint[1] === startingPoint[1] &&
         isInBound({range, point: destinationAttempt})
     ) {
-        console.log(`destination attempt: ${destinationAttempt}`);
+        //console.log(`destination attempt: ${destinationAttempt}`);
         // Needed to prevent updating the original coords before the checks for
         // degenerate triangles and overlapping sides
         const coordsCopy = [...coords];

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -11,7 +11,7 @@ import _ from "underscore";
 
 import {getArrayWithoutDuplicates} from "../graphs/utils";
 import {clamp, clampToBox, inset, snap, X, Y} from "../math";
-import {bound, isInBound, isUnlimitedGraphState} from "../utils";
+import {bound, isUnlimitedGraphState} from "../utils";
 
 import {initializeGraphState} from "./initialize-graph-state";
 import {
@@ -468,7 +468,7 @@ function doMovePoint(
             let newValue: vec.Vector2;
             if (state.snapTo === "sides") {
                 newValue = boundAndSnapToSides(
-                    boundAndSnapToGrid(action.destination, state),
+                    action.destination,
                     state,
                     action.index,
                 );
@@ -1061,123 +1061,80 @@ function boundAndSnapToPolygonAngle(
 
 function boundAndSnapToSides(
     destinationPoint: vec.Vector2,
-    {
-        range,
-        coords,
-        snapStep,
-    }: {range: [Interval, Interval]; coords: Coord[]; snapStep: vec.Vector2},
+    {range, coords}: {range: [Interval, Interval]; coords: Coord[]},
     index: number,
 ) {
     const startingPoint = coords[index];
 
-    // The direction the user is attempting to move the point in.
-    const direction: Coord = [
-        destinationPoint[0] - startingPoint[0],
-        destinationPoint[1] - startingPoint[1],
-    ];
-    let destinationAttempt: Coord = destinationPoint;
+    // Needed to prevent updating the original coords before the checks for
+    // degenerate triangles and overlapping sides
+    const coordsCopy = [...coords];
 
-    let newPoint = startingPoint;
+    // Takes the destination point and makes sure it is within the bounds of the graph
+    // SnapStep is [0, 0] because we don't want to snap to the grid
+    coordsCopy[index] = bound({
+        snapStep: [0, 0],
+        range,
+        point: destinationPoint,
+    });
 
-    // Will need to tell it to stop if we're beyond the bounds.
-    // Initial thoughts, much better keyboard movement.
-    // Mouse movement is janky and flashing. Gross!!
-    // The agressive janking is the fact that even the smallest
-    // Movement gets this function called again on mouse, and because it's
-    // the same point it tries to find another one. Dang it.
-    // Maybe there's a ways I can turn off this functionality if it's a keyboard
-    // vs a mouse user....
-    while (
-        newPoint[0] === startingPoint[0] &&
-        newPoint[1] === startingPoint[1] &&
-        isInBound({range, point: destinationAttempt})
+    // Gets the relative index of a point
+    const rel = (j): number => {
+        return (index + j + coordsCopy.length) % coordsCopy.length;
+    };
+    const sides = _.map(
+        [
+            [coordsCopy[rel(-1)], coordsCopy[index]],
+            [coordsCopy[index], coordsCopy[rel(1)]],
+            [coordsCopy[rel(-1)], coordsCopy[rel(1)]],
+        ],
+        function (coordsCopy) {
+            // @ts-expect-error - TS2345 - Argument of type 'number[]' is not assignable to parameter of type 'readonly Coord[]'. | TS2556 - A spread argument must either have a tuple type or be passed to a rest parameter.
+            return magnitude(vector(...coordsCopy));
+        },
+    );
+
+    // Round the sides to left and right of the current point
+    _.each([0, 1], function (j) {
+        sides[j] = Math.round(sides[j]);
+    });
+
+    // Avoid degenerate triangles
+    if (
+        leq(sides[1] + sides[2], sides[0]) ||
+        leq(sides[0] + sides[2], sides[1]) ||
+        leq(sides[0] + sides[1], sides[2])
     ) {
-        //console.log(`destination attempt: ${destinationAttempt}`);
-        // Needed to prevent updating the original coords before the checks for
-        // degenerate triangles and overlapping sides
-        const coordsCopy = [...coords];
-
-        // Takes the destination point and makes sure it is within the bounds of the graph
-        coordsCopy[index] = bound({
-            snapStep: snapStep,
-            range,
-            point: destinationAttempt,
-        });
-        //console.log(`bound: ${coordsCopy[index]}`);
-
-        // Gets the relative index of a point
-        const rel = (j): number => {
-            return (index + j + coordsCopy.length) % coordsCopy.length;
-        };
-        const sides = _.map(
-            [
-                [coordsCopy[rel(-1)], coordsCopy[index]],
-                [coordsCopy[index], coordsCopy[rel(1)]],
-                [coordsCopy[rel(-1)], coordsCopy[rel(1)]],
-            ],
-            function (coordsCopy) {
-                // @ts-expect-error - TS2345 - Argument of type 'number[]' is not assignable to parameter of type 'readonly Coord[]'. | TS2556 - A spread argument must either have a tuple type or be passed to a rest parameter.
-                return magnitude(vector(...coordsCopy));
-            },
-        );
-
-        // Round the sides to left and right of the current point
-        _.each([0, 1], function (j) {
-            // The snap length should be determined by the snapSteps to ensure
-            // successful snapping for all graphs.
-            const lowestValue = Math.min(snapStep[0], snapStep[1]);
-            sides[j] = Math.round(sides[j] / lowestValue) * lowestValue;
-        });
-
-        // Avoid degenerate triangles
-        if (
-            leq(sides[1] + sides[2], sides[0]) ||
-            leq(sides[0] + sides[2], sides[1]) ||
-            leq(sides[0] + sides[1], sides[2])
-        ) {
-            return startingPoint;
-        }
-
-        // Solve for angle by using the law of cosines
-        // Angle at the first vertex of the polygon
-        const innerAngle = lawOfCosines(sides[0], sides[2], sides[1]);
-
-        // Angle at the second vertex of the polygon
-        const outerAngle = getAngleFromVertex(
-            coordsCopy[rel(1)],
-            coordsCopy[rel(-1)],
-        );
-
-        // Returns true if the points form a counter-clockwise turn;
-        // a.k.a if the point is on the left or right of the polygon.
-        // This is used to determine how to adjust the point: if the point is on the left,
-        // we want to add the inner angle to the outer angle, and if it's on the right,
-        // we want to subtract the inner angle from the outer angle. The angle solved
-        // for is then used in the polar function to determine the new point.
-        const onLeft =
-            sign(
-                ccw(coordsCopy[rel(-1)], coordsCopy[rel(1)], coordsCopy[index]),
-            ) === 1;
-
-        // Uses the length of the first side of the polygon (radial coordinate)
-        // and the angle between the first and second sides of the
-        // polygon (angular coordinate) to determine how to adjust the point
-        const offset = polar(
-            sides[0],
-            outerAngle + (onLeft ? 1 : -1) * innerAngle,
-        );
-
-        newPoint = kvector.add(coordsCopy[rel(-1)], offset) as vec.Vector2;
-
-        // Set the initial destination attempt to the destination point.
-        // For every time it does not work increment the direction for x and y.
-        destinationAttempt = [
-            destinationAttempt[0] + direction[0],
-            destinationAttempt[1] + direction[1],
-        ];
+        return startingPoint;
     }
 
-    return newPoint;
+    // Solve for angle by using the law of cosines
+    // Angle at the first vertex of the polygon
+    const innerAngle = lawOfCosines(sides[0], sides[2], sides[1]);
+
+    // Angle at the second vertex of the polygon
+    const outerAngle = getAngleFromVertex(
+        coordsCopy[rel(1)],
+        coordsCopy[rel(-1)],
+    );
+
+    // Returns true if the points form a counter-clockwise turn;
+    // a.k.a if the point is on the left or right of the polygon.
+    // This is used to determine how to adjust the point: if the point is on the left,
+    // we want to add the inner angle to the outer angle, and if it's on the right,
+    // we want to subtract the inner angle from the outer angle. The angle solved
+    // for is then used in the polar function to determine the new point.
+    const onLeft =
+        sign(
+            ccw(coordsCopy[rel(-1)], coordsCopy[rel(1)], coordsCopy[index]),
+        ) === 1;
+
+    // Uses the length of the first side of the polygon (radial coordinate)
+    // and the angle between the first and second sides of the
+    // polygon (angular coordinate) to determine how to adjust the point
+    const offset = polar(sides[0], outerAngle + (onLeft ? 1 : -1) * innerAngle);
+
+    return kvector.add(coordsCopy[rel(-1)], offset) as vec.Vector2;
 }
 
 // Returns the vector from the given point to the top-right corner of the graph when snapped to the grid

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -1069,27 +1069,43 @@ function boundAndSnapToSides(
     index: number,
 ) {
     const startingPoint = coords[index];
-
-    // Needed to prevent updating the original coords before the checks for
-    // degenerate triangles and overlapping sides
     const coordsCopy = [...coords];
 
+    return calculateSideSnap(
+        destinationPoint,
+        range,
+        coordsCopy,
+        snapStep,
+        index,
+        startingPoint,
+    ) as vec.Vector2;
+}
+
+export function calculateSideSnap(
+    destinationPoint: vec.Vector2,
+    range: [Interval, Interval],
+    coords: Coord[],
+    snapStep: vec.Vector2,
+    index: number,
+    startingPoint: vec.Vector2,
+) {
     // Takes the destination point and makes sure it is within the bounds of the graph
-    coordsCopy[index] = bound({
+    coords[index] = bound({
         snapStep: snapStep,
         range,
         point: destinationPoint,
     });
+    //console.log(`bound: ${coordsCopy[index]}`);
 
     // Gets the relative index of a point
     const rel = (j): number => {
-        return (index + j + coordsCopy.length) % coordsCopy.length;
+        return (index + j + coords.length) % coords.length;
     };
     const sides = _.map(
         [
-            [coordsCopy[rel(-1)], coordsCopy[index]],
-            [coordsCopy[index], coordsCopy[rel(1)]],
-            [coordsCopy[rel(-1)], coordsCopy[rel(1)]],
+            [coords[rel(-1)], coords[index]],
+            [coords[index], coords[rel(1)]],
+            [coords[rel(-1)], coords[rel(1)]],
         ],
         function (coordsCopy) {
             // @ts-expect-error - TS2345 - Argument of type 'number[]' is not assignable to parameter of type 'readonly Coord[]'. | TS2556 - A spread argument must either have a tuple type or be passed to a rest parameter.
@@ -1119,10 +1135,7 @@ function boundAndSnapToSides(
     const innerAngle = lawOfCosines(sides[0], sides[2], sides[1]);
 
     // Angle at the second vertex of the polygon
-    const outerAngle = getAngleFromVertex(
-        coordsCopy[rel(1)],
-        coordsCopy[rel(-1)],
-    );
+    const outerAngle = getAngleFromVertex(coords[rel(1)], coords[rel(-1)]);
 
     // Returns true if the points form a counter-clockwise turn;
     // a.k.a if the point is on the left or right of the polygon.
@@ -1131,16 +1144,14 @@ function boundAndSnapToSides(
     // we want to subtract the inner angle from the outer angle. The angle solved
     // for is then used in the polar function to determine the new point.
     const onLeft =
-        sign(
-            ccw(coordsCopy[rel(-1)], coordsCopy[rel(1)], coordsCopy[index]),
-        ) === 1;
+        sign(ccw(coords[rel(-1)], coords[rel(1)], coords[index])) === 1;
 
     // Uses the length of the first side of the polygon (radial coordinate)
     // and the angle between the first and second sides of the
     // polygon (angular coordinate) to determine how to adjust the point
     const offset = polar(sides[0], outerAngle + (onLeft ? 1 : -1) * innerAngle);
 
-    return kvector.add(coordsCopy[rel(-1)], offset) as vec.Vector2;
+    return kvector.add(coords[rel(-1)], offset) as vec.Vector2;
 }
 
 // Returns the vector from the given point to the top-right corner of the graph when snapped to the grid

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -1,5 +1,3 @@
-import {start} from "repl";
-
 import {
     angles,
     coefficients,

--- a/packages/perseus/src/widgets/interactive-graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/utils.ts
@@ -66,6 +66,22 @@ export function bound({
     return clampToBox(boundingBox, point);
 }
 
+// Returns true if the point is within the bounds of the graph.
+export function isInBound({
+    range,
+    point,
+}: {
+    range: [Interval, Interval];
+    point: vec.Vector2;
+}): boolean {
+    return (
+        point[0] >= range[0][0] &&
+        point[0] <= range[0][1] &&
+        point[1] >= range[1][0] &&
+        point[1] <= range[1][1]
+    );
+}
+
 export function isUnlimitedGraphState(
     state: InteractiveGraphState,
 ): state is UnlimitedGraphState {


### PR DESCRIPTION
## Summary:
Updating Polygon interactive graph implementation to have keyboard accessible side snapping. This is done by hooking up the side snapping behavior into a constraint function to make to keyboard arrow keys.

Issue: LEMS-2243

## Test plan: