### PR TITLE
Add a basic FreeResponse widget

### DIFF
--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -131,6 +131,7 @@ export interface PerseusWidgetTypes {
     dropdown: DropdownWidget;
     explanation: ExplanationWidget;
     expression: ExpressionWidget;
+    "free-response": FreeResponseWidget;
     grapher: GrapherWidget;
     "graded-group-set": GradedGroupSetWidget;
     "graded-group": GradedGroupWidget;
@@ -336,6 +337,8 @@ export type DropdownWidget = WidgetOptions<'dropdown', PerseusDropdownWidgetOpti
 export type ExplanationWidget = WidgetOptions<'explanation', PerseusExplanationWidgetOptions>;
 // prettier-ignore
 export type ExpressionWidget = WidgetOptions<'expression', PerseusExpressionWidgetOptions>;
+// prettier-ignore
+export type FreeResponseWidget = WidgetOptions<'free-response', PerseusFreeResponseWidgetOptions>;
 // prettier-ignore
 export type GradedGroupSetWidget = WidgetOptions<'graded-group-set', PerseusGradedGroupSetWidgetOptions>;
 // prettier-ignore
@@ -1663,6 +1666,10 @@ export type PerseusPythonProgramWidgetOptions = {
     height: number;
 };
 
+export type PerseusFreeResponseWidgetOptions = {
+    question: string;
+};
+
 export type PerseusIFrameWidgetOptions = {
     // A URL to display OR a CS Program ID
     url: string;
@@ -1728,6 +1735,7 @@ export type PerseusWidgetOptions =
     | PerseusDropdownWidgetOptions
     | PerseusExplanationWidgetOptions
     | PerseusExpressionWidgetOptions
+    | PerseusFreeResponseWidgetOptions
     | PerseusGradedGroupSetWidgetOptions
     | PerseusGradedGroupWidgetOptions
     | PerseusIFrameWidgetOptions

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -60,6 +60,8 @@ export type {ExplanationDefaultWidgetOptions} from "./widgets/explanation";
 export {default as expressionLogic} from "./widgets/expression";
 export type {ExpressionDefaultWidgetOptions} from "./widgets/expression";
 export {default as gradedGroupLogic} from "./widgets/graded-group";
+export {default as freeResponseLogic} from "./widgets/free-response";
+export type {FreeResponseDefaultWidgetOptions} from "./widgets/free-response";
 export type {GradedGroupDefaultWidgetOptions} from "./widgets/graded-group";
 export {default as gradedGroupSetLogic} from "./widgets/graded-group-set";
 export type {GradedGroupSetDefaultWidgetOptions} from "./widgets/graded-group-set";

--- a/packages/perseus-core/src/widgets/free-response/index.ts
+++ b/packages/perseus-core/src/widgets/free-response/index.ts
@@ -1,0 +1,18 @@
+import type {PerseusFreeResponseWidgetOptions} from "../../data-schema";
+import type {WidgetLogic} from "../logic-export.types";
+
+export type FreeResponseDefaultWidgetOptions = Pick<
+    PerseusFreeResponseWidgetOptions,
+    "question"
+>;
+
+const defaultWidgetOptions: PerseusFreeResponseWidgetOptions = {
+    question: "",
+};
+
+const freeResponseWidgetLogic: WidgetLogic = {
+    name: "free-response",
+    defaultWidgetOptions,
+};
+
+export default freeResponseWidgetLogic;

--- a/packages/perseus-editor/src/all-editors.ts
+++ b/packages/perseus-editor/src/all-editors.ts
@@ -5,6 +5,7 @@ import DeprecatedStandinEditor from "./widgets/deprecated-standin-editor";
 import DropdownEditor from "./widgets/dropdown-editor";
 import ExplanationEditor from "./widgets/explanation-editor";
 import ExpressionEditor from "./widgets/expression-editor";
+import FreeResponseEditor from "./widgets/free-response-editor";
 import GradedGroupEditor from "./widgets/graded-group-editor";
 import GradedGroupSetEditor from "./widgets/graded-group-set-editor";
 import GrapherEditor from "./widgets/grapher-editor";
@@ -40,6 +41,7 @@ export default [
     DropdownEditor,
     ExplanationEditor,
     ExpressionEditor,
+    FreeResponseEditor,
     GradedGroupEditor,
     GradedGroupSetEditor,
     GrapherEditor,

--- a/packages/perseus-editor/src/widgets/__stories__/free-response-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/free-response-editor.stories.tsx
@@ -1,0 +1,15 @@
+import FreeResponseEditor from "../free-response-editor";
+
+import type {Meta, StoryObj} from "@storybook/react";
+
+const meta: Meta<typeof FreeResponseEditor> = {
+    component: FreeResponseEditor,
+    title: "PerseusEditor/Widgets/Free Response Editor",
+};
+
+export default meta;
+type Story = StoryObj<typeof FreeResponseEditor>;
+
+export const Primary: Story = {
+    args: {},
+};

--- a/packages/perseus-editor/src/widgets/__tests__/free-response-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/free-response-editor.test.tsx
@@ -1,0 +1,92 @@
+import {Dependencies} from "@khanacademy/perseus";
+import {render, screen} from "@testing-library/react";
+import {userEvent as userEventLib} from "@testing-library/user-event";
+import * as React from "react";
+
+import {testDependencies} from "../../../../../testing/test-dependencies";
+import FreeResponseEditor from "../free-response-editor";
+
+import type {UserEvent} from "@testing-library/user-event";
+
+describe("free-response editor", () => {
+    let userEvent: UserEvent;
+    beforeEach(() => {
+        userEvent = userEventLib.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("renders the question", async () => {
+        // Act
+        render(
+            <FreeResponseEditor question="test-question" onChange={() => {}} />,
+        );
+
+        // Assert
+        expect(screen.getByText("Question")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("test-question")).toBeInTheDocument();
+    });
+
+    it("calls onChange when the question is changed", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+
+        // Act
+        render(<FreeResponseEditor onChange={onChangeMock} />);
+        await userEvent.type(screen.getByLabelText("Question"), "2");
+
+        // Assert
+        expect(onChangeMock).toBeCalledWith({question: "2"});
+    });
+
+    it("returns a warning when the question is empty", async () => {
+        // Arrange
+        const ref = React.createRef<FreeResponseEditor>();
+
+        // Act
+        render(
+            <FreeResponseEditor ref={ref} question="" onChange={() => {}} />,
+        );
+
+        // Assert
+        expect(ref.current?.getSaveWarnings()).toEqual([
+            "The question is empty",
+        ]);
+    });
+
+    it("serializes the question value", async () => {
+        // Arrange
+        const ref = React.createRef<FreeResponseEditor>();
+
+        // Act
+        render(
+            <FreeResponseEditor
+                ref={ref}
+                question="test-question"
+                onChange={() => {}}
+            />,
+        );
+
+        // Assert
+        expect(ref.current?.serialize()).toEqual({
+            question: "test-question",
+        });
+    });
+
+    it("the question defaults to an empty string", async () => {
+        // Arrange
+        const ref = React.createRef<FreeResponseEditor>();
+
+        // Act
+        render(<FreeResponseEditor ref={ref} onChange={() => {}} />);
+
+        // Assert
+        expect(ref.current?.serialize()).toEqual({
+            question: "",
+        });
+    });
+});

--- a/packages/perseus-editor/src/widgets/free-response-editor.tsx
+++ b/packages/perseus-editor/src/widgets/free-response-editor.tsx
@@ -1,0 +1,46 @@
+import {freeResponseLogic} from "@khanacademy/perseus-core";
+import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import * as React from "react";
+
+import type {PerseusFreeResponseWidgetOptions} from "@khanacademy/perseus-core";
+
+type Props = PerseusFreeResponseWidgetOptions & {
+    onChange: (arg1: {question?: Props["question"]}) => void;
+};
+
+class FreeResponseEditor extends React.Component<Props> {
+    static defaultProps: PerseusFreeResponseWidgetOptions =
+        freeResponseLogic.defaultWidgetOptions;
+
+    static widgetName = "free-response" as const;
+
+    serialize(): PerseusFreeResponseWidgetOptions {
+        return {
+            question: this.props.question,
+        };
+    }
+
+    getSaveWarnings(): Array<string> {
+        const warnings: Array<string> = [];
+        if (!this.props.question) {
+            warnings.push("The question is empty");
+        }
+        return warnings;
+    }
+
+    render(): React.ReactNode {
+        return (
+            <LabeledTextField
+                label={"Question"}
+                value={this.props.question}
+                onChange={(question: string) => this.props.onChange({question})}
+                style={{
+                    marginBottom: spacing.large_24,
+                }}
+            />
+        );
+    }
+}
+
+export default FreeResponseEditor;

--- a/packages/perseus-score/src/validation.types.ts
+++ b/packages/perseus-score/src/validation.types.ts
@@ -225,6 +225,11 @@ export type PerseusNumericInputUserInput = {
     currentValue: string;
 };
 
+export type PerseusFreeResponseUserInput = {
+    currentValue: string;
+    question: string;
+};
+
 export type PerseusOrdererRubric = PerseusOrdererWidgetOptions;
 
 export type PerseusOrdererUserInput = {
@@ -321,6 +326,7 @@ interface UserInputRegistry {
     "cs-program": PerseusCSProgramUserInput;
     dropdown: PerseusDropdownUserInput;
     expression: PerseusExpressionUserInput;
+    "free-response": PerseusFreeResponseUserInput;
     grapher: PerseusGrapherUserInput;
     group: PerseusGroupUserInput;
     iframe: PerseusIFrameUserInput;

--- a/packages/perseus/src/extra-widgets.ts
+++ b/packages/perseus/src/extra-widgets.ts
@@ -8,6 +8,7 @@ import Definition from "./widgets/definition";
 import DeprecatedStandin from "./widgets/deprecated-standin";
 import Dropdown from "./widgets/dropdown";
 import Explanation from "./widgets/explanation";
+import FreeResponse from "./widgets/free-response";
 import GradedGroup from "./widgets/graded-group";
 import GradedGroupSet from "./widgets/graded-group-set";
 import Grapher from "./widgets/grapher";
@@ -36,22 +37,24 @@ import Video from "./widgets/video";
 import type {WidgetExports} from "./types";
 
 export default [
-    Categorizer,
     CSProgram,
+    Categorizer,
+    Definition,
+    DeprecatedStandin,
     Dropdown,
     Explanation,
-    Definition,
-    Grapher,
+    FreeResponse,
     GradedGroup,
     GradedGroupSet,
+    Grapher,
     Group,
     Iframe,
     Image,
     Interactive,
     InteractiveGraph,
     LabelImage,
-    Matrix,
     Matcher,
+    Matrix,
     Measurer,
     Molecule,
     NumberLine,
@@ -65,5 +68,4 @@ export default [
     Sorter,
     Table,
     Video,
-    DeprecatedStandin,
 ] as ReadonlyArray<WidgetExports>;

--- a/packages/perseus/src/util/widget-enum-utils.ts
+++ b/packages/perseus/src/util/widget-enum-utils.ts
@@ -13,6 +13,7 @@ type WidgetName =
     | "dropdown"
     | "explanation"
     | "expression"
+    | "free-response"
     | "graded-group-set"
     | "graded-group"
     | "grapher"
@@ -53,6 +54,7 @@ type WidgetEnum =
     | "DROPDOWN"
     | "EXPLANATION"
     | "EXPRESSION"
+    | "FREE_RESPONSE"
     | "GRADED_GROUP"
     | "GRADED_GROUP_SET"
     | "GRAPHER"
@@ -94,6 +96,7 @@ const widgetNameToEnum: Record<WidgetName, WidgetEnum> = {
     dropdown: "DROPDOWN",
     explanation: "EXPLANATION",
     expression: "EXPRESSION",
+    "free-response": "FREE_RESPONSE",
     "graded-group-set": "GRADED_GROUP_SET",
     "graded-group": "GRADED_GROUP",
     grapher: "GRAPHER",

--- a/packages/perseus/src/widgets/free-response/__snapshots__/free-response.test.tsx.snap
+++ b/packages/perseus/src/widgets/free-response/__snapshots__/free-response.test.tsx.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`free-response widget should snapshot on mobile: first mobile render 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <div
+            class="default_xu2jcg"
+          >
+            <label
+              for=":r1:"
+            >
+              test-question
+            </label>
+            <textarea
+              id=":r1:"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`free-response widget should snapshot: first render 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <div
+            class="default_xu2jcg"
+          >
+            <label
+              for=":r0:"
+            >
+              test-question
+            </label>
+            <textarea
+              id=":r0:"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/perseus/src/widgets/free-response/free-response.cypress.ts
+++ b/packages/perseus/src/widgets/free-response/free-response.cypress.ts
@@ -1,0 +1,24 @@
+import renderQuestion from "../../../../../testing/render-question-with-cypress";
+import {cypressTestDependencies} from "../../../../../testing/test-dependencies";
+import * as Dependencies from "../../dependencies";
+import * as Perseus from "../../index";
+
+import {question} from "./free-response.testdata";
+
+describe("FreeResponse Widget", () => {
+    beforeEach(() => {
+        Dependencies.setDependencies(cypressTestDependencies);
+        Perseus.init();
+    });
+
+    it("allows text input", () => {
+        // Arrange
+        renderQuestion(question);
+
+        // Act - type some text
+        cy.get("textarea").focus().type("my answer");
+
+        // Assert
+        cy.focused().should("have.text", "my answer");
+    });
+});

--- a/packages/perseus/src/widgets/free-response/free-response.stories.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.stories.tsx
@@ -1,0 +1,17 @@
+import {FreeResponse} from "./free-response";
+
+import type {Meta, StoryObj} from "@storybook/react";
+
+const meta: Meta<typeof FreeResponse> = {
+    component: FreeResponse,
+    title: "Perseus/Widgets/FreeResponse",
+};
+
+export default meta;
+type Story = StoryObj<typeof FreeResponse>;
+
+export const Primary: Story = {
+    args: {
+        question: "What is the theme of the essay?",
+    },
+};

--- a/packages/perseus/src/widgets/free-response/free-response.test.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.test.tsx
@@ -1,0 +1,94 @@
+import {screen} from "@testing-library/react";
+import {userEvent as userEventLib} from "@testing-library/user-event";
+
+import {testDependencies} from "../../../../../testing/test-dependencies";
+import * as Dependencies from "../../dependencies";
+import {renderQuestion} from "../__testutils__/renderQuestion";
+
+import {question} from "./free-response.testdata";
+
+import type {APIOptions} from "../../types";
+import type {UserEvent} from "@testing-library/user-event";
+
+describe("free-response widget", () => {
+    let userEvent: UserEvent;
+
+    beforeEach(() => {
+        userEvent = userEventLib.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("should snapshot", () => {
+        // Arrange
+        const apiOptions: APIOptions = {
+            isMobile: false,
+        };
+
+        // Act
+        const {container} = renderQuestion(question, apiOptions);
+
+        // Assert
+        expect(container).toMatchSnapshot("first render");
+    });
+
+    it("should snapshot on mobile", () => {
+        // Arrange
+        const apiOptions: APIOptions = {
+            isMobile: true,
+        };
+
+        // Act
+        const {container} = renderQuestion(question, apiOptions);
+
+        // Assert
+        expect(container).toMatchSnapshot("first mobile render");
+    });
+
+    it("should render the question text", () => {
+        // Arrange
+        // Act
+        renderQuestion(question, {});
+
+        // Assert
+        expect(screen.getByLabelText("test-question")).toBeVisible();
+    });
+
+    it("should return the correct user input", async () => {
+        // Arrange
+        const {renderer} = renderQuestion(question);
+        await userEvent.type(
+            screen.getByLabelText("test-question"),
+            "test-answer",
+        );
+
+        // Act
+        const userInput = renderer.getUserInputMap();
+
+        // Assert
+        expect(userInput).toMatchObject({
+            "free-response 1": {
+                currentValue: "test-answer",
+                question: "test-question",
+            },
+        });
+    });
+
+    // TODO(agoforth): Create a custom validator for the free-response widget
+    //   that will cause this test to pass.
+    // it("should be included in the empty widgets list if no text has been input yet", async () => {
+    //     // Arrange
+    //     const {renderer} = renderQuestion(question1);
+
+    //     // Act
+    //     const userInput = renderer.emptyWidgets();
+
+    //     // Assert
+    //     expect(userInput).toHaveLength(1);
+    //     expect(userInput[0]).toBe("free-response 1");
+    // });
+});

--- a/packages/perseus/src/widgets/free-response/free-response.testdata.ts
+++ b/packages/perseus/src/widgets/free-response/free-response.testdata.ts
@@ -1,0 +1,21 @@
+import type {
+    PerseusRenderer,
+    FreeResponseWidget,
+} from "@khanacademy/perseus-core";
+
+export const question: PerseusRenderer = {
+    content: "[[\u2603 free-response 1]]\n",
+    images: {},
+    widgets: {
+        "free-response 1": {
+            graded: false,
+            version: {major: 0, minor: 0},
+            static: false,
+            type: "free-response",
+            options: {
+                question: "test-question",
+            },
+            alignment: "default",
+        } as FreeResponseWidget,
+    },
+};

--- a/packages/perseus/src/widgets/free-response/free-response.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.tsx
@@ -1,0 +1,68 @@
+/**
+ * This widget is used for freeform text input. It is configured with a question
+ * as an option and renders the question text along with a text input area where
+ * the user can type any text as their answer. The initial use case for this widget
+ * is "short answer" type questions.
+ */
+
+import {View, Id} from "@khanacademy/wonder-blocks-core";
+import * as React from "react";
+
+import type {Widget, WidgetExports, WidgetProps} from "../../types";
+import type {PerseusFreeResponseWidgetOptions} from "@khanacademy/perseus-core";
+import type {UserInput} from "@khanacademy/perseus-score";
+
+type RenderProps = PerseusFreeResponseWidgetOptions;
+type Props = WidgetProps<RenderProps, PerseusFreeResponseWidgetOptions>;
+
+type State = {
+    currentValue: string;
+};
+
+export class FreeResponse
+    extends React.Component<Props, State>
+    implements Widget
+{
+    state: State = {
+        currentValue: "",
+    };
+
+    handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+        this.setState({currentValue: event.target.value});
+    };
+
+    getUserInput(): UserInput {
+        return {
+            currentValue: this.state.currentValue,
+            question: this.props.question,
+        };
+    }
+
+    render(): React.ReactNode {
+        return (
+            <Id>
+                {(id) => {
+                    return (
+                        <View>
+                            <label htmlFor={id}>{this.props.question}</label>
+                            <textarea
+                                id={id}
+                                value={this.state.currentValue}
+                                onChange={this.handleChange}
+                            />
+                        </View>
+                    );
+                }}
+            </Id>
+        );
+    }
+}
+
+export default {
+    name: "free-response",
+    accessible: true,
+    displayName: "Free Response",
+    widget: FreeResponse,
+    // Hides widget from content creators until full release
+    hidden: true,
+} as WidgetExports<typeof FreeResponse>;

--- a/packages/perseus/src/widgets/free-response/index.ts
+++ b/packages/perseus/src/widgets/free-response/index.ts
@@ -1,0 +1,1 @@
+export {default} from "./free-response";


### PR DESCRIPTION
## Summary:
This commit adds a basic version of the new FreeResponse widget. This
widget allows users to enter free text into an input field. The initial
use case is for "short answer" type questions.

The UX of the widget is not complete in this commit. Instead, the
intention is to get all of the files in place with a basic UI which will
then be iterated on with more widget options and more sophisticated
rendering.

Issue: https://khanacademy.atlassian.net/browse/LIT-1661

## Test plan:
- View the editor and rendered widget stories in Storybook.
- Run the tests.