### PR TITLE
[control-aria-z] Temporarily adding back the default aria label for Numeric Input while we fix downstream issues.

### DIFF
--- a/.changeset/olive-gorillas-report.md
+++ b/.changeset/olive-gorillas-report.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Temporarily adding back the default aria label for Numeric Input while we fix downstream issues.

--- a/packages/perseus/src/widgets/graded-group-set/__snapshots__/graded-group-set-jipt.test.ts.snap
+++ b/packages/perseus/src/widgets/graded-group-set/__snapshots__/graded-group-set-jipt.test.ts.snap
@@ -62,6 +62,7 @@ exports[`graded-group-set should render all graded groups 1`] = `
                       <input
                         aria-disabled="false"
                         aria-invalid="false"
+                        aria-label="Your answer:"
                         aria-required="false"
                         autocapitalize="off"
                         autocomplete="off"
@@ -139,6 +140,7 @@ exports[`graded-group-set should render all graded groups 1`] = `
                       <input
                         aria-disabled="false"
                         aria-invalid="false"
+                        aria-label="Your answer:"
                         aria-required="false"
                         autocapitalize="off"
                         autocomplete="off"
@@ -216,6 +218,7 @@ exports[`graded-group-set should render all graded groups 1`] = `
                       <input
                         aria-disabled="false"
                         aria-invalid="false"
+                        aria-label="Your answer:"
                         aria-required="false"
                         autocapitalize="off"
                         autocomplete="off"

--- a/packages/perseus/src/widgets/graded-group-set/__snapshots__/graded-group-set.test.ts.snap
+++ b/packages/perseus/src/widgets/graded-group-set/__snapshots__/graded-group-set.test.ts.snap
@@ -128,6 +128,7 @@ exports[`graded group widget should snapshot 1`] = `
                       <input
                         aria-disabled="false"
                         aria-invalid="false"
+                        aria-label="Your answer:"
                         aria-required="false"
                         autocapitalize="off"
                         autocomplete="off"

--- a/packages/perseus/src/widgets/numeric-input/__snapshots__/numeric-input.test.ts.snap
+++ b/packages/perseus/src/widgets/numeric-input/__snapshots__/numeric-input.test.ts.snap
@@ -95,6 +95,7 @@ exports[`numeric-input widget Should render predictably: after interaction 1`] =
           <input
             aria-disabled="false"
             aria-invalid="false"
+            aria-label="Your answer:"
             aria-required="false"
             autocapitalize="off"
             autocomplete="off"
@@ -147,6 +148,7 @@ exports[`numeric-input widget Should render predictably: first render 1`] = `
           <input
             aria-disabled="false"
             aria-invalid="false"
+            aria-label="Your answer:"
             aria-required="false"
             autocapitalize="off"
             autocomplete="off"
@@ -200,6 +202,7 @@ exports[`numeric-input widget Should render tooltip as list when multiple format
             aria-describedby="aria-for-:rf:"
             aria-disabled="false"
             aria-invalid="false"
+            aria-label="Your answer:"
             aria-required="false"
             autocapitalize="off"
             autocomplete="off"
@@ -315,6 +318,7 @@ exports[`numeric-input widget Should render tooltip when format option is given:
             aria-describedby="aria-for-:r9:"
             aria-disabled="false"
             aria-invalid="false"
+            aria-label="Your answer:"
             aria-required="false"
             autocapitalize="off"
             autocomplete="off"

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
@@ -97,7 +97,6 @@ export const NumericInputComponent = forwardRef(
                 </div>
             );
         }
-        // (desktop-only) Otherwise, use the InputWithExamples component
 
         // If the labelText is not provided by the Content Creators, use the default label text
         let labelText = props.labelText;
@@ -105,6 +104,7 @@ export const NumericInputComponent = forwardRef(
             labelText = context.strings.yourAnswerLabel;
         }
 
+        // (desktop-only) Otherwise, use the InputWithExamples component
         return (
             <InputWithExamples
                 ref={inputRef as React.RefObject<typeof InputWithExamples>}

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
@@ -98,12 +98,19 @@ export const NumericInputComponent = forwardRef(
             );
         }
         // (desktop-only) Otherwise, use the InputWithExamples component
+
+        // If the labelText is not provided by the Content Creators, use the default label text
+        let labelText = props.labelText;
+        if (labelText == null || labelText === "") {
+            labelText = context.strings.yourAnswerLabel;
+        }
+
         return (
             <InputWithExamples
                 ref={inputRef as React.RefObject<typeof InputWithExamples>}
                 value={props.currentValue}
                 onChange={handleChange}
-                labelText={props.labelText}
+                labelText={labelText}
                 examples={generateExamples(props.answerForms, context.strings)}
                 shouldShowExamples={shouldShowExamples(props.answerForms)}
                 onFocus={handleFocus}


### PR DESCRIPTION
## Summary:
This tiny PR (proposal) adds back the default ariaLabel for Numeric Input, as we have several cypress tests that are failing downstream. We have looked at several possible ways around this issue, but it looks like we may need a larger fix before this work can be deployed. 

## Test plan:
- Updated snapshots 
- Tests pass 