### PR TITLE
[poly-gets-updated-coords] docs(changeset): Bugfix to ensure that the Interactive Graph Editor updates the Polygon start coords if the number of sides change.

### DIFF
--- a/.changeset/cuddly-snails-work.md
+++ b/.changeset/cuddly-snails-work.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Bugfix to ensure that the Interactive Graph Editor updates the Polygon start coords if the number of sides change.

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
@@ -510,6 +510,7 @@ class InteractiveGraphEditor extends React.Component<Props> {
                                                 numSides:
                                                     parsePointCount(newValue),
                                                 coords: null,
+                                                startCoords: undefined,
                                                 // reset the snap for UNLIMITED, which
                                                 // only supports "grid"
                                                 // From: D6578

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
@@ -305,11 +305,13 @@ export function getPolygonCoords(
         return coords;
     }
 
+    // If we have startCoords AND they match the number of sides, use them
     const startCoords = graph.startCoords?.slice();
-    if (startCoords) {
+    if (startCoords && startCoords.length === graph.numSides) {
         return startCoords;
     }
 
+    // Otherwise, generate some default coords
     const n = graph.numSides || 3;
 
     if (n === "unlimited") {

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
@@ -305,13 +305,11 @@ export function getPolygonCoords(
         return coords;
     }
 
-    // If we have startCoords AND they match the number of sides, use them
     const startCoords = graph.startCoords?.slice();
-    if (startCoords && startCoords.length === graph.numSides) {
+    if (startCoords) {
         return startCoords;
     }
 
-    // Otherwise, generate some default coords
     const n = graph.numSides || 3;
 
     if (n === "unlimited") {


### PR DESCRIPTION
## Summary:
This PR is part of the Interactive Graph project. 

The purpose of this simple PR is to implement a fix that ensures that the start coords are always updated when content creators update the number of sides for the graph. 

Issue: LEMS-2883

## Test plan:
- manual testing 